### PR TITLE
fix(attachments): note-image upload works in WKWebView via WebP→PNG fallback

### DIFF
--- a/src-tauri/src/commands/attachments.rs
+++ b/src-tauri/src/commands/attachments.rs
@@ -193,12 +193,18 @@ pub(crate) fn add_note_attachment_inner(
     gate_attachment_owner(state, &owner)?;
     let data = decode_base64(data_base64)?;
     let image = validate_image(mime_type, &data)?;
-    if image.mime_type != "image/webp" {
-        return Err(AppError::InvalidArg(
-            "new images must be locally normalized to metadata-free WebP".into(),
-        ));
+    // WebKit's <canvas> cannot ENCODE WebP (`toBlob("image/webp")` silently yields PNG), so the FE
+    // falls back to a metadata-free PNG. Accept both, running the metadata rejector that matches the
+    // container. JPEG and any other source container are never produced by the local normalizer.
+    match image.mime_type {
+        "image/webp" => reject_webp_metadata(&data)?,
+        "image/png" => reject_png_metadata(&data)?,
+        _ => {
+            return Err(AppError::InvalidArg(
+                "new images must be locally normalized to metadata-free WebP or PNG".into(),
+            ))
+        }
     }
-    reject_webp_metadata(&data)?;
     let id = uuid::Uuid::new_v4().to_string();
     let hash: [u8; 32] = Sha256::digest(&data).into();
     let created_at = chrono::Utc::now().timestamp_millis();
@@ -352,9 +358,14 @@ pub fn validate_incoming_attachment_bundle(
     let mut seen = HashSet::new();
     let mut total = 0usize;
     for item in incoming {
-        if item.mime_type != "image/webp" || item.extension != "webp" {
+        // A shared note may carry either a normalized WebP or the metadata-free PNG fallback that
+        // WebKit clients now produce; both must materialize on the recipient.
+        if !matches!(
+            (item.mime_type.as_str(), item.extension.as_str()),
+            ("image/webp", "webp") | ("image/png", "png")
+        ) {
             return Err(AppError::InvalidArg(
-                "attachments must be normalized WebP images".into(),
+                "attachments must be normalized WebP or PNG images".into(),
             ));
         }
         let parsed = uuid::Uuid::parse_str(&item.id)
@@ -368,7 +379,15 @@ pub fn validate_incoming_attachment_bundle(
             ));
         }
         let image = validate_image(&item.mime_type, &item.data)?;
-        reject_webp_metadata(&item.data)?;
+        match image.mime_type {
+            "image/webp" => reject_webp_metadata(&item.data)?,
+            "image/png" => reject_png_metadata(&item.data)?,
+            _ => {
+                return Err(AppError::InvalidArg(
+                    "attachments must be normalized WebP or PNG images".into(),
+                ))
+            }
+        }
         if image.extension != item.extension
             || image.width != item.width
             || image.height != item.height
@@ -1446,6 +1465,72 @@ fn reject_webp_metadata(data: &[u8]) -> Result<(), AppError> {
     Ok(())
 }
 
+/// Enforce that a PNG the FE claims is metadata-free actually is. Walk the chunk stream with checked
+/// arithmetic, require the canonical `IHDR`-first / `IEND`-last framing, reject any trailing bytes,
+/// and fail closed if any privacy-bearing ancillary chunk is present. `sRGB` (WebKit's own encoder
+/// emits it) and other rendering-intent chunks are benign and allowed. No PII is placed in errors.
+fn reject_png_metadata(data: &[u8]) -> Result<(), AppError> {
+    const SIGNATURE: &[u8; 8] = b"\x89PNG\r\n\x1a\n";
+    if data.len() < SIGNATURE.len() || &data[..SIGNATURE.len()] != SIGNATURE {
+        return Err(AppError::InvalidArg("malformed PNG".into()));
+    }
+    let mut offset = SIGNATURE.len();
+    let mut first = true;
+    let mut saw_iend = false;
+    while offset < data.len() {
+        if offset + 8 > data.len() {
+            return Err(AppError::InvalidArg("malformed PNG chunks".into()));
+        }
+        let len = u32::from_be_bytes([
+            data[offset],
+            data[offset + 1],
+            data[offset + 2],
+            data[offset + 3],
+        ]) as usize;
+        let tag = &data[offset + 4..offset + 8];
+        if first {
+            if tag != b"IHDR" {
+                return Err(AppError::InvalidArg("PNG must begin with IHDR".into()));
+            }
+            first = false;
+        }
+        // eXIf/tEXt/zTXt/iTXt carry arbitrary embedded text, iCCP an ICC profile, tIME a timestamp —
+        // all can re-introduce the private metadata the local normalizer exists to strip.
+        if matches!(
+            tag,
+            b"eXIf" | b"tEXt" | b"zTXt" | b"iTXt" | b"iCCP" | b"tIME"
+        ) {
+            return Err(AppError::InvalidArg(
+                "PNG metadata chunks are not allowed".into(),
+            ));
+        }
+        let is_iend = tag == b"IEND";
+        // Advance past length(4) + type(4) + data(len) + crc(4).
+        let advance = len
+            .checked_add(12)
+            .ok_or_else(|| AppError::InvalidArg("malformed PNG chunks".into()))?;
+        offset = offset
+            .checked_add(advance)
+            .ok_or_else(|| AppError::InvalidArg("malformed PNG chunks".into()))?;
+        if offset > data.len() {
+            return Err(AppError::InvalidArg("malformed PNG chunks".into()));
+        }
+        if is_iend {
+            saw_iend = true;
+            break;
+        }
+    }
+    if !saw_iend {
+        return Err(AppError::InvalidArg("PNG is missing its IEND chunk".into()));
+    }
+    if offset != data.len() {
+        return Err(AppError::InvalidArg(
+            "trailing bytes after PNG IEND".into(),
+        ));
+    }
+    Ok(())
+}
+
 fn decode_base64(input: &str) -> Result<Vec<u8>, AppError> {
     if input.len() > MAX_BASE64_INPUT {
         return Err(AppError::InvalidArg(
@@ -1553,6 +1638,92 @@ mod tests {
         b.extend_from_slice(&height.to_be_bytes());
         b.extend_from_slice(&[8, 6, 0, 0, 0, 0, 0, 0, 0]);
         b
+    }
+
+    fn png_crc32(bytes: &[u8]) -> u32 {
+        let mut crc = 0xFFFF_FFFFu32;
+        for &byte in bytes {
+            crc ^= u32::from(byte);
+            for _ in 0..8 {
+                crc = if crc & 1 != 0 {
+                    (crc >> 1) ^ 0xEDB8_8320
+                } else {
+                    crc >> 1
+                };
+            }
+        }
+        crc ^ 0xFFFF_FFFF
+    }
+
+    fn png_chunk(kind: &[u8; 4], data: &[u8]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(12 + data.len());
+        out.extend_from_slice(&(data.len() as u32).to_be_bytes());
+        out.extend_from_slice(kind);
+        out.extend_from_slice(data);
+        let mut crc_input = Vec::with_capacity(4 + data.len());
+        crc_input.extend_from_slice(kind);
+        crc_input.extend_from_slice(data);
+        out.extend_from_slice(&png_crc32(&crc_input).to_be_bytes());
+        out
+    }
+
+    /// A canvas-style PNG (`IHDR sRGB IDAT IEND`) with an optional extra ancillary chunk inserted
+    /// after `sRGB`, mirroring what WebKit's own encoder emits.
+    fn png_document(extra: Option<(&[u8; 4], &[u8])>) -> Vec<u8> {
+        let mut out = b"\x89PNG\r\n\x1a\n".to_vec();
+        let mut ihdr = Vec::new();
+        ihdr.extend_from_slice(&8u32.to_be_bytes());
+        ihdr.extend_from_slice(&8u32.to_be_bytes());
+        ihdr.extend_from_slice(&[8, 6, 0, 0, 0]);
+        out.extend_from_slice(&png_chunk(b"IHDR", &ihdr));
+        out.extend_from_slice(&png_chunk(b"sRGB", &[0]));
+        if let Some((kind, data)) = extra {
+            out.extend_from_slice(&png_chunk(kind, data));
+        }
+        out.extend_from_slice(&png_chunk(b"IDAT", &[0x78, 0x9c, 0x63, 0x00, 0x01]));
+        out.extend_from_slice(&png_chunk(b"IEND", &[]));
+        out
+    }
+
+    #[test]
+    fn reject_png_metadata_allows_clean_srgb_png() {
+        assert!(reject_png_metadata(&png_document(None)).is_ok());
+        // A bare `IHDR IDAT IEND` PNG (no rendering-intent chunk) is equally clean.
+        let mut bare = b"\x89PNG\r\n\x1a\n".to_vec();
+        let mut ihdr = Vec::new();
+        ihdr.extend_from_slice(&2u32.to_be_bytes());
+        ihdr.extend_from_slice(&2u32.to_be_bytes());
+        ihdr.extend_from_slice(&[8, 6, 0, 0, 0]);
+        bare.extend_from_slice(&png_chunk(b"IHDR", &ihdr));
+        bare.extend_from_slice(&png_chunk(b"IDAT", &[0x78, 0x9c, 0x63, 0x00, 0x01]));
+        bare.extend_from_slice(&png_chunk(b"IEND", &[]));
+        assert!(reject_png_metadata(&bare).is_ok());
+    }
+
+    #[test]
+    fn reject_png_metadata_rejects_privacy_bearing_chunks() {
+        for kind in [b"eXIf", b"tEXt", b"zTXt", b"iTXt", b"iCCP", b"tIME"] {
+            let bytes = png_document(Some((kind, b"payload")));
+            assert!(
+                matches!(reject_png_metadata(&bytes), Err(AppError::InvalidArg(_))),
+                "chunk {:?} must be rejected",
+                std::str::from_utf8(kind).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn reject_png_metadata_rejects_bad_framing_and_trailing_bytes() {
+        assert!(reject_png_metadata(b"not a png at all").is_err());
+        // Trailing bytes after IEND are refused.
+        let mut trailing = png_document(None);
+        trailing.extend_from_slice(b"junk");
+        assert!(reject_png_metadata(&trailing).is_err());
+        // A declared length that overruns the buffer is refused via checked arithmetic.
+        let mut overrun = b"\x89PNG\r\n\x1a\n".to_vec();
+        overrun.extend_from_slice(&0xffff_ffffu32.to_be_bytes());
+        overrun.extend_from_slice(b"IHDR");
+        assert!(reject_png_metadata(&overrun).is_err());
     }
 
     #[test]

--- a/src-tauri/src/commands/org.rs
+++ b/src-tauri/src/commands/org.rs
@@ -113,17 +113,26 @@ pub(crate) fn prepare_incoming_attachment_bundle(
             attachment.sha256.as_slice().try_into().map_err(|_| {
                 AppError::InvalidArg("shared image hash has the wrong length".into())
             })?;
-        if attachment.mime_type != "image/webp" {
-            return Err(AppError::InvalidArg(
-                "shared images must be normalized WebP".into(),
-            ));
-        }
+        // Derive the canonical extension from the container. WebKit clients cannot canvas-encode
+        // WebP and now share metadata-free PNGs (see attachments::add_note_attachment_inner), so both
+        // are accepted here; the authoritative check — magic bytes, dims, sha, and the
+        // container-matched metadata rejector — runs in validate_incoming_attachment_bundle below,
+        // before any DB write.
+        let extension = match attachment.mime_type.as_str() {
+            "image/webp" => "webp",
+            "image/png" => "png",
+            _ => {
+                return Err(AppError::InvalidArg(
+                    "shared images must be normalized WebP or PNG".into(),
+                ))
+            }
+        };
         let local_id = uuid::Uuid::new_v4().to_string();
         id_map.insert(wire_id, local_id.clone());
         incoming.push(crate::storage::IncomingAttachment {
             id: local_id,
             mime_type: attachment.mime_type.clone(),
-            extension: "webp".to_string(),
+            extension: extension.to_string(),
             width: attachment.width,
             height: attachment.height,
             sha256,

--- a/src-tauri/src/commands/tests/attachment_tests.rs
+++ b/src-tauri/src/commands/tests/attachment_tests.rs
@@ -87,6 +87,51 @@ fn webp(width: u32, height: u32) -> Vec<u8> {
     bytes
 }
 
+fn png_crc32(bytes: &[u8]) -> u32 {
+    let mut crc = 0xFFFF_FFFFu32;
+    for &byte in bytes {
+        crc ^= u32::from(byte);
+        for _ in 0..8 {
+            crc = if crc & 1 != 0 {
+                (crc >> 1) ^ 0xEDB8_8320
+            } else {
+                crc >> 1
+            };
+        }
+    }
+    crc ^ 0xFFFF_FFFF
+}
+
+fn png_chunk(kind: &[u8; 4], data: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(12 + data.len());
+    out.extend_from_slice(&(data.len() as u32).to_be_bytes());
+    out.extend_from_slice(kind);
+    out.extend_from_slice(data);
+    let mut crc_input = Vec::with_capacity(4 + data.len());
+    crc_input.extend_from_slice(kind);
+    crc_input.extend_from_slice(data);
+    out.extend_from_slice(&png_crc32(&crc_input).to_be_bytes());
+    out
+}
+
+/// A canvas-style PNG (`IHDR sRGB IDAT IEND`), optionally carrying one extra ancillary chunk after
+/// `sRGB` — exactly the shape WebKit's `canvas.toBlob("image/png")` produces (it emits `eXIf`).
+fn png_image(width: u32, height: u32, extra: Option<(&[u8; 4], &[u8])>) -> Vec<u8> {
+    let mut out = b"\x89PNG\r\n\x1a\n".to_vec();
+    let mut ihdr = Vec::new();
+    ihdr.extend_from_slice(&width.to_be_bytes());
+    ihdr.extend_from_slice(&height.to_be_bytes());
+    ihdr.extend_from_slice(&[8, 6, 0, 0, 0]);
+    out.extend_from_slice(&png_chunk(b"IHDR", &ihdr));
+    out.extend_from_slice(&png_chunk(b"sRGB", &[0]));
+    if let Some((kind, data)) = extra {
+        out.extend_from_slice(&png_chunk(kind, data));
+    }
+    out.extend_from_slice(&png_chunk(b"IDAT", &[0x78, 0x9c, 0x63, 0x00, 0x01]));
+    out.extend_from_slice(&png_chunk(b"IEND", &[]));
+    out
+}
+
 fn base64url(data: &[u8]) -> String {
     const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
     let mut out = String::new();
@@ -129,6 +174,31 @@ fn add_webp(state: &AppState, owner_kind: &str, owner_id: &str, bytes: &[u8]) ->
         &base64url(bytes),
     )
     .expect("add normalized WebP")
+}
+
+fn add_png(state: &AppState, owner_kind: &str, owner_id: &str, bytes: &[u8]) -> AttachmentDto {
+    add_note_attachment_inner(
+        state,
+        owner_kind,
+        owner_id,
+        "clipboard.png",
+        "image/png",
+        &base64url(bytes),
+    )
+    .expect("add normalized PNG")
+}
+
+fn incoming_png(bytes: &[u8], width: u32, height: u32) -> crate::storage::IncomingAttachment {
+    use sha2::{Digest, Sha256};
+    crate::storage::IncomingAttachment {
+        id: uuid::Uuid::new_v4().to_string(),
+        mime_type: "image/png".into(),
+        extension: "png".into(),
+        width,
+        height,
+        sha256: Sha256::digest(bytes).into(),
+        data: bytes.to_vec(),
+    }
 }
 
 fn meeting_folder(db: &Db, id: &str) {
@@ -902,4 +972,142 @@ fn org_feed_attachment_bundle_remaps_and_authoritatively_replaces_local_replica(
         .list_attachments(&owner)
         .expect("empty org images")
         .is_empty());
+}
+
+#[test]
+fn add_note_attachment_accepts_metadata_free_png_and_rejects_exif() {
+    let state = build_state("png-upload", None);
+    let folder = create_note_folder_inner(&state, "PNG", None).expect("folder");
+    let note_id = create_note_inner(&state, Some(&folder.id), "PNG").expect("note");
+
+    // The WebKit fallback path: a clean, metadata-free PNG must round-trip through the gated add.
+    let clean = png_image(48, 32, None);
+    let dto = add_png(&state, "note", &note_id, &clean);
+    assert_eq!(dto.mime_type, "image/png");
+    assert_eq!(dto.extension, "png");
+    assert_eq!((dto.width, dto.height), (48, 32));
+
+    // WebP still works alongside the new PNG path.
+    add_webp(&state, "note", &note_id, &webp(40, 30));
+
+    // A PNG that still carries an eXIf chunk (the exact chunk WebKit emits before the FE strips it)
+    // is rejected: the strip is enforced by the backend, not merely assumed.
+    let with_exif = png_image(48, 32, Some((b"eXIf", b"\x00\x01\x02")));
+    assert!(matches!(
+        add_note_attachment_inner(
+            &state,
+            "note",
+            &note_id,
+            "clipboard.png",
+            "image/png",
+            &base64url(&with_exif),
+        ),
+        Err(AppError::InvalidArg(_))
+    ));
+}
+
+#[test]
+fn locked_folder_png_attachment_seals_and_round_trips_byte_identical() {
+    let vault = temp_vault("png-seal");
+    let state = build_state("png-seal", Some(&vault));
+    let folder = create_note_folder_inner(&state, "Private PNG", None).expect("folder");
+    let note_id = create_note_inner(&state, Some(&folder.id), "Screens").expect("note");
+    let bytes = png_image(64, 40, None);
+    add_png(&state, "note", &note_id, &bytes);
+    let owner = AttachmentOwner::Document {
+        document_id: note_id.clone(),
+    };
+
+    lock_folder_inner(&state, folder.id.clone()).expect("lock folder");
+    let sealed = &state.db.list_attachments(&owner).expect("sealed row")[0];
+    assert!(sealed.data.is_empty(), "plaintext blanked after verified seal");
+    assert!(sealed.data_blob.is_some(), "recoverable seal retained");
+
+    let ck = cache_kek_and_folder_ck(&state, &folder.id);
+    unseal_attachments_in_folder(&state, &folder.id, &ck, false).expect("session restore");
+    assert_eq!(
+        state.db.list_attachments(&owner).expect("restored row")[0].data,
+        bytes,
+        "PNG seal decrypts byte-identical to the original plaintext"
+    );
+    let _ = std::fs::remove_dir_all(vault);
+}
+
+#[test]
+fn share_ingest_accepts_clean_png_and_rejects_metadata_png() {
+    let clean = incoming_png(&png_image(96, 64, None), 96, 64);
+    validate_incoming_attachment_bundle(std::slice::from_ref(&clean))
+        .expect("a clean PNG share bundle materializes on the recipient");
+
+    let with_exif = incoming_png(&png_image(96, 64, Some((b"eXIf", b"payload"))), 96, 64);
+    assert!(matches!(
+        validate_incoming_attachment_bundle(std::slice::from_ref(&with_exif)),
+        Err(AppError::InvalidArg(_))
+    ));
+
+    // A WebP bundle still validates unchanged.
+    let webp_bytes = webp(96, 64);
+    let webp_item = crate::storage::IncomingAttachment {
+        id: uuid::Uuid::new_v4().to_string(),
+        mime_type: "image/webp".into(),
+        extension: "webp".into(),
+        width: 96,
+        height: 64,
+        sha256: {
+            use sha2::{Digest, Sha256};
+            Sha256::digest(&webp_bytes).into()
+        },
+        data: webp_bytes,
+    };
+    validate_incoming_attachment_bundle(std::slice::from_ref(&webp_item))
+        .expect("WebP share bundle still validates");
+}
+
+/// RED→GREEN for the org / Murmur↔Murmur E2EE share-ingest ENTRYPOINT (not the inner validator the
+/// other test exercises). WebKit clients now share metadata-free PNGs; `prepare_incoming_attachment_bundle`
+/// used to hard-reject non-WebP and hardcode `extension: "webp"`, so accepting a shared note that
+/// carried a PNG image failed (`ingest_shared_note` → `?`). This asserts the real entrypoint now
+/// remaps + validates a clean PNG bundle end-to-end, deriving the correct extension.
+#[test]
+fn org_share_ingest_entrypoint_accepts_clean_png_bundle() {
+    use sha2::{Digest, Sha256};
+
+    let wire_id = uuid::Uuid::new_v4().to_string();
+    let bytes = png_image(96, 64, None);
+    let markdown = format!("before ![shot](murmur-attachment://{wire_id}) after");
+    let wire = murmur_protocol::envelope::ShareAttachment {
+        id: wire_id.clone(),
+        mime_type: "image/png".into(),
+        width: 96,
+        height: 64,
+        sha256: Sha256::digest(&bytes).to_vec(),
+        data: bytes.clone(),
+    };
+    let (local_markdown, incoming) =
+        crate::commands::org_commands::prepare_incoming_attachment_bundle(&markdown, &[wire])
+            .expect("a PNG share bundle must materialize through the real ingest entrypoint");
+    assert_eq!(incoming.len(), 1);
+    assert_eq!(incoming[0].mime_type, "image/png");
+    assert_eq!(incoming[0].extension, "png");
+    assert_eq!(incoming[0].data, bytes);
+    assert_ne!(incoming[0].id, wire_id);
+    assert!(local_markdown.contains(&incoming[0].id));
+
+    // A PNG that still carries an eXIf chunk is rejected by the entrypoint (metadata rejector runs
+    // inside prepare's validate_incoming_attachment_bundle), not merely by the inner validator.
+    let exif_id = uuid::Uuid::new_v4().to_string();
+    let exif_bytes = png_image(96, 64, Some((b"eXIf", b"payload")));
+    let exif_md = format!("![x](murmur-attachment://{exif_id})");
+    let exif_wire = murmur_protocol::envelope::ShareAttachment {
+        id: exif_id,
+        mime_type: "image/png".into(),
+        width: 96,
+        height: 64,
+        sha256: Sha256::digest(&exif_bytes).to_vec(),
+        data: exif_bytes,
+    };
+    assert!(matches!(
+        crate::commands::org_commands::prepare_incoming_attachment_bundle(&exif_md, &[exif_wire]),
+        Err(AppError::InvalidArg(_))
+    ));
 }

--- a/src/app/services/note-attachment.service.ts
+++ b/src/app/services/note-attachment.service.ts
@@ -19,6 +19,74 @@ const INPUT_IMAGE_TYPES = new Set([
 ]);
 const ATTACHMENT_REF_RE =
   /murmur-attachment:\/\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/gi;
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] as const;
+// Ancillary chunks that can carry embedded text / profiles / timestamps — the private metadata the
+// local normalizer exists to strip. WebKit's own `canvas.toBlob("image/png")` emits `eXIf`, so it
+// MUST be dropped before upload; `sRGB` (and other rendering-intent chunks) are benign and kept.
+const PNG_METADATA_CHUNKS = new Set(["eXIf", "tEXt", "zTXt", "iTXt", "iCCP", "tIME"]);
+
+/**
+ * Remove privacy-bearing ancillary chunks from a PNG byte stream, preserving chunk order and every
+ * structural/rendering chunk verbatim (each PNG chunk carries its own CRC, so dropping an ancillary
+ * chunk needs no re-CRC). If the input is not a well-formed PNG it is returned unchanged and the
+ * backend validator fails closed. Exported for direct unit testing.
+ */
+export function stripPngMetadata(
+  bytes: Uint8Array<ArrayBuffer>,
+): Uint8Array<ArrayBuffer> {
+  // Signature (8) + at least one 12-byte chunk header/footer must be present.
+  if (bytes.length < PNG_SIGNATURE.length + 12) {
+    return bytes;
+  }
+  for (let i = 0; i < PNG_SIGNATURE.length; i += 1) {
+    if (bytes[i] !== PNG_SIGNATURE[i]) {
+      return bytes;
+    }
+  }
+  const kept: Uint8Array<ArrayBuffer>[] = [bytes.subarray(0, PNG_SIGNATURE.length)];
+  let offset: number = PNG_SIGNATURE.length;
+  let sawIend = false;
+  while (offset + 8 <= bytes.length) {
+    const length =
+      ((bytes[offset] << 24) >>> 0) +
+      (bytes[offset + 1] << 16) +
+      (bytes[offset + 2] << 8) +
+      bytes[offset + 3];
+    const type = String.fromCharCode(
+      bytes[offset + 4],
+      bytes[offset + 5],
+      bytes[offset + 6],
+      bytes[offset + 7],
+    );
+    const end = offset + 12 + length;
+    if (end > bytes.length) {
+      // Malformed length overruns the buffer — leave the bytes untouched; the backend rejects them.
+      return bytes;
+    }
+    if (!PNG_METADATA_CHUNKS.has(type)) {
+      kept.push(bytes.subarray(offset, end));
+    }
+    offset = end;
+    if (type === "IEND") {
+      sawIend = true;
+      break;
+    }
+  }
+  if (!sawIend) {
+    return bytes;
+  }
+  let total = 0;
+  for (const part of kept) {
+    total += part.length;
+  }
+  const out = new Uint8Array(total);
+  let cursor = 0;
+  for (const part of kept) {
+    out.set(part, cursor);
+    cursor += part.length;
+  }
+  return out;
+}
 
 interface ImageDimensions {
   width: number;
@@ -284,9 +352,10 @@ export function referencedNoteAttachments(
 
 /**
  * Local-only image preparation and attachment IPC. Every accepted input is
- * decoded into a canvas and encoded as a NEW WebP before it crosses IPC. This
- * strips source metadata and guarantees the backend never receives the original
- * PNG/JPEG container. No remote URL is fetched by this service.
+ * decoded into a canvas and re-encoded before it crosses IPC — as WebP where the
+ * engine can encode it, otherwise as a metadata-free PNG (WebKit's <canvas>
+ * cannot encode WebP). Either way the backend never receives the original
+ * container or its metadata. No remote URL is fetched by this service.
  */
 @Injectable({ providedIn: "root" })
 export class NoteAttachmentService {
@@ -369,19 +438,23 @@ export class NoteAttachmentService {
     return { markdown: chunks.join("\n\n"), images };
   }
 
-  /** Decode → scale → WebP encode locally, then persist through the typed IPC seam. */
+  /** Decode → scale → WebP-or-PNG encode locally, then persist through the typed IPC seam. */
   async importImage(
     ownerKind: NoteAttachmentOwnerKind,
     ownerId: string,
     image: LocalImageCandidate,
   ): Promise<NoteAttachmentDto> {
-    const normalized = await this.normalizeToWebp(image.blob);
+    const normalized = await this.normalizeForUpload(image.blob);
     const dataBase64 = await this.base64Url(normalized.blob);
+    // The declared MIME must match the bytes (the backend re-detects and rejects a mismatch), and
+    // the neutral filename keeps person/project names out of Markdown/shareable metadata.
+    const fileName =
+      normalized.mime === "image/png" ? "note-image.png" : "note-image.webp";
     return this.ipc.addNoteAttachment(
       ownerKind,
       ownerId,
-      "note-image.webp",
-      "image/webp",
+      fileName,
+      normalized.mime,
       dataBase64,
     );
   }
@@ -598,9 +671,9 @@ export class NoteAttachmentService {
     }
   }
 
-  private async normalizeToWebp(
+  private async normalizeForUpload(
     sourceBlob: Blob,
-  ): Promise<{ blob: Blob; width: number; height: number }> {
+  ): Promise<{ blob: Blob; mime: "image/webp" | "image/png"; width: number; height: number }> {
     const mimeType = sourceBlob.type.toLowerCase();
     if (!INPUT_IMAGE_TYPES.has(mimeType)) {
       throw new Error("Choose a PNG, JPEG, or WebP image.");
@@ -640,6 +713,7 @@ export class NoteAttachmentService {
       let width = Math.max(1, Math.round(decoded.width * initialScale));
       let height = Math.max(1, Math.round(decoded.height * initialScale));
       const qualities = [0.86, 0.74, 0.62, 0.5, 0.4];
+      let producedAnyBlob = false;
 
       for (let resizeAttempt = 0; resizeAttempt < 7; resizeAttempt += 1) {
         const canvas = document.createElement("canvas");
@@ -650,12 +724,42 @@ export class NoteAttachmentService {
           throw new Error("Image processing is unavailable in this window.");
         }
         context.drawImage(decoded.source, 0, 0, width, height);
+
+        // Prefer WebP when the engine can genuinely encode it (Chromium today, WebKit later).
+        // WebKit's `toBlob("image/webp")` silently returns a PNG-typed blob, so gate on the actual
+        // returned type — never trust the requested MIME.
         for (const quality of qualities) {
-          const output = await this.canvasWebp(canvas, quality);
+          const output = await this.encodeCanvas(canvas, "image/webp", quality);
+          if (!output) {
+            break;
+          }
+          producedAnyBlob = true;
+          if (output.type.toLowerCase() !== "image/webp") {
+            // This engine cannot encode WebP (WebKit yields a PNG-typed blob). Lowering the quality
+            // will not change that, so stop probing WebP and take the PNG fallback below.
+            break;
+          }
           if (output.size <= MAX_OUTPUT_BYTES) {
-            return { blob: output, width, height };
+            return { blob: output, mime: "image/webp", width, height };
           }
         }
+
+        // WebP unavailable → fall back to a metadata-free PNG (lossless, alpha-safe). Strip the
+        // metadata chunks WebKit's own encoder emits so the backend's reject_png_metadata accepts it.
+        const png = await this.encodeCanvas(canvas, "image/png");
+        if (png) {
+          producedAnyBlob = true;
+          const stripped = stripPngMetadata(new Uint8Array(await png.arrayBuffer()));
+          if (stripped.length <= MAX_OUTPUT_BYTES) {
+            return {
+              blob: new Blob([stripped], { type: "image/png" }),
+              mime: "image/png",
+              width,
+              height,
+            };
+          }
+        }
+
         // One shared scale preserves panoramas/portraits; each axis bottoms at
         // one pixel instead of independently clamping and distorting the image.
         const nextWidth = Math.max(1, Math.floor(width * 0.78));
@@ -665,6 +769,11 @@ export class NoteAttachmentService {
         }
         width = nextWidth;
         height = nextHeight;
+      }
+      if (!producedAnyBlob) {
+        throw new Error(
+          "This browser can’t encode images for upload. Update macOS and try again.",
+        );
       }
       throw new Error("That image is too detailed to fit the 3 MB note-image limit.");
     } finally {
@@ -721,16 +830,15 @@ export class NoteAttachmentService {
     });
   }
 
-  private async canvasWebp(canvas: HTMLCanvasElement, quality: number): Promise<Blob> {
-    const blob = await new Promise<Blob | null>((resolve) => {
-      canvas.toBlob(resolve, "image/webp", quality);
+  /** Encode a canvas to a blob of the requested type, resolving null when the engine cannot. */
+  private encodeCanvas(
+    canvas: HTMLCanvasElement,
+    type: "image/webp" | "image/png",
+    quality?: number,
+  ): Promise<Blob | null> {
+    return new Promise<Blob | null>((resolve) => {
+      canvas.toBlob((blob) => resolve(blob), type, quality);
     });
-    if (!blob || blob.type.toLowerCase() !== "image/webp") {
-      throw new Error(
-        "This WebView cannot safely encode WebP images. Update macOS and try again.",
-      );
-    }
-    return blob;
   }
 
   private async base64Url(blob: Blob): Promise<string> {


### PR DESCRIPTION


WebKit cannot canvas-encode WebP (canvas.toBlob("image/webp") silently returns a PNG-typed blob), so note-image upload never worked in any packaged Murmur build — only in a Chromium dev browser. The FE now falls back to a metadata-free PNG when the engine can't encode WebP, stripping the eXIf chunk WebKit's own encoder injects; the backend accepts image/png at the add gate, the local-bundle validator, and the E2EE share-ingest entrypoint (org.rs), each routed to a container-matched metadata rejector. Locked-folder PNG attachments seal with verify-before-destroy and gate-every-read is preserved.

No new deps. cargo test --lib green (2275/0); lock-security + adversarial review PASS.