### PR TITLE
fix(harness): robustness — degraded-writer recovery, env-BLOCKED checks, glob classifier, dev-run deadlock

### DIFF
--- a/.agents/harness/config.json
+++ b/.agents/harness/config.json
@@ -71,7 +71,7 @@
       "src-tauri/src/mcp.rs",
       "src/app/**/lock*",
       "src/app/**/share*",
-      "src/app/**/attachment*"
+      "src/app/**/*attachment*"
     ],
     "egress": [
       "src-tauri/src/summarize/**",

--- a/.agents/harness/task_runner.py
+++ b/.agents/harness/task_runner.py
@@ -489,13 +489,42 @@ def unsafe_changed_nodes(worktree: Path, paths: Sequence[str]) -> List[str]:
     return unsafe
 
 
+def _glob_pattern_to_regex(pattern: str) -> str:
+    """Translate a repo path glob into an anchored, path-aware regex.
+
+    gitignore-style `**` spans path separators (zero or more whole segments); a
+    single `*`/`?` never crosses `/`. This replaces a former static-prefix
+    fallback that collapsed e.g. ``src-tauri/**/*.swift`` to the bare directory
+    ``src-tauri`` and then matched EVERY file under it (the bug that spuriously
+    flagged a pure ``commands/attachments.rs`` change as ``runtime`` and pulled
+    in the env-fragile tauri-boot gate).
+    """
+
+    out: List[str] = ["^"]
+    index = 0
+    length = len(pattern)
+    while index < length:
+        if pattern.startswith("**/", index):
+            out.append("(?:[^/]+/)*")
+            index += 3
+        elif pattern.startswith("**", index):
+            out.append(".*")
+            index += 2
+        elif pattern[index] == "*":
+            out.append("[^/]*")
+            index += 1
+        elif pattern[index] == "?":
+            out.append("[^/]")
+            index += 1
+        else:
+            out.append(re.escape(pattern[index]))
+            index += 1
+    out.append("$")
+    return "".join(out)
+
+
 def _owned_matches_pattern(owned: str, pattern: str) -> bool:
-    if fnmatch.fnmatchcase(owned, pattern):
-        return True
-    wildcard_positions = [index for index in (pattern.find("*"), pattern.find("?"), pattern.find("[")) if index >= 0]
-    static = pattern[: min(wildcard_positions)] if wildcard_positions else pattern
-    static = static.rstrip("/")
-    return bool(static) and path_overlaps(owned, static)
+    return re.match(_glob_pattern_to_regex(pattern), owned) is not None
 
 
 def classify_risks(
@@ -1739,6 +1768,56 @@ def run_logged_process(
     }
 
 
+# A check's stdout is WRITER-CONTROLLED (the writer authors the code a check runs), so it
+# can never be authoritative over the outcome — the harness derives PASS/FAIL from the exit
+# code alone. The single exception is an ENVIRONMENTAL block: a stray dev server owning an
+# exclusive port must read as "cannot evaluate here", not as a red test, and must not burn
+# repair rounds. That signal is trustworthy ONLY from a runner-owned probe whose command is
+# a canonical, scope-verified runner script (stage_owned_paths rejects any non-owned change
+# before checks run) that decides on foreign port ownership BEFORE executing writer code.
+# So it is bound to a specific canonical check id AND a dedicated exit code — never stdout.
+ENVIRONMENT_PROBE_CHECK_IDS = frozenset({"tauri-boot"})
+ENVIRONMENT_BLOCKED_EXIT_CODE = 3
+
+
+def _check_outcome(check_id: str, exit_code: int, timed_out: bool) -> Tuple[bool, str]:
+    """Derive ``(passed, outcome)`` from a check's exit code only. Returns outcome
+    ``BLOCKED`` (not ``passed``, but not a code FAIL either) only for a runner-owned
+    environment probe that exits with the dedicated blocked code."""
+
+    if timed_out:
+        return (False, "FAIL")
+    if exit_code == 0:
+        return (True, "PASS")
+    if check_id in ENVIRONMENT_PROBE_CHECK_IDS and exit_code == ENVIRONMENT_BLOCKED_EXIT_CODE:
+        return (False, "BLOCKED")
+    return (False, "FAIL")
+
+
+def _probe_blocked_reason(stdout_path: Path) -> Optional[str]:
+    """Best-effort human reason from an env-probe's JSON stdout — informational ONLY.
+
+    The BLOCKED decision is made by :func:`_check_outcome` from the exit code; this merely
+    surfaces the probe's own message and never influences the verdict.
+    """
+
+    last = None
+    try:
+        with stdout_path.open("r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                stripped = line.strip()
+                if stripped:
+                    last = stripped
+        if last is None:
+            return None
+        obj = json.loads(last)
+    except (OSError, json.JSONDecodeError):
+        return None
+    if isinstance(obj, dict) and isinstance(obj.get("reason"), str):
+        return obj["reason"].strip() or None
+    return None
+
+
 def run_check(worktree: Path, task_dir: Path, check: Mapping[str, Any], phase: str) -> Dict[str, Any]:
     safe_phase = re.sub(r"[^a-z0-9._-]+", "-", phase.lower())
     log_path = task_dir / "logs" / f"{safe_phase}-{check['id']}.log"
@@ -1842,13 +1921,20 @@ def run_check(worktree: Path, task_dir: Path, check: Mapping[str, Any], phase: s
         "started_at": started_at,
         "created_at": utc_now(),
     }
+    # Outcome is derived from the EXIT CODE only (stdout is writer-controlled). A runner-owned
+    # environment probe may report BLOCKED via its dedicated exit code — "cannot evaluate in
+    # this environment", not a red test — so a stray dev server owning a port does not read as
+    # a code FAIL or burn repair rounds. See _check_outcome for the security rationale.
+    passed, outcome = _check_outcome(check["id"], result["exit_code"], result["timed_out"])
+    blocked_reason = _probe_blocked_reason(stdout_path) if outcome == "BLOCKED" else None
     evidence = {
         "id": check["id"],
         "command": check["command"],
         "phase": phase,
         **result,
-        "passed": result["exit_code"] == 0 and not result["timed_out"],
-        "outcome": "PASS" if result["exit_code"] == 0 and not result["timed_out"] else "FAIL",
+        "passed": passed,
+        "outcome": outcome,
+        "blocked_reason": blocked_reason,
     }
     append_jsonl(
         task_dir / "events.jsonl",
@@ -1862,6 +1948,7 @@ def run_check(worktree: Path, task_dir: Path, check: Mapping[str, Any], phase: s
             "duration_ms": evidence["duration_ms"],
             "passed": evidence["passed"],
             "outcome": evidence["outcome"],
+            "blocked_reason": evidence["blocked_reason"],
             "log_path": evidence["log_path"],
             "network_mode": evidence["network_mode"],
             "sandbox_mode": evidence["sandbox_mode"],
@@ -1939,6 +2026,59 @@ def _extract_claude_result(log_path: Path) -> Any:
     if candidate is None:
         raise HarnessError(f"Claude returned no structured result; inspect {log_path}")
     return candidate
+
+
+# A WRITER's final structured report (status/summary/tests_run/remaining_risks) is
+# METADATA only: the harness re-derives the diff itself (stage_owned_paths) and the
+# verdict rests on deterministic checks + fresh independent reviews, none of which trust
+# the self-report. So a purely cosmetic model output-formatting failure must NOT forfeit
+# a complete, staged, checks-green deliverable. These subtypes are recoverable — a stub
+# is synthesized and the loop proceeds to checks+reviews on the produced tree. REVIEWER
+# output is load-bearing and is NEVER stubbed (a malformed reviewer verdict still raises).
+_RECOVERABLE_WRITER_REPORT_SUBTYPES = {"error_max_structured_output_retries"}
+
+
+def _claude_terminal_subtype(log_path: Path) -> Optional[str]:
+    """The `subtype` of the last Claude-CLI `{"type":"result"}` event, or None."""
+
+    subtype: Optional[str] = None
+    try:
+        with log_path.open("r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if (
+                    isinstance(event, dict)
+                    and event.get("type") == "result"
+                    and isinstance(event.get("subtype"), str)
+                ):
+                    subtype = event["subtype"]
+    except OSError:
+        return None
+    return subtype
+
+
+def _degraded_writer_document(vendor: str, subtype: str) -> Dict[str, Any]:
+    """A schema-valid writer stub used when the writer's self-report was unparseable."""
+
+    return {
+        "status": "completed",
+        "summary": (
+            f"<recovered> the {vendor} writer's final structured report was malformed "
+            f"({subtype}); the staged diff is intact. This self-report is metadata only — "
+            "the verdict rests on the harness's deterministic checks and independent reviews."
+        ),
+        "tests_run": [],
+        "remaining_risks": [
+            "writer self-report was not machine-readable; the verdict relies on "
+            "deterministic checks and the independent reviews, not this report",
+        ],
+    }
 
 
 def extract_model_metadata(log_path: Path, vendor: str, fallback_session: str) -> Dict[str, str]:
@@ -2191,8 +2331,27 @@ def invoke_model(
             env=environment,
         )
         if process_result["exit_code"] != 0 or process_result["timed_out"]:
-            raise HarnessError(f"Claude {label} failed; inspect {log_path}")
-        document = _extract_claude_result(log_path)
+            subtype = None if process_result["timed_out"] else _claude_terminal_subtype(log_path)
+            if role == "writer" and subtype in _RECOVERABLE_WRITER_REPORT_SUBTYPES:
+                # The writer produced its edits but could not emit a well-formed final
+                # report. Proceed on the STAGED tree — checks + independent reviews own
+                # the verdict — instead of forfeiting a complete, compiling deliverable.
+                document = _degraded_writer_document(vendor, subtype)
+                append_jsonl(
+                    task_dir / "events.jsonl",
+                    {
+                        "at": utc_now(),
+                        "event": "writer-report-degraded",
+                        "label": label,
+                        "vendor": vendor,
+                        "subtype": subtype,
+                        "reason": "writer structured-output retries exhausted; proceeding on the staged tree",
+                    },
+                )
+            else:
+                raise HarnessError(f"Claude {label} failed; inspect {log_path}")
+        else:
+            document = _extract_claude_result(log_path)
         atomic_write_json(result_path, document)
     else:
         raise HarnessError(f"unsupported model adapter: {vendor}")
@@ -2877,6 +3036,23 @@ def run_task(
                 )
             assert_provenance(contract, task_dir)
             all_checks.extend(round_checks)
+            blocked_checks = [c for c in round_checks if c.get("outcome") == "BLOCKED"]
+            if blocked_checks:
+                reasons = "; ".join(
+                    f"{c['id']}: {c.get('blocked_reason') or 'environment unavailable'}"
+                    for c in blocked_checks
+                )
+                set_state(
+                    task_dir,
+                    "BLOCKED",
+                    round=round_number,
+                    phase="checks",
+                    reason=(
+                        "a required check could not run in this environment; "
+                        f"re-run in a clean environment: {reasons}"
+                    ),
+                )
+                return "BLOCKED"
             failed_checks = [check for check in round_checks if not check["passed"]]
             successful_ids = {check["id"] for check in round_checks if check["passed"]}
             missing_risk_evidence = [
@@ -2937,6 +3113,23 @@ def run_task(
                 )
             assert_provenance(contract, task_dir)
             all_checks.extend(final_checks)
+            blocked_final = [c for c in final_checks if c.get("outcome") == "BLOCKED"]
+            if blocked_final:
+                reasons = "; ".join(
+                    f"{c['id']}: {c.get('blocked_reason') or 'environment unavailable'}"
+                    for c in blocked_final
+                )
+                set_state(
+                    task_dir,
+                    "BLOCKED",
+                    round=round_number,
+                    phase="final-checks",
+                    reason=(
+                        "a required final check could not run in this environment; "
+                        f"re-run in a clean environment: {reasons}"
+                    ),
+                )
+                return "BLOCKED"
             if any(not check["passed"] for check in final_checks):
                 set_state(
                     task_dir,
@@ -4714,6 +4907,61 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
     )
     if "lock" not in attachment_risks:
         failures.append("attachment read surfaces are not automatically classified as lock-sensitive")
+    # Regression (glob-prefix-collapse): a pure backend commands/attachments.rs change is
+    # lock, NEVER runtime. The former static-prefix fallback collapsed `src-tauri/**/*.swift`
+    # to the bare directory `src-tauri` and matched every backend file, spuriously attaching
+    # the env-fragile tauri-boot gate. RED on the old matcher, GREEN on the path-aware one.
+    backend_only_risks = classify_risks(["src-tauri/src/commands/attachments.rs"], [], config)
+    if "runtime" in backend_only_risks:
+        failures.append("a pure commands/attachments.rs change was spuriously classified as runtime")
+    if "lock" not in backend_only_risks:
+        failures.append("commands/attachments.rs lost its lock classification")
+    # The path-aware matcher still classifies the intended runtime targets (top-level and nested swift).
+    if "runtime" not in classify_risks(["src-tauri/audiocap.swift"], [], config):
+        failures.append("a top-level src-tauri/*.swift file is no longer classified as runtime")
+    if "runtime" not in classify_risks(["src-tauri/deep/nested/helper.swift"], [], config):
+        failures.append("a nested src-tauri/**/*.swift file is no longer classified as runtime")
+    # The FE attachment service (real name note-attachment.service.ts) stays lock + ui and
+    # leaks no unrelated flag — the `*attachment*` pattern catches the note- prefix.
+    fe_attachment_risks = classify_risks(["src/app/services/note-attachment.service.ts"], [], config)
+    if "lock" not in fe_attachment_risks or "ui" not in fe_attachment_risks:
+        failures.append("the FE note-attachment service is not classified lock + ui")
+    if any(flag in fe_attachment_risks for flag in ("runtime", "egress", "protocol", "performance", "release")):
+        failures.append("the FE note-attachment service leaked an unrelated risk flag")
+    # Fix: a runner-owned environment probe signals BLOCKED via a DEDICATED EXIT CODE (never
+    # stdout, which is writer-controlled) and only for its canonical check id — so a stray dev
+    # server owning a port reads as "cannot evaluate here", not a code FAIL, while a forged
+    # non-probe check can never escape a FAIL (the infra-blocked case below proves the latter).
+    if _check_outcome("tauri-boot", ENVIRONMENT_BLOCKED_EXIT_CODE, False) != (False, "BLOCKED"):
+        failures.append("the runner-owned env probe blocked exit code was not read as BLOCKED")
+    if _check_outcome("rust-lib", ENVIRONMENT_BLOCKED_EXIT_CODE, False) != (False, "FAIL"):
+        failures.append("a non-probe check exiting the blocked code was wrongly read as BLOCKED")
+    if _check_outcome("tauri-boot", 1, False) != (False, "FAIL"):
+        failures.append("a genuine env-probe boot failure was not read as a FAIL")
+    if _check_outcome("tauri-boot", 0, False) != (True, "PASS"):
+        failures.append("a passing env probe was not read as PASS")
+    if _check_outcome("tauri-boot", ENVIRONMENT_BLOCKED_EXIT_CODE, True) != (False, "FAIL"):
+        failures.append("a timed-out env probe was not read as a FAIL")
+    # Fix: an unparseable writer SELF-REPORT yields a schema-valid completed stub so the loop
+    # proceeds to checks + independent reviews on the staged tree. Recovery is writer-only.
+    degraded_stub = _degraded_writer_document("claude", "error_max_structured_output_retries")
+    try:
+        validate_schema(degraded_stub, load_schema("model-result"), label="degraded writer stub")
+    except HarnessError:
+        failures.append("the degraded writer stub is not schema-valid")
+    if degraded_stub.get("status") != "completed":
+        failures.append("the degraded writer stub must carry a completed status")
+    if "error_max_structured_output_retries" not in _RECOVERABLE_WRITER_REPORT_SUBTYPES:
+        failures.append("the recoverable writer-report subtype set regressed")
+    with tempfile.TemporaryDirectory(prefix="murmur-harness-subtype-") as stmp:
+        spath = Path(stmp) / "claude.jsonl"
+        spath.write_text(
+            '{"type":"assistant","message":{}}\n'
+            '{"type":"result","subtype":"error_max_structured_output_retries","is_error":true}\n',
+            encoding="utf-8",
+        )
+        if _claude_terminal_subtype(spath) != "error_max_structured_output_retries":
+            failures.append("the Claude terminal result subtype was not extracted")
     claude_schema = schema_for_model_cli(load_schema("review"), "claude")
     if "$schema" in claude_schema or "$id" in claude_schema:
         failures.append("Claude CLI schema retained unsupported draft metadata")

--- a/scripts/agent-dev-run
+++ b/scripts/agent-dev-run
@@ -253,25 +253,42 @@ def validate_proxy_context(tool):
     return real
 
 
+def laned_child_env(base_env, proxy_dir, real_cargo, real_rustc):
+    """Environment for the REAL tool a proxy execs under the resource lane.
+
+    This top-level proxy call enters the kernel flock via agent-resource-run; from that
+    point the ENTIRE build subtree must resolve the REAL toolchain directly and NEVER
+    re-enter a proxy. A build.rs / proc-macro / tauri CLI that spawns `cargo`/`rustc` by
+    BARE NAME would otherwise hit the proxy again and deadlock on the non-reentrant flock
+    this very call already holds. So remove the private proxy dir from the child PATH and
+    pin CARGO+RUSTC to the resolved real tools — the outer lane already covers the subtree.
+    The forgeable LANE_ACTIVE marker is never trusted as authority and is dropped.
+    """
+
+    env = dict(base_env)
+    env.pop(LANE_ACTIVE_ENV, None)
+    if proxy_dir:
+        proxy_abs = Path(proxy_dir).absolute()
+        env["PATH"] = os.pathsep.join(
+            entry
+            for entry in env.get("PATH", "").split(os.pathsep)
+            if entry and Path(entry).absolute() != proxy_abs
+        )
+    env["CARGO"] = str(real_cargo)
+    env["RUSTC"] = str(real_rustc)
+    return env
+
+
 def proxy_main(tool, argv):
     try:
         real = validate_proxy_context(tool)
+        real_cargo = validate_proxy_context("cargo")
         real_rustc = validate_proxy_context("rustc")
     except RuntimeError as error:
         print("agent-dev-run {} proxy: {}".format(tool, error), file=sys.stderr)
         return SUPERVISOR_EXIT
 
-    env = os.environ.copy()
-    # A repository child can forge any environment marker it inherits or creates.
-    # Therefore the proxy never treats LANE_ACTIVE_ENV as authority. Every direct
-    # proxy call reacquires the kernel flock. Cargo alone receives the resolved real
-    # rustc path before entering the lane, avoiding only its own non-reentrant
-    # compiler recursion.
-    env.pop(LANE_ACTIVE_ENV, None)
-    if tool == "cargo":
-        # Cargo now owns the lane, so its compiler must not recursively acquire
-        # the same non-reentrant flock. Explicit RUSTC also covers rustup shims.
-        env["RUSTC"] = str(real_rustc)
+    env = laned_child_env(os.environ, os.environ.get(PROXY_DIR_ENV), real_cargo, real_rustc)
     resource_runner = Path(__file__).resolve().parent / "agent-resource-run"
     if not resource_runner.is_file() or not os.access(resource_runner, os.X_OK):
         print("agent-dev-run {} proxy: resource runner is unavailable".format(tool), file=sys.stderr)
@@ -283,10 +300,43 @@ def proxy_main(tool, argv):
     )
 
 
+def selftest():
+    """Regress the proxy re-entry deadlock fix: a laned build's child subtree must resolve
+    the REAL toolchain (proxy stripped from PATH, CARGO+RUSTC pinned), so a bare `cargo`/
+    `rustc` from a build.rs never re-enters the proxy and self-deadlocks on the flock."""
+
+    failures = []
+    proxy_dir = "/private/tmp/murmur-dev-proxy-selftest"
+    base = {
+        "PATH": os.pathsep.join([proxy_dir, "/usr/bin", "/bin"]),
+        LANE_ACTIVE_ENV: "1",
+        "KEEP": "value",
+    }
+    env = laned_child_env(base, proxy_dir, "/real/cargo", "/real/rustc")
+    if proxy_dir in env.get("PATH", "").split(os.pathsep):
+        failures.append("proxy dir was not stripped from the laned child PATH")
+    if "/usr/bin" not in env.get("PATH", "").split(os.pathsep):
+        failures.append("laned child PATH lost its real toolchain entries")
+    if env.get("CARGO") != "/real/cargo" or env.get("RUSTC") != "/real/rustc":
+        failures.append("laned child CARGO/RUSTC were not pinned to the real tools")
+    if LANE_ACTIVE_ENV in env:
+        failures.append("the forgeable lane marker was not dropped from the child env")
+    if env.get("KEEP") != "value":
+        failures.append("laned child env dropped an unrelated inherited variable")
+    for message in failures:
+        print("agent-dev-run selftest FAIL: {}".format(message), file=sys.stderr)
+    if failures:
+        return 1
+    print("agent-dev-run selftest: OK")
+    return 0
+
+
 def main(argv):
     invoked_as = Path(sys.argv[0]).name
     if invoked_as in {"cargo", "rustc"}:
         return proxy_main(invoked_as, argv)
+    if argv[:1] == ["selftest"]:
+        return selftest()
 
     args = parse_args(argv)
     invocation_dir = Path.cwd().resolve()

--- a/scripts/harness-runtime-smoke.py
+++ b/scripts/harness-runtime-smoke.py
@@ -104,7 +104,14 @@ def emit(verdict: str, reason: str, log_path: Path | None, started_at: str) -> i
         "log_path": str(log_path) if log_path else None,
     }
     print(json.dumps(payload, sort_keys=True))
-    return 0 if verdict == "PASS" else 2
+    # Dedicated exit codes so the harness distinguishes an ENVIRONMENTAL block (a stray dev
+    # server owning an exclusive port — not this change's fault) from a genuine boot FAILURE.
+    # The harness honors code 3 as BLOCKED only for this runner-owned canonical probe.
+    if verdict == "PASS":
+        return 0
+    if verdict == "BLOCKED":
+        return 3
+    return 1
 
 
 def main() -> int:


### PR DESCRIPTION
## Why

A retrospective on the `webp-png-fallback` harness run (6 independent investigators reading the actual code/logs) found the harness did **not** complete on its own: a cosmetic model output-formatting glitch hard-aborted the writer **before any review ran**, and two required gates were red for purely environmental reasons the change never touched. Every value-adding stage (reviews, attestation, guarded commit) had to be done manually. These are the four verified, systemic fixes so future iterations don't hit this.

## Fixes (each with a RED→GREEN selftest)

- **#1 — writer degraded-recovery** (`invoke_model`): a WRITER whose final `StructuredOutput` is unparseable (`error_max_structured_output_retries`) no longer aborts the task. The self-report is metadata — the verdict rests on the harness's re-derived diff + deterministic checks + independent reviews — so a schema-valid stub is synthesized and the loop proceeds. **Reviewer output stays strict** (a malformed reviewer verdict still blocks; never stubbed to PASS).
- **#3 — env-BLOCKED checks** (`run_check` + `harness-runtime-smoke`): outcome stays **exit-code-only** (stdout is writer-controlled — the forgery selftest still passes). A runner-owned environment probe (`tauri-boot`) now signals BLOCKED via a **dedicated exit code (3)**, honored **only for that canonical check id**, so a stray dev server owning `:1420` reads as "cannot evaluate here" — not a code FAIL, and it no longer burns repair rounds.
- **#5 — glob classifier** (`classify_risks`): a path-aware `**` matcher replaces a static-prefix fallback that collapsed `src-tauri/**/*.swift` → bare `src-tauri` and flagged **every** backend file `runtime` (which is how the env-fragile `tauri-boot` gate got attached to a pure `commands/attachments.rs` change). The FE attachment pattern is broadened so `note-attachment.service.ts` stays lock-classified.
- **#6 — `agent-dev-run` deadlock**: a proxied build's subtree now resolves the **real** toolchain (proxy stripped from `PATH`, `CARGO`+`RUSTC` pinned), so a bare `cargo`/`rustc` from a `build.rs`/proc-macro/tauri-CLI can no longer re-enter the proxy and self-deadlock on the flock its ancestor holds.

## Verification

- `scripts/agent-harness selftest --ci` — PASS (incl. new glob / `_check_outcome` / degraded-writer / dev-proxy regressions, and the existing stdout-forgery guard).
- `scripts/agent-config-audit --ci` — PASS (137 checks, 0 warnings).
- `bash .claude/hooks/selftest.sh` — PASS (234 assertions).
- `scripts/agent-dev-run selftest` — OK.
- **Live `claude→claude` end-to-end flow** — writer → real check → spec + adversarial reviews → attestation → **PASSED (round 1)**, no environmental errors.

## Deferred (documented)

- **#2** terminal-BLOCKED resumability — largely moot now that #1 stops the abort before review.
- **#4** `base_sha` gate baselining (subtract pre-existing trunk failures) — a larger feature; doing it wrong risks masking real regressions. The specific e2e debris that triggered it is removed in a separate PR.
