### PR TITLE
perf(ci): ~30min → ~14min — parallel rust/web lanes + prebuilt tools + workers + nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,20 @@ name: CI
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Murmur PR gate. `scripts/ci.sh` is the SINGLE SOURCE OF TRUTH for what "green"
-# means; this workflow only WRAPS it on a macOS runner (swiftc / whisper.cpp Metal /
+# means; this workflow only WRAPS it on macOS runners (swiftc / whisper.cpp Metal /
 # ScreenCaptureKit are macOS-only, so Linux runners cannot mirror the gate).
 #
 # RELEASE PARITY (2026-07-05): every PR runs the COMPLETE ci.sh — the exact gate
 # the release preflight (/release-murmur) requires — including the headless audio
-# E2E. The whisper model (~142 MB) is cached between runs and ffmpeg is a one-line
-# brew install, so parity costs little after the first run. `MURMUR_CI_SKIP_E2E=1`
-# remains a LOCAL iteration convenience only — CI never sets it.
+# E2E. As of 2026-07-25 the gate is split into TWO PARALLEL macOS lanes so wall-
+# clock is max(lanes), not the sum:
+#   • rust  — `bash scripts/ci.sh rust`  (control plane, swiftc, clippy/test/build,
+#             supply-chain, audio E2E via cargo-run examples). No Node.
+#   • web   — `bash scripts/ci.sh web`   (ng lint + ng build + Playwright UI E2E).
+#             No Rust / murmur-server.
+# The `gate (full ci.sh — release parity)` aggregation job below is the REQUIRED
+# status check: it fails unless BOTH lanes pass. `ci.sh` with no arg still runs
+# `full` (= rust ∪ web), so `bash scripts/ci.sh` locally is unchanged.
 #
 # Node comes from `.nvmrc` (24.18.0) — Angular 22's CLI refuses Node < 24.15, so
 # the version is pinned in ONE place shared by CI and local nvm users.
@@ -55,12 +61,13 @@ env:
   MURMUR_E2E_NO_EGRESS: "1"
 
 jobs:
-  gate:
-    name: gate (full ci.sh — release parity)
+  # ── Rust lane: control plane + clippy/test/build + supply-chain + audio E2E. ──
+  rust:
+    name: rust lane (ci.sh rust)
     # macOS is MANDATORY: swiftc ScreenCaptureKit sidecar typecheck + whisper.cpp Metal.
     # macos-14 = Apple Silicon, matching the dev Mac's arch and the release target.
     runs-on: macos-14
-    timeout-minutes: 120
+    timeout-minutes: 90
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -104,12 +111,6 @@ jobs:
           git -C "$SERVER_DIR" checkout --detach FETCH_HEAD
           test "$(git -C "$SERVER_DIR" rev-parse HEAD)" = "$SERVER_REV"
 
-      - name: Setup Node (version from .nvmrc — Angular 22 needs >= 24.15)
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-        with:
-          node-version-file: .nvmrc
-          cache: npm
-
       - name: Install pinned Rust toolchain (rust-toolchain.toml → 1.96.0 + clippy/rustfmt)
         run: rustup show
 
@@ -118,13 +119,16 @@ jobs:
         with:
           workspaces: ". -> target"
 
-      - name: Install pinned cargo-audit + cargo-deny (prebuilt — skips ci.sh's slow cargo install)
-        uses: taiki-e/install-action@678b06b887cdbf44fa0601e5915f865e17c2241d # v2.44.60
+      - name: Install pinned cargo-audit + cargo-deny + cargo-nextest (prebuilt — skips ci.sh's slow cargo install)
+        uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094 # v2.85.1
         with:
           # Explicit tool versions are required: an action-SHA-relative `latest`
           # installed cargo-audit 0.21.0, which cannot parse CVSS 4.0 entries in
           # the current RustSec database (for example RUSTSEC-2026-0073).
-          tool: cargo-audit@0.22.2,cargo-deny@0.20.2
+          # Keep the action SHA fresh: a pin older than the tool versions has no
+          # prebuilt manifest entry and SILENTLY source-compiles (~5 min). If the
+          # tool-install step ever exceeds ~30s, bump this action SHA.
+          tool: cargo-audit@0.22.2,cargo-deny@0.20.2,cargo-nextest@0.9.98
 
       - name: Install ffmpeg (audio E2E — aiff to 16 kHz mono WAV)
         run: brew list ffmpeg >/dev/null 2>&1 || brew install ffmpeg
@@ -138,19 +142,7 @@ jobs:
       - name: Install or verify immutable Whisper model
         run: bash scripts/ensure-whisper-model.sh
 
-      - name: Install JS deps
-        run: npm ci
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/Library/Caches/ms-playwright
-          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}
-
-      - name: Install Playwright browser runtimes
-        run: npx playwright install chromium webkit
-
-      - name: Run the FULL gate (scripts/ci.sh incl. headless audio E2E)
+      - name: Run the Rust lane (scripts/ci.sh rust)
         # Every PR performs a live public audit with only its ordinary GITHUB_TOKEN.
         # It does NOT claim bypass actors or repository security settings: those are
         # explicitly MONITOR_ONLY and are verified by trusted schedule/dispatch runs.
@@ -163,4 +155,55 @@ jobs:
           MURMUR_CI_PUBLIC_REMOTE_AUDIT: ${{ github.event_name == 'pull_request' && '1' || '0' }}
           MURMUR_REMOTE_AUDIT_TOKEN: ${{ secrets.MURMUR_REMOTE_AUDIT_TOKEN }}
           MURMUR_PUBLIC_REMOTE_AUDIT_TOKEN: ${{ github.event_name == 'pull_request' && github.token || '' }}
-        run: bash scripts/ci.sh
+        run: bash scripts/ci.sh rust
+
+  # ── Web lane: ng lint + ng build + Playwright UI E2E. Node only — no Rust. ──
+  web:
+    name: web lane (ci.sh web)
+    # macos-14 to mirror the release/dev WebKit + Chromium behavior of the shipped app.
+    runs-on: macos-14
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node (version from .nvmrc — Angular 22 needs >= 24.15)
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install JS deps
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/Library/Caches/ms-playwright
+          key: playwright-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browser runtimes
+        run: npx playwright install chromium webkit
+
+      - name: Run the Web lane (scripts/ci.sh web)
+        run: bash scripts/ci.sh web
+
+  # ── Aggregation: the SINGLE required status check. Its name is the branch-
+  #    ruleset's required context, so keep it EXACTLY "gate (full ci.sh — release
+  #    parity)". Runs on Linux (trivial) to avoid a third 10x-billed macOS job. ──
+  gate:
+    name: gate (full ci.sh — release parity)
+    needs: [rust, web]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require both lanes green
+        run: |
+          echo "rust lane: ${{ needs.rust.result }}"
+          echo "web  lane: ${{ needs.web.result }}"
+          if [ "${{ needs.rust.result }}" != "success" ] || [ "${{ needs.web.result }}" != "success" ]; then
+            echo "::error::a ci.sh lane failed — the full gate is RED"
+            exit 1
+          fi
+          echo "✅ both lanes green — full ci.sh gate satisfied"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,12 +1,30 @@
 #!/usr/bin/env bash
 # Local CI gate for MeetNotes — the single command that must stay green.
 # Runs: Rust lint + tests + build, the Angular build, and the headless core E2E.
-# Usage: bash scripts/ci.sh
+#
+# Usage: bash scripts/ci.sh [STAGE]
+#   (no arg) / full  → the complete release-parity gate (unchanged behavior).
+#   rust             → the Rust lane: control plane, swiftc, clippy/test/build,
+#                      supply-chain, and the audio E2E (cargo-run examples).
+#   web              → the Web lane: ng lint + ng build + the Playwright UI E2E.
+#
+# The STAGE selector exists ONLY so GitHub Actions can run the two independent
+# lanes as PARALLEL jobs (wall-clock = max, not sum). It changes NOTHING about
+# WHAT is checked: every command stays verbatim below, and `full` runs both
+# lanes, so `full == rust ∪ web` by construction — no gate can silently drop.
 set -euo pipefail
 # shellcheck disable=SC1091
 source "$HOME/.cargo/env" 2>/dev/null || true
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO"
+
+STAGE="${1:-full}"
+case "$STAGE" in
+  full | rust | web) ;;
+  *) echo "usage: bash scripts/ci.sh [full|rust|web]" >&2; exit 2 ;;
+esac
+run_rust() { [ "$STAGE" = "full" ] || [ "$STAGE" = "rust" ]; }
+run_web() { [ "$STAGE" = "full" ] || [ "$STAGE" = "web" ]; }
 
 # mistralrs/metal is ALWAYS compiled (the local brain ships by default). Its build script precompiles
 # Metal shaders via `xcrun metal`, which needs the FULL Xcode toolchain — this machine has only the
@@ -14,200 +32,225 @@ cd "$REPO"
 # below fail at link time. Safe to always set (it only changes WHEN shaders compile, not whether).
 export MISTRALRS_METAL_PRECOMPILE=0
 
-# ── Remote merge enforcement is the first, cheapest gate. Local runs exercise the evaluator
-#    deterministically. GitHub Actions lends either the ordinary PR token or the dedicated
-#    privileged monitoring credential only to the matching audit command. Copy then immediately
-#    drop all exported token names before executing repo code. Privileged mode has no fallback:
-#    a missing dedicated credential is an explicit gate failure. PRs attest only merge scope;
-#    admin-only controls are MONITOR_ONLY and checked by trusted schedule/manual runs. ──
-echo "── development agent remote enforcement audit ──"
-remote_audit_token="${MURMUR_REMOTE_AUDIT_TOKEN:-}"
-public_audit_token="${MURMUR_PUBLIC_REMOTE_AUDIT_TOKEN:-}"
-unset MURMUR_REMOTE_AUDIT_TOKEN MURMUR_PUBLIC_REMOTE_AUDIT_TOKEN GH_TOKEN GITHUB_TOKEN
-if [ "${MURMUR_CI_LIVE_REMOTE_AUDIT:-0}" = "1" ]; then
-  if [ -z "$remote_audit_token" ]; then
-    echo "remote audit: MURMUR_REMOTE_AUDIT_TOKEN is required for privileged monitoring" >&2
-    exit 1
-  fi
-  GH_TOKEN="$remote_audit_token" scripts/agent-remote-audit
-elif [ "${MURMUR_CI_PUBLIC_REMOTE_AUDIT:-0}" = "1" ]; then
-  if [ -z "$public_audit_token" ]; then
-    echo "remote audit: ordinary pull-request token is missing" >&2
-    exit 1
-  fi
-  GH_TOKEN="$public_audit_token" scripts/agent-remote-audit --public
-else
-  scripts/agent-remote-audit --selftest
-  echo "  (live GitHub audit skipped — set MURMUR_CI_PUBLIC_REMOTE_AUDIT=1 or use privileged live mode)"
-fi
-remote_audit_token=
-public_audit_token=
-unset GH_TOKEN GITHUB_TOKEN
+# Kept at top level (not inside a lane function): bash traps are global, and this
+# helper is only referenced by the swiftc block within rust_gate.
+cleanup_swift_src_tests() {
+  for artifact in meetnotes-audiocap meetnotes-aeccap; do
+    if [ -e "$SWIFT_SRC_TEST_DIR/$artifact" ]; then
+      /bin/unlink "$SWIFT_SRC_TEST_DIR/$artifact"
+    fi
+  done
+  /bin/rmdir "$SWIFT_SRC_TEST_DIR"
+}
 
-# ── Development-agent control plane: fail before paying for any product build. The audit checks
-#    both Claude and Codex wiring/config parity; the selftest proves lifecycle, isolation, scope,
-#    stale-attestation rejection and the known hook bypasses with fake agents only. ──
-echo "── development agent config audit ──"
-scripts/agent-config-audit --ci
-
-echo "── development agent hooks: adversarial self-test ──"
-bash .codex/hooks/selftest.sh
-
-echo "── development agent harness: deterministic self-test ──"
-scripts/agent-harness selftest --ci
-
-echo "── development agent eval harness: deterministic self-test ──"
-scripts/agent-harness eval selftest
-
-echo "── swiftc: system-audio sidecar typecheck ──"
-if command -v swiftc >/dev/null 2>&1; then
-  swiftc -typecheck src-tauri/sysaudio/sysaudio.swift \
-    -framework ScreenCaptureKit -framework AVFoundation
-
-  echo "── swift capture helpers: TCC-free SRC executable self-tests ──"
-  SWIFT_SRC_TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/murmur-swift-src.XXXXXX")"
-  cleanup_swift_src_tests() {
-    for artifact in meetnotes-audiocap meetnotes-aeccap; do
-      if [ -e "$SWIFT_SRC_TEST_DIR/$artifact" ]; then
-        /bin/unlink "$SWIFT_SRC_TEST_DIR/$artifact"
-      fi
-    done
-    /bin/rmdir "$SWIFT_SRC_TEST_DIR"
-  }
-  trap cleanup_swift_src_tests EXIT
-  trap 'exit 129' HUP
-  trap 'exit 130' INT
-  trap 'exit 143' TERM
-
-  SWIFT_HOST_ARCH="$(uname -m)"
-  case "$SWIFT_HOST_ARCH" in
-    arm64 | x86_64) ;;
-    *)
-      echo "unsupported macOS Swift host architecture: $SWIFT_HOST_ARCH" >&2
+rust_gate() {
+  # ── Remote merge enforcement is the first, cheapest gate. Local runs exercise the evaluator
+  #    deterministically. GitHub Actions lends either the ordinary PR token or the dedicated
+  #    privileged monitoring credential only to the matching audit command. Copy then immediately
+  #    drop all exported token names before executing repo code. Privileged mode has no fallback:
+  #    a missing dedicated credential is an explicit gate failure. PRs attest only merge scope;
+  #    admin-only controls are MONITOR_ONLY and checked by trusted schedule/manual runs. ──
+  echo "── development agent remote enforcement audit ──"
+  remote_audit_token="${MURMUR_REMOTE_AUDIT_TOKEN:-}"
+  public_audit_token="${MURMUR_PUBLIC_REMOTE_AUDIT_TOKEN:-}"
+  unset MURMUR_REMOTE_AUDIT_TOKEN MURMUR_PUBLIC_REMOTE_AUDIT_TOKEN GH_TOKEN GITHUB_TOKEN
+  if [ "${MURMUR_CI_LIVE_REMOTE_AUDIT:-0}" = "1" ]; then
+    if [ -z "$remote_audit_token" ]; then
+      echo "remote audit: MURMUR_REMOTE_AUDIT_TOKEN is required for privileged monitoring" >&2
       exit 1
-      ;;
-  esac
+    fi
+    GH_TOKEN="$remote_audit_token" scripts/agent-remote-audit
+  elif [ "${MURMUR_CI_PUBLIC_REMOTE_AUDIT:-0}" = "1" ]; then
+    if [ -z "$public_audit_token" ]; then
+      echo "remote audit: ordinary pull-request token is missing" >&2
+      exit 1
+    fi
+    GH_TOKEN="$public_audit_token" scripts/agent-remote-audit --public
+  else
+    scripts/agent-remote-audit --selftest
+    echo "  (live GitHub audit skipped — set MURMUR_CI_PUBLIC_REMOTE_AUDIT=1 or use privileged live mode)"
+  fi
+  remote_audit_token=
+  public_audit_token=
+  unset GH_TOKEN GITHUB_TOKEN
 
-  swiftc -O -target "${SWIFT_HOST_ARCH}-apple-macos14.4" \
-    -o "$SWIFT_SRC_TEST_DIR/meetnotes-audiocap" \
-    src-tauri/audiocap/audiocap.swift \
-    -framework AVFoundation -framework CoreAudio -framework Foundation
-  "$SWIFT_SRC_TEST_DIR/meetnotes-audiocap" --self-test-src
+  # ── Development-agent control plane: fail before paying for any product build. The audit checks
+  #    both Claude and Codex wiring/config parity; the selftest proves lifecycle, isolation, scope,
+  #    stale-attestation rejection and the known hook bypasses with fake agents only. ──
+  echo "── development agent config audit ──"
+  scripts/agent-config-audit --ci
 
-  swiftc -O -target "${SWIFT_HOST_ARCH}-apple-macos13.4" \
-    -o "$SWIFT_SRC_TEST_DIR/meetnotes-aeccap" \
-    src-tauri/aeccap/aeccap.swift \
-    -framework AVFoundation -framework Foundation
-  "$SWIFT_SRC_TEST_DIR/meetnotes-aeccap" --self-test-src
+  echo "── development agent hooks: adversarial self-test ──"
+  bash .codex/hooks/selftest.sh
 
-  cleanup_swift_src_tests
-  trap - EXIT HUP INT TERM
-else
-  echo "  (swiftc not found — skipping Swift sidecar typecheck + capture SRC self-tests)"
-fi
+  echo "── development agent harness: deterministic self-test ──"
+  scripts/agent-harness selftest --ci
 
-echo "── cargo clippy (deny warnings) ──"
-( cd src-tauri && cargo clippy --all-targets -- -D warnings )
+  echo "── development agent eval harness: deterministic self-test ──"
+  scripts/agent-harness eval selftest
 
-echo "── cargo test ──"
-# The normal test set includes the deterministic synthetic FTS floor. Semantic/reranked and
-# note-generation quality remain manual: they require real local models and/or a labeled vault.
-( cd src-tauri && cargo test --quiet )
+  echo "── swiftc: system-audio sidecar typecheck ──"
+  if command -v swiftc >/dev/null 2>&1; then
+    swiftc -typecheck src-tauri/sysaudio/sysaudio.swift \
+      -framework ScreenCaptureKit -framework AVFoundation
 
-echo "── murmur-brain sidecar: clippy + tests ──"
-cargo clippy -p murmur-brain --all-targets -- -D warnings
-cargo test -p murmur-brain --quiet
+    echo "── swift capture helpers: TCC-free SRC executable self-tests ──"
+    SWIFT_SRC_TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/murmur-swift-src.XXXXXX")"
+    trap cleanup_swift_src_tests EXIT
+    trap 'exit 129' HUP
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
 
-# ── Supply-chain gates (D11/F5): advisories + license/ban/source policy, BEFORE the build. ──
-echo "── cargo audit (RUSTSEC advisories) ──"
-# Outside the agent sandbox and the SHA-pinned GitHub install step, ALWAYS
-# (re)install, never merely "if missing" — local caches can otherwise retain
-# whatever cargo-audit binary was built months ago indefinitely. That
-# defeats the entire point of the tool: a stale binary can't parse newer advisory-db entries
-# (hit 2026-07-12 — RUSTSEC-2026-0073 uses `cvss = "CVSS:4.0/…"`, which an old cargo-audit's
-# RUSTSEC-parser rejects as "unsupported CVSS version: 4.0", failing CI on an unrelated PR).
-# `--force` is required, not optional: without it, `cargo install` errors "binary already
-# exists in destination" the instant a rust-cache restore leaves a binary on disk whose
-# install-tracking metadata (~/.cargo/.crates2.json) doesn't fully agree with it (observed on
-# CI: it re-downloaded the crate, then refused to place the binary over the existing file) —
-# so a bare `cargo install --locked` is NOT reliably a no-op across a restored cache; `--force`
-# makes the outcome deterministic (always freshly placed) regardless of that metadata's state.
-if [ "${MURMUR_HARNESS:-0}" = "1" ] || [ "${MURMUR_CI_TOOLS_PREINSTALLED:-0}" = "1" ]; then
-  # Harness checks are intentionally network-denied. Setup/fetching belongs
-  # outside the evidence boundary; inside it we require the pinned local tool
-  # and cached advisory DB or fail closed.
-  command -v cargo-audit >/dev/null || {
-    echo "cargo-audit is required by the preinstalled-tool policy" >&2
-    exit 1
-  }
-else
-  echo "  installing/updating cargo-audit…"
-  cargo install --locked --force cargo-audit
-fi
-# Gate on actual VULNERABILITIES (default behavior: non-zero exit on any RUSTSEC vulnerability).
-# We deliberately do NOT pass `--deny warnings`: the Tauri framework pulls in transitive crates
-# with unmaintained/unsound *warnings* (unic-ucd-*, glib) that we cannot fix here and that are not
-# exploitable in this app. The maintenance dimension is still gated — narrowly, on our DIRECT deps
-# — by `cargo deny check` below (`advisories.unmaintained = "workspace"`).
-# The cargo lock moved to the WORKSPACE ROOT (`./Cargo.lock`) when the brain-sidecar extraction made
-# this a virtual workspace; cargo-audit reads the lock from the cwd and does NOT walk up to find it,
-# so point it at the root lock explicitly (this now also covers the `crates/murmur-brain` member).
-if [ "${MURMUR_HARNESS:-0}" = "1" ]; then
-  cargo audit --no-fetch --db "${CARGO_HOME}/advisory-db" --file Cargo.lock
-else
-  cargo audit --file Cargo.lock
-fi
+    SWIFT_HOST_ARCH="$(uname -m)"
+    case "$SWIFT_HOST_ARCH" in
+      arm64 | x86_64) ;;
+      *)
+        echo "unsupported macOS Swift host architecture: $SWIFT_HOST_ARCH" >&2
+        exit 1
+        ;;
+    esac
 
-echo "── cargo deny check (advisories, licenses, bans, sources) ──"
-# Same install rationale as cargo-audit above — same cached-~/.cargo/bin staleness
-# risk, same category of supply-chain tool where "quietly stopped updating" is the failure mode
-# to avoid, not a build-time optimization to chase. Same `--force` reasoning too.
-if [ "${MURMUR_HARNESS:-0}" = "1" ] || [ "${MURMUR_CI_TOOLS_PREINSTALLED:-0}" = "1" ]; then
-  command -v cargo-deny >/dev/null || {
-    echo "cargo-deny is required by the preinstalled-tool policy" >&2
-    exit 1
-  }
-else
-  echo "  installing/updating cargo-deny…"
-  cargo install --locked --force cargo-deny
-fi
-if [ "${MURMUR_HARNESS:-0}" = "1" ]; then
-  cargo deny --offline --manifest-path src-tauri/Cargo.toml check
-else
-  cargo deny --manifest-path src-tauri/Cargo.toml check
-fi
+    swiftc -O -target "${SWIFT_HOST_ARCH}-apple-macos14.4" \
+      -o "$SWIFT_SRC_TEST_DIR/meetnotes-audiocap" \
+      src-tauri/audiocap/audiocap.swift \
+      -framework AVFoundation -framework CoreAudio -framework Foundation
+    "$SWIFT_SRC_TEST_DIR/meetnotes-audiocap" --self-test-src
 
-echo "── cargo build ──"
-( cd src-tauri && cargo build )
-cargo build -p murmur-brain
+    swiftc -O -target "${SWIFT_HOST_ARCH}-apple-macos13.4" \
+      -o "$SWIFT_SRC_TEST_DIR/meetnotes-aeccap" \
+      src-tauri/aeccap/aeccap.swift \
+      -framework AVFoundation -framework Foundation
+    "$SWIFT_SRC_TEST_DIR/meetnotes-aeccap" --self-test-src
 
-echo "── ng lint ──"
-npx ng lint
+    cleanup_swift_src_tests
+    trap - EXIT HUP INT TERM
+  else
+    echo "  (swiftc not found — skipping Swift sidecar typecheck + capture SRC self-tests)"
+  fi
 
-echo "── ng build ──"
-npx ng build
+  echo "── cargo clippy (deny warnings) ──"
+  ( cd src-tauri && cargo clippy --all-targets -- -D warnings )
 
-# ── Runtime/E2E lane. Playwright is hermetic per invocation (private port, no server reuse) and
-#    exercises Chromium + WebKit over synthetic Tauri IPC. Audio E2E is host-specific: it needs
-#    `say` (macOS TTS), ffmpeg, and a
-#    ~142 MB whisper model download (e2e-core.sh) — and cloud PR runners have no signed
-#    provider. The E2E provider is a deterministic no-egress stub by construction; the
-#    example contains no cloud-provider branch. `MURMUR_CI_SKIP_E2E=1` is a
-#    local-iteration escape hatch that skips
-#    ONLY these three runtime/E2E steps (everything above still runs). GitHub Actions never sets it:
-#    every PR, scheduled, and manually dispatched run executes this complete release-parity gate. ──
-if [ "${MURMUR_CI_SKIP_E2E:-0}" = "1" ]; then
-  echo "── headless E2E: SKIPPED for local iteration (MURMUR_CI_SKIP_E2E=1) — GitHub CI always runs the full gate ──"
-else
+  echo "── cargo test ──"
+  # The normal test set includes the deterministic synthetic FTS floor. Semantic/reranked and
+  # note-generation quality remain manual: they require real local models and/or a labeled vault.
+  # nextest parallelizes the test RUN (the slow slice once compiled); it does not run doctests, and
+  # this crate has none to lose. Fall back to `cargo test` where nextest is not installed (dev Macs).
+  if command -v cargo-nextest >/dev/null 2>&1; then
+    ( cd src-tauri && cargo nextest run --no-fail-fast )
+  else
+    ( cd src-tauri && cargo test --quiet )
+  fi
+
+  echo "── murmur-brain sidecar: clippy + tests ──"
+  cargo clippy -p murmur-brain --all-targets -- -D warnings
+  cargo test -p murmur-brain --quiet
+
+  # ── Supply-chain gates (D11/F5): advisories + license/ban/source policy, BEFORE the build. ──
+  echo "── cargo audit (RUSTSEC advisories) ──"
+  # Outside the agent sandbox and the SHA-pinned GitHub install step, ALWAYS
+  # (re)install, never merely "if missing" — local caches can otherwise retain
+  # whatever cargo-audit binary was built months ago indefinitely. That
+  # defeats the entire point of the tool: a stale binary can't parse newer advisory-db entries
+  # (hit 2026-07-12 — RUSTSEC-2026-0073 uses `cvss = "CVSS:4.0/…"`, which an old cargo-audit's
+  # RUSTSEC-parser rejects as "unsupported CVSS version: 4.0", failing CI on an unrelated PR).
+  # `--force` is required, not optional: without it, `cargo install` errors "binary already
+  # exists in destination" the instant a rust-cache restore leaves a binary on disk whose
+  # install-tracking metadata (~/.cargo/.crates2.json) doesn't fully agree with it (observed on
+  # CI: it re-downloaded the crate, then refused to place the binary over the existing file) —
+  # so a bare `cargo install --locked` is NOT reliably a no-op across a restored cache; `--force`
+  # makes the outcome deterministic (always freshly placed) regardless of that metadata's state.
+  if [ "${MURMUR_HARNESS:-0}" = "1" ] || [ "${MURMUR_CI_TOOLS_PREINSTALLED:-0}" = "1" ]; then
+    # Harness checks are intentionally network-denied. Setup/fetching belongs
+    # outside the evidence boundary; inside it we require the pinned local tool
+    # and cached advisory DB or fail closed.
+    command -v cargo-audit >/dev/null || {
+      echo "cargo-audit is required by the preinstalled-tool policy" >&2
+      exit 1
+    }
+  else
+    echo "  installing/updating cargo-audit…"
+    cargo install --locked --force cargo-audit
+  fi
+  # Gate on actual VULNERABILITIES (default behavior: non-zero exit on any RUSTSEC vulnerability).
+  # We deliberately do NOT pass `--deny warnings`: the Tauri framework pulls in transitive crates
+  # with unmaintained/unsound *warnings* (unic-ucd-*, glib) that we cannot fix here and that are not
+  # exploitable in this app. The maintenance dimension is still gated — narrowly, on our DIRECT deps
+  # — by `cargo deny check` below (`advisories.unmaintained = "workspace"`).
+  # The cargo lock moved to the WORKSPACE ROOT (`./Cargo.lock`) when the brain-sidecar extraction made
+  # this a virtual workspace; cargo-audit reads the lock from the cwd and does NOT walk up to find it,
+  # so point it at the root lock explicitly (this now also covers the `crates/murmur-brain` member).
+  if [ "${MURMUR_HARNESS:-0}" = "1" ]; then
+    cargo audit --no-fetch --db "${CARGO_HOME}/advisory-db" --file Cargo.lock
+  else
+    cargo audit --file Cargo.lock
+  fi
+
+  echo "── cargo deny check (advisories, licenses, bans, sources) ──"
+  # Same install rationale as cargo-audit above — same cached-~/.cargo/bin staleness
+  # risk, same category of supply-chain tool where "quietly stopped updating" is the failure mode
+  # to avoid, not a build-time optimization to chase. Same `--force` reasoning too.
+  if [ "${MURMUR_HARNESS:-0}" = "1" ] || [ "${MURMUR_CI_TOOLS_PREINSTALLED:-0}" = "1" ]; then
+    command -v cargo-deny >/dev/null || {
+      echo "cargo-deny is required by the preinstalled-tool policy" >&2
+      exit 1
+    }
+  else
+    echo "  installing/updating cargo-deny…"
+    cargo install --locked --force cargo-deny
+  fi
+  if [ "${MURMUR_HARNESS:-0}" = "1" ]; then
+    cargo deny --offline --manifest-path src-tauri/Cargo.toml check
+  else
+    cargo deny --manifest-path src-tauri/Cargo.toml check
+  fi
+
+  echo "── cargo build ──"
+  ( cd src-tauri && cargo build )
+  cargo build -p murmur-brain
+}
+
+web_gate() {
+  echo "── ng lint ──"
+  npx ng lint
+
+  echo "── ng build ──"
+  npx ng build
+}
+
+playwright_e2e() {
   echo "── Playwright UI E2E (fresh server, Chromium + WebKit) ──"
-  npm run test:e2e -- --workers=1
+  # workers=2 (not 1): specs are page-side mocked and hermetic (private port, no server reuse, no
+  # shared state), so spec-file-level parallelism is safe. macos-14 has 3 cores; 2 keeps contention
+  # mild against the 30s per-test timeout with retries:0. Do NOT go to 3 without config retries:1.
+  npm run test:e2e -- --workers=2
+}
 
+audio_e2e() {
   echo "── headless core E2E (say → ffmpeg → Whisper → provider → Obsidian) ──"
   bash scripts/e2e-core.sh
 
   echo "── headless mixing E2E (mic + system → mixed transcript, both sides) ──"
   bash scripts/e2e-mix.sh
+}
+
+if run_rust; then rust_gate; fi
+if run_web; then web_gate; fi
+
+# ── Runtime/E2E lane. Playwright is hermetic per invocation (private port, no server reuse) and
+#    exercises Chromium + WebKit over synthetic Tauri IPC. Audio E2E is host-specific: it needs
+#    `say` (macOS TTS), ffmpeg, a ~142 MB whisper model (e2e-core.sh) and the cargo-run example — and
+#    cloud PR runners have no signed provider. The E2E provider is a deterministic no-egress stub by
+#    construction; the example contains no cloud-provider branch. `MURMUR_CI_SKIP_E2E=1` is a
+#    local-iteration escape hatch that skips ONLY these runtime/E2E steps (everything above still
+#    runs). GitHub Actions never sets it: every PR, scheduled, and manually dispatched run executes
+#    this complete release-parity gate. ──
+if [ "${MURMUR_CI_SKIP_E2E:-0}" = "1" ]; then
+  echo "── headless E2E: SKIPPED for local iteration (MURMUR_CI_SKIP_E2E=1) — GitHub CI always runs the full gate ──"
+else
+  if run_web; then playwright_e2e; fi
+  if run_rust; then audio_e2e; fi
 fi
 
 echo
-echo "✅ CI: all gates green"
+echo "✅ CI: all gates green (stage: $STAGE)"


### PR DESCRIPTION
## Why

The `gate (full ci.sh — release parity)` check takes **~30 min**. I measured it (run 30139766639) instead of guessing — the top 3 eat **71%**, all **sequential in one job**:

| Cost | Time | Cause |
|---|---|---|
| Playwright E2E | **550 s** | `--workers=1` (fully serial) |
| `cargo test` | **418 s** | full test binary + ML codegen |
| cargo-audit + cargo-deny "prebuilt" install | **321 s** | action pin predates the tool versions → **silently source-compiles** |

## What (4 verified levers)

- **A — bump `taiki-e/install-action`** v2.44.60 → v2.85.1. The Nov-2024 pin has no manifest entry for cargo-audit 0.22.2 / cargo-deny 0.20.2, so it compiles from source (~321 s). arm64-macOS prebuilts exist → ~15 s download. **~305 s.**
- **B — Playwright `--workers=1` → `2`.** Specs are page-side mocked + hermetic (verified: private port, no server reuse, no shared state, no `toHaveScreenshot`). **~245 s.**
- **C — `cargo test` → `cargo-nextest run`** (parallel test run; no doctests to lose) with a `cargo test` fallback where nextest is absent.
- **D — split the single job into two PARALLEL macOS lanes** via a `STAGE` selector in `ci.sh` (`full|rust|web`) — **commands stay verbatim, `full` = `rust ∪ web` by construction** (release parity intact; `bash scripts/ci.sh` unchanged):
  - **rust lane** — control-plane · swiftc · clippy/test/build · supply-chain · audio E2E (`cargo run --example`). No Node.
  - **web lane** — ng lint · ng build · Playwright. No Rust / murmur-server.
  - A trivial **ubuntu** aggregation job named **exactly** `gate (full ci.sh — release parity)` (the ruleset's required context) fails unless BOTH lanes pass → **no ruleset edit needed**, required check unchanged.

**Wall-clock → `max(rust ~14min, web ~6min)`, not the sum. ~30 min → ~14 min.**

## Trade-offs / notes

- **macOS billing:** two macOS jobs bill more *minutes* than one (macOS = 10×) — a deliberate speed-vs-cost trade. The aggregation job runs on ubuntu to avoid a third macOS charge.
- **`full == rust ∪ web` is structural** (both lanes are functions; `full` calls both), so no gate can silently drop into only one lane.
- Watch the tool-install step: if it ever exceeds ~30 s again, the action pin has aged past the tool versions — bump the SHA (the fallback is silent).

## Verification

`bash -n` · a command-set diff proving the refactor drops no gate (only the intended workers/nextest swaps) · YAML valid · taiki-e SHA = Release 2.85.1 · cargo-nextest 0.9.98 present · **end-to-end validated by this PR's own CI run** (the two parallel lanes + the aggregation gate).

## Do-NOT (verified wrong)

Don't flip `fullyParallel:true`; don't go `workers=3` without `retries:1`; don't drop `cargo build`/`clippy --all-targets`; don't add sccache; don't move lanes to Linux (macOS-mandatory); don't drop the aggregation job without a ruleset edit.
