### PR TITLE
chore(release): 1.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4637,7 +4637,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "scripts": {
     "start": "cargo build -p murmur-brain && ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "1.0.2"
+version = "1.0.3"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump 1.0.2 → 1.0.3. Ships since 1.0.2: WKWebView note-image upload fix (#445), e2e debris cleanup (#444), harness robustness fixes (#446), and the ~30→~17min parallel-lane CI speedup (#447).