### PR TITLE
feat(documents): smart-note engine — doc/photo into a structured Obsidian note

### DIFF
--- a/src-tauri/src/commands/documents.rs
+++ b/src-tauri/src/commands/documents.rs
@@ -498,3 +498,638 @@ pub(crate) async fn delete_document_inner(state: &AppState, id: &str) -> Result<
     tracing::info!(target: "documents", document_id = %id, "document deleted");
     Ok(())
 }
+
+// ── SMART-NOTE ENGINE (2026-07-25) — turn an ingested document/photo into a readable Obsidian note ──
+//
+// We already extract flat text on-device (`extract::extract_blocks` → `documents.text`), but ingest
+// only ever produced RETRIEVAL text, never a readable note. `generate_note_from_document` takes the
+// EXISTING extracted text of a `documents` row and produces a NEW `kind='note'` documents row → `.md`
+// through the provider seam, in TWO selectable recipe shapes (see `summarize::recipes::NoteRecipe`):
+// SYNTHESIS (`provider.complete()` over one fixed anti-slop template) and STRUCTURE-MIRROR
+// (`provider.complete_json()` into a generic opaque-string schema + a DETERMINISTIC Rust renderer).
+//
+// LOCK-MODEL: the source doc's folder is BOTH the read source and the write target, so ONE gate
+// (`folder_is_unlocked`, refuse `AppError::Locked`) covers both — exactly `import_document`'s posture.
+// The note is birthed seal-aware (SEAL-THEN-INSERT for a session-unlocked LOCKED folder, mirroring
+// `create_note_inner`), then written through the authored-note funnel `update_note_doc_inner`
+// (seal-on-write + gated `.md` export + chunk/wikilink re-index). Any embedded source image is
+// re-materialized under the NEW note's owner through the existing E2EE bundle seam
+// (`materialize_attachment_bundle`, seal-on-birth + verify) — the source's bytes are only READ; its
+// AAD is never weakened. The current/last meeting link is gated (a sealed-latest meeting contributes
+// neither its title nor an edge). §10: no money/arithmetic — the structure schema is opaque strings.
+//
+// EGRESS: the note text goes out through the SAME `provider_for(Role::Notes, …)` factory as every
+// other note — the consent gate + `RedactingProvider` firewall + egress ledger all live inside it,
+// so ONLY REDACTED TEXT egresses. No image bytes are ever sent (there is no multimodal path here).
+
+/// The assembled, ready-to-persist smart note — the output of [`prepare_smart_note`] (the async
+/// egress phase) and the input to [`persist_generated_note`] (the sync, off-thread write phase).
+#[derive(Debug)]
+pub(crate) struct PreparedNote {
+    /// The source document's folder (also the new note's folder — one gate covers read + write).
+    pub folder_id: String,
+    /// The note's display title (drives the `.md` filename + the front-matter `title:`).
+    pub title: String,
+    /// The complete note markdown: `---` front-matter FIRST, then the H1 + recipe body + (when a
+    /// visible last meeting exists) a `[[Title]]` wikilink footer. NO image markers yet — those are
+    /// appended in [`persist_generated_note`] once the attachments are materialized under the new id.
+    pub markdown: String,
+    /// The SOURCE document id (its image attachments, if any, are re-embedded into the note).
+    pub source_document_id: String,
+    /// The VISIBLE current/last meeting id to link the note to, or `None` (no meeting, or the latest
+    /// meeting is sealed-not-unlocked — then neither its title nor an edge surfaces).
+    pub meeting_id: Option<String>,
+}
+
+/// Filesystem/display TITLE for a smart note: the source file's stem (never a full path — no PII in
+/// logs), capped, falling back to a generic label. Deterministic + pure.
+fn smart_note_title(source_name: &str) -> String {
+    let stem = std::path::Path::new(source_name)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("Smart note");
+    stem.chars().take(120).collect()
+}
+
+/// Drop a leading YAML front-matter block a synthesis model may have emitted despite the prompt (the
+/// command prepends its OWN deterministic front-matter — two blocks would be invalid). A body with no
+/// leading `---` is returned trimmed but otherwise unchanged.
+fn strip_leading_front_matter(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.starts_with("---") {
+        let (_yaml, body) = crate::storage::db::split_front_matter(trimmed);
+        let body = body.trim();
+        if !body.is_empty() {
+            return body.to_string();
+        }
+    }
+    trimmed.to_string()
+}
+
+/// Provider dispatch for one recipe → the note BODY markdown (no front-matter). SYNTHESIS runs
+/// `complete()` over the anti-slop template; STRUCTURE-MIRROR runs `complete_json()` into the generic
+/// opaque-string schema, then the DETERMINISTIC Rust renderer. This is the ONLY egress on the path.
+async fn build_smart_note_body(
+    provider: &dyn crate::summarize::provider::SummarizerProvider,
+    recipe: crate::summarize::recipes::NoteRecipe,
+    source_name: &str,
+    text: &str,
+    note_language: &str,
+) -> Result<String, AppError> {
+    use crate::summarize::recipes::{self, NoteRecipe};
+    match recipe {
+        NoteRecipe::Synthesis => {
+            let (system, user) = recipes::build_synthesis_prompt(source_name, text, note_language);
+            let raw = provider.complete(&system, &user).await?;
+            let body = strip_leading_front_matter(&raw);
+            if body.trim().is_empty() {
+                return Err(AppError::Summarize(
+                    "the note model returned an empty synthesis".into(),
+                ));
+            }
+            Ok(body)
+        }
+        NoteRecipe::StructureMirror => {
+            let (system, user) = recipes::build_structure_prompt(source_name, text, note_language);
+            let schema = recipes::structure_mirror_schema();
+            let value = provider.complete_json(&system, &user, &schema).await?;
+            let doc: recipes::StructuredDoc = serde_json::from_value(value).map_err(|e| {
+                AppError::Summarize(format!(
+                    "structure-mirror: invalid JSON shape from provider: {e}"
+                ))
+            })?;
+            Ok(recipes::render_structure_markdown(&doc))
+        }
+    }
+}
+
+/// The async EGRESS phase: gate the source folder, read + clean the extracted text, run the recipe
+/// through the provider, and assemble the complete `---`-first note markdown (front-matter + H1 +
+/// body + a GATED last-meeting wikilink footer). Returns a [`PreparedNote`] for the sync write phase.
+/// Refuses a sealed-not-unlocked folder (`AppError::Locked`) and an empty/unknown source
+/// (`AppError::InvalidArg`) BEFORE any provider call.
+pub(crate) async fn prepare_smart_note(
+    state: &AppState,
+    provider: &dyn crate::summarize::provider::SummarizerProvider,
+    document_id: &str,
+    recipe: crate::summarize::recipes::NoteRecipe,
+    note_language: &str,
+) -> Result<PreparedNote, AppError> {
+    // Read the source row (raw stored text) + resolve its folder.
+    let (folder_id, source_name, stored_text) = state
+        .db
+        .get_document(document_id)?
+        .ok_or_else(|| AppError::InvalidArg(format!("no document {document_id}")))?;
+    // GATE (read + write, one folder): refuse a sealed-and-NOT-session-unlocked folder — the same
+    // posture as `import_document`'s write-gate. A blanked (sealed) source has no text to read either.
+    if !folder_is_unlocked(state, &folder_id)? {
+        return Err(AppError::Locked(
+            "this folder is locked — unlock it to make a note from this document".into(),
+        ));
+    }
+    // Clean display text (strips the PR-2 block-structure markers; md/txt/note rows pass through).
+    let display_text = crate::extract::render_display_text(&stored_text);
+    if display_text.trim().is_empty() {
+        return Err(AppError::InvalidArg(
+            "this document has no extractable text to turn into a note".into(),
+        ));
+    }
+
+    // The current/last meeting — GATED: a sealed-not-unlocked latest meeting contributes neither its
+    // title (leak) nor a link. `meeting_is_unlocked` treats a folderless/open meeting as visible.
+    let last_meeting = state.db.latest_meeting()?;
+    let visible_meeting = match &last_meeting {
+        Some(m) if meeting_is_unlocked(state, &m.id)? => Some(m.clone()),
+        _ => None,
+    };
+
+    // The ONLY egress — redaction firewall applied inside the provider wrapper.
+    let body = build_smart_note_body(provider, recipe, &source_name, &display_text, note_language).await?;
+
+    let title = smart_note_title(&source_name);
+    let date_iso = chrono::Utc::now().format("%Y-%m-%d").to_string();
+    let front =
+        crate::summarize::template::smart_note_front_matter(&title, &date_iso, &source_name, recipe.as_str());
+    // `---` front-matter FIRST (the load-bearing Obsidian invariant), then the H1 + body.
+    let mut markdown = format!("{front}\n# {title}\n\n{body}\n");
+    if let Some(meeting_title) = visible_meeting
+        .as_ref()
+        .and_then(|m| m.title.as_deref())
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+    {
+        // A `[[wikilink]]` back to the meeting (indexed rename-proof on save); the manual edge is
+        // created in the persist phase. Only ever a VISIBLE meeting's title reaches here.
+        markdown.push_str(&format!("\n---\n\nGenerated from meeting [[{meeting_title}]].\n"));
+    }
+
+    Ok(PreparedNote {
+        folder_id,
+        title,
+        markdown,
+        source_document_id: document_id.to_string(),
+        meeting_id: visible_meeting.map(|m| m.id),
+    })
+}
+
+/// Best-effort: re-embed the SOURCE document's image attachments into the NEW note. Reads the source
+/// bytes READ-ONLY (never mutates/deletes them) and creates a fresh sealed copy under the NEW note's
+/// owner through the existing E2EE bundle seam ([`materialize_attachment_bundle`] — seal-on-birth +
+/// verify), so nothing about the source's AAD is weakened. Only normalized WebP/PNG images (the only
+/// shapes the seam accepts) are carried; the returned markdown gains a canonical
+/// `![](murmur-attachment://<new-id>)` marker per embedded image. No source attachments ⇒ the
+/// markdown is returned unchanged.
+fn embed_source_attachments(
+    state: &AppState,
+    source_document_id: &str,
+    new_note_id: &str,
+    markdown: &str,
+) -> Result<String, AppError> {
+    let src_owner = crate::storage::AttachmentOwner::Document {
+        document_id: source_document_id.to_string(),
+    };
+    let rows = state.db.list_attachments(&src_owner)?;
+    if rows.is_empty() {
+        return Ok(markdown.to_string());
+    }
+    let mut incoming: Vec<crate::storage::IncomingAttachment> = Vec::new();
+    let mut markers = String::new();
+    for row in rows.iter().take(crate::storage::MAX_ATTACHMENTS_PER_OWNER) {
+        // `materialize_attachment_bundle` only accepts a normalized WebP/PNG image; skip anything else.
+        if !matches!(
+            (row.mime_type.as_str(), row.extension.as_str()),
+            ("image/webp", "webp") | ("image/png", "png")
+        ) {
+            continue;
+        }
+        let data = plaintext_attachment_data(state, row)?;
+        let new_att_id = uuid::Uuid::new_v4().to_string();
+        // The canonical marker form parsed by `commands::attachments::parse_attachment_markers`
+        // (`murmur-attachment://<UUIDv4>`) — kept in sync with that module's `ATTACHMENT_URI_PREFIX`.
+        markers.push_str(&format!("\n\n![](murmur-attachment://{new_att_id})"));
+        incoming.push(crate::storage::IncomingAttachment {
+            id: new_att_id,
+            mime_type: row.mime_type.clone(),
+            extension: row.extension.clone(),
+            width: row.width,
+            height: row.height,
+            sha256: row.sha256,
+            data,
+        });
+    }
+    if incoming.is_empty() {
+        return Ok(markdown.to_string());
+    }
+    let new_owner = crate::storage::AttachmentOwner::Document {
+        document_id: new_note_id.to_string(),
+    };
+    materialize_attachment_bundle(state, &new_owner, &incoming)?;
+    Ok(format!("{markdown}{markers}"))
+}
+
+/// The sync WRITE phase (run off the runtime thread behind the heavy permit): birth a seal-aware
+/// `kind='note'` documents row in the source's folder, best-effort re-embed the source's images under
+/// the new note, write the body through the authored-note funnel `update_note_doc_inner` (seal-on-
+/// write + gated `.md` export + chunk/wikilink re-index), and (best-effort, gated) link the note to
+/// the current/last meeting. Returns the new note id. Refuses a sealed-not-unlocked folder.
+pub(crate) fn persist_generated_note(
+    state: &AppState,
+    prepared: &PreparedNote,
+) -> Result<String, AppError> {
+    let id = uuid::Uuid::new_v4().to_string();
+    let now = chrono::Utc::now().timestamp_millis();
+    let name = crate::export::sanitize_title(&prepared.title);
+    // BIRTH — seal-aware empty note in the source's folder (mirrors `create_note_inner`'s F1/W3
+    // SEAL-THEN-INSERT birth-seal: a session-unlocked LOCKED folder gets a verified `text_blob` from
+    // birth so there is never a blob-less plaintext row behind the lock; an open folder plain-inserts).
+    {
+        let _lifecycle = lifecycle_guard(state);
+        // Re-check the gate under the lifecycle guard: a relock racing between `prepare_smart_note`
+        // and here must refuse, never land plaintext at rest behind a lock.
+        if !folder_is_unlocked(state, &prepared.folder_id)? {
+            return Err(AppError::Locked(
+                "this folder is locked — unlock it to add a note".into(),
+            ));
+        }
+        let locked = state
+            .db
+            .folder_by_id(&prepared.folder_id)?
+            .map(|f| f.locked)
+            .unwrap_or(false);
+        if locked {
+            let blob = sealed_document_blob(state, &prepared.folder_id, &id, "")?;
+            state
+                .db
+                .insert_note_sealed(&id, &prepared.folder_id, &name, &prepared.title, "", &blob, now)?;
+        } else {
+            state
+                .db
+                .insert_note(&id, &prepared.folder_id, &name, &prepared.title, "", now)?;
+        }
+        index_wikilinks_best_effort(state, crate::links::LinkKind::Note, &id, "");
+    }
+
+    // ATTACHMENTS (best-effort — a failure keeps the text note, never loses the untouched source).
+    let final_markdown = match embed_source_attachments(state, &prepared.source_document_id, &id, &prepared.markdown) {
+        Ok(md) => md,
+        Err(e) => {
+            tracing::warn!(target: "documents", error = %e, "smart-note: attachment embed skipped (text kept)");
+            prepared.markdown.clone()
+        }
+    };
+
+    // WRITE the body through the authored-note funnel (seal-on-write + gated `.md` export + chunk +
+    // wikilink re-index). Re-gates the folder itself — fail-closed on a mid-flight relock.
+    update_note_doc_inner(state, &id, &prepared.title, &final_markdown)?;
+
+    // LINK note → current/last meeting (best-effort, gated). A locked/absent meeting silently skips.
+    if let Some(meeting_id) = prepared.meeting_id.as_deref() {
+        if let Err(e) = link_items_inner(state, "note", &id, "meeting", meeting_id) {
+            tracing::warn!(target: "documents", error = %e, "smart-note: meeting link skipped");
+        }
+    }
+
+    tracing::info!(
+        target: "documents",
+        note_id = %id,
+        folder_id = %prepared.folder_id,
+        source_document_id = %prepared.source_document_id,
+        "smart note generated from document"
+    );
+    Ok(id)
+}
+
+/// Turn an already-ingested `documents` row into a formatted Obsidian note (`kind='note'` row → `.md`)
+/// through the provider seam, in one of two selectable recipe shapes: `"synthesis"` (flagship
+/// free-form) or `"structure-mirror"` (deterministic form/table transpile). Returns the NEW note id.
+///
+/// LOCK: refuses a sealed-not-unlocked folder (`AppError::Locked`). EGRESS: only redacted text leaves
+/// the device (the redaction firewall lives inside `provider_for`); no image bytes are ever sent.
+#[tauri::command]
+pub async fn generate_note_from_document(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    document_id: String,
+    recipe: String,
+) -> Result<String, AppError> {
+    let recipe = crate::summarize::recipes::NoteRecipe::parse(&recipe).ok_or_else(|| {
+        AppError::InvalidArg(format!(
+            "unknown note recipe {recipe:?} (expected \"synthesis\" or \"structure-mirror\")"
+        ))
+    })?;
+    let config = {
+        state
+            .config
+            .lock()
+            .map_err(|_| AppError::Config("config mutex poisoned".into()))?
+            .clone()
+    };
+    // The provider factory owns the consent gate + redaction firewall + egress ledger.
+    let provider = crate::summarize::provider_for(
+        crate::summarize::roles::Role::Notes,
+        &config,
+        &state.heavy_inference,
+    )?;
+
+    // EGRESS phase (async, on the runtime task) — gate + read + provider + assemble.
+    let prepared =
+        prepare_smart_note(state.inner(), provider.as_ref(), &document_id, recipe, &config.note_language)
+            .await?;
+
+    // WRITE phase off the runtime thread behind the heavy permit (birth-seal + attachment re-seal +
+    // note re-embed are Candle/Metal + crypto work — mirror `update_note_doc`'s H3 offload). A bare
+    // `&AppState` cannot cross into a `'static` closure, so re-fetch it from the `AppHandle` inside.
+    let heavy = state.heavy_inference.clone();
+    let app_for_persist = app.clone();
+    let new_id = crate::perf::run_heavy(&heavy, move || {
+        let state = app_for_persist.state::<AppState>();
+        persist_generated_note(&state, &prepared)
+    })
+    .await?;
+    Ok(new_id)
+}
+
+#[cfg(test)]
+mod smart_note_tests {
+    use super::*;
+    use crate::settings::AppConfig;
+    use crate::storage::models::{Folder, Meeting, MeetingStatus};
+    use crate::storage::Db;
+    use crate::summarize::provider::{Availability, SummarizeRequest, SummarizerProvider};
+    use crate::summarize::recipes::NoteRecipe;
+    use std::collections::HashSet;
+    use std::sync::{Arc, Mutex};
+
+    const DB_KEY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    fn tmp_db_path(tag: &str) -> std::path::PathBuf {
+        let p = crate::storage::db::unique_temp_path(&format!("murmur-smartnote-{tag}"), "sqlite");
+        let _ = std::fs::remove_file(&p);
+        p
+    }
+
+    /// A minimal [`AppState`] backed by a real temp SQLCipher DB (no Keychain, no Tauri, no vault) —
+    /// the same shape `commands/tests` uses. Enough to exercise the gate + note write end-to-end.
+    fn build_state(tag: &str) -> AppState {
+        let db = Arc::new(Db::open_with_key(&tmp_db_path(tag), DB_KEY).unwrap());
+        AppState {
+            recorder: Mutex::new(None),
+            recording_stop: Mutex::new(None),
+            voice_listener: Mutex::new(None),
+            voice_listener_lifecycle: Mutex::new(()),
+            recording_starting: std::sync::atomic::AtomicBool::new(false),
+            voice_command_capture: Mutex::new(None),
+            pending_manual_command: Mutex::new(None),
+            live_running: std::sync::atomic::AtomicBool::new(false),
+            db,
+            config: Arc::new(Mutex::new(AppConfig::default())),
+            reasoner: crate::reason::ReasonerCell::fixed(Arc::new(crate::reason::StubReasoner)),
+            current_meeting: Mutex::new(None),
+            focus_meeting: Mutex::new(None),
+            live_transcript: Mutex::new(String::new()),
+            live_bullets: Mutex::new(String::new()),
+            live_bullets_tracker: Mutex::new(crate::transcribe::bullets::BulletsTracker::default()),
+            capped_notified: std::sync::atomic::AtomicBool::new(false),
+            capture_fault_notified: std::sync::atomic::AtomicBool::new(false),
+            reactions_shadow_count: std::sync::atomic::AtomicU64::new(0),
+            reactions_emitted: Mutex::new(HashSet::new()),
+            in_flight_turns: Mutex::new(std::collections::HashMap::new()),
+            user_turn_in_progress: std::sync::atomic::AtomicBool::new(false),
+            verify_cache: Mutex::new(std::collections::HashMap::new()),
+            unlocked_folders: Arc::new(Mutex::new(HashSet::new())),
+            master_kek: Mutex::new(None),
+            org_ock_cache: Mutex::new(std::collections::HashMap::new()),
+            account_session: Mutex::new(None),
+            lifecycle: Mutex::new(()),
+            active_salvages: Mutex::new(HashSet::new()),
+            share_refresh_lock: tokio::sync::Mutex::new(()),
+            seal_epoch: std::sync::atomic::AtomicU64::new(0),
+            heavy_inference: Arc::new(tokio::sync::Semaphore::new(1)),
+        }
+    }
+
+    fn block_on<F: std::future::Future>(f: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(f)
+    }
+
+    fn seed_folder(db: &Db, id: &str, locked: bool) {
+        db.insert_folder(&Folder {
+            id: id.to_string(),
+            name: id.to_string(),
+            path: id.to_string(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-07-25T00:00:00Z".to_string(),
+        })
+        .unwrap();
+        if locked {
+            db.set_folder_locked(id, true, None).unwrap();
+        }
+    }
+
+    fn seed_document(db: &Db, id: &str, folder_id: &str, name: &str, text: &str) {
+        db.insert_document(id, folder_id, name, text, "document", 1_700_000_000_000)
+            .unwrap();
+    }
+
+    /// A stub provider: `complete` returns a fixed SYNTHESIS body; `complete_json_with_meta` returns a
+    /// fixed STRUCTURE-MIRROR payload. No egress, no model — the note plumbing is what's under test.
+    struct StubProvider;
+
+    #[async_trait::async_trait]
+    impl SummarizerProvider for StubProvider {
+        fn id(&self) -> &str {
+            "stub"
+        }
+        async fn availability(&self) -> Availability {
+            Availability::Available
+        }
+        async fn summarize(&self, _req: &SummarizeRequest) -> Result<String, AppError> {
+            Ok(String::new())
+        }
+        async fn complete(&self, _system: &str, _user: &str) -> Result<String, AppError> {
+            Ok("## Summary\nA fixed synthesis body.\n\n## Outline\n- point one\n\n## Action items\n- None"
+                .to_string())
+        }
+        async fn complete_json_with_meta(
+            &self,
+            _system: &str,
+            _user: &str,
+            _schema: &serde_json::Value,
+        ) -> Result<(serde_json::Value, crate::summarize::meta::CallMeta), AppError> {
+            Ok((
+                serde_json::json!({
+                    "fields": [{"key": "Invoice #", "value": "1042"}],
+                    "tables": [{"title": "Line items", "rows": [["Item", "Amount"], ["Widget", "$30.00"]]}],
+                    "sections": []
+                }),
+                crate::summarize::meta::CallMeta::default(),
+            ))
+        }
+    }
+
+    /// SYNTHESIS: a fixed extracted-text fixture becomes a valid, FRONT-MATTER-FIRST `.md` note whose
+    /// body carries the section skeleton, persisted as a `kind='note'` row.
+    #[test]
+    fn synthesis_produces_a_front_matter_first_note() {
+        let state = build_state("synth");
+        seed_folder(&state.db, "f-open", false);
+        seed_document(
+            &state.db,
+            "doc1",
+            "f-open",
+            "whiteboard.png",
+            "Q3 goals: ship v2. Anna owns QA by 2026-08-01.",
+        );
+
+        let prepared = block_on(prepare_smart_note(
+            &state,
+            &StubProvider,
+            "doc1",
+            NoteRecipe::Synthesis,
+            "auto",
+        ))
+        .expect("prepare must succeed for an open folder");
+        assert!(
+            prepared.markdown.starts_with("---\n"),
+            "note must be front-matter-first: {}",
+            prepared.markdown
+        );
+        assert!(prepared.markdown.contains("recipe: synthesis"));
+        assert!(prepared.markdown.contains("## Summary"));
+        assert!(prepared.markdown.contains("## Action items"));
+
+        let id = persist_generated_note(&state, &prepared).expect("persist must succeed");
+        let row = state.db.get_note_row(&id).unwrap().expect("note row exists");
+        assert!(
+            row.text.starts_with("---\n"),
+            "persisted note text must be front-matter-first: {}",
+            row.text
+        );
+        assert!(row.text.contains("## Summary"));
+        // It is a real `kind='note'` row, gate-anchored and folder-anchored to the source folder.
+        let anchor = state.db.note_gate_anchor(&id).unwrap().expect("gate anchor");
+        assert_eq!(anchor.0, "f-open");
+    }
+
+    /// STRUCTURE-MIRROR: the same path renders the opaque-string payload DETERMINISTICALLY into a
+    /// front-matter-first `.md` — a valid table + fields, amounts copied verbatim, NEVER summed (§10).
+    #[test]
+    fn structure_mirror_produces_a_deterministic_front_matter_first_note() {
+        let state = build_state("struct");
+        seed_folder(&state.db, "f-open", false);
+        seed_document(&state.db, "doc1", "f-open", "invoice.pdf", "Invoice 1042. Widget $30.00.");
+
+        let prepared = block_on(prepare_smart_note(
+            &state,
+            &StubProvider,
+            "doc1",
+            NoteRecipe::StructureMirror,
+            "auto",
+        ))
+        .expect("prepare must succeed");
+        assert!(prepared.markdown.starts_with("---\n"), "{}", prepared.markdown);
+        assert!(prepared.markdown.contains("recipe: structure-mirror"));
+        assert!(prepared.markdown.contains("## Details"));
+        assert!(prepared.markdown.contains("| Item | Amount |"));
+        assert!(prepared.markdown.contains("$30.00"));
+        assert!(
+            !prepared.markdown.contains("$60.00"),
+            "structure-mirror must never sum amounts (§10): {}",
+            prepared.markdown
+        );
+
+        let id = persist_generated_note(&state, &prepared).unwrap();
+        let row = state.db.get_note_row(&id).unwrap().expect("note row exists");
+        assert!(row.text.starts_with("---\n"));
+        assert!(row.text.contains("## Details"));
+    }
+
+    /// A visible last meeting is linked (a `[[Title]]` wikilink footer + a manual note→meeting edge).
+    #[test]
+    fn links_the_note_to_the_visible_last_meeting() {
+        let state = build_state("link");
+        seed_folder(&state.db, "f-open", false);
+        seed_document(&state.db, "doc1", "f-open", "notes.txt", "Some plan for the launch.");
+        state
+            .db
+            .insert_meeting(&Meeting {
+                id: "m1".to_string(),
+                started_at: "2026-07-24T09:00:00Z".to_string(),
+                ended_at: None,
+                title: Some("Launch Sync".to_string()),
+                duration_s: 60,
+                audio_path: None,
+                status: MeetingStatus::Summarized,
+                folder_id: None,
+            })
+            .unwrap();
+
+        let prepared = block_on(prepare_smart_note(
+            &state,
+            &StubProvider,
+            "doc1",
+            NoteRecipe::Synthesis,
+            "auto",
+        ))
+        .unwrap();
+        assert_eq!(prepared.meeting_id.as_deref(), Some("m1"));
+        assert!(prepared.markdown.contains("[[Launch Sync]]"));
+
+        let id = persist_generated_note(&state, &prepared).unwrap();
+        let unlocked = HashSet::new();
+        let links = state
+            .db
+            .links_for_visible(crate::links::LinkKind::Note, &id, &unlocked)
+            .unwrap();
+        assert!(
+            links
+                .iter()
+                .any(|e| e.other_kind == "meeting" && e.other_id == "m1"),
+            "the note must carry a link to the last meeting"
+        );
+    }
+
+    /// A sealed-and-NOT-session-unlocked source folder is REFUSED (`AppError::Locked`) BEFORE any
+    /// provider call — never read a sealed doc, never land a note behind the lock. RED before the gate.
+    #[test]
+    fn sealed_folder_is_refused() {
+        let state = build_state("sealed");
+        seed_folder(&state.db, "f-lock", true); // locked, NOT session-unlocked
+        seed_document(&state.db, "doc1", "f-lock", "secret.pdf", "confidential text");
+
+        let err = block_on(prepare_smart_note(
+            &state,
+            &StubProvider,
+            "doc1",
+            NoteRecipe::Synthesis,
+            "auto",
+        ))
+        .expect_err("a sealed folder must be refused");
+        assert!(
+            matches!(err, AppError::Locked(_)),
+            "expected AppError::Locked, got {err:?}"
+        );
+    }
+
+    /// An unknown document id is a clean `InvalidArg` (never a panic / empty note).
+    #[test]
+    fn unknown_document_is_invalid_arg() {
+        let state = build_state("unknown");
+        let err = block_on(prepare_smart_note(
+            &state,
+            &StubProvider,
+            "nope",
+            NoteRecipe::Synthesis,
+            "auto",
+        ))
+        .expect_err("unknown id must error");
+        assert!(matches!(err, AppError::InvalidArg(_)), "got {err:?}");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -204,6 +204,7 @@ pub fn run() {
             commands::brain_overview,
             commands::list_documents,
             commands::get_document,
+            commands::generate_note_from_document,
             commands::delete_document,
             commands::get_user_memory,
             commands::forget_user_fact,

--- a/src-tauri/src/summarize/recipes.rs
+++ b/src-tauri/src/summarize/recipes.rs
@@ -1,10 +1,22 @@
 //! "Recipes": run a builtin or saved prompt template over ONE meeting's transcript via the
 //! configured provider's complete() — grounded recap emails, decision logs, work tickets,
 //! and per-meeting-type recaps (1:1 / standup / sales / interview). Mirrors chat.rs/timeline.rs.
+//!
+//! SMART-NOTE ENGINE (2026-07-25): the lower half of this module turns an already-extracted
+//! `documents.text` into a readable Obsidian note in TWO selectable recipe shapes — `synthesis`
+//! (a flagship anti-slop free-form summary → outline → action items, the whiteboard-photo case)
+//! and `structure-mirror` (a deterministic Rust JSON→markdown transpile of a form/table, EVERY
+//! value an OPAQUE STRING — §10: no money/arithmetic, an invoice's line items are copied verbatim,
+//! never summed). Both the prompt builders and the deterministic renderer are PURE functions of
+//! their inputs (no DB, no clock, no egress) so they are unit-testable in isolation; the wiring
+//! (provider call + gated note write) lives in `commands/documents.rs`.
 
 use crate::summarize::template::language_directive;
 
 const MAX_TRANSCRIPT_CHARS: usize = 40_000;
+/// Char cap on the extracted document text fed to a smart-note recipe prompt — the note-generation
+/// twin of [`MAX_TRANSCRIPT_CHARS`] (bounds the local prefill KV / cloud prompt for a huge doc).
+const MAX_DOC_CHARS: usize = 40_000;
 
 /// Built-in recipes shown as quick chips: (id, label, instruction prompt).
 pub const BUILTIN_RECIPES: &[(&str, &str, &str)] = &[
@@ -78,6 +90,290 @@ TASK: {recipe_prompt}\n\n{lang}",
     (system, user)
 }
 
+// ── SMART-NOTE ENGINE — turn an extracted document into a readable Obsidian note ─────────────────
+
+/// The two selectable smart-note recipe shapes.
+///
+/// * [`Synthesis`](NoteRecipe::Synthesis) — the flagship free-form path for a whiteboard photo /
+///   screenshot / slide deck with NO inherent schema: `provider.complete()` over one fixed
+///   anti-slop template (summary → outline → action items) → readable markdown.
+/// * [`StructureMirror`](NoteRecipe::StructureMirror) — for forms/tables: `provider.complete_json()`
+///   into a generic `{fields, tables, sections}` schema of OPAQUE STRINGS, then a DETERMINISTIC
+///   Rust JSON→markdown renderer. Never computes or sums anything (§10).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoteRecipe {
+    Synthesis,
+    StructureMirror,
+}
+
+impl NoteRecipe {
+    /// Parse the IPC recipe token; `None` for anything unknown (the command rejects it as
+    /// `InvalidArg` — never silently coerces).
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "synthesis" => Some(Self::Synthesis),
+            "structure" | "structure-mirror" | "structure_mirror" => Some(Self::StructureMirror),
+            _ => None,
+        }
+    }
+
+    /// Stable lowercase token (stamped into the note's front-matter `recipe:` key).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Synthesis => "synthesis",
+            Self::StructureMirror => "structure-mirror",
+        }
+    }
+}
+
+/// Cap the extracted text on a char boundary (never splits a multibyte char), appending a marker
+/// when truncated so the model knows the doc was clipped. Mirrors `build_recipe_prompt`.
+fn cap_doc(text: &str) -> String {
+    if text.chars().count() > MAX_DOC_CHARS {
+        let head: String = text.chars().take(MAX_DOC_CHARS).collect();
+        format!("{head}\n[document truncated]")
+    } else {
+        text.to_string()
+    }
+}
+
+/// SYNTHESIS recipe — build the (system, user) prompt pair. The model emits the note BODY ONLY (no
+/// YAML front-matter — the command prepends deterministic front-matter): a tight anti-slop
+/// `## Summary` → `## Outline` → `## Action items` (owners + dates when stated). Grounded: it must
+/// stick to the document, never invent. Output language follows `note_language`.
+pub fn build_synthesis_prompt(source_name: &str, text: &str, note_language: &str) -> (String, String) {
+    let system = format!(
+        "You turn ONE already-extracted document (a whiteboard photo, screenshot, slide deck, or \
+pasted notes) into a clean, scannable Obsidian note. Output ONLY the note BODY in Markdown — NO \
+YAML front-matter, NO surrounding code fences, NO preamble or commentary before or after.\n\n\
+Write EXACTLY these sections (omit a section only if there is genuinely nothing to say):\n\
+## Summary\n\
+A tight 2–4 sentence overview of what this document is and what it's about.\n\
+## Outline\n\
+- The key points / structure of the document as specific, factual bullets (nest sub-bullets where \
+the source is hierarchical).\n\
+## Action items\n\
+- [ ] Owner — action (due date if stated)\n\n\
+Anti-slop rules — be faithful, be specific, add NOTHING:\n\
+- Base everything STRICTLY on the document below. Never invent facts, owners, dates, decisions, or \
+action items that are not supported by the text.\n\
+- No filler, no hedging, no 'In conclusion', no restating the instructions. Cut empty phrases.\n\
+- Copy names, figures, and quoted strings VERBATIM — never re-compute, re-total, or re-interpret a \
+number.\n\
+- If the document has no action items, write '- None' under Action items rather than inventing one.\n\n\
+{lang}",
+        lang = language_directive(note_language)
+    );
+    let user = format!("DOCUMENT: {source_name}\n\nCONTENT:\n{}", cap_doc(text));
+    (system, user)
+}
+
+/// The generic STRUCTURE-MIRROR schema: `{fields, tables, sections}` where EVERY leaf value is an
+/// OPAQUE STRING. Passed to the provider for native constrained decoding (the default
+/// `complete_json` impl only stringifies it into the system prompt). No numeric/amount types exist
+/// in the schema by design (§10) — an invoice's totals ride through as plain strings.
+pub fn structure_mirror_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "fields": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "key":   {"type": "string"},
+                        "value": {"type": "string"}
+                    },
+                    "required": ["key", "value"],
+                    "additionalProperties": false
+                }
+            },
+            "tables": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string"},
+                        "rows":  {"type": "array", "items": {"type": "array", "items": {"type": "string"}}}
+                    },
+                    "required": ["title", "rows"],
+                    "additionalProperties": false
+                }
+            },
+            "sections": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "heading": {"type": "string"},
+                        "body":    {"type": "string"}
+                    },
+                    "required": ["heading", "body"],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "required": ["fields", "tables", "sections"],
+        "additionalProperties": false
+    })
+}
+
+/// STRUCTURE-MIRROR recipe — build the (system, user) prompt pair for the constrained-JSON
+/// transcription. The model TRANSCRIBES the document's structure verbatim into `{fields, tables,
+/// sections}`; it computes nothing. §10 is load-bearing here: every value is an opaque string, so
+/// an invoice/receipt/form is mirrored, never totalled.
+pub fn build_structure_prompt(source_name: &str, text: &str, note_language: &str) -> (String, String) {
+    let system = format!(
+        "You TRANSCRIBE the structure of ONE already-extracted document (a form, invoice, receipt, \
+spreadsheet, or table) into JSON. You are a faithful transcriber, NOT an analyst.\n\
+- `fields`: labelled key/value pairs from the document header/body (e.g. \"Invoice #\": \"1042\", \
+\"Date\": \"2026-07-01\"). Copy both the label and the value VERBATIM.\n\
+- `tables`: each repeating/tabular region as a `title` plus `rows` (the FIRST row is the header). \
+Copy every cell verbatim as a string.\n\
+- `sections`: any free-text regions (notes, terms) as `heading` + `body`.\n\
+CRITICAL RULES:\n\
+- EVERY value is an OPAQUE STRING copied exactly as written — keep currency symbols, units, and \
+formatting inside the string.\n\
+- NEVER compute, sum, total, average, or re-derive ANY number. Do not add a 'Total' the document \
+does not itself contain. If the document shows a total, copy that shown string verbatim.\n\
+- Never invent a field, row, or value that is not in the document. Omit what isn't there (empty \
+arrays are fine).\n\n\
+{lang}",
+        lang = language_directive(note_language)
+    );
+    let user = format!("DOCUMENT: {source_name}\n\nCONTENT:\n{}", cap_doc(text));
+    (system, user)
+}
+
+/// One labelled key/value pair transcribed from a document (opaque strings).
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct StructuredField {
+    #[serde(default)]
+    pub key: String,
+    #[serde(default)]
+    pub value: String,
+}
+
+/// One tabular region: a title + rows of opaque string cells (the first row is the header).
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct StructuredTable {
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub rows: Vec<Vec<String>>,
+}
+
+/// One free-text region: a heading + body (opaque strings).
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct StructuredSection {
+    #[serde(default)]
+    pub heading: String,
+    #[serde(default)]
+    pub body: String,
+}
+
+/// The parsed structure-mirror payload (mirrors [`structure_mirror_schema`]). All values are opaque
+/// strings; the renderer never interprets them.
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct StructuredDoc {
+    #[serde(default)]
+    pub fields: Vec<StructuredField>,
+    #[serde(default)]
+    pub tables: Vec<StructuredTable>,
+    #[serde(default)]
+    pub sections: Vec<StructuredSection>,
+}
+
+/// Collapse a value to a single inline-safe line: newlines → spaces, trimmed. Keeps the markdown
+/// tidy without interpreting the (opaque) content.
+fn inline(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Make an opaque cell safe inside a markdown table: escape the `|` delimiter and flatten newlines,
+/// so a value containing a pipe can never break the table structure. Content is otherwise verbatim.
+fn table_cell(s: Option<&String>) -> String {
+    match s {
+        Some(v) => inline(v).replace('|', "\\|"),
+        None => String::new(),
+    }
+}
+
+/// DETERMINISTIC JSON→markdown BODY renderer for the structure-mirror recipe (no front-matter — the
+/// command prepends deterministic front-matter). Pure + deterministic: the SAME [`StructuredDoc`]
+/// always renders byte-identical markdown. §10: it copies opaque strings only — it never parses,
+/// sums, or re-derives a number. Empty payload → a clear placeholder (never an empty note).
+pub fn render_structure_markdown(doc: &StructuredDoc) -> String {
+    let mut out = String::new();
+
+    // Fields → a "## Details" definition list (skip a blank key).
+    let fields: Vec<&StructuredField> = doc
+        .fields
+        .iter()
+        .filter(|f| !f.key.trim().is_empty())
+        .collect();
+    if !fields.is_empty() {
+        out.push_str("## Details\n\n");
+        for f in fields {
+            out.push_str(&format!("- **{}**: {}\n", inline(&f.key), inline(&f.value)));
+        }
+        out.push('\n');
+    }
+
+    // Tables → a `## <title>` heading + a valid markdown table (first row = header).
+    for t in &doc.tables {
+        let rows: Vec<&Vec<String>> = t.rows.iter().filter(|r| !r.is_empty()).collect();
+        if rows.is_empty() {
+            continue;
+        }
+        let cols = rows.iter().map(|r| r.len()).max().unwrap_or(0);
+        if cols == 0 {
+            continue;
+        }
+        let title = inline(&t.title);
+        if !title.is_empty() {
+            out.push_str(&format!("## {title}\n\n"));
+        }
+        // Header row (first), then the `---` separator, then the body rows. Every cell is an opaque
+        // string with `|` escaped so the value can never break the table structure.
+        for (r, row) in rows.iter().enumerate() {
+            out.push('|');
+            for c in 0..cols {
+                out.push_str(&format!(" {} |", table_cell(row.get(c))));
+            }
+            out.push('\n');
+            if r == 0 {
+                out.push('|');
+                for _ in 0..cols {
+                    out.push_str(" --- |");
+                }
+                out.push('\n');
+            }
+        }
+        out.push('\n');
+    }
+
+    // Sections → `## <heading>` + verbatim body.
+    for s in &doc.sections {
+        let heading = inline(&s.heading);
+        if !heading.is_empty() {
+            out.push_str(&format!("## {heading}\n\n"));
+        }
+        let body = s.body.trim();
+        if !body.is_empty() {
+            out.push_str(body);
+            out.push_str("\n\n");
+        }
+    }
+
+    let trimmed = out.trim_end();
+    if trimmed.is_empty() {
+        "## Details\n\n_No structured content could be transcribed from this document._".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -102,5 +398,122 @@ mod tests {
             .iter()
             .any(|(id, _, _)| *id == "grounded-email"));
         assert!(BUILTIN_RECIPES.len() >= 5);
+    }
+
+    // ── Smart-note engine ────────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn note_recipe_parses_both_shapes_and_rejects_unknown() {
+        assert_eq!(NoteRecipe::parse("synthesis"), Some(NoteRecipe::Synthesis));
+        assert_eq!(
+            NoteRecipe::parse("structure-mirror"),
+            Some(NoteRecipe::StructureMirror)
+        );
+        assert_eq!(
+            NoteRecipe::parse("STRUCTURE"),
+            Some(NoteRecipe::StructureMirror)
+        );
+        assert_eq!(NoteRecipe::parse("nonsense"), None);
+        assert_eq!(NoteRecipe::Synthesis.as_str(), "synthesis");
+        assert_eq!(NoteRecipe::StructureMirror.as_str(), "structure-mirror");
+    }
+
+    /// SYNTHESIS: the prompt carries the document + instructs the fixed anti-slop section skeleton,
+    /// and forbids the model from emitting its own front-matter (the command prepends deterministic
+    /// front-matter). This is the "synthesis produces the section skeleton" leg.
+    #[test]
+    fn synthesis_prompt_requests_the_section_skeleton_and_grounds_on_the_doc() {
+        let (system, user) =
+            build_synthesis_prompt("whiteboard.png", "Q3 goals: ship v2. Anna owns QA.", "auto");
+        assert!(system.contains("## Summary"));
+        assert!(system.contains("## Outline"));
+        assert!(system.contains("## Action items"));
+        assert!(
+            system.contains("NO \nYAML front-matter") || system.contains("NO YAML front-matter"),
+            "synthesis must forbid model-emitted front-matter: {system}"
+        );
+        assert!(system.contains("Never invent"));
+        assert!(user.contains("Q3 goals: ship v2. Anna owns QA."));
+        assert!(user.contains("whiteboard.png"));
+    }
+
+    #[test]
+    fn synthesis_prompt_caps_a_huge_document() {
+        let huge = "word ".repeat(20_000); // ~100k chars
+        let (_s, user) = build_synthesis_prompt("big.txt", &huge, "auto");
+        assert!(user.contains("[document truncated]"));
+        assert!(user.chars().count() < MAX_DOC_CHARS + 2_000);
+    }
+
+    /// STRUCTURE-MIRROR: the schema is `{fields, tables, sections}` with EVERY value a string — no
+    /// numeric/amount type exists (§10 — an invoice is transpiled, never summed).
+    #[test]
+    fn structure_schema_has_only_opaque_string_values() {
+        let schema = structure_mirror_schema();
+        let s = serde_json::to_string(&schema).unwrap();
+        assert!(s.contains("fields") && s.contains("tables") && s.contains("sections"));
+        // No number/integer JSON-schema type anywhere — every leaf is a string.
+        assert!(
+            !s.contains("\"number\"") && !s.contains("\"integer\""),
+            "the structure schema must contain NO numeric types (opaque strings only): {s}"
+        );
+        assert!(build_structure_prompt("invoice.pdf", "Total: $50", "auto")
+            .0
+            .contains("NEVER compute"));
+    }
+
+    /// STRUCTURE-MIRROR renders DETERMINISTICALLY: the same payload → byte-identical markdown, with
+    /// a valid table (header + separator), fields, and a section. §10: an invoice's amounts ride
+    /// through verbatim as opaque strings; the renderer sums nothing.
+    #[test]
+    fn structure_renders_deterministically_and_never_computes() {
+        let doc = StructuredDoc {
+            fields: vec![
+                StructuredField {
+                    key: "Invoice #".into(),
+                    value: "1042".into(),
+                },
+                StructuredField {
+                    key: "  ".into(), // blank key is dropped
+                    value: "ignored".into(),
+                },
+            ],
+            tables: vec![StructuredTable {
+                title: "Line items".into(),
+                rows: vec![
+                    vec!["Item".into(), "Amount".into()],
+                    vec!["Widget | A".into(), "$30.00".into()],
+                    vec!["Gadget".into(), "$20.00".into()],
+                ],
+            }],
+            sections: vec![StructuredSection {
+                heading: "Terms".into(),
+                body: "Net 30.".into(),
+            }],
+        };
+        let md1 = render_structure_markdown(&doc);
+        let md2 = render_structure_markdown(&doc);
+        assert_eq!(md1, md2, "structure-mirror must render deterministically");
+        assert!(md1.contains("## Details"));
+        assert!(md1.contains("- **Invoice #**: 1042"));
+        assert!(!md1.contains("ignored"), "blank-key field must be dropped");
+        assert!(md1.contains("## Line items"));
+        assert!(md1.contains("| Item | Amount |"));
+        assert!(md1.contains("| --- | --- |"));
+        assert!(
+            md1.contains("Widget \\| A"),
+            "a pipe in an opaque cell must be escaped so the table stays valid: {md1}"
+        );
+        // Amounts are copied verbatim — never a computed total row.
+        assert!(md1.contains("$30.00") && md1.contains("$20.00"));
+        assert!(!md1.contains("$50.00"), "the renderer must NEVER sum amounts");
+        assert!(md1.contains("## Terms") && md1.contains("Net 30."));
+    }
+
+    #[test]
+    fn structure_render_empty_payload_is_a_placeholder_never_blank() {
+        let md = render_structure_markdown(&StructuredDoc::default());
+        assert!(!md.trim().is_empty());
+        assert!(md.contains("## Details"));
     }
 }

--- a/src-tauri/src/summarize/template.rs
+++ b/src-tauri/src/summarize/template.rs
@@ -312,6 +312,43 @@ pub fn render_user_content(req: &SummarizeRequest) -> String {
     out
 }
 
+// ── SMART-NOTE ENGINE — deterministic front-matter for a generated document note ─────────────────
+
+/// YAML-quote an opaque string value so a `:` / `"` / `#` / newline in a title or source name can
+/// never break the front-matter block. Wraps in double quotes and escapes `\` and `"`; newlines
+/// collapse to spaces (a front-matter scalar is single-line).
+fn yaml_quote(s: &str) -> String {
+    let flat = s.split_whitespace().collect::<Vec<_>>().join(" ");
+    let escaped = flat.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{escaped}\"")
+}
+
+/// Build the deterministic YAML front-matter block for a smart note generated from a document — the
+/// first line is exactly `---` (the load-bearing Obsidian invariant the whole app depends on), and
+/// the closing `---` is the last line. The `title`/`source` values are opaque strings, YAML-quoted;
+/// `date` is an ISO `YYYY-MM-DD`; `recipe` is the [`crate::summarize::recipes::NoteRecipe`] token.
+/// Deterministic + pure — no clock, no DB.
+pub fn smart_note_front_matter(
+    title: &str,
+    date_iso: &str,
+    source_name: &str,
+    recipe: &str,
+) -> String {
+    format!(
+        "---\n\
+title: {title}\n\
+date: {date}\n\
+tags: [note, smart-note]\n\
+source: {source}\n\
+recipe: {recipe}\n\
+---\n",
+        title = yaml_quote(title),
+        date = date_iso,
+        source = yaml_quote(source_name),
+        recipe = recipe,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -504,6 +541,27 @@ mod tests {
             s.contains("the transcript below is authoritative"),
             "transcript stays authoritative: {s}"
         );
+    }
+
+    /// SMART-NOTE front-matter is `---`-first, `---`-closed, YAML-safe (a `:` in the title/source
+    /// can't break parsing), and stamps the deterministic keys. The load-bearing invariant: the very
+    /// first line is exactly `---`.
+    #[test]
+    fn smart_note_front_matter_is_dashes_first_and_yaml_safe() {
+        let fm = smart_note_front_matter(
+            "Q3: Planning \"board\"",
+            "2026-07-25",
+            "whiteboard.png",
+            "synthesis",
+        );
+        assert!(fm.starts_with("---\n"), "front-matter must start with ---: {fm}");
+        assert!(fm.trim_end().ends_with("---"), "front-matter must close with ---: {fm}");
+        // The colon + quotes in the title are quoted+escaped, never bare.
+        assert!(fm.contains("title: \"Q3: Planning \\\"board\\\"\""), "{fm}");
+        assert!(fm.contains("date: 2026-07-25"));
+        assert!(fm.contains("tags: [note, smart-note]"));
+        assert!(fm.contains("source: \"whiteboard.png\""));
+        assert!(fm.contains("recipe: synthesis"));
     }
 
     /// TIER 0: the speaker-attribution directive is appended ONLY when `labeled`, and the

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -47,6 +47,7 @@ import type {
   DossierData,
   EntityDetail,
   EntityKnowledgeDiff,
+  NoteRecipe,
   Folder,
   FolderNode,
   FullGraphData,
@@ -1561,6 +1562,27 @@ export class IpcService {
    */
   getDocument(id: string): Promise<string> {
     return invoke<string>("get_document", { id });
+  }
+
+  /**
+   * SMART-NOTE ENGINE — turn an already-ingested document/photo (`documentId`) into a
+   * formatted Obsidian note through the provider seam, in one of two recipe shapes
+   * ({@link NoteRecipe}: `"synthesis"` for whiteboards/screenshots, `"structure-mirror"`
+   * for forms/tables). Resolves with the NEW `kind='note'` document id (open it via the
+   * usual note surfaces). Only REDACTED TEXT egresses (the redaction firewall lives in the
+   * backend provider factory); no image bytes are ever sent. Rejects with `AppError::Locked`
+   * when the document's folder is sealed-and-NOT-session-unlocked, `AppError::Unavailable`
+   * when cloud egress isn't consented, and `AppError::InvalidArg` for an unknown id / a
+   * document with no extractable text — surface each as a friendly message.
+   */
+  generateNoteFromDocument(
+    documentId: string,
+    recipe: NoteRecipe,
+  ): Promise<string> {
+    return invoke<string>("generate_note_from_document", {
+      documentId,
+      recipe,
+    });
   }
 
   /**

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1095,6 +1095,16 @@ export interface DocumentPreviewTarget {
 }
 
 /**
+ * The two selectable SMART-NOTE recipe shapes for `IpcService.generateNoteFromDocument`
+ * (mirrors the Rust `summarize::recipes::NoteRecipe` tokens):
+ * - `"synthesis"` — the flagship free-form path for a whiteboard photo / screenshot / slide
+ *   deck with no inherent schema (summary → outline → action items).
+ * - `"structure-mirror"` — for forms/tables: a deterministic transpile of the document's
+ *   structure into markdown, every value an opaque string (never summed — §10).
+ */
+export type NoteRecipe = "synthesis" | "structure-mirror";
+
+/**
  * brain2 — headline counts + semantic flags for the Brain page ("what's in my
  * brain"). Mirrors the Rust `BrainOverview` (serde camelCase). Every count is
  * over VISIBLE/unlocked content only (a sealed-not-unlocked folder's items are

--- a/src/app/features/brain/document-preview/document-preview.component.html
+++ b/src/app/features/brain/document-preview/document-preview.component.html
@@ -62,6 +62,44 @@
       } @else {
         <pre class="dp-body" tabindex="0">{{ content() }}</pre>
       }
+
+      <!-- SMART-NOTE ENGINE — "Make a note from this" (source documents only, once
+           the content has loaded and is not locked-masked). -->
+      @if (canMakeNote()) {
+        <footer class="dp-makenote">
+          @if (genCreated()) {
+            <span class="dp-makenote-done" role="status">
+              <span aria-hidden="true">✓</span> Note created — find it in your notes.
+            </span>
+          } @else if (generating()) {
+            <span class="dp-makenote-busy" role="status" aria-live="polite">
+              <mur-spinner [size]="16" />
+              <span>Making a note…</span>
+            </span>
+          } @else {
+            <span class="dp-makenote-label">Make a note from this:</span>
+            <span class="dp-makenote-actions">
+              <button
+                type="button"
+                class="btn btn-primary"
+                (click)="makeNote('synthesis')"
+              >
+                Summary note
+              </button>
+              <button
+                type="button"
+                class="btn btn-ghost"
+                (click)="makeNote('structure-mirror')"
+              >
+                Structured note
+              </button>
+            </span>
+          }
+          @if (genError(); as ge) {
+            <span class="dp-makenote-error" role="alert">{{ ge }}</span>
+          }
+        </footer>
+      }
     </div>
   </div>
 }

--- a/src/app/features/brain/document-preview/document-preview.component.scss
+++ b/src/app/features/brain/document-preview/document-preview.component.scss
@@ -137,6 +137,46 @@
   color: var(--text-secondary);
 }
 
+/* "Make a note from this" footer — a compact action row under the content well. */
+.dp-makenote {
+  flex: none;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2) var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.dp-makenote-label {
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+}
+
+.dp-makenote-actions {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.dp-makenote-busy,
+.dp-makenote-done {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+}
+
+.dp-makenote-done {
+  color: var(--accent);
+}
+
+.dp-makenote-error {
+  flex-basis: 100%;
+  color: var(--live);
+  font-size: 0.8125rem;
+}
+
 @keyframes dp-fade {
   from {
     opacity: 0;

--- a/src/app/features/brain/document-preview/document-preview.component.ts
+++ b/src/app/features/brain/document-preview/document-preview.component.ts
@@ -13,7 +13,7 @@ import {
   viewChild,
 } from "@angular/core";
 import { IpcService } from "../../../core/ipc.service";
-import type { DocumentPreviewTarget } from "../../../core/models";
+import type { DocumentPreviewTarget, NoteRecipe } from "../../../core/models";
 import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
 
 /**
@@ -71,12 +71,26 @@ export class DocumentPreviewComponent {
   // BrainNoteEditorComponent modal's `dismiss` convention.
   readonly dismiss = output<void>();
 
+  /**
+   * Emits the NEW note id after "Make a note from this" succeeds (the smart-note
+   * engine). Optional to bind — a parent that ignores it still works; a parent
+   * that binds it can navigate to / open the generated note.
+   */
+  readonly noteCreated = output<string>();
+
   /** The fetched clean text ("" when sealed-masked or genuinely empty). */
   protected readonly content = signal<string>("");
   /** True while `getDocument` is in flight. */
   protected readonly loading = signal(false);
   /** A read failure (e.g. transient IPC error) — distinct from locked/empty. */
   protected readonly error = signal<string | null>(null);
+
+  /** True while `generateNoteFromDocument` is in flight (the "Make a note" action). */
+  protected readonly generating = signal(false);
+  /** A generation failure message (locked / no-consent / no-text), or null. */
+  protected readonly genError = signal<string | null>(null);
+  /** True once a note was successfully generated from this document. */
+  protected readonly genCreated = signal(false);
 
   private readonly closeBtn =
     viewChild<ElementRef<HTMLButtonElement>>("closeBtn");
@@ -136,6 +150,23 @@ export class DocumentPreviewComponent {
     () => !this.loading() && !this.error() && this.content().length === 0,
   );
 
+  /**
+   * Show the "Make a note from this" entry point only for a SOURCE document
+   * (`kind: "document"` — never an existing note) whose content actually loaded
+   * (not while loading / errored / locked-masked). A locked doc has no readable
+   * text and the backend would refuse generation anyway.
+   */
+  protected readonly canMakeNote = computed<boolean>(() => {
+    const d = this.doc();
+    return (
+      !!d &&
+      d.kind !== "note" &&
+      !this.loading() &&
+      !this.error() &&
+      !this.masked()
+    );
+  });
+
   constructor() {
     // Focus the close button when the modal OPENS. This host is now MOUNTED ONCE
     // in the app shell (globally reachable) with `doc` toggled null↔target — so
@@ -160,6 +191,11 @@ export class DocumentPreviewComponent {
     // effect genuinely orchestrates an async IPC fetch, the sanctioned case.
     effect(() => {
       const d = this.doc();
+      // Reset the "Make a note" state on every open / target change so a prior
+      // success or error never bleeds into a different document.
+      this.generating.set(false);
+      this.genError.set(null);
+      this.genCreated.set(false);
       if (!d) {
         this.content.set("");
         this.loading.set(false);
@@ -172,6 +208,53 @@ export class DocumentPreviewComponent {
       this.content.set("");
       void this.fetch(id);
     });
+  }
+
+  /**
+   * Generate a formatted note from THIS document via the smart-note engine, then
+   * emit its new id. Stale-guarded on the doc id (the user may close/switch mid-
+   * flight). A locked / no-consent / no-text failure surfaces inline; the source
+   * document is never modified.
+   */
+  protected async makeNote(recipe: NoteRecipe): Promise<void> {
+    const d = this.doc();
+    if (!d || this.generating()) {
+      return;
+    }
+    const id = d.id;
+    this.generating.set(true);
+    this.genError.set(null);
+    try {
+      const noteId = await this.ipc.generateNoteFromDocument(id, recipe);
+      if (this.doc()?.id !== id) {
+        return; // the user moved on — drop the late result.
+      }
+      this.genCreated.set(true);
+      this.noteCreated.emit(noteId);
+    } catch (e) {
+      if (this.doc()?.id !== id) {
+        return;
+      }
+      this.genError.set(this.friendlyGenError(String(e)));
+    } finally {
+      if (this.doc()?.id === id) {
+        this.generating.set(false);
+      }
+    }
+  }
+
+  /** Map a raw backend error string to a short, friendly message. */
+  private friendlyGenError(raw: string): string {
+    if (/locked/i.test(raw)) {
+      return "This document is in a locked folder — unlock it first.";
+    }
+    if (/consent|egress|Unavailable/i.test(raw)) {
+      return "Turn on your note provider (Settings) to make a note.";
+    }
+    if (/no extractable text|InvalidArg/i.test(raw)) {
+      return "This document has no text to turn into a note.";
+    }
+    return "Couldn’t make a note from this document. Please try again.";
   }
 
   /** Await the gated read; drop the response if the open doc changed since. */


### PR DESCRIPTION
## Smart-note engine (T3, flagship) — doc/photo → structured Obsidian note

Turns an already-ingested `documents` row (whiteboard photo, screenshot, slide deck, form, PDF) into a readable `kind='note'` Obsidian note. Ingest already extracts flat text on-device (`extract::extract_blocks` → `documents.text`); until now that text was retrieval-only and never became a note.

### What landed
- New `generate_note_from_document(document_id, recipe)` Tauri command (registered in `lib.rs`), in two selectable recipe shapes:
  - **synthesis** (flagship, for content with no inherent schema) — `provider.complete()` over one fixed anti-slop template (summary → outline → action items with owners/dates), modelled on the `dossier.rs` multi-section shape → markdown.
  - **structure-mirror** (for forms/tables) — `provider.complete_json()` into a generic `{fields, tables, sections}` schema where **every value is an opaque string**, then a **deterministic Rust JSON→markdown renderer**.
- Note is written as a gated `kind='note'` `documents` row → `.md` (front-matter + `[[wikilinks]]`) through the existing gated writers, linked to the current/last meeting; a source image attachment is re-embedded read-only via the existing attachments seam.
- One typed FE IPC method (`ipc.service.ts` `generateNoteFromDocument` + a `models.ts` type) and a minimal **"Make a note from this"** entry point on the existing `document-preview` component.

### Hard constraints honored
- **§10 (no money/arithmetic):** an invoice's structure is transpiled as opaque strings only — no numeric/amount types, no summing/totalling. Prompts explicitly forbid re-computing; amounts are copied verbatim.
- **No cloud vision:** only redacted **text** egresses, through the existing `provider_for(Role::Notes)` → `RedactingProvider` firewall (already consent-gated + ledgered). No multimodal/image-bytes egress added.
- **Write-gate:** the target folder is refused with `AppError::Locked` when sealed-and-not-unlocked, exactly like `import_document`; all reads/writes route through the existing unlock gates; no new seal primitive (birth/body-write/attachment re-embed all reuse the verify-before-destroy helpers).
- **No new crates.**

### Verification — full `/harness` run (claude → claude, `--allow-same-vendor-high-risk`)
- Risk flags: `lock, egress, runtime, ui`. Same-vendor reviewer kept by explicit flag (fresh independent Claude session per review).
- Checks green: `rust-lib` (`cargo test --lib`, incl. new RED-before-GREEN regressions for both recipes + sealed-folder refusal), `tauri-boot`, `playwright`.
- Reviews **PASS**: spec, adversarial, lock-security, egress-security.
- Hash-bound PASS attestation on the committed tree.

### Honest bar
OCR fidelity on real whiteboards and on-device model note quality can only be judged on a **signed Mac with real documents** — this PR verifies the plumbing (gating, redaction path, deterministic renderer, RED-before-GREEN tests), not real-world note quality.
