### PR TITLE
fix(dossier): attribute open commitments to the owner only, not co-participants

### DIFF
--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -2703,16 +2703,19 @@
         let state = build_state("person-dossier");
         let db = &state.db;
         make_open_folder(db, "f-lock", "Locked");
+        // B4: the commitment filter is OWNER-ONLY, so this GATING test's fixture commitments must be
+        // OWNED BY Atlas (the entity under test) to surface at all — the test exercises the visibility
+        // gate (sealed source hidden → revealed on unlock), not the mention-vs-owner predicate.
         seed_meeting(
             db,
             "open1",
-            "## Action items\n- [ ] Anna — draft Atlas spec 2026-07-01\n",
+            "## Action items\n- [ ] Atlas — draft Atlas spec 2026-07-01\n",
             None,
         );
         seed_meeting(
             db,
             "sealedX",
-            "LOCKED Atlas price\n## Action items\n- [ ] Carol — sign 2026-07-09\n",
+            "LOCKED Atlas price\n## Action items\n- [ ] Atlas — sign the deal 2026-07-09\n",
             Some("f-lock"),
         );
         let atlas = db
@@ -2775,10 +2778,12 @@
     fn get_person_dossier_dto_omits_corpus_and_is_camelcase() {
         let state = build_state("person-dossier-dto");
         let db = &state.db;
+        // B4 owner-only: the fixture commitment must be OWNED BY Atlas to appear (and thus serialize)
+        // — this test locks the DTO camelCase/omit-corpus contract, not the mention-vs-owner filter.
         seed_meeting(
             db,
             "m-open",
-            "## Action items\n- [ ] Anna — draft Atlas spec 2026-07-01\n",
+            "## Action items\n- [ ] Atlas — draft Atlas spec 2026-07-01\n",
             None,
         );
         let atlas = db

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -6060,10 +6060,11 @@ impl Db {
     ///
     /// `open_commitment_count` MUST use the exact same predicate as the person-dossier's "who owes
     /// what" section (`summarize::dossier::build_dossier_data`) — an open item belongs to this
-    /// person iff it's from one of their VISIBLE mentioning meetings OR its owner name-matches —
-    /// otherwise the card badge and the dossier opened from that same card can disagree (a person
-    /// mentioned in a meeting with an open, unowned/differently-owned action item was undercounted
-    /// here while the dossier counted it).
+    /// person iff its owner name-matches this person (case-insensitive) — otherwise the card badge
+    /// and the dossier opened from that same card can disagree. B4 fix (2026-07-25): the predicate
+    /// was narrowed from "VISIBLE mentioning meeting OR owner-name match" to owner-only, so a
+    /// co-participant's commitment sharing a mentioning meeting is no longer falsely attributed to
+    /// this person (badge == dossier count still holds — both are now owner-only).
     ///
     /// Returns [`PeopleList`], not a bare `Vec`, because the candidate set is itself capped
     /// UPSTREAM by `list_entities_visible`'s `MAX_VISIBLE_ENTITIES` (500, ordered by mention
@@ -6080,8 +6081,7 @@ impl Db {
             .filter(|n| n.kind == EntityKind::Person)
             .collect();
         // The full VISIBLE open-commitment rollup, computed ONCE and reused per person below —
-        // mirrors `build_dossier_data`'s corpus (mention-id match OR owner-name match), NOT a
-        // narrower owner-only bucket.
+        // mirrors `build_dossier_data`'s "who owes what" (owner-name match only).
         let all_commitments = self.list_open_commitments(unlocked, None)?;
         let mut out: Vec<PersonCard> = Vec::with_capacity(people.len());
         for p in people {
@@ -6092,18 +6092,16 @@ impl Db {
             // current_fact_count: currently-valid facts about this person from VISIBLE meetings.
             let current_fact_count = self.list_facts_visible(&p.id, unlocked)?.len() as i64;
             // open_commitment_count: same predicate as the dossier's "who owes what" — an open item
-            // from one of this person's mentioning meetings, OR owned by this person (name match).
-            let mention_ids: std::collections::HashSet<&str> =
-                mentions.iter().map(|m| m.meeting_id.as_str()).collect();
+            // OWNED BY this person (name match, case-insensitive). B4 fix (2026-07-25): owner-only,
+            // so a co-participant's commitment from a shared mentioning meeting is not attributed here.
             let name_lc = p.name.trim().to_lowercase();
             let open_commitment_count = all_commitments
                 .iter()
                 .filter(|c| {
-                    mention_ids.contains(c.meeting_id.as_str())
-                        || c.owner
-                            .as_deref()
-                            .map(|o| o.trim().to_lowercase() == name_lc)
-                            .unwrap_or(false)
+                    c.owner
+                        .as_deref()
+                        .map(|o| o.trim().to_lowercase() == name_lc)
+                        .unwrap_or(false)
                 })
                 .count() as i64;
             out.push(PersonCard {

--- a/src-tauri/src/storage/db_tests/graph_tests.rs
+++ b/src-tauri/src/storage/db_tests/graph_tests.rs
@@ -1004,43 +1004,69 @@ fn list_people_excludes_sealed_person_and_counts_visible_only() {
 
 /// The People card's `open_commitment_count` badge MUST agree with the count backing the same
 /// person's dossier "who owes what" section one click away
-/// (`summarize::dossier::build_dossier_data`), which counts an open item as this person's iff
-/// it's from one of their mentioning meetings OR owner-name-matches — NOT owner-name-match
-/// alone. RED-before-GREEN: a narrower owner-only bucket undercounts a person mentioned in a
-/// meeting with an open, unowned action item, so the card badge (0) disagrees with the dossier
-/// (1) for the exact same person.
+/// (`summarize::dossier::build_dossier_data`). B4 fix (2026-07-25): the shared predicate is now
+/// OWNER-ONLY — an open item is this person's iff its owner name-matches. This asserts, via BOTH
+/// `list_people`'s badge AND `build_dossier_data`'s commitments, that badge == dossier count for
+/// two cases: (a) a person who OWNS an open commitment → 1 in both (they AGREE); (b) a person
+/// merely MENTIONED in a meeting whose open commitment is owned by SOMEONE ELSE → 0 in both (they
+/// AGREE). The badge==dossier invariant is the point; only the predicate (now owner-only) changed.
 #[test]
-fn list_people_open_commitment_count_matches_dossier_mention_or_owner_filter() {
+fn list_people_open_commitment_count_matches_dossier_owner_filter() {
     let db = file_db("people-dossier-parity");
+    // ONE meeting mentions BOTH people; its single open commitment is OWNED BY Priya. Sam is a
+    // co-participant (mentioned) but owns nothing — under owner-only, Sam's item from this shared
+    // meeting must NOT be attributed to Sam.
     seed_note(
         &db,
         "m1",
-        "## Action items\n- [ ] Follow up on pricing 2026-08-01\n",
+        "## Action items\n- [ ] Priya — ship the pricing page 2026-08-01\n",
         None,
     );
     let priya = db.upsert_entity("Priya", EntityKind::Person).unwrap();
+    let sam = db.upsert_entity("Sam", EntityKind::Person).unwrap();
     db.add_mention(&priya, "m1").unwrap();
+    db.add_mention(&sam, "m1").unwrap();
 
     let empty: HashSet<String> = HashSet::new();
     let cards = db.list_people(&empty).unwrap().people;
+
+    // (a) Priya OWNS the commitment → badge 1, dossier 1, they agree.
     let priya_card = cards
         .iter()
         .find(|p| p.id == priya)
         .expect("Priya is visible via her mention");
     assert_eq!(
         priya_card.open_commitment_count, 1,
-        "the card badge must count the open, unowned action item from Priya's mentioned \
-             meeting, same as the dossier's 'who owes what' section"
+        "the card badge must count the open commitment OWNED BY Priya"
     );
-
-    let dossier = crate::summarize::dossier::build_dossier_data(&db, &priya, &empty)
+    let priya_dossier = crate::summarize::dossier::build_dossier_data(&db, &priya, &empty)
         .unwrap()
         .expect("Priya has a visible dossier");
     assert_eq!(
-        dossier.commitments.len() as i64,
+        priya_dossier.commitments.len() as i64,
         priya_card.open_commitment_count,
         "the People card badge and the dossier 'who owes what' count must never disagree \
-             for the same person"
+             for the owning person"
+    );
+
+    // (b) Sam is only MENTIONED; the commitment is owned by someone else → badge 0, dossier 0.
+    let sam_card = cards
+        .iter()
+        .find(|p| p.id == sam)
+        .expect("Sam is visible via his mention");
+    assert_eq!(
+        sam_card.open_commitment_count, 0,
+        "a co-participant's commitment from a shared mentioning meeting must NOT be attributed \
+             to Sam — owner-only"
+    );
+    let sam_dossier = crate::summarize::dossier::build_dossier_data(&db, &sam, &empty)
+        .unwrap()
+        .expect("Sam has a visible dossier");
+    assert_eq!(
+        sam_dossier.commitments.len() as i64,
+        sam_card.open_commitment_count,
+        "the People card badge and the dossier 'who owes what' count must never disagree \
+             for the merely-mentioned person"
     );
 }
 

--- a/src-tauri/src/summarize/dossier.rs
+++ b/src-tauri/src/summarize/dossier.rs
@@ -51,8 +51,9 @@ pub struct DossierData {
     pub entity: GraphEntity,
     /// Visible meetings mentioning this entity (newest first), as `[[Title]]` citation chips.
     pub meetings: Vec<VaultSource>,
-    /// Open commitments tied to this entity: an OPEN item from one of the entity's visible
-    /// mentioning meetings, OR an OPEN item whose owner matches the entity name.
+    /// Open commitments OWNED BY this entity: an OPEN item whose owner name-matches the entity
+    /// (case-insensitive). B4 fix — owner-only, so a co-participant's commitment from a shared
+    /// mentioning meeting is never falsely attributed here.
     pub commitments: Vec<Commitment>,
     /// Top co-occurring neighbour entities (shared visible meetings).
     pub neighbors: Vec<EntityNeighbor>,
@@ -136,21 +137,22 @@ pub fn build_dossier_data(
     // here: a sealed-not-unlocked meeting's facts (its source meeting) never surface.
     let facts = db.list_facts_visible(entity_id, unlocked)?;
 
-    // The visible meetings that mention this entity, as an id set for the commitment filter.
-    let mention_ids: HashSet<&str> = meetings.iter().map(|m| m.meeting_id.as_str()).collect();
     let name_lc = entity.name.trim().to_lowercase();
     // `list_open_commitments` is itself double-gated (list_meetings_visible + get_note_if_visible),
-    // so every candidate already comes from a visible meeting. Keep an item iff it belongs to one
-    // of this entity's mentioning meetings OR is owned by this entity (name match, case-insensitive).
+    // so every candidate already comes from a visible meeting. Keep an item iff it is OWNED BY this
+    // entity (name match, case-insensitive). B4 fix (2026-07-25): the former "belongs to one of this
+    // entity's mentioning meetings OR owned" predicate FALSELY attributed a co-participant's
+    // commitment to the entity merely because it shared a mentioning meeting (e.g. "Jakub — fix your
+    // branch" surfacing under Klaudia). Owner-only never widens what is shown; the visibility gate is
+    // unchanged. This predicate MUST stay identical to `Db::list_people`'s `open_commitment_count`.
     let commitments: Vec<Commitment> = db
         .list_open_commitments(unlocked, None)?
         .into_iter()
         .filter(|c| {
-            mention_ids.contains(c.meeting_id.as_str())
-                || c.owner
-                    .as_deref()
-                    .map(|o| o.trim().to_lowercase() == name_lc)
-                    .unwrap_or(false)
+            c.owner
+                .as_deref()
+                .map(|o| o.trim().to_lowercase() == name_lc)
+                .unwrap_or(false)
         })
         .collect();
 
@@ -389,14 +391,17 @@ mod tests {
 
     /// build_dossier_data assembles the entity's VISIBLE mentioning meetings (with [[Title]] cites
     /// in the corpus), its open commitments, and its neighbours — and EXCLUDES a sealed-not-unlocked
-    /// mentioning meeting, which reappears once the folder is session-unlocked. The owner/entity
-    /// commitment filter works.
+    /// mentioning meeting, which reappears once the folder is session-unlocked. B4 fix: the
+    /// commitment filter is OWNER-ONLY — an item owned by a co-participant (Anna) in one of the
+    /// entity's mentioning meetings is NOT attributed to the entity (Atlas); only an item Atlas OWNS
+    /// surfaces.
     #[test]
     fn build_dossier_gates_sealed_and_filters_commitments() {
         let db = temp_db();
         // Atlas (the dossier subject) + Anna co-occur in an OPEN meeting; Atlas is also mentioned
         // in a SEALED meeting. A commitment owned by "Atlas" lives in a third (open) meeting that
-        // does NOT mention Atlas as an entity — caught only by the owner filter.
+        // does NOT mention Atlas as an entity — caught only by the owner filter. Anna's item in
+        // open1 shares Atlas's mentioning meeting but is OWNED BY Anna → excluded under owner-only.
         seed_meeting(
             &db,
             "open1",
@@ -405,11 +410,13 @@ mod tests {
             None,
         );
         seed_folder(&db, "f-lock");
+        // The sealed meeting holds a commitment OWNED BY Atlas — gated out while sealed, and it
+        // must reappear (owner match) once the folder is session-unlocked.
         seed_meeting(
             &db,
             "sealedX",
             "Secret Atlas Review",
-            "LOCKED Atlas acquisition price\n## Action items\n- [ ] Carol — sign 2026-07-09\n",
+            "LOCKED Atlas acquisition price\n## Action items\n- [ ] Atlas — sign the deal 2026-07-09\n",
             Some("f-lock"),
         );
         seed_meeting(
@@ -451,17 +458,22 @@ mod tests {
             "sealed note body leaked into the dossier corpus (gate violation)"
         );
 
-        // Commitment filter: 'draft Atlas spec' is in a mentioning meeting (open1);
-        // 'own the rollout' is owner==Atlas (owner filter). Carol's sealed item is excluded.
-        assert!(data
-            .commitments
-            .iter()
-            .any(|c| c.text.contains("draft Atlas spec")));
+        // Commitment filter (OWNER-ONLY, B4): 'own the rollout' is owner==Atlas → included.
+        // 'draft Atlas spec' is owned by Anna (a co-participant) though it lives in Atlas's
+        // mentioning meeting → EXCLUDED (mention-only no longer attributes). The sealed 'sign the
+        // deal' item (owner==Atlas) is gated out while sealed, and reappears on unlock (below).
         assert!(
             data.commitments
                 .iter()
                 .any(|c| c.text.contains("own the rollout")),
             "owner==entity-name commitment must be included"
+        );
+        assert!(
+            data.commitments
+                .iter()
+                .all(|c| !c.text.contains("draft Atlas spec")),
+            "a co-participant's (Anna's) commitment from a shared mentioning meeting must NOT be \
+             attributed to Atlas (owner-only, B4)"
         );
         assert!(
             data.commitments.iter().all(|c| !c.text.contains("sign")),
@@ -486,7 +498,65 @@ mod tests {
             data2.corpus.contains("LOCKED Atlas acquisition"),
             "unlocked content must reappear"
         );
-        assert!(data2.commitments.iter().any(|c| c.text.contains("sign")));
+        // The sealed meeting's Atlas-OWNED commitment reappears on unlock (owner match survives).
+        assert!(
+            data2.commitments.iter().any(|c| c.text.contains("sign the deal")),
+            "the unlocked Atlas-owned commitment must reappear"
+        );
+    }
+
+    /// B4 (2026-07-25) RED-before-GREEN: the dossier's OPEN COMMITMENTS must attribute an item ONLY
+    /// to its OWNER, never to a co-participant merely because the item shares one of the entity's
+    /// mentioning meetings. Live QA repro: `get_entity_dossier("Klaudia")` listed "Jakub — fix your
+    /// branch…" under Klaudia merely because the meeting mentions Klaudia. This test FAILS on the
+    /// old `mention_ids.contains(...) || owner==name` predicate and PASSES on owner-only.
+    #[test]
+    fn dossier_open_commitments_are_owner_only_not_mention_attributed() {
+        let db = temp_db();
+        // ONE meeting mentions Klaudia; its open commitment is OWNED BY Jakub. Klaudia also owns a
+        // commitment of her own in a second mentioning meeting.
+        seed_meeting(
+            &db,
+            "m-standup",
+            "Standup",
+            "## Action items\n- [ ] Jakub — fix your branch 2026-07-30\n",
+            None,
+        );
+        seed_meeting(
+            &db,
+            "m-review",
+            "Review",
+            "## Action items\n- [ ] Klaudia — send the design doc 2026-07-31\n",
+            None,
+        );
+        let klaudia = db
+            .upsert_entity("Klaudia", crate::storage::models::EntityKind::Person)
+            .unwrap();
+        // Klaudia is MENTIONED in BOTH meetings (co-participant in the standup).
+        db.add_mention(&klaudia, "m-standup").unwrap();
+        db.add_mention(&klaudia, "m-review").unwrap();
+
+        let nothing = HashSet::new();
+        let data = build_dossier_data(&db, &klaudia, &nothing).unwrap().unwrap();
+
+        assert!(
+            data.commitments
+                .iter()
+                .all(|c| !c.text.contains("fix your branch")),
+            "Jakub's commitment must NOT be attributed to Klaudia just because it shares her \
+             mentioning meeting (B4 mis-attribution)"
+        );
+        assert!(
+            data.commitments
+                .iter()
+                .any(|c| c.text.contains("send the design doc")),
+            "Klaudia's own (owner-matched) commitment must still appear"
+        );
+
+        // Belt-and-suspenders: the rendered OPEN COMMITMENTS section leaks neither the foreign item.
+        let rendered = render_structured(&data);
+        assert!(!rendered.contains("fix your branch"));
+        assert!(rendered.contains("send the design doc"));
     }
 
     /// brain2 R2 — the dossier surfaces the entity's CURRENT FACTS (open) + WHAT CHANGED (closed),


### PR DESCRIPTION
## B4 — dossier open-commitments falsely attributed co-participants' tasks

From a live QA session: `get_entity_dossier("Klaudia")` listed **"Jakub — fix your branch…"** under *Klaudia's* OPEN COMMITMENTS, purely because that item came from a meeting that mentions Klaudia. An agent reading the dossier would assign Jakub's task to Klaudia.

**Root cause:** the commitment predicate kept an item if it was *from one of the entity's mentioning meetings* **OR** *owned by the entity*. The mention leg attributes other people's commitments to the entity.

**Fix (decision: owner-only):** narrowed the predicate to **owner-name match only**. Critically, this predicate is duplicated by design in **two** coupled sites — bound by a doc-comment contract and a test that enforces *"the People-card badge and the dossier count must never disagree."* Both were changed identically:
- `summarize::dossier::build_dossier_data` (powers the MCP `get_entity_dossier` and the `get_person_dossier` command)
- `Db::list_people`'s `open_commitment_count` (the People-card badge)

The badge==dossier invariant is preserved (both are now owner-only). This is strict **display-narrowing** over already-visibility-gated data — no lock/visibility gate is touched.

## Tests

- The existing `build_dossier_gates_sealed_and_filters_commitments` was **strengthened**: it now asserts a co-participant's commitment (owned by Anna, in Atlas's mentioning meeting) is **excluded** from Atlas's dossier, while Atlas's owned commitment is included — the RED-before-GREEN for B4.
- The badge/dossier-parity test (`graph_tests`) updated to assert owner-only for both surfaces (a mentioned-but-not-owner person → 0 in both; an owner → 1 in both — they still agree).
- The two `get_person_dossier` lifecycle tests (gating + DTO serialization) adapted to use an owned commitment so they still exercise a present commitment under owner-only.
- `cargo test --lib` green; independent spec/adversarial/lock-security/egress-security reviews all PASS; hash-bound attestation.

Part of the MCP-tools QA remediation series (follows #453).
