### PR TITLE
fix(facts): pin fact extraction to the note language + guard same-instant self-supersession

### DIFF
--- a/src-tauri/src/brain_reactions.rs
+++ b/src-tauri/src/brain_reactions.rs
@@ -103,13 +103,15 @@ pub fn detect_reactions(
     unlocked: &HashSet<String>,
     entities: &[(String, String)],
     window: &str,
+    note_language: &str,
     at: &str,
 ) -> Vec<WhisperCard> {
     if entities.is_empty() || window.trim().is_empty() {
         return Vec::new();
     }
-    // Stage 1 — light LLM extraction of the window into candidates (capped decode).
-    let candidates = extract_fact_candidates_capped(reasoner, window, entities);
+    // Stage 1 — light LLM extraction of the window into candidates (capped decode). The extractor is
+    // language-pinned like the persisted path (facts.rs) so a Polish window can't emit a PL+EN twin.
+    let candidates = extract_fact_candidates_capped(reasoner, window, entities, note_language);
     if candidates.is_empty() {
         return Vec::new();
     }
@@ -136,6 +138,7 @@ fn extract_fact_candidates_capped(
     reasoner: &dyn LocalReasoner,
     window: &str,
     entities: &[(String, String)],
+    note_language: &str,
 ) -> Vec<FactCandidate> {
     // The title is unused for a live window; pass a short marker. The cap rides GenOptions through the
     // extractor's structured_with call (see facts.rs).
@@ -144,6 +147,7 @@ fn extract_fact_candidates_capped(
         "live",
         window,
         entities,
+        note_language,
         GenOptions::light_extraction(),
     )
 }
@@ -218,8 +222,12 @@ pub fn reactions_scan(
         tracing::debug!(target: "reactions", "user turn in flight; deferring scan");
         return empty;
     }
-    let (brain_live, emit) = match st.config.lock() {
-        Ok(c) => (c.brain_live, c.brain_contradiction_cards),
+    let (brain_live, emit, note_language) = match st.config.lock() {
+        Ok(c) => (
+            c.brain_live,
+            c.brain_contradiction_cards,
+            c.note_language.clone(),
+        ),
         Err(_) => return empty,
     };
     if !brain_live {
@@ -255,7 +263,15 @@ pub fn reactions_scan(
         };
     }
     let entities = filter_window_entities(entities, &window);
-    let cards = detect_reactions(&*reasoner, &st.db, &unlocked, &entities, &window, now);
+    let cards = detect_reactions(
+        &*reasoner,
+        &st.db,
+        &unlocked,
+        &entities,
+        &window,
+        &note_language,
+        now,
+    );
     // SESSION dedup (deep-review): a contradiction surfaces at most ONCE per recording — else the same
     // card re-emits every ~21 s scan and (in shadow mode) re-inflates the calibration count. Keyed on
     // (entity | predicate | old-value); `HashSet::insert` returns true only for a NOT-yet-seen key.

--- a/src-tauri/src/commands/facts.rs
+++ b/src-tauri/src/commands/facts.rs
@@ -122,12 +122,21 @@ pub(crate) fn persist_facts_for_meeting(
             .extraction_reasoner_for_recording(token.clone()),
         None => state.reasoner.extraction_reasoner(),
     };
+    // Pin the extractor's OUTPUT language to the note-language config knob (default "auto") so a
+    // Polish-dominant note can't emit the same fact in two languages. Fail-safe like
+    // `user_memory_enabled`: a poisoned config mutex falls back to "auto".
+    let note_language = state
+        .config
+        .lock()
+        .map(|c| c.note_language.clone())
+        .unwrap_or_else(|_| "auto".to_string());
     let candidates = crate::facts::extract_fact_candidates(
         // Brain Live ON ⇒ the LOCAL light engine (facts stop egressing); OFF ⇒ today's Notes reasoner.
         reasoner.as_ref(),
         title,
         markdown,
         entity_refs,
+        &note_language,
         // Post-call extraction over the full note: no tight cap (the realtime path uses a capped preset).
         crate::reason::GenOptions::default(),
     );
@@ -282,6 +291,13 @@ pub(crate) fn persist_user_facts_for_meeting(
             .extraction_reasoner_for_recording(token.clone()),
         None => state.reasoner.extraction_reasoner(),
     };
+    // Pin the extractor's output language (default "auto") — same fail-safe as `user_memory_enabled`
+    // — so a Polish-dominant note can't duplicate a "me" fact as a PL+EN twin.
+    let note_language = state
+        .config
+        .lock()
+        .map(|c| c.note_language.clone())
+        .unwrap_or_else(|_| "auto".to_string());
     let candidates = crate::user_memory::extract_user_fact_candidates(
         // Brain Live ON ⇒ the LOCAL light engine (user facts stop egressing); OFF ⇒ today's reasoner.
         reasoner.as_ref(),
@@ -289,6 +305,7 @@ pub(crate) fn persist_user_facts_for_meeting(
         markdown,
         &typed_notes,
         &thread_turns,
+        &note_language,
     );
     if candidates.is_empty() {
         return Ok(()); // nothing to reconcile — common in the default (no-model) build.

--- a/src-tauri/src/facts.rs
+++ b/src-tauri/src/facts.rs
@@ -118,13 +118,17 @@ pub(crate) fn norm(s: &str) -> String {
 /// junk). Closed (`valid_to.is_some()`) existing facts are ignored — only open facts are matchable.
 pub fn reconcile_facts(existing: &[Fact], candidates: &[FactCandidate], at: &str) -> Vec<FactOp> {
     use std::collections::HashMap;
+    // (entity_id, norm(subject), norm(predicate)) — the identity key used throughout reconciliation.
+    type FactKey = (String, String, String);
+    // (open-row id if from an existing row, normalized object, valid_from) — an open fact's working
+    // state; factored into a `type` so the `open` map stays under clippy::type_complexity.
+    type OpenFactState = (Option<String>, String, String);
     // key -> (id-of-open-row-if-from-existing, normalized current object, its valid_from). `None` id
     // means the open fact was created earlier IN THIS BATCH (no row id yet) and so cannot be
     // Invalidated. The valid_from is carried so the DIFFERENT-object arm can refuse a supersession
     // that would not STRICTLY post-date the open fact (a zero/negative-duration closed row = false
     // history — e.g. a PL→EN self-flip on the SAME meeting instant).
-    let mut open: HashMap<(String, String, String), (Option<String>, String, String)> =
-        HashMap::new();
+    let mut open: HashMap<FactKey, OpenFactState> = HashMap::new();
     for f in existing {
         if f.valid_to.is_some() {
             continue; // only OPEN facts are matchable.
@@ -140,8 +144,8 @@ pub fn reconcile_facts(existing: &[Fact], candidates: &[FactCandidate], at: &str
     // two conflicting "current" values for the same (entity, subject, predicate) — without this, two
     // same-key candidates each emitted an Add and produced two simultaneously-open ("current") facts.
     // First-seen key order is preserved so the op output stays deterministic.
-    let mut last_by_key: HashMap<(String, String, String), &FactCandidate> = HashMap::new();
-    let mut order: Vec<(String, String, String)> = Vec::new();
+    let mut last_by_key: HashMap<FactKey, &FactCandidate> = HashMap::new();
+    let mut order: Vec<FactKey> = Vec::new();
     for c in candidates {
         let entity_id = c.entity_id.trim();
         let subject = c.subject.trim();

--- a/src-tauri/src/facts.rs
+++ b/src-tauri/src/facts.rs
@@ -103,9 +103,13 @@ pub(crate) fn norm(s: &str) -> String {
 /// `(entity_id, norm(subject), norm(predicate))` and `valid_to IS NULL`:
 ///   * **no match** → [`FactOp::Add`] (valid_from = recorded_at = `at`, open),
 ///   * **match, SAME object** → [`FactOp::NoOp`],
-///   * **match, DIFFERENT object** → [`FactOp::Invalidate`] the old (valid_to = `at`) **and**
-///     [`FactOp::Add`] the new (valid_from = `at`, open) — the old fact STAYS, closed, so history
-///     is preserved.
+///   * **match, DIFFERENT object, and the open fact's `valid_from` STRICTLY precedes `at`** →
+///     [`FactOp::Invalidate`] the old (valid_to = `at`) **and** [`FactOp::Add`] the new
+///     (valid_from = `at`, open) — the old fact STAYS, closed, so history is preserved,
+///   * **match, DIFFERENT object, but the open fact's `valid_from` is NOT before `at`** (same-instant
+///     re-processing of one meeting — e.g. a PL→EN translation of the same fact on the meeting's
+///     stable `started_at`, or an out-of-order earlier candidate) → [`FactOp::NoOp`]: superseding
+///     here would mint a zero/negative-duration closed row = false bitemporal history.
 ///
 /// Determinism + within-batch safety: a working view of the currently-open object per key is
 /// threaded through the candidate loop, starting from `existing` and updated as ops are emitted, so
@@ -114,15 +118,22 @@ pub(crate) fn norm(s: &str) -> String {
 /// junk). Closed (`valid_to.is_some()`) existing facts are ignored — only open facts are matchable.
 pub fn reconcile_facts(existing: &[Fact], candidates: &[FactCandidate], at: &str) -> Vec<FactOp> {
     use std::collections::HashMap;
-    // key -> (id-of-open-row-if-from-existing, normalized current object). `None` id means the open
-    // fact was created earlier IN THIS BATCH (no row id yet) and so cannot be Invalidated.
-    let mut open: HashMap<(String, String, String), (Option<String>, String)> = HashMap::new();
+    // key -> (id-of-open-row-if-from-existing, normalized current object, its valid_from). `None` id
+    // means the open fact was created earlier IN THIS BATCH (no row id yet) and so cannot be
+    // Invalidated. The valid_from is carried so the DIFFERENT-object arm can refuse a supersession
+    // that would not STRICTLY post-date the open fact (a zero/negative-duration closed row = false
+    // history — e.g. a PL→EN self-flip on the SAME meeting instant).
+    let mut open: HashMap<(String, String, String), (Option<String>, String, String)> =
+        HashMap::new();
     for f in existing {
         if f.valid_to.is_some() {
             continue; // only OPEN facts are matchable.
         }
         let key = (f.entity_id.clone(), norm(&f.subject), norm(&f.predicate));
-        open.insert(key, (Some(f.id.clone()), norm(&f.object)));
+        open.insert(
+            key,
+            (Some(f.id.clone()), norm(&f.object), f.valid_from.clone()),
+        );
     }
 
     // Dedup candidates within THIS batch by key, LAST mention wins: a single note must not assert
@@ -165,15 +176,24 @@ pub fn reconcile_facts(existing: &[Fact], candidates: &[FactCandidate], at: &str
         };
         match open.get(key).cloned() {
             None => ops.push(FactOp::Add(mk_new())),
-            Some((_, prev_obj)) if prev_obj == nobj => ops.push(FactOp::NoOp),
-            Some((maybe_id, _)) => {
-                if let Some(id) = maybe_id {
-                    ops.push(FactOp::Invalidate {
-                        id,
-                        valid_to: at.to_string(),
-                    });
+            Some((_, prev_obj, _)) if prev_obj == nobj => ops.push(FactOp::NoOp),
+            Some((maybe_id, _, existing_vf)) => {
+                // A fact can only be superseded by a LATER one. If the open fact's valid_from is not
+                // STRICTLY before `at` (same-instant re-processing of ONE meeting → a PL→EN self-flip
+                // on the meeting's stable started_at, or an out-of-order earlier candidate), an
+                // Invalidate+Add would mint a zero/negative-duration closed row = false bitemporal
+                // history. Keep the already-open fact (NoOp). Forward-only: stored rows untouched.
+                if cmp_instant(&existing_vf, at) == std::cmp::Ordering::Less {
+                    if let Some(id) = maybe_id {
+                        ops.push(FactOp::Invalidate {
+                            id,
+                            valid_to: at.to_string(),
+                        });
+                    }
+                    ops.push(FactOp::Add(mk_new()));
+                } else {
+                    ops.push(FactOp::NoOp);
                 }
-                ops.push(FactOp::Add(mk_new()));
             }
         }
     }
@@ -518,6 +538,32 @@ note, as entity·predicate·object triples. Output STRICT JSON ONLY (no prose, n
 - Only durable state worth tracking across meetings — not one-off remarks. Empty array if none.\n\
 Output ONLY the JSON.";
 
+/// [`EXTRACT_SYSTEM`] + a LANGUAGE directive that pins the extractor's OUTPUT language so a
+/// Polish-dominant note can never emit the SAME fact twice (a Polish `rola:` AND an English `role:`
+/// twin — two different reconcile keys that dedup can't merge). PURE + headless-testable.
+///
+/// A pinned `note_language` (e.g. `"pl"` → "Polish", via [`crate::summarize::template::language_name`])
+/// forces every predicate/object into that ONE language; `"auto"`/`""` instead pins to "the same
+/// language as the note", still ONE consistent language. Both variants forbid a two-language twin and
+/// PROTECT the entity name (kept verbatim so the case-insensitive entity match in
+/// [`candidates_from_triples`] still resolves).
+fn extract_system_prompt(note_language: &str) -> String {
+    match crate::summarize::template::language_name(note_language) {
+        Some(name) => format!(
+            "{EXTRACT_SYSTEM}\n\
+LANGUAGE: Write EVERY predicate and object in {name}. Use ONE language for all facts. \
+NEVER output the same fact twice in two languages (never emit both a {name} and an English version \
+of one attribute). Keep the ENTITY name EXACTLY as listed — do not translate it."
+        ),
+        None => format!(
+            "{EXTRACT_SYSTEM}\n\
+LANGUAGE: Write predicates and objects in the SAME language as the NOTE below; use ONE consistent \
+language for all facts; never emit the same fact in two languages. Keep the ENTITY name EXACTLY as \
+listed — do not translate it."
+        ),
+    }
+}
+
 /// Maximum note chars fed to the extractor (bounds the prompt / leak surface, like graph.rs).
 const EXTRACT_EXCERPT_CHARS: usize = 8000;
 
@@ -531,6 +577,7 @@ pub fn extract_fact_candidates(
     title: &str,
     note_markdown: &str,
     entities: &[(String, String)],
+    note_language: &str,
     opts: GenOptions,
 ) -> Vec<FactCandidate> {
     if entities.is_empty() {
@@ -567,7 +614,8 @@ pub fn extract_fact_candidates(
         "required": ["facts"]
     });
 
-    let value = match reasoner.structured_with(EXTRACT_SYSTEM, &user, &schema, opts) {
+    let value = match reasoner.structured_with(&extract_system_prompt(note_language), &user, &schema, opts)
+    {
         Ok(v) => v,
         Err(e) => {
             tracing::debug!(target: "facts", error = %e, "fact extraction failed; no candidates (best-effort)");
@@ -717,6 +765,94 @@ mod tests {
                 .any(|o| matches!(o, FactOp::Add(nf) if nf.object == "in-progress")),
             "the superseded object must not be re-added"
         );
+    }
+
+    /// LEVER A (RED-before-GREEN) — the extractor system prompt is LANGUAGE-PINNED. A pinned code
+    /// (`"pl"`) names the concrete language AND forbids a two-language twin; `"auto"` pins to the
+    /// note's own language, still one consistent language. This is the only lever that can stop the
+    /// within-note PL+EN twin ("rola:"/"role:"), since a language-insensitive reconcile key is
+    /// infeasible without translation/embeddings. RED before `extract_system_prompt` existed.
+    #[test]
+    fn extract_system_prompt_pins_output_language() {
+        let pl = extract_system_prompt("pl");
+        assert!(pl.contains("Polish"), "a pinned code names the language: {pl}");
+        assert!(
+            pl.contains("ONE language for all facts"),
+            "one-language instruction present: {pl}"
+        );
+        assert!(
+            pl.contains("NEVER output the same fact twice in two languages"),
+            "no-duplicate-language instruction present: {pl}"
+        );
+        // The entity name must be protected so candidates_from_triples still resolves it.
+        assert!(
+            pl.contains("Keep the ENTITY name EXACTLY"),
+            "entity-name protection present: {pl}"
+        );
+
+        let auto = extract_system_prompt("auto");
+        assert!(
+            auto.contains("SAME language as the NOTE"),
+            "auto pins to the note's language: {auto}"
+        );
+        assert!(
+            auto.contains("ONE consistent language"),
+            "auto still forces one consistent language: {auto}"
+        );
+        // Empty string behaves like "auto" (no pin).
+        assert!(extract_system_prompt("").contains("SAME language as the NOTE"));
+    }
+
+    /// LEVER B (RED-before-GREEN, core of symptom 2) — same-day SELF-supersession guard. An OPEN
+    /// existing fact whose `valid_from` EQUALS `at` (the meeting's stable started_at, re-extracted on
+    /// multiple funnels) reconciled against a DIFFERENT-language object at the SAME `at` must NOT
+    /// close the open row: an Invalidate+Add there mints `valid_from == valid_to == at`, a
+    /// zero-duration closed fact = false bitemporal history (the observed "deadline: was '…'
+    /// (2026-07-22 -> 2026-07-22)" WHAT-CHANGED row). The guard keeps the open fact (NoOp). RED on
+    /// the pre-guard code (it emitted Invalidate + Add).
+    #[test]
+    fn reconcile_does_not_self_supersede_at_the_same_instant() {
+        let at = "2026-07-22T09:00:00Z";
+        let existing = vec![dated_fact(
+            "f1",
+            "Klaudia",
+            "deadline",
+            "skończyć projekt w tym tygodniu",
+            at,
+            None,
+            "m1",
+        )];
+        let ops = reconcile_facts(
+            &existing,
+            &[cand("atlas", "Klaudia", "deadline", "finish project this week")],
+            at,
+        );
+        assert_eq!(
+            ops,
+            vec![FactOp::NoOp],
+            "a same-instant object flip must not mint a zero-duration closed row"
+        );
+    }
+
+    /// LEVER B — the guard must ALSO block a supersession whose open fact's valid_from is AFTER `at`
+    /// (an out-of-order earlier candidate) — that would be a NEGATIVE-duration closed row.
+    #[test]
+    fn reconcile_does_not_supersede_when_open_fact_postdates_at() {
+        let existing = vec![dated_fact(
+            "f1",
+            "Klaudia",
+            "deadline",
+            "later value",
+            "2026-07-25T00:00:00Z", // AFTER `at`
+            None,
+            "m1",
+        )];
+        let ops = reconcile_facts(
+            &existing,
+            &[cand("atlas", "Klaudia", "deadline", "earlier value")],
+            "2026-07-22T09:00:00Z",
+        );
+        assert_eq!(ops, vec![FactOp::NoOp], "a negative-duration close is refused");
     }
 
     /// WITHIN-BATCH dedup (RED-before-GREEN for the data-quality fix): a single note that asserts two

--- a/src-tauri/src/summarize/template.rs
+++ b/src-tauri/src/summarize/template.rs
@@ -116,27 +116,38 @@ Formatting rules:
     )
 }
 
+/// Map a `note_language` config code to a human-readable language NAME, single-sourcing the
+/// code→name table used by every prompt that pins an output language. `"pl"` → `Some("Polish")`;
+/// `"auto"` / `""` (whitespace-trimmed, case-insensitive) → `None` (no pin — match the source);
+/// an unknown code passes through as `Some(code)` so a valid but untabled ISO code still names a
+/// concrete target rather than silently falling back to "auto".
+pub fn language_name(note_language: &str) -> Option<String> {
+    let lang = note_language.trim();
+    if lang.is_empty() || lang.eq_ignore_ascii_case("auto") {
+        return None;
+    }
+    let name = match lang {
+        "en" => "English",
+        "pl" => "Polish",
+        "de" => "German",
+        "es" => "Spanish",
+        "fr" => "French",
+        "it" => "Italian",
+        "pt" => "Portuguese",
+        "uk" => "Ukrainian",
+        "nl" => "Dutch",
+        other => other,
+    };
+    Some(name.to_string())
+}
+
 /// An explicit output-language directive appended to the summary system prompt so the WHOLE
 /// note (section headings AND content) comes out in one consistent language. The YAML
 /// front-matter KEYS stay English so Obsidian keeps parsing them.
 pub fn language_directive(note_language: &str) -> String {
-    let lang = note_language.trim();
-    let target = if lang.is_empty() || lang.eq_ignore_ascii_case("auto") {
-        "the SAME language as the meeting transcript below (match the speakers)".to_string()
-    } else {
-        let name = match lang {
-            "en" => "English",
-            "pl" => "Polish",
-            "de" => "German",
-            "es" => "Spanish",
-            "fr" => "French",
-            "it" => "Italian",
-            "pt" => "Portuguese",
-            "uk" => "Ukrainian",
-            "nl" => "Dutch",
-            other => other,
-        };
-        name.to_string()
+    let target = match language_name(note_language) {
+        None => "the SAME language as the meeting transcript below (match the speakers)".to_string(),
+        Some(name) => name,
     };
     format!(
         "OUTPUT LANGUAGE: Write the section headings AND the body content in {target}. \

--- a/src-tauri/src/user_memory.rs
+++ b/src-tauri/src/user_memory.rs
@@ -242,6 +242,30 @@ one-off remarks, or anything not clearly about the USER. Precision over recall �
 worse than a missing one. Empty array if none.\n\
 Output ONLY the JSON.";
 
+/// [`EXTRACT_SYSTEM`] + a LANGUAGE directive pinning the extractor's OUTPUT language, the sibling of
+/// [`crate::facts::extract_system_prompt`]: without it a Polish-dominant note makes the 1.7B reasoner
+/// emit the SAME "me" fact twice (a Polish `rola:` AND an English `role:` twin — two reconcile keys
+/// dedup can't merge). PURE + headless-testable. A pinned `note_language` (`"pl"` → "Polish", via
+/// [`crate::summarize::template::language_name`]) forces every predicate/object into that ONE
+/// language; `"auto"`/`""` pins to "the same language as the note", still ONE consistent language.
+/// Both variants forbid a two-language twin. (The subject is always the English sentinel
+/// [`USER_SUBJECT`] "You" — never emitted by the model — so there is no entity name to protect here.)
+fn user_extract_system_prompt(note_language: &str) -> String {
+    match crate::summarize::template::language_name(note_language) {
+        Some(name) => format!(
+            "{EXTRACT_SYSTEM}\n\
+LANGUAGE: Write EVERY predicate and object in {name}. Use ONE language for all facts. \
+NEVER output the same fact twice in two languages (never emit both a {name} and an English version \
+of one attribute)."
+        ),
+        None => format!(
+            "{EXTRACT_SYSTEM}\n\
+LANGUAGE: Write predicates and objects in the SAME language as the NOTE below; use ONE consistent \
+language for all facts; never emit the same fact in two languages."
+        ),
+    }
+}
+
 /// The stable subject stored on every user fact (the memory is about "you"). A single constant
 /// subject keeps the reconcile key `(USER_SCOPE, subject, predicate)` effectively
 /// `(predicate)`-keyed — so a later note that changes the user's answer to the SAME predicate
@@ -290,6 +314,7 @@ pub fn extract_user_fact_candidates(
     note_markdown: &str,
     typed_notes: &str,
     thread_turns: &str,
+    note_language: &str,
 ) -> Vec<FactCandidate> {
     // No real brain (the default build / no model) → no extraction. The deterministic reconcile +
     // synthesis are still exercised on whatever candidates a real brain would produce.
@@ -315,7 +340,8 @@ pub fn extract_user_fact_candidates(
         "required": ["facts"]
     });
 
-    let value = match reasoner.structured(EXTRACT_SYSTEM, &user, &schema) {
+    let value = match reasoner.structured(&user_extract_system_prompt(note_language), &user, &schema)
+    {
         Ok(v) => v,
         Err(e) => {
             tracing::debug!(target: "user_memory", error = %e, "user-fact extraction failed; no candidates (best-effort)");
@@ -749,6 +775,36 @@ mod tests {
     fn extract_imported_memories_stub_is_empty() {
         let out = extract_imported_memories(&crate::reason::StubReasoner, "remember: I like tea");
         assert!(out.is_empty());
+    }
+
+    /// LEVER A sibling (RED-before-GREEN) — the USER-memory extractor system prompt is
+    /// LANGUAGE-PINNED, the twin of `crate::facts::extract_system_prompt`: without it a Polish note
+    /// duplicated a "me" fact as a PL+EN twin in the dossier/brief. A pinned code names the language
+    /// and forbids a two-language twin; `"auto"` pins to the note's own language, one consistent
+    /// language. RED before `user_extract_system_prompt` existed.
+    #[test]
+    fn user_extract_system_prompt_pins_output_language() {
+        let pl = user_extract_system_prompt("pl");
+        assert!(pl.contains("Polish"), "a pinned code names the language: {pl}");
+        assert!(
+            pl.contains("ONE language for all facts"),
+            "one-language instruction present: {pl}"
+        );
+        assert!(
+            pl.contains("NEVER output the same fact twice in two languages"),
+            "no-duplicate-language instruction present: {pl}"
+        );
+
+        let auto = user_extract_system_prompt("auto");
+        assert!(
+            auto.contains("SAME language as the NOTE"),
+            "auto pins to the note's language: {auto}"
+        );
+        assert!(
+            auto.contains("ONE consistent language"),
+            "auto still forces one consistent language: {auto}"
+        );
+        assert!(user_extract_system_prompt("").contains("SAME language as the NOTE"));
     }
 
     /// candidates_from_raw scopes every candidate to the user + drops empty pairs.


### PR DESCRIPTION
## B3 — bilingual fact duplicates + false same-day self-supersession

From a live QA session, `get_entity_dossier("Klaudia")` showed:
1. the **same fact twice** — a Polish `rola: projektuje…` and an English `role: designer presenting…` twin, and
2. a WHAT-CHANGED row `deadline: was "skończyć…" (2026-07-22 → 2026-07-22)` — a fact "superseded" by its own PL→EN translation on the same day.

**Root cause (one root, two symptoms):** the fact extractors don't pin an output language, so a Polish-dominant note sometimes renders the same fact in two languages. The dedup/supersession key is `(entity_id, norm(subject), norm(predicate))` — `norm("rola") ≠ norm("role")`, so the twins are different keys that can't merge; and a PL→EN object flip on the meeting's *stable* `started_at` makes `reconcile_facts` close a fact with `valid_from == valid_to` (a zero-duration closed row = false history).

## Fix (forward-only — no stored row is rewritten)

- **Lever A — pin extraction to the note's language.** `extract_system_prompt(note_language)` appends a directive forcing every predicate/object into one language (the note's, via the existing `language_name` plumbing) and forbidding two-language twins, while keeping the entity name verbatim. Threaded through `extract_fact_candidates` + its call sites, and applied to the sibling `user_memory` "me"-fact extractor (same disease).
- **Lever B — reconcile guard.** `reconcile_facts` now supersedes an open fact only when its `valid_from` **strictly precedes** the new instant; otherwise `NoOp`. A same-instant self-flip (or out-of-order candidate) can never mint a zero/negative-duration closed row. This is a correctness invariant independent of language.

No visibility/seal/rollup/egress path is touched; no reindex; no new dep.

## Tests

- New model-free RED tests: the reconcile guard (an open fact with `valid_from == at` + a different-language object at the same instant → `NoOp`, not `Invalidate+Add`) and the prompt wiring (`extract_system_prompt("pl")` pins Polish; `"auto"` pins "same language as the note").
- Regression guard: a genuine *later* supersession (`valid_from` strictly before `at`) still `Invalidate+Add`s.
- `cargo test --lib` green; spec/adversarial/lock-security/egress-security reviews all PASS.

**Honest scope:** the real bilingual-emission *frequency* drop can only be confirmed on a signed Mac with the real on-device reasoner (the stub returns empty, so `cargo test` exercises the deterministic guard, not real extraction). A cross-*meeting* cross-language duplicate under `note_language="auto"` is not fully fixed (language-insensitive keys would need translation/embeddings — out of scope); the mitigation is a config choice (set `note_language="pl"`). Part of the MCP-tools QA remediation series (follows #453, #454).
