### PR TITLE
feat(templates): user-authored note templates (Granola-style named sections)

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -23,6 +23,7 @@ use tauri::State;
 
 use crate::error::AppError;
 use crate::state::AppState;
+use crate::storage::models::{NoteTemplate, NoteTemplateSection};
 
 /// E10 — grant the one-time cloud-egress consent. This is the ONLY supported way to flip
 /// `cloud_egress_consented` true: it persists the flag AND updates the in-memory config cache, so
@@ -96,5 +97,117 @@ pub fn consent_to_slack(state: State<'_, AppState>) -> Result<(), AppError> {
         .lock()
         .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
     cache.grant_slack_consent(&state.db)?;
+    Ok(())
+}
+
+// ── Note templates (user-authored named sections) ────────────────────────────────────────────────
+//
+// CONTENT-FREE, single-user metadata — exactly like `save_recipe` / `upsert_saved_view`: these
+// persist only a note SHAPE (a name, a tone line, ordered `{heading, instruction}` sections, and
+// extra front-matter keys), NEVER meeting content, so they are NOT visibility-gated (there is
+// nothing sealed to leak). A saved template is rendered into the summarizer SYSTEM PROMPT by
+// `summarize::template::build_template` (the same `SummarizeRequest.template` seam the built-in
+// styles use) and still passes the `RedactingProvider` firewall on egress, unchanged.
+//
+// SECURITY: `save_note_template` REJECTS any template whose text carries a scripting token
+// (`<%` / `tp.` / `require(` / `process.`) with `AppError::InvalidArg` — a template is DECLARATIVE
+// data, never code. After every mutation we refresh the process-global saved-template registry
+// (`template::set_saved_templates`) so the next note generation resolves the live data (the pipeline
+// renders through `build_template` with only the style string, so the registry — not `AppState` —
+// is how a saved-template id reaches the renderer).
+
+/// List the user's saved note templates (newest first). CONTENT-FREE; not gated.
+#[tauri::command]
+pub fn list_note_templates(state: State<'_, AppState>) -> Result<Vec<NoteTemplate>, AppError> {
+    state.db.list_note_templates()
+}
+
+/// Save (create or replace) a note template. Validates the name + at least one section, REJECTS any
+/// scripting token, persists, refreshes the registry, and returns the stored row. An empty `id`
+/// mints a new uuid; a non-empty existing id replaces in place.
+#[tauri::command]
+pub fn save_note_template(
+    state: State<'_, AppState>,
+    id: Option<String>,
+    name: String,
+    tone: String,
+    sections: Vec<NoteTemplateSection>,
+    extra_frontmatter_keys: Vec<String>,
+) -> Result<NoteTemplate, AppError> {
+    let name = name.trim().to_string();
+    if name.is_empty() {
+        return Err(AppError::InvalidArg("template name is required".into()));
+    }
+    // SECURITY GATE — no scripting, ever. Validate the RAW inputs (before any normalization drops
+    // blank-heading rows) so a forbidden token can never slip through in a discarded field. A note
+    // template is DECLARATIVE data rendered into the system prompt, never code.
+    {
+        let raw = NoteTemplate {
+            id: String::new(),
+            name: name.clone(),
+            tone: tone.clone(),
+            sections: sections.clone(),
+            extra_frontmatter_keys: extra_frontmatter_keys.clone(),
+            created_at: String::new(),
+        };
+        crate::summarize::template::validate_note_template(&raw.name, &raw.tone, &raw)?;
+    }
+    // Normalize: drop wholly-blank sections/keys so a stray empty row can't produce a bare `## `.
+    let sections: Vec<NoteTemplateSection> = sections
+        .into_iter()
+        .filter(|s| !s.heading.trim().is_empty())
+        .map(|s| NoteTemplateSection {
+            heading: s.heading.trim().to_string(),
+            instruction: s.instruction.trim().to_string(),
+        })
+        .collect();
+    if sections.is_empty() {
+        return Err(AppError::InvalidArg(
+            "a note template needs at least one section".into(),
+        ));
+    }
+    let extra_frontmatter_keys: Vec<String> = extra_frontmatter_keys
+        .into_iter()
+        .map(|k| k.trim().to_string())
+        .filter(|k| !k.is_empty())
+        .collect();
+
+    let id = id
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+    // Preserve the original created_at when replacing an existing template.
+    let created_at = state
+        .db
+        .list_note_templates()?
+        .into_iter()
+        .find(|t| t.id == id)
+        .map(|t| t.created_at)
+        .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
+
+    let rec = NoteTemplate {
+        id,
+        name: name.clone(),
+        tone: tone.trim().to_string(),
+        sections,
+        extra_frontmatter_keys,
+        created_at,
+    };
+    // SECURITY GATE (belt-and-suspenders) — re-validate the exact normalized row that will be
+    // persisted + egressed. Normalization only trims, so this can't newly pass what the raw check
+    // above rejected; it guarantees the STORED bytes carry no scripting token.
+    crate::summarize::template::validate_note_template(&rec.name, &rec.tone, &rec)?;
+
+    state.db.insert_note_template(&rec)?;
+    // Refresh the renderer's registry so the next note generation sees the live template.
+    crate::summarize::template::set_saved_templates(state.db.list_note_templates()?);
+    Ok(rec)
+}
+
+/// Delete a saved note template by id, then refresh the renderer's registry.
+#[tauri::command]
+pub fn delete_note_template(state: State<'_, AppState>, id: String) -> Result<(), AppError> {
+    state.db.delete_note_template(&id)?;
+    crate::summarize::template::set_saved_templates(state.db.list_note_templates()?);
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -333,6 +333,9 @@ pub fn run() {
             commands::list_saved_recipes,
             commands::save_recipe,
             commands::delete_recipe,
+            commands::list_note_templates,
+            commands::save_note_template,
+            commands::delete_note_template,
             commands::list_saved_views,
             commands::upsert_saved_view,
             commands::delete_saved_view,
@@ -488,6 +491,22 @@ pub fn run() {
                 crate::summarize::egress_log::set_egress_sink(std::sync::Arc::new(
                     crate::summarize::egress_log::DbEgressSink::new(state.db.clone()),
                 ));
+            }
+
+            // Load the user's saved NOTE TEMPLATES into the renderer registry so a note-style
+            // selection of a saved template resolves at Stop-time (`summarize::template::
+            // build_template` sees only the style STRING, not the DB). Best-effort: a read failure
+            // just leaves the registry empty (built-in styles still work) — never crash boot.
+            {
+                let state = app.state::<AppState>();
+                match state.db.list_note_templates() {
+                    Ok(templates) => crate::summarize::template::set_saved_templates(templates),
+                    Err(e) => tracing::warn!(
+                        target: "note_templates",
+                        error = %e,
+                        "failed to load saved note templates at startup"
+                    ),
+                }
             }
 
             // Crash-recovery (STAGE 2 spill salvage + STAGE 3 disk salvage + STAGE 1 reconcile) +

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -12,8 +12,9 @@ use crate::embed::Embedder;
 use crate::storage::models::{
     Analytics, BacklinkSource, Commitment, CorrectionRecord, DayCount, DocChunkHit,
     DocOutlineEntry, DocumentInfo, DocumentSummary, EntityKind, GraphNode, Meeting,
-    MeetingActionSummary, MeetingStatus, NoteCitation, PendingShareAccept, PeopleList, PersonCard,
-    PropertyKind, PropertyValue, RecipeRecord, SavedView, SearchHit, StatusCount,
+    MeetingActionSummary, MeetingStatus, NoteCitation, NoteTemplate, NoteTemplateSection,
+    PendingShareAccept, PeopleList, PersonCard, PropertyKind, PropertyValue, RecipeRecord, SavedView,
+    SearchHit, StatusCount,
 };
 use crate::transcribe::types::Segment;
 
@@ -406,6 +407,19 @@ impl Db {
                id TEXT PRIMARY KEY,
                title TEXT NOT NULL,
                prompt TEXT NOT NULL,
+               created_at TEXT NOT NULL
+             );
+             -- User-authored NOTE TEMPLATES (Granola-style named sections). CONTENT-FREE,
+             -- single-user metadata (mirrors `saved_recipes`): a note SHAPE only — tone +
+             -- ordered sections (JSON) + extra front-matter keys (JSON) — never meeting content,
+             -- so it is not visibility-gated. Selected by id via the note-style selector and
+             -- rendered into the summarizer system prompt by `summarize::template::build_template`.
+             CREATE TABLE IF NOT EXISTS note_templates (
+               id TEXT PRIMARY KEY,
+               name TEXT NOT NULL,
+               tone TEXT NOT NULL DEFAULT '',
+               sections TEXT NOT NULL DEFAULT '[]',
+               extra_frontmatter_keys TEXT NOT NULL DEFAULT '[]',
                created_at TEXT NOT NULL
              );
              CREATE TABLE IF NOT EXISTS saved_views (
@@ -4968,6 +4982,77 @@ impl Db {
         let conn = self.lock();
         conn.execute(
             "DELETE FROM saved_recipes WHERE id = ?1",
+            rusqlite::params![id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    // ── note templates (user-authored named sections) ────────────────────────
+    //
+    // CONTENT-FREE, single-user metadata (mirrors `saved_recipes`): a note SHAPE only, never
+    // meeting content, so these paths are NOT visibility-gated. `sections` and
+    // `extra_frontmatter_keys` are stored as JSON TEXT and parsed here; a corrupt/legacy row
+    // falls back to an empty list rather than failing the whole read.
+
+    pub fn list_note_templates(&self) -> Result<Vec<NoteTemplate>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, name, tone, sections, extra_frontmatter_keys, created_at \
+                 FROM note_templates ORDER BY created_at DESC",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |r| {
+                let sections_json: String = r.get(3)?;
+                let extra_json: String = r.get(4)?;
+                Ok(NoteTemplate {
+                    id: r.get(0)?,
+                    name: r.get(1)?,
+                    tone: r.get(2)?,
+                    sections: serde_json::from_str::<Vec<NoteTemplateSection>>(&sections_json)
+                        .unwrap_or_default(),
+                    extra_frontmatter_keys: serde_json::from_str::<Vec<String>>(&extra_json)
+                        .unwrap_or_default(),
+                    created_at: r.get(5)?,
+                })
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    pub fn insert_note_template(&self, t: &NoteTemplate) -> Result<()> {
+        let sections_json = serde_json::to_string(&t.sections)
+            .map_err(|e| AppError::Storage(format!("serialize note-template sections: {e}")))?;
+        let extra_json = serde_json::to_string(&t.extra_frontmatter_keys)
+            .map_err(|e| AppError::Storage(format!("serialize note-template keys: {e}")))?;
+        let conn = self.lock();
+        conn.execute(
+            "INSERT OR REPLACE INTO note_templates \
+             (id, name, tone, sections, extra_frontmatter_keys, created_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            rusqlite::params![
+                t.id,
+                t.name,
+                t.tone,
+                sections_json,
+                extra_json,
+                t.created_at
+            ],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    pub fn delete_note_template(&self, id: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "DELETE FROM note_templates WHERE id = ?1",
             rusqlite::params![id],
         )
         .map_err(map_err)?;

--- a/src-tauri/src/storage/db_tests/tests.rs
+++ b/src-tauri/src/storage/db_tests/tests.rs
@@ -10782,3 +10782,56 @@ fn clear_meeting_audio_path_if_only_nulls_a_matching_path() {
     db.clear_meeting_audio_path_if("M", "/d/M.wav").unwrap();
     assert_eq!(db.get_meeting("M").unwrap().unwrap().audio_path, None);
 }
+
+/// note_templates round-trip: insert → list returns the row with its `sections` (ordered) and
+/// `extra_frontmatter_keys` intact through the JSON TEXT columns; REPLACE by id overwrites; delete
+/// removes. CONTENT-FREE metadata (mirrors saved_recipes) — no visibility gate.
+#[test]
+fn note_templates_round_trip() {
+    use crate::storage::models::{NoteTemplate, NoteTemplateSection};
+    let db = mem_db();
+    assert!(db.list_note_templates().unwrap().is_empty());
+
+    let t = NoteTemplate {
+        id: "tpl-1".to_string(),
+        name: "Client call".to_string(),
+        tone: "Warm, outcome-first".to_string(),
+        sections: vec![
+            NoteTemplateSection {
+                heading: "Outcome".to_string(),
+                instruction: "What we agreed.".to_string(),
+            },
+            NoteTemplateSection {
+                heading: "Next steps".to_string(),
+                instruction: "Owner — action.".to_string(),
+            },
+        ],
+        extra_frontmatter_keys: vec!["client".to_string(), "project".to_string()],
+        created_at: "2026-07-25T00:00:00Z".to_string(),
+    };
+    db.insert_note_template(&t).unwrap();
+
+    let got = db.list_note_templates().unwrap();
+    assert_eq!(got.len(), 1);
+    assert_eq!(got[0].name, "Client call");
+    assert_eq!(got[0].sections.len(), 2);
+    assert_eq!(got[0].sections[0].heading, "Outcome");
+    assert_eq!(got[0].sections[1].heading, "Next steps");
+    assert_eq!(
+        got[0].extra_frontmatter_keys,
+        vec!["client".to_string(), "project".to_string()]
+    );
+
+    // REPLACE by id (INSERT OR REPLACE): same id, new content.
+    let mut t2 = t.clone();
+    t2.name = "Renamed".to_string();
+    t2.sections.truncate(1);
+    db.insert_note_template(&t2).unwrap();
+    let got = db.list_note_templates().unwrap();
+    assert_eq!(got.len(), 1, "replace, not append");
+    assert_eq!(got[0].name, "Renamed");
+    assert_eq!(got[0].sections.len(), 1);
+
+    db.delete_note_template("tpl-1").unwrap();
+    assert!(db.list_note_templates().unwrap().is_empty());
+}

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -1073,6 +1073,36 @@ pub struct RecipeRecord {
     pub created_at: String,
 }
 
+/// One ordered `## {heading}` block of a user-authored note template. `instruction` is the plain,
+/// DECLARATIVE guidance the model gets for that section — it is DATA, never code (see
+/// `summarize::template::validate_note_template`, which rejects scripting tokens at save).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NoteTemplateSection {
+    pub heading: String,
+    pub instruction: String,
+}
+
+/// A user-authored NOTE TEMPLATE (Granola-style named sections). CONTENT-FREE, single-user metadata
+/// (exactly like `saved_recipes` / `saved_views`): it stores only a note SHAPE — a tone line, an
+/// ordered list of `{heading, instruction}` sections, and any extra front-matter keys — never meeting
+/// content, so its read/write path is NOT visibility-gated. Selected by id via the note-style
+/// selector; rendered into the summarizer system prompt by `summarize::template::build_template`
+/// (the same `SummarizeRequest.template` seam the built-in styles use). `sections` and
+/// `extra_frontmatter_keys` persist as JSON TEXT columns.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NoteTemplate {
+    pub id: String,
+    pub name: String,
+    /// A short style/tone directive appended to the prompt preamble (may be empty).
+    pub tone: String,
+    pub sections: Vec<NoteTemplateSection>,
+    /// Additional YAML front-matter keys to request beyond the fixed 5 (may be empty).
+    pub extra_frontmatter_keys: Vec<String>,
+    pub created_at: String,
+}
+
 /// A user-saved VIEW over a list surface (Feature B — "Saved views over the meetings list").
 ///
 /// LOCK MODEL: this is CONTENT-FREE user metadata (like `saved_recipes`) — a single-user,

--- a/src-tauri/src/summarize/template.rs
+++ b/src-tauri/src/summarize/template.rs
@@ -1,4 +1,76 @@
+use std::collections::HashMap;
+use std::sync::{OnceLock, RwLock};
+
+use crate::error::{AppError, Result};
+use crate::storage::models::{NoteTemplate, NoteTemplateSection};
 use crate::summarize::provider::SummarizeRequest;
+
+/// Scripting tokens that are FORBIDDEN in a user-authored note template. A note template is
+/// DECLARATIVE DATA rendered into the summarizer system prompt — never code. These are the
+/// hallmark openings of the templating/scripting engines an Obsidian user might paste from
+/// (Templater `<%`/`tp.`, Node `require(`/`process.`). We refuse them at SAVE (below), so no such
+/// text can ever be persisted, let alone egressed as the system prompt.
+pub const FORBIDDEN_TEMPLATE_TOKENS: [&str; 4] = ["<%", "tp.", "require(", "process."];
+
+/// Reject a note template whose ANY text field contains a scripting token. Called by the
+/// `save_note_template` command BEFORE persisting. Declarative data only, ever — this is the
+/// security boundary for the template layer (the rendered prompt still passes the
+/// `RedactingProvider` firewall on egress, unchanged).
+pub fn validate_note_template(name: &str, tone: &str, t: &NoteTemplate) -> Result<()> {
+    let mut fields: Vec<&str> = vec![name, tone];
+    for s in &t.sections {
+        fields.push(&s.heading);
+        fields.push(&s.instruction);
+    }
+    for k in &t.extra_frontmatter_keys {
+        fields.push(k);
+    }
+    for f in fields {
+        for tok in FORBIDDEN_TEMPLATE_TOKENS {
+            if f.contains(tok) {
+                return Err(AppError::InvalidArg(format!(
+                    "note template may not contain the scripting token `{tok}` — templates are \
+                     declarative data, not code"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Process-global registry of saved note templates, keyed by id. Populated at boot from the DB
+/// (`lib.rs` setup → `Db::list_note_templates`) and refreshed on every save/delete
+/// (`commands::settings`). It exists because `build_template` is a PURE renderer called from the
+/// pipeline with only the style STRING (`pipeline.rs:2266`) — it has no `AppState`/DB handle — so
+/// resolving a saved-template id to its data goes through this cache. Same `OnceLock<RwLock<…>>`
+/// shape already used elsewhere in `summarize/` (e.g. `claude_code.rs`, `ner_deberta.rs`). Holds
+/// CONTENT-FREE metadata only (a note shape), never meeting content.
+fn saved_template_registry() -> &'static RwLock<HashMap<String, NoteTemplate>> {
+    static REG: OnceLock<RwLock<HashMap<String, NoteTemplate>>> = OnceLock::new();
+    REG.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// Replace the saved-template registry with `templates` (id → template). Idempotent; called at boot
+/// and after each save/delete so `build_template(<saved id>, …)` renders the live data.
+pub fn set_saved_templates(templates: Vec<NoteTemplate>) {
+    let mut map = match saved_template_registry().write() {
+        Ok(m) => m,
+        Err(poison) => poison.into_inner(),
+    };
+    map.clear();
+    for t in templates {
+        map.insert(t.id.clone(), t);
+    }
+}
+
+/// Resolve a saved template by id from the registry (a cheap read-lock clone), or `None`.
+fn lookup_saved_template(id: &str) -> Option<NoteTemplate> {
+    let map = match saved_template_registry().read() {
+        Ok(m) => m,
+        Err(poison) => poison.into_inner(),
+    };
+    map.get(id).cloned()
+}
 
 /// The canonical Obsidian note-format prompt (front-matter + sections), shared by all providers.
 ///
@@ -74,19 +146,77 @@ pub fn template_for_style(style: &str) -> String {
             "Be ACTION-FOCUSED — the reader cares most about what happens next and who owns it.",
             "# <title>\n\n## Summary\n1–2 sentences of context.\n\n## Action items\n- [ ] Owner — action (due date if mentioned)\n\n## Decisions\n- Decisions made (or \"None recorded\").\n\n## Follow-ups\n- Open questions / things to revisit.\n",
         ),
-        _ => default_template(),
+        // "standard" and "" render the canonical default template, byte-identical to the legacy
+        // `_ => default_template()` arm. Any OTHER id is a saved user template: resolve it from the
+        // registry and render it from its data (same `style_variant` shape). An id that is NOT a
+        // known saved template falls back to `default_template()` — byte-identical to the legacy
+        // behavior for an unknown/hand-edited style value.
+        "standard" | "" => default_template(),
+        other => lookup_saved_template(other)
+            .map(|t| render_saved_template(&t))
+            .unwrap_or_else(default_template),
     }
+}
+
+/// Render a saved user template into the style-prompt portion (the `style_variant` shape) from its
+/// DATA: `tone` becomes the preamble directive, `sections` become the ordered `## heading` body,
+/// and `extra_frontmatter_keys` are appended to the fixed front-matter key list. A template with
+/// empty tone / no extra keys renders the same shape a built-in style does.
+pub fn render_saved_template(t: &NoteTemplate) -> String {
+    style_variant_with_keys(
+        t.tone.trim(),
+        &render_sections(&t.sections),
+        &t.extra_frontmatter_keys,
+    )
+}
+
+/// Build the `# <title>` + ordered `## {heading}\n{instruction}` body from a template's sections,
+/// matching the exact spacing the built-in `body_sections` string literals use: a leading
+/// `# <title>\n\n`, sections joined by a blank line, and a single trailing newline. An empty
+/// section list degrades to just the title line (a template with no sections is still a valid,
+/// front-matter-first note).
+fn render_sections(sections: &[NoteTemplateSection]) -> String {
+    if sections.is_empty() {
+        return "# <title>\n".to_string();
+    }
+    let joined = sections
+        .iter()
+        .map(|s| format!("## {}\n{}", s.heading.trim(), s.instruction.trim()))
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    format!("# <title>\n\n{joined}\n")
 }
 
 /// Build a style variant: the shared front-matter contract + a style-specific tone line and
 /// body section layout. Mirrors `default_template`'s invariants (first line `---`, no fences).
+/// Thin wrapper over [`style_variant_with_keys`] with no extra front-matter keys — the built-in
+/// styles call this, so their output stays byte-identical.
 fn style_variant(tone: &str, body_sections: &str) -> String {
+    style_variant_with_keys(tone, body_sections, &[])
+}
+
+/// The general form of [`style_variant`], adding `extra_keys` to the front-matter key list. When
+/// `tone` is empty the tone clause is omitted (the preamble ends at the period); a non-empty tone
+/// renders as `… whole note. {tone}` exactly as the built-in styles do. When `extra_keys` is empty
+/// the front-matter block is byte-identical to the legacy `style_variant` output (the built-in
+/// styles rely on this for the byte-identity regression). Each extra key is requested as an
+/// optional line so a template can add e.g. `project` / `client` front-matter.
+fn style_variant_with_keys(tone: &str, body_sections: &str, extra_keys: &[String]) -> String {
+    let tone_clause = if tone.is_empty() {
+        String::new()
+    } else {
+        format!(" {tone}")
+    };
+    let extra = extra_keys
+        .iter()
+        .map(|k| format!("- {}: (fill in from the meeting, or omit if unknown)\n", k.trim()))
+        .collect::<String>();
     format!(
         r#"You are a meticulous meeting-notes writer for an Obsidian vault.
 
 Produce a SINGLE, complete Markdown note summarizing the meeting transcript that
 follows. Output ONLY the note — no preamble, no explanation, no code fences around
-the whole note. {tone}
+the whole note.{tone_clause}
 
 The note MUST begin, on the very first line, with a YAML front-matter block delimited
 by a line containing exactly three dashes (`---`), then the front-matter keys, then a
@@ -98,7 +228,7 @@ Front-matter (YAML) keys to include:
 - duration_minutes: integer minutes (rounded)
 - tags: a YAML list including at least [meeting]
 - participants: a YAML list (may be empty if unknown)
-
+{extra}
 After the closing `---`, write the note body using these sections (omit a section only
 if there is genuinely nothing to say):
 
@@ -593,5 +723,184 @@ mod tests {
             "instructs action-item OWNER attribution"
         );
         assert!(labeled.contains("(speaker)") && labeled.contains("others"));
+    }
+
+    fn tpl(id: &str, tone: &str, sections: &[(&str, &str)], extra: &[&str]) -> NoteTemplate {
+        NoteTemplate {
+            id: id.to_string(),
+            name: format!("{id}-name"),
+            tone: tone.to_string(),
+            sections: sections
+                .iter()
+                .map(|(h, i)| NoteTemplateSection {
+                    heading: h.to_string(),
+                    instruction: i.to_string(),
+                })
+                .collect(),
+            extra_frontmatter_keys: extra.iter().map(|k| k.to_string()).collect(),
+            created_at: "2026-07-25T00:00:00Z".to_string(),
+        }
+    }
+
+    /// (i) BYTE-IDENTITY REGRESSION: after the data-driven refactor, the built-in `brief` style must
+    /// render EXACTLY the same prompt as before (the full literal is pinned so any spacing/keyword
+    /// drift from the `style_variant` → `style_variant_with_keys` change fails here). RED if the
+    /// refactor leaks an extra-key line, drops the tone clause, or shifts the front-matter spacing.
+    #[test]
+    fn builtin_brief_style_is_byte_identical() {
+        let expected = r#"You are a meticulous meeting-notes writer for an Obsidian vault.
+
+Produce a SINGLE, complete Markdown note summarizing the meeting transcript that
+follows. Output ONLY the note — no preamble, no explanation, no code fences around
+the whole note. Keep it SHORT — a busy reader skims this in 15 seconds.
+
+The note MUST begin, on the very first line, with a YAML front-matter block delimited
+by a line containing exactly three dashes (`---`), then the front-matter keys, then a
+closing `---` line. Do not emit anything before the opening `---`.
+
+Front-matter (YAML) keys to include:
+- title: a concise human-readable meeting title (string)
+- date: the meeting date in ISO format (YYYY-MM-DD)
+- duration_minutes: integer minutes (rounded)
+- tags: a YAML list including at least [meeting]
+- participants: a YAML list (may be empty if unknown)
+
+After the closing `---`, write the note body using these sections (omit a section only
+if there is genuinely nothing to say):
+
+# <title>
+
+## TL;DR
+Max 2 sentences capturing the outcome.
+
+## Decisions
+- Only the decisions actually made (or omit).
+
+## Action items
+- [ ] Owner — action (due date if mentioned)
+
+Linking rules:
+- When the meeting clearly references one of the EXISTING NOTE TITLES provided below,
+  link to it using Obsidian wikilink syntax: [[Exact Title]]. Only link titles that
+  appear in that list; never invent links.
+
+Formatting rules:
+- Use plain Markdown. Use real newlines.
+- Be faithful to the transcript; do not fabricate participants, decisions, or action
+  items that are not supported by the transcript.
+"#;
+        assert_eq!(template_for_style("brief"), expected);
+    }
+
+    /// (i, continued) The other three built-in ids preserve their exact touched-seam bytes: no
+    /// leaked extra-key line, the front-matter/`After the closing` spacing unchanged, and the tone
+    /// clause intact. `standard`/`""`/unknown all render the canonical default template unchanged.
+    #[test]
+    fn builtin_styles_have_no_extra_key_leak_and_default_fallback() {
+        for style in ["brief", "detailed", "action"] {
+            let out = template_for_style(style);
+            assert!(
+                !out.contains("(fill in from the meeting"),
+                "{style}: a built-in style must not render an extra-key line"
+            );
+            assert!(
+                out.contains("may be empty if unknown)\n\nAfter the closing"),
+                "{style}: front-matter → body spacing must be byte-identical"
+            );
+            assert!(
+                out.contains("the whole note. "),
+                "{style}: the tone clause must render as `whole note. <tone>`"
+            );
+        }
+        // standard, "" and any unknown/unregistered id all resolve to the canonical default.
+        assert_eq!(template_for_style("standard"), default_template());
+        assert_eq!(template_for_style(""), default_template());
+        assert_eq!(
+            template_for_style("no-such-template-id-xyz"),
+            default_template()
+        );
+    }
+
+    /// (ii) A saved template renders the expected prompt SHAPE from its DATA: the tone clause, its
+    /// ordered `## heading` sections (in order, with their instructions), and each extra
+    /// front-matter key as an optional line — all inside the same front-matter-first contract. And
+    /// once registered, `build_template(<saved id>, …)` resolves it through the registry (the exact
+    /// path the pipeline uses) and wraps it with the language directive.
+    #[test]
+    fn saved_template_renders_expected_prompt_from_data() {
+        let t = tpl(
+            "tpl-client-call",
+            "Write it for the CLIENT — warm, outcome-first.",
+            &[
+                ("Outcome", "One line: what we agreed."),
+                ("Next steps", "- [ ] Owner — action"),
+            ],
+            &["client", "project"],
+        );
+
+        let body = render_saved_template(&t);
+        // Front-matter-first invariant is unchanged (the style portion starts with the shared
+        // preamble; the whole rendered prompt still instructs a `---`-first note).
+        assert!(body.contains("no code fences around\nthe whole note. Write it for the CLIENT"));
+        assert!(body.contains("Do not emit anything before the opening `---`."));
+        // Extra front-matter keys are requested, after the fixed 5, before the blank line + body.
+        assert!(body.contains(
+            "- participants: a YAML list (may be empty if unknown)\n\
+             - client: (fill in from the meeting, or omit if unknown)\n\
+             - project: (fill in from the meeting, or omit if unknown)\n\n\
+             After the closing"
+        ));
+        // Ordered sections, in order, with instructions.
+        let out_at = body.find("## Outcome\nOne line: what we agreed.").expect("s1");
+        let next_at = body
+            .find("## Next steps\n- [ ] Owner — action")
+            .expect("s2");
+        assert!(out_at < next_at, "sections render in author order");
+        assert!(body.contains("# <title>\n\n## Outcome"), "title heads the body");
+
+        // Registered → build_template resolves it (pipeline's exact call) + appends the language
+        // directive; unlabeled adds no speaker directive.
+        set_saved_templates(vec![t.clone()]);
+        let built = build_template("tpl-client-call", "auto", false);
+        assert!(built.starts_with(&body), "build_template renders the saved body");
+        assert!(built.contains("OUTPUT LANGUAGE:"), "language directive appended");
+        assert!(!built.contains("SPEAKER ATTRIBUTION"), "no attribution when unlabeled");
+        // Cleanup so the process-global registry doesn't leak into other tests.
+        set_saved_templates(vec![]);
+    }
+
+    /// (iii) SECURITY: a template whose ANY field carries a scripting token (`<%`, `tp.`,
+    /// `require(`, `process.`) is REJECTED with `AppError::InvalidArg` at save — declarative data
+    /// only, never code. RED if a token slips through into a persisted (and thus egress-able)
+    /// template.
+    #[test]
+    fn scripting_tokens_are_rejected() {
+        // A clean template validates.
+        let ok = tpl("t1", "warm", &[("Summary", "One line.")], &["client"]);
+        assert!(validate_note_template(&ok.name, &ok.tone, &ok).is_ok());
+
+        // Each forbidden token, in a DIFFERENT field, must be refused.
+        let name_bad = tpl("t2", "warm", &[("Summary", "<% tp.file.title %>")], &[]);
+        let tone_bad = tpl("t3", "process.env.SECRET", &[("S", "ok")], &[]);
+        let heading_bad = tpl("t4", "warm", &[("require(fs)", "ok")], &[]);
+        let key_bad = tpl("t5", "warm", &[("S", "ok")], &["tp.frontmatter"]);
+        for t in [&name_bad, &tone_bad, &heading_bad, &key_bad] {
+            let err = validate_note_template(&t.name, &t.tone, t);
+            assert!(
+                matches!(err, Err(AppError::InvalidArg(_))),
+                "scripting token must be rejected as InvalidArg; got {err:?}"
+            );
+        }
+    }
+
+    /// A saved template with empty tone and no sections still renders a valid front-matter-first
+    /// prompt (no trailing-space tone artifact, just `## <title>`).
+    #[test]
+    fn saved_template_empty_tone_and_sections_is_valid() {
+        let t = tpl("bare", "", &[], &[]);
+        let body = render_saved_template(&t);
+        assert!(body.contains("no code fences around\nthe whole note.\n\nThe note MUST begin"));
+        assert!(body.contains("# <title>\n\nLinking rules:"));
+        assert!(!body.contains("(fill in from the meeting"));
     }
 }

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -91,6 +91,8 @@ import type {
   VerifyFindingDto,
   ProviderStatus,
   SavedRecipe,
+  NoteTemplate,
+  NoteTemplateSection,
   SavedView,
   MeetingActionSummary,
   SearchHit,
@@ -1092,6 +1094,36 @@ export class IpcService {
   /** Delete a saved recipe. */
   deleteRecipe(id: string): Promise<void> {
     return invoke<void>("delete_recipe", { id });
+  }
+
+  /** User-authored note templates (Granola-style named sections). */
+  listNoteTemplates(): Promise<NoteTemplate[]> {
+    return invoke<NoteTemplate[]>("list_note_templates");
+  }
+
+  /**
+   * Save (create or replace) a note template. Pass `id: null` to create; the backend rejects
+   * scripting tokens (`<%`, `tp.`, `require(`, `process.`) and returns the stored row.
+   */
+  saveNoteTemplate(
+    id: string | null,
+    name: string,
+    tone: string,
+    sections: NoteTemplateSection[],
+    extraFrontmatterKeys: string[],
+  ): Promise<NoteTemplate> {
+    return invoke<NoteTemplate>("save_note_template", {
+      id,
+      name,
+      tone,
+      sections,
+      extraFrontmatterKeys,
+    });
+  }
+
+  /** Delete a saved note template by id. */
+  deleteNoteTemplate(id: string): Promise<void> {
+    return invoke<void>("delete_note_template", { id });
   }
 
   /** Run a recipe prompt over a meeting's transcript (grounded). */

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1311,6 +1311,27 @@ export interface SavedRecipe {
   createdAt: string;
 }
 
+/** One ordered `## {heading}` block of a user-authored note template (declarative data). */
+export interface NoteTemplateSection {
+  heading: string;
+  instruction: string;
+}
+
+/**
+ * A user-authored NOTE TEMPLATE (Granola-style named sections). Selected by `id` via the note-style
+ * selector and rendered into the summarizer system prompt. Mirrors the Rust `storage::models::
+ * NoteTemplate`. Declarative data only — the backend rejects scripting tokens (`<%`, `tp.`,
+ * `require(`, `process.`) at save.
+ */
+export interface NoteTemplate {
+  id: string;
+  name: string;
+  tone: string;
+  sections: NoteTemplateSection[];
+  extraFrontmatterKeys: string[];
+  createdAt: string;
+}
+
 export interface ActionItem {
   idx: number;
   done: boolean;

--- a/src/app/features/settings/sections/note-templates-editor/note-templates-editor.component.html
+++ b/src/app/features/settings/sections/note-templates-editor/note-templates-editor.component.html
@@ -1,0 +1,133 @@
+<div class="note-templates">
+  <div class="nt-head">
+    <span class="field-label">Your templates</span>
+    @if (!editing()) {
+      <button type="button" class="btn btn-ghost btn-sm" (click)="startNew()">
+        + New template
+      </button>
+    }
+  </div>
+  <p class="field-help text-muted">
+    Author your own named sections (Granola-style). A saved template appears in the
+    "Summary style" selector above. Templates are plain instructions — not scripts.
+  </p>
+
+  @if (error(); as err) {
+    <p class="nt-error" role="alert">{{ err }}</p>
+  }
+
+  @if (!editing()) {
+    @if (templates().length === 0) {
+      <p class="text-muted nt-empty">No templates yet — create one to get started.</p>
+    } @else {
+      <ul class="nt-list">
+        @for (t of templates(); track t.id) {
+          <li class="nt-row">
+            <span class="nt-row-main">
+              <span class="nt-name">{{ t.name }}</span>
+              <span class="text-muted nt-meta">
+                {{ t.sections.length }} section{{ t.sections.length === 1 ? "" : "s" }}
+              </span>
+            </span>
+            <span class="nt-row-actions">
+              <button type="button" class="btn btn-ghost btn-sm" (click)="edit(t)">
+                Edit
+              </button>
+              <button
+                type="button"
+                class="btn btn-ghost btn-sm"
+                [disabled]="busy()"
+                (click)="remove(t)"
+              >
+                Delete
+              </button>
+            </span>
+          </li>
+        }
+      </ul>
+    }
+  } @else {
+    <div class="nt-form">
+      <label class="field">
+        <span class="field-label">Template name</span>
+        <input
+          type="text"
+          [value]="name()"
+          (input)="name.set(inputValue($event))"
+          placeholder="e.g. Client call"
+        />
+      </label>
+
+      <label class="field">
+        <span class="field-label">Tone / style (optional)</span>
+        <input
+          type="text"
+          [value]="tone()"
+          (input)="tone.set(inputValue($event))"
+          placeholder="e.g. Warm and outcome-first, written for the client"
+        />
+      </label>
+
+      <div class="field">
+        <span class="field-label">Sections</span>
+        @for (s of sections(); track s.id) {
+          <div class="nt-section">
+            <input
+              type="text"
+              class="nt-section-heading"
+              aria-label="Section heading"
+              [value]="s.heading"
+              (input)="setHeading(s.id, inputValue($event))"
+              placeholder="Heading (e.g. Decisions)"
+            />
+            <textarea
+              class="nt-section-instruction"
+              aria-label="Section instruction"
+              rows="2"
+              [value]="s.instruction"
+              (input)="setInstruction(s.id, inputValue($event))"
+              placeholder="What the model should write here"
+            ></textarea>
+            <button
+              type="button"
+              class="btn btn-ghost btn-sm nt-section-remove"
+              (click)="removeSection(s.id)"
+            >
+              Remove
+            </button>
+          </div>
+        }
+        <button type="button" class="btn btn-ghost btn-sm" (click)="addSection()">
+          + Add section
+        </button>
+      </div>
+
+      <label class="field">
+        <span class="field-label">Extra front-matter keys (optional)</span>
+        <input
+          type="text"
+          [value]="extraKeys()"
+          (input)="extraKeys.set(inputValue($event))"
+          placeholder="comma-separated, e.g. project, client"
+        />
+        <span class="field-help text-muted">
+          Added to the note's YAML front-matter beyond the standard keys.
+        </span>
+      </label>
+
+      <div class="nt-actions">
+        <button
+          type="button"
+          class="btn btn-primary btn-sm"
+          [disabled]="!canSave() || busy()"
+          (click)="save()"
+        >
+          Save template
+        </button>
+        <button type="button" class="btn btn-ghost btn-sm" (click)="cancel()">
+          Cancel
+        </button>
+      </div>
+    </div>
+  }
+</div>

--- a/src/app/features/settings/sections/note-templates-editor/note-templates-editor.component.scss
+++ b/src/app/features/settings/sections/note-templates-editor/note-templates-editor.component.scss
@@ -1,0 +1,104 @@
+.note-templates {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.nt-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+/* Local size modifier — the shared primitives only ship the base .btn sizes. */
+.btn-sm {
+  padding: var(--space-1) var(--space-2);
+  font-size: 0.85em;
+}
+
+.nt-error {
+  color: var(--danger);
+  background: var(--danger-soft);
+  border-radius: var(--radius-md);
+  padding: var(--space-2);
+  margin: 0;
+}
+
+.nt-empty {
+  margin: 0;
+}
+
+.nt-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.nt-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+}
+
+.nt-row-main {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.nt-name {
+  font-weight: 600;
+}
+
+.nt-meta {
+  font-size: 0.85em;
+}
+
+.nt-row-actions {
+  display: flex;
+  gap: var(--space-1);
+  flex-shrink: 0;
+}
+
+.nt-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+}
+
+.nt-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  margin-bottom: var(--space-2);
+}
+
+.nt-section-instruction {
+  resize: vertical;
+  font: inherit;
+}
+
+.nt-section-remove {
+  align-self: flex-end;
+}
+
+.nt-actions {
+  display: flex;
+  gap: var(--space-2);
+}

--- a/src/app/features/settings/sections/note-templates-editor/note-templates-editor.component.ts
+++ b/src/app/features/settings/sections/note-templates-editor/note-templates-editor.component.ts
@@ -1,0 +1,135 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from "@angular/core";
+import { SettingsStore } from "../../settings.store";
+import type { NoteTemplate } from "../../../../core/models";
+
+/** A draft section carries a client-only `id` so `@for … track s.id` keeps each input's DOM node
+ * (and focus) stable across keystrokes, even though every edit replaces the object in the signal. */
+interface DraftSection {
+  id: number;
+  heading: string;
+  instruction: string;
+}
+
+/**
+ * Minimal editor for user-authored NOTE TEMPLATES (Granola-style named sections). Lists the saved
+ * templates and hosts a create/edit form (name + tone + ordered sections + optional extra
+ * front-matter keys). All persistence goes through {@link SettingsStore} → IpcService; the backend
+ * rejects scripting tokens (`<%`, `tp.`, `require(`, `process.`) and surfaces the error in
+ * `noteTemplateError`. A saved template becomes selectable in the "Summary style" selector by id.
+ */
+@Component({
+  selector: "app-note-templates-editor",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: "./note-templates-editor.component.html",
+  styleUrl: "./note-templates-editor.component.scss",
+})
+export class NoteTemplatesEditorComponent {
+  private readonly store = inject(SettingsStore);
+
+  readonly templates = this.store.noteTemplates;
+  readonly busy = this.store.noteTemplateBusy;
+  readonly error = this.store.noteTemplateError;
+
+  /** True while the create/edit form is open (else the list is shown). */
+  readonly editing = signal(false);
+  /** The id being edited, or null when creating a new template. */
+  private readonly editingId = signal<string | null>(null);
+  private nextSectionId = 0;
+
+  readonly name = signal("");
+  readonly tone = signal("");
+  readonly sections = signal<DraftSection[]>([]);
+  /** Comma-separated extra front-matter keys (parsed on save). */
+  readonly extraKeys = signal("");
+
+  /** A template needs a name and at least one non-blank section heading before it can be saved. */
+  readonly canSave = computed(
+    () =>
+      this.name().trim().length > 0 &&
+      this.sections().some((s) => s.heading.trim().length > 0),
+  );
+
+  private draftSection(heading = "", instruction = ""): DraftSection {
+    return { id: this.nextSectionId++, heading, instruction };
+  }
+
+  startNew(): void {
+    this.editingId.set(null);
+    this.name.set("");
+    this.tone.set("");
+    this.sections.set([this.draftSection("Summary")]);
+    this.extraKeys.set("");
+    this.editing.set(true);
+  }
+
+  edit(t: NoteTemplate): void {
+    this.editingId.set(t.id);
+    this.name.set(t.name);
+    this.tone.set(t.tone);
+    this.sections.set(
+      t.sections.map((s) => this.draftSection(s.heading, s.instruction)),
+    );
+    this.extraKeys.set(t.extraFrontmatterKeys.join(", "));
+    this.editing.set(true);
+  }
+
+  cancel(): void {
+    this.editing.set(false);
+  }
+
+  addSection(): void {
+    this.sections.set([...this.sections(), this.draftSection()]);
+  }
+
+  removeSection(id: number): void {
+    this.sections.set(this.sections().filter((s) => s.id !== id));
+  }
+
+  setHeading(id: number, value: string): void {
+    this.sections.set(
+      this.sections().map((s) => (s.id === id ? { ...s, heading: value } : s)),
+    );
+  }
+
+  setInstruction(id: number, value: string): void {
+    this.sections.set(
+      this.sections().map((s) =>
+        s.id === id ? { ...s, instruction: value } : s,
+      ),
+    );
+  }
+
+  async save(): Promise<void> {
+    const keys = this.extraKeys()
+      .split(",")
+      .map((k) => k.trim())
+      .filter((k) => k.length > 0);
+    const saved = await this.store.saveNoteTemplate({
+      id: this.editingId(),
+      name: this.name(),
+      tone: this.tone(),
+      sections: this.sections().map((s) => ({
+        heading: s.heading,
+        instruction: s.instruction,
+      })),
+      extraFrontmatterKeys: keys,
+    });
+    // Only close on success — a rejection (e.g. a scripting token) keeps the draft so the user can fix it.
+    if (saved) this.editing.set(false);
+  }
+
+  async remove(t: NoteTemplate): Promise<void> {
+    await this.store.deleteNoteTemplate(t.id);
+  }
+
+  /** Handler helper so the template can read `$event.target.value` without an inline cast. */
+  inputValue(event: Event): string {
+    return (event.target as HTMLInputElement | HTMLTextAreaElement).value;
+  }
+}

--- a/src/app/features/settings/sections/settings-notes-section/settings-notes-section.component.html
+++ b/src/app/features/settings/sections/settings-notes-section/settings-notes-section.component.html
@@ -15,19 +15,21 @@
                 <option value="brief">Brief (TL;DR + actions)</option>
                 <option value="detailed">Detailed (full depth)</option>
                 <option value="action">Action-focused</option>
-                @if (
-                  form.controls.noteStyle.value !== "standard" &&
-                  form.controls.noteStyle.value !== "brief" &&
-                  form.controls.noteStyle.value !== "detailed" &&
-                  form.controls.noteStyle.value !== "action"
-                ) {
+                @if (noteTemplates().length > 0) {
+                  <optgroup label="Your templates">
+                    @for (t of noteTemplates(); track t.id) {
+                      <option [value]="t.id">{{ t.name }}</option>
+                    }
+                  </optgroup>
+                }
+                @if (showCustomOption()) {
                   <!--
                     note_style is a free-form String on the Rust side (commands.rs
                     `AppConfigDto.note_style`) with no enum validation — a hand-edited
                     config.json, legacy/removed style, or seed data can carry a value
-                    outside the four options above. Without this, the native <select>
-                    shows no visible selection at all. Surface the raw stored value as
-                    its own option instead of rendering blank.
+                    outside the four built-ins AND the saved templates above. Without
+                    this, the native <select> shows no visible selection at all. Surface
+                    the raw stored value as its own option instead of rendering blank.
                   -->
                   <option [value]="form.controls.noteStyle.value">
                     {{ form.controls.noteStyle.value }} (custom)
@@ -51,12 +53,23 @@
                     meetings.
                   }
                   @default {
-                    An unrecognized saved style — pick one of the options above to
-                    reset it to a supported style.
+                    @if (selectedTemplate(); as t) {
+                      Your template “{{ t.name }}” — {{ t.sections.length }} custom
+                      section{{ t.sections.length === 1 ? "" : "s" }}, written to
+                      your instructions.
+                    } @else {
+                      An unrecognized saved style — pick one of the options above to
+                      reset it to a supported style.
+                    }
                   }
                 }
               </span>
             </label>
+
+            <div class="field">
+              <span class="field-label">Custom templates</span>
+              <app-note-templates-editor />
+            </div>
 
             <label class="field">
               <span class="field-label">Your typed notes</span>

--- a/src/app/features/settings/sections/settings-notes-section/settings-notes-section.component.ts
+++ b/src/app/features/settings/sections/settings-notes-section/settings-notes-section.component.ts
@@ -1,18 +1,30 @@
-import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+} from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
 import { ReactiveFormsModule } from "@angular/forms";
+import { startWith } from "rxjs";
 import { MurToggleComponent } from "../../../../design-system/toggle/toggle.component";
 import { SettingsStore } from "../../settings.store";
+import { NoteTemplatesEditorComponent } from "../note-templates-editor/note-templates-editor.component";
+
+/** The four fixed built-in summary styles (everything else is a saved template id). */
+const BUILTIN_STYLES = ["standard", "brief", "detailed", "action"];
 
 /**
  * Settings → notes section (Stage-1 split): the `@case ("notes")` block of the
- * former settings.component.ts monolith, moved VERBATIM. State/actions live in
- * the shell-provided SettingsStore so section switches never drop them.
+ * former settings.component.ts monolith. State/actions live in the shell-provided
+ * SettingsStore so section switches never drop them. Extended with the
+ * user-authored note-template layer (saved templates list in the style selector +
+ * the {@link NoteTemplatesEditorComponent}).
  */
 @Component({
   selector: "app-settings-notes-section",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [
-    MurToggleComponent,ReactiveFormsModule],
+  imports: [MurToggleComponent, ReactiveFormsModule, NoteTemplatesEditorComponent],
   templateUrl: "./settings-notes-section.component.html",
   styleUrl: "./settings-notes-section.component.scss",
 })
@@ -20,4 +32,29 @@ export class SettingsNotesSectionComponent {
   private readonly store = inject(SettingsStore);
 
   readonly form = this.store.form;
+  readonly noteTemplates = this.store.noteTemplates;
+
+  /** Live mirror of the noteStyle control so the computed below is reactive under zoneless. */
+  private readonly _noteStyleValue = toSignal(
+    this.form.controls.noteStyle.valueChanges.pipe(
+      startWith(this.form.controls.noteStyle.value),
+    ),
+    { initialValue: this.form.controls.noteStyle.value },
+  );
+
+  /**
+   * Whether to render the stored value as its own "(custom)" option — only when it matches
+   * NEITHER a built-in style NOR a known saved template (a hand-edited / legacy value). A saved
+   * template id renders through the `@for` options instead, so it must not also appear here.
+   */
+  readonly showCustomOption = computed(() => {
+    const v = this._noteStyleValue();
+    if (BUILTIN_STYLES.includes(v)) return false;
+    return !this.noteTemplates().some((t) => t.id === v);
+  });
+
+  /** The saved template the style selector currently points at, or null (a built-in / unknown). */
+  readonly selectedTemplate = computed(
+    () => this.noteTemplates().find((t) => t.id === this._noteStyleValue()) ?? null,
+  );
 }

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -16,6 +16,8 @@ import type {
   GatewayModel,
   InputDeviceInfo,
   ModelClass,
+  NoteTemplate,
+  NoteTemplateSection,
   Posture,
   ProviderStatus,
   ReindexResult,
@@ -352,6 +354,75 @@ export class SettingsStore {
   /** Reveal the recordings folder in Finder (best-effort; fire-and-forget). */
   revealAudioDir(): void {
     void this.ipc.revealAudioDir();
+  }
+
+  // ── Note templates (user-authored named sections) ───────────────────────
+
+  /** The user's saved note templates (newest first). Loaded in load(); refreshed on save/delete. */
+  private readonly _noteTemplates = signal<NoteTemplate[]>([]);
+  readonly noteTemplates = this._noteTemplates.asReadonly();
+  /** True while a note-template save/delete IPC call is in flight (debounces the buttons). */
+  private readonly _noteTemplateBusy = signal(false);
+  readonly noteTemplateBusy = this._noteTemplateBusy.asReadonly();
+  /** Surfaced if a save/delete rejects — notably the backend's scripting-token rejection. */
+  private readonly _noteTemplateError = signal<string | null>(null);
+  readonly noteTemplateError = this._noteTemplateError.asReadonly();
+
+  /** Refresh the saved note-template list (best-effort; a failure or non-array leaves it empty). */
+  async loadNoteTemplates(): Promise<void> {
+    const list = await this.ipc.listNoteTemplates().catch(() => []);
+    this._noteTemplates.set(Array.isArray(list) ? list : []);
+  }
+
+  /**
+   * Create or replace a note template, then refresh the list. Returns the stored row, or null on
+   * rejection (the error — e.g. a forbidden scripting token — is surfaced in `noteTemplateError`).
+   * Deliberately NOT tied to the settings auto-save: templates are their own persisted rows, not a
+   * field of AppConfig.
+   */
+  async saveNoteTemplate(draft: {
+    id: string | null;
+    name: string;
+    tone: string;
+    sections: NoteTemplateSection[];
+    extraFrontmatterKeys: string[];
+  }): Promise<NoteTemplate | null> {
+    this._noteTemplateBusy.set(true);
+    this._noteTemplateError.set(null);
+    try {
+      const saved = await this.ipc.saveNoteTemplate(
+        draft.id,
+        draft.name,
+        draft.tone,
+        draft.sections,
+        draft.extraFrontmatterKeys,
+      );
+      await this.loadNoteTemplates();
+      return saved;
+    } catch (e) {
+      this._noteTemplateError.set(String(e));
+      return null;
+    } finally {
+      this._noteTemplateBusy.set(false);
+    }
+  }
+
+  /** Delete a saved note template; if it was the selected note-style, fall back to "standard". */
+  async deleteNoteTemplate(id: string): Promise<void> {
+    this._noteTemplateBusy.set(true);
+    this._noteTemplateError.set(null);
+    try {
+      await this.ipc.deleteNoteTemplate(id);
+      if (this.form.controls.noteStyle.value === id) {
+        this.form.patchValue({ noteStyle: "standard" });
+        this.form.markAsDirty(); // user-driven reset → auto-save persists it
+      }
+      await this.loadNoteTemplates();
+    } catch (e) {
+      this._noteTemplateError.set(String(e));
+    } finally {
+      this._noteTemplateBusy.set(false);
+    }
   }
 
   private readonly _hasKey = signal(false);
@@ -1438,6 +1509,8 @@ export class SettingsStore {
       this._appInfo.set(await this.ipc.appInfo().catch(() => null));
       // Recording-storage usage report (best-effort; drives the Storage section + Library bar).
       await this.loadStorageReport();
+      // User-authored note templates (best-effort; feeds the note-style selector + editor).
+      await this.loadNoteTemplates();
       // MCP config block for Claude Code — carries the private bearer token so the copied
       // snippet authenticates (fixes the `-32001 unauthorized` handshake). Best-effort: on a
       // keychain read failure it stays empty and the copy button no-ops rather than pasting a


### PR DESCRIPTION
## What

Adds a user-authored note-template layer (Granola-style named sections) on top of the existing `SummarizeRequest.template` seam.

- `build_template` is now **data-driven**: builtin style ids (standard/brief/detailed/action) render **byte-identical** to before; a saved template renders the same prompt shape from its data (`{name, tone, ordered [{heading, instruction}], extra_frontmatter_keys}`).
- Additive `note_templates` table (`CREATE TABLE IF NOT EXISTS`), mirroring the `saved_recipes` store pattern.
- `list_note_templates` / `save_note_template` / `delete_note_template` commands registered in `lib.rs`, one typed IPC method + model each.
- Minimal FE editor (`note-templates-editor`) + the note-style selector extended to list saved templates (signals-first, `settings.store.ts`).

## Security

- At save, templates containing `<%`, `tp.`, `require(`, or `process.` are rejected with `AppError::InvalidArg` (declarative data, never scripting).
- The template string still egresses only as the provider system prompt through the existing `RedactingProvider` firewall — unchanged. No new crates. Front-matter-first invariant preserved.

## Tests / gates (all green via the harness)

- RED-before-GREEN: builtin ids byte-identical; saved template renders expected prompt; a `<%`-bearing template is rejected at save.
- rust-lib (unit tests), tauri-boot smoke, and Playwright e2e all PASS. Reviews: spec + adversarial + egress-security.

Task T4 of the competitive-gaps program (`docs/research/2026-07-25-implementation-harness-tasks.md`).
