### PR TITLE
feat(retrieval): cosine floor on vector-KNN search + AND->OR full-text fallback

### DIFF
--- a/src-tauri/src/commands/enrich.rs
+++ b/src-tauri/src/commands/enrich.rs
@@ -890,7 +890,7 @@ pub(crate) fn gather_note_enhance_citations(
                 Some(qvec) => {
                     state
                         .db
-                        .search_doc_chunks_visible(&qvec, MAX_CITATIONS as i64, &unlocked)?
+                        .search_doc_chunks_visible(&qvec, MAX_CITATIONS as i64, 0.0, &unlocked)?
                 }
                 None => Vec::new(),
             }

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -12245,7 +12245,7 @@
         let emb = crate::embed::StubEmbedder;
         let qv = emb.embed(std::slice::from_ref(&text.to_string())).unwrap();
         let qvec = qv.into_iter().next().unwrap_or_default();
-        db.search_semantic_visible(&qvec, 50, unlocked)
+        db.search_semantic_visible(&qvec, 50, 0.0, unlocked)
             .unwrap()
             .iter()
             .any(|h| h.meeting.id == mid)

--- a/src-tauri/src/embed.rs
+++ b/src-tauri/src/embed.rs
@@ -91,6 +91,17 @@ pub const SCORE_FUSE_W_KNN: f64 = 0.4;
 /// Weight of the entity-graph leg in [`score_fuse`].
 pub const SCORE_FUSE_W_GRAPH: f64 = 0.2;
 
+/// Minimum cosine (over L2-normalized e5 vectors) for a vector-KNN candidate to survive into a
+/// SEARCH result. Below it, the k-nearest neighbour is noise on a tiny/irrelevant corpus (S1 QA).
+/// PROVISIONAL value derived from the already-calibrated persistent auto-link floor
+/// (links::SEMANTIC_LINK_FLOOR = 0.80): search is ephemeral + user-initiated, so it sits just
+/// BELOW the link floor to protect recall. Finalize on a real vault via eval::calibration +
+/// eval::bakeoff (see PR body) — the mechanism is opt-in so tuning is a one-line const change.
+pub const KNN_SEARCH_COSINE_FLOOR: f32 = 0.78;
+
+/// Org-partition int8 KNN floor (own distribution — the int8 /127 rescale is approximate).
+pub const ORG_KNN_SEARCH_COSINE_FLOOR: f32 = 0.78;
+
 /// The swappable embedding backend. Pure + synchronous: `embed` maps a batch of texts to a batch
 /// of `dim()`-length vectors. The real model implements this over multilingual-e5-small; tests +
 /// the no-model floor use [`StubEmbedder`].

--- a/src-tauri/src/eval/bakeoff.rs
+++ b/src-tauri/src/eval/bakeoff.rs
@@ -78,7 +78,8 @@ fn semantic_ranked(
         return Ok(Vec::new());
     }
     // KNN returns one hit per meeting (nearest chunk) already deduped by `search_semantic_visible`.
-    let hits = db.search_semantic_visible(&query_vec, (k.max(1) * 4) as i64, unlocked)?;
+    // No S1 floor in the bake-off (0.0) — the committed baseline must stay byte-identical.
+    let hits = db.search_semantic_visible(&query_vec, (k.max(1) * 4) as i64, 0.0, unlocked)?;
     Ok(hits.into_iter().map(|h| h.meeting.id).collect())
 }
 
@@ -102,6 +103,7 @@ fn hybrid_hits(
         query,
         &query_vec,
         (k.max(1) * 4) as i64,
+        0.0, // no S1 floor in the bake-off — the committed baseline must stay byte-identical.
         unlocked,
         date_filter,
     )

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -4179,7 +4179,7 @@ mod tests {
             ))
             .unwrap();
         let qvec = qv.into_iter().next().unwrap_or_default();
-        db.search_semantic_visible(&qvec, 10, unlocked)
+        db.search_semantic_visible(&qvec, 10, 0.0, unlocked)
             .unwrap()
             .iter()
             .any(|h| h.meeting.id == mid)

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -3231,10 +3231,17 @@ impl Db {
     /// applies EXACTLY the `search_visible` visibility predicate (a meeting is kept iff it has a
     /// VISIBLE note row — open/NULL folder OR session-unlocked) so a sealed-and-not-unlocked meeting
     /// is excluded even if a stray chunk survived. Dedups to one hit per meeting (best/nearest).
+    ///
+    /// `min_cosine` (S1) is an OPT-IN relevance FLOOR over the vector leg: a candidate whose cosine
+    /// (mapped from the vec0 L2 distance over UNIT vectors via [`crate::links::cosine_from_l2_distance`],
+    /// since `|a-b|² = 2 − 2·cos`) is BELOW it is dropped as noise. Sentinel `0.0` = NO floor
+    /// (behaviour-identical to before S1). Applied strictly AFTER the visibility gate, so it can only
+    /// ever REMOVE rows — never widen or reorder a leg around its gate.
     pub fn search_semantic_visible(
         &self,
         query_vec: &[f32],
         k: i64,
+        min_cosine: f32,
         unlocked: &HashSet<String>,
     ) -> Result<Vec<SearchHit>> {
         if query_vec.is_empty() || k <= 0 {
@@ -3270,14 +3277,22 @@ impl Db {
             .query_map(rusqlite::params![blob, k], |row| {
                 let meeting = row_to_meeting(row)?;
                 let snippet: String = row.get(8)?;
-                Ok((meeting, snippet))
+                let distance: f64 = row.get(9)?;
+                Ok((meeting, snippet, distance))
             })
             .map_err(map_err)?;
 
         let mut seen: HashSet<String> = HashSet::new();
         let mut hits = Vec::new();
         for r in rows {
-            let (meeting, snippet) = r.map_err(map_err)?;
+            let (meeting, snippet, distance) = r.map_err(map_err)?;
+            // S1 relevance floor: drop a below-floor neighbour (noise on a tiny/irrelevant corpus).
+            // Applied AFTER the SQL visibility gate — it can only REMOVE rows.
+            if min_cosine > 0.0
+                && crate::links::cosine_from_l2_distance(distance as f32) < min_cosine
+            {
+                continue;
+            }
             let meeting = meeting?;
             if !seen.insert(meeting.id.clone()) {
                 continue; // already have a nearer chunk for this meeting.
@@ -3364,7 +3379,8 @@ impl Db {
         }
 
         // GATED KNN. Ask for k+1 because self is always the nearest hit; then drop self + truncate.
-        let mut hits = self.search_semantic_visible(&centroid, k + 1, unlocked)?;
+        // No S1 floor here (0.0) — related-meetings is behaviour-preserving; only the MCP search arms floor.
+        let mut hits = self.search_semantic_visible(&centroid, k + 1, 0.0, unlocked)?;
         hits.retain(|h| h.meeting.id != meeting_id);
         hits.truncate(k as usize);
         tracing::debug!(
@@ -3388,7 +3404,7 @@ impl Db {
         date_filter: Option<&(String, String)>,
     ) -> Result<Vec<(String, f64)>> {
         let q = query.trim();
-        let Some(match_expr) = fts_match_query(q) else {
+        let Some(and_expr) = fts_match_query(q) else {
             return Ok(Vec::new());
         };
         let conn = self.lock();
@@ -3432,16 +3448,32 @@ impl Db {
               LIMIT ?2"
         );
         let mut stmt = conn.prepare(&sql).map_err(map_err)?;
-        let rows = stmt
-            .query_map(rusqlite::params![match_expr, limit], |r| {
-                let id: String = r.get(0)?;
-                let rank: f64 = r.get(1)?;
-                Ok((id, -rank)) // FTS5 bm25() is lower/more-negative = better ⇒ negate to higher-better.
-            })
-            .map_err(map_err)?;
-        let mut out = Vec::new();
-        for r in rows {
-            out.push(r.map_err(map_err)?);
+        // Run the (already-gated) FTS body with a given match expression. The visibility predicate is
+        // baked into the SQL, so swapping AND→OR only ever changes WHICH visible rows match.
+        let run = |stmt: &mut rusqlite::Statement, expr: &str| -> Result<Vec<(String, f64)>> {
+            let rows = stmt
+                .query_map(rusqlite::params![expr, limit], |r| {
+                    let id: String = r.get(0)?;
+                    let rank: f64 = r.get(1)?;
+                    Ok((id, -rank)) // FTS5 bm25() is lower/more-negative = better ⇒ negate to higher-better.
+                })
+                .map_err(map_err)?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(r.map_err(map_err)?);
+            }
+            Ok(out)
+        };
+        // S2 AND→OR fallback: implicit-AND matched nothing ⇒ retry with the content-word OR twin
+        // (stopwords/<3-char dropped). Only fires on an EMPTY AND result, so it never widens a
+        // successful query; stays exact-word lexical.
+        let mut out = run(&mut stmt, &and_expr)?;
+        if out.is_empty() {
+            if let Some(any_expr) = fts_match_query_any(q) {
+                if any_expr != and_expr {
+                    out = run(&mut stmt, &any_expr)?;
+                }
+            }
         }
         Ok(out)
     }
@@ -3454,6 +3486,7 @@ impl Db {
         &self,
         query_vec: &[f32],
         k: i64,
+        min_cosine: f32,
         unlocked: &HashSet<String>,
         date_filter: Option<&(String, String)>,
     ) -> Result<Vec<(String, f64)>> {
@@ -3505,7 +3538,13 @@ impl Db {
             .map_err(map_err)?;
         let mut out = Vec::new();
         for r in rows {
-            out.push(r.map_err(map_err)?);
+            let (id, d) = r.map_err(map_err)?;
+            // S1 relevance floor over the vector leg (opt-in; 0.0 = none). Applied AFTER the SQL
+            // visibility gate, so it can only REMOVE below-floor rows — never widen or reorder.
+            if min_cosine > 0.0 && crate::links::cosine_from_l2_distance(d as f32) < min_cosine {
+                continue;
+            }
+            out.push((id, d));
         }
         Ok(out)
     }
@@ -3524,11 +3563,18 @@ impl Db {
     /// the window itself becomes the FTS leg (visible meetings in range, newest-first) — the
     /// "what did we discuss last week" shape. All legs route through the SAME
     /// `visibility_clause`, so the fused output stays gated.
+    ///
+    /// `min_cosine` (S1) is the vector-leg relevance FLOOR, threaded to BOTH vector legs
+    /// (`search_semantic_visible` for the snippet leg, `knn_meeting_distances` for the score leg);
+    /// the FTS and graph legs are NEVER floored. Sentinel `0.0` = no floor. When the floor empties
+    /// the KNN leg on an irrelevant corpus, `score_fuse`'s empty-leg redistribution rescales the
+    /// surviving FTS + graph legs, so an exact-word FTS hit still surfaces (recall safety).
     pub fn search_hybrid_visible(
         &self,
         query: &str,
         query_vec: &[f32],
         limit: i64,
+        min_cosine: f32,
         unlocked: &HashSet<String>,
         date_filter: Option<(String, String)>,
     ) -> Result<Vec<SearchHit>> {
@@ -3544,7 +3590,7 @@ impl Db {
 
         // Snippet-bearing hit lists (each already gated); ordering comes from the scored legs.
         let fts = self.search_visible_impl(query, limit, unlocked, range)?;
-        let semantic = self.search_semantic_visible(query_vec, limit, unlocked)?;
+        let semantic = self.search_semantic_visible(query_vec, limit, min_cosine, unlocked)?;
 
         // GraphRAG-lite leg: resolve the query to known VISIBLE entities (deterministic, no LLM),
         // then gather their co-mention neighbourhood. Both the resolver and the neighbour reader
@@ -3566,7 +3612,7 @@ impl Db {
                 .map(|(i, m)| (m.id.clone(), 1.0 / (i as f64 + 1.0)))
                 .collect();
         }
-        let knn_scored = self.knn_meeting_distances(query_vec, limit, unlocked, range)?;
+        let knn_scored = self.knn_meeting_distances(query_vec, limit, min_cosine, unlocked, range)?;
         let graph_scored: Vec<(String, f64)> = graph
             .iter()
             .enumerate()
@@ -4417,10 +4463,16 @@ impl Db {
     /// winner's `sibling_hits` across the pre-dedup KNN candidates ([`Db::fold_doc_candidates`]).
     /// Returns the chunk snippet + the document name + its folder id + the winning chunk's
     /// hierarchy metadata (NO meeting — documents are not meetings).
+    ///
+    /// `min_cosine` (S1) is the OPT-IN vector-leg relevance floor (cosine mapped from the vec0 L2
+    /// distance via [`crate::links::cosine_from_l2_distance`]); a below-floor candidate is dropped
+    /// as noise. Sentinel `0.0` = NO floor. Applied AFTER the SQL visibility gate, so it can only
+    /// ever REMOVE rows.
     pub fn search_doc_chunks_visible(
         &self,
         query_vec: &[f32],
         k: i64,
+        min_cosine: f32,
         unlocked: &HashSet<String>,
     ) -> Result<Vec<DocChunkHit>> {
         if query_vec.is_empty() || k <= 0 {
@@ -4429,6 +4481,7 @@ impl Db {
         let conn = self.lock();
         let visible = visibility_clause("f", unlocked);
         // KNN isolated to the vec0 table in a CTE; visibility + document columns joined OUTSIDE it.
+        // The trailing `knn.distance` column feeds the S1 relevance floor (dropped below-floor).
         let sql = format!(
             "WITH knn(chunk_id, distance) AS (
                  SELECT chunk_id, distance FROM doc_vec_chunks
@@ -4436,7 +4489,7 @@ impl Db {
                   ORDER BY distance
              )
              SELECT d.id, d.name, d.folder_id, dc.text, d.kind,
-                    dc.id, dc.parent_id, dc.section_path, dc.page_no, dc.level
+                    dc.id, dc.parent_id, dc.section_path, dc.page_no, dc.level, knn.distance
                FROM knn
                JOIN doc_chunks dc ON dc.id = knn.chunk_id
                JOIN documents d ON d.id = dc.document_id
@@ -4447,10 +4500,27 @@ impl Db {
         let blob = crate::embed::vec_to_blob(query_vec);
         let mut stmt = conn.prepare(&sql).map_err(map_err)?;
         let rows = stmt
-            .query_map(rusqlite::params![blob, k], Self::doc_candidate_from_row)
+            .query_map(rusqlite::params![blob, k], |row| {
+                let hit = Self::doc_candidate_from_row(row)?;
+                let distance: f64 = row.get(10)?;
+                Ok((hit, distance))
+            })
             .map_err(map_err)?;
-        // The k-row KNN CTE already bounds the candidate set; every deduped hit is kept (as before).
-        Self::fold_doc_candidates(rows, None)
+        // Drop below-floor candidates (0.0 = no floor) BEFORE the per-document dedup/fold, so the
+        // fold's winner is the nearest SURVIVING chunk. The k-row KNN CTE bounds the candidate set.
+        let filtered = rows.filter_map(|r| match r {
+            Ok((hit, distance)) => {
+                if min_cosine > 0.0
+                    && crate::links::cosine_from_l2_distance(distance as f32) < min_cosine
+                {
+                    None
+                } else {
+                    Some(Ok(hit))
+                }
+            }
+            Err(e) => Some(Err(e)),
+        });
+        Self::fold_doc_candidates(filtered, None)
     }
 
     /// GATED keyword (FTS5/BM25) search over DOCUMENT chunks — the model-free twin of
@@ -4470,7 +4540,8 @@ impl Db {
         if limit <= 0 {
             return Ok(Vec::new());
         }
-        let Some(match_expr) = fts_match_query(query.trim()) else {
+        let q = query.trim();
+        let Some(and_expr) = fts_match_query(q) else {
             return Ok(Vec::new()); // punctuation-only / empty query → no hits, never an FTS error.
         };
         let conn = self.lock();
@@ -4486,13 +4557,31 @@ impl Db {
               ORDER BY bm25(fts_doc_chunks) ASC, d.id ASC"
         );
         let mut stmt = conn.prepare(&sql).map_err(map_err)?;
-        let rows = stmt
-            .query_map(rusqlite::params![match_expr], Self::doc_candidate_from_row)
-            .map_err(map_err)?;
         // Bound the sibling-count scan so a stop-word-ish query over a large corpus stays cheap;
         // sibling counts are then a LOWER bound, which can only under-trigger expansion (safe).
         let scan_cap = (limit as usize).saturating_mul(10).max(64);
-        Self::fold_doc_candidates(rows.take(scan_cap), Some(limit as usize))
+        // Collect the (already-gated) candidate rows for a given match expression, bounded by scan_cap.
+        let run = |stmt: &mut rusqlite::Statement, expr: &str| -> Result<Vec<DocChunkHit>> {
+            let rows = stmt
+                .query_map(rusqlite::params![expr], Self::doc_candidate_from_row)
+                .map_err(map_err)?;
+            let mut cands = Vec::new();
+            for r in rows.take(scan_cap) {
+                cands.push(r.map_err(map_err)?);
+            }
+            Ok(cands)
+        };
+        // S2 AND→OR fallback: implicit-AND matched nothing ⇒ retry with the content-word OR twin.
+        // Fires only on an empty AND result — never widens a successful query.
+        let mut cands = run(&mut stmt, &and_expr)?;
+        if cands.is_empty() {
+            if let Some(any_expr) = fts_match_query_any(q) {
+                if any_expr != and_expr {
+                    cands = run(&mut stmt, &any_expr)?;
+                }
+            }
+        }
+        Self::fold_doc_candidates(cands.into_iter().map(Ok), Some(limit as usize))
     }
 
     /// Brain v3 audit Fix 1 — HIT-ALIGNED, SIBLING-GATED parent expansion (LlamaIndex auto-merging
@@ -5541,7 +5630,7 @@ impl Db {
         date_filter: Option<&(String, String)>,
     ) -> Result<Vec<SearchHit>> {
         let q = query.trim();
-        let Some(match_expr) = fts_match_query(q) else {
+        let Some(and_expr) = fts_match_query(q) else {
             return Ok(Vec::new());
         };
         let conn = self.lock();
@@ -5592,12 +5681,28 @@ impl Db {
               LIMIT ?2"
         );
         let mut stmt = conn.prepare(&sql).map_err(map_err)?;
-        let rows = stmt
-            .query_map(rusqlite::params![match_expr, limit], row_to_meeting)
-            .map_err(map_err)?;
-        let mut meetings = Vec::new();
-        for r in rows {
-            meetings.push(r.map_err(map_err)??);
+        // Run the (already-gated) FTS body with a given match expression; only WHICH visible rows
+        // match changes when we swap AND→OR.
+        let run = |stmt: &mut rusqlite::Statement, expr: &str| -> Result<Vec<Meeting>> {
+            let rows = stmt
+                .query_map(rusqlite::params![expr, limit], row_to_meeting)
+                .map_err(map_err)?;
+            let mut meetings = Vec::new();
+            for r in rows {
+                meetings.push(r.map_err(map_err)??);
+            }
+            Ok(meetings)
+        };
+        // S2 AND→OR fallback: implicit-AND matched nothing ⇒ retry with the content-word OR twin
+        // (stopwords/<3-char dropped). Fires ONLY on an empty AND result, so it never widens a
+        // successful query and stays exact-word lexical (the crisp "no match" is preserved).
+        let mut meetings = run(&mut stmt, &and_expr)?;
+        if meetings.is_empty() {
+            if let Some(any_expr) = fts_match_query_any(q) {
+                if any_expr != and_expr {
+                    meetings = run(&mut stmt, &any_expr)?;
+                }
+            }
         }
         let like = format!("%{}%", escape_like(q));
         let mut hits = Vec::with_capacity(meetings.len());

--- a/src-tauri/src/storage/db_tests/tests.rs
+++ b/src-tauri/src/storage/db_tests/tests.rs
@@ -307,7 +307,7 @@ fn org_ingest_round_trips_through_int8_knn_and_fts() {
         .embed_query(&["apollo budget".to_string()])
         .unwrap()
         .remove(0);
-    let knn = db.search_org_chunks_knn(&qv, 10).unwrap();
+    let knn = db.search_org_chunks_knn(&qv, 10, 0.0).unwrap();
     assert!(
         knn.iter().any(|h| h.item_id == "it-1"),
         "int8 KNN must retrieve the ingested item"
@@ -352,7 +352,7 @@ fn org_ingest_fts_only_when_no_embedder() {
         .embed_query(&["hiring platform".to_string()])
         .unwrap()
         .remove(0);
-    let knn = db.search_org_chunks_knn(&qv, 10).unwrap();
+    let knn = db.search_org_chunks_knn(&qv, 10, 0.0).unwrap();
     assert!(knn.is_empty(), "no int8 vectors when ingested FTS-only");
 
     // The re-embed backlog lists exactly this item.
@@ -911,7 +911,7 @@ fn org_tombstone_evicts_from_retrieval_and_viewer() {
         .unwrap()
         .remove(0);
     assert!(
-        db.search_org_chunks_knn(&qv, 10).unwrap().is_empty(),
+        db.search_org_chunks_knn(&qv, 10, 0.0).unwrap().is_empty(),
         "tombstoned item must vanish from KNN"
     );
     assert!(
@@ -1016,7 +1016,7 @@ fn purge_org_replica_drops_the_whole_decrypted_replica() {
         .embed_query(&["falcon rollout".to_string()])
         .unwrap()
         .remove(0);
-    let knn = db.search_org_chunks_knn(&qv, 10).unwrap();
+    let knn = db.search_org_chunks_knn(&qv, 10, 0.0).unwrap();
     assert!(
         knn.iter()
             .all(|h| h.item_id != "it-a" && h.item_id != "it-b"),
@@ -1269,7 +1269,7 @@ fn disabled_org_is_excluded_from_both_retrieval_legs_while_enabled_org_still_sur
         .embed_query(&["quantum ledger migration".to_string()])
         .unwrap()
         .remove(0);
-    let knn_after = db.search_org_chunks_knn(&qv, 10).unwrap();
+    let knn_after = db.search_org_chunks_knn(&qv, 10, 0.0).unwrap();
     assert!(
         knn_after.iter().all(|h| h.item_id != "it-disabled"),
         "the disabled org's item must be ABSENT from KNN too: {:?}",
@@ -5847,7 +5847,7 @@ fn vec_knn_orders_nearest_first() {
     insert_known_chunk(&db, "m-far", "far", &one_hot(2));
 
     let nothing = std::collections::HashSet::new();
-    let hits = db.search_semantic_visible(&query, 3, &nothing).unwrap();
+    let hits = db.search_semantic_visible(&query, 3, 0.0, &nothing).unwrap();
     let order: Vec<&str> = hits.iter().map(|h| h.meeting.id.as_str()).collect();
     assert_eq!(
         order,
@@ -5876,7 +5876,7 @@ fn vec_semantic_search_is_gated_by_visibility() {
     let query = one_hot(0);
     // Empty unlock set → excluded.
     let nothing = std::collections::HashSet::new();
-    let hidden = db.search_semantic_visible(&query, 10, &nothing).unwrap();
+    let hidden = db.search_semantic_visible(&query, 10, 0.0, &nothing).unwrap();
     assert!(
         !hidden.iter().any(|h| h.meeting.id == "sealed"),
         "sealed-not-unlocked meeting leaked through the semantic gate"
@@ -5884,7 +5884,7 @@ fn vec_semantic_search_is_gated_by_visibility() {
     // Folder session-unlocked → present.
     let mut unlocked = std::collections::HashSet::new();
     unlocked.insert("f-locked".to_string());
-    let shown = db.search_semantic_visible(&query, 10, &unlocked).unwrap();
+    let shown = db.search_semantic_visible(&query, 10, 0.0, &unlocked).unwrap();
     assert!(
         shown.iter().any(|h| h.meeting.id == "sealed"),
         "session-unlocked meeting must reappear in semantic results"
@@ -5911,7 +5911,7 @@ fn vec_hybrid_search_is_gated_by_visibility() {
     // Empty unlock set → the sealed meeting is absent through the whole fused reader.
     let nothing = std::collections::HashSet::new();
     let hidden = db
-        .search_hybrid_visible("budget", &query_vec, 10, &nothing, None)
+        .search_hybrid_visible("budget", &query_vec, 10, 0.0, &nothing, None)
         .unwrap();
     assert!(
         !hidden.iter().any(|h| h.meeting.id == "sealed"),
@@ -5922,7 +5922,7 @@ fn vec_hybrid_search_is_gated_by_visibility() {
     let mut unlocked = std::collections::HashSet::new();
     unlocked.insert("f-locked".to_string());
     let shown = db
-        .search_hybrid_visible("budget", &query_vec, 10, &unlocked, None)
+        .search_hybrid_visible("budget", &query_vec, 10, 0.0, &unlocked, None)
         .unwrap();
     assert!(
         shown.iter().any(|h| h.meeting.id == "sealed"),
@@ -6322,7 +6322,7 @@ fn doc_chunk_search_is_gated_by_visibility() {
     // Open folder → visible.
     let nothing = std::collections::HashSet::new();
     assert!(
-        db.search_doc_chunks_visible(&query, 10, &nothing)
+        db.search_doc_chunks_visible(&query, 10, 0.0, &nothing)
             .unwrap()
             .iter()
             .any(|h| h.document_id == "d1"),
@@ -6331,7 +6331,7 @@ fn doc_chunk_search_is_gated_by_visibility() {
 
     // Seal the folder (chunk row deliberately survives) → INVISIBLE with empty unlock set.
     db.set_folder_locked("f-locked", true, None).unwrap();
-    let hidden = db.search_doc_chunks_visible(&query, 10, &nothing).unwrap();
+    let hidden = db.search_doc_chunks_visible(&query, 10, 0.0, &nothing).unwrap();
     assert!(
         !hidden.iter().any(|h| h.document_id == "d1"),
         "sealed-not-unlocked document chunk leaked through the gate"
@@ -6340,7 +6340,7 @@ fn doc_chunk_search_is_gated_by_visibility() {
     // Session-unlock → present again.
     let mut unlocked = std::collections::HashSet::new();
     unlocked.insert("f-locked".to_string());
-    let shown = db.search_doc_chunks_visible(&query, 10, &unlocked).unwrap();
+    let shown = db.search_doc_chunks_visible(&query, 10, 0.0, &unlocked).unwrap();
     assert!(
         shown.iter().any(|h| h.document_id == "d1"),
         "session-unlocked document chunk must reappear in search"
@@ -9532,7 +9532,7 @@ fn transcript_chunks_are_gated_by_visibility_semantic() {
 
     let query = one_hot(0);
     let nothing = std::collections::HashSet::new();
-    let hidden = db.search_semantic_visible(&query, 10, &nothing).unwrap();
+    let hidden = db.search_semantic_visible(&query, 10, 0.0, &nothing).unwrap();
     assert!(
         !hidden.iter().any(|h| h.meeting.id == "sealed"),
         "sealed meeting's TRANSCRIPT chunk leaked through the semantic gate"
@@ -9540,7 +9540,7 @@ fn transcript_chunks_are_gated_by_visibility_semantic() {
     // Session-unlock → it reappears (proves the row + gate, not purge).
     let mut unlocked = std::collections::HashSet::new();
     unlocked.insert("f-locked".to_string());
-    let shown = db.search_semantic_visible(&query, 10, &unlocked).unwrap();
+    let shown = db.search_semantic_visible(&query, 10, 0.0, &unlocked).unwrap();
     assert!(
         shown.iter().any(|h| h.meeting.id == "sealed"),
         "session-unlocked meeting's transcript chunk must reappear in semantic results"
@@ -9581,7 +9581,7 @@ fn transcript_chunks_are_gated_by_visibility_hybrid() {
     let query_vec = one_hot(0);
     let nothing = std::collections::HashSet::new();
     let hidden = db
-        .search_hybrid_visible("merger", &query_vec, 10, &nothing, None)
+        .search_hybrid_visible("merger", &query_vec, 10, 0.0, &nothing, None)
         .unwrap();
     assert!(
         !hidden.iter().any(|h| h.meeting.id == "sealed"),
@@ -9590,7 +9590,7 @@ fn transcript_chunks_are_gated_by_visibility_hybrid() {
     let mut unlocked = std::collections::HashSet::new();
     unlocked.insert("f-locked".to_string());
     let shown = db
-        .search_hybrid_visible("merger", &query_vec, 10, &unlocked, None)
+        .search_hybrid_visible("merger", &query_vec, 10, 0.0, &unlocked, None)
         .unwrap();
     assert!(
         shown.iter().any(|h| h.meeting.id == "sealed"),
@@ -9655,14 +9655,14 @@ fn transcript_chunks_purged_on_seal() {
     let query = one_hot(0);
     let nothing = std::collections::HashSet::new();
     assert!(
-        !db.search_semantic_visible(&query, 10, &nothing)
+        !db.search_semantic_visible(&query, 10, 0.0, &nothing)
             .unwrap()
             .iter()
             .any(|h| h.meeting.id == "m1"),
         "sealed meeting must not surface via semantic search after purge"
     );
     assert!(
-        !db.search_hybrid_visible("marketing", &query, 10, &nothing, None)
+        !db.search_hybrid_visible("marketing", &query, 10, 0.0, &nothing, None)
             .unwrap()
             .iter()
             .any(|h| h.meeting.id == "m1"),
@@ -9735,7 +9735,7 @@ fn vec_hybrid_fuses_fts_and_vector() {
 
     let nothing = std::collections::HashSet::new();
     let hits = db
-        .search_hybrid_visible("alpha", &query, 10, &nothing, None)
+        .search_hybrid_visible("alpha", &query, 10, 0.0, &nothing, None)
         .unwrap();
     let ids: Vec<&str> = hits.iter().map(|h| h.meeting.id.as_str()).collect();
     // One hit per meeting (dedup).
@@ -9794,14 +9794,14 @@ fn graph_leg_surfaces_co_mentioned_meeting_fts_and_vector_miss() {
     );
     // ... and absent from vector (no chunk at all → empty KNN).
     assert!(
-        db.search_semantic_visible(&empty_vec, 10, &nothing)
+        db.search_semantic_visible(&empty_vec, 10, 0.0, &nothing)
             .unwrap()
             .is_empty(),
         "vector must miss B"
     );
     // The query names entity Atlas → graph leg pulls in its neighbour B.
     let hits = db
-        .search_hybrid_visible("atlas status", &empty_vec, 10, &nothing, None)
+        .search_hybrid_visible("atlas status", &empty_vec, 10, 0.0, &nothing, None)
         .unwrap();
     assert!(
         hits.iter().any(|h| h.meeting.id == "B"),
@@ -9900,7 +9900,7 @@ fn no_entity_match_leaves_hybrid_identical_to_two_leg_fusion() {
 
     // Expected = RRF over EXACTLY the two legs.
     let fts = db.search_visible("budget planning", 10, &nothing).unwrap();
-    let sem = db.search_semantic_visible(&query, 10, &nothing).unwrap();
+    let sem = db.search_semantic_visible(&query, 10, 0.0, &nothing).unwrap();
     let fts_ids: Vec<String> = fts.iter().map(|h| h.meeting.id.clone()).collect();
     let sem_ids: Vec<String> = sem.iter().map(|h| h.meeting.id.clone()).collect();
     let expected: Vec<String> = crate::embed::rrf_fuse(&[fts_ids, sem_ids], crate::embed::RRF_K)
@@ -9909,7 +9909,7 @@ fn no_entity_match_leaves_hybrid_identical_to_two_leg_fusion() {
         .collect();
 
     let got: Vec<String> = db
-        .search_hybrid_visible("budget planning", &query, 10, &nothing, None)
+        .search_hybrid_visible("budget planning", &query, 10, 0.0, &nothing, None)
         .unwrap()
         .into_iter()
         .map(|h| h.meeting.id)
@@ -9946,7 +9946,7 @@ fn three_leg_rrf_ranks_multi_leg_first_and_dedups() {
 
     let nothing = std::collections::HashSet::new();
     let hits = db
-        .search_hybrid_visible("atlas budget", &query, 10, &nothing, None)
+        .search_hybrid_visible("atlas budget", &query, 10, 0.0, &nothing, None)
         .unwrap();
     let ids: Vec<&str> = hits.iter().map(|h| h.meeting.id.as_str()).collect();
     // Dedup: each meeting once.
@@ -10362,7 +10362,7 @@ fn hybrid_date_filter_excludes_out_of_window_lexical_match() {
 
     // RED baseline (no filter): BOTH lexical matches surface.
     let unfiltered = db
-        .search_hybrid_visible("budżet", &[], 10, &nothing, None)
+        .search_hybrid_visible("budżet", &[], 10, 0.0, &nothing, None)
         .unwrap();
     assert!(unfiltered.iter().any(|h| h.meeting.id == "m-in"));
     assert!(
@@ -10373,7 +10373,7 @@ fn hybrid_date_filter_excludes_out_of_window_lexical_match() {
     // GREEN: the "last week of the 2026-06-29 anchor" window excludes m-out on EVERY leg.
     let window = Some(("2026-06-22".to_string(), "2026-06-29".to_string()));
     let filtered = db
-        .search_hybrid_visible("budżet", &[], 10, &nothing, window)
+        .search_hybrid_visible("budżet", &[], 10, 0.0, &nothing, window)
         .unwrap();
     assert!(
         filtered.iter().any(|h| h.meeting.id == "m-in"),
@@ -10781,4 +10781,287 @@ fn clear_meeting_audio_path_if_only_nulls_a_matching_path() {
     // Matching snapshot (no concurrent seal) → clears.
     db.clear_meeting_audio_path_if("M", "/d/M.wav").unwrap();
     assert_eq!(db.get_meeting("M").unwrap().unwrap().audio_path, None);
+}
+
+// ── S1 cosine-similarity floor + S2 AND→OR FTS fallback (retrieval-floor-fts-fallback) ──────────
+
+/// Insert a doc-chunk row + its `doc_vec_chunks` embedding under a MEANING-controlled vector (the
+/// document twin of [`insert_known_chunk`]). Used by the S1 floor tests.
+fn insert_known_doc_chunk(db: &Db, document_id: &str, text: &str, vector: &[f32]) -> i64 {
+    let conn = db.lock();
+    conn.execute(
+        "INSERT INTO doc_chunks (document_id, chunk_index, text) VALUES (?1, 0, ?2)",
+        rusqlite::params![document_id, text],
+    )
+    .unwrap();
+    let chunk_id = conn.last_insert_rowid();
+    let blob = crate::embed::vec_to_blob(vector);
+    conn.execute(
+        "INSERT INTO doc_vec_chunks(chunk_id, embedding) VALUES (?1, ?2)",
+        rusqlite::params![chunk_id, blob],
+    )
+    .unwrap();
+    chunk_id
+}
+
+/// Insert an org item + one chunk + its int8 `org_vec_chunks` embedding under a controlled vector
+/// (the KNN leg quantizes to int8, so the stored vector is `round(unit·127)`). `seed_org_state`
+/// must have run first (the reader INNER JOINs `org_state` on `context_enabled = 1`).
+fn insert_known_org_chunk(
+    db: &Db,
+    org_id: &str,
+    item_id: &str,
+    title: &str,
+    text: &str,
+    vector: &[f32],
+) {
+    let conn = db.lock();
+    conn.execute(
+        "INSERT INTO org_items (item_id, org_id, seq, author_hint, title, markdown, created_at, rev, generation, content_sha256, tombstoned)
+             VALUES (?1, ?2, 1, 'anna', ?3, ?4, '2026-07-10T09:00:00Z', 1, 1, NULL, 0)",
+        rusqlite::params![item_id, org_id, title, text],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO org_chunks (item_id, chunk_idx, text) VALUES (?1, 0, ?2)",
+        rusqlite::params![item_id, text],
+    )
+    .unwrap();
+    let chunk_id = conn.last_insert_rowid();
+    let blob = crate::embed::vec_to_int8_blob(vector);
+    conn.execute(
+        "INSERT INTO org_vec_chunks(chunk_id, embedding) VALUES (?1, vec_int8(?2))",
+        rusqlite::params![chunk_id, blob],
+    )
+    .unwrap();
+}
+
+/// S1 Test A (meetings): the cosine floor drops an ORTHOGONAL (cos 0.0) k-nearest neighbour while
+/// keeping the near (cos 1.0) one. Proving BOTH survive with `min_cosine = 0.0` shows the exclusion
+/// is the FLOOR, not the visibility gate.
+#[test]
+fn s1_floor_drops_orthogonal_semantic_neighbour() {
+    let db = mem_db();
+    db.insert_meeting(&sample_meeting("m-near", "2026-06-24T10:00:00Z"))
+        .unwrap();
+    db.insert_meeting(&sample_meeting("m-far", "2026-06-24T11:00:00Z"))
+        .unwrap();
+    note_for(&db, "m-near", "claude_code", "near");
+    note_for(&db, "m-far", "claude_code", "far");
+    insert_known_chunk(&db, "m-near", "near", &one_hot(0)); // cos 1.0 vs query
+    insert_known_chunk(&db, "m-far", "far", &one_hot(2)); // cos 0.0 vs query
+
+    let nothing = std::collections::HashSet::new();
+    let query = one_hot(0);
+
+    // No floor (0.0) → BOTH returned.
+    let all = db.search_semantic_visible(&query, 10, 0.0, &nothing).unwrap();
+    let ids: Vec<&str> = all.iter().map(|h| h.meeting.id.as_str()).collect();
+    assert!(
+        ids.contains(&"m-near") && ids.contains(&"m-far"),
+        "no-floor must return both, got {ids:?}"
+    );
+
+    // Floor 0.75 → only the near (cos 1.0) survives.
+    let floored = db.search_semantic_visible(&query, 10, 0.75, &nothing).unwrap();
+    let fids: Vec<&str> = floored.iter().map(|h| h.meeting.id.as_str()).collect();
+    assert_eq!(
+        fids,
+        vec!["m-near"],
+        "floor must drop the orthogonal filler, got {fids:?}"
+    );
+}
+
+/// S1 Test A (documents): same floor behaviour for the doc-chunk vector leg.
+#[test]
+fn s1_floor_drops_orthogonal_doc_chunk() {
+    let db = mem_db();
+    seed_folder(&db, "f-open", "Project");
+    db.insert_document("d-near", "f-open", "near.md", "near body", "document", 100)
+        .unwrap();
+    db.insert_document("d-far", "f-open", "far.md", "far body", "document", 100)
+        .unwrap();
+    insert_known_doc_chunk(&db, "d-near", "near body", &one_hot(0));
+    insert_known_doc_chunk(&db, "d-far", "far body", &one_hot(2));
+
+    let nothing = std::collections::HashSet::new();
+    let query = one_hot(0);
+
+    let all = db
+        .search_doc_chunks_visible(&query, 10, 0.0, &nothing)
+        .unwrap();
+    let ids: Vec<&str> = all.iter().map(|h| h.document_id.as_str()).collect();
+    assert!(
+        ids.contains(&"d-near") && ids.contains(&"d-far"),
+        "no-floor must return both docs, got {ids:?}"
+    );
+
+    let floored = db
+        .search_doc_chunks_visible(&query, 10, 0.75, &nothing)
+        .unwrap();
+    let fids: Vec<&str> = floored.iter().map(|h| h.document_id.as_str()).collect();
+    assert_eq!(
+        fids,
+        vec!["d-near"],
+        "floor must drop the orthogonal doc, got {fids:?}"
+    );
+}
+
+/// S1 Test A (org int8): the floor drops an orthogonal item on the int8 leg — proving the `/127`
+/// rescale (the int8 vectors are `round(unit·127)`, a different distance distribution).
+#[test]
+fn s1_floor_drops_orthogonal_org_chunk_int8() {
+    let db = mem_db();
+    seed_org_state(&db, "org-1");
+    insert_known_org_chunk(&db, "org-1", "it-near", "Near", "near body", &one_hot(0));
+    insert_known_org_chunk(&db, "org-1", "it-far", "Far", "far body", &one_hot(2));
+
+    let query = one_hot(0);
+
+    let all = db.search_org_chunks_knn(&query, 10, 0.0).unwrap();
+    let ids: Vec<&str> = all.iter().map(|h| h.item_id.as_str()).collect();
+    assert!(
+        ids.contains(&"it-near") && ids.contains(&"it-far"),
+        "no-floor must return both items, got {ids:?}"
+    );
+
+    let floored = db.search_org_chunks_knn(&query, 10, 0.75).unwrap();
+    let fids: Vec<&str> = floored.iter().map(|h| h.item_id.as_str()).collect();
+    assert_eq!(
+        fids,
+        vec!["it-near"],
+        "int8 /127-rescaled floor must drop the orthogonal item, got {fids:?}"
+    );
+}
+
+/// S1 Test B (recall safety): with the vector leg FLOORED to empty on an irrelevant corpus, an
+/// EXACT-WORD FTS hit still surfaces through `search_hybrid_visible` — the floor never touches the
+/// FTS/graph legs, and `score_fuse`'s empty-leg redistribution rescales the survivors.
+#[test]
+fn s1_floor_keeps_fts_hit_when_vector_leg_floored_empty() {
+    let db = mem_db();
+    db.insert_meeting(&sample_meeting("m-budget", "2026-06-24T10:00:00Z"))
+        .unwrap();
+    // FTS text carries "budget"; the ONLY chunk is orthogonal (one_hot(2)) to the query one_hot(0).
+    note_for(&db, "m-budget", "claude_code", "the quarterly budget review");
+    insert_known_chunk(&db, "m-budget", "the quarterly budget review", &one_hot(2));
+
+    let nothing = std::collections::HashSet::new();
+    let hits = db
+        .search_hybrid_visible("budget", &one_hot(0), 10, 0.75, &nothing, None)
+        .unwrap();
+    assert!(
+        hits.iter().any(|h| h.meeting.id == "m-budget"),
+        "an exact-word FTS hit must survive even when the vector leg is floored to empty"
+    );
+}
+
+/// S2 Test C (meetings): the AND→OR fallback recovers a multi-word miss — "etykieta parcel" (AND
+/// misses, no "etykieta") matches a note containing only "parcel" via the OR twin.
+#[test]
+fn s2_and_to_or_fallback_recovers_multiword_miss_meetings() {
+    let db = mem_db();
+    db.insert_meeting(&sample_meeting("m1", "2026-06-24T10:00:00Z"))
+        .unwrap();
+    note_for(&db, "m1", "claude_code", "parcel size delivery schedule");
+    let nothing = std::collections::HashSet::new();
+    let hits = db.search_visible("etykieta parcel", 10, &nothing).unwrap();
+    assert!(
+        hits.iter().any(|h| h.meeting.id == "m1"),
+        "AND→OR fallback must recover a note sharing only 'parcel'"
+    );
+}
+
+/// S2 Test C (documents): the same AND→OR fallback in the doc-chunk FTS reader.
+#[test]
+fn s2_and_to_or_fallback_recovers_multiword_miss_docs() {
+    let db = mem_db();
+    seed_folder(&db, "f-open", "Project");
+    db.insert_document(
+        "d1",
+        "f-open",
+        "spec.md",
+        "parcel size delivery schedule",
+        "document",
+        100,
+    )
+    .unwrap();
+    db.index_document_chunks("d1", None).unwrap();
+    let nothing = std::collections::HashSet::new();
+    let hits = db
+        .search_doc_chunks_fts_visible("etykieta parcel", 10, &nothing)
+        .unwrap();
+    assert!(
+        hits.iter().any(|h| h.document_id == "d1"),
+        "AND→OR fallback must recover a document sharing only 'parcel'"
+    );
+}
+
+/// S2 Test C (org): the same AND→OR fallback in the org-chunk FTS reader.
+#[test]
+fn s2_and_to_or_fallback_recovers_multiword_miss_org() {
+    let db = mem_db();
+    seed_org_state(&db, "org-1");
+    db.upsert_org_item(
+        "it-1",
+        "org-1",
+        1,
+        "anna",
+        "Parcels",
+        "parcel size delivery schedule",
+        "2026-07-10T09:00:00Z",
+        1,
+        1,
+        &sha32(1),
+        None,
+        None,
+        None,
+    )
+    .unwrap();
+    let hits = db.search_org_chunks_fts("etykieta parcel", 10).unwrap();
+    assert!(
+        hits.iter().any(|h| h.item_id == "it-1"),
+        "AND→OR fallback must recover an org item sharing only 'parcel'"
+    );
+}
+
+/// S2 Test D (precision preserved — the QA "No meetings match" guard): a query whose content words
+/// appear in NONE of the corpus notes stays EMPTY even after the OR fallback (no shared content
+/// word ⇒ the OR built from the query's own content words matches nothing).
+#[test]
+fn s2_precision_preserved_no_shared_content_word() {
+    let db = mem_db();
+    db.insert_meeting(&sample_meeting("m1", "2026-06-24T10:00:00Z"))
+        .unwrap();
+    db.insert_meeting(&sample_meeting("m2", "2026-06-24T11:00:00Z"))
+        .unwrap();
+    note_for(&db, "m1", "claude_code", "parcel size delivery schedule");
+    note_for(&db, "m2", "claude_code", "roadmap planning session notes");
+    let nothing = std::collections::HashSet::new();
+    let hits = db
+        .search_visible("shipment label generation", 10, &nothing)
+        .unwrap();
+    assert!(
+        hits.is_empty(),
+        "OR fallback must NOT match when no content word is shared, got {:?}",
+        hits.iter().map(|h| h.meeting.id.clone()).collect::<Vec<_>>()
+    );
+}
+
+/// S2 Test E (stopword-only overlap must NOT hit): a query sharing ONLY stopwords ("the", "is")
+/// with a note stays empty — `fts_match_query_any` drops stopwords/<3-char before building the OR,
+/// so the shared function words can never produce a hit through the fallback.
+#[test]
+fn s2_stopword_only_overlap_does_not_hit() {
+    let db = mem_db();
+    db.insert_meeting(&sample_meeting("m1", "2026-06-24T10:00:00Z"))
+        .unwrap();
+    note_for(&db, "m1", "claude_code", "the plan is done");
+    let nothing = std::collections::HashSet::new();
+    let hits = db.search_visible("what is the status", 10, &nothing).unwrap();
+    assert!(
+        hits.is_empty(),
+        "stopword-only overlap must not produce a hit through the OR fallback, got {:?}",
+        hits.iter().map(|h| h.meeting.id.clone()).collect::<Vec<_>>()
+    );
 }

--- a/src-tauri/src/storage/org_store.rs
+++ b/src-tauri/src/storage/org_store.rs
@@ -25,7 +25,7 @@ use rusqlite::OptionalExtension;
 
 use crate::embed::Embedder;
 use crate::error::Result;
-use crate::storage::db::{fts_match_query, map_err, Db};
+use crate::storage::db::{fts_match_query, fts_match_query_any, map_err, Db};
 use crate::storage::models::OrgChunkHit;
 
 /// Chunk/vector material for one org item, prepared before entering the short feed-commit
@@ -1515,7 +1515,18 @@ impl Db {
     /// disabled org's chunks are EXCLUDED at the SQL level, never read into Rust at all. This is the
     /// hard data-level gate (not a UI hide): a caller cannot accidentally surface a disabled org's
     /// content by forgetting to filter it downstream.
-    pub fn search_org_chunks_knn(&self, query_vec: &[f32], k: i64) -> Result<Vec<OrgChunkHit>> {
+    ///
+    /// `min_cosine` (S1) is the OPT-IN relevance floor for the int8 leg. The stored vectors are
+    /// `round(unit·127)`, so the vec0 L2 distance is over 127-scaled vectors — divide by `127.0`
+    /// BEFORE the cosine map (`cos ≈ cosine_from_l2_distance(d/127)`; a DIFFERENT distribution from
+    /// the f32 legs, hence its own const). Sentinel `0.0` = NO floor. Applied AFTER the
+    /// tombstone/context-enabled SQL gate — it can only ever REMOVE below-floor rows.
+    pub fn search_org_chunks_knn(
+        &self,
+        query_vec: &[f32],
+        k: i64,
+        min_cosine: f32,
+    ) -> Result<Vec<OrgChunkHit>> {
         if query_vec.is_empty() || k <= 0 {
             return Ok(Vec::new());
         }
@@ -1538,16 +1549,32 @@ impl Db {
         let mut stmt = conn.prepare(sql).map_err(map_err)?;
         let rows = stmt
             .query_map(rusqlite::params![blob, k], |row| {
-                Ok(OrgChunkHit {
+                let hit = OrgChunkHit {
                     item_id: row.get(0)?,
                     author_hint: row.get(1)?,
                     title: row.get(2)?,
                     snippet: row.get(3)?,
                     content_sha256: row.get::<_, Option<Vec<u8>>>(4)?.unwrap_or_default(),
-                })
+                };
+                let distance: f64 = row.get(5)?;
+                Ok((hit, distance))
             })
             .map_err(map_err)?;
-        Self::dedup_org_hits_by_item(rows)
+        // Drop below-floor candidates BEFORE the per-item dedup so the winner is the nearest survivor.
+        // int8 rescale: the distance is over 127-scaled vectors ⇒ divide by 127 before the cosine map.
+        let filtered = rows.filter_map(|r| match r {
+            Ok((hit, distance)) => {
+                if min_cosine > 0.0
+                    && crate::links::cosine_from_l2_distance((distance as f32) / 127.0) < min_cosine
+                {
+                    None
+                } else {
+                    Some(Ok(hit))
+                }
+            }
+            Err(e) => Some(Err(e)),
+        });
+        Self::dedup_org_hits_by_item(filtered)
     }
 
     /// KEYWORD (FTS5/BM25) leg over the org partition — the model-free twin of
@@ -1562,7 +1589,8 @@ impl Db {
         if limit <= 0 {
             return Ok(Vec::new());
         }
-        let Some(match_expr) = fts_match_query(query.trim()) else {
+        let q = query.trim();
+        let Some(and_expr) = fts_match_query(q) else {
             return Ok(Vec::new()); // punctuation-only / empty query → no hits, never an FTS error.
         };
         let conn = self.lock();
@@ -1579,18 +1607,36 @@ impl Db {
               ORDER BY rank ASC, oi.item_id ASC
               LIMIT ?2";
         let mut stmt = conn.prepare(sql).map_err(map_err)?;
-        let rows = stmt
-            .query_map(rusqlite::params![match_expr, sql_cap], |row| {
-                Ok(OrgChunkHit {
-                    item_id: row.get(0)?,
-                    author_hint: row.get(1)?,
-                    title: row.get(2)?,
-                    snippet: row.get(3)?,
-                    content_sha256: row.get::<_, Option<Vec<u8>>>(4)?.unwrap_or_default(),
+        // Collect the (already-gated) candidate rows for a given match expression.
+        let run = |stmt: &mut rusqlite::Statement, expr: &str| -> Result<Vec<OrgChunkHit>> {
+            let rows = stmt
+                .query_map(rusqlite::params![expr, sql_cap], |row| {
+                    Ok(OrgChunkHit {
+                        item_id: row.get(0)?,
+                        author_hint: row.get(1)?,
+                        title: row.get(2)?,
+                        snippet: row.get(3)?,
+                        content_sha256: row.get::<_, Option<Vec<u8>>>(4)?.unwrap_or_default(),
+                    })
                 })
-            })
-            .map_err(map_err)?;
-        let mut hits = Self::dedup_org_hits_by_item(rows)?;
+                .map_err(map_err)?;
+            let mut out = Vec::new();
+            for r in rows {
+                out.push(r.map_err(map_err)?);
+            }
+            Ok(out)
+        };
+        // S2 AND→OR fallback: implicit-AND matched nothing ⇒ retry with the content-word OR twin.
+        // Fires only on an empty AND result — never widens a successful query.
+        let mut rows_vec = run(&mut stmt, &and_expr)?;
+        if rows_vec.is_empty() {
+            if let Some(any_expr) = fts_match_query_any(q) {
+                if any_expr != and_expr {
+                    rows_vec = run(&mut stmt, &any_expr)?;
+                }
+            }
+        }
+        let mut hits = Self::dedup_org_hits_by_item(rows_vec.into_iter().map(Ok))?;
         hits.truncate(limit as usize);
         Ok(hits)
     }

--- a/src-tauri/src/summarize/related_context.rs
+++ b/src-tauri/src/summarize/related_context.rs
@@ -382,7 +382,7 @@ fn gated_candidates(
             // No temporal window here: the grounding query is a derived salient-term string, not
             // a user question (a temporal phrase in it would be note prose, not intent).
             Some(qv) if !qv.is_empty() => {
-                db.search_hybrid_visible(query, &qv, limit, unlocked, None)
+                db.search_hybrid_visible(query, &qv, limit, 0.0, unlocked, None)
             }
             // Empty/degenerate query vector → FTS (never a stub-vector KNN).
             _ => db.search_visible(query, limit, unlocked),

--- a/src-tauri/src/summarize/vault_context.rs
+++ b/src-tauri/src/summarize/vault_context.rs
@@ -119,7 +119,7 @@ pub fn build_vault_context_hybrid_visible(
     // Brain v2 L1.5 — temporal window (all hybrid legs apply it; query-time `now` anchor).
     let date_filter =
         crate::summarize::temporal::extract_date_filter(query, chrono::Utc::now().date_naive());
-    let mut hits = db.search_hybrid_visible(query, query_vec, 40, unlocked, date_filter)?;
+    let mut hits = db.search_hybrid_visible(query, query_vec, 40, 0.0, unlocked, date_filter)?;
 
     // Brain v2 L1.4 — the RERANKER seam (Ask-only): reorder the TOP-K fused candidates before
     // packing. The reranker sees ONLY already-gated hits (id + title/snippet — content the caller
@@ -194,7 +194,7 @@ pub fn build_meeting_listing_visible(
             .map(|h| h.meeting)
             .collect()
     } else {
-        db.search_hybrid_visible(query, query_vec, limit, unlocked, date_filter)?
+        db.search_hybrid_visible(query, query_vec, limit, 0.0, unlocked, date_filter)?
             .into_iter()
             .map(|h| h.meeting)
             .collect()
@@ -235,7 +235,7 @@ fn pack_doc_chunks(
     let knn = if query_vec.is_empty() {
         Vec::new()
     } else {
-        db.search_doc_chunks_visible(query_vec, 20, unlocked)?
+        db.search_doc_chunks_visible(query_vec, 20, 0.0, unlocked)?
     };
     let fts = db.search_doc_chunks_fts_visible(query, 20, unlocked)?;
     let mut hits = crate::embed::fuse_doc_hits(knn, fts);

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -565,7 +565,12 @@ pub fn execute_tool(
             // against `unlocked`, so a locked-and-not-unlocked folder's documents are invisible here
             // exactly like a sealed meeting. Appended as a `DOCUMENTS:` section.
             let knn_docs = db
-                .search_doc_chunks_visible(&query_vec, 20, unlocked)
+                .search_doc_chunks_visible(
+                    &query_vec,
+                    20,
+                    crate::embed::KNN_SEARCH_COSINE_FLOOR,
+                    unlocked,
+                )
                 .unwrap_or_default();
             let fts_docs = db
                 .search_doc_chunks_fts_visible(q, 20, unlocked)
@@ -589,7 +594,14 @@ pub fn execute_tool(
                     }
                 }
             }
-            match db.search_hybrid_visible(q, &query_vec, 20, unlocked, date_filter) {
+            match db.search_hybrid_visible(
+                q,
+                &query_vec,
+                20,
+                crate::embed::KNN_SEARCH_COSINE_FLOOR,
+                unlocked,
+                date_filter,
+            ) {
                 Ok(hits) if hits.is_empty() && docs.is_empty() => {
                     Ok(format!("No meetings or documents match \"{q}\"."))
                 }
@@ -1290,7 +1302,8 @@ pub(crate) fn search_org_brain_hits(
         match embedder.embed_query(std::slice::from_ref(&q.to_string())) {
             Ok(v) => {
                 let qv = v.into_iter().next().unwrap_or_default();
-                db.search_org_chunks_knn(&qv, 20).unwrap_or_default()
+                db.search_org_chunks_knn(&qv, 20, crate::embed::ORG_KNN_SEARCH_COSINE_FLOOR)
+                    .unwrap_or_default()
             }
             Err(_) => Vec::new(),
         }


### PR DESCRIPTION
Two retrieval-quality fixes from the MCP QA session, designed by the retrieval architect and grounded in the existing calibration machinery.

## S1 — vector-KNN relevance floor (the org_search "precision ~0" bug)

The vector-KNN legs returned the k-nearest neighbours with **no relevance floor**, so on a tiny/irrelevant corpus they returned pure noise — `org_search("shipment label generation")` surfaced 4 unrelated notes, and an empty semantic query returned everything.

**Fix:** an **opt-in `min_cosine` floor** applied *inside* each vector reader, **after** the visibility gate (so it can only ever remove below-floor rows — never widen or reorder a leg around its gate). Cosine is mapped from the vec0 L2 distance via the existing `links::cosine_from_l2_distance` (`|a−b|² = 2 − 2·cos`); the org int8 leg divides the distance by 127 first (its vectors are `round(unit·127)`). Sentinel `0.0` = no floor — **every non-MCP caller passes `0.0`** (behaviour-identical), and only the two MCP search arms enforce `KNN_SEARCH_COSINE_FLOOR` / `ORG_KNN_SEARCH_COSINE_FLOOR`. The FTS and entity-graph legs are **never** floored, so when the floor empties the KNN leg on an irrelevant corpus, `score_fuse`'s empty-leg redistribution still surfaces an exact-word FTS hit (recall-safe).

> ⚠️ **The floor value (0.78) is PROVISIONAL** — derived from the already-calibrated persistent auto-link floor (`SEMANTIC_LINK_FLOOR = 0.80`), sitting just below it since search is ephemeral. The mechanism is opt-in, so finalizing it is a one-line const change after running `eval::calibration::calibrate_semantic_link_threshold_from_env` (null-cosine p99) + `eval::bakeoff::run_bakeoff_over_real_db_from_env` (recall@k unchanged) **on a real vault on a signed Mac**. The org int8 floor needs its own calibration (different distribution). This is the one item in the QA remediation that can't be finalized headless.

## S2 — Polish/multi-word full-text recall (no new dependency)

`fts_match_query` joins tokens with implicit AND and the tokenizer has no stemmer, so `"etykieta parcel"` missed a note containing `parcel`. **Fix:** an **AND→OR fallback** — when the implicit-AND match returns zero rows, retry with the existing content-word OR twin (`fts_match_query_any`, which drops stopwords + <3-char tokens). It fires **only** on an empty AND result, so it never widens a successful query and stays exact-word lexical — the crisp "No meetings match" the QA praised is preserved (a query sharing no content word still returns empty). Applied in all four FTS readers (meetings, hybrid-scoring, docs, org). Single-token inflection (`shipments` vs `shipment`) is intentionally left to semantic search — which S1's floor now makes precise.

## Tests

8 new model-free RED tests: S1 floor drops an orthogonal (cos 0) neighbour across all three legs (incl. the int8 `/127` path) + FTS survives a floored-empty vector leg (recall safety); S2 AND→OR recovers a multi-word miss across meetings/docs/org + precision preserved when no content word is shared. Every existing gating/bakeoff test threads the `0.0` sentinel and stays green. `cargo test --lib` green; spec/adversarial/lock-security/egress-security reviews all PASS.

Final PR of the MCP-tools QA remediation series (#453 B1/B2/E1/R1 · #454 B4 · #455 B3).
