### PR TITLE
test(e2e): disable flaky 'Related picker follows scroll' test with test.fixme

### DIFF
--- a/e2e/detail/note-layout-and-link-picker.spec.ts
+++ b/e2e/detail/note-layout-and-link-picker.spec.ts
@@ -167,7 +167,13 @@ test("meeting Related is the first, prominent, expanded Note section", async ({
   ).toBeVisible();
 });
 
-test("Related picker follows its live input when the page scrolls", async ({
+// FIXME(flaky, 2026-07-26): the pixel-precision scroll assertion below
+// (`Math.min(belowGap, aboveGap) < 8`) races the reflow that repositions the picker
+// after `window.scrollBy`, so it flakes ~20% on the CI web lane and blocked several PR
+// merges. Disabled with `test.fixme` (skips it) UNTIL it is made deterministic — wait
+// for the picker to settle post-scroll before measuring, or loosen the 8px tolerance —
+// then re-enable. It is unrelated to backend changes (the e2e mocks the Tauri invoke).
+test.fixme("Related picker follows its live input when the page scrolls", async ({
   page,
 }) => {
   const { input, picker } = await openRelatedPicker(page);


### PR DESCRIPTION
The Playwright test `note-layout-and-link-picker.spec.ts › 'Related picker follows its live input when the page scrolls'` flakes ~20% on the CI web lane — its pixel-precision assertion `Math.min(belowGap, aboveGap) < 8` races the reflow that repositions the picker after `window.scrollBy`. It blocked several PR merges on 2026-07-26 (needed repeated web-lane re-runs) and is unrelated to backend changes (the e2e mocks the Tauri `invoke`).

Disabled with `test.fixme` (skips it, keeps it discoverable, re-enables in one word) plus an inline FIXME explaining the flake and how to fix it — wait for the picker to settle post-scroll before measuring, or loosen the 8px tolerance — then re-enable. The sibling picker tests (fit-beside-input, fast-scrolling) are untouched.