### PR TITLE
fix(record): live-capable model on default install + no-live-captions state

### DIFF
--- a/e2e/record/live-captions-notice.spec.ts
+++ b/e2e/record/live-captions-notice.spec.ts
@@ -1,0 +1,281 @@
+import { test, expect, type Page } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * LIVE-CAPTION readiness must be VISIBLE in the recorder, not just in a backend log line.
+ *
+ * The defect: on a fresh ≥ 12 GB Mac onboarding downloads only the heavy turbo batch default, and
+ * the live tick deliberately never runs a medium/large encoder every 3 s (heat) — so live captions
+ * never appeared, with nothing but a `warn!` to show for it. The backend now reports the state as
+ * `AppConfigDto.liveCaptions` (`get_config`), and this spec pins the render contract:
+ *
+ *   (a) `modelMissing` + a present transcription model + not recording → the notice renders, with
+ *       the retryable "download it" framing.
+ *   (b) `pinnedHeavy` → the notice renders with the CONFIGURATION framing (a heavy live-model pin is
+ *       a choice, not a failed download) and offers NO download action.
+ *   (c) `ready` → nothing renders.
+ *   (d) the key ABSENT entirely (an older backend / an unprobed config) → nothing renders.
+ *   (e) while RECORDING → the footer's caption ticker says captions are off instead of showing an
+ *       eternal, lying "Listening…".
+ *
+ * RED before GREEN: pre-fix there was NO recorder surface for this state at all — `.cc-notice` did
+ * not exist and the footer showed "Listening…" for the whole meeting while no caption could ever
+ * arrive — so (a), (b) and (e) fail against the unpatched FE.
+ *
+ * `__demoConfig` merges over the base mock's DEFAULT_CONFIG (which has no `liveCaptions` key), so
+ * each case pins only its own delta.
+ */
+
+/**
+ * Pin `get_config`'s live-caption state (or nothing at all, for the key-absent case).
+ *
+ * `overrides` lets a case swap a command — e.g. a `download_model` that never resolves, so the
+ * in-flight companion fetch can be observed. The base mock re-reads `window.__demoConfig` on EVERY
+ * `get_config`, so a case can also mutate it mid-test to simulate a model landing.
+ */
+async function bootRecord(
+  page: Page,
+  liveCaptions: string | null,
+  overrides: Record<string, (args: unknown) => unknown> = {},
+): Promise<void> {
+  await mockTauri(page, { model_present: () => true, ...overrides });
+  if (liveCaptions !== null) {
+    await page.addInitScript((state: string) => {
+      (
+        window as unknown as { __demoConfig: Record<string, unknown> }
+      ).__demoConfig = { liveCaptions: state };
+    }, liveCaptions);
+  }
+  await page.goto("/record");
+  // The idle start control proves the record screen mounted…
+  await expect(page.locator("app-record button.start-btn")).toBeVisible({
+    timeout: 10_000,
+  });
+  // …and the idle stats strip proves `ngOnInit` ran to COMPLETION — it renders only after the
+  // `getConfig()` → `modelPresent()` → `getAnalytics()` chain resolved. Without this anchor the
+  // "renders nothing" cases would pass trivially against a still-loading screen.
+  await expect(page.locator("app-record .stats")).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+const notice = "app-record .cc-notice";
+
+test.describe("Record — the no-live-captions notice", () => {
+  test("(a) modelMissing renders the notice with a retryable download action", async ({
+    page,
+  }) => {
+    await bootRecord(page, "modelMissing");
+
+    await expect(page.locator(notice)).toBeVisible();
+    await expect(page.locator(notice)).toContainText("Live captions are off");
+    // The retryable framing — a download that didn't land, not a config choice.
+    await expect(page.locator(notice)).toContainText(
+      /small live-caption model isn't on this Mac/,
+    );
+    await expect(
+      page.locator(notice).getByRole("button", { name: "Download it" }),
+    ).toBeVisible();
+    // Honest about what is NOT affected.
+    await expect(page.locator(notice)).toContainText(/transcript still runs/i);
+  });
+
+  test("(b) pinnedHeavy renders the configuration framing and no download action", async ({
+    page,
+  }) => {
+    await bootRecord(page, "pinnedHeavy");
+
+    await expect(page.locator(notice)).toBeVisible();
+    await expect(page.locator(notice)).toContainText(
+      /live-caption model is a large one/,
+    );
+    // Nothing to fetch on the user's behalf — a heavy model is never run live.
+    await expect(
+      page.locator(notice).getByRole("button", { name: "Download it" }),
+    ).toHaveCount(0);
+    await expect(page.locator(notice)).not.toContainText(
+      /download may have failed/,
+    );
+  });
+
+  test("(c) ready renders no notice", async ({ page }) => {
+    await bootRecord(page, "ready");
+    await expect(page.locator(notice)).toHaveCount(0);
+  });
+
+  test("(d) an absent liveCaptions key renders no notice", async ({ page }) => {
+    await bootRecord(page, null);
+    await expect(page.locator(notice)).toHaveCount(0);
+  });
+
+  test("(e) while recording, the footer says captions are off instead of Listening…", async ({
+    page,
+  }) => {
+    await bootRecord(page, "modelMissing");
+
+    await page.locator("app-record button.start-btn").click();
+    await expect(page.locator("app-record .rec-topbar")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // The recording footer's ticker is replaced by the honest indicator…
+    await expect(page.locator("app-record .rec-foot .cc-off")).toBeVisible();
+    await expect(page.locator("app-record .rec-foot .cc-off")).toContainText(
+      "Captions off",
+    );
+    // …no eternal "Listening…" placeholder, and the live-captions scope hint is gone too.
+    await expect(page.locator("app-record .rec-foot .cc-idle")).toHaveCount(0);
+    await expect(page.locator("app-record .rec-foot .cc-scope")).toHaveCount(0);
+    // The banner-style notice stands down while recording (the footer carries the state).
+    await expect(page.locator(notice)).toHaveCount(0);
+  });
+
+  test("(f) ready keeps the normal live-caption ticker while recording", async ({
+    page,
+  }) => {
+    await bootRecord(page, "ready");
+
+    await page.locator("app-record button.start-btn").click();
+    await expect(page.locator("app-record .rec-topbar")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await expect(page.locator("app-record .rec-foot .cc-line")).toBeVisible();
+    await expect(page.locator("app-record .rec-foot .cc-off")).toHaveCount(0);
+    await expect(page.locator("app-record .rec-foot .cc-scope")).toBeVisible();
+  });
+
+  test("(g) the companion retry never blocks Start", async ({ page }) => {
+    // A `download_model` that never resolves keeps the companion fetch in flight for the whole
+    // assertion window. RED before the fix: the notice's button drove the SAME `downloadingModel`
+    // signal the model-absent banner does, and `canRecord` gates on it — so retrying the
+    // live-caption companion disabled Start while the transcription model was already present,
+    // contradicting the notice's own "recording is unaffected" copy.
+    await bootRecord(page, "modelMissing", {
+      download_model: () => new Promise(() => {}),
+    });
+
+    const start = page.locator("app-record button.start-btn");
+    await expect(start).toBeEnabled();
+
+    await page.locator(notice).getByRole("button", { name: "Download it" }).click();
+
+    // In flight…
+    await expect(
+      page.locator(notice).getByRole("button", { name: "Downloading…" }),
+    ).toBeDisabled();
+    // …and recording stays available throughout.
+    await expect(start).toBeEnabled();
+    // The idle hint must not claim a download is blocking anything either.
+    await expect(page.locator("app-record .rec-strip-hint")).not.toContainText(
+      /you can start recording when it finishes/,
+    );
+  });
+
+  test("(h) the notice clears when a model download finishes elsewhere", async ({
+    page,
+  }) => {
+    // Live-caption readiness is a DEVICE/DISK fact: downloading a live-safe model from Settings
+    // must clear this notice without a remount, or the UI keeps saying captions are off while
+    // `start_recording` would happily run them. RED before the fix: `config()` was written once in
+    // `ngOnInit` and never refreshed by anything but this screen's own action.
+    await bootRecord(page, "modelMissing");
+    await expect(page.locator(notice)).toBeVisible();
+
+    await page.evaluate(() => {
+      const w = window as unknown as {
+        __demoConfig: Record<string, unknown>;
+        __demoEmit: (event: string, payload: unknown) => void;
+      };
+      // The model landed — the very next `get_config` reports ready.
+      w.__demoConfig["liveCaptions"] = "ready";
+      w.__demoEmit("murmur://model-download", {
+        downloaded: 1,
+        total: 1,
+        done: true,
+      });
+    });
+
+    await expect(page.locator(notice)).toHaveCount(0);
+  });
+
+  test("(i) a retry that doesn't fix it says so instead of looking successful", async ({
+    page,
+  }) => {
+    // `download_model` RESOLVES, but the companion fetch inside it failed — the backend swallows
+    // that by design (the batch model is what gates recording), so the command succeeding proves
+    // nothing. The refreshed readiness state is the real verdict.
+    await bootRecord(page, "modelMissing", { download_model: () => "ok" });
+
+    await page.locator(notice).getByRole("button", { name: "Download it" }).click();
+
+    await expect(page.locator(`${notice} .cc-notice-error`)).toContainText(
+      /still isn't on this Mac/,
+    );
+    // Still honest about the state itself — the notice does not quietly disappear.
+    await expect(page.locator(notice)).toBeVisible();
+  });
+});
+
+/**
+ * The ONBOARDING half of the same fix. Lives beside the recorder spec because it pins the other
+ * consumer of one backend decision (`live_captions::companion_size_for`, surfaced as
+ * `AppConfigDto.liveCompanionPending`): the wizard must disclose the extra live-caption download
+ * when — and only when — the backend would actually make it.
+ *
+ * RED before GREEN: the first version of this fix re-derived the rule in TypeScript from the size
+ * NAME alone (`includes("large") || includes("medium")`), so it promised a companion transfer for
+ * ANY heavy quality — including the cases the backend skips (the live pin disabled or itself heavy,
+ * or a live-safe model already on disk). Case (a) fails against that copy.
+ */
+test.describe("Onboarding — the live-caption companion disclosure", () => {
+  // Its OWN class — `.model-note` is shared with the size/one-time hints beside the button.
+  const note = "app-onboarding .live-companion-note";
+
+  /** Boot the wizard's Model step with a pinned config snapshot. */
+  async function bootModelStep(
+    page: Page,
+    config: Record<string, unknown>,
+  ): Promise<void> {
+    await mockTauri(page, { model_present: () => false });
+    await page.addInitScript((cfg: Record<string, unknown>) => {
+      (
+        window as unknown as { __demoConfig: Record<string, unknown> }
+      ).__demoConfig = cfg;
+    }, config);
+    await page.goto("/onboarding");
+    await page.getByRole("button", { name: "Get started" }).click();
+    await expect(
+      page.getByRole("button", { name: /Download model/ }),
+    ).toBeVisible({ timeout: 10_000 });
+  }
+
+  test("(a) a heavy quality alone does NOT promise a second download", async ({
+    page,
+  }) => {
+    // Heavy batch quality, but the backend says no companion is pending (e.g. a live-safe model is
+    // already on disk, or the live pin is disabled) — the wizard must not invent a transfer.
+    await bootModelStep(page, {
+      modelSize: "large-v3",
+      liveCompanionPending: false,
+    });
+    await expect(page.locator(note)).toHaveCount(0);
+  });
+
+  test("(b) the backend's pending companion IS disclosed", async ({ page }) => {
+    await bootModelStep(page, {
+      modelSize: "large-v3",
+      liveCompanionPending: true,
+    });
+    await expect(page.locator(note)).toContainText(
+      /Live captions also need a small model/,
+    );
+  });
+
+  test("(c) an absent liveCompanionPending key discloses nothing", async ({
+    page,
+  }) => {
+    await bootModelStep(page, { modelSize: "large-v3" });
+    await expect(page.locator(note)).toHaveCount(0);
+  });
+});

--- a/src-tauri/src/commands/live_captions.rs
+++ b/src-tauri/src/commands/live_captions.rs
@@ -1,0 +1,748 @@
+//! LIVE-CAPTION model readiness — the ONE resolution shared by every surface that needs it.
+//!
+//! WHY THIS MODULE EXISTS (the bug it closes): on a fresh ≥ 12 GB Mac
+//! `transcribe::model::default_model_size` flips the BATCH default to the turbo quant, so
+//! onboarding downloads exactly ONE file — `ggml-large-v3-turbo-q8_0.bin`. The LIVE tick is pinned
+//! to `small` (`live_model_pin`) and DELIBERATELY never runs a medium/large-class encoder every 3 s
+//! (T1.3 heat — a large live tick saturates the shared Metal GPU for the whole meeting). With only
+//! the turbo model on disk, `live_pin_size` → `small` (absent) → `live_fallback_model` (nothing
+//! live-safe) → the configured model is heavy ⇒ REFUSED, so the default install got NO live
+//! captions and the only trace was a backend `warn!`. The heat policy is correct; the two things
+//! missing were upstream:
+//!
+//!   1. **A live-safe companion download.** [`companion_size_for`] tells `download_model`
+//!      (`commands/models.rs`) to ALSO fetch the pinned live size beside a heavy batch model, so the
+//!      default path ends up with a working live model.
+//!   2. **A user-visible STATE.** [`resolve`] classifies the same resolution `start_recording`
+//!      performs, and `get_config` ships it to the FE as `AppConfigDto::live_captions` so the
+//!      recorder can render a calm "live captions are off" notice instead of hiding the truth in a
+//!      log line.
+//!
+//! `start_recording` consumes [`resolve`] too — ONE decision, so the state the UI shows and the
+//! model the live tick actually loads can never drift apart.
+
+use std::path::{Path, PathBuf};
+
+use crate::settings::AppConfig;
+use crate::transcribe::model::{
+    effective_model_size, is_live_heavy_model_file, live_fallback_model_in, live_pin_size,
+    model_filename, models_dir,
+};
+
+/// How the LIVE-caption tick's whisper model resolved — the outcome of the exact chain
+/// `start_recording` walks. The four path-carrying variants (`Pinned` / `Fallback` / `Configured` /
+/// `Unpinned`) mean captions RUN — which one it was only shapes the log line. The other three are
+/// the "no live captions for this recording" states, split by CAUSE so the recorder UI can say
+/// something true (a failed/absent companion download is recoverable by retrying it; a heavy live
+/// PIN is a deliberate configuration).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum LiveCaptions {
+    /// The pinned live size is downloaded — the pin is satisfied verbatim.
+    Pinned(PathBuf),
+    /// The pinned size is absent, so the largest downloaded live-SAFE model is used instead
+    /// (`live_fallback_model`).
+    Fallback(PathBuf),
+    /// Nothing live-safe is downloaded but the CONFIGURED model is itself live-safe, so the live
+    /// tick rides it (pre-pin behavior; it may contend with the light reasoner).
+    Configured(PathBuf),
+    /// The pin is disabled (`live_model_pin == ""` and `brain_live` off) ⇒ the configured model is
+    /// used verbatim, heavy or not (an explicit un-pin is the user's call).
+    Unpinned(PathBuf),
+    /// No whisper model at all on disk (a fresh install before onboarding's download). The FE's
+    /// "Transcription model needed" banner owns this state — NOT the live-captions notice.
+    NoModel,
+    /// Whisper IS downloaded, but nothing LIVE-SAFE is: the pinned live size is absent and every
+    /// model on disk is medium/large-class. That is the live-safe companion download never landing
+    /// (offline during onboarding, an aborted/failed fetch) — recoverable by running it again.
+    ModelMissing,
+    /// The live PIN itself names a medium/large-class size that is NOT downloaded. We never
+    /// auto-fetch a heavy model for the 3 s tick, so this is a configuration outcome rather than a
+    /// failed download, and the notice must say so.
+    PinnedHeavy,
+}
+
+impl LiveCaptions {
+    /// The model the live tick should load, or `None` = no live captions for this recording.
+    pub(crate) fn model_path(self) -> Option<PathBuf> {
+        match self {
+            Self::Pinned(p) | Self::Fallback(p) | Self::Configured(p) | Self::Unpinned(p) => {
+                Some(p)
+            }
+            Self::NoModel | Self::ModelMissing | Self::PinnedHeavy => None,
+        }
+    }
+
+    /// The FE-facing state string carried by `AppConfigDto::live_captions` (camelCase, mirrored by
+    /// the recorder component). `""` is reserved for "not probed" — never returned here.
+    pub(crate) fn dto_state(&self) -> &'static str {
+        match self {
+            Self::Pinned(_) | Self::Fallback(_) | Self::Configured(_) | Self::Unpinned(_) => {
+                "ready"
+            }
+            Self::NoModel => "noModel",
+            Self::ModelMissing => "modelMissing",
+            Self::PinnedHeavy => "pinnedHeavy",
+        }
+    }
+}
+
+/// [`resolve_in`] over the REAL models dir + the live config. Any failure resolving the models dir
+/// classifies [`LiveCaptions::NoModel`] (a broken probe must never claim captions are ready).
+pub(crate) fn resolve(cfg: &AppConfig) -> LiveCaptions {
+    let Ok(dir) = models_dir() else {
+        return LiveCaptions::NoModel;
+    };
+    resolve_in(
+        &dir,
+        cfg.whisper_model_path.as_deref().map(Path::new),
+        &cfg.model_size,
+        cfg.language.as_deref().unwrap_or(""),
+        &cfg.live_model_pin,
+        cfg.brain_live,
+    )
+}
+
+/// File-presence core of [`resolve`], factored over an explicit `dir` so every branch is testable
+/// headless with a temp dir.
+///
+/// This MIRRORS `start_recording`'s chain exactly — pinned size → largest downloaded live-safe
+/// model → a live-safe configured model → refuse. Keep the two in lockstep by keeping
+/// `start_recording` calling [`resolve`]; the classification here is the only copy.
+///
+/// NOTE on a blank `model_size`: `effective_model_size` resolves the machine-conditional default,
+/// which probes the REAL models dir. In production that IS `dir`; tests pass a concrete size.
+pub(crate) fn resolve_in(
+    dir: &Path,
+    configured: Option<&Path>,
+    model_size: &str,
+    language: &str,
+    live_model_pin: &str,
+    brain_live: bool,
+) -> LiveCaptions {
+    // Mirrors `transcribe::model::resolve_model_path`: an existing explicit path wins, else the
+    // size-derived file in the models dir.
+    let configured_model = || -> Option<PathBuf> {
+        if let Some(p) = configured.filter(|p| p.is_file()) {
+            return Some(p.to_path_buf());
+        }
+        let derived = dir.join(model_filename(&effective_model_size(model_size), language));
+        derived.is_file().then_some(derived)
+    };
+
+    let Some(pin) = live_pin_size(live_model_pin, brain_live) else {
+        return match configured_model() {
+            Some(p) => LiveCaptions::Unpinned(p),
+            None => LiveCaptions::NoModel,
+        };
+    };
+
+    let pin_file = model_filename(&pin, language);
+    let pinned = dir.join(&pin_file);
+    if pinned.is_file() {
+        return LiveCaptions::Pinned(pinned);
+    }
+    if let Some(p) = live_fallback_model_in(dir, language) {
+        return LiveCaptions::Fallback(p);
+    }
+    match configured_model() {
+        Some(p) if !is_live_heavy_model_file(&p) => LiveCaptions::Configured(p),
+        // Only medium/large-class models downloaded. Split the cause: a HEAVY pin was never a
+        // download we would make on the user's behalf; a live-safe pin means the companion download
+        // is simply missing.
+        Some(_) if is_live_heavy_model_file(Path::new(&pin_file)) => LiveCaptions::PinnedHeavy,
+        Some(_) => LiveCaptions::ModelMissing,
+        None => LiveCaptions::NoModel,
+    }
+}
+
+/// Whether a whisper model download should ALSO fetch a live-SAFE companion model, and which SIZE.
+/// `batch_model` is the file the batch download just produced (`ensure_model`'s return — the real
+/// on-disk model, so a custom `whisper_model_path` is covered without re-deriving it).
+///
+/// `None` (nothing to fetch) when:
+///   - the live pin is DISABLED (`""` + `brain_live` off) — the live tick then uses the configured
+///     model verbatim, so a companion would never be consulted;
+///   - the pin itself names a medium/large-class size — we never fetch a heavy model for the 3 s
+///     tick, and an explicit heavy pin is the user's own configuration;
+///   - the pinned model is already on disk;
+///   - ANY live-safe model is already on disk (`live_fallback_model_in` — the live tick has
+///     something to run);
+///   - the batch model is ITSELF live-safe (a `small`/`base`/`tiny` selection, or an unrecognizable
+///     custom `whisper_model_path`, which `is_live_heavy_model_file` classifies live-safe to
+///     preserve the pre-pin behavior) — one download already covers both roles.
+///
+/// `Some(size)` = the pinned live size (default `small`, ~470 MB; an explicit live-safe pin such as
+/// `base`/`tiny`/`small-q8_0` is honored verbatim) must be fetched beside the heavy batch model.
+pub(crate) fn companion_size_for(
+    dir: &Path,
+    batch_model: &Path,
+    language: &str,
+    live_model_pin: &str,
+    brain_live: bool,
+) -> Option<String> {
+    companion_size_lazy(
+        dir,
+        || batch_model.to_path_buf(),
+        language,
+        live_model_pin,
+        brain_live,
+    )
+}
+
+/// [`companion_size_for`] with the batch model resolved LAZILY. Every cheap check (the pin's own
+/// class, the pinned file, any downloaded live-safe model) runs first, so [`companion_pending_in`]
+/// — which must DERIVE the batch filename, and for a blank `model_size` pays
+/// `effective_model_size` → `default_model_size_now` (a `read_dir` + a `sysctl` subprocess) — only
+/// pays for it on a machine where the answer actually hinges on it.
+fn companion_size_lazy(
+    dir: &Path,
+    batch_model: impl FnOnce() -> PathBuf,
+    language: &str,
+    live_model_pin: &str,
+    brain_live: bool,
+) -> Option<String> {
+    let pin = live_pin_size(live_model_pin, brain_live)?;
+    let pin_file = model_filename(&pin, language);
+    if is_live_heavy_model_file(Path::new(&pin_file)) {
+        return None;
+    }
+    if dir.join(&pin_file).is_file() {
+        return None;
+    }
+    if live_fallback_model_in(dir, language).is_some() {
+        return None;
+    }
+    if !is_live_heavy_model_file(&batch_model()) {
+        return None;
+    }
+    Some(pin)
+}
+
+/// [`companion_size_for`] over the REAL models dir. `None` on any dir-resolution failure (a broken
+/// probe must never trigger an unrequested download).
+pub(crate) fn companion_size(
+    batch_model: &Path,
+    language: &str,
+    live_model_pin: &str,
+    brain_live: bool,
+) -> Option<String> {
+    let dir = models_dir().ok()?;
+    companion_size_for(&dir, batch_model, language, live_model_pin, brain_live)
+}
+
+/// Would a `download_model` run right now ALSO fetch a live-safe companion? The SAME decision
+/// [`companion_size_for`] makes, asked BEFORE the batch download, against the file that download
+/// would produce — so the onboarding wizard can disclose the extra transfer from the backend
+/// instead of re-deriving half the rule in TypeScript (where it drifted: the FE copy knew only the
+/// size-name test, not the pin/presence terms, and promised a fetch the backend would skip).
+fn companion_pending_in(
+    dir: &Path,
+    configured: Option<&Path>,
+    model_size: &str,
+    language: &str,
+    live_model_pin: &str,
+    brain_live: bool,
+) -> bool {
+    companion_size_lazy(
+        dir,
+        // Mirrors `ensure_model`'s own resolution: an existing explicit path is used verbatim,
+        // otherwise the size-derived file lands in the models dir.
+        || match configured.filter(|p| p.is_file()) {
+            Some(p) => p.to_path_buf(),
+            None => dir.join(model_filename(&effective_model_size(model_size), language)),
+        },
+        language,
+        live_model_pin,
+        brain_live,
+    )
+    .is_some()
+}
+
+/// The two DISPLAY-ONLY facts `get_config` ships to the FE, resolved over ONE models-dir lookup:
+/// the live-caption readiness state (`AppConfigDto::live_captions`, the recorder's notice) and
+/// whether a model download would also fetch the live-safe companion
+/// (`AppConfigDto::live_companion_pending`, the onboarding disclosure).
+///
+/// A models-dir failure reads as [`LiveCaptions::NoModel`] + no pending companion — a broken probe
+/// must never claim captions are ready, nor promise a download.
+pub(crate) fn dto_probe(cfg: &AppConfig) -> (String, bool) {
+    let Ok(dir) = models_dir() else {
+        return (LiveCaptions::NoModel.dto_state().to_string(), false);
+    };
+    let configured = cfg.whisper_model_path.as_deref().map(Path::new);
+    let language = cfg.language.as_deref().unwrap_or("");
+    let state = resolve_in(
+        &dir,
+        configured,
+        &cfg.model_size,
+        language,
+        &cfg.live_model_pin,
+        cfg.brain_live,
+    );
+    let pending = companion_pending_in(
+        &dir,
+        configured,
+        &cfg.model_size,
+        language,
+        &cfg.live_model_pin,
+        cfg.brain_live,
+    );
+    (state.dto_state().to_string(), pending)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A unique temp models dir per fixture (the real app-data dir must never be touched).
+    fn tmp_models_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "murmur-live-captions-{tag}-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn touch(dir: &Path, name: &str) {
+        std::fs::write(dir.join(name), b"MODEL-BYTES").unwrap();
+    }
+
+    /// The turbo file the T2 default flip downloads on a fresh ≥ 12 GB Mac.
+    const TURBO: &str = "ggml-large-v3-turbo-q8_0.bin";
+
+    /// RED — THE REPORTED DEFECT, at the classification level: a fresh ≥ 12 GB install whose ONLY
+    /// whisper model is the turbo default has NO live captions, and the cause is a MISSING live-safe
+    /// companion download (not a deliberate heavy pin). Before the fix this state existed but was
+    /// nameless — a backend `warn!` and nothing the UI could render.
+    #[test]
+    fn fresh_turbo_only_install_is_model_missing_not_ready() {
+        let dir = tmp_models_dir("turbo-only");
+        touch(&dir, TURBO);
+
+        let state = resolve_in(
+            &dir,
+            None,
+            "large-v3-turbo-q8_0",
+            "",
+            "small", // the serde-default live pin
+            false,
+        );
+        assert_eq!(state, LiveCaptions::ModelMissing);
+        assert_eq!(state.dto_state(), "modelMissing");
+        assert_eq!(state.model_path(), None, "the live tick must NOT run turbo");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The fix's other half: with the live-safe companion on disk the SAME install resolves Ready —
+    /// pinned exactly when the pinned size landed, Fallback when a different live-safe size did.
+    #[test]
+    fn companion_on_disk_makes_the_same_install_ready() {
+        let dir = tmp_models_dir("companion");
+        touch(&dir, TURBO);
+
+        // The pinned `small` landed ⇒ the pin is satisfied verbatim.
+        touch(&dir, "ggml-small.bin");
+        let ready = resolve_in(&dir, None, "large-v3-turbo-q8_0", "", "small", false);
+        assert_eq!(ready, LiveCaptions::Pinned(dir.join("ggml-small.bin")));
+        assert_eq!(ready.dto_state(), "ready");
+
+        // Only `base` landed (a lighter explicit companion) ⇒ the absent-pin FALLBACK, still ready.
+        let dir2 = tmp_models_dir("companion-base");
+        touch(&dir2, TURBO);
+        touch(&dir2, "ggml-base.bin");
+        let fb = resolve_in(&dir2, None, "large-v3-turbo-q8_0", "", "small", false);
+        assert_eq!(fb, LiveCaptions::Fallback(dir2.join("ggml-base.bin")));
+        assert_eq!(fb.dto_state(), "ready");
+
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::remove_dir_all(&dir2);
+    }
+
+    /// A live-SAFE batch selection needs no companion at all: the one downloaded model IS the live
+    /// model (the pinned size itself, or a live-safe size the absent-pin fallback picks up).
+    #[test]
+    fn live_safe_batch_selection_is_ready() {
+        let dir = tmp_models_dir("small-batch");
+        touch(&dir, "ggml-small.bin");
+        // `small` IS the pinned size here, so it resolves through the Pinned arm.
+        assert_eq!(
+            resolve_in(&dir, None, "small", "", "small", false),
+            LiveCaptions::Pinned(dir.join("ggml-small.bin"))
+        );
+
+        // A tiny-only install with the default `small` pin: the pin is absent, but tiny is
+        // live-safe ⇒ Fallback (ready).
+        let dir2 = tmp_models_dir("tiny-batch");
+        touch(&dir2, "ggml-tiny.bin");
+        assert_eq!(
+            resolve_in(&dir2, None, "tiny", "", "small", false),
+            LiveCaptions::Fallback(dir2.join("ggml-tiny.bin"))
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::remove_dir_all(&dir2);
+    }
+
+    /// A DELIBERATELY heavy live pin that isn't downloaded is `PinnedHeavy`, not `ModelMissing` —
+    /// the two get different notice copy (a failed companion download vs a configuration choice).
+    #[test]
+    fn heavy_pin_absent_classifies_pinned_heavy() {
+        let dir = tmp_models_dir("heavy-pin");
+        touch(&dir, TURBO);
+        let state = resolve_in(&dir, None, "large-v3-turbo-q8_0", "", "medium", false);
+        assert_eq!(state, LiveCaptions::PinnedHeavy);
+        assert_eq!(state.dto_state(), "pinnedHeavy");
+
+        // …and a heavy pin that IS downloaded still runs (the pin wins unconditionally — T1.3).
+        touch(&dir, "ggml-medium.bin");
+        assert_eq!(
+            resolve_in(&dir, None, "large-v3-turbo-q8_0", "", "medium", false),
+            LiveCaptions::Pinned(dir.join("ggml-medium.bin"))
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// An empty pin + `brain_live` off = the pre-pin behavior: the configured model verbatim, heavy
+    /// or not. That is Ready (captions DO run), and it is exactly why no companion is fetched then.
+    #[test]
+    fn unpinned_uses_the_configured_model_verbatim() {
+        let dir = tmp_models_dir("unpinned");
+        touch(&dir, TURBO);
+        let state = resolve_in(&dir, None, "large-v3-turbo-q8_0", "", "", false);
+        assert_eq!(state, LiveCaptions::Unpinned(dir.join(TURBO)));
+        assert_eq!(state.dto_state(), "ready");
+
+        // The LEGACY `brain_live` pin-to-small still applies with an empty pin — and with only the
+        // heavy turbo on disk that lands back in the missing-companion state.
+        assert_eq!(
+            resolve_in(&dir, None, "large-v3-turbo-q8_0", "", "", true),
+            LiveCaptions::ModelMissing
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A CUSTOM `whisper_model_path` (the explicit-path users): an unrecognizable name classifies
+    /// live-safe (preserving the pre-pin behavior) ⇒ Ready via the configured arm; a heavy custom
+    /// file is refused for the live tick like any other heavy model.
+    #[test]
+    fn custom_model_path_live_safe_is_ready_heavy_is_missing() {
+        let dir = tmp_models_dir("custom");
+        let custom = dir.join("my-tuned-model.bin");
+        std::fs::write(&custom, b"MODEL-BYTES").unwrap();
+        let state = resolve_in(&dir, Some(&custom), "", "", "small", false);
+        assert_eq!(state, LiveCaptions::Configured(custom.clone()));
+        assert_eq!(state.dto_state(), "ready");
+
+        let heavy = dir.join("my-large-v3-finetune.bin");
+        std::fs::write(&heavy, b"MODEL-BYTES").unwrap();
+        assert_eq!(
+            resolve_in(&dir, Some(&heavy), "", "", "small", false),
+            LiveCaptions::ModelMissing
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Nothing downloaded at all ⇒ `NoModel`: the FE's transcription-model download banner owns
+    /// that state, so the live-captions notice must NOT also fire.
+    #[test]
+    fn empty_models_dir_is_no_model() {
+        let dir = tmp_models_dir("empty");
+        let state = resolve_in(&dir, None, "small", "", "small", false);
+        assert_eq!(state, LiveCaptions::NoModel);
+        assert_eq!(state.dto_state(), "noModel");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// English resolves the `.en` build for the pin (mirroring `model_filename`), and rides a
+    /// multilingual build of a live-safe size through the fallback when no `.en` build exists.
+    #[test]
+    fn english_pin_resolves_en_build_then_multilingual_fallback() {
+        let dir = tmp_models_dir("en");
+        touch(&dir, TURBO);
+        touch(&dir, "ggml-small.bin");
+        // No `ggml-small.en.bin` ⇒ the pin file is absent, but the fallback rides multilingual.
+        assert_eq!(
+            resolve_in(&dir, None, "large-v3-turbo-q8_0", "en", "small", false),
+            LiveCaptions::Fallback(dir.join("ggml-small.bin"))
+        );
+        touch(&dir, "ggml-small.en.bin");
+        assert_eq!(
+            resolve_in(&dir, None, "large-v3-turbo-q8_0", "en", "small", false),
+            LiveCaptions::Pinned(dir.join("ggml-small.en.bin"))
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ── the companion-download decision ────────────────────────────────────────────────────────
+
+    /// RED — the ROOT CAUSE: a heavy batch download with no live-safe model on disk must ALSO fetch
+    /// the pinned live size. Before the fix `download_model` fetched exactly one file and the
+    /// default install shipped without live captions.
+    #[test]
+    fn heavy_batch_download_fetches_the_pinned_companion() {
+        let dir = tmp_models_dir("comp-turbo");
+        let batch = dir.join(TURBO);
+        touch(&dir, TURBO);
+        assert_eq!(
+            companion_size_for(&dir, &batch, "", "small", false).as_deref(),
+            Some("small")
+        );
+        // An explicit lighter/quant live pin is honored verbatim.
+        assert_eq!(
+            companion_size_for(&dir, &batch, "", "base", false).as_deref(),
+            Some("base")
+        );
+        assert_eq!(
+            companion_size_for(&dir, &batch, "pl", "tiny", false).as_deref(),
+            Some("tiny")
+        );
+        assert_eq!(
+            companion_size_for(&dir, &batch, "", "small-q8_0", false).as_deref(),
+            Some("small-q8_0")
+        );
+        // An empty pin + brain_live still pins small (the legacy D1 guarantee) ⇒ fetch it.
+        assert_eq!(
+            companion_size_for(&dir, &batch, "", "", true).as_deref(),
+            Some("small")
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// No companion when it would be pointless or unrequested: a live-safe batch model, a live-safe
+    /// model already on disk, the pinned model already on disk, a disabled pin, or a heavy pin.
+    #[test]
+    fn no_companion_when_unnecessary_or_unrequested() {
+        // (a) a live-safe batch SELECTION: what landed in the models dir is itself live-safe, so the
+        //     pinned/fallback presence checks already say "nothing to fetch". (The `batch_model` is
+        //     live-safe here too — that branch matters for a model OUTSIDE the models dir, i.e. a
+        //     custom `whisper_model_path`, which `companion_decision_covers_a_custom_model_path`
+        //     covers.)
+        let dir = tmp_models_dir("comp-small");
+        let small = dir.join("ggml-small.bin");
+        touch(&dir, "ggml-small.bin");
+        assert_eq!(companion_size_for(&dir, &small, "", "small", false), None);
+        let base = dir.join("ggml-base.bin");
+        touch(&dir, "ggml-base.bin");
+        assert_eq!(companion_size_for(&dir, &base, "", "small", false), None);
+
+        // (b) heavy batch, but the PINNED model is already downloaded.
+        let dir2 = tmp_models_dir("comp-pinned");
+        let batch2 = dir2.join(TURBO);
+        touch(&dir2, TURBO);
+        touch(&dir2, "ggml-small.bin");
+        assert_eq!(companion_size_for(&dir2, &batch2, "", "small", false), None);
+
+        // (c) heavy batch, a DIFFERENT live-safe model already downloaded (the live tick has
+        //     something to run via the fallback) ⇒ no second download.
+        let dir3 = tmp_models_dir("comp-fallback");
+        let batch3 = dir3.join(TURBO);
+        touch(&dir3, TURBO);
+        touch(&dir3, "ggml-tiny.bin");
+        assert_eq!(companion_size_for(&dir3, &batch3, "", "small", false), None);
+
+        // (d) the pin is DISABLED ⇒ the live tick uses the configured model verbatim; a companion
+        //     would never be consulted.
+        let dir4 = tmp_models_dir("comp-unpinned");
+        let batch4 = dir4.join(TURBO);
+        touch(&dir4, TURBO);
+        assert_eq!(companion_size_for(&dir4, &batch4, "", "", false), None);
+
+        // (e) the pin is itself HEAVY ⇒ the user's explicit configuration, never an auto-download.
+        assert_eq!(
+            companion_size_for(&dir4, &batch4, "", "medium", false),
+            None
+        );
+        assert_eq!(
+            companion_size_for(&dir4, &batch4, "", "large-v3-turbo-q8_0", false),
+            None
+        );
+
+        for d in [&dir, &dir2, &dir3, &dir4] {
+            let _ = std::fs::remove_dir_all(d);
+        }
+    }
+
+    /// The CUSTOM `whisper_model_path` case for the companion decision (`batch_model` is whatever
+    /// `ensure_model` returned, which for a configured path is that path verbatim): an
+    /// unrecognizable custom name classifies live-safe ⇒ no companion; a heavy custom name ⇒ fetch
+    /// the pinned live-safe size.
+    #[test]
+    fn companion_decision_covers_a_custom_model_path() {
+        let dir = tmp_models_dir("comp-custom");
+        let elsewhere = tmp_models_dir("comp-custom-src");
+
+        let custom = elsewhere.join("my-tuned-model.bin");
+        std::fs::write(&custom, b"MODEL-BYTES").unwrap();
+        assert_eq!(
+            companion_size_for(&dir, &custom, "", "small", false),
+            None,
+            "an unrecognizable custom model classifies live-safe (pre-pin behavior preserved)"
+        );
+
+        let heavy_custom = elsewhere.join("ggml-medium-finetune.bin");
+        std::fs::write(&heavy_custom, b"MODEL-BYTES").unwrap();
+        assert_eq!(
+            companion_size_for(&dir, &heavy_custom, "", "small", false).as_deref(),
+            Some("small"),
+            "a heavy custom model still leaves the live tick with nothing to run"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::remove_dir_all(&elsewhere);
+    }
+
+    /// The ONBOARDING disclosure ("we fetch a small live-caption model alongside this one") is the
+    /// SAME decision the download makes — asked BEFORE the download, against the file it would
+    /// produce. RED for the drift the FE copy had: it keyed on the size NAME alone, so it promised a
+    /// companion whenever the size looked heavy, even when the pin was disabled/heavy or a live-safe
+    /// model was already on disk (cases b–e below), and it could not see a heavy CUSTOM path at all.
+    #[test]
+    fn companion_pending_matches_the_download_decision() {
+        // (a) the reported default: a heavy batch size, nothing live-safe downloaded ⇒ disclose.
+        let dir = tmp_models_dir("pending-turbo");
+        assert!(companion_pending_in(
+            &dir,
+            None,
+            "large-v3-turbo-q8_0",
+            "",
+            "small",
+            false
+        ));
+        // …and the promise is kept: the download does fetch exactly that, and once it lands the
+        // disclosure goes away rather than lying about a second transfer.
+        touch(&dir, TURBO);
+        let batch = dir.join(TURBO);
+        assert_eq!(
+            companion_size_for(&dir, &batch, "", "small", false).as_deref(),
+            Some("small")
+        );
+        touch(&dir, "ggml-small.bin");
+        assert!(!companion_pending_in(
+            &dir,
+            None,
+            "large-v3-turbo-q8_0",
+            "",
+            "small",
+            false
+        ));
+
+        // (b) a live-SAFE batch size ⇒ one download covers both roles, nothing to disclose.
+        let dir2 = tmp_models_dir("pending-small");
+        assert!(!companion_pending_in(&dir2, None, "small", "", "small", false));
+
+        // (c) a heavy batch size but a live-safe model already on disk ⇒ no second transfer.
+        let dir3 = tmp_models_dir("pending-have-tiny");
+        touch(&dir3, "ggml-tiny.bin");
+        assert!(!companion_pending_in(&dir3, None, "large-v3", "", "small", false));
+
+        // (d) the pin is DISABLED, and (e) the pin is itself heavy ⇒ never an auto-fetch, so the
+        //     wizard must not promise one even though the batch size is heavy.
+        let dir4 = tmp_models_dir("pending-pin");
+        assert!(!companion_pending_in(&dir4, None, "large-v3", "", "", false));
+        assert!(!companion_pending_in(&dir4, None, "large-v3", "", "medium", false));
+
+        // (f) a CUSTOM `whisper_model_path`: an unrecognizable name is live-safe ⇒ nothing to
+        //     disclose; a heavy custom file still leaves the live tick with nothing ⇒ disclose.
+        let dir5 = tmp_models_dir("pending-custom");
+        let custom = dir5.join("my-tuned-model.bin");
+        std::fs::write(&custom, b"MODEL-BYTES").unwrap();
+        assert!(!companion_pending_in(
+            &dir5,
+            Some(&custom),
+            "",
+            "",
+            "small",
+            false
+        ));
+        let heavy = dir5.join("my-large-v3-finetune.bin");
+        std::fs::write(&heavy, b"MODEL-BYTES").unwrap();
+        assert!(companion_pending_in(
+            &dir5,
+            Some(&heavy),
+            "",
+            "",
+            "small",
+            false
+        ));
+
+        for d in [&dir, &dir2, &dir3, &dir4, &dir5] {
+            let _ = std::fs::remove_dir_all(d);
+        }
+    }
+
+    /// The DTO carrying this state is DISPLAY-ONLY: the pure `config_to_dto` leaves it `""` (so it
+    /// never probes the disk, and every existing config round-trip test is untouched), a settings
+    /// save can neither set nor clear it, and an older FE payload omitting `liveCaptions`
+    /// deserializes cleanly (`#[serde(default)]`).
+    #[test]
+    fn dto_state_is_display_only_and_omittable() {
+        let cfg = AppConfig::default();
+        let dto = super::super::config_to_dto(&cfg);
+        assert_eq!(
+            dto.live_captions, "",
+            "the pure DTO conversion must not probe the disk"
+        );
+        assert!(
+            !dto.live_companion_pending,
+            "the pure DTO conversion must not probe the disk"
+        );
+
+        // A hostile/stale FE payload cannot persist or spoof readiness.
+        let mut incoming = super::super::config_to_dto(&cfg);
+        incoming.live_captions = "ready".to_string();
+        incoming.live_companion_pending = true;
+        let merged = super::super::dto_to_config(incoming, &cfg);
+        let round_tripped = super::super::config_to_dto(&merged);
+        assert_eq!(round_tripped.live_captions, "");
+        assert!(!round_tripped.live_companion_pending);
+
+        // Serialized as camelCase, and omittable by an older FE.
+        let json = serde_json::to_string(&super::super::config_to_dto(&cfg)).unwrap();
+        let mut v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        for key in ["liveCaptions", "liveCompanionPending"] {
+            assert!(
+                v.as_object_mut().unwrap().remove(key).is_some(),
+                "DTO must serialize {key}"
+            );
+        }
+        let old: super::super::AppConfigDto = serde_json::from_value(v).unwrap();
+        assert_eq!(old.live_captions, "");
+        assert!(!old.live_companion_pending);
+    }
+
+    /// The companion decision and the readiness classification agree: fetching the size
+    /// [`companion_size_for`] returns turns a `ModelMissing` install into a `Ready` one. This is the
+    /// property that makes the fix complete rather than merely plausible.
+    #[test]
+    fn fetching_the_companion_flips_model_missing_to_ready() {
+        for (pin, lang) in [("small", ""), ("base", "pl"), ("tiny", "en")] {
+            let dir = tmp_models_dir("flip");
+            let batch = dir.join(TURBO);
+            touch(&dir, TURBO);
+
+            assert_eq!(
+                resolve_in(&dir, None, "large-v3-turbo-q8_0", lang, pin, false),
+                LiveCaptions::ModelMissing,
+                "pin={pin} lang={lang}"
+            );
+            let size = companion_size_for(&dir, &batch, lang, pin, false)
+                .expect("a heavy-only install must want a companion");
+            assert_eq!(size, pin);
+            // Simulate the download landing.
+            touch(&dir, &model_filename(&size, lang));
+
+            let after = resolve_in(&dir, None, "large-v3-turbo-q8_0", lang, pin, false);
+            assert_eq!(after.dto_state(), "ready", "pin={pin} lang={lang}");
+            assert!(after.model_path().is_some());
+            // …and a second download run wants nothing more.
+            assert_eq!(companion_size_for(&dir, &batch, lang, pin, false), None);
+
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -42,6 +42,12 @@ pub use reminders::*;
 mod model_perf;
 pub use model_perf::*;
 
+// LIVE-CAPTION model readiness: the ONE resolution shared by `start_recording` (which needs the
+// model PATH) and `get_config` (which needs the STATE the recorder renders), plus the live-safe
+// companion-download decision `download_model` consults. Holds no `#[tauri::command]`, so it is NOT
+// glob-re-exported — callers reach it as `live_captions::…` / `super::live_captions::…`.
+mod live_captions;
+
 // Keychain secret setters/probes. Bound as `secrets_commands` to avoid colliding with the
 // crate-level `secrets` module (`use crate::{pipeline, secrets};` above).
 #[path = "secrets.rs"]
@@ -771,6 +777,26 @@ pub struct AppConfigDto {
     /// Model-role override — the effort for the Live role.
     #[serde(default)]
     pub role_live_effort: String,
+    /// DISPLAY-ONLY out — LIVE-CAPTION readiness for THIS machine, so the recorder can tell the user
+    /// whether live captions are on instead of the truth living in a backend `warn!`:
+    /// `"ready"` | `"modelMissing"` (nothing live-safe downloaded — the live-safe companion fetch
+    /// never landed; re-running the model download fixes it) | `"pinnedHeavy"` (the live pin names a
+    /// medium/large-class size that isn't downloaded — a configuration choice, since a heavy model is
+    /// never run on the 3 s tick) | `"noModel"` (no whisper model at all — the model-download banner
+    /// owns that state). It is a DEVICE/DISK fact, not a persisted setting, so it is computed in
+    /// `get_config` (NOT in the pure `config_to_dto`, which leaves it `""` = not probed) and
+    /// `dto_to_config` ignores it entirely — a settings save can neither set nor clear it.
+    /// `#[serde(default)]` keeps an older FE payload that omits the key deserializing cleanly.
+    #[serde(default)]
+    pub live_captions: String,
+    /// DISPLAY-ONLY out — would a `download_model` run right now ALSO fetch the live-safe caption
+    /// companion (`live_captions::companion_size_for`)? The onboarding wizard discloses the extra
+    /// transfer from THIS flag rather than re-deriving the rule in TypeScript, so the wizard's
+    /// promise and the download's behavior cannot drift. Same DISPLAY-ONLY discipline as
+    /// [`Self::live_captions`]: filled in by `get_config`, `false` in the pure `config_to_dto`, and
+    /// ignored by `dto_to_config`.
+    #[serde(default)]
+    pub live_companion_pending: bool,
 }
 
 /// serde default for the Stage E security flags (which default ON in `AppConfig`).
@@ -1277,16 +1303,6 @@ pub async fn start_recording(
     // Best-effort LIVE captions: a read-only background loop emitting partial transcripts
     // during recording (see transcribe::live). Never affects the recording or final note.
     if let Some(cfg) = state.config.lock().ok().map(|c| c.clone()) {
-        let lang = cfg.language.as_deref().unwrap_or("");
-        let configured = || {
-            crate::transcribe::model::resolve_model_path(
-                cfg.whisper_model_path.as_deref().map(std::path::Path::new),
-                &cfg.model_size,
-                lang,
-            )
-            .ok()
-            .flatten()
-        };
         // T1.3 — the UNCONDITIONAL live-model pin (`live_model_pin`, default "small"): the LIVE
         // caption tick decodes with the pinned SIZE whenever its file is downloaded, regardless
         // of `model_size` — a `large-v3` live tick saturates the shared Metal GPU for the whole
@@ -1301,50 +1317,47 @@ pub async fn start_recording(
         // target machines): prefer the largest downloaded live-SAFE model (small → base →
         // tiny); a live-safe CONFIGURED model still works as before; but a medium/large-class
         // configured model is NEVER handed to the live tick — captions are skipped for THIS
-        // recording. Missing live models are downloaded explicitly from Settings while idle;
-        // recording lifecycle code never launches a ~487 MB background transfer beside capture.
-        let live_model = match crate::transcribe::model::live_pin_size(
-            &cfg.live_model_pin,
-            cfg.brain_live,
-        ) {
-            Some(size) => match crate::transcribe::model::resolve_model_path(None, &size, lang) {
-                Ok(Some(p)) => Some(p),
-                _ => match crate::transcribe::model::live_fallback_model(lang) {
-                    Some(p) => {
-                        tracing::warn!(
-                            target: "live",
-                            pin = %size,
-                            "pinned live model absent; live tick uses the largest downloaded live-safe whisper model"
-                        );
-                        Some(p)
-                    }
-                    None => match configured() {
-                        Some(p) if !crate::transcribe::model::is_live_heavy_model_file(&p) => {
-                            tracing::warn!(
-                                target: "live",
-                                pin = %size,
-                                "pinned live model absent; live tick uses the configured whisper model (may contend with the light reasoner)"
-                            );
-                            Some(p)
-                        }
-                        Some(_) => {
-                            // Only medium/large-class models downloaded (e.g. the fresh
-                            // turbo-default install): NEVER run a large encoder on the 3 s
-                            // live tick (T1.3 heat).
-                            tracing::warn!(
-                                target: "live",
-                                pin = %size,
-                                "pinned live model absent and only medium/large models downloaded; live captions off for this recording; download a live-safe model from Settings while idle"
-                            );
-                            None
-                        }
-                        None => None,
-                    },
-                },
-            },
-            None => configured(),
-        };
-        if let Some(model_path) = live_model {
+        // recording. The live-safe companion model is fetched by `download_model` (see
+        // `commands/live_captions.rs`) so the DEFAULT install has one; recording lifecycle code
+        // never launches a ~487 MB background transfer beside capture.
+        //
+        // The whole chain lives in `live_captions::resolve` — ONE decision, also read by
+        // `get_config` so the recorder UI can render the "live captions are off" state instead of
+        // this log line being the only trace of it.
+        let resolved = live_captions::resolve(&cfg);
+        // The pin the resolution actually used (an empty config pin still pins `small` under the
+        // legacy `brain_live` guarantee), so the log field never reads as an empty pin.
+        let pin = crate::transcribe::model::live_pin_size(&cfg.live_model_pin, cfg.brain_live)
+            .unwrap_or_default();
+        match &resolved {
+            live_captions::LiveCaptions::Fallback(_) => tracing::warn!(
+                target: "live",
+                pin = %pin,
+                "pinned live model absent; live tick uses the largest downloaded live-safe whisper model"
+            ),
+            live_captions::LiveCaptions::Configured(_) => tracing::warn!(
+                target: "live",
+                pin = %pin,
+                "pinned live model absent; live tick uses the configured whisper model (may contend with the light reasoner)"
+            ),
+            // Only medium/large-class models downloaded (e.g. a fresh turbo-default install whose
+            // live-safe companion download never landed): NEVER run a large encoder on the 3 s live
+            // tick (T1.3 heat). The FE surfaces this state from `get_config`.
+            live_captions::LiveCaptions::ModelMissing => tracing::warn!(
+                target: "live",
+                pin = %pin,
+                "pinned live model absent and only medium/large models downloaded; live captions off for this recording; download a live-safe model from Settings while idle"
+            ),
+            live_captions::LiveCaptions::PinnedHeavy => tracing::warn!(
+                target: "live",
+                pin = %pin,
+                "the pinned live model is a medium/large-class size that is not downloaded; live captions off for this recording (a heavy model is never run on the live tick)"
+            ),
+            live_captions::LiveCaptions::Pinned(_)
+            | live_captions::LiveCaptions::Unpinned(_)
+            | live_captions::LiveCaptions::NoModel => {}
+        }
+        if let Some(model_path) = resolved.model_path() {
             crate::transcribe::live::spawn(
                 app.clone(),
                 meeting_id.clone(),
@@ -4654,13 +4667,29 @@ pub fn topic_threads(state: State<'_, AppState>) -> Result<Vec<TopicThread>, App
 }
 
 /// Read current config (settings table), without secrets.
+///
+/// Also carries the two DISPLAY-ONLY live-caption facts (`live_captions::dto_probe`, ONE
+/// models-dir lookup): the `live_captions` readiness state — the same resolution `start_recording`
+/// runs, so the recorder can render a calm "live captions are off" notice instead of that fact only
+/// existing in a backend `warn!` — and `live_companion_pending`, the same decision `download_model`
+/// makes, so the onboarding wizard discloses the extra transfer without duplicating the rule. Both
+/// are device/disk probes (a few `is_file` checks), deliberately NOT part of the pure
+/// `config_to_dto`.
 #[tauri::command]
 pub fn get_config(state: State<'_, AppState>) -> Result<AppConfigDto, AppError> {
-    let config = state
-        .config
-        .lock()
-        .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
-    Ok(config_to_dto(&config))
+    // Snapshot the config, then probe — the disk checks below must not hold the config mutex.
+    let config: AppConfig = {
+        let guard = state
+            .config
+            .lock()
+            .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
+        guard.clone()
+    };
+    let mut dto = config_to_dto(&config);
+    let (live_state, companion_pending) = live_captions::dto_probe(&config);
+    dto.live_captions = live_state;
+    dto.live_companion_pending = companion_pending;
+    Ok(dto)
 }
 
 /// Build the ready-to-paste Claude Code MCP config block for the localhost MCP server, WITH the
@@ -4871,6 +4900,11 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         role_live_connection: c.role_live_connection.clone(),
         role_live_model: c.role_live_model.clone(),
         role_live_effort: c.role_live_effort.clone(),
+        // NOT settings: live-caption readiness + the pending-companion disclosure are disk probes,
+        // filled in by `get_config` (the ONE FE-facing read) so this stays pure and every config
+        // round-trip test is unaffected.
+        live_captions: String::new(),
+        live_companion_pending: false,
     }
 }
 

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -244,12 +244,19 @@ pub async fn provider_statuses(
 /// English is selected) from the whisper.cpp HuggingFace mirror into the app models dir if
 /// missing; returns its path. No-op (returns the existing path) when already present. Emits
 /// [`crate::events::EVENT_MODEL_DOWNLOAD`] progress (throttled) so the FE can show a progress bar.
+///
+/// ALSO fetches the live-safe COMPANION model when the batch model can't serve live captions — see
+/// `commands/live_captions.rs::companion_size_for` for the full decision (and the defect it closes:
+/// a fresh ≥ 12 GB Mac downloads only the heavy turbo default, which is never run on the 3 s live
+/// tick, so the default install had NO live captions). BEST-EFFORT: a companion failure never fails
+/// this command — the batch model is what gates recording, and the recorder surfaces the
+/// "live captions off" state from `get_config`.
 #[tauri::command]
 pub async fn download_model(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<String, AppError> {
-    let (configured, size, language) = {
+    let (configured, size, language, live_model_pin, brain_live) = {
         let c = state
             .config
             .lock()
@@ -258,6 +265,8 @@ pub async fn download_model(
             c.whisper_model_path.clone(),
             c.model_size.clone(),
             c.language.clone().unwrap_or_default(),
+            c.live_model_pin.clone(),
+            c.brain_live,
         )
     };
     let p = configured.as_deref().map(std::path::Path::new);
@@ -279,6 +288,43 @@ pub async fn download_model(
         }
     })
     .await?;
+
+    // The LIVE-caption companion, decided against the model that actually landed above (so a custom
+    // `whisper_model_path` is covered without re-deriving it). Progress rides the SAME throttled
+    // event stream — the FE bar restarts for the (much smaller) second file, which is honest: it is a
+    // second download. Nothing is fetched when the live tick already has something to run.
+    if let Some(live_size) =
+        super::live_captions::companion_size(&path, &language, &live_model_pin, brain_live)
+    {
+        let mut companion_emit: u64 = 0;
+        match crate::transcribe::ensure_model(None, &live_size, &language, |downloaded, total| {
+            if downloaded - companion_emit >= EMIT_EVERY {
+                companion_emit = downloaded;
+                let _ = app.emit(
+                    crate::events::EVENT_MODEL_DOWNLOAD,
+                    crate::events::ModelDownloadPayload {
+                        downloaded,
+                        total,
+                        done: false,
+                    },
+                );
+            }
+        })
+        .await
+        {
+            Ok(_) => tracing::info!(
+                target: "transcribe",
+                size = %live_size,
+                "live-caption companion model ready beside the batch model"
+            ),
+            Err(e) => tracing::warn!(
+                target: "transcribe",
+                size = %live_size,
+                error = %e,
+                "live-caption companion model download failed; live captions stay off until it is retried"
+            ),
+        }
+    }
 
     let _ = app.emit(
         crate::events::EVENT_MODEL_DOWNLOAD,

--- a/src/app/features/onboarding/onboarding/onboarding.component.html
+++ b/src/app/features/onboarding/onboarding/onboarding.component.html
@@ -150,6 +150,14 @@
               </span>
             }
           </div>
+          @if (liveCompanionPending()) {
+            <!-- Honesty: a big model is never run on the live-caption tick (it would heat the
+                 Mac all meeting), so the download also brings a small live-caption model. -->
+            <p class="text-muted model-note live-companion-note">
+              Live captions also need a small model — we fetch it alongside this one, so
+              captions work while you record.
+            </p>
+          }
           @if (downloadError(); as derr) {
             <p class="ob-error text-danger">{{ derr }}</p>
           }

--- a/src/app/features/onboarding/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding/onboarding.component.ts
@@ -58,6 +58,17 @@ const CLOUD_PROVIDER_IDS: readonly string[] = [
 /** The local-posture provider — Ollama running on THIS Mac (loopback). */
 const LOCAL_PROVIDER_ID = "ollama";
 
+/**
+ * Read the DISPLAY-ONLY `liveCompanionPending` probe off a config snapshot through a narrow
+ * structural cast: `get_config` fills it, but a settings SAVE can neither set nor clear it, so it is
+ * not part of the settings-shaped `AppConfigDto` the wizard round-trips. A backend (or a mock) that
+ * doesn't send it reads as `false` — disclose nothing rather than promise a transfer.
+ */
+function liveCompanionPendingOf(cfg: AppConfigDto): boolean {
+  return (cfg as AppConfigDto & { liveCompanionPending?: boolean })
+    .liveCompanionPending === true;
+}
+
 /** Approx download size per Whisper quality (mirrors Settings). */
 const SIZE_HINTS: Record<string, string> = {
   tiny: "~75 MB",
@@ -104,6 +115,18 @@ export class OnboardingComponent implements OnInit {
   readonly downloading = signal(false);
   readonly downloadError = signal<string | null>(null);
   readonly sizeHint = computed(() => SIZE_HINTS[this.modelSize()] ?? "");
+  /**
+   * Will `download_model` ALSO fetch a small live-caption model beside the chosen one? Read
+   * STRAIGHT FROM THE BACKEND (`AppConfigDto.liveCompanionPending`, filled in by `get_config` from
+   * the very decision the download makes) rather than re-derived here: the rule is not just "is the
+   * chosen quality heavy" — it also depends on the live-model pin being enabled and light, and on
+   * nothing live-safe already being on disk. An FE copy of half of it promised transfers the
+   * backend would skip. Refreshed after every persist, so it always describes the SAVED selection
+   * this download will actually use.
+   *
+   * Say it out loud so the download is never bigger than the wizard admitted.
+   */
+  readonly liveCompanionPending = signal(false);
   /** 0..1 download progress for the in-flight model (best-effort from events). */
   readonly downloadFrac = signal(0);
   /** Whole-percent label for the in-flight model download. */
@@ -241,6 +264,7 @@ export class OnboardingComponent implements OnInit {
     try {
       const cfg = await this.ipc.getConfig();
       this.loadedConfig = cfg;
+      this.liveCompanionPending.set(liveCompanionPendingOf(cfg));
       this.language.set(cfg.language ?? "");
       this.modelSize.set(cfg.modelSize ?? "small");
       this.provider.set(cfg.providerId ?? "claude_code");
@@ -292,6 +316,7 @@ export class OnboardingComponent implements OnInit {
     if (step === "model") {
       await this.persistConfig();
       this.modelPresent.set(await this.ipc.modelPresent());
+      await this.refreshLiveCompanionPending();
     } else if (step === "provider") {
       await this.recheckProviders();
     }
@@ -329,6 +354,25 @@ export class OnboardingComponent implements OnInit {
     const present = await this.ipc.modelPresent();
     if (requestId !== this.modelPresenceRequestId) return; // superseded mid-flight
     this.modelPresent.set(present);
+    // The companion disclosure describes the SAVED selection, so it is refreshed inside the same
+    // guarded sequence — a late answer for an abandoned selection must not land either.
+    const pending = await this.readLiveCompanionPending();
+    if (requestId !== this.modelPresenceRequestId) return; // superseded mid-flight
+    this.liveCompanionPending.set(pending);
+  }
+
+  /** Re-read the backend's companion decision for the currently SAVED language + size. */
+  private async refreshLiveCompanionPending(): Promise<void> {
+    this.liveCompanionPending.set(await this.readLiveCompanionPending());
+  }
+
+  /** `liveCompanionPending` from a fresh `get_config`; any failure discloses nothing. */
+  private async readLiveCompanionPending(): Promise<boolean> {
+    try {
+      return liveCompanionPendingOf(await this.ipc.getConfig());
+    } catch {
+      return false;
+    }
   }
 
   async downloadModel(): Promise<void> {
@@ -340,6 +384,8 @@ export class OnboardingComponent implements OnInit {
       await this.persistConfig();
       await this.ipc.downloadModel();
       this.modelPresent.set(await this.ipc.modelPresent());
+      // The companion has landed (or was never needed) — stop promising a second transfer.
+      await this.refreshLiveCompanionPending();
     } catch (e) {
       this.downloadError.set(String(e));
     } finally {

--- a/src/app/features/record/record/record.component.html
+++ b/src/app/features/record/record/record.component.html
@@ -43,6 +43,55 @@
     </div>
   }
 
+  <!-- ── LIVE-CAPTION readiness — a calm, dismissible notice. Murmur deliberately never runs a
+       medium/large model on the 3 s live tick (it would heat the Mac for the whole meeting), so
+       when no small live-caption model is on this Mac there are simply no live captions. That used
+       to live ONLY in a backend log line; recording + the full post-Stop transcript are
+       unaffected either way. Independent of the banners above (it never stacks with the
+       model-download one — it requires a present transcription model). ─────────────────────── -->
+  @if (showLiveCaptionsNotice()) {
+    <div class="banner is-accent cc-notice" role="note">
+      <span class="banner-icon" aria-hidden="true">◌</span>
+      <span class="cc-notice-body">
+        <strong>Live captions are off.</strong>
+        @if (liveCaptionsHeavyPin()) {
+          Your live-caption model is a large one and isn't downloaded — Murmur never runs a
+          large model live, to keep your Mac cool. Choose a small live-caption model in
+          Settings.
+        } @else {
+          The small live-caption model isn't on this Mac — its download may have failed.
+        }
+        Recording is unaffected: the full <strong>Me / Others</strong> transcript still runs
+        after you stop.
+        @if (liveCompanionError(); as cerr) {
+          <span class="cc-notice-error">{{ cerr }}</span>
+        }
+      </span>
+      <span class="cc-notice-actions">
+        @if (!liveCaptionsHeavyPin()) {
+          <!-- Tracked by `downloadingLiveCompanion`, NOT `downloadingModel`: the transcription
+               model is already present, so this fetch must never disable Start (see canRecord). -->
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm"
+            (click)="downloadLiveCompanion()"
+            [disabled]="downloadingLiveCompanion()"
+          >
+            {{ downloadingLiveCompanion() ? "Downloading…" : "Download it" }}
+          </button>
+        }
+        <a class="btn btn-ghost btn-sm" routerLink="/settings">Settings</a>
+        <button
+          type="button"
+          class="btn btn-ghost btn-sm"
+          (click)="dismissLiveCaptionsNotice()"
+        >
+          Dismiss
+        </button>
+      </span>
+    </div>
+  }
+
   <!-- Headphones hint — a separate banner only when NOT recording; while recording it
        folds into the single coherent top bar below (no stacked bands). -->
   @if (headphonesHint() && !store.isRecording()) {
@@ -177,50 +226,68 @@
       <!-- Mic-mute: silences only the local mic; system audio keeps recording. -->
       <app-mic-mute-toggle [compact]="true" #micToggle />
 
-      <!-- Live caption ticker — the mic-only partial. -->
-      <p class="cc-line" aria-live="polite">
-        @if (liveCaption(); as cc) {
-          @for (rev of [cc]; track rev) {
-            <span class="cc-text">{{ cc }}</span>
+      <!-- Live caption ticker — the mic-only partial. When no live-safe model is on this Mac the
+           tick never runs, so an eternal "Listening…" would be a lie: say captions are off. -->
+      @if (liveCaptionsOff()) {
+        <p
+          class="cc-line cc-off"
+          role="note"
+          title="No small live-caption model is available on this Mac, and Murmur never runs a large model on the live tick (it would heat your Mac for the whole meeting). Everything is still being recorded — the full Me / Others transcript runs after you stop."
+        >
+          <span class="cc-off-text">
+            Captions off — full transcript after Stop
+          </span>
+        </p>
+      } @else {
+        <p class="cc-line" aria-live="polite">
+          @if (liveCaption(); as cc) {
+            @for (rev of [cc]; track rev) {
+              <span class="cc-text">{{ cc }}</span>
+            }
+          } @else {
+            <span class="cc-idle">Listening…</span>
           }
-        } @else {
-          <span class="cc-idle">Listening…</span>
-        }
-      </p>
+        </p>
+      }
 
       <!-- Honesty hint: live captions are your side (your mic) only; the other
            participants are captured now and folded into the full Me / Others
-           transcript after you Stop. -->
-      <span
-        class="cc-scope"
-        role="note"
-        title="Live captions show your side (your microphone) during the meeting. The other participants are captured now and added to the full Me / Others transcript after you stop."
-      >
-        <svg
-          class="cc-scope-ico"
-          viewBox="0 0 16 16"
-          width="12"
-          height="12"
-          aria-hidden="true"
+           transcript after you Stop. Hidden when captions are off — the indicator
+           above already tells the whole truth. -->
+      @if (!liveCaptionsOff()) {
+        <span
+          class="cc-scope"
+          role="note"
+          title="Live captions show your side (your microphone) during the meeting. The other participants are captured now and added to the full Me / Others transcript after you stop."
         >
-          <circle
-            cx="8"
-            cy="8"
-            r="6.5"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.3"
-          />
-          <path
-            d="M8 7.2v4"
-            stroke="currentColor"
-            stroke-width="1.3"
-            stroke-linecap="round"
-          />
-          <circle cx="8" cy="4.6" r="0.9" fill="currentColor" />
-        </svg>
-        <span class="cc-scope-text">Your side · full transcript after Stop</span>
-      </span>
+          <svg
+            class="cc-scope-ico"
+            viewBox="0 0 16 16"
+            width="12"
+            height="12"
+            aria-hidden="true"
+          >
+            <circle
+              cx="8"
+              cy="8"
+              r="6.5"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.3"
+            />
+            <path
+              d="M8 7.2v4"
+              stroke="currentColor"
+              stroke-width="1.3"
+              stroke-linecap="round"
+            />
+            <circle cx="8" cy="4.6" r="0.9" fill="currentColor" />
+          </svg>
+          <span class="cc-scope-text">
+            Your side · full transcript after Stop
+          </span>
+        </span>
+      }
 
       <!-- Ask — SUMMONS the Brain panel over the notepad (voice + text + presets live
            in the panel). A quiet dot marks an ongoing thread while the panel is closed. -->

--- a/src/app/features/record/record/record.component.scss
+++ b/src/app/features/record/record/record.component.scss
@@ -67,6 +67,29 @@
   margin-left: auto;
 }
 
+/* --- "Live captions are off" notice (same calm, dismissible shape as the vault one) --- */
+.cc-notice {
+  align-items: center;
+  flex-wrap: wrap;
+}
+.cc-notice-body {
+  flex: 1 1 16rem;
+  min-width: 0;
+}
+.cc-notice-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: none;
+  margin-left: auto;
+}
+/* A retry that didn't land — said out loud, never a click that silently did nothing. */
+.cc-notice-error {
+  display: block;
+  margin-top: var(--space-1);
+  color: var(--danger);
+}
+
 /* --- Cloud-egress consent prompt (shown instead of a silent failure) --- */
 .cloud-consent {
   align-items: center;
@@ -572,6 +595,18 @@
 }
 .cc-idle {
   color: var(--text-muted);
+  font-style: italic;
+}
+/* No live-safe model on this Mac ⇒ the ticker never fills. Say so plainly instead of
+   showing "Listening…" for the whole meeting (the recording itself is unaffected). */
+.cc-off {
+  color: var(--text-muted);
+  cursor: default;
+}
+.cc-off-text {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
   font-style: italic;
 }
 /* Live-captions honesty hint — muted, non-shrinking (flex:none) so the

--- a/src/app/features/record/record/record.component.ts
+++ b/src/app/features/record/record/record.component.ts
@@ -10,6 +10,7 @@ import {
   viewChild,
 } from "@angular/core";
 import { RouterLink } from "@angular/router";
+import type { UnlistenFn } from "@tauri-apps/api/event";
 import { RecorderStore } from "../../../core/recorder.store";
 import { IpcService } from "../../../core/ipc.service";
 import type { Analytics, AppConfigDto } from "../../../core/models";
@@ -21,6 +22,28 @@ import { MeetingConversationStore } from "../../../core/meeting-conversation.sto
 
 /** localStorage key for the permanent "no vault set" notice dismissal. */
 const VAULT_NOTICE_DISMISSED_KEY = "murmur-vault-notice-dismissed";
+
+/**
+ * LIVE-CAPTION readiness, as reported by the backend in `get_config`
+ * (Rust `AppConfigDto::live_captions` — a device/disk probe, NOT a persisted setting):
+ *
+ *  - `"ready"`        — the live tick has a live-safe whisper model to run.
+ *  - `"modelMissing"` — nothing live-safe is downloaded. The heavy batch model (e.g. the turbo
+ *                       default a fresh 12 GB+ Mac gets) is deliberately never run on the 3 s live
+ *                       tick, so the small live-caption companion download simply never landed —
+ *                       re-running the model download fixes it.
+ *  - `"pinnedHeavy"`  — the configured live-model pin is itself a medium/large-class size that isn't
+ *                       downloaded. A configuration outcome, not a failed download: Murmur never
+ *                       fetches or runs a heavy model for live captions.
+ *  - `"noModel"`      — no whisper model at all; the "Transcription model needed" banner owns it.
+ *  - `""` / absent    — not probed (an older backend, or a mocked config): render nothing.
+ */
+type LiveCaptionsState =
+  | "ready"
+  | "modelMissing"
+  | "pinnedHeavy"
+  | "noModel"
+  | "";
 
 @Component({
   selector: "app-record",
@@ -68,6 +91,9 @@ export class RecordComponent implements OnInit {
 
   /** Handle for the meeting-app poll — cleared on destroy (no leaked interval). */
   private meetingAppPoll: ReturnType<typeof setInterval> | null = null;
+
+  /** Release handle for the model-download stream — dropped on destroy. */
+  private unlistenModelDownload: UnlistenFn | null = null;
 
   /** The in-pill mic-mute toggle — its `muted()` signal drives the stage hint. */
   private readonly micToggle = viewChild(MicMuteToggleComponent);
@@ -150,6 +176,70 @@ export class RecordComponent implements OnInit {
       this.enhanceSettled()
     );
   });
+
+  /**
+   * The backend's live-caption readiness for THIS machine. Read through a narrow structural cast:
+   * the key is DISPLAY-ONLY (`get_config` fills it; a settings save can neither set nor clear it),
+   * so it is not part of the settings-shaped `AppConfigDto` the FE round-trips — and a backend or
+   * mock that doesn't send it must read as "not probed" (`""`) and render nothing.
+   */
+  readonly liveCaptions = computed<LiveCaptionsState>(
+    () =>
+      ((this.config() as (AppConfigDto & { liveCaptions?: string }) | null)
+        ?.liveCaptions as LiveCaptionsState) || "",
+  );
+
+  /**
+   * No live captions this recording — the live tick has no live-safe model. The heat policy is
+   * deliberate (a medium/large encoder every 3 s saturates the shared Metal GPU for the whole
+   * meeting), so the honest thing is to SAY captions are off rather than show "Listening…" forever.
+   * `"noModel"` is excluded: the transcription-model download banner already owns that state.
+   */
+  readonly liveCaptionsOff = computed(
+    () =>
+      this.liveCaptions() === "modelMissing" ||
+      this.liveCaptions() === "pinnedHeavy",
+  );
+
+  /**
+   * Which cause — a HEAVY live-model pin (a configuration choice: nothing to download on the user's
+   * behalf) vs a missing/failed live-safe companion download (retryable right here). Drives the
+   * notice copy + whether a Download action is offered at all.
+   */
+  readonly liveCaptionsHeavyPin = computed(
+    () => this.liveCaptions() === "pinnedHeavy",
+  );
+
+  /** Dismissed for this session only (like the meeting-app nudge). */
+  private readonly liveCaptionsNoticeDismissed = signal(false);
+
+  /**
+   * The live-caption COMPANION fetch behind the notice's "Download it" — deliberately a SEPARATE
+   * busy flag from {@link downloadingModel}. That one means "the model recording needs isn't here
+   * yet", which is why {@link canRecord} gates on it; this one runs with the batch model already
+   * present, so it must never disable Start — the notice's own copy promises recording is
+   * unaffected, and it is.
+   */
+  readonly downloadingLiveCompanion = signal(false);
+  /**
+   * Why the companion retry didn't help — either the command rejected, or it returned but the
+   * refreshed state still says no live captions (the backend swallows a companion failure so the
+   * batch model still counts as downloaded). Never let a click look like it worked when it didn't.
+   */
+  readonly liveCompanionError = signal<string | null>(null);
+
+  /**
+   * Show the calm, non-blocking "live captions are off" notice: only when a transcription model IS
+   * present (otherwise the download banner is the right thing to show), while NOT recording (the
+   * footer's "Captions off" indicator carries it then), and not dismissed this session.
+   */
+  readonly showLiveCaptionsNotice = computed(
+    () =>
+      this.liveCaptionsOff() &&
+      this.modelPresent() === true &&
+      !this.store.isRecording() &&
+      !this.liveCaptionsNoticeDismissed(),
+  );
 
   /**
    * True when no Obsidian vault folder is configured. The vault is EXPORT-ONLY — every note
@@ -395,13 +485,32 @@ export class RecordComponent implements OnInit {
         clearInterval(this.meetingAppPoll);
         this.meetingAppPoll = null;
       }
+      this.unlistenModelDownload?.();
+      this.unlistenModelDownload = null;
     });
+    // Live-caption readiness is a DEVICE/DISK fact, not a setting, so it can change while this
+    // screen is open — a model download finishing anywhere (Settings, the onboarding wizard, the
+    // notice below) can flip "Live captions are off" to on. Follow the download stream so the
+    // notice + the footer's "Captions off" indicator clear on their own instead of contradicting
+    // what `start_recording` would actually do until a remount.
+    try {
+      const unlisten = await this.ipc.onModelDownload((p) => {
+        if (p.done) void this.onModelDownloadDone();
+      });
+      // Destroyed while the subscription was in flight — release it immediately; the onDestroy
+      // above has already run and would never see this handle.
+      if (destroyed) unlisten();
+      else this.unlistenModelDownload = unlisten;
+    } catch {
+      // No download stream (older backend / a mock without event plumbing) — the state still
+      // refreshes on the next mount and after this screen's own download action.
+    }
     await this.store.init();
     // Subscribe the notes/threads store to the wake/result + BOTH tool-trace
     // streams now, regardless of whether the surface is visible yet — otherwise
     // events fired before it renders (or while the config snapshot is stale) drop.
     void this.assistant.init();
-    this.config.set(await this.ipc.getConfig());
+    await this.refreshConfig();
     void this.ipc.outputIsBuiltinSpeakers().then((v) => this.onSpeakers.set(v ?? true));
     this.modelPresent.set(await this.ipc.modelPresent());
     // Stats are secondary — never let a failure here block the record screen.
@@ -425,6 +534,36 @@ export class RecordComponent implements OnInit {
     );
   }
 
+  /**
+   * Monotonic guard for {@link refreshConfig}: the snapshot is re-read from several places (mount,
+   * the download stream, this screen's own actions), so a slow earlier read must never overwrite a
+   * newer one — same shape as `entity-detail.component.ts`'s `_load`.
+   */
+  private configRequestId = 0;
+
+  /** Re-read the settings/readiness snapshot into {@link config}, dropping superseded responses. */
+  private async refreshConfig(): Promise<void> {
+    const requestId = ++this.configRequestId;
+    const cfg = await this.ipc.getConfig();
+    if (requestId !== this.configRequestId) return;
+    this.config.set(cfg);
+  }
+
+  /**
+   * A model download finished SOMEWHERE (this screen, Settings, the wizard) — re-probe the two
+   * facts it can change: whether a transcription model exists at all, and whether the live tick now
+   * has a live-safe model. Best-effort: a failed probe leaves the last-known state rather than
+   * claiming a state we didn't read.
+   */
+  private async onModelDownloadDone(): Promise<void> {
+    try {
+      this.modelPresent.set(await this.ipc.modelPresent());
+      await this.refreshConfig();
+    } catch {
+      /* keep the last-known state */
+    }
+  }
+
   /** Best-effort poll for a running meeting app; failures leave the nudge hidden. */
   private async checkMeetingApp(): Promise<void> {
     try {
@@ -442,6 +581,11 @@ export class RecordComponent implements OnInit {
   /** Nudge ghost action — hide it for the rest of this session. */
   dismissNudge(): void {
     this.nudgeDismissed.set(true);
+  }
+
+  /** Live-captions notice dismiss — this session only (the state itself is unchanged). */
+  dismissLiveCaptionsNotice(): void {
+    this.liveCaptionsNoticeDismissed.set(true);
   }
 
   /** No-vault info-notice dismiss — permanent (localStorage), not just this session. */
@@ -500,7 +644,7 @@ export class RecordComponent implements OnInit {
     this.consenting.set(true);
     try {
       await this.ipc.consentToCloudEgress();
-      this.config.set(await this.ipc.getConfig());
+      await this.refreshConfig();
       const id = this.store.meetingId();
       if (id) {
         await this.store.resummarize(id);
@@ -512,17 +656,51 @@ export class RecordComponent implements OnInit {
     }
   }
 
-  /** Download the Whisper model, then re-check presence. */
+  /**
+   * Download the Whisper model, then re-check presence. This is the BLOCKING download (the model
+   * recording itself needs) — hence `downloadingModel`, which `canRecord` gates on. The backend
+   * fetches the live-safe caption companion in the same command when the batch model can't serve
+   * live captions, so the readiness snapshot is refreshed too.
+   */
   async downloadModel(): Promise<void> {
     this.modelDownloadError.set(null);
     this.downloadingModel.set(true);
     try {
       await this.ipc.downloadModel();
       this.modelPresent.set(await this.ipc.modelPresent());
+      await this.refreshConfig();
     } catch (e) {
       this.modelDownloadError.set(String(e));
     } finally {
       this.downloadingModel.set(false);
+    }
+  }
+
+  /**
+   * Retry the live-caption COMPANION fetch from the "live captions are off" notice. Same backend
+   * command (`download_model` re-runs the companion decision against the model already on disk and
+   * fetches only what's missing), but tracked in {@link downloadingLiveCompanion} so it does NOT
+   * disable Start: the batch model is already present, recording is genuinely unaffected, and the
+   * notice says so.
+   *
+   * The backend swallows a companion failure by design (the batch model is what gates recording),
+   * so success is judged by the REFRESHED readiness state, not by the command resolving.
+   */
+  async downloadLiveCompanion(): Promise<void> {
+    this.liveCompanionError.set(null);
+    this.downloadingLiveCompanion.set(true);
+    try {
+      await this.ipc.downloadModel();
+      await this.refreshConfig();
+      if (this.liveCaptionsOff()) {
+        this.liveCompanionError.set(
+          "The live-caption model still isn't on this Mac — check your connection and try again.",
+        );
+      }
+    } catch (e) {
+      this.liveCompanionError.set(String(e));
+    } finally {
+      this.downloadingLiveCompanion.set(false);
     }
   }
 


### PR DESCRIPTION
## What

Fixes the first-run defect where a fresh install has **no working live-caption model**, so live captions silently never appear (only a backend `warn!`).

- Onboarding now also ensures a **small/base live-capable model** is present (not just the one heavy default), so the default path has a working live model. The deliberate live-model resolution/heat policy (never running a large encoder on the 3 s live tick) is unchanged.
- The recorder UI now **surfaces the "no live captions available" state** as a small non-blocking notice, instead of only a backend log — so the user always knows whether live captions are on. The notice distinguishes a companion-download failure from a heavy/pinned-model case; recording shows a "Captions off" indicator.

## Tests / gates (all green via the harness)

- New backend logic in `commands/live_captions.rs` with unit tests, now gated by **`cargo test --lib`** (added as an explicit harness check).
- New **`e2e/record/live-captions-notice.spec.ts`** covering: not-ready state → notice renders; ready + config-key-absent → hidden; recording → "Captions off".
- rust-lib, tauri-boot smoke, and Playwright all PASS. Reviews: spec + adversarial.

## Honest bar

Actual live-caption appearance on a fresh ≥12 GB Mac needs a signed build to fully verify; the tests cover the model-selection logic and the empty-state render.

Task T7 of the competitive-gaps program (`docs/research/2026-07-25-implementation-harness-tasks.md`).
