### PR TITLE
fix(org): close the revoke crash window and refresh the UI after a withdrawal

### DIFF
--- a/src-tauri/src/commands/org.rs
+++ b/src-tauri/src/commands/org.rs
@@ -41,6 +41,10 @@
 //! crypto LOGIC changed — only relocation.
 
 use super::*;
+// Brought into scope (rather than spelled out at the call site) so the `org-feed-updated` notice is
+// callable on a `&dyn` notifier — the seam that makes "did this command tell the FE to re-fetch?"
+// unit-testable without a Tauri runtime.
+use crate::events::OrgFeedNotifier;
 
 /// Resolve only exact-owner images referenced by outgoing Markdown. Missing/foreign markers are
 /// flattened to inert alt text; arbitrary URLs are never fetched.
@@ -3940,12 +3944,39 @@ pub fn org_live_shares_for_source(
         .collect())
 }
 
-/// `revoke_org_share(item_id)` — tombstone a published org item (destroys its server ciphertext) and
-/// mark the local row revoked. Marks `revoke_pending` first (crash-safe: the launch sweep completes a
-/// `revoke_pending` if the tombstone call didn't land).
+/// `revoke_org_share(item_id)` — tombstone a published org item (destroys its server ciphertext), evict
+/// this device's own decrypted replica of it, and mark the local row revoked.
+///
+/// CRASH-SAFE ORDER, each step idempotent so an interruption is always re-drivable:
+/// `revoke_pending` → server DELETE → local eviction → `revoked`. Marking `revoke_pending` FIRST means
+/// the launch sweep completes a tombstone that didn't land; evicting BEFORE the `revoked` flip means an
+/// interruption can never leave withdrawn content live locally under a row no queue re-drives (see the
+/// ordering note inside `revoke_org_share_inner_with_policy`).
+///
+/// Emits [`crate::events::EVENT_ORG_FEED_UPDATED`] on success — like every other org-item-mutating
+/// command here — so the org roster, the Settings organization section and an open org-item viewer
+/// re-fetch immediately instead of showing the withdrawn row until some later productive sync tick.
 #[tauri::command]
-pub async fn revoke_org_share(state: State<'_, AppState>, item_id: String) -> Result<(), AppError> {
-    revoke_org_share_inner(state.inner(), item_id).await
+pub async fn revoke_org_share(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    item_id: String,
+) -> Result<(), AppError> {
+    revoke_org_share_notifying(state.inner(), item_id, &app).await
+}
+
+/// Inner of [`revoke_org_share`] with the FE notice expressed as the testable
+/// [`crate::events::OrgFeedNotifier`] seam instead of a concrete `AppHandle`. The notice fires ONLY
+/// after the revoke fully succeeded — a failed revoke changed nothing worth re-fetching, and the row
+/// the FE already shows is still the truth.
+pub(crate) async fn revoke_org_share_notifying(
+    state: &AppState,
+    item_id: String,
+    notifier: &dyn OrgFeedNotifier,
+) -> Result<(), AppError> {
+    revoke_org_share_inner(state, item_id).await?;
+    notifier.org_feed_updated(1);
+    Ok(())
 }
 
 pub(crate) async fn revoke_org_share_inner(
@@ -4001,23 +4032,34 @@ async fn revoke_org_share_inner_with_policy(
             "background org revoke deferred for recording".into(),
         ));
     }
+    // EVICT THE LOCAL REPLICA ON THE PUBLISHING DEVICE — *BEFORE* the `revoked` state flip. Withdrawing
+    // a share used to mutate ONLY the `org_shares` state machine, so the device that revoked kept its
+    // own `org_items` row — markdown, chunks, FTS tokens, int8 vectors and the image BLOBs — live and
+    // searchable through org search / Ask / MCP `org_search` forever. Routed through the ONE eviction
+    // primitive so this path gets exactly the same cleanup as a feed tombstone or the reconcile sweep.
+    // AFTER the server DELETE succeeded (an eviction before a failed tombstone would blind this device
+    // to still-shared content), and idempotent — a device with no local replica row is simply a no-op.
+    //
+    // ORDER IS LOAD-BEARING (eviction THEN state, never state THEN eviction). These are two separate
+    // commits, so a crash / quit / background-epoch flip lands between them:
+    //   - state-then-eviction (the pre-2026-07-26 order) leaves a row marked `revoked` whose decrypted
+    //     replica is still live and searchable. `org_sweep_pending` only re-drives `revoke_pending`, so
+    //     that row NEVER re-enters the crash-safe recovery path and the leak persists until the slow
+    //     anti-entropy sweep happens to walk that seq.
+    //   - eviction-then-state (this order) leaves a `revoke_pending` row whose replica is ALREADY gone.
+    //     The server tombstone and the eviction are both idempotent, so the launch sweep re-drives the
+    //     row harmlessly and completes the flip. Strictly safer: the interrupted state is a stale
+    //     bookkeeping row, never live withdrawn content.
     if policy
-        .commit(|| state.db.set_org_share_state(&row.id, "revoked", &now))?
+        .commit(|| state.db.evict_org_item(&item_id).map(|_| ()))?
         .is_none()
     {
         return Err(AppError::Unavailable(
             "background org revoke deferred for recording".into(),
         ));
     }
-    // EVICT THE LOCAL REPLICA ON THE PUBLISHING DEVICE. Withdrawing a share used to mutate ONLY the
-    // `org_shares` state machine, so the device that revoked kept its own `org_items` row — markdown,
-    // chunks, FTS tokens, int8 vectors and the image BLOBs — live and searchable through org search /
-    // Ask / MCP `org_search` forever. Routed through the ONE eviction primitive so this path gets
-    // exactly the same cleanup as a feed tombstone or the reconcile sweep. AFTER the server DELETE
-    // succeeded (an eviction before a failed tombstone would blind this device to still-shared
-    // content), and idempotent — a device with no local replica row is simply a no-op.
     if policy
-        .commit(|| state.db.evict_org_item(&item_id).map(|_| ()))?
+        .commit(|| state.db.set_org_share_state(&row.id, "revoked", &now))?
         .is_none()
     {
         return Err(AppError::Unavailable(
@@ -4329,7 +4371,11 @@ pub(crate) async fn org_background_sync_tick(state: &AppState) -> bool {
 
 /// `org_sweep_pending()` — the on-launch org queue sweep (extends the mode-B `share_rewrap_pending`
 /// launch pattern). Idempotent + OFFLINE-TOLERANT: logged out / no server / a per-row failure leaves
-/// the row where it is for the next pass (never an error). Three queues:
+/// the row where it is for the next pass (never an error). One local repair pass plus three queues:
+///   - `revoked` rows whose LOCAL replica is somehow still live → evicted through the ONE eviction
+///     primitive, NO network (the server tombstone already landed for a `revoked` row). Defence in
+///     depth behind `revoke_org_share_inner_with_policy`'s evict-before-flip ordering, and the one
+///     step that runs even while logged out, since it needs neither a server nor a session;
 ///   - `queued`, or a `failed` row that NEVER published (`item_id` still `NULL`) → fresh publish via
 ///     `share_to_org_inner` (re-seal under the current OCK + upload + publish → `uploaded`);
 ///   - a `failed` row that WAS live before (`item_id` set — the row's LAST republish attempt failed,
@@ -4357,20 +4403,62 @@ async fn org_sweep_pending_with_policy(
     if !policy.is_current() {
         return Ok(0);
     }
-    let base = share_base_url(state)?;
-    if base.trim().is_empty() {
-        return Ok(0);
-    }
-    // Logged out ⇒ nothing to do (best-effort launch sweep, not an error).
-    if valid_access_token(state).await.is_err() {
-        return Ok(0);
-    }
-    if !policy.is_current() {
-        return Ok(0);
-    }
     let mut advanced = 0u32;
     let mut attempted = 0usize;
     let background_limit = policy.background_epoch.map(|_| 1usize);
+
+    // 0a) LOCAL-ONLY ORPHAN REPAIR (defence in depth behind the eviction-before-`revoked` ordering in
+    //     `revoke_org_share_inner_with_policy`). A device interrupted in the OLD order — or by any
+    //     future bug that flips a row to `revoked` without evicting — keeps a fully decrypted, fully
+    //     searchable replica of content it already withdrew from the server, and no queue re-drives a
+    //     `revoked` row. This pass converges exactly those: for each `revoked` row that still names a
+    //     server item, ask the (indexed, content-free) replica state whether a LIVE local row remains
+    //     and, if so, run the ONE eviction primitive. NO NETWORK — the server tombstone already
+    //     happened for a `revoked` row, so re-issuing it would only re-DELETE an already-gone item on
+    //     every launch. Runs BEFORE the logged-out / no-server early returns because it needs neither,
+    //     and is a pure read (zero write transactions) once every replica has converged. It does NOT
+    //     spend the per-tick `attempted` budget — that budget bounds NETWORK/model work, and starving
+    //     an outbound publish for a minute behind a purely local tombstone would be the wrong trade —
+    //     but it IS bounded by `ORG_REVOKED_ORPHAN_REPAIR_PER_SWEEP` and by the background epoch.
+    let mut repaired = 0usize;
+    for row in state.db.list_org_shares_in_state("revoked")? {
+        if repaired >= ORG_REVOKED_ORPHAN_REPAIR_PER_SWEEP || !policy.is_current() {
+            break;
+        }
+        let Some(item_id) = row.item_id.as_deref() else {
+            continue;
+        };
+        if !state
+            .db
+            .org_replica_state(item_id)?
+            .is_some_and(|held| !held.tombstoned)
+        {
+            continue;
+        }
+        if policy
+            .commit(|| state.db.evict_org_item(item_id))?
+            .unwrap_or(false)
+        {
+            repaired += 1;
+            advanced += 1;
+            tracing::info!(
+                target: "org",
+                "evicted an orphaned local replica of an already-revoked org share"
+            );
+        }
+    }
+
+    let base = share_base_url(state)?;
+    if base.trim().is_empty() {
+        return Ok(advanced);
+    }
+    // Logged out ⇒ nothing more to do (best-effort launch sweep, not an error).
+    if valid_access_token(state).await.is_err() {
+        return Ok(advanced);
+    }
+    if !policy.is_current() {
+        return Ok(advanced);
+    }
 
     // 0) DEDUP (auto-clean, user-opted-in): collapse accidental DUPLICATE live items — same org + same
     //    source — down to the earliest, tombstoning the extras. Fixes duplicates created BEFORE the
@@ -4527,6 +4615,13 @@ pub async fn org_sync_now(
 /// One deliberately small feed page per org-sync invocation. A protocol-valid org blob may be up to
 /// 16 MiB; keeping this at four bounds the decrypted/prepared page far below the old 200-item shape.
 const ORG_FEED_PAGE: u32 = 4;
+
+/// How many orphaned local replicas of ALREADY-`revoked` shares one `org_sweep_pending` pass may
+/// evict (step 0a). Bounded for the same reason every other sweep step is: a launch/background pass
+/// must stay a short, predictable amount of local work. The steady state is zero — the scan itself is
+/// one indexed read per revoked row and writes nothing once every replica has converged — so this cap
+/// only ever bites on a device with a genuine backlog, which the next pass continues.
+const ORG_REVOKED_ORPHAN_REPAIR_PER_SWEEP: usize = 8;
 
 /// One deliberately small ANTI-ENTROPY page per reconcile tick — same order of magnitude as
 /// [`ORG_FEED_PAGE`], so the slow sweep can never starve the live pull nor hammer the server. The
@@ -5149,13 +5244,6 @@ async fn org_sync_one(
 // sweep is what repairs replicas ALREADY orphaned on real machines, and remains a correct backstop
 // afterwards.
 
-/// One anti-entropy reconcile tick: pick one joined org (round-robin) and walk one bounded
-/// [`ORG_RECONCILE_PAGE`] of its feed from the SLOW cursor. Returns how many local replica rows this
-/// tick actually changed (evicted + re-ingested), so the caller can fire `org-feed-updated`.
-///
-/// Best-effort and offline-tolerant in exactly the same shape as the live pull: logged out / no org /
-/// no server ⇒ `Ok(0)`, never an error. Honors the background epoch through `policy` at every await
-/// boundary and every DB commit.
 /// Run ONE anti-entropy reconcile step immediately (manual policy — never epoch-deferred). Returns
 /// the number of local replica rows this step changed. The scheduled path is
 /// `org_background_sync_tick`; this is the direct entry point for internal callers and for the
@@ -5164,6 +5252,22 @@ pub async fn org_reconcile_now_inner(state: &AppState) -> Result<u32, AppError> 
     org_reconcile_tick_with_policy(state, OrgWorkPolicy::manual()).await
 }
 
+/// One anti-entropy reconcile tick: pick one joined org (round-robin) and walk one bounded
+/// [`ORG_RECONCILE_PAGE`] of its feed from the SLOW cursor. Returns how many local replica rows this
+/// tick actually changed (evicted + re-ingested), so the caller can fire `org-feed-updated`.
+///
+/// CONFIGURATION-tolerant, NOT network-tolerant — the distinction matters, so state it exactly. No
+/// joined org, no configured server, or no valid session ⇒ `Ok(0)`: nothing to reconcile is not a
+/// failure. But once a request is actually made, a failing `client.org_feed(..)` PROPAGATES as `Err`
+/// from here (unlike the per-record failures inside `org_reconcile_one`, which are deliberately
+/// swallowed so the slow cursor can never stall short of a tombstone). The scheduled caller
+/// `org_background_sync_tick` is what makes an offline tick harmless: it logs a non-PII warning and
+/// returns `false`. Kept as an `Err` rather than folded into `Ok(0)` because the manual entry point
+/// (`org_reconcile_now_inner`, used by internal callers and the regression tests) needs to be able to
+/// tell "the feed is genuinely converged" from "the server could not be reached" — collapsing them
+/// would make an unreachable server indistinguishable from a healthy no-op.
+///
+/// Honors the background epoch through `policy` at every await boundary and every DB commit.
 async fn org_reconcile_tick_with_policy(
     state: &AppState,
     policy: OrgWorkPolicy,

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -18921,35 +18921,10 @@
     fn revoke_org_share_evicts_the_local_replica_on_the_publishing_device() {
         let mock = MockOrgServer::start();
         let state = build_state("org-revoke-evicts");
-        seed_org(&state.db, "org-1", "Acme", "member", 1);
-        state.config.lock().unwrap().share_base_url = mock.base.clone();
-        seed_live_session(&state);
-        seed_ock(&state, "org-1", 1);
-
-        // A published share, with the publishing device's own local replica of it.
-        state
-            .db
-            .insert_org_share(
-                "os-rv",
-                "org-1",
-                None,
-                Some("n-rv"),
-                "note",
-                Some("Quarterly acquisition plan"),
-                1,
-                1,
-                &[7u8; 32],
-                "2026-07-11T00:00:00Z",
-            )
-            .unwrap();
-        state
-            .db
-            .set_org_share_uploaded("os-rv", "it-rv", "2026-07-11T00:00:00Z")
-            .unwrap();
-        seed_replica_item(&state, "it-rv", "org-1", 5);
+        // A published share, with the publishing device's own local replica of it (the helper also
+        // asserts the pre-state: the replica really is present, indexed and attached).
+        seed_published_share_with_replica(&state, &mock.base);
         assert!(state.db.get_org_item("it-rv").unwrap().is_some());
-        let (chunks, vectors, fts, attachments) = replica_counts(&state, "it-rv");
-        assert!(chunks > 0 && vectors > 0 && fts > 0 && attachments == 1);
 
         block_on(revoke_org_share_inner(&state, "it-rv".to_string())).unwrap();
 
@@ -18971,6 +18946,262 @@
             state.db.get_org_share("os-rv").unwrap().unwrap().state,
             "revoked"
         );
+    }
+
+    /// Seed the exact shape every revoke-window test needs: one joined org with a live session + OCK,
+    /// one PUBLISHED share (`os-rv` → `it-rv`) and the publishing device's own fully-indexed,
+    /// fully-attached local replica of it.
+    fn seed_published_share_with_replica(state: &AppState, base: &str) {
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        state.config.lock().unwrap().share_base_url = base.to_string();
+        seed_live_session(state);
+        seed_ock(state, "org-1", 1);
+        state
+            .db
+            .insert_org_share(
+                "os-rv",
+                "org-1",
+                None,
+                Some("n-rv"),
+                "note",
+                Some("Quarterly acquisition plan"),
+                1,
+                1,
+                &[7u8; 32],
+                "2026-07-11T00:00:00Z",
+            )
+            .unwrap();
+        state
+            .db
+            .set_org_share_uploaded("os-rv", "it-rv", "2026-07-11T00:00:00Z")
+            .unwrap();
+        seed_replica_item(state, "it-rv", "org-1", 5);
+        let (chunks, vectors, fts, attachments) = replica_counts(state, "it-rv");
+        assert!(chunks > 0 && vectors > 0 && fts > 0 && attachments == 1);
+    }
+
+    /// Install a raw SQLite guard/fault trigger on the test DB (dropped again by `drop_test_trigger`).
+    /// This is the only seam that can interrupt a revoke BETWEEN its two local commits without adding
+    /// a production-code test hook: SQLite enforces it inside the very transaction being committed.
+    fn install_test_trigger(state: &AppState, sql: &str) {
+        state.db.lock().execute_batch(sql).unwrap();
+    }
+
+    fn drop_test_trigger(state: &AppState, name: &str) {
+        state
+            .db
+            .lock()
+            .execute_batch(&format!("DROP TRIGGER {name};"))
+            .unwrap();
+    }
+
+    /// THE REVOKE CRASH WINDOW, part 1 — the ORDERING itself.
+    ///
+    /// A revoke makes two SEPARATE local commits after the server DELETE lands: the `org_shares` state
+    /// flip and the local replica eviction. Whichever runs second defines what a crash / quit /
+    /// background-epoch flip between them leaves behind. Pre-fix the order was state-THEN-eviction, so
+    /// the interrupted state was a row marked `revoked` whose decrypted replica — markdown, chunks,
+    /// int8 vectors, FTS tokens, image BLOBs — was still live and searchable through org search / Ask /
+    /// MCP `org_search`, and `org_sweep_pending` (which only re-drives `revoke_pending`) could never
+    /// reach it again.
+    ///
+    /// The invariant is asserted where it actually lives — in the DB, not in the call sequence: a
+    /// BEFORE-UPDATE trigger ABORTS any transition of a share row to `revoked` while that item's
+    /// replica row is still live. On the pre-fix order that abort fires and the revoke returns `Err`
+    /// (RED); on the fixed order the eviction has already happened, the guard is satisfied, and the
+    /// revoke completes.
+    #[test]
+    fn revoke_evicts_the_local_replica_before_it_flips_the_share_to_revoked() {
+        let mock = MockOrgServer::start();
+        let state = build_state("org-revoke-order");
+        seed_published_share_with_replica(&state, &mock.base);
+
+        install_test_trigger(
+            &state,
+            "CREATE TRIGGER guard_revoke_order BEFORE UPDATE ON org_shares
+               WHEN NEW.state = 'revoked'
+                AND EXISTS (SELECT 1 FROM org_items
+                             WHERE item_id = NEW.item_id AND tombstoned = 0)
+             BEGIN
+               SELECT RAISE(ABORT, 'share flipped to revoked while its replica was still live');
+             END;",
+        );
+
+        block_on(revoke_org_share_inner(&state, "it-rv".to_string()))
+            .expect("the eviction must be committed BEFORE the revoked state flip");
+
+        assert_eq!(
+            mock.log.lock().unwrap().tombstoned,
+            vec!["it-rv".to_string()],
+            "the server is still told FIRST — an eviction before a failed tombstone would blind us"
+        );
+        assert!(state.db.get_org_item("it-rv").unwrap().is_none());
+        assert_eq!(replica_counts(&state, "it-rv"), (0, 0, 0, 0));
+        assert_eq!(
+            state.db.get_org_share("os-rv").unwrap().unwrap().state,
+            "revoked"
+        );
+    }
+
+    /// THE REVOKE CRASH WINDOW, part 2 — what an INTERRUPTION in the window actually leaves, and that
+    /// the launch sweep still repairs it.
+    ///
+    /// The interruption is injected as a fault trigger that ABORTS the eviction's `org_items` write —
+    /// the observable equivalent of the process dying at that instant: the server tombstone has landed,
+    /// the eviction has not. What matters is the state the share row is left in.
+    ///   - Pre-fix (state THEN eviction) it is `revoked`: `org_sweep_pending` only re-drives
+    ///     `revoke_pending`, so the still-live replica is unreachable by the crash-safe recovery path.
+    ///   - Post-fix (eviction THEN state) it is `revoke_pending`: both the server tombstone and the
+    ///     eviction are idempotent, so the very next sweep re-drives the row and converges it.
+    #[test]
+    fn an_interrupted_revoke_leaves_a_re_drivable_row_not_a_live_orphaned_replica() {
+        let mock = MockOrgServer::start();
+        let state = build_state("org-revoke-interrupted");
+        seed_published_share_with_replica(&state, &mock.base);
+
+        // Fault injection: the eviction's tombstone write fails (≙ the process stopping right there).
+        install_test_trigger(
+            &state,
+            "CREATE TRIGGER fault_on_evict BEFORE UPDATE ON org_items
+               WHEN NEW.tombstoned = 1
+             BEGIN SELECT RAISE(ABORT, 'simulated interruption during the local eviction'); END;",
+        );
+
+        block_on(revoke_org_share_inner(&state, "it-rv".to_string()))
+            .expect_err("the interrupted eviction must surface, not be silently swallowed");
+
+        assert_eq!(
+            mock.log.lock().unwrap().tombstoned,
+            vec!["it-rv".to_string()],
+            "the server withdrawal already happened — this is exactly the dangerous window"
+        );
+        assert!(
+            state.db.get_org_item("it-rv").unwrap().is_some(),
+            "the eviction really did not happen (its transaction rolled back)"
+        );
+        assert_eq!(
+            state.db.get_org_share("os-rv").unwrap().unwrap().state,
+            "revoke_pending",
+            "an interruption must NEVER leave a `revoked` row whose replica is still live — that row \
+             re-enters no queue"
+        );
+
+        // The interruption is over (the app relaunches): the sweep re-drives the `revoke_pending` row.
+        drop_test_trigger(&state, "fault_on_evict");
+        assert!(block_on(org_sweep_pending_inner(&state)).unwrap() >= 1);
+
+        assert!(
+            state.db.get_org_item("it-rv").unwrap().is_none(),
+            "the launch sweep converged the replica the interrupted revoke left behind"
+        );
+        assert_eq!(replica_counts(&state, "it-rv"), (0, 0, 0, 0));
+        assert_eq!(
+            state.db.get_org_share("os-rv").unwrap().unwrap().state,
+            "revoked"
+        );
+    }
+
+    /// DEFENCE IN DEPTH behind the ordering fix: `org_sweep_pending` now also converges a `revoked`
+    /// row that still has a LIVE local replica — the shape a device interrupted under the OLD order is
+    /// stuck in, and the one shape no queue used to re-drive. Local-only: no server, no session, no
+    /// network call (the server tombstone already landed for a `revoked` row, so re-issuing it every
+    /// launch would be pure waste).
+    #[test]
+    fn the_launch_sweep_evicts_an_orphaned_replica_of_an_already_revoked_share() {
+        let state = build_state("org-revoked-orphan-repair");
+        // No `share_base_url`, no session — deliberately: the repair must not depend on either (and
+        // this test must never reach out to the default production host).
+        state.config.lock().unwrap().share_base_url = String::new();
+        seed_org(&state.db, "org-1", "Acme", "member", 1);
+        state
+            .db
+            .insert_org_share(
+                "os-orphan",
+                "org-1",
+                None,
+                Some("n-orphan"),
+                "note",
+                Some("Quarterly acquisition plan"),
+                1,
+                1,
+                &[7u8; 32],
+                "2026-07-11T00:00:00Z",
+            )
+            .unwrap();
+        state
+            .db
+            .set_org_share_uploaded("os-orphan", "it-orphan", "2026-07-11T00:00:00Z")
+            .unwrap();
+        state
+            .db
+            .set_org_share_state("os-orphan", "revoked", "2026-07-11T00:05:00Z")
+            .unwrap();
+        seed_replica_item(&state, "it-orphan", "org-1", 5);
+
+        assert_eq!(block_on(org_sweep_pending_inner(&state)).unwrap(), 1);
+        assert!(state.db.get_org_item("it-orphan").unwrap().is_none());
+        assert_eq!(replica_counts(&state, "it-orphan"), (0, 0, 0, 0));
+
+        // Converged ⇒ the next pass is a pure no-op (it must not keep counting the same row forever).
+        assert_eq!(block_on(org_sweep_pending_inner(&state)).unwrap(), 0);
+    }
+
+    /// Records every [`crate::events::EVENT_ORG_FEED_UPDATED`] notice a command fires, so the "does the
+    /// FE actually get told to re-fetch?" half of an org mutation is assertable without a Tauri runtime.
+    #[derive(Default)]
+    struct RecordingOrgFeedNotifier {
+        calls: Mutex<Vec<u32>>,
+    }
+
+    impl crate::events::OrgFeedNotifier for RecordingOrgFeedNotifier {
+        fn org_feed_updated(&self, orgs_changed: u32) {
+            self.calls.lock().unwrap().push(orgs_changed);
+        }
+    }
+
+    /// `revoke_org_share` was the ONLY org-item-mutating command that never emitted `org-feed-updated`
+    /// — every sibling (`delete_org_item_as_author`, the share/publish paths) does. Now that a revoke
+    /// mutates the LOCAL replica too, the omission left `OrgBrainService.loadOrgs()`, the Settings
+    /// organization section and an open org-item viewer showing the withdrawn row until some unrelated
+    /// productive sync tick (up to `ORG_SYNC_TICK_SECS` later, or never on a quiet feed) — and the
+    /// reconcile sweep cannot cover the gap, since it emits only when it changed something and the item
+    /// is already locally tombstoned by then.
+    #[test]
+    fn a_successful_revoke_tells_the_frontend_to_refresh() {
+        let mock = MockOrgServer::start();
+        let state = build_state("org-revoke-emits");
+        seed_published_share_with_replica(&state, &mock.base);
+
+        let notifier = RecordingOrgFeedNotifier::default();
+        block_on(revoke_org_share_notifying(
+            &state,
+            "it-rv".to_string(),
+            &notifier,
+        ))
+        .unwrap();
+
+        assert_eq!(
+            *notifier.calls.lock().unwrap(),
+            vec![1],
+            "a successful revoke must fire exactly one org-feed-updated notice"
+        );
+    }
+
+    /// The flip side: a revoke that FAILED changed nothing the FE needs to re-fetch, so it must stay
+    /// silent (a notice there would make every open view re-fetch identical state on every error).
+    #[test]
+    fn a_failed_revoke_does_not_tell_the_frontend_to_refresh() {
+        let state = build_state("org-revoke-no-emit-on-failure");
+        let notifier = RecordingOrgFeedNotifier::default();
+
+        block_on(revoke_org_share_notifying(
+            &state,
+            "it-does-not-exist".to_string(),
+            &notifier,
+        ))
+        .expect_err("no local org share for that item");
+
+        assert!(notifier.calls.lock().unwrap().is_empty());
     }
 
     /// ITEM 4 — `list_org_shares` takes the caller's chosen org. Pre-fix it ignored the caller and

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -447,6 +447,38 @@ pub fn emit_org_feed_updated(app: &AppHandle, orgs_changed: u32) {
     }
 }
 
+/// The [`EVENT_ORG_FEED_UPDATED`] emit seen as a capability rather than as a concrete `AppHandle`.
+///
+/// Exists so the "did this command actually tell the FE to re-fetch?" half of an org-item mutation is
+/// UNIT-TESTABLE. An org-item-mutating command that stays silent leaves `OrgBrainService.loadOrgs()`,
+/// the Settings organization section and the org-item viewer showing a row that no longer exists
+/// until an unrelated background tick happens to be productive (up to
+/// [`crate::commands::ORG_SYNC_TICK_SECS`] later, or never on a quiet feed). That omission shipped
+/// once already (`revoke_org_share`), so THAT command's emit is expressed as a seam a test can
+/// observe rather than a bare line that is easy to forget and impossible to assert on. The other
+/// org-item-mutating commands still call [`emit_org_feed_updated`] directly — this trait is the
+/// testing seam for the path that regressed, not (yet) a repo-wide convention.
+///
+/// The production implementation is the `AppHandle` one below; the crate's tests substitute a
+/// recording double. Content-free by construction — the only argument is a count.
+///
+/// `Send + Sync` is REQUIRED, not decorative: the notifier is held across the `await` of the revoke
+/// inside an `async` `#[tauri::command]`, and Tauri's `generate_handler!` demands a `Send` future.
+/// Without the supertraits `&dyn OrgFeedNotifier` is neither, and the command fails to compile with
+/// "future returned by `revoke_org_share` is not `Send`". Both implementations (`AppHandle` and the
+/// tests' `Mutex`-backed recorder) already satisfy them.
+pub trait OrgFeedNotifier: Send + Sync {
+    /// Tell the FE that `orgs_changed` orgs' local replicas changed and every org view should
+    /// re-fetch. Best-effort: an implementation must never fail the caller's operation.
+    fn org_feed_updated(&self, orgs_changed: u32);
+}
+
+impl OrgFeedNotifier for AppHandle {
+    fn org_feed_updated(&self, orgs_changed: u32) {
+        emit_org_feed_updated(self, orgs_changed);
+    }
+}
+
 /// DELETE FAN-OUT FIX (2026-07-15): emitted once a note/meeting delete has FULLY succeeded — local
 /// rows gone AND (per the org-share revoke-cascade fix) any live org shares of it already revoked.
 /// Root cause this closes: no delete flow ever told OTHER open consumers (most visibly the tab-strip,

--- a/src-tauri/src/storage/org_store.rs
+++ b/src-tauri/src/storage/org_store.rs
@@ -37,20 +37,27 @@ pub(crate) struct PreparedOrgItemIndex {
     vector_blobs: Option<Vec<Vec<u8>>>,
 }
 
+/// What this device currently holds for ONE org item id — the minimum the anti-entropy reconcile
+/// sweep needs to decide "already converged, skip" vs "fetch + ingest" WITHOUT downloading a blob,
+/// and the same read [`crate::commands::org_sweep_pending`] uses to spot an orphaned replica of an
+/// already-revoked share. Content-free: a tombstone flag plus the opaque plaintext hash the publisher
+/// sealed under — never the markdown, the title, or any key material.
+#[derive(Clone, Debug)]
+pub(crate) struct OrgReplicaState {
+    /// `true` once the item has been evicted here. Append-only and permanent: a later live feed
+    /// record must never resurrect withdrawn plaintext.
+    pub(crate) tombstoned: bool,
+    /// The publisher's plaintext hash for the version stored locally, or `None` for a row written
+    /// before the feed carried one. Equality with the feed's hash is what lets the sweep skip an
+    /// already-converged item with no blob fetch.
+    pub(crate) content_sha256: Option<Vec<u8>>,
+}
+
 /// One live org item's existing chunk rows, loaded for a model-switch reindex. The keyset iterator
 /// returns exactly one item at a time so a large local replica never becomes one plaintext RAM
 /// buffer. Ordered chunk ids plus the canonical item version/hash form the optimistic concurrency
 /// token for the vector-only commit (SQLite rowids may be reused after a clean replace, so ids alone
 /// are insufficient).
-/// What this device currently holds for ONE org item id — the minimum the anti-entropy reconcile
-/// sweep needs to decide "already converged, skip" vs "fetch + ingest" WITHOUT downloading a blob.
-/// Content-free: a tombstone flag plus the opaque plaintext hash the publisher sealed under.
-#[derive(Clone, Debug)]
-pub(crate) struct OrgReplicaState {
-    pub(crate) tombstoned: bool,
-    pub(crate) content_sha256: Option<Vec<u8>>,
-}
-
 pub(crate) struct OrgItemVectorBatch {
     pub(crate) item_id: String,
     pub(crate) chunk_ids: Vec<i64>,


### PR DESCRIPTION
Closes the three reviewer findings raised against #461 (they were real, but scoped out of that task —
the reviewers PASSED it and flagged them as MINOR).

## 1. The revoke crash window — root-cause ordering fix

`revoke_org_share_inner_with_policy` committed the local eviction **after** flipping the share row
`revoke_pending → revoked`. A crash, quit, or background-epoch flip between those two commits left the
item withdrawn **on the server** while the decrypted replica — markdown, chunks, int8 vectors, FTS
tokens, image BLOBs — stayed live and searchable via org search, Ask and MCP `org_search`. The launch
queue only re-drives `revoke_pending` rows, so a `revoked` row never re-entered crash-safe recovery.

The eviction now commits **before** the `revoked` flip (still after the server tombstone). Both steps
in the new window are genuinely idempotent — `evict_org_item` is an idempotent UPDATE and
`ShareClient::org_tombstone_item` maps 404 to success — so an interruption now leaves a
`revoke_pending` row whose replica is already gone, which sweep step 1 re-drives harmlessly.

Defence in depth on top (explicitly permitted by the contract, not instead of the fix): sweep step 0a,
a local-only, network-free, bounded (`ORG_REVOKED_ORPHAN_REPAIR_PER_SWEEP = 8`) pass that evicts the
replica of any `revoked` row still reporting a live local row. It reuses the **single**
`evict_org_item` primitive — no second partial-cleanup path — and correctly skips `item_id = None`
rows so the two cancel-locally revoke paths cannot trigger a spurious eviction.

## 2. Missing refresh event

`revoke_org_share` was the only org-item-mutating command that did not emit `org-feed-updated`. Since
#461 made revoke mutate the local replica, the stale row lingered in the UI up to 60 s, or
indefinitely on a quiet feed. Now emitted, with both a positive and a negative test.

## 3. Doc comments attached to the wrong item

A struct had been inserted between an existing doc comment and the type it described, leaving
`OrgItemVectorBatch` — the type carrying the vector-CAS concurrency-token fields — undocumented while
its prose sat on an unrelated struct. Also corrected an `org_reconcile_now_inner` comment that claimed
offline-tolerance the code does not have (a failing `org_feed()` propagates `Err`).

This is not tidiness. A confidently-worded stale comment in `migrations/0006_orgs.sql` — asserting
that soft tombstones reach already-synced members — is exactly what let the original bug survive
review.

## Verification

Harness task `org-revoke-crashwindow-20260726-v2`, **PASSED in round 2**. Round 1 failed on a build
break, not on logic: the new `OrgFeedNotifier` trait lacked `Send + Sync`, so `&dyn OrgFeedNotifier`
held across the `await` in the async command made the future non-`Send`, which
`tauri::generate_handler!` rejects. Repaired with the bounds plus a note explaining why they are
load-bearing.

- reviews: spec **PASS**, adversarial **PASS**, lock-security **PASS**, egress-security **PASS**
- both contract checks green on the exact staged tree

The ordering fix is pinned by a **DB-level trigger assertion**, not a call-sequence assertion, plus a
second test that injects the interruption and proves the leftover row is `revoke_pending`
(re-drivable) rather than `revoked` (orphaned). The spec reviewer separately confirmed the re-drive
assumption against the real server: an already-tombstoned item yields 404 and the client treats 404 as
success.

## New MINOR findings from this round — landing next, not here

1. **`revoke_shares_for_folder`** (the "Revoke & lock" command) calls `revoke_org_share_inner` in a
   loop and still never emits `org-feed-updated` — the same staleness bug as #2 on a sibling path.
2. `org_background_sync_tick` discards the sweep's return value, so when step 0a actually evicts an
   orphan the UI is not refreshed.
3. `list_org_shares_in_state`'s doc is now stale — the sweep also pulls `revoked` (and already pulled
   `failed`). Ironic given deliverable 3.
4. Step 0a runs on every 60 s tick over an unindexed `WHERE state = ?` scan, and `revoked` rows are
   never pruned, so the cost grows without bound.
