### PR TITLE
feat(templates): logic-less variable DSL + Murmur-assembled front-matter

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -141,6 +141,24 @@ pub fn consent_to_clickup(state: State<'_, AppState>) -> Result<(), AppError> {
 // (`template::set_saved_templates`) so the next note generation resolves the live data (the pipeline
 // renders through `build_template` with only the style string, so the registry — not `AppState` —
 // is how a saved-template id reaches the renderer).
+//
+// T4b — the `{{}}` VARIABLE DSL. A template may reference a small FIXED set of variables
+// (`summarize::template::TEMPLATE_VARS`) as `{{name}}` / `{{name:format}}`, Obsidian-compatible for
+// the shared keys (`{{title}}`, `{{date:YYYY-MM-DD}}`). It is deliberately LOGIC-LESS: no
+// expressions, no conditionals, no nesting, no recursion — just a closed `match` resolved by Murmur
+// AFTER the provider call, so a variable can never widen egress. The same
+// `validate_note_template` gate is therefore also the DSL gate: an ident outside the allowlist (or
+// a malformed `{{ … }}`) is refused HERE, FAIL-CLOSED, rather than silently disappearing from the
+// user's notes at render time. `{{meeting_id}}` is intentionally NOT a variable.
+//
+// WHICH FIELDS TAKE VARIABLES (enforced by `validate_note_template`, not just documented):
+//   * `sections[].heading` / `sections[].instruction` — YES. They render into the note body, and any
+//     placeholder the model echoes back from an instruction is resolved when Murmur assembles the
+//     finished note, so it can never reach the user unresolved.
+//   * `extra_frontmatter_keys` — YES; this is the deterministic front-matter binding.
+//   * `name` / `tone` — NO. Neither is ever rendered into a note (the name is a picker label, the
+//     tone is a directive sent verbatim to the model), so a `{{}}` there is REFUSED rather than
+//     accepted-and-silently-ignored.
 
 /// List the user's saved note templates (newest first). CONTENT-FREE; not gated.
 #[tauri::command]
@@ -149,8 +167,13 @@ pub fn list_note_templates(state: State<'_, AppState>) -> Result<Vec<NoteTemplat
 }
 
 /// Save (create or replace) a note template. Validates the name + at least one section, REJECTS any
-/// scripting token, persists, refreshes the registry, and returns the stored row. An empty `id`
+/// scripting token AND any unknown/malformed `{{var}}` (T4b — fail-closed at SAVE, never a silent
+/// drop at render), persists, refreshes the registry, and returns the stored row. An empty `id`
 /// mints a new uuid; a non-empty existing id replaces in place.
+///
+/// An `extra_frontmatter_keys` entry may be a plain key (`project` — still just a REQUEST to the
+/// model) or a DSL binding (`client: {{entities}}`, `slug: {{date:YYYY}}-review`), which Murmur
+/// resolves and YAML-escapes itself when it assembles the note's front-matter.
 #[tauri::command]
 pub fn save_note_template(
     state: State<'_, AppState>,

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -3211,7 +3211,7 @@ fn wikilink_targets(body: &str) -> Vec<String> {
         // `[[Target|alias]]` / `[[Target#heading]]` — everything after the first `|` or `#` is
         // presentation, not the target.
         let target = raw
-            .split(|c| c == '|' || c == '#')
+            .split(['|', '#'])
             .next()
             .unwrap_or_default()
             .trim()

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -2331,6 +2331,34 @@ async fn summarize_and_export(
         markdown
     };
 
+    // T4b — MURMUR ASSEMBLES THE FRONT-MATTER (it is no longer the model's guess).
+    //
+    // Everything above produced the model's note; from here the note Murmur persists/exports is
+    // `markdown` = a DETERMINISTIC, sanitized, YAML-escaped `---` block PREPENDED to that model
+    // body, while `classification` holds the PRE-assembly output for the two CLASSIFICATION-only
+    // consumers (`resolve_subfolder`, the graph-extraction step). They are the cloud-bound ones and
+    // they do not need the resolved values, so they take the `ClassificationInput` TYPE — handing
+    // either one the assembled note is a compile error, not a review catch. The vars are resolved
+    // AFTER the provider call by construction (the generation prompt is already sent).
+    //
+    // `classification_title` is the MODEL-derived title (the exact value `derive_title` produced
+    // before assembly) — it is what the vault filename, the classifier and the graph step all see,
+    // so the assembly changes neither the filename nor any downstream key.
+    let classification_title = derive_title(&markdown, date_iso);
+    let vars = resolve_template_vars(
+        state,
+        meeting_id,
+        &classification_title,
+        date_iso,
+        duration_s,
+        request.meta.language.as_deref(),
+        &markdown,
+    );
+    // Resolve the saved template ONCE here (the registry read the renderer would otherwise do
+    // internally), so every renderer below stays pure and explicitly parameterized.
+    let note_template = template::saved_template(&config.note_style);
+    let (markdown, classification) = assemble_and_split(note_template.as_ref(), &vars, markdown);
+
     state
         .db
         .update_meeting_status(meeting_id, MeetingStatus::Summarized)?;
@@ -2486,7 +2514,8 @@ async fn summarize_and_export(
     // terminal `Summarized` state — NOT `Error`. Recording without a vault is fully supported.
     let Some(vault_path) = config.vault_path.as_deref().filter(|p| !p.is_empty()) else {
         // Title the meeting so the library/detail view shows it (same title we'd derive on export).
-        let title = finalize_note_without_vault(&state.db, meeting_id, &markdown, date_iso)?;
+        let title =
+            finalize_note_without_vault(&state.db, meeting_id, classification.as_str(), date_iso)?;
         emit_status(
             app,
             "saved",
@@ -2495,12 +2524,13 @@ async fn summarize_and_export(
         );
         // Best-effort self-assembling graph: the encrypted DB (Sink A) is the canonical store and
         // works without a vault; never fail the saved note on a graph hiccup.
-        if let Err(e) = crate::commands::build_and_persist_entities(
+        // T4b: classification-only ⇒ the PRE-assembly model output (no resolved deterministic vars).
+        if let Err(e) = persist_entities_for_classification(
             app,
             state,
             meeting_id,
             &title,
-            &markdown,
+            &classification,
             postprocess_token.clone(),
         )
         .await
@@ -2523,7 +2553,8 @@ async fn summarize_and_export(
     // exactly like the no-vault path (title + `Summarized`, `exported_path: None`). The
     // `meeting_locked` decision was read under the SAME lifecycle guard as the persist (W4).
     if meeting_locked {
-        let title = finalize_note_without_vault(&state.db, meeting_id, &markdown, date_iso)?;
+        let title =
+            finalize_note_without_vault(&state.db, meeting_id, classification.as_str(), date_iso)?;
         emit_status(
             app,
             "saved",
@@ -2532,12 +2563,13 @@ async fn summarize_and_export(
         );
         // Same best-effort graph persist as the no-vault path (Sink B's own gate skips vault stubs
         // for a locked folder; Sink A rows are visibility-gated on read).
-        if let Err(e) = crate::commands::build_and_persist_entities(
+        // T4b: classification-only ⇒ the PRE-assembly model output (no resolved deterministic vars).
+        if let Err(e) = persist_entities_for_classification(
             app,
             state,
             meeting_id,
             &title,
-            &markdown,
+            &classification,
             postprocess_token.clone(),
         )
         .await
@@ -2554,9 +2586,18 @@ async fn summarize_and_export(
 
     emit_status(app, "exporting", "Writing note to vault…", meeting_id);
 
-    let title = derive_title(&markdown, date_iso);
-    let subfolder =
-        resolve_subfolder(config, provider.as_ref(), vault_path, &title, &markdown).await;
+    // T4b: the model-derived title computed BEFORE assembly — byte-identical to the legacy
+    // `derive_title(&markdown, …)` value, so the vault filename and every downstream key are
+    // unchanged, and the classifier below is handed the PRE-assembly note.
+    let title = classification_title;
+    let subfolder = resolve_subfolder(
+        config,
+        provider.as_ref(),
+        vault_path,
+        &title,
+        &classification,
+    )
+    .await;
     // Phase 5 — inject model-provenance keys into the YAML frontmatter before the vault write.
     // The note markdown already has the `---` / `---` block generated by the LLM; we append
     // `ai-provider:` and `ai-model:` to it. Pure + idempotent: if the keys are already present
@@ -2639,19 +2680,21 @@ async fn summarize_and_export(
         // The meeting's folder was locked during the `resolve_subfolder` await: NO plaintext `.md`
         // is written (the note is already durably sealed in the DB by that lock). Finish exactly
         // like the meeting-locked path above.
-        let title = finalize_note_without_vault(&state.db, meeting_id, &markdown, date_iso)?;
+        let title =
+            finalize_note_without_vault(&state.db, meeting_id, classification.as_str(), date_iso)?;
         emit_status(
             app,
             "saved",
             "Saved to Murmur — this folder is locked, so no plaintext note was exported.",
             meeting_id,
         );
-        if let Err(e) = crate::commands::build_and_persist_entities(
+        // T4b: classification-only ⇒ the PRE-assembly model output (no resolved deterministic vars).
+        if let Err(e) = persist_entities_for_classification(
             app,
             state,
             meeting_id,
             &title,
-            &markdown,
+            &classification,
             postprocess_token.clone(),
         )
         .await
@@ -2672,12 +2715,13 @@ async fn summarize_and_export(
     // + mirror vault stubs for unsealed folders (Sink B). NEVER fail the note on a graph error —
     // a graph-extraction LLM hiccup must not block note export. `add_mention` idempotency makes
     // the `resummarize_existing` path safe (re-extraction refreshes without double-counting).
-    if let Err(e) = crate::commands::build_and_persist_entities(
+    // T4b: classification-only ⇒ the PRE-assembly model output (no resolved deterministic vars).
+    if let Err(e) = persist_entities_for_classification(
         app,
         state,
         meeting_id,
         &title,
-        &markdown,
+        &classification,
         postprocess_token.clone(),
     )
     .await
@@ -2911,18 +2955,23 @@ pub(crate) fn build_grounding_context(
 /// Pick the vault subfolder for a note: AI thematic filing (nested under the configured
 /// subfolder, if any) when `auto_organize` is on; otherwise just the configured subfolder.
 /// Classification failures degrade gracefully to the configured subfolder.
+///
+/// T4b: takes a [`ClassificationInput`], not a `&str`. `classify_subfolder` may reach a CLOUD
+/// provider, so the type is what guarantees it sees the PRE-assembly model output rather than the
+/// note Murmur assembled from resolved deterministic variables.
 async fn resolve_subfolder(
     config: &AppConfig,
     provider: &dyn crate::summarize::provider::SummarizerProvider,
     vault_path: &str,
     title: &str,
-    markdown: &str,
+    input: &ClassificationInput,
 ) -> Option<String> {
     if !config.auto_organize {
         return config.vault_subfolder.clone();
     }
     let existing = export::list_subfolders(Path::new(vault_path)).unwrap_or_default();
-    match crate::summarize::organize::classify_subfolder(provider, title, markdown, &existing).await
+    match crate::summarize::organize::classify_subfolder(provider, title, input.as_str(), &existing)
+        .await
     {
         Some(folder) => match config.vault_subfolder.as_deref().filter(|s| !s.is_empty()) {
             Some(base) => Some(format!("{base}/{folder}")),
@@ -3036,6 +3085,213 @@ fn derive_title(markdown: &str, date_iso: &str) -> String {
         }
     }
     format!("Meeting {date_iso}")
+}
+
+/// T4b — resolve the DETERMINISTIC `{{}}` template variables for ONE meeting.
+///
+/// GATE: the entity leg reads through `Db::list_entities_for_meeting_visible`, i.e. the SAME
+/// `visibility_clause` predicate as every other graph read — a sealed-and-not-session-unlocked
+/// meeting resolves an EMPTY list, so a locked folder's entity names can never surface in a note
+/// header. Thin wrapper: this fn owns ONLY the gated read; every rule about what becomes a variable
+/// lives in the pure [`resolve_vars_from_note`], which is where the tests bind it.
+///
+/// EGRESS: called AFTER the provider call, and its result is handed ONLY to the persistence/export
+/// half of [`note_split::assemble_and_split`] — never to a `ClassificationInput` consumer.
+/// `meeting_id` is deliberately NOT a variable (no note value, highest linkability cost).
+fn resolve_template_vars(
+    state: &AppState,
+    meeting_id: &str,
+    title: &str,
+    date_iso: &str,
+    duration_s: i64,
+    language: Option<&str>,
+    model_markdown: &str,
+) -> template::ResolvedVars {
+    let unlocked = state
+        .unlocked_folders
+        .lock()
+        .map(|g| g.clone())
+        .unwrap_or_default();
+    // The gated graph read. It is EMPTY on a meeting's FIRST summarize — `entity_mentions` rows are
+    // written by the graph step, which by design runs AFTER assembly (see `resolve_vars_from_note`,
+    // which is why `{{entities}}` does not depend on it alone).
+    let gated_entities = state
+        .db
+        .list_entities_for_meeting_visible(meeting_id, &unlocked)
+        .unwrap_or_default();
+    resolve_vars_from_note(
+        gated_entities,
+        title,
+        date_iso,
+        duration_s,
+        language,
+        model_markdown,
+    )
+}
+
+/// The PURE half of [`resolve_template_vars`] — every rule about what a `{{}}` variable resolves to,
+/// with the one gated DB read hoisted out as `gated_entities` so the whole thing is unit-testable.
+///
+/// Sources, and why each is the honest one:
+/// * `participants` — the MODEL's own `participants:` front-matter list, re-read with
+///   `front_matter_list` and re-rendered safely. It is the only source that heard the room. The
+///   gated ENTITY list is deliberately NOT merged in here: it is a mixed-kind list (people,
+///   organizations, projects — see the `kind = 'person'` ORDER BY, not filter, in
+///   `list_entities_for_meeting_visible`), so folding it into `participants` would file `ACME Corp`
+///   as an attendee.
+/// * `entities` — `gated_entities` UNION the `[[wikilink]]` targets in the note's own body. The
+///   union is load-bearing, not belt-and-braces: `entity_mentions` for this meeting are written by
+///   the graph step, which runs AFTER the note is assembled, so on a meeting's FIRST summarize —
+///   the primary path — `gated_entities` is EMPTY and the wikilinks are the only thing that exists
+///   at assembly time. On a re-summarize both legs are populated and the gated names come first.
+///   Wikilinks add no read path: they are already text in the note being assembled.
+/// * `tags` — the model's list, with `meeting` guaranteed present (the note-format contract).
+/// * `action_items` — the note body's own `- [ ]` items, via the shared parser.
+/// * `title` / `date_iso` / `duration_minutes` / `language` — this meeting's own row.
+///
+/// Every leg degrades to empty rather than failing: a note is never failed by a variable that would
+/// not resolve.
+fn resolve_vars_from_note(
+    gated_entities: Vec<String>,
+    title: &str,
+    date_iso: &str,
+    duration_s: i64,
+    language: Option<&str>,
+    model_markdown: &str,
+) -> template::ResolvedVars {
+    let (model_yaml, model_body) = crate::storage::db::split_front_matter(model_markdown);
+
+    let participants = template::front_matter_list(&model_yaml, "participants");
+
+    let mut entities = gated_entities;
+    for link in wikilink_targets(&model_body) {
+        if !entities.iter().any(|e| e.eq_ignore_ascii_case(&link)) {
+            entities.push(link);
+        }
+    }
+
+    // Tags keep the note-format contract ("a YAML list including at least [meeting]").
+    let mut tags = template::front_matter_list(&model_yaml, "tags");
+    if !tags.iter().any(|t| t.eq_ignore_ascii_case("meeting")) {
+        tags.insert(0, "meeting".to_string());
+    }
+
+    let action_items = crate::summarize::action_items::parse_action_items(&model_body)
+        .into_iter()
+        .map(|i| i.text)
+        .collect();
+
+    template::ResolvedVars {
+        title: title.to_string(),
+        date_iso: date_iso.to_string(),
+        duration_minutes: (duration_s as f64 / 60.0).round() as i64,
+        participants,
+        action_items,
+        entities,
+        tags,
+        language: language.map(str::to_string),
+    }
+}
+
+/// The `[[Target]]` / `[[Target|alias]]` / `[[Target#heading]]` link TARGETS in a note body, in
+/// first-appearance order, de-duplicated case-insensitively. Hand-rolled (no new crate), bounded by
+/// the caller's list cap downstream. An unterminated `[[` yields nothing.
+fn wikilink_targets(body: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut rest = body;
+    while let Some(open) = rest.find("[[") {
+        rest = &rest[open + 2..];
+        let Some(close) = rest.find("]]") else { break };
+        let raw = &rest[..close];
+        rest = &rest[close + 2..];
+        // A link never spans lines; anything that does is not a wikilink.
+        if raw.contains('\n') {
+            continue;
+        }
+        // `[[Target|alias]]` / `[[Target#heading]]` — everything after the first `|` or `#` is
+        // presentation, not the target.
+        let target = raw
+            .split(|c| c == '|' || c == '#')
+            .next()
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+        if !target.is_empty() && !out.iter().any(|e| e.eq_ignore_ascii_case(&target)) {
+            out.push(target);
+        }
+    }
+    out
+}
+
+/// T4b — the EGRESS TYPE BOUNDARY between the note Murmur assembles and the note a CLASSIFICATION
+/// step is allowed to see. The invariant is enforced by the TYPE SYSTEM, not by a convention:
+/// [`ClassificationInput`]'s field is private to this module and [`assemble_and_split`] is its only
+/// constructor, so a consumer typed on `&ClassificationInput` structurally CANNOT be handed the
+/// assembled note. Re-wiring a call site back to the assembled `markdown` is a COMPILE ERROR, which
+/// is exactly the RED the previous string-typed split could not produce.
+mod note_split {
+    use super::template;
+    use crate::storage::models::NoteTemplate;
+
+    /// The PRE-ASSEMBLY model output — byte-identical to what the provider returned, and the ONLY
+    /// note text a classification-only consumer may receive.
+    ///
+    /// Consumers: `resolve_subfolder` (thematic vault filing) and
+    /// [`super::persist_entities_for_classification`] (graph extraction). Both may reach a CLOUD
+    /// provider, and neither needs Murmur's resolved deterministic values — so no resolved variable
+    /// can ride them off-device.
+    pub(super) struct ClassificationInput(String);
+
+    impl ClassificationInput {
+        pub(super) fn as_str(&self) -> &str {
+            &self.0
+        }
+    }
+
+    /// Split the model's output into `(assembled_note, classification_input)`.
+    ///
+    /// * `.0` — Murmur's deterministic, sanitized, YAML-escaped `---` block prepended to the model's
+    ///   body. This is what is persisted, sealed and exported.
+    /// * `.1` — the same model output, TYPED so it can only flow to a classification consumer.
+    ///
+    /// `template_row` is the caller's already-resolved saved template (`None` for a built-in style),
+    /// passed explicitly rather than looked up here — that keeps this pure and keeps its tests off
+    /// the process-global template registry.
+    pub(super) fn assemble_and_split(
+        template_row: Option<&NoteTemplate>,
+        vars: &template::ResolvedVars,
+        model_markdown: String,
+    ) -> (String, ClassificationInput) {
+        let assembled = template::assemble_note_with_template(template_row, vars, &model_markdown);
+        (assembled, ClassificationInput(model_markdown))
+    }
+}
+
+use note_split::{assemble_and_split, ClassificationInput};
+
+/// The SOLE pipeline call path into the graph-extraction step, typed on [`ClassificationInput`] so
+/// the assembled note (with Murmur's resolved deterministic values) can never be handed to it.
+///
+/// Every `summarize_and_export` finish path goes through here; nothing else in this module may call
+/// [`crate::commands::build_and_persist_entities`] directly (pinned by
+/// `graph_extraction_has_exactly_one_typed_call_site`).
+async fn persist_entities_for_classification(
+    app: &AppHandle,
+    state: &AppState,
+    meeting_id: &str,
+    title: &str,
+    input: &ClassificationInput,
+    recording_model_token: Option<crate::perf::RecordingSessionToken>,
+) -> Result<crate::summarize::graph::GraphPayload> {
+    crate::commands::build_and_persist_entities(
+        app,
+        state,
+        meeting_id,
+        title,
+        input.as_str(),
+        recording_model_token,
+    )
+    .await
 }
 
 /// Whether the post-note AUTO semantic index should run: requires BOTH the master flag AND the real
@@ -3348,6 +3604,249 @@ mod tests {
         );
         assert!(!should_auto_index(false, true), "flag off → never index");
         assert!(!should_auto_index(false, false));
+    }
+
+    // ── T4b — Murmur-assembled front-matter: the EGRESS split ────────────────────────────────────
+
+    fn t4b_vars() -> template::ResolvedVars {
+        template::ResolvedVars {
+            title: "Q3 planning".to_string(),
+            date_iso: "2026-07-26".to_string(),
+            duration_minutes: 30,
+            // The three hostile transcript-derived shapes the escaping exists for.
+            participants: vec![
+                "---\nadmin: true".to_string(),
+                "<% tp.system.prompt() %>".to_string(),
+                "Ann: the CFO".to_string(),
+            ],
+            action_items: vec!["Bob — ship it".to_string()],
+            // A GATED-DB-derived value that appears NOWHERE in the model's own output: if it shows
+            // up in the classification input, a `visibility_clause`-gated name just gained a new
+            // cloud egress path.
+            entities: vec!["ACME Corp".to_string()],
+            tags: vec!["meeting".to_string()],
+            language: Some("en".to_string()),
+        }
+    }
+
+    /// A saved template that binds the GATED-DB `{{entities}}` variable into a front-matter key, so
+    /// the assembled note provably carries a value that exists ONLY in the gated store. Passed
+    /// EXPLICITLY (never through `template::set_saved_templates`) so this test never mutates the
+    /// process-global registry — under a parallel `cargo test` (which `scripts/ci.sh` falls back to
+    /// when cargo-nextest is absent) a registry-mutating test races every other one in the binary.
+    fn t4b_template() -> crate::storage::models::NoteTemplate {
+        crate::storage::models::NoteTemplate {
+            id: "tpl-t4b-egress".to_string(),
+            name: "t4b".to_string(),
+            tone: String::new(),
+            sections: vec![crate::storage::models::NoteTemplateSection {
+                heading: "Outcome".to_string(),
+                instruction: "One line.".to_string(),
+            }],
+            extra_frontmatter_keys: vec!["client: {{entities}}".to_string()],
+            created_at: "2026-07-26T00:00:00Z".to_string(),
+        }
+    }
+
+    /// The EGRESS invariant, bound to the SPLIT: the resolved deterministic variables land in the
+    /// note Murmur persists/exports, and the `ClassificationInput` the two cloud-bound consumers
+    /// take is the byte-identical PRE-assembly model output.
+    ///
+    /// HONESTY NOTE on what this test does and does not prove. Asserting
+    /// `classification.as_str() == model` only pins THIS function's behavior — it cannot, on its
+    /// own, prove that the pipeline's four hand-off sites actually pass it. What binds those is the
+    /// TYPE: `resolve_subfolder` and `persist_entities_for_classification` take
+    /// `&ClassificationInput`, whose field is private to `mod note_split` and whose only constructor
+    /// is `assemble_and_split`. Passing the assembled `markdown` (a `String`) at any of those call
+    /// sites does not compile. `graph_extraction_has_exactly_one_typed_call_site` closes the one
+    /// remaining hole — a NEW direct call to the untyped command.
+    #[test]
+    fn resolved_vars_never_reach_the_classification_input() {
+        let t = t4b_template();
+        let vars = t4b_vars();
+        let model = "---\ntitle: model guess\n---\n\n# Q3 planning\n\n- [ ] Bob — ship it\n";
+        let (assembled, classification) = assemble_and_split(Some(&t), &vars, model.to_string());
+
+        // The gated-DB entity IS in the note Murmur persists…
+        assert!(
+            assembled.contains("client: [\"ACME Corp\"]"),
+            "the gated `{{{{entities}}}}` binding must render into the note: {assembled}"
+        );
+
+        // (1) The classification input is the model's output, UNCHANGED — byte-identical.
+        assert_eq!(
+            classification.as_str(),
+            model,
+            "classifiers must see the pre-assembly model output verbatim"
+        );
+
+        // (2) …and therefore carries NONE of the resolved deterministic values.
+        for leaked in [
+            "ACME Corp",    // gated-DB entity
+            "admin: true",  // sanitized participant
+            "tp.system",    // sanitized participant
+            "Ann: the CFO", // sanitized participant
+            "duration_minutes: 30",
+        ] {
+            assert!(
+                !classification.as_str().contains(leaked),
+                "`{leaked}` must never reach the cloud-bound classification input:\n{}",
+                classification.as_str()
+            );
+        }
+
+        // (3) The PERSISTED/EXPORTED note DOES carry them, assembled and escaped.
+        assert!(assembled.starts_with("---\n"), "{assembled}");
+        assert_eq!(
+            assembled.lines().filter(|l| l.trim() == "---").count(),
+            2,
+            "exactly one front-matter block: {assembled}"
+        );
+        assert!(assembled.contains("title: \"Q3 planning\""), "{assembled}");
+        assert!(assembled.contains("date: 2026-07-26"), "{assembled}");
+        assert!(assembled.contains("duration_minutes: 30"), "{assembled}");
+        assert!(assembled.contains("\"admin: true\""), "{assembled}");
+        assert!(assembled.contains("\"Ann: the CFO\""), "{assembled}");
+        assert!(!assembled.contains("<%"), "{assembled}");
+        assert!(!assembled.contains("model guess"), "{assembled}");
+        assert!(
+            assembled.contains("# Q3 planning"),
+            "body preserved: {assembled}"
+        );
+
+        // (4) The title every downstream key uses is unchanged by the assembly.
+        assert_eq!(
+            derive_title(&assembled, "2026-01-01"),
+            "Q3 planning",
+            "the assembled note must derive the SAME title the classifier was given"
+        );
+    }
+
+    /// The one hole the TYPE cannot close: someone adding a NEW call to the untyped
+    /// `crate::commands::build_and_persist_entities` (which takes `&str`) instead of going through
+    /// the `&ClassificationInput`-typed `persist_entities_for_classification`. Exactly ONE such call
+    /// may exist in this module — the one inside that wrapper.
+    ///
+    /// RED by construction: add a second call (e.g. re-wire one finish path to pass `&markdown`
+    /// directly) and the count becomes 2. The needle is assembled with `concat!` so this
+    /// assertion's own source text is not itself an occurrence.
+    #[test]
+    fn graph_extraction_has_exactly_one_typed_call_site() {
+        let src = include_str!("pipeline.rs");
+        let needle = concat!("build_and_persist_entities", "(");
+        assert_eq!(
+            src.matches(needle).count(),
+            1,
+            "graph extraction must be reached ONLY through \
+             persist_entities_for_classification(&ClassificationInput); found {} direct calls",
+            src.matches(needle).count()
+        );
+        // …and that one call must hand it the TYPED input, never a raw note string. `concat!` again,
+        // so this line is not itself the occurrence it is looking for.
+        let typed_arg = concat!("input.as_str", "(),");
+        assert!(
+            src.contains(typed_arg),
+            "the wrapper must pass ClassificationInput::as_str()"
+        );
+    }
+
+    /// FIRST-RUN pin for `{{entities}}` (the MAJOR the previous round shipped): `entity_mentions`
+    /// rows are written by the graph step, which runs AFTER assembly — so on a meeting's first
+    /// summarize the gated read returns NOTHING. With `gated_entities` empty the variable must
+    /// still resolve to something real: the note's own `[[wikilink]]` targets.
+    ///
+    /// Also pins that the mixed-kind gated entity list is NOT folded into `participants` (it would
+    /// file `ACME Corp` as an attendee), and that tags/action items/duration come from the note.
+    #[test]
+    fn template_vars_resolve_on_a_first_summarize_with_no_graph_rows() {
+        let model = "---\n\
+                     title: model guess\n\
+                     participants: [Anna, \"Bob C\"]\n\
+                     tags: [q3]\n\
+                     ---\n\n\
+                     # Q3 planning\n\n\
+                     Discussed [[Roadmap]] and [[Pricing|the pricing note]] again, plus [[Roadmap]].\n\n\
+                     ## Action items\n- [ ] Anna — ship it\n";
+
+        // FIRST summarize: the gated graph read is empty.
+        let first = resolve_vars_from_note(
+            Vec::new(),
+            "Q3 planning",
+            "2026-07-26",
+            1800,
+            Some("en"),
+            model,
+        );
+        assert_eq!(
+            first.entities,
+            vec!["Roadmap".to_string(), "Pricing".to_string()],
+            "with no graph rows yet, `{{{{entities}}}}` must resolve from the note's own wikilinks \
+             (de-duplicated, alias stripped, first-appearance order)"
+        );
+        assert_eq!(
+            first.participants,
+            vec!["Anna".to_string(), "Bob C".to_string()],
+            "participants come from the model's own front-matter, nothing else"
+        );
+        assert_eq!(first.tags, vec!["meeting".to_string(), "q3".to_string()]);
+        assert_eq!(first.action_items, vec!["Anna — ship it".to_string()]);
+        assert_eq!(first.duration_minutes, 30);
+        assert_eq!(first.title, "Q3 planning");
+        assert_eq!(first.language.as_deref(), Some("en"));
+
+        // RE-summarize: the gated rows exist now — they lead, wikilinks fill in the rest, and they
+        // still do NOT contaminate `participants` (the list is mixed-kind: people AND orgs).
+        let again = resolve_vars_from_note(
+            vec!["ACME Corp".to_string(), "Roadmap".to_string()],
+            "Q3 planning",
+            "2026-07-26",
+            1800,
+            Some("en"),
+            model,
+        );
+        assert_eq!(
+            again.entities,
+            vec![
+                "ACME Corp".to_string(),
+                "Roadmap".to_string(),
+                "Pricing".to_string()
+            ],
+            "gated names lead; a wikilink already present is not duplicated"
+        );
+        assert_eq!(
+            again.participants, first.participants,
+            "the mixed-kind entity list must never be folded into participants"
+        );
+
+        // A note with no links and no model front-matter degrades to empty lists, never a panic.
+        let bare = resolve_vars_from_note(Vec::new(), "T", "2026-07-26", 0, None, "# Body\n");
+        assert!(bare.entities.is_empty() && bare.participants.is_empty());
+        assert_eq!(bare.tags, vec!["meeting".to_string()]);
+        assert_eq!(bare.duration_minutes, 0);
+    }
+
+    /// `wikilink_targets` handles the shapes Obsidian actually emits and refuses the malformed ones.
+    #[test]
+    fn wikilink_targets_parses_aliases_headings_and_refuses_junk() {
+        assert_eq!(
+            wikilink_targets("see [[A]], [[B|alias]], [[C#Section]], [[  D  ]]"),
+            vec![
+                "A".to_string(),
+                "B".to_string(),
+                "C".to_string(),
+                "D".to_string()
+            ]
+        );
+        // Case-insensitive de-dup, first spelling wins.
+        assert_eq!(
+            wikilink_targets("[[Roadmap]] then [[roadmap]]"),
+            vec!["Roadmap".to_string()]
+        );
+        // Unterminated / empty / line-spanning are not links.
+        assert!(wikilink_targets("[[unterminated").is_empty());
+        assert!(wikilink_targets("[[]] [[   ]]").is_empty());
+        assert!(wikilink_targets("[[spans\nlines]]").is_empty());
+        assert!(wikilink_targets("no links here").is_empty());
     }
 
     #[test]

--- a/src-tauri/src/summarize/template.rs
+++ b/src-tauri/src/summarize/template.rs
@@ -12,20 +12,40 @@ use crate::summarize::provider::SummarizeRequest;
 /// text can ever be persisted, let alone egressed as the system prompt.
 pub const FORBIDDEN_TEMPLATE_TOKENS: [&str; 4] = ["<%", "tp.", "require(", "process."];
 
-/// Reject a note template whose ANY text field contains a scripting token. Called by the
-/// `save_note_template` command BEFORE persisting. Declarative data only, ever — this is the
-/// security boundary for the template layer (the rendered prompt still passes the
+/// Reject a note template whose ANY text field contains a scripting token, OR misuses the `{{}}`
+/// DSL. Called by the `save_note_template` command BEFORE persisting. Declarative data only, ever —
+/// this is the security boundary for the template layer (the rendered prompt still passes the
 /// `RedactingProvider` firewall on egress, unchanged).
+///
+/// WHICH FIELDS SUPPORT THE `{{}}` DSL (T4b) — the split is deliberate and enforced HERE:
+///   * `sections[].heading` / `sections[].instruction` — YES. They are rendered into the body: the
+///     `body_scaffold` substitutes them ([`render_body_scaffold`]) and any placeholder the model
+///     echoes back from the instruction is resolved in the finished note
+///     ([`assemble_note_with_template`]), so a placeholder in a section can never reach the user
+///     unresolved.
+///   * `extra_frontmatter_keys` — YES (`client: {{entities}}`). This is the deterministic
+///     front-matter binding: Murmur resolves + YAML-escapes it itself.
+///   * `name` / `tone` — NO. Neither is ever rendered into a note: `name` is a picker label and
+///     `tone` is a directive sent verbatim to the model. A `{{}}` there would silently be literal
+///     text forever, so it is REFUSED outright rather than accepted-and-ignored.
+///
+/// FAIL-CLOSED at SAVE: an unknown / malformed `{{ … }}` is REFUSED here rather than silently
+/// dropped at render time, so a typo'd variable can never quietly vanish from a user's notes and an
+/// ident outside the closed `match` can never reach the renderer at all.
 pub fn validate_note_template(name: &str, tone: &str, t: &NoteTemplate) -> Result<()> {
-    let mut fields: Vec<&str> = vec![name, tone];
+    // Fields that DO render `{{}}` (validated against the allowlist) …
+    let mut dsl_fields: Vec<&str> = Vec::new();
     for s in &t.sections {
-        fields.push(&s.heading);
-        fields.push(&s.instruction);
+        dsl_fields.push(&s.heading);
+        dsl_fields.push(&s.instruction);
     }
     for k in &t.extra_frontmatter_keys {
-        fields.push(k);
+        dsl_fields.push(k);
     }
-    for f in fields {
+    // … and fields that never do (any `{{` is refused).
+    let plain_fields: [&str; 2] = [name, tone];
+
+    for f in plain_fields.iter().copied().chain(dsl_fields.iter().copied()) {
         for tok in FORBIDDEN_TEMPLATE_TOKENS {
             if f.contains(tok) {
                 return Err(AppError::InvalidArg(format!(
@@ -34,6 +54,19 @@ pub fn validate_note_template(name: &str, tone: &str, t: &NoteTemplate) -> Resul
                 )));
             }
         }
+    }
+    for f in plain_fields {
+        if f.contains("{{") {
+            return Err(AppError::InvalidArg(
+                "`{{ … }}` variables are only supported in a template's SECTIONS and its \
+                 front-matter keys — the template name and tone are never rendered into a note, \
+                 so a variable there would stay literal text"
+                    .to_string(),
+            ));
+        }
+    }
+    for f in dsl_fields {
+        validate_template_vars(f)?;
     }
     Ok(())
 }
@@ -61,6 +94,14 @@ pub fn set_saved_templates(templates: Vec<NoteTemplate>) {
     for t in templates {
         map.insert(t.id.clone(), t);
     }
+}
+
+/// Resolve a saved template by id from the registry (a cheap read-lock clone), or `None` for a
+/// built-in / unknown id. THE registry seam callers outside this module use, so a consumer (the
+/// pipeline) resolves the row ONCE and then passes it EXPLICITLY to the pure renderers — which is
+/// what keeps the renderers unit-testable without mutating process-global state.
+pub fn saved_template(id: &str) -> Option<NoteTemplate> {
+    lookup_saved_template(id)
 }
 
 /// Resolve a saved template by id from the registry (a cheap read-lock clone), or `None`.
@@ -207,8 +248,13 @@ fn style_variant_with_keys(tone: &str, body_sections: &str, extra_keys: &[String
     } else {
         format!(" {tone}")
     };
+    // T4b: a key whose entry carries a `{{}}` value is filled DETERMINISTICALLY by Murmur after the
+    // provider call — asking the model for it would be wasted prompt AND a second, guessed source of
+    // truth, so it is omitted here. A plain key (no `{{}}`) renders the legacy request line
+    // byte-identically.
     let extra = extra_keys
         .iter()
+        .filter(|k| !k.contains("{{"))
         .map(|k| format!("- {}: (fill in from the meeting, or omit if unknown)\n", k.trim()))
         .collect::<String>();
     format!(
@@ -488,6 +534,636 @@ recipe: {recipe}\n\
         source = yaml_quote(source_name),
         recipe = recipe,
     )
+}
+
+// ── T4b — the LOGIC-LESS `{{}}` variable DSL + MURMUR-ASSEMBLED front-matter ─────────────────────
+//
+// WHY. Until now the note's YAML front-matter was GUESSED BY THE MODEL from the transcript and only
+// validated to start with `---` (`claude_code.rs`'s output check). That is both a correctness
+// problem (a hallucinated `date:`, a dropped `participants:`) and an INJECTION surface: whatever the
+// model echoes lands verbatim in a file Obsidian parses — a transcript-derived participant literally
+// named `---\nadmin: true` closes the fence and opens a second document, and `<% tp.system %>` is a
+// Templater payload the vault would EXECUTE.
+//
+// So Murmur assembles the front-matter itself: the LLM produces the BODY, Murmur resolves a small
+// FIXED set of deterministic variables, strips the fence/scripting tokens out of every resolved
+// value, YAML-escapes it, builds the `---` block and PREPENDS it.
+//
+// GRAMMAR (deliberately not a language): `{{ident}}` or `{{ident:format}}`, `ident` ∈ a closed Rust
+// `match` ([`is_known_template_var`]). No expressions, no conditionals, no loops, no nesting, no
+// recursion — [`substitute_vars`] is a SINGLE pass whose replacement text is never re-scanned, and
+// every resolved value has `{{` stripped so a value can never become a placeholder.
+//
+// EGRESS — SCOPE, precisely. Resolved values are computed AFTER the provider call, so they cannot
+// ride the generation prompt. On top of that, `pipeline::note_split::assemble_and_split` types
+// the pre-assembly output as a `ClassificationInput`, and the two CLASSIFICATION-only consumers
+// (`resolve_subfolder` → the thematic folder classifier, and the graph-extraction step) take that
+// TYPE — so they structurally cannot be handed the assembled note. That is the enforced guarantee
+// and it is exactly two call paths wide; it is NOT a claim that the resolved values never leave the
+// device by any route. The assembled note is what gets persisted, sealed and exported, so anything
+// that later reads the STORED note (Ask grounding, a re-summarize, a share/publish) sees them —
+// which is why every value must come from this meeting's own note plus its own
+// `visibility_clause`-gated reads, and nothing wider. `meeting_id` is deliberately NOT a variable —
+// no user-facing note value, highest linkability cost.
+
+/// The FIXED allowlist of `{{}}` identifiers, in the order the error message lists them. Kept in
+/// lockstep with the closed `match` in [`is_known_template_var`] (pinned by a test).
+///
+/// `title` / `date` reuse the Obsidian/Templater spellings so a template pasted from a vault keeps
+/// working for the shared keys.
+///
+/// What each resolves FROM is the pipeline's job — see `pipeline::resolve_vars_from_note`. Two are
+/// worth knowing here: `participants` is the model's own front-matter list (the only source that
+/// heard the room), and `entities` is the `visibility_clause`-gated graph list UNION the note's own
+/// `[[wikilink]]` targets, because the graph rows for a meeting are written AFTER its note is
+/// assembled and so are empty on a first summarize.
+pub const TEMPLATE_VARS: [&str; 8] = [
+    "title",
+    "date",
+    "duration_minutes",
+    "participants",
+    "action_items",
+    "entities",
+    "tags",
+    "language",
+];
+
+/// Is `ident` a known template variable? THE allowlist — a closed `match`, no dynamic namespace.
+///
+/// NOT included, on purpose: `meeting_id` (a UUID with no user-facing note value and the highest
+/// linkability cost of anything we hold — dropped by the 2026-07-26 egress review).
+pub fn is_known_template_var(ident: &str) -> bool {
+    matches!(
+        ident,
+        "title"
+            | "date"
+            | "duration_minutes"
+            | "participants"
+            | "action_items"
+            | "entities"
+            | "tags"
+            | "language"
+    )
+}
+
+/// The front-matter keys Murmur OWNS: it renders each one deterministically, so a model-emitted line
+/// for the same key is dropped during the merge rather than duplicated.
+const OWNED_FRONT_MATTER_KEYS: [&str; 5] = [
+    "title",
+    "date",
+    "duration_minutes",
+    "tags",
+    "participants",
+];
+
+/// Bound on how many items a list variable renders (a runaway entity list must not turn the
+/// front-matter block into the note) and on how many model-emitted lines survive the merge.
+const MAX_LIST_ITEMS: usize = 24;
+const MAX_PRESERVED_FRONT_MATTER_LINES: usize = 32;
+
+/// The DETERMINISTIC values behind the `{{}}` variables for ONE meeting. Resolved by the pipeline
+/// from the meeting's own row plus the GATED store (`Db::list_entities_for_meeting_visible`, i.e.
+/// the same `visibility_clause` predicate as every other graph read), never by the model.
+///
+/// Plain data + pure rendering, so the whole escaping/stripping contract is unit-testable without a
+/// DB or an `AppState`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ResolvedVars {
+    pub title: String,
+    pub date_iso: String,
+    pub duration_minutes: i64,
+    pub participants: Vec<String>,
+    pub action_items: Vec<String>,
+    pub entities: Vec<String>,
+    pub tags: Vec<String>,
+    pub language: Option<String>,
+}
+
+/// Tokens a RESOLVED value may never carry into the note: the front-matter fence (`---`), the
+/// Templater opening/closing pair, and `{{`/`}}` (so a value can never be re-read as a placeholder).
+/// Stripped ANYWHERE in the value, not just leading — `<% tp.system %>` is a live payload wherever
+/// it sits in a line Obsidian renders.
+const VALUE_STRIP_TOKENS: [&str; 5] = ["<%", "%>", "{{", "}}", "---"];
+
+/// Make an arbitrary resolved value safe to place in a note:
+///   1. strip every fence/scripting token, repeating until STABLE so a removal can never SPLICE a
+///      new token into existence (`<<%%>>` → `<%>` → …) — bounded, never recursive;
+///   2. collapse ALL whitespace to single spaces (a front-matter scalar is single-line by
+///      construction — this is what defuses `---\nadmin: true`, and it tidies the gaps step 1 left);
+///   3. strip once more, because collapsing whitespace is the only way step 1's output could change.
+fn sanitize_value(raw: &str) -> String {
+    fn strip_tokens(mut s: String) -> String {
+        for _ in 0..4 {
+            let before = s.clone();
+            for tok in VALUE_STRIP_TOKENS {
+                if s.contains(tok) {
+                    s = s.replace(tok, "");
+                }
+            }
+            if s == before {
+                break;
+            }
+        }
+        s
+    }
+    let stripped = strip_tokens(raw.to_string());
+    let flat = stripped.split_whitespace().collect::<Vec<_>>().join(" ");
+    strip_tokens(flat).trim().to_string()
+}
+
+/// Would YAML re-TYPE this plain scalar as something other than a string? A reserved boolean/null
+/// word (YAML 1.1 accepts `y`/`yes`/`on`/`off` too, and Obsidian's parser follows suit) or anything
+/// that parses as a number — a participant literally named `No`, or a purely numeric title like
+/// `2026`, must come out of the block as a STRING, not `false` / `2026`.
+///
+/// `f64::from_str` also accepts `inf` / `infinity` / `nan` (case-insensitively), so the numeric test
+/// covers those spellings on its own.
+fn is_yaml_typed_plain(v: &str) -> bool {
+    let lower = v.to_ascii_lowercase();
+    matches!(
+        lower.as_str(),
+        "y" | "n"
+            | "yes"
+            | "no"
+            | "true"
+            | "false"
+            | "on"
+            | "off"
+            | "null"
+            | "~"
+            | ".nan"
+            | ".inf"
+            | "+.inf"
+            | "-.inf"
+    ) || v.parse::<f64>().is_ok()
+}
+
+/// Render one sanitized value as a YAML scalar: bare when it is unambiguously a plain STRING token
+/// (`2026-07-26`, `Q3_planning`), double-quoted+escaped otherwise — so a raw `:` / `"` / `#` in a
+/// participant name can never break the block, and a reserved word / number
+/// ([`is_yaml_typed_plain`]) can never be re-typed away from the string the user meant.
+fn yaml_scalar(raw: &str) -> String {
+    let v = sanitize_value(raw);
+    let bare = !v.is_empty()
+        && !v.starts_with('-')
+        && v.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '/' | '-'))
+        && !is_yaml_typed_plain(&v);
+    if bare {
+        v
+    } else {
+        yaml_quote(&v)
+    }
+}
+
+/// Render a list variable as a YAML flow list of scalars (`[]` when empty), capped at
+/// [`MAX_LIST_ITEMS`]. Every item goes through [`yaml_scalar`], so an injected item is quoted, not
+/// executed.
+fn yaml_flow_list(items: &[String]) -> String {
+    let rendered = items
+        .iter()
+        .map(|s| sanitize_value(s.as_str()))
+        .filter(|s| !s.is_empty())
+        .take(MAX_LIST_ITEMS)
+        .map(|s| yaml_scalar(&s))
+        .collect::<Vec<_>>();
+    format!("[{}]", rendered.join(", "))
+}
+
+/// Format an ISO date with an Obsidian/moment-style pattern (`YYYY-MM-DD`, `DD.MM.YYYY`, `MMMM D`).
+/// Unparseable date or empty format ⇒ the sanitized ISO string, unchanged. Single left-to-right
+/// pass, longest token first — emitted text is never re-scanned, so a month NAME containing `M`
+/// cannot re-expand.
+fn format_date(date_iso: &str, format: Option<&str>) -> String {
+    let iso = sanitize_value(date_iso);
+    let Some(fmt) = format.map(str::trim).filter(|f| !f.is_empty()) else {
+        return iso;
+    };
+    let Some(date) = iso
+        .get(..10)
+        .and_then(|d| chrono::NaiveDate::parse_from_str(d, "%Y-%m-%d").ok())
+    else {
+        return iso;
+    };
+    let tokens: [(&str, String); 9] = [
+        ("YYYY", date.format("%Y").to_string()),
+        ("YY", date.format("%y").to_string()),
+        ("MMMM", date.format("%B").to_string()),
+        ("MMM", date.format("%b").to_string()),
+        ("MM", date.format("%m").to_string()),
+        ("dddd", date.format("%A").to_string()),
+        ("ddd", date.format("%a").to_string()),
+        ("DD", date.format("%d").to_string()),
+        ("D", date.format("%e").to_string().trim().to_string()),
+    ];
+    let mut out = String::new();
+    let mut at = 0usize;
+    while at < fmt.len() {
+        let rest = &fmt[at..];
+        match tokens.iter().find(|(tok, _)| rest.starts_with(tok)) {
+            Some((tok, value)) => {
+                out.push_str(value);
+                at += tok.len();
+            }
+            None => {
+                let ch = rest.chars().next().unwrap_or('\u{0}');
+                out.push(ch);
+                at += ch.len_utf8();
+            }
+        }
+    }
+    sanitize_value(&out)
+}
+
+/// The compiled `{{ident}}` / `{{ident:format}}` grammar, shared by the renderer and the save-time
+/// validator so the two can never drift. `None` only if the (constant, test-pinned) pattern failed
+/// to compile — callers then fail CLOSED rather than `expect()`-ing.
+fn var_regex() -> Option<&'static regex::Regex> {
+    static RE: OnceLock<Option<regex::Regex>> = OnceLock::new();
+    RE.get_or_init(|| {
+        regex::Regex::new(r"\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?::([^{}\r\n]*))?\}\}").ok()
+    })
+    .as_ref()
+}
+
+/// Resolve one variable to its INLINE (body) text form. Lists comma-join; `date` honors the
+/// optional format. Returns `None` for an ident outside the allowlist.
+fn resolve_var_inline(vars: &ResolvedVars, ident: &str, format: Option<&str>) -> Option<String> {
+    let join = |items: &[String]| {
+        items
+            .iter()
+            .map(|s| sanitize_value(s.as_str()))
+            .filter(|s| !s.is_empty())
+            .take(MAX_LIST_ITEMS)
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    let value = match ident {
+        "title" => sanitize_value(&vars.title),
+        "date" => format_date(&vars.date_iso, format),
+        "duration_minutes" => vars.duration_minutes.to_string(),
+        "participants" => join(&vars.participants),
+        "action_items" => join(&vars.action_items),
+        "entities" => join(&vars.entities),
+        "tags" => join(&vars.tags),
+        "language" => sanitize_value(vars.language.as_deref().unwrap_or("")),
+        _ => return None,
+    };
+    Some(value)
+}
+
+/// Resolve one variable to its YAML (front-matter) value form: a flow list for the list vars, a
+/// bare/quoted scalar otherwise.
+fn resolve_var_yaml(vars: &ResolvedVars, ident: &str, format: Option<&str>) -> Option<String> {
+    match ident {
+        "participants" => Some(yaml_flow_list(&vars.participants)),
+        "action_items" => Some(yaml_flow_list(&vars.action_items)),
+        "entities" => Some(yaml_flow_list(&vars.entities)),
+        "tags" => Some(yaml_flow_list(&vars.tags)),
+        "duration_minutes" => Some(vars.duration_minutes.to_string()),
+        _ => resolve_var_inline(vars, ident, format).map(|v| yaml_scalar(&v)),
+    }
+}
+
+/// SINGLE-PASS `{{}}` substitution over arbitrary text. `replace_all` writes each replacement
+/// straight to the output (it is never re-scanned) and every resolved value has `{{`/`<%` stripped,
+/// so expansion is non-recursive BY CONSTRUCTION. An ident outside the allowlist is left VERBATIM —
+/// visible in the note, never silently dropped (and it cannot get this far: `validate_note_template`
+/// refuses it at save).
+pub fn substitute_vars(input: &str, vars: &ResolvedVars) -> String {
+    let Some(re) = var_regex() else {
+        return input.to_string();
+    };
+    re.replace_all(input, |caps: &regex::Captures<'_>| {
+        let whole = caps.get(0).map(|m| m.as_str()).unwrap_or_default();
+        let ident = caps.get(1).map(|m| m.as_str()).unwrap_or_default();
+        let format = caps.get(2).map(|m| m.as_str());
+        resolve_var_inline(vars, ident, format).unwrap_or_else(|| whole.to_string())
+    })
+    .into_owned()
+}
+
+/// Fail-closed save-time check: EVERY `{{` in `field` must open a well-formed placeholder whose
+/// ident is in the allowlist. Anything else — a typo, a `{{meeting_id}}`, an unterminated `{{` — is
+/// `AppError::InvalidArg`. Uses the SAME regex the renderer substitutes with, anchored at each `{{`,
+/// so validation and rendering cannot disagree.
+fn validate_template_vars(field: &str) -> Result<()> {
+    if !field.contains("{{") {
+        return Ok(());
+    }
+    let Some(re) = var_regex() else {
+        // The grammar is unavailable ⇒ nothing can be rendered safely ⇒ refuse the `{{` outright.
+        return Err(AppError::InvalidArg(
+            "note template variables are unavailable — remove the `{{ … }}` placeholders".into(),
+        ));
+    };
+    let mut from = 0usize;
+    while let Some(rel) = field[from..].find("{{") {
+        let at = from + rel;
+        let caps = re
+            .captures_at(field, at)
+            .filter(|c| c.get(0).map(|m| m.start()) == Some(at));
+        let Some(caps) = caps else {
+            return Err(AppError::InvalidArg(format!(
+                "malformed template variable in `{field}` — the only supported forms are \
+                 `{{{{name}}}}` and `{{{{name:format}}}}`, with name one of: {}",
+                TEMPLATE_VARS.join(", ")
+            )));
+        };
+        let ident = caps.get(1).map(|m| m.as_str()).unwrap_or_default();
+        if !is_known_template_var(ident) {
+            return Err(AppError::InvalidArg(format!(
+                "unknown template variable `{{{{{ident}}}}}` — allowed: {}",
+                TEMPLATE_VARS.join(", ")
+            )));
+        }
+        from = caps.get(0).map(|m| m.end()).unwrap_or(at + 2);
+    }
+    Ok(())
+}
+
+/// Read one LIST-valued key out of a raw YAML front-matter block: flow (`participants: [A, B]`) or
+/// block (`participants:` + `- A` lines) or a single scalar. Hand-rolled, dep-free, best-effort —
+/// it parses the MODEL's guess so [`ResolvedVars`] can re-render it safely; it is never trusted to
+/// be well-formed.
+pub(crate) fn front_matter_list(yaml: &str, key: &str) -> Vec<String> {
+    fn push(out: &mut Vec<String>, raw: &str) {
+        let s = raw
+            .trim()
+            .trim_matches('"')
+            .trim_matches('\'')
+            .trim()
+            .to_string();
+        if !s.is_empty() {
+            out.push(s);
+        }
+    }
+    let mut out = Vec::new();
+    let mut lines = yaml.lines().peekable();
+    while let Some(line) = lines.next() {
+        let Some((k, v)) = line.split_once(':') else {
+            continue;
+        };
+        if !k.trim().eq_ignore_ascii_case(key) {
+            continue;
+        }
+        let v = v.trim();
+        if let Some(inner) = v.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+            for item in inner.split(',') {
+                push(&mut out, item);
+            }
+        } else if !v.is_empty() {
+            push(&mut out, v);
+        } else {
+            while let Some(next) = lines.peek() {
+                let t = next.trim();
+                match t.strip_prefix('-') {
+                    Some(item) => {
+                        push(&mut out, item);
+                        lines.next();
+                    }
+                    None => break,
+                }
+            }
+        }
+        break;
+    }
+    out
+}
+
+/// The deterministic front-matter LINES (no fences) Murmur owns, in a stable order: the fixed five,
+/// then each of the template's `extra_frontmatter_keys` that carries a `{{}}` value.
+fn deterministic_front_matter_lines(t: Option<&NoteTemplate>, vars: &ResolvedVars) -> Vec<String> {
+    let mut lines = vec![
+        format!("title: {}", yaml_scalar(&vars.title)),
+        format!("date: {}", yaml_scalar(&vars.date_iso)),
+        format!("duration_minutes: {}", vars.duration_minutes),
+        format!("tags: {}", yaml_flow_list(&vars.tags)),
+        format!("participants: {}", yaml_flow_list(&vars.participants)),
+    ];
+    if let Some(t) = t {
+        for entry in &t.extra_frontmatter_keys {
+            if let Some(line) = render_extra_key_line(entry, vars) {
+                lines.push(line);
+            }
+        }
+    }
+    lines
+}
+
+/// Render ONE `extra_frontmatter_keys` entry into a deterministic front-matter line — but only when
+/// it actually carries a `{{}}` value. Supported shapes:
+///   * `client: {{participants}}` → the variable's YAML form (flow list / scalar), Murmur-quoted.
+///   * `slug: {{date:YYYY}}-review` → substituted, then emitted as ONE opaque scalar (quoted unless
+///     the result is already a plain token).
+///   * `project` (no `{{}}`) → `None`: no deterministic value exists, so the key stays a REQUEST to
+///     the model (the prompt still lists it) and the model's own line survives the merge.
+/// An unsafe/absent key name, or a key Murmur already owns, yields `None`.
+fn render_extra_key_line(entry: &str, vars: &ResolvedVars) -> Option<String> {
+    let (key, value_tpl) = entry.split_once(':')?;
+    let key = key.trim();
+    let lower = key.to_ascii_lowercase();
+    if !is_safe_yaml_key(key) || OWNED_FRONT_MATTER_KEYS.contains(&lower.as_str()) {
+        return None;
+    }
+    let value_tpl = value_tpl.trim();
+    if !value_tpl.contains("{{") {
+        return None;
+    }
+    // The whole value is exactly one placeholder ⇒ render its native YAML form (a list stays a list).
+    if let Some(re) = var_regex() {
+        if let Some(caps) = re.captures(value_tpl) {
+            let whole = caps.get(0).map(|m| m.as_str()).unwrap_or_default();
+            if whole == value_tpl {
+                let ident = caps.get(1).map(|m| m.as_str()).unwrap_or_default();
+                let format = caps.get(2).map(|m| m.as_str());
+                if let Some(v) = resolve_var_yaml(vars, ident, format) {
+                    return Some(format!("{key}: {v}"));
+                }
+                return None;
+            }
+        }
+    }
+    // Mixed literal + placeholder(s) ⇒ substitute, then quote the result as ONE opaque scalar.
+    let rendered = substitute_vars(value_tpl, vars);
+    Some(format!("{key}: {}", yaml_scalar(&rendered)))
+}
+
+/// A YAML key we are willing to emit: a conservative identifier, so a model-echoed "key" can never
+/// smuggle punctuation (or a fence) into the block.
+fn is_safe_yaml_key(key: &str) -> bool {
+    !key.is_empty()
+        && key.len() <= 64
+        && key
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && key
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-'))
+}
+
+/// RENDER a note template against the resolved variables.
+///
+/// Returns `(frontmatter_yaml, body_scaffold)`:
+///   * `frontmatter_yaml` — the COMPLETE `---`-fenced block Murmur prepends. First line is exactly
+///     `---`, last is exactly `---`; every value is sanitized + YAML-escaped, so it is always ONE
+///     well-formed single-document block.
+///   * `body_scaffold` — the template's section skeleton with `{{}}` resolved. The model normally
+///     supplies the body; the scaffold is what a body-less generation degrades to, so a note is
+///     never just front-matter.
+///
+/// `template = None` (a built-in style / unknown id) renders the fixed five keys and a bare title
+/// scaffold. Pure: no clock, no DB, no I/O.
+pub fn render_template(template: Option<&NoteTemplate>, vars: &ResolvedVars) -> (String, String) {
+    let lines = deterministic_front_matter_lines(template, vars);
+    let front = format!("---\n{}\n---\n", lines.join("\n"));
+    (front, render_body_scaffold(template, vars))
+}
+
+fn render_body_scaffold(t: Option<&NoteTemplate>, vars: &ResolvedVars) -> String {
+    let sections = match t {
+        Some(t) if !t.sections.is_empty() => render_sections(&t.sections),
+        _ => "# <title>\n".to_string(),
+    };
+    let title = sanitize_value(&vars.title);
+    let sections = sections.replacen("# <title>", &format!("# {title}"), 1);
+    substitute_vars(&sections, vars)
+}
+
+/// ASSEMBLE the final note: Murmur's deterministic front-matter block PREPENDED to the model's body.
+///
+/// * The model's own front-matter is NOT trusted — it is split off and re-merged key-by-key: a key
+///   Murmur owns is dropped (Murmur's deterministic value wins), a surviving key keeps its line only
+///   if it is a safe `key: scalar` (else the value is re-quoted), and list continuations / bare
+///   fences are discarded. This is what preserves stamps like `murmur_enhanced: true` and a
+///   template's model-filled extra keys while making a fence-injection structurally impossible.
+/// * A body-empty generation degrades to the template's `body_scaffold`.
+/// * The BODY is `{{}}`-substituted too. A section instruction may legitimately carry a
+///   placeholder (`Attendees: {{participants}}`), and that instruction reaches the model VERBATIM
+///   in the prompt — so the model can echo the raw `{{participants}}` into its note. Resolving the
+///   body here is what guarantees a placeholder never reaches the user unresolved, on the
+///   model-body path as well as on the scaffold path. Substitution is the SAME single pass with the
+///   SAME sanitized values (`{{`/`<%`/`---` stripped), so it cannot recurse and cannot inject.
+///
+/// Pure + idempotent-shaped: re-assembling an already-assembled note re-derives the same block.
+pub fn assemble_note_with_template(
+    template: Option<&NoteTemplate>,
+    vars: &ResolvedVars,
+    model_markdown: &str,
+) -> String {
+    let (model_yaml, model_body) = crate::storage::db::split_front_matter(model_markdown);
+    let mut lines = deterministic_front_matter_lines(template, vars);
+    let owned: std::collections::HashSet<String> = lines
+        .iter()
+        .filter_map(|l| l.split_once(':').map(|(k, _)| k.trim().to_ascii_lowercase()))
+        .collect();
+    lines.extend(preserved_front_matter_lines(&model_yaml, &owned));
+
+    let body = if model_body.trim().is_empty() {
+        render_body_scaffold(template, vars)
+    } else {
+        substitute_vars(&model_body, vars)
+    };
+    format!(
+        "---\n{}\n---\n\n{}",
+        lines.join("\n"),
+        body.trim_start_matches('\n')
+    )
+}
+
+/// The model-emitted front-matter lines that SURVIVE the merge, re-quoted where needed. Everything
+/// structural (blank lines, comments, a bare `---`) and every key Murmur already rendered is
+/// dropped.
+///
+/// A key with NO inline value is a YAML BLOCK list: its `- item` continuation lines are CONSUMED
+/// with it, and — when the key is one Murmur does not own — re-emitted as a sanitized flow list
+/// (`project: ["Atlas", "Beta"]`) so a model that answers a template's plain
+/// `extra_frontmatter_keys` entry in block style keeps its value instead of losing it silently.
+/// A block under a key Murmur DOES own (or an unsafe key) is dropped WITH its items, so the block
+/// can never end on a dangling key or an orphaned `- item`.
+fn preserved_front_matter_lines(
+    yaml: &str,
+    owned: &std::collections::HashSet<String>,
+) -> Vec<String> {
+    let lines: Vec<&str> = yaml.lines().collect();
+    let mut out = Vec::new();
+    let mut i = 0usize;
+    while i < lines.len() {
+        if out.len() >= MAX_PRESERVED_FRONT_MATTER_LINES {
+            break;
+        }
+        let t = lines[i].trim();
+        i += 1;
+        // A bare fence / a list item with no owning key / a comment is structural noise.
+        if t.is_empty() || t.starts_with('-') || t.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = t.split_once(':') else {
+            continue;
+        };
+        let key = key.trim();
+        let value = value.trim();
+        let keep = is_safe_yaml_key(key) && !owned.contains(&key.to_ascii_lowercase());
+
+        if value.is_empty() {
+            // BLOCK form — consume this key's `- item` continuation lines either way.
+            let mut items = Vec::new();
+            while i < lines.len() {
+                let c = lines[i].trim();
+                // A bare fence terminates the block; it is not an item.
+                if c == "---" {
+                    break;
+                }
+                let Some(item) = c.strip_prefix('-') else { break };
+                // Unwrap the model's own quoting so the re-emitted flow list quotes ONCE.
+                items.push(
+                    item.trim()
+                        .trim_matches('"')
+                        .trim_matches('\'')
+                        .trim()
+                        .to_string(),
+                );
+                i += 1;
+            }
+            if keep && !items.is_empty() {
+                let flow = yaml_flow_list(&items);
+                if flow != "[]" {
+                    out.push(format!("{key}: {flow}"));
+                }
+            }
+            continue;
+        }
+        if !keep {
+            continue;
+        }
+        if is_simple_yaml_value(value) {
+            out.push(format!("{key}: {value}"));
+        } else {
+            let unquoted = value
+                .strip_prefix('"')
+                .and_then(|v| v.strip_suffix('"'))
+                .unwrap_or(value);
+            out.push(format!("{key}: {}", yaml_quote(&sanitize_value(unquoted))));
+        }
+    }
+    out
+}
+
+/// Is this model-emitted YAML value safe to keep VERBATIM? A bare scalar or a flow list built from
+/// plain tokens — anything with a fence, a scripting opening, a quote, or `{{` gets re-quoted.
+fn is_simple_yaml_value(value: &str) -> bool {
+    if VALUE_STRIP_TOKENS.iter().any(|tok| value.contains(tok)) {
+        return false;
+    }
+    let inner = value
+        .strip_prefix('[')
+        .and_then(|v| v.strip_suffix(']'))
+        .unwrap_or(value);
+    !inner.is_empty()
+        && inner
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '/' | '-' | ',' | ' '))
 }
 
 #[cfg(test)]
@@ -902,6 +1578,423 @@ Formatting rules:
                 "scripting token must be rejected as InvalidArg; got {err:?}"
             );
         }
+    }
+
+    // ── T4b — the `{{}}` DSL + Murmur-assembled front-matter ─────────────────────────────────────
+
+    /// A `ResolvedVars` carrying the three HOSTILE transcript-derived values the whole feature
+    /// exists for, plus a benign one.
+    fn hostile_vars() -> ResolvedVars {
+        ResolvedVars {
+            title: "Q3 planning".to_string(),
+            date_iso: "2026-07-26".to_string(),
+            duration_minutes: 42,
+            participants: vec![
+                // (a) closes the fence and opens a SECOND YAML document.
+                "---\nadmin: true".to_string(),
+                // (b) an Obsidian Templater payload the vault would EXECUTE on open.
+                "<% tp.system.prompt() %>".to_string(),
+                // (c) a raw `:` — breaks an unquoted YAML scalar.
+                "Ann: the CFO".to_string(),
+                "Bob".to_string(),
+            ],
+            action_items: vec!["Bob — ship it".to_string()],
+            entities: vec!["ACME Corp".to_string()],
+            tags: vec!["meeting".to_string()],
+            language: Some("en".to_string()),
+        }
+    }
+
+    /// Count the `---` FENCE lines in a note (a well-formed single-document front-matter block has
+    /// exactly two, and they are the first line and the block terminator).
+    fn fence_lines(s: &str) -> usize {
+        s.lines().filter(|l| l.trim() == "---").count()
+    }
+
+    /// RED-before-GREEN (the escaping/stripping core). A transcript-derived participant named
+    /// `---\nadmin: true`, one containing `<% tp.system %>`, and one with a raw `:` must ALL come out
+    /// of the assembler as inert, quoted, single-line YAML scalars:
+    ///   * the assembled note starts with `---` and contains EXACTLY ONE front-matter block,
+    ///   * no injected fence, no `<%`/`%>`, no `{{`,
+    ///   * `admin: true` never becomes a front-matter KEY of its own.
+    /// Without the sanitize+quote step every one of these assertions fails (the fence closes early,
+    /// the Templater token survives, and the bare `:` splits the scalar).
+    #[test]
+    fn resolved_values_cannot_inject_a_fence_or_a_scripting_token() {
+        let vars = hostile_vars();
+        let (front, _scaffold) = render_template(None, &vars);
+
+        assert!(front.starts_with("---\n"), "front-matter must open with ---: {front}");
+        assert!(front.trim_end().ends_with("---"), "…and close with ---: {front}");
+        assert_eq!(fence_lines(&front), 2, "exactly ONE yaml document: {front}");
+        assert!(!front.contains("<%") && !front.contains("%>"), "{front}");
+        assert!(!front.contains("{{"), "{front}");
+        // The fence text is gone from the VALUE, and `admin: true` never becomes its own line.
+        assert!(
+            !front.lines().any(|l| l.trim_start().starts_with("admin:")),
+            "an injected key must never reach the block: {front}"
+        );
+        // Every hostile participant survives as CONTENT — quoted, escaped, single-line.
+        let participants = front
+            .lines()
+            .find(|l| l.starts_with("participants:"))
+            .expect("participants line");
+        assert!(participants.contains("\"admin: true\""), "{participants}");
+        assert!(participants.contains("\"tp.system.prompt()\""), "{participants}");
+        assert!(participants.contains("\"Ann: the CFO\""), "{participants}");
+        assert!(participants.contains("Bob"), "{participants}");
+        assert!(!participants.contains('\n'), "single-line: {participants}");
+
+        // The same holds for the FULL assembled note (front-matter + the model's body).
+        let note = assemble_note_with_template(None, &vars, "---\ntitle: guessed\n---\n\n# Body\n");
+        assert!(note.starts_with("---\n"), "{note}");
+        assert_eq!(fence_lines(&note), 2, "assembled note is one yaml doc: {note}");
+        assert!(!note.contains("<%") && !note.contains("%>"), "{note}");
+        assert!(note.contains("# Body"), "the model body survives: {note}");
+        // Murmur's deterministic title WINS over the model's guess.
+        assert!(note.contains("title: \"Q3 planning\""), "{note}");
+        assert!(!note.contains("title: guessed"), "{note}");
+    }
+
+    /// RED-before-GREEN (`{{date}}`). Bare `{{date}}` renders the ISO date; `{{date:FORMAT}}` honors
+    /// the Obsidian/moment tokens; an unparseable date degrades to the raw ISO string instead of
+    /// erroring; and the emitted month NAME is never re-scanned (no token re-expansion).
+    #[test]
+    fn date_variable_renders_iso_and_obsidian_formats() {
+        let vars = hostile_vars();
+        assert_eq!(substitute_vars("{{date}}", &vars), "2026-07-26");
+        assert_eq!(substitute_vars("{{date:YYYY}}", &vars), "2026");
+        assert_eq!(substitute_vars("{{date:YYYY-MM-DD}}", &vars), "2026-07-26");
+        assert_eq!(substitute_vars("{{date:DD.MM.YYYY}}", &vars), "26.07.2026");
+        assert_eq!(substitute_vars("{{date:YY}}", &vars), "26");
+        // A month NAME contains `M`/`D` letters — they must NOT re-expand.
+        assert_eq!(substitute_vars("{{date:MMMM D}}", &vars), "July 26");
+        // Whitespace inside the braces is tolerated (Obsidian-style).
+        assert_eq!(substitute_vars("{{ date : YYYY }}", &vars), "2026");
+        // A non-ISO date passes through sanitized rather than failing.
+        let mut odd = hostile_vars();
+        odd.date_iso = "not-a-date".to_string();
+        assert_eq!(substitute_vars("{{date:YYYY}}", &odd), "not-a-date");
+    }
+
+    /// The DSL is LOGIC-LESS and NON-RECURSIVE: a resolved value that itself looks like a
+    /// placeholder is never expanded (the `{{` is stripped from every value AND `replace_all` never
+    /// re-scans its own output), and an ident outside the allowlist is left VERBATIM — visible, not
+    /// silently dropped.
+    #[test]
+    fn substitution_is_single_pass_and_never_recurses() {
+        let vars = ResolvedVars {
+            title: "{{participants}} <% tp.file %>".to_string(),
+            participants: vec!["Anna".to_string()],
+            ..Default::default()
+        };
+        let out = substitute_vars("T: {{title}}", &vars);
+        assert!(!out.contains("Anna"), "a value must not re-expand: {out}");
+        assert!(!out.contains("{{") && !out.contains("<%"), "{out}");
+        assert_eq!(out, "T: participants tp.file");
+        // Unknown ident ⇒ untouched text (save-time validation is what refuses it).
+        assert_eq!(
+            substitute_vars("{{meeting_id}} {{nope}}", &vars),
+            "{{meeting_id}} {{nope}}"
+        );
+    }
+
+    /// The allowlist is a CLOSED `match`, `TEMPLATE_VARS` mirrors it exactly, and `meeting_id` is
+    /// deliberately absent (2026-07-26 egress review: no note value, highest linkability cost).
+    #[test]
+    fn allowlist_is_closed_and_excludes_meeting_id() {
+        for v in TEMPLATE_VARS {
+            assert!(is_known_template_var(v), "{v} must be known");
+        }
+        for v in ["meeting_id", "transcript", "note", "audio_path", "folder", ""] {
+            assert!(!is_known_template_var(v), "{v} must NOT be a template var");
+        }
+        assert!(!TEMPLATE_VARS.contains(&"meeting_id"));
+        // Every allowlisted ident actually resolves (no half-wired var).
+        let vars = hostile_vars();
+        for v in TEMPLATE_VARS {
+            assert!(resolve_var_inline(&vars, v, None).is_some(), "{v} unresolved");
+            assert!(resolve_var_yaml(&vars, v, None).is_some(), "{v} unresolved");
+        }
+        // The grammar itself compiles (the renderer/validator share it).
+        assert!(var_regex().is_some(), "the `{{{{}}}}` grammar must compile");
+    }
+
+    /// RED-before-GREEN (fail-closed at SAVE). An unknown `{{var}}` — including the deliberately
+    /// dropped `{{meeting_id}}` — and a malformed/unterminated `{{` are REFUSED with
+    /// `AppError::InvalidArg`, in every field that RENDERS the DSL. Known vars save fine.
+    #[test]
+    fn unknown_template_var_is_rejected_at_save() {
+        // Known vars, in each RENDERING field shape, validate.
+        let ok = tpl(
+            "t-ok",
+            "Warm and outcome-first.",
+            &[("Summary {{date:YYYY}}", "Attendees: {{participants}}")],
+            &["client: {{entities}}", "plainkey"],
+        );
+        assert!(validate_note_template(&ok.name, &ok.tone, &ok).is_ok());
+
+        // meeting_id was REMOVED from the allowlist — it must be refused like any other unknown.
+        let mid = tpl("t1", "warm", &[("S", "id {{meeting_id}}")], &[]);
+        // A typo'd var must never silently vanish from the user's notes.
+        let typo = tpl("t2", "warm", &[("S", "{{participant}}")], &[]);
+        // …in an extra front-matter key.
+        let key = tpl("t4", "warm", &[("S", "ok")], &["client: {{secrets}}"]);
+        // …and a malformed / unterminated placeholder is refused too (fail-closed).
+        let open = tpl("t5", "warm", &[("S", "{{title")], &[]);
+        let junk = tpl("t6", "warm", &[("S", "{{ 1title }}")], &[]);
+        for t in [&mid, &typo, &key, &open, &junk] {
+            let err = validate_note_template(&t.name, &t.tone, t);
+            assert!(
+                matches!(err, Err(AppError::InvalidArg(_))),
+                "{} must be rejected as InvalidArg; got {err:?}",
+                t.id
+            );
+        }
+        // The refusal NAMES the allowlist so the user can fix it.
+        let msg = format!("{:?}", validate_note_template(&mid.name, &mid.tone, &mid));
+        assert!(msg.contains("participants"), "error must list the allowlist: {msg}");
+    }
+
+    /// The DSL's FIELD SCOPE is enforced, not merely documented: `name` and `tone` are never
+    /// rendered into a note (the name is a picker label; the tone is a directive sent verbatim to
+    /// the model), so ANY `{{ … }}` there is refused at save — even a perfectly valid one. Accepting
+    /// it would leave the user with literal `{{date}}` text in their prompt forever.
+    #[test]
+    fn dsl_is_rejected_in_the_fields_that_never_render_it() {
+        // A VALID variable is still refused in tone…
+        let tone_known = tpl("t-tone", "It is {{date:YYYY}}.", &[("S", "ok")], &[]);
+        // …and in an unknown spelling…
+        let tone_unknown = tpl("t-tone2", "{{everything}}", &[("S", "ok")], &[]);
+        for t in [&tone_known, &tone_unknown] {
+            let err = validate_note_template(&t.name, &t.tone, t);
+            assert!(
+                matches!(err, Err(AppError::InvalidArg(_))),
+                "{} — `{{{{}}}}` in tone must be refused; got {err:?}",
+                t.id
+            );
+        }
+        // …and in the template NAME.
+        let named = tpl("t-name", "warm", &[("S", "ok")], &[]);
+        let err = validate_note_template("Weekly {{title}}", &named.tone, &named);
+        assert!(
+            matches!(err, Err(AppError::InvalidArg(_))),
+            "`{{{{}}}}` in the name must be refused; got {err:?}"
+        );
+        // The refusal explains WHERE variables are supported.
+        let msg = format!("{:?}", validate_note_template("Weekly {{title}}", &named.tone, &named));
+        assert!(msg.contains("SECTIONS"), "error must name the supported fields: {msg}");
+    }
+
+    /// A section instruction reaches the model VERBATIM in the prompt, so the model can echo the raw
+    /// `{{participants}}` back into its note. The assembler resolves the MODEL BODY too, so a
+    /// placeholder can never survive into the user's note. RED without the body substitution: the
+    /// literal `{{participants}}` stays in the assembled note.
+    #[test]
+    fn placeholders_echoed_by_the_model_are_resolved_in_the_body() {
+        let vars = hostile_vars();
+        let model = "---\ntitle: guess\n---\n\n# Q3\n\nAttendees: {{participants}}\nOn {{date:YYYY}}.\n";
+        let note = assemble_note_with_template(None, &vars, model);
+
+        assert!(
+            !note.contains("{{"),
+            "no placeholder may survive into the user's note: {note}"
+        );
+        assert!(note.contains("Attendees: admin: true, tp.system.prompt()"), "{note}");
+        assert!(note.contains("On 2026."), "{note}");
+        // Resolution in the body is still sanitized — the fence/Templater tokens stay stripped.
+        assert!(!note.contains("<%") && !note.contains("%>"), "{note}");
+        assert_eq!(fence_lines(&note), 2, "one yaml doc: {note}");
+        // An ident outside the allowlist stays VERBATIM (visible, never silently dropped).
+        let unknown = assemble_note_with_template(None, &vars, "# B\n\nid {{meeting_id}}\n");
+        assert!(unknown.contains("{{meeting_id}}"), "{unknown}");
+    }
+
+    /// YAML would RE-TYPE a bare reserved word or a number: a participant literally named `No`, or a
+    /// purely numeric title, must round-trip as the STRING the user meant. RED without the
+    /// [`is_yaml_typed_plain`] guard (they render bare and parse as `false` / `2026`).
+    #[test]
+    fn yaml_reserved_words_and_numbers_are_quoted() {
+        let vars = ResolvedVars {
+            title: "2026".to_string(),
+            date_iso: "2026-07-26".to_string(),
+            duration_minutes: 30,
+            participants: vec![
+                "No".to_string(),
+                "yes".to_string(),
+                "Off".to_string(),
+                "null".to_string(),
+                "~".to_string(),
+                "3.14".to_string(),
+                "Anna".to_string(),
+            ],
+            tags: vec!["meeting".to_string()],
+            ..Default::default()
+        };
+        let (front, _) = render_template(None, &vars);
+
+        // A numeric title is a STRING, not the number 2026.
+        assert!(front.contains("title: \"2026\""), "{front}");
+        let participants = front
+            .lines()
+            .find(|l| l.starts_with("participants:"))
+            .expect("participants line");
+        for quoted in ["\"No\"", "\"yes\"", "\"Off\"", "\"null\"", "\"~\"", "\"3.14\""] {
+            assert!(
+                participants.contains(quoted),
+                "{quoted} must be quoted, not re-typed by YAML: {participants}"
+            );
+        }
+        // A plain name still renders BARE — the guard must not over-quote everything.
+        assert!(participants.contains("Anna,") || participants.contains("Anna]"), "{participants}");
+        // The ISO date is not a number, so it stays bare (Obsidian parses it as a date).
+        assert!(front.contains("date: 2026-07-26"), "{front}");
+        // duration_minutes is a REAL number and must stay unquoted.
+        assert!(front.contains("duration_minutes: 30"), "{front}");
+    }
+
+    /// A model that answers a template's PLAIN `extra_frontmatter_keys` entry in YAML BLOCK-list
+    /// style must keep its value. RED before the block-list re-read: the `project:` key and every
+    /// `- item` under it were dropped silently. A block under a key MURMUR owns is still discarded
+    /// (Murmur's own deterministic value wins).
+    #[test]
+    fn model_block_lists_survive_for_keys_murmur_does_not_own() {
+        let vars = hostile_vars();
+        let model = "---\n\
+                     project:\n\
+                     - Atlas\n\
+                     - \"Beta Phase\"\n\
+                     tags:\n\
+                     - dropped-because-owned\n\
+                     empty_block:\n\
+                     decisions: [a, b]\n\
+                     ---\n\n\
+                     # Body\n";
+        let note = assemble_note_with_template(None, &vars, model);
+
+        assert!(
+            note.contains("project: [Atlas, \"Beta Phase\"]"),
+            "a non-owned block list must be re-emitted as a sanitized flow list: {note}"
+        );
+        // Murmur owns `tags` — its deterministic value wins and the model's block is dropped whole.
+        assert!(!note.contains("dropped-because-owned"), "{note}");
+        assert_eq!(
+            note.lines().filter(|l| l.starts_with("tags:")).count(),
+            1,
+            "no duplicate owned key: {note}"
+        );
+        // A key with an empty block and no items is dropped (never a dangling key).
+        assert!(!note.contains("empty_block"), "{note}");
+        // An inline flow list is untouched.
+        assert!(note.contains("decisions: [a, b]"), "{note}");
+        assert_eq!(fence_lines(&note), 2, "one yaml doc: {note}");
+    }
+
+    /// A template's `extra_frontmatter_keys` carry the DSL: `key: {{var}}` renders the variable's
+    /// native YAML form (a list stays a list), a mixed literal+placeholder value is quoted as one
+    /// opaque scalar, and a PLAIN key stays a request to the model (byte-identical prompt line).
+    #[test]
+    fn extra_frontmatter_keys_render_deterministic_values() {
+        let t = tpl(
+            "tpl-vars",
+            "",
+            &[("Outcome", "Attendees: {{participants}}")],
+            &["client: {{entities}}", "slug: {{date:YYYY}}-q3", "project"],
+        );
+        let vars = hostile_vars();
+        let (front, scaffold) = render_template(Some(&t), &vars);
+
+        // A whole-placeholder value keeps its NATIVE yaml form (a list stays a list)…
+        assert!(front.contains("client: [\"ACME Corp\"]"), "{front}");
+        // …a mixed literal+placeholder value becomes one scalar (bare here — it is a plain token).
+        assert!(front.contains("slug: 2026-q3"), "{front}");
+        // A plain key has no deterministic value ⇒ Murmur emits nothing for it.
+        assert!(!front.contains("project:"), "{front}");
+        assert_eq!(fence_lines(&front), 2, "{front}");
+
+        // The prompt still ASKS for the plain key, and no longer asks for the ones Murmur fills.
+        let prompt = render_saved_template(&t);
+        assert!(prompt.contains("- project: (fill in from the meeting"), "{prompt}");
+        assert!(!prompt.contains("- client:"), "{prompt}");
+        assert!(!prompt.contains("- slug:"), "{prompt}");
+
+        // The body scaffold resolves its vars and heads with the real title.
+        assert!(scaffold.starts_with("# Q3 planning\n"), "{scaffold}");
+        assert!(scaffold.contains("Attendees: admin: true, tp.system.prompt()"), "{scaffold}");
+        assert!(!scaffold.contains("{{"), "{scaffold}");
+    }
+
+    /// The MERGE with the model's own front-matter: keys Murmur owns are replaced (never
+    /// duplicated), a foreign stamp like `murmur_enhanced: true` is PRESERVED verbatim, a hostile
+    /// model key is re-quoted, and structural junk (a bare `---`, list continuations, an empty key)
+    /// is dropped — the result is always one well-formed block.
+    #[test]
+    fn model_front_matter_is_merged_not_trusted() {
+        let vars = hostile_vars();
+        let model = "---\n\
+                     murmur_enhanced: true\n\
+                     title: model guess\n\
+                     participants:\n\
+                     - someone\n\
+                     project: <% tp.system %>\n\
+                     empty:\n\
+                     bad key!: x\n\
+                     ---\n\n\
+                     # Real body\n\nText.\n";
+        let note = assemble_note_with_template(None, &vars, model);
+
+        assert_eq!(fence_lines(&note), 2, "one yaml doc: {note}");
+        assert!(note.contains("murmur_enhanced: true"), "stamp preserved: {note}");
+        assert_eq!(
+            note.lines().filter(|l| l.starts_with("title:")).count(),
+            1,
+            "no duplicate owned key: {note}"
+        );
+        assert!(note.contains("title: \"Q3 planning\""), "{note}");
+        assert!(!note.contains("model guess"), "{note}");
+        assert!(!note.contains("<%"), "hostile value re-quoted: {note}");
+        assert!(note.contains("project: \"tp.system\""), "{note}");
+        assert!(!note.contains("empty:"), "dangling key dropped: {note}");
+        assert!(!note.contains("bad key!"), "unsafe key dropped: {note}");
+        assert!(!note.contains("- someone"), "orphan list item dropped: {note}");
+        assert!(note.contains("# Real body"), "{note}");
+    }
+
+    /// A generation with NO front-matter, and one with an EMPTY body, both still produce a valid
+    /// `---`-first note (the scaffold fills a body-less generation).
+    #[test]
+    fn assembly_handles_missing_front_matter_and_empty_body() {
+        let vars = hostile_vars();
+        let bare = assemble_note_with_template(None, &vars, "# Just a body\n\nText.\n");
+        assert!(bare.starts_with("---\n"), "{bare}");
+        assert_eq!(fence_lines(&bare), 2, "{bare}");
+        assert!(bare.contains("# Just a body"), "{bare}");
+
+        let t = tpl("t-scaffold", "", &[("Outcome", "One line.")], &[]);
+        let empty = assemble_note_with_template(Some(&t), &vars, "---\ntitle: x\n---\n");
+        assert!(empty.starts_with("---\n"), "{empty}");
+        assert_eq!(fence_lines(&empty), 2, "{empty}");
+        assert!(empty.contains("# Q3 planning"), "scaffold body: {empty}");
+        assert!(empty.contains("## Outcome"), "scaffold sections: {empty}");
+    }
+
+    /// The model's guessed lists are RE-READ (so nothing the user expects is lost) but never
+    /// trusted: `front_matter_list` handles the flow, block and scalar shapes.
+    #[test]
+    fn front_matter_list_reads_flow_block_and_scalar() {
+        assert_eq!(
+            front_matter_list("participants: [Anna, \"Bob C\"]", "participants"),
+            vec!["Anna".to_string(), "Bob C".to_string()]
+        );
+        assert_eq!(
+            front_matter_list("tags:\n  - meeting\n  - q3\ntitle: x", "tags"),
+            vec!["meeting".to_string(), "q3".to_string()]
+        );
+        assert_eq!(
+            front_matter_list("participants: Anna", "participants"),
+            vec!["Anna".to_string()]
+        );
+        assert!(front_matter_list("title: x", "participants").is_empty());
     }
 
     /// A saved template with empty tone and no sections still renders a valid front-matter-first

--- a/src-tauri/src/summarize/template.rs
+++ b/src-tauri/src/summarize/template.rs
@@ -958,6 +958,7 @@ fn deterministic_front_matter_lines(t: Option<&NoteTemplate>, vars: &ResolvedVar
 ///     the result is already a plain token).
 ///   * `project` (no `{{}}`) → `None`: no deterministic value exists, so the key stays a REQUEST to
 ///     the model (the prompt still lists it) and the model's own line survives the merge.
+///
 /// An unsafe/absent key name, or a key Murmur already owns, yields `None`.
 fn render_extra_key_line(entry: &str, vars: &ResolvedVars) -> Option<String> {
     let (key, value_tpl) = entry.split_once(':')?;
@@ -1617,6 +1618,7 @@ Formatting rules:
     ///   * the assembled note starts with `---` and contains EXACTLY ONE front-matter block,
     ///   * no injected fence, no `<%`/`%>`, no `{{`,
     ///   * `admin: true` never becomes a front-matter KEY of its own.
+    ///
     /// Without the sanitize+quote step every one of these assertions fails (the fence closes early,
     /// the Templater token survives, and the bare `:` splits the scalar).
     #[test]


### PR DESCRIPTION
## What

Extends the T4 template layer with a **logic-less `{{}}` variable DSL** and makes **Murmur assemble the front-matter itself** (a privacy + correctness win — previously front-matter was LLM-guessed, only validated to start with `---`).

- `render_template(template, resolved_vars) -> (frontmatter_yaml, body_scaffold)`: grammar is ONLY `{{ident}}` / `{{ident:format}}` where `ident` is a **fixed Rust `match` allowlist** (title, date, participants, action_items, entities, …), resolved from the gated DB through `visibility_clause`. No expression evaluator, no recursion, single pass.
- The LLM produces the **body only**; Murmur resolves the deterministic vars, YAML-escapes them, **strips any leading `---` / `<%` / `{{`** from resolved values, assembles the `---` block, and prepends it. Obsidian-compatible `{{title}}` / `{{date:FORMAT}}`.
- Unknown `{{var}}` is **rejected at save** (fail-closed), never silently dropped at render.

## Privacy (the fix vs the first attempt)

The first attempt leaked resolved deterministic vars into cloud-bound folder/entity classification. This version keeps them **out of the classification steps** — `resolve_subfolder` / `build_and_persist_entities` get the pre-assembly model output; front-matter is assembled and prepended **after**. `meeting_id` was dropped from the allowlist (no note value, high linkability). A regression asserts resolved vars never reach the classification consumers.

## Tests / gates (all green via the harness)

- RED-before-GREEN injection cases: a participant named `"---\nadmin: true"`, a `<% tp.system %>` value, a raw `:`, and `{{date}}` — assembled block is valid single-document YAML, starts with `---`, carries no injected fence/token; unknown `{{var}}` rejected at save; resolved vars absent from classification input.
- Builtin styles still render byte-identical (T4 invariant preserved).
- rust-lib, protocol-server, tauri-boot, perf-contracts PASS. Reviews: spec + adversarial + protocol-security + egress-security.

Task T5 of the competitive-gaps program (`docs/research/2026-07-25-implementation-harness-tasks.md`).
