### PR TITLE
chore(harness): 1h agent budget, reap an untouched task, warn on a stale server pin

### DIFF
--- a/.agents/harness/config.json
+++ b/.agents/harness/config.json
@@ -3,8 +3,8 @@
   "default_writer": "claude",
   "default_reviewer": "claude",
   "max_repair_rounds": 2,
-  "task_timeout_seconds": 7200,
-  "agent_timeout_seconds": 1800,
+  "task_timeout_seconds": 21600,
+  "agent_timeout_seconds": 3600,
   "check_timeout_seconds": 1800,
   "max_diff_bytes_for_review": 500000,
   "commit_identity": {

--- a/.agents/harness/task_runner.py
+++ b/.agents/harness/task_runner.py
@@ -711,6 +711,42 @@ def dependency_revisions(repo_root: Path) -> Dict[str, str]:
     return {"murmur-server.expected": expected, "murmur-server.head": head, "murmur-server.dirty": dirty}
 
 
+def warn_if_protocol_pin_is_stale(repo_root: Path) -> None:
+    """Warn (never fail) when `.murmur-server-revision` lags the sibling's `origin/main`.
+
+    The pin decides which `murmur-protocol` tree a task compiles against, and `init` materialises the
+    sibling worktree at exactly that SHA. A stale pin is therefore SILENT: every check passes, against
+    a server that is not the deployed one. On 2026-07-26 a task compiled against a tree three merged
+    server PRs behind and only a protocol reviewer noticed, after two wasted rounds.
+
+    Advisory on purpose. Pinning deliberately BEHIND `origin/main` is legitimate -- a client change
+    that must not assume an unreleased server surface -- so this only makes the choice visible rather
+    than accidental. Any git failure (no sibling, no remote, offline) is swallowed: a warning must
+    never be able to block `init`.
+    """
+    sibling = (repo_root / ".." / "murmur-server").resolve()
+    revision_path = repo_root / ".murmur-server-revision"
+    if not sibling.is_dir() or not revision_path.is_file():
+        return
+    try:
+        pinned = revision_path.read_text(encoding="utf-8").strip()
+        upstream = git(sibling, "rev-parse", "--verify", "origin/main^{commit}", check=False)
+    except Exception:  # noqa: BLE001 - advisory only; never let this break init
+        return
+    if not SHA1_RE.fullmatch(pinned) or not SHA1_RE.fullmatch(upstream or ""):
+        return
+    if pinned == upstream:
+        return
+    behind = git(sibling, "rev-list", "--count", f"{pinned}..{upstream}", check=False)
+    detail = f" ({behind} commit(s) behind)" if (behind or "").isdigit() and behind != "0" else ""
+    print(
+        f"[harness] WARNING: .murmur-server-revision pins {pinned[:12]} but the sibling "
+        f"origin/main is {upstream[:12]}{detail}; this task compiles against the PINNED tree. "
+        "Bump the pin first if it needs the newer protocol surface.",
+        file=sys.stderr,
+    )
+
+
 def validate_protocol_dependency(revisions: Mapping[str, str]) -> None:
     expected = revisions.get("murmur-server.expected", "")
     head = revisions.get("murmur-server.head", "")
@@ -3899,6 +3935,7 @@ def cmd_init(args: argparse.Namespace) -> int:
         contract["dependency_revisions"] = dependency_revisions(worktree)
         if contract["dependency_revisions"]:
             validate_protocol_dependency(contract["dependency_revisions"])
+            warn_if_protocol_pin_is_stale(primary)
         contract["contract_sha256"] = contract_hash(contract)
         validate_schema(contract, load_schema("task"), label="task contract")
         atomic_write_json(task_dir / "task.json", contract)
@@ -4430,6 +4467,27 @@ def _remove_task_worktrees(
     return archive_ref, snapshot_sha
 
 
+def task_worktree_is_untouched(contract: Mapping[str, Any]) -> bool:
+    """True when a task's worktree still holds exactly its base commit and no edits.
+
+    Lets `reap` discard a freshly mis-parameterised INITIALIZED task. Fails CLOSED: a missing
+    worktree, a moved HEAD, an unreadable status, or any git error all return False, so the only path
+    to an immediate reap is a worktree provably identical to its base. A VANISHED worktree is not
+    treated as untouched -- the work may have been moved elsewhere, and the age-based gc sweep is the
+    right tool for that case.
+    """
+    worktree = Path(str(contract.get("worktree_path", "")))
+    base_sha = str(contract.get("base_sha", ""))
+    if not worktree.is_dir() or not SHA1_RE.fullmatch(base_sha):
+        return False
+    try:
+        if git(worktree, "rev-parse", "HEAD", check=False) != base_sha:
+            return False
+        return not git_bytes(worktree, "status", "--porcelain", check=False).strip()
+    except Exception:  # noqa: BLE001 - any git failure means "not provably clean"
+        return False
+
+
 def cmd_reap(args: argparse.Namespace) -> int:
     contract, task_dir, _ = load_task_from_current_repo(args.task_id, Path.cwd())
     lock = acquire_run_lock(
@@ -4448,10 +4506,18 @@ def cmd_reap(args: argparse.Namespace) -> int:
                 )
                 <= stale_before
             )
+            # An INITIALIZED task whose worktree is still untouched holds no work to lose, so it can
+            # be discarded now rather than waiting for the age-based gc sweep. Without this a
+            # mis-parameterised init (wrong --base, stale dependency pin) leaves a task that can be
+            # neither closed (needs COMMITTED) nor reaped (needs a terminal state) -- dead task dirs
+            # accumulate, and reusing the id later trips "task already exists". Deliberately narrow:
+            # only INITIALIZED, and only with a verifiably empty worktree.
+            if not stale_abandoned and prior_status == "INITIALIZED":
+                stale_abandoned = task_worktree_is_untouched(contract)
             if not stale_abandoned:
                 raise HarnessError(
-                    "reap accepts only FAILED/BLOCKED/CLOSED tasks, or an abandoned "
-                    f"stale task selected by gc; found {prior_status!r}"
+                    "reap accepts only FAILED/BLOCKED/CLOSED tasks, an untouched INITIALIZED "
+                    f"task, or an abandoned stale task selected by gc; found {prior_status!r}"
                 )
             set_state(
                 task_dir,


### PR DESCRIPTION
Three ergonomics fixes, all found by driving the harness hard through a multi-PR org-sharing program
today (6 PRs landed, 3 tasks blocked or failed).

## 1. Agent budget 30 min → 1 h (task budget 2 h → 6 h)

Two task attempts died at **exactly `1799715 ms`**, mid-tool-call, losing the entire round. 30 minutes
is short for a real change in this tree: the writer reads a large Rust module, edits five files, and
writes regressions — and cargo here is slow.

Those tasks were also over-scoped, and that was **my** fault as operator. But a budget that turns an
over-scoped task into a *total* loss rather than a *slow* one is the wrong shape — you lose the work
and learn nothing about the scope. 1 h is still bounded; the runaway backstop is unchanged.

## 2. `reap` accepts an untouched INITIALIZED task

A mis-parameterised `init` (wrong `--base`, stale dependency pin) left a task that could be neither
`close`d (needs `COMMITTED`) nor `reap`ed (needs a terminal state). Dead task dirs accumulated, and
reusing the id later tripped *"task already exists"*. Hit this twice today.

Deliberately narrow and fail-closed: only `INITIALIZED`, only with `HEAD == base_sha` **and** a clean
`git status`, and a **vanished** worktree does *not* qualify — the work may have been moved elsewhere,
and the age-based `gc` sweep owns that case.

## 3. `init` warns when the server pin is stale

`.murmur-server-revision` decides which `murmur-protocol` tree a task compiles against, and `init`
materialises the sibling worktree at exactly that SHA. So a stale pin is **silent**: every check
passes, against a server that is not the deployed one.

Today a task compiled against a tree **three merged server PRs behind**, and only a protocol reviewer
noticed — after two wasted rounds.

Advisory, never fatal: pinning deliberately *behind* `origin/main` is legitimate (a client change that
must not assume an unreleased server surface), so this makes the choice visible rather than
accidental. Any git failure — no sibling, no remote, offline — is swallowed, because a warning must
never be able to block `init`.

## Verification

Run from a clean worktree with **no task in flight**:

```
scripts/agent-config-audit --ci      → PASS (137 checks, 0 warnings)
scripts/agent-harness selftest --ci  → PASS
```

Worth recording *why* that caveat matters: the instructions hash covers `.agents/harness/*`, not just
`CLAUDE.md`. Editing these files while a task is running invalidates that task's contract mid-flight.
An earlier attempt at this change did exactly that, in the shared working checkout, and looked broken
for reasons that had nothing to do with the diff. This branch was built in an isolated worktree.

## Not fixed here — a design question worth raising

**A `spec` FAIL short-circuits the whole review round.** Today's key-rotation task burned three full
rounds and never ran `adversarial`, `lock-security`, `egress-security` or `protocol-security` **even
once** — on a change flagged `lock + egress + protocol`. The blocker was a single contract item that
was *impossible within the task's owned paths* (it needed an `AppHandle` that only exists in three
files the task did not own), so the writer documented it instead of faking it — correctly.

The net effect: an operator's contract-scoping error consumed the entire budget of a security-relevant
task and produced zero security review. Worth considering whether risk reviews should run regardless
of the spec verdict, or whether `spec` should distinguish "contract not met" from "code defective".
Left out of this PR because it changes review semantics, not ergonomics.
