### PR TITLE
feat(models): pick transcription quality with a power slider, not a filename

### DIFF
--- a/.claude/skills/pr-program/SKILL.md
+++ b/.claude/skills/pr-program/SKILL.md
@@ -59,15 +59,83 @@ Order PRs by dependency (shared-file PRs serialize; disjoint ones can overlap bu
 on the LATEST trunk; if two touch the same file, the second rebases + resolves (usually a clean
 union — e.g. two additive blocks in `detail.component.ts`).
 
+## ALWAYS `--base origin/murmur` (2026-07-26 — the single biggest time sink found so far)
+
+`scripts/agent-harness init` defaults `--base` to **HEAD, i.e. your LOCAL `murmur`** — which goes
+stale the moment any PR merges (yours or someone else's). Two failures, both observed in one program:
+
+1. **Every PR's CI ran TWICE.** A branch cut from stale trunk is refused at merge
+   ("Required status check … is expected" = *branch not up to date*), so you merge `origin/murmur` in,
+   push, and pay a second full CI cycle. ~26 min per PR, and it looked like "CI is slow".
+2. **A PR was created WITHOUT its dependency's work in it.** P2's worktree came up with no
+   `machine.service.ts` and no `catalog.rs` because local trunk predated P1's merge — the writer would
+   have spent a full round building on a foundation that was not there.
+
+**The rule:** `git fetch origin murmur -q` then `init … --base origin/murmur`. Verify before running:
+`ls <worktree>/<a file the previous PR added>`. And `git merge --ff-only origin/murmur` on the local
+trunk periodically so the working checkout doesn't drift either.
+
+## CLEANING UP A FAILED `init` TOUCHES **TWO** REPOS
+
+The harness pairs a `meetnotes` worktree with a `../murmur-server` worktree. `rm -rf` on the task dir
+leaves BOTH registrations dangling, and the next `init` dies with *"missing but already registered
+worktree"* — pointing at `murmur-server`, which is the confusing part. Full cleanup:
+
+```bash
+rm -rf ../.murmur-agent-tasks/<task-id> .git/agent-harness/tasks/<task-id>
+git worktree prune && git -C ../murmur-server worktree prune
+git branch -D agent/<task-id>
+```
+
+## THE INSTRUCTIONS HASH COVERS `.agents/harness/*`, NOT JUST `CLAUDE.md`
+
+`run` refuses with *"active agent instructions changed after init"* if anything in the hashed
+instruction set moves between `init` and `run` — and that set includes `.agents/harness/config.json`
+and `task_runner.py`. Uncommitted local edits there (a teammate's in-progress harness improvement) are
+enough to trip it. Init and run back-to-back, and if it fires, re-init rather than hunting for the diff.
+
 ## THE PRE-PUSH CHECKLIST (each catches a real CI-cycle-waster)
 
-- `cargo test --lib <targeted>` green (NOT the full suite).
+- `cargo test --lib <targeted>` green (NOT the full suite). **This is not advice, it is arithmetic:**
+  the full suite is ~170 s, and running it 5× "to be sure" burned ~14 min of a program's wall clock
+  while CI was going to run it anyway. Filter locally; the full gate is CI's job.
 - **`cargo clippy --lib -- -D warnings` clean** — link-free, ~15s. Catches the `dead_code` class that
   `cargo test` AND `clippy --lib --tests` MASK (a const/fn used only in `#[cfg(test)]` is "unused" in
   CI's lib-only build; often the feature is inert too). Ate a CI cycle when skipped.
 - **MSRV grep**: `git diff origin/murmur -- src-tauri | grep '^+' | grep -oE 'is_none_or|LazyLock|split_at_checked|take_if'`
   → empty. `-D warnings` implies `-D clippy::incompatible_msrv` (MSRV 1.77); `is_none_or`(1.82) → `map_or(true, …)`.
 - FE PRs: `npx ng lint && npx ng build` (never `ng test`).
+
+## WHEN THE HARNESS WRITER DIES MID-ROUND (it is usually NOT the code)
+
+A writer session can be killed by a **tool-permission rejection**, not a build failure. Observed:
+4 of 68 shell calls refused (two heredocs, a `grep` with an odd pattern, a warnings sweep) — the
+`cargo test` runs in the same session had all SUCCEEDED, and ~1000 lines of good work were already on
+disk. The task lands in `BLOCKED`, which `reap` accepts but `close` does not.
+
+**Do not restart from zero.** Salvage:
+1. Inspect the log to find the ACTUAL cause — `logs/round-01-writer-<vendor>.jsonl`, look for the
+   `tool_result` with `is_error` and match its `tool_use_id` back to the `tool_use` block. If it says
+   *"The user doesn't want to proceed with this tool use"*, it was a permission denial, not a defect.
+2. Verify the worktree YOURSELF: targeted `cargo test`, `clippy --lib -D warnings`, `ng lint`,
+   `ng build`. Check the contract's load-bearing invariants by hand (e.g. "the pre-existing tests must
+   be byte-identical" → extract them from base and HEAD and diff).
+3. Finish whatever the writer never reached.
+4. **Then get an INDEPENDENT review anyway** — you are now an author. The harness is blocked, so run
+   the reviewers as a Workflow instead; the principle (the implementer never owns the verdict) is what
+   matters, not the runner.
+
+## TELL REVIEWERS THE PROVENANCE — IT CHANGES WHAT THEY FIND
+
+When part of a diff was written by the orchestrator, or salvaged, or hand-patched, **say so in the
+review prompt and tell them to treat those parts with MORE suspicion, not less.** This is not
+politeness; it is targeting. Doing it produced a same-round catch of a missing stale-result guard in
+orchestrator-written Angular — the exact class the repo's own rules call out, in the exact file the
+reviewer had been told to distrust. A reviewer given a diff with no provenance spreads attention
+evenly over code that does not deserve it evenly.
+
+Corollary: **fold fixes into ONE round.** Review → fix → re-review ran ~21 min sequentially; asking
+reviewers for exact patches alongside findings collapses that to one pass.
 
 ## VERIFIER DISCIPLINE (this is where the real bugs hide)
 

--- a/docs/research/2026-07-26-ux-program-five-workstreams.md
+++ b/docs/research/2026-07-26-ux-program-five-workstreams.md
@@ -1,0 +1,739 @@
+# Murmur Program Spec — Five Workstreams, Consolidated & Corrected
+
+*Synthesized 2026-07-26 from five ground-truth maps, five designs, and five adversarial critiques. Every load-bearing contested claim below was re-verified against the current tree before inclusion; verification results are inline. This document replaces further design work.*
+
+---
+
+## 1. Executive summary
+
+When all five land, Murmur stops making the user wait and stops making them guess. You press Stop and can immediately start the next meeting — the note writes itself in the background, visibly, resumably, and it yields the moment you record again. You pick transcription quality on a four-rung "power" slider that says what each level *does for you* rather than naming an ML checkpoint, with the level Murmur picked for your actual Mac (RAM, Apple Silicon vs Intel) badged and explained. Every screen speaks plain English — no egress, no GGUF, no posture, no ciphertext — while every privacy fact gets *more* explicit, not less, enforced by a CI vocabulary gate. Settings drops from ~70 everyday controls to ~30 behind real progressive disclosure. And Murmur updates itself: one calm daily check, a quiet download, Apple-notarisation verified on your own Mac before anything is touched, installed when you quit — never restarting on its own, never interrupting a recording, always able to put the old version back.
+
+---
+
+## 2. Cross-workstream coupling
+
+### 2.1 The dependency graph
+
+```
+                     ┌─────────────────────────────────────────┐
+                     │ P0  FOUNDATIONS                          │
+                     │ mur-progress, mur-disclosure, mur-select │
+                     │ CVA+value, copy modules, ErrorCopySvc,   │
+                     │ sizeLabel(), PipelineBusy guard,         │
+                     │ isPolish decouple, dead-code delete      │
+                     └───────┬──────────────┬──────────────┬────┘
+                             │              │              │
+              ┌──────────────▼───┐   ┌──────▼──────┐   ┌───▼──────────────┐
+              │ P1 CATALOG (Rust)│   │ P6 QUEUE    │   │ P8 UPDATER core  │
+              │ machine profile  │   │ core        │   │ (needs Pipeline- │
+              │ + whisper registry│  │ (BE+FE      │   │  Busy from P0)   │
+              │ + recommendation │   │  atomic)    │   └───┬──────────────┘
+              └──────┬───────────┘   └──────┬──────┘       │
+                     │                      │              │
+              ┌──────▼───────────┐   ┌──────▼──────┐   ┌───▼──────────────┐
+              │ P2 POWER SLIDER  │   │ P7 QUEUE    │   │ P9 UPDATER auto  │
+              │ (consumes P1 DTO)│   │ surface     │   │ (scheduler,      │
+              └──────┬───────────┘   └─────────────┘   │  on-quit, chip)  │
+                     │                                  └──────────────────┘
+              ┌──────▼───────────────────────────┐
+              │ P3 VOCAB machinery + errors      │
+              │ P4 SETTINGS IA (disclosure)      │
+              │ P5 VOCAB long tail + gate=FAIL   │
+              └──────────────────────────────────┘
+```
+
+### 2.2 Hard ordering constraints (each with its reason)
+
+| Constraint | Why |
+|---|---|
+| **P1 before P2** | The slider renders `WhisperModelDto[]` + `recommendedId`. Without the Rust catalog the FE would need a fourth hardcoded size table — the exact duplication P2 exists to delete. |
+| **P1 and P2 own ONE registry** | The "recommendation" and "power slider" designs independently proposed a `WhisperModel` registry + DTO. **Merged**: one `src-tauri/src/transcribe/catalog.rs`. Landing them separately would create two competing registries. |
+| **P2 before P3–P5** | The vocabulary pass must rename the *new* surface once, not the old nine-option `<select>` and then the new slider. Reversing this doubles the copy work and re-breaks `e2e/onboarding/model-presence-race.spec.ts` twice. |
+| **P0 before P6 and P8** | `PipelineBusy` (RAII counter on `retry_transcription` / `resummarize` / startup salvage) is the *shared* interlock primitive. Verified: `perf::recording_has_priority()` (perf.rs:298) is `active.is_some()`, and `begin_recording_session()` has exactly ONE non-test caller — `commands/mod.rs:1014` `start_recording`. `retry_transcription_prep` (mod.rs:5334) *checks* that flag, meaning while it runs the flag is **false**; `resummarize` (mod.rs:5221) never checks it at all. Both the queue worker and the updater need this counter to be correct. |
+| **P6 before P9** | P6 narrows `recording_has_priority()` from "Start→note exported" to "Start→end-of-Draining". An updater that shipped Automatic-install first would silently gain permission to install *during* the note pipeline. `PipelineBusy` closes that, but the queue worker MUST take the guard — a named, tested requirement in P6. |
+| **P8 before P9** | Manual "Download & Install" is independently shippable and exercises the whole verify/stage/swap/rollback chain under user supervision before any of it runs unattended. |
+| **P6 is atomic (BE+FE in one PR)** | A partial landing surfaces the raw `provider unavailable: another recording model session is already active` to users. The RED test `record-while-processing.spec.ts` is the acceptance gate that both halves are present. |
+
+### 2.3 Shared-file collision map (the merge-conflict surface)
+
+Every file below is touched by 2+ workstreams. Sequential PRs make each safe; **fanning these out in parallel is the merge-skew shape that has bitten this repo before.**
+
+| File | Touched by (in landing order) | Nature of the collision |
+|---|---|---|
+| `src/app/features/onboarding/onboarding/onboarding.component.{ts,html,scss}` | **P2** (model step rewrite, delete `SIZE_HINTS`, delete `modelSize=signal("small")` at :113 and `?? "small"` at :269) → **P4/P5** (posture tiles, Kong removal, Ollama copy, "Enable the brain" → "Turn on memory and search") | The single hottest file in the program. P2 restructures the model step; P5 rewrites the provider + brain steps. The `modelPresenceRequestId` triple stale-result guard must survive both, verbatim. |
+| `src/app/features/settings/sections/settings-transcription-section/*` | **P2** (card 1 → `<app-model-power>`) → **P4** (cards 2+3 behind `<mur-disclosure>`, renames) → **P7** (the "When recordings are processed" policy card) | Three structural rewrites of one section. |
+| `src/app/features/settings/settings.store.ts` | **P2** (delete `updateDownloadHint` + 9-row map, add `modelSizeValue`/`setModelSize` bridges) → **P3** (`CONNECTION_LABELS` → `glossary.ts`) → **P7** (policy form controls) | |
+| `src-tauri/src/transcribe/model.rs` | **P1** (registry, `recommend()`, `total_ram_bytes` pub(crate), `quality_tier_label`) → **P2** (cancel-generation threading, `delete_whisper_model_files`) | Merged registry; the six existing `default_model_size` tests must pass **unedited** through P1. |
+| `src-tauri/src/settings/ai_map.rs` | **P1** (transcription `model` cell → tier label; the assertion that breaks is **:181** `assert_eq!(tr.model, default_model_size_now())`, *not* the :165/:211/:234 brand names) → **P3** (`"On-device NER"`→`"Name masking"`, `"Retrieval only (no model)"`→`"Search only — no AI writing"`) | |
+| `src-tauri/src/commands/models.rs` | **P0** (`PipelineBusy` is separate, but the 5 download commands take a busy guard here) → **P1** (`machine_profile`, `list_whisper_models`, `whisper_recommendation`) → **P2** (`delete_whisper_model`, `cancel_model_download`, `fileIndex`/`fileCount`) | |
+| `src-tauri/src/events.rs` | **P1** (none — machine-change becomes a *pull*, see §3.3) → **P6** (`EVENT_PROCESSING_QUEUE`, `StatusPayload.progress/total_s`) → **P8** (`EVENT_UPDATE`) | |
+| `src-tauri/src/lib.rs` | Every PR (`generate_handler!` + `setup` wiring) | Serial cadence makes this trivial; parallel would guarantee conflicts. |
+| `src/app/app-shell/app-shell.component.{ts,html,scss}` | **P5** (nav `Graph`→`Connections`, relock toast copy) → **P7** (Processing chip + panel mount) → **P9** (Update chip) | Three chips land in `.sidebar-footer` above `.unlocked-pill`; ordering avoids three-way conflict. |
+| `src/app/features/record/record/record.component.{ts,html}` | **P5** (provider labels, consent banner via `ErrorCopyService`) → **P6** (delete `isProcessing`, drop `!isBusy()` from `canRecord`, hand-off strip) | P5's `needsCloudConsent` switch from prose regex to `code === "cloud-consent"` must land before P6 touches the same file. |
+| `src/app/core/{models.ts,ipc.service.ts}` | All PRs | Append-only; safe in series. |
+| `e2e/onboarding/model-presence-race.spec.ts` | **P2** (rewrite against the slider) → **P4** (the control moves behind a disclosure) | Must stay RED-before-GREEN in both rewrites — verify by reverting `modelPresenceRequestId` and watching it fail. |
+| `src/app/features/settings/sections/settings-about-section/*` | **P5** (keywords, licence lines preserved) → **P8** (Software update block rewrite) | |
+| `scripts/ci.sh` | **P3** (vocabulary gate, WARN) → **P5** (gate → FAIL) | |
+| `scripts/macos-sign-notarize.sh` + `.claude/skills/release-murmur/SKILL.md` | **P8** (app-level staple + `.sha256` sidecar) | Isolated; can land any time before P9. |
+
+---
+
+## 3. The corrected designs
+
+### 3.0 Program-wide corrections (apply to all five)
+
+Three claims appeared in multiple designs and are **wrong**. They are corrected once here.
+
+1. **`.field-help` is NOT a global primitive.** Verified: absent from `src/app/design-system/primitives.css` and `src/styles.css`; it is redeclared per-section (`settings-notes-section.component.scss:33`, `settings-audio-section.component.scss:27`, `settings-transcription-section.component.scss:92`, `model-effort-picker.component.scss:224`, `ai-connection-card.component.scss:82`). **P0 promotes it to `primitives.css` once and deletes the five copies.**
+2. **There are SEVEN hand-rolled progress bars, not four.** Verified `grep -rln "progress-track" src/app`: onboarding, brain-posture-block, local-models-list, model-effort-picker, on-device-intelligence-block, settings-privacy-section, settings-transcription-section. **P0 ships `mur-progress`; P0 migrates all seven** (it is mechanical and prevents the count growing to nine).
+3. **The global reduced-motion block already exists** (`src/styles.css:112-118`, `*, *::before, *::after { transition-duration: 0.01ms !important; animation-duration: 0.01ms !important }`). Per-component `prefers-reduced-motion` blocks are belt-and-braces only — say so, don't present them as the mechanism. One exception is legitimate: a keyframe whose `from` state hides content (`opacity: 0`) needs a component-level `animation: none` so the content is not left invisible.
+
+---
+
+### 3.1 W1 — Background processing queue
+
+**The one architectural change stands, verified.** `commands/mod.rs:1891` `transition_to_postprocess()` → `:1940` `run_file_backed(...)` → `:1962` `model_session.finish()`; `perf.rs:521` `begin_recording_session` refuses while `active.is_some()`; `finish()` is the only clearer. Ending Stop at enqueue frees the slot.
+
+#### Accepted corrections
+
+**A1 — LOCKED holds are a REACHABLE, normal state. The "unreachable" argument is deleted.**
+Verified in `commands/lock.rs`: `if folder.locked { … finish_folder_lock_after_seal(...); return Ok(()); }` returns **before** the `folder_has_nonterminal_recording_generation` refusal further down. That early return is the *common* case (folder `locked=1`, merely session-unlocked). `relock_folder` (lock.rs:658) and `relock_all_inner` (lock.rs:732) never check it at all. Consequence: the whole checkpoint-safety argument that rested on "a pending job's folder can never be locked" is void.
+
+**A2 — `postprocess_asr_windows` is first-class sealed content, cleared on EVERY relock path.**
+Verified: `relock_folder` and `relock_all_inner` both funnel through `commands/mod.rs:8139 reblank_folder_extras`, which knows only `raw_segments`/`raw_timeline`/the session WAV. `seal_folder_extras` (mod.rs:7395) is a *different* function on a *different* path.
+→ `clear_asr_windows_for_folder` + per-stream cursor reset goes into **both** `reblank_folder_extras` **and** `seal_folder_extras`. It is a pure cache drop (the verified archive WAV remains the source), never content loss. RED test: seed a checkpoint row, call `relock_all_inner`, assert zero rows.
+
+**A3 — TRANSCRIBE→SUMMARIZE is a single NON-yielding unit.**
+`pipeline.rs:1080 db.replace_segments(...)` writes plaintext segments; the seal happens later (`seal_auto_filed_note`). `reblank_folder_extras` skips a segment set with no `text_blob` (`mod.rs:8156 if s.text_blob.is_some() && !s.text.is_empty()`). A job parked at the stage boundary under `manual` policy would leave unsealed plaintext indefinitely. **Yield boundaries are: (a) an ASR chunk edge, (b) *before* the ASR stage begins. Never between `replace_segments` and the terminal seal.**
+
+**A4 — Pause on a RUNNING job gets a real mechanism.**
+`should_yield` becomes composite: `perf::background_should_yield() || postprocess::hold_requested(meeting_id)`, backed by a process-global `Mutex<HashSet<String>>` set by `hold_processing_job` **before** its CAS, plus `background_yield_notify().notify_waiters()`.
+
+**A5 — Yield latency is sub-window, and the 30 s Start budget is the binding constraint.**
+Verified `pipeline.rs:1134` `const WINDOW_FRAMES: usize = 120 * audio::TARGET_RATE_HZ` — 120 **seconds of audio** per window, tens of seconds of large-v3 decode. Plus an uninterruptible `Transcriber::load` of a 2.9 GB model at `pipeline.rs:1036-1042`. `start_recording` hard-fails after 30 s with `"local AI did not quiesce in time to start recording safely"`.
+→ `should_yield` is checked **inside `transcribe_stream`'s per-VAD-chunk loop**, not only at window edges. Additionally the worker refuses to *claim* a new job when the whisper model is not already resident. Wall-clock Stop→Start must be **measured on a real Mac**; a green unit test is not proof.
+
+**A6 — The ASR checkpoint is written by a sink passed INTO the closure, and resume is per-stream.**
+Verified: `transcribe_raw_windows` is called twice — mic at `pipeline.rs:1043`, system at `:1056` — both inside ONE `run_heavy_maybe_recording` closure opened at `:1036`. `run_file_backed_inner` never sees intermediate windows.
+→ Signature gains `sink: &dyn WindowSink` (an `Arc<Db>` + meeting id + stream tag behind a trait) that persists each window **as it completes**, so the checkpoint is a *crash* checkpoint as well as a pause checkpoint. `AsrOutcome::Yielded` then carries only `next_frame`.
+→ **`postprocess_jobs.asr_cursor_frames` is DELETED.** Resume is derived: `SELECT stream, MAX(end_frame) FROM postprocess_asr_windows WHERE meeting_id=? GROUP BY stream`. A single scalar cannot express "mic complete, system at frame N". A denormalised `transcribed_s` stays for the progress DTO only.
+
+**A7 — Progress denominator is total decodable frames across both streams**, not `audio_duration_s` (which would stall at 50 % then restart). Copy: `Transcribing… 12 of 31 min` where both numbers are stream-summed.
+
+**A8 — The admission gate is corrected and completed.**
+- `topic_backfill_ram_permits_now()` is called **alone** — verified `transcribe/model.rs:391` already ends in `crate::perf::heavy_op_permitted(floor_ok)`. The design's double-wrap is deleted, as is the false claim that this is the first batch-pipeline consumer (it is used at `audit.rs:414`, `lib.rs:741`, `commands/documents.rs:81`, `commands/models.rs:507`).
+- **Add the standby voice listener** to the gate: it owns Whisper RAM (`lib.rs` restarts it only after recovery relinquishes priority; `start_recording` stops it at `mod.rs:1016`). Either idle while it holds a model, or stop/restart it around a claimed job the way `start_recording` does.
+- Add `perf::startup_recovery_has_priority()` (verified `perf.rs:212`).
+
+**A9 — Worker spawn ordering is a HARD constraint, not a soft one.**
+Verified `lib.rs:559` calls `perf::begin_startup_recovery()` **synchronously** on the setup thread; on `Err` → `show_fatal_init_dialog(...); return Ok(())` — the app is dead. `perf.rs:194-197` refuses when `!state.generations.is_empty()`. A worker that claims a generation before line 559 **hard-kills launch**, violating the binding "startup must never hard-crash" rule. The spawn goes strictly after, with a comment at the site.
+
+**A10 — Retry copy tells the truth about degradation.**
+Verified `pipeline.rs:1194-1197` doc: `run_salvage_from_disk` re-runs from the combined archive → single-stream, every segment attributed to `me`, no diarization. Row copy: **`Try again — speaker labels will be lost`**. The WAV path comes from the archive assertion (`audio_dir()?.join(assertion.basename())`), gated by `meeting_is_unlocked` first.
+
+**A11 — `list_processing_jobs` states its gate literally.**
+There is no reusable title-masking helper — `get_meeting_detail` uses `masked_detail(anchor)` (`commands/meetings.rs:502`), a whole-DTO builder. Per row: `if !meeting_is_unlocked(state, &id)? { title = "🔒 Locked"; durationS = None; transcribedS = None; folderName = None; }`. Never an on-disk path. RED test named in the verification bar.
+
+**A12 — `between_meetings` gets a persisted anchor.** `last_capture_end_ms` initialised from `MAX(meetings.ended_at)` at boot, not `0` — otherwise the policy silently degrades to `immediate` after every relaunch. Explainer copy states the rule plainly: *"Waits until you've been done recording for N minutes."*
+
+**A13 — Offline is a hold, not a failure.** New `hold_reason='OFFLINE'`. Network-classified errors do **not** increment `attempts`; copy: `Waiting — you're offline`. Without this a cloud summarize on a plane burns all three retries in ~45 s and becomes permanently `FAILED`.
+
+**A14 — Settings and the panel do NOT share a form.** Verified `settings.store.ts:104` is bare `@Injectable()`, provided at `settings.component.ts:91` and `brain-enable-card.component.ts:38`. The shell-mounted panel calls `set_processing_policy` directly (which already validates + clamps server-side) and reads a small root signal-holder; `SettingsStore` refreshes from the same command.
+
+**A15 — `mur-segmented` is not a CVA.** Verified `segmented.component.ts:33 readonly value = model("")`. Bind `[(value)]` + an explicit write, in both the Settings card and the panel. (P0 does **not** add CVA to `mur-segmented`; the two-way binding is sufficient and lower-risk.)
+
+**A16 — Minor fixes:** drop `CHECK (updated_at_ms >= enqueued_at_ms)` (an NTP correction must never wedge a state machine — write `updated_at_ms = MAX(?, enqueued_at_ms)` instead); audit `src-tauri/src/mcp.rs` and the search/graph readers for the new `QUEUED` variant; reconcile the 20 s `finish_task` timeout continuation (which already writes `Error` + `release_for_recovery`) against the enqueue path so both cannot target the same generation.
+
+#### Rejected / partially rejected
+
+- **Rejected: adding a third owner kind to `perf.rs`.** The existing unscoped-generation semantics already encode the priority we want, and a new owner kind fans out through `acquire_work_lease`, `run_heavy_maybe_recording`, `make_provider_resolved` and all three `acquire_external_egress_lease` sites in `summarize/redact.rs`. The two-function `perf.rs` addition (`background_should_yield`, `background_yield_notify`) stands.
+- **Partially rejected: "cancel".** The critique is right that refusing a cancel state is a scope reduction the user should be told about, and it is now in §5. But the design's reasoning holds: `Pause` covers "not now", `Discard` covers "gone", and a third "cancelled-but-half-processed" state would be a lie about what happened to the content. **Kept as designed, surfaced as a user decision.**
+- **Rejected: making `Processing` the queue's problem to define for the updater.** It is the updater's `PipelineBusy` guard (P0); the queue worker takes one. Two owners of one truth is worse than one.
+
+#### The plaintext-WAV window (new, disclosed)
+
+A `HELD`/`LOCKED` or `manual`-paused job leaves an unencrypted archive WAV in the scoped audio dir indefinitely. The `convertFileSrc` gate still holds (the masked DTO nulls `audio_path`, `commands/meetings.rs:501-502`), so this is **not** a leak — but "briefly" becomes "days". Stated explicitly in the PR body and the lock-security review scope.
+
+---
+
+### 3.2 W2 — Transcription power slider
+
+#### Accepted corrections
+
+**B1 — `mur-power-slider` owns its own `<input type="range">`.**
+Verified `slider.component.html`: one `(input)` listener, no `(change)`, no `[attr.aria-valuetext]`, no `[attr.aria-describedby]`, no keydown, no pointer events. Composing it would require six passthroughs and would break the "Appearance is byte-identical" promise. The new control reuses `mur-slider`'s track/thumb SCSS via shared rules in `primitives.css`, not by wrapping the component.
+
+**B2 — `mur-power-slider` IS a `ControlValueAccessor`.** The design's refusal violated `angular-zoneless.md` §6b and its premise was false: `select.component.ts::onChangeEvent` already demonstrates a CVA that calls `onChange` **only** on `change`. Same here — preview on `input`, commit (and `onChange`) on `change`. Settings then binds `formControlName="modelSize"` directly, and `setModelSize`/`languageValue`/`modelSizeValue` all disappear from `SettingsStore`.
+
+**B3 — `MurSelectComponent` gains `value = model<string>("")` + `disabled = input(false)` alongside the CVA.** Verified: it exposes only `ariaLabel` as an input; `value`/`disabled` are internal signals written solely by `writeValue`/`setDisabledState`, and there is no `output()`. Onboarding has no reactive form, so signal I/O is required there. `select.component.{ts,html}` is now in P0's file list.
+
+**B4 — The card is FULLY CONTROLLED in both hosts.** `[size]` in, `(sizeChange)` out. The catalog's `selectedId` seeds the host on first load and drives `selectedOffCatalog`; it never fights the host. Onboarding's handler sets the signal **then** calls `refreshModelPresence()` in that order (`persistConfig` reads `this.modelSize()` — reversing it persists the old size).
+
+**B5 — `delete_whisper_model` gains a fourth refusal: the live-caption pin.**
+Verified: `live_model_pin` serde-defaults to `"small"` and `live_pin_size` returns it unconditionally; on the shipped turbo default the batch model is `large-v3-turbo-q8_0` while live captions run `small`. The design would let a user delete `small` (its "Balanced" rung) with no way back — `modelPresent` reports the *batch* model, so the Download button never appears, and `companion_size` is only reachable from `download_model`.
+→ Refuse any size whose resolved filename equals `model_filename(live_pin_size(cfg), language)`, with copy naming it as the live-caption model. **Plus a repair affordance**: when `live_captions::dto_probe` reports `NoModel`, the card shows a `Get the live-caption model` button independent of `modelPresent`.
+
+**B6 — Every RAM number comes from `docs/research/2026-07-09-transcription-performance.md`, rounded UP, with the source line in the registry doc-comment.** The design's figures (Sharp "about 1 GB", Maximum "about 3.1 GB", Balanced "about 0.6 GB") all *understate* the cited source (turbo-q8 ~1.2–1.5 GB, large-v3 fp16 ~3.9 GB, small ~0.9 GB). The invented `"Maximum wants about 16 GB of RAM"` sentence is **deleted** — no `min_ram_gb` for `large-v3` exists anywhere in the tree.
+
+**B7 — The `.en` state is explicit.** `model_filename` appends `.en` only for exact `tiny|base|small|medium`. A user with `ggml-small.bin` who selects English sees Balanced flip to not-downloaded. New §6 row: *"You have the multilingual build; English-only is a separate ~470 MB file — or leave Language on Auto-detect and use what you have."* Either add `approx_download_bytes_en` to the registry, or delete the claim that the size changes per language. (Recommend: delete the claim; the `.en` build's size delta is not measured.)
+
+**B8 — Cancel is a generation counter, not a global bool.** `cancel_model_download` bumps `model_download_generation: AtomicU64`; each download captures it at entry and its `should_continue` closure compares. Self-clearing, immune to the post-completion race, and immune to the bug where a cancelled whisper download kills the next Parakeet download (`download_parakeet_models` is a separate command the design never cleared the flag in). Lives as a module-private static in `transcribe::model`, **not** on `AppState` — verified five exhaustive `AppState { … }` literals exist (`commands/documents.rs:877`, three test builders, `AppState::init_at`) with no `..Default::default()`.
+
+**B9 — Cancel returns `Ok`, not `Err`.** Mapping a user-initiated cancel to `AppError::Unavailable("download cancelled")` is the wrong failure domain and forces the card to string-match. `download_model` returns `Ok(DownloadOutcome::Cancelled)`.
+
+**B10 — The "latent double-subscription" bug is DELETED, along with its verification step.** Verified: `TabRouteReuseStrategy::tabKey` covers only `meeting/:id`, `notes/:id`, `org-item/:id`; `/settings` and `/onboarding` are destroyed on navigate; `SettingsStore` is component-provided and releases its listener in `destroyRef.onDestroy`; both handlers self-gate. The two listeners can never be simultaneously alive. **A verification step that cannot fail is worse than none.** The root `TranscriptionModelsService` remains justified on its real merits: two hosts, and `SettingsStore` dies on leaving Settings.
+
+**B11 — The pre-download file plan uses `companion_pending_in`, made `pub(crate)`.** `companion_size` takes the *post*-download path (`&path`, the `ensure_model` return). `src-tauri/src/commands/live_captions.rs` joins the file list. The "never a second FE-side rule" framing is softened — a pre-fetch plan is unavoidably a derivation — and a test asserts `companion_pending_in` agrees with `companion_size` for the default install (template: the existing `companion_pending_matches_the_download_decision`).
+
+**B12 — Onboarding gets a cold-cache fallback.** Onboarding *is* first launch; the root service has nothing cached, and `list_whisper_models` is fallible (`models_dir()?` → `AppError::Transcribe` on `create_dir_all` failure). The step is the app's only hard gate with no skip. → Label gated: `@if (models().length) { Download {{recName()}} ({{size}}) } @else { Download model }`, and the "Show all sizes" disclosure is **always openable** regardless of catalog state.
+
+**B13 — `whisper_model_path` is modelled.** Verified `resolve_model_path` returns the configured path verbatim when it `is_file()`, **before** any size resolution. `WhisperCatalogDto` gains `custom_path_override: bool`; when true the ladder dims and the card says *"A custom model file is configured in Settings → General; it overrides this choice."* — no badge, no tier word.
+
+**B14 — `#[serde(default)]` on `ModelDownloadPayload` is dropped** (verified `events.rs:178` derives `Serialize` only; the cited `EmbedDownloadPayload` mirror carries no such attribute). Fields added plainly.
+
+**B15 — Delete is gated by `lifecycle_guard`, not only `recording_has_priority`.** Verified `retry_transcription_prep` refuses when `recording_has_priority()` — meaning while a retry runs, that flag is false and a delete would sail through. Use the same guard `retry_transcription_prep` uses.
+
+**B16 — The power rank and the accuracy meter agree.** `large-v3` ranks after `large-v3-turbo-q8_0` **on cost, not on accuracy** — stated in the `power` field's doc comment. The cited research lists `large` at FLEURS Polish 7.2, *worse* than large-v2's 5.4, and flags direct turbo-vs-large-v3 as unpublished. Sharp and Maximum share an accuracy meter; the ordering tiebreak is honest.
+
+**B17 — `live_safe` is USED or removed.** Kept, and consumed by: the delete guard (B5) and a `Also powers live captions` note on Balanced. The catalog↔`is_live_heavy_model_file` equivalence test stays.
+
+**B18 — Minor:** `[disabled]` flipping mid-drag must force a DOM resync (write the element's `value` property directly — the signal-CVA revert-coalescing trap); "Auto-detect plus the existing **nine** languages" (not ten).
+
+#### The ONE ladder (reconciling W2 and W5)
+
+The vocabulary workstream proposed a *different* three-tier ladder (`Fast`=small-q8_0 / `Balanced`=turbo-q8 / `Best`=large-v3). That ladder is **wrong**: verified `default_model_size` returns `"small"` on every <12 GiB Mac and on every existing install without turbo on disk (`transcribe/model.rs`, three branches, presence-first). `small` is not on that ladder, so **"Custom" would be the default display state for a whole class of Macs**.
+
+**Binding: one four-rung ladder, and both backend defaults are on it.**
+
+| Rung | id | size | headline |
+|---|---|---|---|
+| **Light** | `base` | ~150 MB | Gets the gist. |
+| **Balanced** | `small` | ~470 MB | Readable transcripts, small footprint. *(a backend default)* |
+| **Sharp** | `large-v3-turbo-q8_0` | ~875 MB | Near-best accuracy, no speed penalty. *(the other backend default)* |
+| **Maximum** | `large-v3` | ~3 GB | The heaviest model, for hard audio. |
+
+`tiny`, `small-q8_0`, `medium`, `medium-q8_0`, `large-v3-turbo` live in the "Show every size" table with the honest id in muted mono. `large-v3-q5_0` ships `provisional: true` and is hidden until its size is measured (it has no size anywhere in the repo, and inventing one would be exactly the slop this program forbids).
+
+---
+
+### 3.3 W3 — Hardware-aware recommendation *(merged into P1 with W2's registry)*
+
+#### Accepted corrections
+
+**C1 — `recommend()` and `default_model_size()` are DIFFERENT functions.**
+Verified `default_model_size` is path-dependent: (1) turbo file on disk → turbo at any RAM; (2) no whisper `ggml-*.bin` **and** RAM ≥ 12 GiB → turbo; (3) else `small`. The shipping tests pin exactly this (`default_model_size(&["ggml-large-v3.bin"], Some(64*GIB)) == "small"`).
+→ `catalog::recommend(total_ram_bytes, apple_silicon) -> Recommendation` is **pure over hardware**; no `models_dir_files` argument. `default_model_size` keeps its three branches and consults `recommend()` only for branch (2). `WhisperCatalogDto` then carries **both**: `recommendedId` (the honest hardware answer, which the badge renders) and `autoDefaultId` (the never-surprise first-run answer). Without this split, `tier` and `batchSize` disagree for **every existing install**, and the flagship "your pick is BELOW the recommendation" state is unreachable.
+
+**C2 — Apple Silicon vs Intel is IN the tier mapping.** The brief named it first; the design probed `hw.optional.arm64` and then never used it. Murmur ships `--target universal-apple-darwin`, and `whisper-rs` runs `features = ["metal"]` — Metal on an Intel iGPU is not the machine the 12 GiB floor was tuned against. **Intel caps at `small` regardless of RAM**, with its own tier and its own reason string. Fail-SMALL on an unreadable arch probe. Also read `sysctl.proc_translated` alongside `hw.optional.arm64` (the Rosetta rationale in the design was probably backwards; both are cheap).
+
+**C3 — The machine-change nudge is a PULL, not a push.**
+Tauri does not buffer events and the webview has not called `listen()` during `setup`. The design also overwrote `machine_fingerprint` at emit time, making the nudge unrecoverable. → At `setup`, on mismatch write a `machine_change_pending` settings row **and only then** the new fingerprint. Add `machine_change_nudge()` / `dismiss_machine_change_nudge()` commands; `MachineService.refresh()` reads it. `EVENT_MACHINE_CHANGED` and `MachineChangedPayload` are **deleted**. Precedent in-tree: `brain_model_retirement_nudge` returns `Option<RetiredModelNudge>`.
+
+**C4 — Brain advice raises its floor.** The design told a 16 GB Mac it can run the full on-device brain on a 12.2 GB *estimate*, while citing the **measured** 14 GB main-process recording peak to justify whisper conservatism. Same evidence, two standards. → `Full` requires ≥ 24 GB until a real measurement exists; below that, `Reactions`. Route the whisper term through the same measured constant.
+
+**C5 — The reason string is authored in Rust with a REASON ENUM.** `recommended_reason: { AlreadyDownloaded, FreshInstallAmpleRam, IntelCap, ExistingInstall }`, returned adjacent to `default_model_size` so it cannot drift. Three copy variants; the RAM-causal sentence ("Your Mac has 32 GB, so Murmur picked Sharp") is only used for `FreshInstallAmpleRam`. Rendering one causal sentence for a presence-first decision is the same class of dishonesty the vocabulary workstream exists to remove.
+
+**C6 — `mur-recommend-badge` is DELETED. Use `<mur-pill kind="accent" [dot]="false">✓ Recommended for this Mac</mur-pill>`.** Verified `primitives.css:229` `.pill.is-accent { background: var(--accent-soft); border-color: transparent; color: var(--accent-hover) }` and `pill.component.ts:21-24`'s `dot` input already deliver the entire spec, minus the ✓ glyph. The proposed `1px solid var(--accent-ring)` border would make it the only accent pill in the app with a visible ring. If the pop entrance is wanted, add one `.pill.is-pop` rule to `primitives.css` — that is *extending* the catalog, which the rule endorses.
+
+**C7 — The free-disk NSURL read is wrapped in `objc2::exception::catch`, not `std::panic::catch_unwind`.** `resourceValuesForKeys:error:` can raise `NSInvalidArgumentException`, which `catch_unwind` cannot catch — the exact FFI-abort class `rust-tauri.md` §7 exists to prevent. The `exception` feature is already enabled (`Cargo.toml:170`). `catch_unwind` stays correct for the NSProcessInfo *getters* (the shipped `thermal::read_thermal_level` precedent).
+
+**C8 — Free disk counts the companion.** `pendingDownloadBytes: u64` computed in Rust = batch row + companion when `companion_pending_in` says one is planned. The FE compares against that one number and never sums sizes itself.
+
+**C9 — `model_size_source` is backfilled and reversible.** When absent AND `onboarded == true` AND `model_size` non-empty → persist `"user"` (an existing install's choice is deliberate). Carried as `Option<String>` in the DTO (absent = preserve, `Some("auto")` = reset, `Some("user")` = mark), so the field is not write-once. `Switch to Sharp` sets `"auto"`; the Quality control sets `"user"`.
+
+**C10 — `machdep.cpu.brand_string` is normalised.** Accept only `Apple …` ≤ 24 chars; otherwise drop the chip clause entirely (Intel returns `Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz`, which would read absurdly). Unit-test both shapes against literal fixtures. The marketing-name ban (`MacBook`, `iMac`, `Mac mini`, `Mac Studio`) is mechanically checkable — verified `rg -i 'macbook|imac|mac mini|mac studio' src/app src-tauri/src` returns **zero hits today**, so the gate is green at baseline and worth wiring into the vocabulary scanner.
+
+**C11 — Ship only what a consumer reads.** `total_ram_bytes`, `apple_silicon`, `chip_name`, `free_disk_bytes` cross IPC. `logical_cores`, `perf_cores`, `os_version`, `low_power_mode`, `thermal` are probed if free but **not** exposed until something branches on them. (This also removes the `ThermalLevel: !Serialize` problem — verified `thermal.rs:42` derives no `Serialize`.)
+
+**C12 — One command, not two.** `whisper_recommendation()` embeds the machine profile; `machine_profile()` is dropped (or references, never duplicates). Two sources that re-read volatile fields at different instants can disagree about free disk.
+
+**C13 — `machine.refresh()` fires on download completion** (`p.done` in both progress handlers). Otherwise `downloaded` flags go stale immediately after the one action the screen exists to perform.
+
+**C14 — `MachineService.dismissed` is `_dismissed` + `.asReadonly()` + `dismiss()`.** Rule §2.
+
+**C15 — `ai_map.rs`'s breaking assertion is `:181`** (`assert_eq!(tr.model, default_model_size_now())`), not the brand-name assertions at :165/:211/:234 which the non-goals list explicitly keeps. Also define the `model_by_id(...) == None` fallback (blank `model_size`, or a custom path): render the raw id, never an empty cell.
+
+**C16 — `mur-banner` has no dismiss.** Verified `banner.component.html` is icon + `<ng-content/>`, and `banner.component.ts:18` hardcodes `role: "alert"`. Project the ✕ as content, and for the passive/info case use `<div class="banner is-info" role="status">` instead — an assertive live region mutated by a background stream during a recording is exactly wrong. One live region per card.
+
+#### Rejected
+
+- **Rejected: adding `"NSValue"` to `objc2-foundation`** as the default path. It *is* a zero-new-crate feature flag (`NSValue = []` in the crate manifest, Cargo.lock unchanged), and it is offered as a user decision in §5 — but the **recommended default is the `respondsToSelector`-guarded `msg_send![num, longLongValue]` under `objc2::exception::catch`**, which needs no manifest edit at all and is fully rules-compliant. Fifteen lines.
+- **Rejected: lowering `TURBO_DEFAULT_MIN_RAM_BYTES` from 12 GiB in this program.** Sharp is ~1.2–1.5 GB resident on top of the app, whisper's working set and the brain sidecar — exactly the pressure class the 2026-07-21 incident measured. It is a behaviour change for low-RAM users and must be gated on one RSS-over-time measurement on a signed build, not a design document. Surfaced in §5 as non-blocking.
+
+---
+
+### 3.4 W4 — Plain-language vocabulary + Settings IA
+
+#### Accepted corrections
+
+**D1 — The Ollama posture tile keeps naming Ollama.**
+Verified `onboarding.component.ts:59 LOCAL_PROVIDER_ID = "ollama"` and `:411-412 if (p === "local") { this.provider.set(LOCAL_PROVIDER_ID) }`. The proposed *"Uses Murmur's built-in AI. Nothing leaves your Mac."* is **false**. Corrected: **`Only on this Mac`** / *"Uses Ollama, free software you install on your Mac. Nothing leaves this Mac."*
+**And the `ollama serve` / `ollama pull` steps do NOT move behind a disclosure** — a required setup step is not progressive-disclosure material. They stay visible, reworded plainly.
+
+**D2 — The `matchLabel` "real bug" is DELETED, along with its RED test.**
+Verified end-to-end: `library.component.ts:914` and `quick-search.component.ts:71` both call `ipc.searchMeetings` → `invoke("search_meetings")` → `commands/meetings.rs:103` → `db.search_visible(...)` → `search_snippet` (db.rs:7295-7326), which returns **only** `"title"`, `"transcript"`, `"note"`. The values `semantic`/`entity`/`topic`/`temporal` are produced by `search_semantic_visible`, `search_hybrid_visible`, `search_visible_in_range` — whose callers are `tools.rs`, `vault_context.rs`, `related_context.rs`, `embed.rs`, none of which returns a `SearchHit` list to a `matchedIn` chip. **A RED test on an unreachable input is a fake RED.**
+→ `matchedInLabel()` ships for the three reachable values (`in the title` / `in the transcript` / `in the note`); the other four arms are either dropped or kept with a comment marking them forward-looking. The claim that this is a bug fix is removed from the design, the risks and the verification plan.
+
+**D3 — The ledger renames are corrected.** `Tokens by model` → **`By model`**, not "By AI service" — verified `storage/egress_store.rs:154` groups by model label and `egress-ledger.component.html:54` renders `{{ m.model }}`; two Anthropic models would render as two "AI services". "model" is the honest word and joins the non-goals list. `Tokens sent` keeps a unit that matches the data (`{{ fmtTokens(l.totalTokens) }}` at :35) — either **`Tokens sent`** with a gloss *"roughly ¾ of a word each"*, or change what is counted. Do not rename a unit without changing the number. `PII scrubbed` → **`Emails, phones and cards removed`** (the design's own rule says redaction is *always enumerated*; "Details removed" is a bare noun).
+
+**D4 — The error-copy layer is scoped honestly and fails DENY-BY-DEFAULT.**
+Verified: **185 `String(e)` sites across 47 files** (design said "~40"). Rust side: ~2100 `AppError::*` constructions, ~161 with a never-show term in the *body* (`"brain sidecar stdin missing"`, `"account-session mutex poisoned"`, `"E2EE decrypt/authentication failed"`, `"HKDF expand failed"`). The design's fallback heuristic ("contains `::`, a path separator, or an all-lowercase-snake token") matches **none** of those.
+→ `[code]` is applied to a named allowlist of the ~20 errors that actually reach a banner or toast, **and any un-coded error renders the generic sentence**. Pass-through is removed. Scope is stated in the PR body: 185 sites, 47 files, routed mechanically.
+
+**D5 — The vocabulary gate scans Rust too.** The single worst offender in the product was a Rust string. A second pass over `src-tauri/src/**/*.rs` restricted to `AppError::*("…")` literals, `format!` args into AppError, and the display fields in `settings/ai_map.rs` + `summarize/roles.rs`. Rust allowlist seeded for log-only strings.
+
+**D6 — The gate ships in WARN mode (P3), flips to FAIL (P5).** The design said both "must fail with dozens of hits on trunk" and "allowlist seeded to pass on current trunk" — an allowlist big enough to make trunk green *is* the rubber stamp its own risk section warns about. → Two files: `.vocabulary-baseline.json` (transitional hit list, asserted monotonically shrinking) and `.vocabulary-allowlist.json` (permanent, `reason` required per entry).
+
+**D7 — Eight `friendly*Error` mappers, not six.** The two missed — `share-panel.component.ts:515` and `note-share-panel.component.ts:406`, both `friendlyUnlockError` on the **lock gate** — join the fold-in list and P3's lock-security scope.
+
+**D8 — A pointer sweep is part of every rename.** Verified dangling cross-references: `ai-privacy-strip.component.html:35` "(in Privacy & integrations)"; `settings-privacy-section.component.html:31` `<h3>Privacy &amp; integrations</h3>` (the section's own heading, not just the sidebar label); `audit.component.html:37` "Settings → AI & Models"; `onboarding.component.html:397` and `:437` the same. Gate rule: a rendered section label appears only in `SETTINGS_SECTIONS` and that section's own `<h3>`.
+
+**D9 — `[code]` coverage or a recorded coupling.** `brain.component.ts:699-738 friendlyImportError` prose-matches six Rust strings. Either extend `[code]`, or record every prose-coupled Rust string in `error.rs`'s doc comment so a future de-jargon PR cannot break them silently. Currently nothing records the coupling.
+
+**D10 — The Quality ladder is W2's four rungs (§3.2), not this workstream's three.** Resolved above.
+
+**D11 — Posture e2e specs are named.** `e2e/settings-ai/brain-posture-block.spec.ts:53,63,66,74,77,79,84` and `e2e/settings-ai/posture-auto-download.spec.ts:14,76,79,86` pin `/Hybrid/`, `/Fully local/`, `/Fully local needs/`, `/Download .* enable Fully local/` — a confirm-first-then-download safety flow. Verified 8 specs assert `"AI & Models"` (of 64 total; the "54 broken" figure was invented). Rewrite selectors to role + testid rather than re-pinning new prose.
+
+**D12 — The `settings.store.ts` `modelSize: "large-v3"` initializer change is REMOVED from this workstream.** Verified `load()` does `cfg.modelSize ?? "small"`, so the initializer never decides anything, and `""` matches no `<option value>`. It is P2's business (the card renders `selectedId`), not a copy PR's.
+
+**D13 — Settings search auto-opens the owning disclosure.** A keyword hit that resolves to an Advanced-only control must reveal it. Precedent exists: `SettingsStore.expandAdvanced()` (settings.store.ts:1186) and the `_autoExpand` effect (ai-advanced-block.component.ts:44-57). The keyword→disclosure map lives in `glossary.ts`; the e2e asserts the **control** is visible, not just the section.
+
+**D14 — `<mur-disclosure>` needs `:host { display: contents; }`** (verified `ai-advanced-block.component.scss:1-3` — required because `settings-ai-section` flex-stacks its children).
+
+**D15 — Label helpers move into a `computed()` view-model**, not template method calls. Verified `library.component.html:206-207` calls `matchBadgeClass(...)` / `matchLabel(...)` inside a `@for` — banned by the rules table. The design *claimed* this was fixed; the file list didn't deliver it.
+
+**D16 — "Connections" is used once.** The glossary bans `connection` as an AI-service alternate, renames nav `Graph`→`Connections`, and renames the lens group `Links`→`Connections`. Resolved: nav → **`Connections`**, lens group stays **`Links`**, and `connection` leaves the never-show list with a note (the graph sense is legitimate).
+
+**D17 — Protected-clause anchors corrected.** P4's broad claim (*"a remote Ollama server counts as cloud"*) lives at `settings-privacy-section.component.html:44-49`, not `ai-connection-card.component.html:326-334` (which says the narrower "a local gateway can still forward to the cloud"). P15's shipped text is *"your **database** encryption keys are never passed through"*. Both fixed so `privacy-honesty.spec.ts` asserts the fact that is actually there. All 15 protected clauses were spot-checked and are real.
+
+**D18 — `note-editor.component.ts:1528/:1606` case-sensitive `"Locked"` guard is fixed in P3.** Verified every producer is lowercase (`error.rs:19 #[error("locked: {0}")]` over `commands/notes.rs:448` etc.), so the guard never fires and a locked-note save falls into the retry branch. It is an error-copy bug, in scope, with a RED test — and it is a warning: **once `humanize()` strips prefixes, every downstream raw-string guard changes behaviour. Enumerate them all before the refactor.**
+
+#### Rejected
+
+- **Rejected: renaming `BRAIN_MODELS[].name`.** Keeping the checkpoint names as *muted secondary* text is both cheaper and more honest (the user should be able to see which model is on their disk) and it keeps `e2e/settings-ai/brain-engine-card.spec.ts:85-86` green. The `isPolish` coupling is decoupled in **P0** regardless (`!m.languages.includes("multi")`, verified equivalent across all six rows).
+- **Rejected: per-component `prefers-reduced-motion` as the mechanism.** See §3.0.3.
+
+---
+
+### 3.5 W5 — Auto-updater
+
+**Track A confirmed** (verified download of the published notarised DMG + Gatekeeper verification on-Mac + verify-before-destroy swap with rollback). Neither critique disputed the recommendation. Track B remains fully specified as a user option (§5).
+
+#### Accepted corrections
+
+**E1 — The interlock is completed. The "safety guarantee is complete for current behaviour" sentence is DELETED.**
+Verified: `recording_has_priority()` is false during `retry_transcription`'s salvage run (it just checked the flag was false at `mod.rs:5334`), during `resummarize` (`mod.rs:5221` — no such check at all), and during startup disk salvage (which uses the separate `startup_recovery_has_priority()`, `perf.rs:212`).
+→ `install_blockers` gains **`startup_recovery_has_priority()`** and **`PipelineBusy`**, an RAII counter taken at the top of `retry_transcription`, `resummarize`, `audio::spill`'s salvage runner, and (later) the queue worker — in addition to the five `commands/models.rs` downloads. `PipelineBusy` lands in **P0**.
+
+**E2 — One-shot installer arming.** Verified `lib.rs:1157 "quit" => app.exit(0)` and `lib.rs:942 RunEvent::ExitRequested` is a single global hook that `AppHandle::exit` also triggers. "Install & Restart" would spawn a second installer racing the first over the same `mv`. → An `AtomicBool`/`Once` consumed by whichever path spawns first, **plus** an explicit `phase != Installing` guard. Unit test: call the install path twice, assert exactly one spawn.
+
+**E3 — Disk preflight sizes the INSTALL, not the download.** The DMG is UDZO-compressed (`macos-sign-notarize.sh:150`); the swap holds the DMG + mount + `staged/` + `rollback/` + `.Murmur-new` + `.Murmur-old` — four uncompressed copies of a bundle carrying five sidecar helpers and the always-compiled ML tree in a 2-arch universal binary. → Preflight `dmg_bytes + 4 × app_uncompressed_bytes`; the sign script emits `app_uncompressed_bytes` into a sidecar. Re-check free space inside `install.sh` immediately before the swap; exit 14 explicitly covers ENOSPC.
+
+**E4 — `install.sh` repeats the FULL verification pin.** The design verified 8 checks at download time and 2 at install time (`codesign --verify --strict` + profile presence) — both trivially satisfiable by anything that can write to `~/Library/Application Support/MeetNotes/updates/staged/`, which is also where the design writes and executes `murmur-install.sh`. → `install.sh` re-runs `codesign -dv --verbose=4` grepped for `TeamIdentifier=BVF778E5QD` and `Authority=Developer ID Application:`, plus `plutil -extract CFBundleIdentifier` == `com.meetnotes.app`, plus the version — each with its own exit code. Better still: Rust re-verifies immediately before spawning and passes a `cdhash` the script pins.
+
+**E5 — Blockers reach the FE via `update_state()`, never a parsed error string.** Verified `error.rs:48-53` serializes `AppError` to a bare `to_string()`. `install_update` returns a plain `AppError::Unavailable`; the FE already holds `blockers: Vec<InstallBlockerDto>` from the authoritative DTO and the `murmur://update` payload. The "serialised blocker list" phrasing is deleted (`rust-tauri.md` §1: *"Do not hand-build error strings the FE has to parse"*).
+
+**E6 — `state::app_dir()` does not exist.** Verified: only `state::app_dir_name() -> &'static str` (state.rs:34). Every real caller does `dirs::data_dir().map(|b| b.join(crate::state::app_dir_name()))`. Spelled out explicitly, or a named helper is added.
+
+**E7 — Update egress is LEDGERED.** Verified `share/mod.rs:226 pub fn ledger_row(db, host, kind, byte_count)` — a content-free host/bytes ledger already exists (the design dismissed only the *LLM* ledger). → `ledger_row(db, "github.com", "update-check", 0)` and `("update-download", bytes)`. One line each; turns the disclosure from a promise into an auditable record, which is the stronger answer to *"new cloud egress must be loud + justified"*.
+
+**E8 — `spctl` output is read from BOTH streams.** Verified `macos-sign-notarize.sh:159` uses `2>&1` precisely because the verbose assessment goes to stderr. Assert on combined output; treat **exit status 0 as the primary signal** and the string as secondary confirmation, so a macOS wording change degrades to a diagnosable refusal. Unit-test against a captured fixture.
+
+**E9 — `ditto` stays, but the claim is verified before implementation, not asserted.** Verified counter-evidence: `macos-sign-notarize.sh:147` stages the signed bundle into every shipped DMG with `cp -R`, and those DMGs notarize and pass `spctl`. The `tar` half of the claim is right; the `cp -R` half was unverified. → The empirical check (`ditto` a signed `Murmur.app`, then `codesign --verify --strict` + `codesign -d --entitlements :-` on the copy) is a **P8 preflight gate**, run before a line is written.
+
+**E10 — Version pinning is real, and the rollback is not pruned on "it launched".**
+The brief asked for the pinning story; the design shipped auto-clearing "Skip". → Add `update_pinned_version` suppressing everything above it, surfaced as **`Stay on 1.0.3`**. And the rollback prune trigger changes from "the new version booted" to an explicit **`Keep the previous version`** default that survives until the user dismisses it or a second successful update lands — because the risks section's own highest-stakes unknown is *whether Touch ID still opens the KEK*, which "it launched" does not test.
+
+**E11 — Every installer exit code has copy, split into "attempted" vs "not attempted".** Exit 10 (timed out), 11 (the *backup* failed verification), 16 (not writable) never move anything, so *"Murmur put 1.0.3 back. Nothing was lost."* is false for them. Exit 11 in particular is realistic and would silently disable updates forever — it needs its own copy and a stated policy.
+
+**E12 — `install_blockers(app: &AppHandle)`, one signature.** Uses `app.try_state::<AppState>()` (the shape `relock_and_zeroize_on_lifecycle` already uses at `lib.rs:1000`, which handles init-failure). Threaded through the scheduler and the download loop.
+
+**E13 — `reveal_update_installer` is new, not "the existing technique".** Verified: the only `Command::new("open")` is `update.rs:202` inside the URL-pinned `open_release_page`. The new command takes **no parameters** and derives its path only from internal staged/mount state; it refuses when `staged` is `None` rather than falling through to a bare `open`.
+
+**E14 — Downgrade detection uses `is_newer`** (already written and tested at `update.rs:112`, tests at `:245-267`), not `!=` — otherwise a manual reinstall of 1.0.3 over 1.0.4 shows *"Updated to 1.0.3"* with a `What's new` button pointing at 1.0.4.
+
+**E15 — The blocker banner is `role="status"`, not `role="alert"`.** Verified `banner.component.ts` hardcodes `role: "alert"`. An assertive region mutated by a background event stream **during a recording** is the one moment the app must be silent. Use the global `.banner.is-info` classes with `role="status"`; keep `alert` for the danger case.
+
+**E16 — `xattr` becomes `removexattr(2)` via `libc`** (already in `Cargo.lock`), or is dropped entirely. It is likely a no-op anyway — `reqwest` never sets `com.apple.quarantine` (LaunchServices does), so the file was probably never quarantined. Either way, the **ordering comment stays**: de-quarantine is step 9 of 10, a consequence of verification and never a precondition.
+
+**E17 — The verification copy is softened to what is actually checked**, or the check is added. Recommend adding `spctl -a -vvv -t exec` on the staged app as step 8b (passes offline once the app-level staple lands, online otherwise) so *"Signed and notarised by Apple — verified on this Mac"* is literally true.
+
+**E18 — Quit-mid-recording is resolved empirically.** `lib.rs:947` runs `relock_and_zeroize_on_lifecycle` → `stop_all_capture`, which finalises helpers but does not run the pipeline; the in-flight WAV is left for next-launch salvage. Whether `recording_has_priority()` is still true at the `arm_on_quit_if_ready` call site must be **determined, not assumed**. Safest: block the on-quit install whenever `spill::claim_inflight` would find anything.
+
+**E19 — A persistent-offline state exists.** Track `update_last_check_failed`; render `Couldn't reach GitHub — last tried 2 hours ago` in the muted line only. No toast, no banner — the anti-nag contract survives, and "Not checked yet" for a week stops being indistinguishable from a broken updater.
+
+**E20 — `mur-progress` comes from P0**, not from this workstream (see §3.0.2).
+
+#### Rejected
+
+- **Rejected: shipping the updater before the queue.** Independently valuable and tempting, but P6 narrows `recording_has_priority()` and the compounding benefit does not outweigh the consequence-of-failure ordering. (If the user wants it earlier, `PipelineBusy` from P0 makes it *safe* to reorder — noted, not recommended.)
+
+---
+
+## 4. PR sequencing plan
+
+**Cadence (binding):** SEQUENTIAL. One writer, one worktree, at a time. Every Cargo/CI command through `scripts/agent-resource-run`; the dev server through `scripts/agent-dev-run`. **Never fan out parallel Rust builders** — the always-compiled ML tree freezes this machine. Each PR is CI-gated and merged to `murmur` via `gh pr create` → `gh pr merge` (never a direct push), authored solely by `QueaT <kgm004a@gmail.com>` with no AI trailers. Run `scripts/agent-harness` for every writer task; the implementer never owns the verdict.
+
+**Pre-empt clippy:** the harness's Rust check is `cargo test --lib`; `clippy -D warnings` (`type_complexity`, `too_many_arguments`) only bites at CI. Watch the widened `transcribe_raw_windows`, `whisper_catalog_dto`, and `download_model_streaming` signatures.
+
+---
+
+### P0 — Foundations, primitives, and free fixes
+**Scope:** `src/app/design-system/{progress,disclosure}/**` (new) · `design-system/select/select.component.{ts,html}` (add `value` model + `disabled` input) · `design-system/primitives.css` (promote `.field-help`, add `.pill.is-pop`) · the seven progress-bar call sites · `src/app/core/copy/{glossary,labels,error-copy.service}.ts` (new, empty-ish scaffolds) · `src/app/core/format.ts` (`sizeLabel`) · `model-effort-picker.component.ts` (`isPolish` → `!languages.includes("multi")`) · `settings/sections/ai/local-models-list/**` (delete) · `library.component.ts` + `meetings-table-view.component.ts` (`statusPillClass`: `RECORDING` → `is-live`, explicit label map) · `src-tauri/src/{commands/mod.rs,commands/models.rs,audio/spill.rs,perf.rs}` (`PipelineBusy` RAII counter, dormant).
+**Delivers alone:** a correct in-progress pill (today `RECORDING` renders red/danger, conflating in-progress with failed), one progress primitive replacing seven copies, a decoupled brain family toggle, ~700 lines of dead UI removed, and the shared interlock counter.
+**Risk:** LOW. **Lock model:** NO.
+**Verification bar:** `cargo test --lib` + `ng lint` + `ng build` + `ci.sh`. Unit test pinning `!languages.includes("multi")` == `name.includes("bielik")` across all six `BRAIN_MODELS` rows. Playwright screenshot diff of Settings → Appearance (the `mur-slider` consumer) before/after. Confirm `app-local-models-list` has zero mount sites (verified today: only its own selector + `brain-engine-card.spec.ts:9` saying it is superseded).
+
+---
+
+### P1 — Machine profile + whisper catalog + recommendation (Rust)
+**Scope:** `src-tauri/src/machine.rs` (new) · `src-tauri/src/transcribe/catalog.rs` (new — the **merged** registry) · `transcribe/model.rs` (delegate branch 2 only; `total_ram_bytes` → `pub(crate)`; `quality_tier_label`) · `transcribe/mod.rs` · `commands/model_perf.rs` (`whisper_recommendation`, `list_whisper_models`, `machine_change_nudge`, `dismiss_machine_change_nudge`) · `reason.rs` (`brain_advice_for`, floor 24 GB) · `settings/{config.rs,ai_map.rs}` · `lib.rs` (registry + fingerprint compare at setup) · `src/app/core/{models.ts,ipc.service.ts}` · `src/app/services/machine.service.ts` (new) · a `<mur-pill kind="accent">` badge next to the **existing** Quality select.
+**Delivers alone:** the badge + the honest reason line on the current UI, the raw `large-v3-turbo-q8_0` gone from the AI map, one fewer `sysctl` subprocess per `list_brain_models`, and the marketing-name gate green.
+**Risk:** MEDIUM (new FFI). **Lock model:** NO — config reads, `read_dir`, hardware probes, no content, no egress. The verifier must confirm by grepping the diff for `meeting_`, `visibility_clause`, `seal` and finding none.
+**Verification bar:** the **six existing `default_model_size` tests must pass UNEDITED** — that is the proof of zero behaviour change. RED-first: `recommendation_ignores_whats_on_disk` (`recommend(Some(64*GIB), Some(true)).batch_id == Some(TURBO)`) **and separately** `default_model_size(&["ggml-large-v3.bin"], Some(64*GIB)) == "small"`. Two separate assertions for Intel (`Some(32*GIB), Some(false)` → `small`; `Some(32*GIB), Some(true)` → turbo) — **never a conjunction**, which pins neither leg. `machine::tests::probes_never_panic` in the `thermal.rs` mould. `registry_live_safe_matches_classifier`. `fingerprint_is_none_without_ram`. Chip-string normalisation against Apple and Intel fixtures.
+
+---
+
+### P2 — Transcription power slider
+**Scope:** `design-system/power-slider/**` (new, own `<input type="range">`, full CVA, `aria-valuetext`, PageUp/PageDown) · `design-system/meter/**` (new) · `settings/sections/settings-transcription-section/model-power/**` + `model-catalog-table/**` (new) · `settings-transcription-section.component.{html,ts}` · `onboarding.component.{ts,html,scss}` · `settings.store.ts` · `services/transcription-models.service.ts` (new root) · `commands/models.rs` (`delete_whisper_model`, `cancel_model_download` generation counter, `fileIndex`/`fileCount`) · `commands/live_captions.rs` (`companion_pending_in` → `pub(crate)`) · `transcribe/model.rs` (cancel threading, delete guards) · `events.rs` · `e2e/onboarding/model-presence-race.spec.ts` (rewrite) · `e2e/settings-ai/model-power.spec.ts` (new).
+**Delivers alone:** the whole "power slider + honest default" experience, three hardcoded size tables deleted, the 9-vs-6 catalog divergence fixed, a cancellable download, and disk reclaim.
+**Risk:** HIGH (destructive `delete_whisper_model`; the app's only unskippable first-run gate). **Lock model:** NO.
+**Verification bar:** RED-first — `delete_refuses_the_effective_model`, `delete_refuses_the_live_caption_pin`, `delete_rejects_a_non_registry_id`, `delete_never_touches_vad_or_parakeet` (over a temp models dir), `download_cancel_removes_the_part_file`. The `model-presence-race` rewrite must go **RED when `modelPresenceRequestId` is temporarily removed** — a rewrite that passes against unguarded code did not capture the bug. E2E: a three-rung drag emits exactly ONE `save_config`; an off-catalog `selectedId` renders the custom banner; `aria-valuetext` reads the human stop name; reduced-motion emulation still commits and swaps copy.
+
+---
+
+### P3 — Vocabulary machinery + error copy + privacy vocabulary
+**Scope:** `src/app/core/copy/**` (fill in) · **185 `String(e)` sites across 47 files** → `ErrorCopyService.humanize()` · all **eight** `friendly*Error` mappers folded in · `note-editor.component.ts:1528/:1606` case-sensitivity fix · `src-tauri/src/summarize/mod.rs` (the `[cloud-consent]` string) · `summarize/roles.rs` + `settings.store.ts::CONNECTION_LABELS` (**same PR**, they are a documented mirror) · `settings/ai_map.rs` display strings · `error.rs` doc comment (the `[code]` convention + the enumerated prose couplings) · `record.component.ts` (`needsCloudConsent` → code match) · `settings-privacy-section` + `ai-privacy-strip` + `egress-ledger` rewrites · `scripts/check-vocabulary.mjs` + both JSON files + `scripts/ci.sh` (**WARN mode**) · `e2e/settings/privacy-honesty.spec.ts` (new, 15 protected clauses).
+**Delivers alone:** no user ever sees `summarizer error:` again; the app's most-hit blocking error becomes readable; the privacy surfaces become plainer AND more explicit.
+**Risk:** HIGH (touches lock/egress copy and the consent flow). **Lock model:** **YES — `lock-security-reviewer` required.**
+**Verification bar:** RED-first Playwright — with `stop_recording` rejecting the NEW `[cloud-consent] …` string, the pre-change FE (prose regex) must FAIL to render the Allow banner and leak the raw string; post-change it renders. `privacy-honesty.spec.ts` asserts each of the 15 clauses by **fact** (e.g. Privacy must still contain `/emails/i` AND `/card/i` AND `/phone/i` AND an explicit negative about names). `humanize()` unit tests: all 14 prefixes stripped; an un-coded internal-looking message → generic; `friendlyImportError`'s **ordered** ladder preserved (`no text found` must still beat `unsupported document type`). Gate runs and prints hits without failing.
+
+---
+
+### P4 — Settings information architecture
+**Scope:** `settings.component.ts` (labels + group names + keyword synonyms, jargon KEPT as hidden synonyms) · `settings-ai-section.component.html` (reorder, privacy strip 8th → 3rd) · `ai-advanced-block` → `<mur-disclosure>` · new disclosures in Transcription / Privacy (MCP) / General / Audio / Connected apps · `glossary.ts` keyword→disclosure map + auto-open · the pointer sweep (D8) · `e2e/settings-ai/{brain-posture-block,posture-auto-download}.spec.ts` + the 8 `"AI & Models"` specs.
+**Delivers alone:** everyday Settings ~70 → ~30 controls, with zero privacy disclosure moved behind a disclosure.
+**Risk:** MEDIUM. **Lock model:** NO.
+**Verification bar:** `ng build` (16 kB budget). E2E: every disclosure toggles `aria-expanded` and `aria-controls` resolves; the AI block's store-owned `_autoExpand` still fires on a role override; **search for `gguf` surfaces the AI section AND the control is visible**, same for `model file`/`egress`/`what leaves`/`mcp`.
+
+---
+
+### P5 — Vocabulary long tail + gate armed
+**Scope:** onboarding (posture tiles with the corrected Ollama copy, Kong removal if approved, "Turn on memory and search") · graph/brain (`entity`→`people and projects`, lens labels, `Chunking…`/`Embedding N/M`) · share panels ×3 (`E2EE ciphertext bundle` → `encrypted together with the note`, P5/P8 clauses verbatim) · audit · storage · org · audio · notes · `app-shell` (nav `Graph`→`Connections`, relock toasts) · `scripts/ci.sh` (**gate → FAIL**) · baseline file emptied.
+**Risk:** MEDIUM. **Lock model:** **YES** (lock-gate copy in `detail.component`, `move-to-menu`, folder rows, share panels) — `lock-security-reviewer` required.
+**Verification bar:** vocabulary gate FAILS on any regression; `privacy-honesty.spec.ts` still green; full e2e suite green.
+
+---
+
+### P6 — Processing queue core *(atomic BE+FE)*
+**Scope:** `storage/postprocess_store.rs` (new) · `postprocess/{mod,worker,policy}.rs` (new) · `commands/postprocess.rs` (new) · `perf.rs` (+2 fns) · `commands/mod.rs` (`stop_recording_owner` enqueue, `seal_folder_extras` cache drop, `StopResult.queued`) · `commands/lock.rs` (`unlock_folder` hold release; `reblank_folder_extras` cache drop) · `pipeline.rs` (`PipelineRun::Yielded`, `WindowSink`, sub-window `should_yield`) · `storage/{db,models,mod}.rs` (`MeetingStatus::Queued`) · `events.rs` · `lib.rs` · `settings/config.rs` (policy) · `audio/spill.rs` (`DeferSealed` → `HELD/LOCKED`) · **FE:** `recorder.store.ts` (meeting-id filter, `isBusy` shrink, `finalizing` stage), `record.component.*` (gate removal + hand-off strip + queue line), `bar.component.*`, `meetings-list-store.service.ts` (passive patch), `detail.component`, `models.ts`, `ipc.service.ts`, `services/processing-queue.service.ts` (new root), `app.component.ts` (`queue.init()`).
+**Delivers alone:** record #2 immediately after Stop; notes finish in the background; the meetings list finally learns a note completed; a completion toast.
+**Risk:** **HIGHEST in the program.** **Lock model:** **YES — `lock-security-reviewer` REQUIRED** (a new content-bearing table + a new deferred-execution window across lock transitions).
+**Verification bar:**
+- RED #1 `e2e/record/record-while-processing.spec.ts` — Start visible AND enabled with a running job. Fails on trunk.
+- RED #2 cross-meeting stage clobber — emit `{stage:'summarizing', meetingId:'other'}` during a live recording; the strip, Stop button and timer must survive. Fails on trunk.
+- RED #3 `Queued` survives launch — three `Queued` meetings survive `reconcile_stuck_recordings_except(&[])`; write the mirror with `Recording` first and watch two of three flip to `Error`.
+- RED #4 yield-is-not-a-failure — `Err(Unavailable)` with the yield predicate **true** → requeue, `attempts` unchanged; predicate **false** → retryable, `attempts+1`. **Two separate tests.**
+- RED #5 relock clears checkpoints — seed a row, `relock_all_inner`, assert zero.
+- Durable-handoff proof: `release_for_recovery` → `claim_stale_recording_generation_for_meeting` returns the identical snapshot.
+- ASR checkpoint round-trip: interrupt at a chunk edge, resume, assert the per-stream window set is byte-identical to an uninterrupted run and `merge_streams` yields identical segments.
+- Migration idempotency: `migrate()` twice over a DB with queue rows.
+- **Live dev-app run:** record 2 min → Stop → Start within ~2 s with no `another recording model session is already active` and no `local AI did not quiesce in time`; job #1 reads `Paused for your recording` within seconds; both notes land; force-quit mid-transcription → relaunch → resume with `· resumed`.
+
+---
+
+### P7 — Processing queue surface
+**Scope:** `features/processing/{processing-panel,processing-row}/**` (new, teleported to `<body>`, opaque per T3, never moved back on destroy) · `app-shell.component.*` (chip + panel mount + ⌘⇧P + partial-aware Lock all) · `settings-transcription-section` policy card · `settings.store.ts` · `folder-lock-flow.service.ts` (the "Finish processing first" pre-check) · `analytics.component.ts` (`QUEUED`) · `e2e/processing/queue-surface.spec.ts` (new).
+**Delivers alone:** visibility and control — Process now, Pause, Retry, the three policies, the lock-hold unlock path, and the raw `AppError::Locked` sentence never reaching the user.
+**Risk:** MEDIUM. **Lock model:** **YES** (masked job rows, lock-hold release) — `lock-security-reviewer` required.
+**Verification bar:** E2E — a masked (locked) row shows `🔒 Locked` with no progress numbers and no audio affordance; `Process now` invokes the command; the policy segmented control round-trips; the lock pre-check confirm appears instead of the raw error.
+
+---
+
+### P8 — Updater core (manual install)
+**Scope:** `src-tauri/src/update/**` (module split + `github.rs`, `download.rs`, `verify.rs`, `install.rs`, `install.sh`) · `events.rs` (`EVENT_UPDATE`) · `settings/config.rs` (5 keys) · `share/mod.rs` ledger calls · `lib.rs` (commands, status file, boot compare) · `settings-about-section/**` (rewrite) · `models.ts`, `ipc.service.ts`, `update.service.ts`, `app.component.ts` · `scripts/macos-sign-notarize.sh` (app-level notarise+staple, warn-and-continue; `.sha256` + uncompressed-size sidecars) · `.claude/skills/release-murmur/SKILL.md` · `e2e/settings-about/software-update.spec.ts` (new — this surface has **zero** e2e coverage today).
+**Preflight gate (before any code):** empirically confirm `ditto` of a signed `Murmur.app` survives `codesign --verify --strict --deep` and retains `keychain-access-groups`. **The whole design rests on this.**
+**Delivers alone:** one-click Download → verify → Install & Restart from Settings, with rollback. No scheduler, no automatic mode, no on-quit.
+**Risk:** **HIGHEST consequence-of-failure** (a broken swap = the user cannot open their encrypted notes). **Lock model:** **YES** (the Keychain ACL is bound to the code signature) — `lock-security-reviewer` required.
+**Verification bar:** RED-first `asset_matcher_rejects_near_misses` (`Murmur-1.0.4.dmg.sha256`, `murmur-1.0.4.dmg`, `Murmur-1.0.40.dmg`); `download_url_host_pinning` incl. `murmur-phish` prefix-boundary (run against a naive `starts_with` first); `install_blockers_matrix` one-per-blocker; `team_id_pin_matches_entitlements` via `include_str!`; `installer_exit_code_mapping` all eight codes. E2E: Install disabled-with-reason under `blockers:['recording']`, enabling live on a `murmur://update` event. **Then a real signed-build old→new run** (see §6).
+
+---
+
+### P9 — Updater automatic
+**Scope:** `update/scheduler.rs` · mode segmented control + the one-time disclosure toast · `arm_on_quit_if_ready` in `RunEvent::ExitRequested` (after relock + sidecar kill) · `update_pinned_version` ("Stay on 1.0.3") · the sidebar chip · `settings-privacy-section` disclosure line.
+**Delivers alone:** the calm experience — checks daily, downloads quietly, installs on quit.
+**Risk:** HIGH. **Lock model:** YES (the on-quit hook sits inside the relock/zeroize path).
+**Verification bar:** exactly one toast per version across two refreshes; a second emit adds nothing; an *upgrade*-direction machine change fires zero toasts; quit-with-armed-installer does not delay shutdown; **one-shot arming test** (call the install path twice, assert one spawn).
+
+---
+
+## 5. Decisions the USER must make
+
+> Everything not listed here the implementer decides. Tier names, the mur-progress migration scope, the disclosure control shape, the four-rung ladder, PR-internal copy: all implementer calls.
+
+### D1 — Auto-updater mechanism and key custody ⚠️ BLOCKING
+
+| Option | Trade-off |
+|---|---|
+| **A. Verified download + verify-before-destroy install** *(recommended)* | **Zero new crates. Zero secrets. Zero key custody. No fourth release pause point.** Verified by Gatekeeper on the user's own Mac (a *stronger* bar than the standard plugin, which runs no `codesign` check on what it installs). Automatic rollback. Cost: ~600 lines of bespoke Rust + one shell script, and a preflight `ditto` verification. |
+| **B. `tauri-plugin-updater`** | Standard, less bespoke code. Cost: **4 new crates** (`tauri-plugin-updater`, `minisign-verify`, `osakit` + its ObjC tree, `tempfile`); a **permanent minisign private key you must generate interactively and back up before the first release that ships its pubkey** — losing it strands the entire installed base on their current version forever; three permanent manual release steps whose omission silently strands users (regenerate the tarball *after* signing or you ship the 0.7.1 AMFI kill; `COPYFILE_DISABLE=1` or `codesign` breaks on extraction; a hand-maintained `latest.json` with **both** `darwin-aarch64` and `darwin-x86_64` entries — `darwin-universal` is not a key the plugin probes). It also runs no `codesign` check on what it installs and can fire a surprise admin-password prompt. |
+
+**Recommendation: A.** Murmur's bundle carries `Contents/embedded.provisionprofile` and a restricted `keychain-access-groups` entitlement, and the SQLCipher DEK + biometric master KEK sit behind a Keychain ACL bound to that signature. A broken self-replacement here does not mean "the app won't start" — it means **the user cannot open their encrypted notes**. Track A applies this repo's own verify-before-destroy discipline to the install.
+
+**If you pick B, the manual step is yours and only yours:** `npx tauri signer generate -w ~/.tauri/murmur-updater.key` run interactively in your terminal (password on stdin), the private key backed up to 1Password + one offline copy **before** the first release, and `TAURI_SIGNING_PRIVATE_KEY` + `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` supplied from your shell at release time. An agent must never touch it.
+
+---
+
+### D2 — The one dependency-shaped ask: `objc2-foundation` `"NSValue"` feature
+
+Needed only to read the `NSNumber` returned by the free-disk `NSURL` probe. It is **not a new crate** — a feature flag on an already-declared dependency whose manifest declares `NSValue = []` (empty body), so `Cargo.lock` is unchanged and `cargo deny` sees nothing new. But it is a manifest edit, and the repo rule is strict.
+
+| Option | Trade-off |
+|---|---|
+| **A. Approve the feature** | Typed, generated FFI. One-line manifest edit. |
+| **B. Guarded `msg_send![num, longLongValue]` under `objc2::exception::catch`** *(recommended)* | **Zero manifest touch.** The `exception` feature is already enabled. Fifteen lines, fully compliant with `rust-tauri.md` §7's escape hatch. |
+| **C. Ship v1 without free disk** | The tier decision, the badge, the reason line and the brain advice all depend on `hw.memsize` alone. Free disk only powers an optional advisory. |
+
+**Recommendation: B.** No approval needed, no precedent set, same result.
+
+---
+
+### D3 — Queue default processing policy ⚠️ affects every Stop
+
+| Option | Trade-off |
+|---|---|
+| **A. `immediate`** *(recommended)* | A note starts as soon as capture ends and pauses itself the instant you start another meeting. Smallest behavioural change from today (notes still appear on their own); the user never has to learn a new concept to get their note. |
+| **B. `between_meetings` (3 min quiet)** | Never competes with a back-to-back meeting. Better for dense calendars. But it is a *timer*, i.e. a heuristic, not the deterministic trigger — and the user must understand the concept to get a note. |
+| **C. `manual`** | Nothing runs until pressed. Maximum control, but silently breaks the mental model "I stop, a note appears". |
+
+**Recommendation: A**, with B one click away in the panel.
+
+---
+
+### D4 — Stop no longer returns the note ⚠️ SHIPPED BEHAVIOUR CHANGE
+
+Today `stop_recording` resolves only after transcribe + summarize + export, and `StopResult` carries the note markdown. After P6 it resolves in ~1–2 s carrying `{ queued: true }`, `markdown: ""`, `exported_path: None`. The Record screen shows `✓ Recording saved — writing your note in the background.` and the Brain-reveal / Re-Truth cards render when the job completes instead of when Stop resolves.
+
+This is the point of the feature, but it is a real contract change. **Confirm you want it.** (If not, the whole queue workstream collapses to "show a better spinner".)
+
+---
+
+### D5 — Queue "cancel" semantics ⚠️ scope reduction
+
+The design deliberately ships **no** "cancel this job but keep a half-processed meeting". `Pause` covers "not now"; `Discard` deletes the meeting entirely (audio, transcript, note) behind the existing delete confirm. The reasoning: a third "cancelled-but-half-processed" state would be a lie about what happened to the content.
+
+| Option | Trade-off |
+|---|---|
+| **A. Pause + Discard only** *(recommended)* | Honest. No state where content is partially gone. |
+| **B. Add a real cancel** | Needs its own verify-before-destroy review for a partially-published archive, and produces a meeting the user cannot reason about. |
+
+---
+
+### D6 — Update default mode ⚠️ SHIPPED BEHAVIOUR CHANGE for all users
+
+`automatic` means Murmur downloads ~214 MB in the background without asking, on a privacy-first app.
+
+| Option | Trade-off |
+|---|---|
+| **A. `automatic`** *(recommended)* | Calmest — the update is simply already there next time you open Murmur. Mitigated by: inbound-only public bytes carrying no identifier beyond the version in the User-Agent; a **one-time, once-ever** disclosure toast on the first automatic download; a permanent plain-language sentence in About **and** Settings → Privacy; a `share::ledger_row` audit entry per check and download; never during a recording; requires the full install-sized free-disk headroom. |
+| **B. `notify`** | Nothing arrives without a click. Maximum restraint; more friction on every update. |
+| **C. `automatic` for fresh installs, `notify` for existing users** | Respects the status quo for people who never opted in. |
+
+**Recommendation: A**, but this is genuinely your call — it is the one place this program makes the app do something on the network without being asked.
+
+---
+
+### D7 — Keep `Brain` as the product name?
+
+It is a nav destination (`/brain`), a page title, an org feature ("Shared Brain"), and an in-note action ("Ask Brain") — ~40 strings. Today it ambiguously means four things: the knowledge base, the local LLM, the sidecar process, and the live reaction loop.
+
+| Option | Trade-off |
+|---|---|
+| **A. Keep for the KNOWLEDGE BASE only; ban for the model and the process** *(recommended)* | Removes the ambiguity, keeps a distinctive product name. "Enable the brain" → "Turn on memory and search"; "On-device brain lifecycle" → "Memory and timeouts"; `/brain`, Shared Brain, Ask Brain all stay. |
+| **B. Keep everywhere** | No work, ambiguity persists. |
+| **C. Retire entirely** | ~40 strings, loses a distinctive name. |
+
+---
+
+### D8 — Remove "Kong AI Gateway" from the first-run wizard?
+
+It is an enterprise product an individual first-run user cannot evaluate, and the wizard currently asks them to paste an "OpenAI-compatible base URL" before they have recorded anything. Removing it from onboarding deletes 21 `gateway` + 7 `Kong` + 4 `OpenAI-compatible` occurrences from the everyday surface in one move. **No capability is lost — it stays fully functional in Settings → AI → Advanced.**
+
+**Recommendation: remove from onboarding.** But I cannot tell from the code whether anyone uses it today, so it is yours.
+
+---
+
+### D9 — Leave `TURBO_DEFAULT_MIN_RAM_BYTES` at 12 GiB? *(non-blocking)*
+
+Sub-12 GB Macs currently default to `small` (Balanced). Lowering the gate would default them to Sharp (~1.2–1.5 GB resident).
+
+**Recommendation: leave it.** The UX change alone already delivers the ask — on a qualifying Mac the default *is* the 875 MB turbo; what was missing was saying so. Lowering it is a real behaviour change for low-RAM users and should be gated on one RSS-over-time measurement on a signed build, not a design document.
+
+---
+
+## 6. What cannot be verified headless
+
+Stated plainly. A green `cargo test --lib` proves plumbing, never any of the following.
+
+| Claim | Why headless fails | What it actually needs |
+|---|---|---|
+| **The updater's self-replacement works** | The swap, signature survival through `ditto`, Gatekeeper's verdict on the installed app | A signed build + a real old→new run: install v1.0.3, publish v1.0.4, let it download/verify/install, confirm no AMFI kill and `spctl -a -vvv -t exec` accepts |
+| **Touch ID still opens the KEK after a self-update** | The Keychain ACL is bound to the code signature | The same signed run, then unlock a locked folder. **The single highest-stakes unknown in the program.** |
+| **The `ditto`-preserves-the-signature assumption** | The one empirical claim the whole updater rests on, and the repo's own release script uses `cp -R` successfully | `ditto` a signed `Murmur.app`, then `codesign --verify --strict --deep` + `codesign -d --entitlements :-` on the copy. **P8 preflight gate.** |
+| **Is `/Applications` writable without elevation?** | Determines whether the Finder hand-off is the rare path or the common one | One real Mac. If common, the copy weighting in About shifts. |
+| **Install-on-quit does not delay or block shutdown** | `RunEvent::ExitRequested` ordering with the relock/zeroize path | Signed build, ⌘Q with an armed installer |
+| **Whether `recording_has_priority()` is still true at `arm_on_quit_if_ready`** | Depends on when `stop_all_capture` drops the session owner | Instrumented dev run, quit mid-recording |
+| **`sysctl` keys resolve: `machdep.cpu.brand_string`, `hw.optional.arm64`, `sysctl.proc_translated`, `hw.nperflevels`, `hw.perflevel0.logicalcpu`** | **Every `sysctl` read returned "Operation not permitted" under the agent sandbox during this synthesis.** Only `hw.memsize` is proven in production (two shipping subprocess probes) | One run on a real Mac, under **both** the arm64 and x86_64 slices of the universal build |
+| **Free disk via `NSURL` returns a plausible number for the models volume** | FFI + volume semantics | Real Mac |
+| **`spctl` writes its assessment to stderr and the exact string form** | The gate is a string match on unversioned CLI prose | Real Mac + a captured fixture, at the 13.4 minimum target if possible |
+| **A background whisper pass and a live capture coexist under real RAM/thermal load** | The measured recording peak is 14.38 GB main + 3.59 GB sidecar | One RSS-over-time measurement across Stop#1 → Start#2 → Stop#2 on a signed build. Reuse PR #425's `measure-recording-ram.sh`. |
+| **Stop→Start wall clock is ~2 s, not ~30 s** | A 120-second ASR window plus an uninterruptible 2.9 GB `Transcriber::load`, against a hard 30 s Start budget | Timed dev-app run with an in-flight ASR |
+| **`approx_resident_bytes` per whisper model** | Currently estimates from a research doc | Peak RSS during an Accurate batch with `small`, `large-v3-turbo-q8_0`, `large-v3` resident. **Until then every string says "about".** |
+| **Real model download sizes** | No ground truth in-repo; the two `model.rs` comment blocks contradict each other on VAD/diarization | A manual `#[ignore]`d `HEAD`-per-row pass (never in CI — it is network egress). Also supplies the missing `large-v3-q5_0` size so its `provisional` flag can clear. |
+| **Screen-share auto-relock moves a running queue job to HELD rather than failing it** | ScreenCaptureKit | Signed build + a real Zoom/Meet share |
+| **Component styles render in the packaged WKWebView** | A green `ng build` proves nothing about the prod CSP (trap T4) | The notarized `.dmg`, not `ng serve`. Never remove `dangerousDisableAssetCspModification: ["style-src"]`. |
+
+---
+
+## 7. Risk register
+
+Sorted by expected damage (probability × severity).
+
+| # | Risk | Damage | Mitigation |
+|---|---|---|---|
+| **1** | **Self-update breaks the code signature → Keychain ACL severed → the user cannot open their encrypted notes.** | Catastrophic, unrecoverable | Five independent defences: `ditto` (never `tar`); the staged bundle passes the **full** pin (codesign strict + TeamIdentifier + Authority + `embedded.provisionprofile` + `CFBundleIdentifier == com.meetnotes.app` + version) **before** anything moves; `install.sh` **repeats the full pin**, not a weaker subset (E4); the installer verifies its **backup** before touching the target; post-swap re-verification restores the old bundle on any failure. Plus the empirical `ditto` preflight (§6) as a P8 gate, and a signed old→new run before P9. |
+| **2** | **Sealed-content leak via `postprocess_asr_windows`** — a new table holding raw transcript text that the relock path does not clear. | Catastrophic (the privacy promise) | Cleared in **both** `reblank_folder_extras` (the funnel for `relock_folder` + `relock_all_inner`, verified lock.rs:658/:732) **and** `seal_folder_extras`; deleted on every terminal outcome; a pure cache drop (the verified archive WAV remains the source). The "unreachable" argument is deleted — LOCKED holds are normal. `lock-security-reviewer` REQUIRED on P6. |
+| **3** | **Unsealed plaintext segments parked indefinitely** at the TRANSCRIBE→SUMMARIZE yield boundary under `manual` policy, which `reblank_folder_extras` skips (`text_blob.is_some()` guard). | Catastrophic | That boundary is **forbidden**. Yield points are ASR chunk edges and pre-ASR only. RED test asserting no job can be persisted in a state between `replace_segments` and the terminal seal. |
+| **4** | **An update kills a running note pipeline** — `retry_transcription`, `resummarize` and startup salvage all run with `recording_has_priority() == false`. | Severe (content loss) | `PipelineBusy` RAII counter (P0) on all three plus the queue worker, `startup_recovery_has_priority()` added to `install_blockers`, blockers consulted at five points, and the "current coverage is complete" claim deleted from the design so nobody stops looking. |
+| **5** | **Double-installer race** — "Install & Restart" exits the process, which re-enters `ExitRequested`, which arms a second installer over the same `mv`. | Severe | One-shot arming (`AtomicBool`/`Once`) + an explicit `phase != Installing` guard. Unit test: two calls, one spawn. |
+| **6** | **Start #2 hangs 30 s then fails** instead of succeeding — a background ASR that yields only at 120-second window edges cannot beat the quiescence budget. | Severe (worse than today's honest refusal) | Sub-window `should_yield` inside the per-VAD-chunk loop; the worker refuses to claim when the model is not resident; `background_yield_notify` wakes parked awaits. **Measured, not asserted** — a timed dev-app run is the acceptance bar. |
+| **7** | **De-jargoning silently makes Murmur less honest** — "names are NOT redacted" compresses beautifully into "your data is protected". | Severe (destroys the differentiator) | 15 protected clauses with file anchors, asserted by fact (not exact sentence) in `e2e/settings/privacy-honesty.spec.ts`. Implementer rule: *a rewrite of a protected clause that is shorter AND drops a noun phrase is wrong.* `lock-security-reviewer` on P3 and P5. |
+| **8** | **The consent flow dies silently** — `record.component.ts:287` regex-matches the raw Rust prose to decide whether to show the Allow banner. | High (every cloud user's first note) | The `[code]` contract lands in the SAME PR as the string change; `needsCloudConsent` matches the **code**. RED test: the pre-change FE must FAIL to render the banner against the new string. **And: enumerate every other raw-string guard before `humanize()` strips prefixes** (`note-editor.component.ts:1528/:1606` is one, already broken today by case-sensitivity). |
+| **9** | **Deleting the live-caption model with no way back** — `delete_whisper_model` guards only the batch selection, and the Download button is gated on `modelPresent` (the batch model). | High | A fourth refusal on the live pin + a repair affordance driven by `live_captions::dto_probe`. RED test `delete_refuses_the_live_caption_pin`. |
+| **10** | **A queued job killed as collateral by `start_recording`'s sidecar/Claude-Code kills is marked FAILED**, so meeting #1 shows an error caused by meeting #2. | High | Classifier rule #1: **any** error observed while `background_should_yield()` is true is a requeue, not a failure, and does not burn a retry. A state check, never a string match, so it cannot drift. |
+| **11** | **The recommendation contradicts itself for every existing install** — `tier` says one thing, `batchSize` says another, because `recommend()` was made the `default_model_size` delegate. | High (the feature reads as broken) | Split the two functions; ship both `recommendedId` and `autoDefaultId`; the six existing tests pass unedited. |
+| **12** | **The updater silently stops working** because a future release names its DMG differently, invisible until users stop updating. | High | The asset matcher is pinned by a `cargo test` asserting it accepts exactly what `macos-sign-notarize.sh` constructs; no match degrades **visibly** to "Version X is out, but Murmur couldn't find a download"; the release runbook's post-release verification adds the same check. |
+| **13** | **`MeetingStatus::Queued` rows destroyed at launch** by `reconcile_stuck_recordings_except`, or a downgrade to an older binary failing `from_str`. | High | `QUEUED` is invisible to `stuck_recording_ids` (which selects `RECORDING` only). RED test with three queued meetings. Downgrade is per-row and loud, never destructive; documented in release notes. Also audit `mcp.rs` and the search/graph readers. |
+| **14** | **A worker spawned before `lib.rs:559` hard-kills launch** (`begin_startup_recovery()` refuses on a non-empty generation set → `show_fatal_init_dialog` → dead app). | High | Hard ordering constraint with a comment at the spawn site; the "no ordering guarantee needed" claim is deleted. |
+| **15** | **Disk exhaustion mid-swap** — the 3× DMG preflight under-provisions the install by several-fold. | High | Preflight `dmg + 4 × app_uncompressed`; re-check inside `install.sh` immediately before the swap; exit 14 covers ENOSPC; the sign script emits the uncompressed size. |
+| **16** | **Onboarding's unskippable model step strands a first-run user** — deleting `SIZE_HINTS` means an empty Download label until three IPCs resolve, permanently if `list_whisper_models` errors. | Medium-High | Gated label fallback; the "Show all sizes" disclosure is always openable; a "Start with Light instead" escape; e2e case for a rejecting catalog. |
+| **17** | **The vocabulary gate becomes a rubber stamp** or is disabled by false positives. | Medium | WARN in P3 → FAIL in P5; separate shrinking baseline vs permanent reason-required allowlist; the scanner strips comments/class bindings/non-visible attributes (the filter that corrects the raw `egress` count from ~20 to 4) and covers **Rust** too. |
+| **18** | **Merge skew across the three workstreams that all rewrite `onboarding.component.html` and `settings-transcription-section`.** | Medium | Strictly sequential PRs, the §2.3 collision map, and re-running gates on merged trunk after each merge (the documented two-green-PRs-break-trunk lesson). |
+| **19** | **A background whisper pass makes the measured 14 GB recording RSS worse.** | Medium | It cannot overlap — `acquire_model_generation` still refuses `(Some(active), None)`. The worker becomes a real consumer of `topic_backfill_ram_permits_now()` (called **once**, not double-wrapped) + thermal. **Honest bar: needs one RSS measurement on a signed build.** |
+| **20** | **Fabricated numbers reach users** — RAM figures, wall-clock claims, benchmark deltas. | Medium (trust) | Every RAM figure from the cited research doc, rounded **up**, source in the registry doc-comment; every string hedged "about"; the invented "16 GB" sentence deleted; benchmark numbers only in the advanced table with the "meeting audio is harder than FLEURS" caveat; Sharp and Maximum share an accuracy meter because the delta is genuinely unpublished. |
+
+---
+
+## 8. Verified addendum — 2026-07-26 (post-synthesis, on the real Mac)
+
+Section 6 listed the `sysctl` probes as unverifiable because **every read returned "Operation not
+permitted" during the synthesis**. That was a pure artefact of the agent sandbox, not a macOS
+restriction. Re-run with the sandbox disabled on the development Mac (`hw.model` = `Mac16,5`):
+
+| Key | Value | Consequence for P1 |
+|---|---|---|
+| `hw.memsize` | `68719476736` (64 GiB) | Already proven in production; unchanged. |
+| `hw.optional.arm64` | `1` | The Apple-Silicon-vs-Intel branch (C2) has a working probe. |
+| `sysctl.proc_translated` | `0` | Native arm64, not Rosetta. Both keys are cheap and readable. |
+| `machdep.cpu.brand_string` | `Apple M4 Max` | 12 chars, `Apple ` prefix — passes the C10 normalisation rule (accept only `Apple …` ≤ 24 chars) against a **real** string, not a fixture. |
+| `hw.nperflevels` | `2` | Available if a later consumer needs it. |
+| `hw.perflevel0.logicalcpu` / `hw.perflevel1.logicalcpu` | `12` / `4` | ditto |
+| `hw.logicalcpu` | `16` | ditto |
+
+**Still unverified and still in §6:** the same probes under the **x86_64 slice** of the universal
+build (needs an Intel Mac — and `machdep.cpu.brand_string` there returns the long
+`Intel(R) Core(TM) …` form that C10's normalisation must *reject*), and the free-disk `NSURL` read.
+
+**Trap recorded for future sessions:** hardware probes (`sysctl`, and anything reading outside the
+project tree) fail with "Operation not permitted" under the default agent sandbox. That is **not**
+evidence the key is missing — re-probe with the sandbox disabled before concluding anything about
+hardware availability.
+
+---
+
+## 9. Decisions taken — 2026-07-26
+
+Recorded so no later PR re-litigates them.
+
+| # | Decision | Choice | Note |
+|---|---|---|---|
+| D1 | Updater mechanism | **Track A** — bespoke verified download → full signature pin → `ditto` swap with verified backup + automatic rollback | Zero new crates, zero key custody. |
+| D2 | `objc2-foundation` `NSValue` feature | **Option B** — guarded `msg_send` under `objc2::exception::catch` | No manifest edit, no approval needed. |
+| D3 | Queue default policy | **`immediate`** | Other policies one click away in the panel. |
+| D4 | Stop returns `{queued:true}` instead of the note | **Confirmed** — this is the requested feature | |
+| D5 | Queue cancel semantics | **Pause + Discard only** | No "cancelled-but-half-processed" state. |
+| D6 | Update default mode | **`automatic`** | With the one-time disclosure, the permanent privacy sentence, and a `share::ledger_row` entry per check/download. |
+| D7 | The word "Brain" | **Knowledge base only** | `/brain`, Shared Brain, Ask Brain stay; "Enable the brain" → "Turn on memory and search". |
+| D8 | Kong AI Gateway in onboarding | **KEPT — the user overrode the recommendation** | Stays in the wizard; gets plain-language copy instead of "OpenAI-compatible base URL". It must NOT be removed. |
+| D9 | `TURBO_DEFAULT_MIN_RAM_BYTES` | **Left at 12 GiB** | Lowering it is a behaviour change gated on an RSS measurement. |
+
+### Deviation from the §4 sequencing
+
+**`PipelineBusy` moves from P0 to P8.** A counter with no reader fails `cargo clippy --lib -D warnings`
+on `dead_code` in CI's lib-only build — the exact class the PR-program playbook warns about. Its only
+reader is `install_blockers`, which lands in P8. P8 therefore also owns applying the guard to
+`retry_transcription`, `resummarize`, the `audio::spill` salvage runner, the five `commands/models.rs`
+downloads, and the P6 queue worker. **P0 is consequently frontend-only and runs no cargo at all.**
+
+### Corrections to §3/§4 counts found while scoping P0
+
+- **`.field-help` is declared in ELEVEN component SCSS files, not five** (§3.0.1 undercounted):
+  settings-notes, settings-audio, settings-transcription, ai/model-effort-picker, ai/ai-connection-card,
+  ai/ai-setup-block, ai/ai-role-rows, ai/brain-posture-block, ai/local-models-list, settings-connectors,
+  settings-storage. Confirmed absent from both `primitives.css` and `styles.css`.
+- **`statusPillClass` is duplicated in FOUR files, not two**: `features/library/library`,
+  `features/library/meetings-table-view`, `features/detail/detail`, `features/analytics/analytics`.
+  Every copy maps `RECORDING` **and** `ERROR` to `is-danger`.
+- **No new CSS is needed for the status-pill fix**: `.pill.is-live` already exists at
+  `primitives.css:233` backed by `--live-soft` / `--live-hover`.
+- The seven `progress-track` call sites in §3.0.2 are **confirmed exactly seven**.
+
+### P1's hardware probe — the actually-zero-manifest path
+
+`libc` is **not** a direct dependency of `src-tauri` (verified: no `libc` line in `Cargo.toml`; it is
+only transitively in `Cargo.lock`). So `use libc::sysctlbyname` would still require a manifest edit,
+which the §5 D2 discussion glossed over.
+
+The genuinely zero-touch path is already shipped in-tree: `transcribe/model.rs::total_ram_bytes`
+(model.rs:157) reads `hw.memsize` by **spawning `sysctl -n`**. P1 extends that same proven pattern to
+`hw.optional.arm64`, `sysctl.proc_translated` and `machdep.cpu.brand_string`, and computes the whole
+`MachineProfile` **once** behind a `OnceLock`. Net effect: no manifest edit, no new crate, and *fewer*
+subprocess spawns than today (the current code re-spawns per call — the §3.3 note about "one fewer
+`sysctl` subprocess per `list_brain_models`" is the same observation).
+
+Free disk keeps decision D2: `objc2` already enables the `exception` feature (`Cargo.toml:170`), and
+`objc2-foundation` already has `NSURL`/`NSDictionary`/`NSArray` but **not** `NSValue` — so the
+`NSNumber` that `resourceValuesForKeys:error:` returns is read with a `respondsToSelector`-guarded
+`msg_send![num, longLongValue]` wrapped in `objc2::exception::catch`. Zero manifest change confirmed.
+
+### P8 PREFLIGHT GATE — PASSED 2026-07-26 (the `ditto` assumption is now measured, not assumed)
+
+§4/P8 made this a hard gate before writing a line of updater code, and risk #1 called it the
+program's highest-stakes unknown. **It passes.** Run against the real notarised
+`/Applications/Murmur.app` 1.0.3 (`Identifier=com.meetnotes.app`,
+`Authority=Developer ID Application: Jakub Gawroski (BVF778E5QD)`, `TeamIdentifier=BVF778E5QD`),
+`ditto`'d to a temp dir and re-verified **inside-out** (per-helper, never `--deep` — the repo hook
+correctly refuses `--deep`, and per-helper is the stronger check anyway):
+
+| Check on the `ditto` copy | Result |
+|---|---|
+| `codesign --verify --strict --verbose=2` (main bundle) | `valid on disk` + **`satisfies its Designated Requirement`**, exit 0 |
+| `codesign --verify --strict` on each of the 4 nested helpers (`meetnotes-aeccap`, `-audiocap`, `-calendar`, `-sysaudio`) | all exit 0 |
+| `codesign -d --entitlements :-` | **`keychain-access-groups` = `BVF778E5QD.com.meetnotes.app` PRESERVED**, alongside `application-identifier`, `allow-jit`, `allow-unsigned-executable-memory`, `disable-library-validation`, `device.audio-input`, `personal-information.calendars` |
+| `Contents/embedded.provisionprofile` | survived, byte-size identical (12275) |
+| `spctl -a -vvv -t exec` | **`accepted` / `source=Notarized Developer ID`** |
+
+**Consequence:** Track A is viable. The Keychain ACL — and therefore Touch ID's ability to release the
+master KEK after a self-update — survives a `ditto` self-replacement. Risk #1's five defences stay in
+the design, but its premise is no longer speculative.
+
+**Correction to E3 (disk preflight).** `ditto` of the 178 MB bundle completed in **0.17 s** because
+APFS `clonefile` makes a same-volume copy near-free in both time and space. So `dmg_bytes + 4 ×
+app_uncompressed_bytes` over-provisions badly for the *rollback* copy (same volume → a clone). The
+real cost is the DMG plus the extraction **off the mounted image** (a different volume → a genuine
+copy). Size the preflight as `dmg_bytes + 2 × app_uncompressed_bytes` and keep the re-check inside
+`install.sh` immediately before the swap; do **not** silently rely on cloning, since the target volume
+is not guaranteed to be APFS.
+
+**Also measured:** the installed bundle is **178 MB**, not the ~214 MB the §5 D6 discussion assumed for
+the download. Use the real DMG size from the release artefact, never a remembered figure.

--- a/e2e/fixtures/whisper-recommendation.json
+++ b/e2e/fixtures/whisper-recommendation.json
@@ -1,0 +1,123 @@
+{
+  "_comment": [
+    "THE `whisper_recommendation` WIRE FORMAT — one fixture, two consumers.",
+    "",
+    "Rust asserts this file's KEY SHAPE and its enum vocabulary against the real serialized",
+    "`WhisperRecommendationDto` (src-tauri/src/commands/model_perf.rs, test",
+    "`whisper_recommendation_wire_format_matches_the_e2e_fixture`), and the Playwright specs feed",
+    "THIS file to the mocked `whisper_recommendation` command. So a renamed / added / dropped field",
+    "on the Rust DTO fails the Rust test, and the UI is only ever driven by a payload the backend",
+    "could really have produced. Before this existed, the camelCase wire format had never been",
+    "exercised end to end at all.",
+    "",
+    "The scenario: a 64 GiB Apple-Silicon Mac that already has Sharp + Balanced on disk.",
+    "Keys starting with `_` are documentation and are ignored by both consumers."
+  ],
+  "machine": {
+    "totalRamBytes": 68719476736,
+    "appleSilicon": true,
+    "chipName": "Apple M4 Max",
+    "freeDiskBytes": 214748364800
+  },
+  "models": [
+    {
+      "id": "tiny",
+      "tier": null,
+      "headline": "Smallest and fastest; makes frequent mistakes.",
+      "approxDownloadBytes": 78643200,
+      "approxRamBytes": null,
+      "liveSafe": true,
+      "power": 1,
+      "downloaded": false
+    },
+    {
+      "id": "base",
+      "tier": "Light",
+      "headline": "Gets the gist.",
+      "approxDownloadBytes": 157286400,
+      "approxRamBytes": null,
+      "liveSafe": true,
+      "power": 2,
+      "downloaded": false
+    },
+    {
+      "id": "small-q8_0",
+      "tier": null,
+      "headline": "Balanced accuracy at a smaller download.",
+      "approxDownloadBytes": 283115520,
+      "approxRamBytes": null,
+      "liveSafe": true,
+      "power": 3,
+      "downloaded": false
+    },
+    {
+      "id": "small",
+      "tier": "Balanced",
+      "headline": "Readable transcripts, small footprint. Also powers live captions.",
+      "approxDownloadBytes": 492830720,
+      "approxRamBytes": 966367641,
+      "liveSafe": true,
+      "power": 4,
+      "downloaded": true
+    },
+    {
+      "id": "medium-q8_0",
+      "tier": null,
+      "headline": "Medium accuracy at a smaller download.",
+      "approxDownloadBytes": 891289600,
+      "approxRamBytes": null,
+      "liveSafe": false,
+      "power": 5,
+      "downloaded": false
+    },
+    {
+      "id": "large-v3-turbo-q8_0",
+      "tier": "Sharp",
+      "headline": "Near-best accuracy, no speed penalty.",
+      "approxDownloadBytes": 917504000,
+      "approxRamBytes": 1610612736,
+      "liveSafe": false,
+      "power": 6,
+      "downloaded": true
+    },
+    {
+      "id": "medium",
+      "tier": null,
+      "headline": "The older mid-size model; superseded by Sharp.",
+      "approxDownloadBytes": 1610612736,
+      "approxRamBytes": null,
+      "liveSafe": false,
+      "power": 7,
+      "downloaded": false
+    },
+    {
+      "id": "large-v3-turbo",
+      "tier": null,
+      "headline": "Sharp without the quantisation; a bigger download for the same speed.",
+      "approxDownloadBytes": 1717567488,
+      "approxRamBytes": null,
+      "liveSafe": false,
+      "power": 8,
+      "downloaded": false
+    },
+    {
+      "id": "large-v3",
+      "tier": "Maximum",
+      "headline": "The heaviest model, for hard audio.",
+      "approxDownloadBytes": 3221225472,
+      "approxRamBytes": 4187593113,
+      "liveSafe": false,
+      "power": 9,
+      "downloaded": false
+    }
+  ],
+  "selectedId": "large-v3-turbo-q8_0",
+  "recommendedId": "large-v3-turbo-q8_0",
+  "autoDefaultId": "large-v3-turbo-q8_0",
+  "reason": "alreadyDownloaded",
+  "modelSizeSource": "auto",
+  "customPathOverride": false,
+  "pendingDownloadBytes": 0,
+  "liveCaptions": "ready",
+  "brainAdvice": "full"
+}

--- a/e2e/onboarding/model-presence-race.spec.ts
+++ b/e2e/onboarding/model-presence-race.spec.ts
@@ -1,29 +1,49 @@
 import { test, expect } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { mockTauri } from "../settings-ai/mock-invoke";
 
+const RECOMMENDATION = JSON.parse(
+  readFileSync(
+    join(__dirname, "..", "fixtures", "whisper-recommendation.json"),
+    "utf8",
+  ),
+);
+
 /**
- * Regression test for the onboarding Model step's stale-response guard.
+ * Regression test for the onboarding Model step's stale-response guard, rewritten
+ * for the power slider (the Quality `<select>` this spec used to drive is gone).
  *
- * `onLanguage`/`onModelSize` each call `refreshModelPresence()`, which does
- * `modelPresent.set(null)` → `await persistConfig()` → `modelPresent.set(await
- * ipc.modelPresent())`. Rapidly switching the Quality dropdown fires two
- * overlapping calls; without a stale-result guard, whichever `model_present`
- * IPC call resolves LAST wins, even if it belongs to an earlier, no-longer-
- * selected quality. This test forces the FIRST call's `model_present`
- * ("small", present) to resolve AFTER the second one ("medium", absent —
- * opposite of call order) and asserts the final `modelPresent()` state
- * matches the CURRENTLY selected quality ("medium", absent), not the stale
- * first pick.
+ * Picking a rung calls `refreshModelPresence()`, which does `modelPresent.set(null)`
+ * → `await persistConfig()` → `modelPresent.set(await ipc.modelPresent())`. Two
+ * rapid picks overlap; without `modelPresenceRequestId`, whichever `model_present`
+ * IPC resolves LAST wins — even when it belongs to an earlier, no-longer-selected
+ * size. Here the FIRST pick ("small", present) is forced to resolve AFTER the
+ * second ("medium", absent), i.e. the opposite of call order, and the final state
+ * must match the CURRENT selection.
+ *
+ * PROVING IT IS REALLY RED: temporarily delete the `modelPresenceRequestId`
+ * comparison in `onboarding.component.ts::refreshModelPresence` and this test must
+ * FAIL with "Model ready" visible. A rewrite that passes against unguarded code
+ * captures nothing.
  */
-test("rapid Quality switches don't leave a stale modelPresent state", async ({
+test("rapid quality picks don't leave a stale modelPresent state", async ({
   page,
 }) => {
   await mockTauri(page, {
-    // "small" resolves SLOW (present); "medium" resolves FAST (absent) — so
-    // if there is no stale-result guard, the slow "small" response lands
-    // LAST and overwrites the fast "medium" response, even though "medium"
-    // is the currently selected quality by the time both probes settle.
-    model_present: (args: any) => {
+    // The picker reads its ladder from here. Without this mock the demo mock's
+    // `default:` branch returns null and no slider renders at all.
+    whisper_recommendation: () => {
+      const w = window as any;
+      const cfg = (w.__demoConfig && w.__demoConfig.modelSize) || "";
+      return Object.assign({}, (window as any).__recFixture, {
+        selectedId: cfg || (window as any).__recFixture.selectedId,
+      });
+    },
+    // "small" resolves SLOW (present); everything else resolves FAST (absent) — so
+    // an unguarded implementation lets the slow "small" answer land LAST and
+    // overwrite the fast "medium" answer that belongs to the current selection.
+    model_present: () => {
       const w = window as any;
       const size = (w.__demoConfig && w.__demoConfig.modelSize) || "";
       const delayMs = size === "small" ? 400 : 50;
@@ -37,33 +57,38 @@ test("rapid Quality switches don't leave a stale modelPresent state", async ({
       return null;
     },
   });
+  await page.addInitScript((rec) => {
+    (window as any).__recFixture = rec;
+  }, RECOMMENDATION);
 
   await page.goto("/onboarding");
   await page.getByRole("button", { name: "Get started" }).click();
 
-  // Let the initial onEnterStep("model") probe (whatever the demo default
-  // quality is) settle into SOME terminal state before starting the race.
-  const qualitySelect = page.locator("select").nth(1);
+  const slider = page.getByRole("slider", {
+    name: "Transcription model power",
+  });
+  await expect(slider).toBeVisible({ timeout: 5_000 });
+
+  // Let the initial probe settle into SOME terminal state before racing.
   await expect(
     page.locator(".model-state .pill.is-success, .model-state button"),
   ).toBeVisible({ timeout: 5_000 });
 
-  // Rapidly switch Quality small -> medium within the round-trip window: the
-  // "small" probe (slow, 400ms) is still in flight when "medium" (fast,
-  // 50ms) fires right after it.
-  await qualitySelect.selectOption("small");
-  await qualitySelect.selectOption("medium");
+  // Balanced = `small` (slow, present), then Maximum = `large-v3` (fast, absent).
+  // The rung ORDER is Light/Balanced/Sharp/Maximum, so indices 1 then 3.
+  await slider.fill("1");
+  await slider.dispatchEvent("change");
+  await slider.fill("3");
+  await slider.dispatchEvent("change");
 
-  // Wait past BOTH probes' resolution windows (400ms slow + 50ms fast) so the
-  // late-resolving "small" response has had every chance to land and, on the
-  // unguarded code, overwrite the correct "medium" result.
+  // Past BOTH windows (400 ms slow + 50 ms fast) so the late "small" answer has
+  // every chance to land and, on unguarded code, overwrite the correct one.
   await page.waitForTimeout(700);
 
-  // The CURRENT selection is "medium", which is NOT present on disk — the
-  // final state must reflect that (a "Download model" affordance), never the
-  // stale "small" response landing later and claiming the model is ready.
-  await expect(
-    page.getByRole("button", { name: /Download model/ }),
-  ).toBeVisible({ timeout: 5_000 });
+  // The CURRENT selection is not on disk, so the step must offer a download —
+  // never the stale "small" answer arriving late and claiming the model is ready.
+  await expect(page.getByRole("button", { name: /Download/ })).toBeVisible({
+    timeout: 5_000,
+  });
   await expect(page.getByText("Model ready")).not.toBeVisible();
 });

--- a/e2e/settings-ai/model-power.spec.ts
+++ b/e2e/settings-ai/model-power.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { mockTauri } from "./mock-invoke";
+
+const RECOMMENDATION = JSON.parse(
+  readFileSync(
+    join(__dirname, "..", "fixtures", "whisper-recommendation.json"),
+    "utf8",
+  ),
+);
+
+/**
+ * The transcription power picker in Settings.
+ *
+ * The FIRST test here is a regression for a real BLOCKER found by review: picking a
+ * rung wrote the form control programmatically with `setValue()`, which does NOT
+ * mark the form dirty — and the store's debounced auto-save is gated on
+ * `form.dirty`. So on a PRISTINE Settings visit (the normal case) the rung moved on
+ * screen and nothing was ever persisted. The picker looked like it worked.
+ *
+ * PROVING IT IS REALLY RED: remove `this.form.markAsDirty()` from
+ * `settings-transcription-section.component.ts::onSizeChange` and the first test must
+ * FAIL with zero recorded saves.
+ */
+async function boot(page: import("@playwright/test").Page) {
+  await mockTauri(
+    page,
+    {
+      save_config: (args: any) => {
+        const w = window as any;
+        w.__saves = w.__saves || [];
+        w.__saves.push(args.config?.modelSize ?? null);
+        w.__demoConfig = Object.assign({}, w.__demoConfig, args.config);
+        return null;
+      },
+    },
+    { whisper_recommendation: RECOMMENDATION },
+  );
+  await page.goto("/settings");
+  await page.getByRole("button", { name: /Transcription/i }).first().click();
+}
+
+test("a rung picked on a PRISTINE form is actually saved", async ({ page }) => {
+  await boot(page);
+
+  const slider = page.getByRole("slider", {
+    name: "Transcription model power",
+  });
+  await expect(slider).toBeVisible({ timeout: 10_000 });
+
+  // Touch NOTHING else first — a pristine form is the case that silently lost the pick.
+  await slider.fill("0");
+  await slider.dispatchEvent("change");
+
+  await expect
+    .poll(async () => await page.evaluate(() => (window as any).__saves ?? []), {
+      timeout: 10_000,
+    })
+    .toContain("base");
+});
+
+test("dragging across rungs commits once, and announces the rung by NAME", async ({
+  page,
+}) => {
+  await boot(page);
+
+  const slider = page.getByRole("slider", {
+    name: "Transcription model power",
+  });
+  await expect(slider).toBeVisible({ timeout: 10_000 });
+
+  // A drag is many `input` events and ONE `change`. Only the change may commit —
+  // otherwise a three-rung drag writes the config three times.
+  await slider.fill("0");
+  await slider.fill("1");
+  await slider.fill("2");
+  await slider.dispatchEvent("change");
+
+  await expect
+    .poll(async () => await page.evaluate(() => (window as any).__saves ?? []), {
+      timeout: 10_000,
+    })
+    .toEqual(["large-v3-turbo-q8_0"]);
+
+  // Accessibility: the value announced is the human rung name, never the index.
+  const text = await slider.getAttribute("aria-valuetext");
+  expect(text).toBeTruthy();
+  expect(text).not.toMatch(/^\d+$/);
+});
+
+test("the badge tracks the selection, and the reason makes no unsupported claim", async ({
+  page,
+}) => {
+  await boot(page);
+
+  const slider = page.getByRole("slider", {
+    name: "Transcription model power",
+  });
+  await expect(slider).toBeVisible({ timeout: 10_000 });
+  const badge = page.getByText("Recommended for this Mac");
+  const card = page.locator("app-model-power");
+
+  // The fixture recommends Sharp (`large-v3-turbo-q8_0`), rung index 2. The badge is a
+  // claim about the CURRENT selection, so it must appear only when they agree.
+  await slider.fill("2");
+  await slider.dispatchEvent("change");
+  await expect(badge).toBeVisible();
+
+  await slider.fill("0");
+  await slider.dispatchEvent("change");
+  await expect(badge).toBeHidden();
+
+  // The fixture's reason is `alreadyDownloaded`, whose whole point is that PRESENCE —
+  // not RAM — decided it, and the machine is Apple Silicon. A RAM-causal sentence or a
+  // chip-family claim here would be the exact dishonesty two P1 review rounds removed.
+  await expect(card).not.toContainText(/\d+\s*GB of (RAM|memory)/i);
+  await expect(card).not.toContainText(/Intel/i);
+});

--- a/src-tauri/src/commands/model_perf.rs
+++ b/src-tauri/src/commands/model_perf.rs
@@ -509,6 +509,12 @@ pub struct WhisperRecommendationDto {
     /// FE must say "size unknown", never "free". The two are deliberately NOT collapsed: an id with
     /// no measured size would otherwise promise a free multi-GB transfer.
     pub pending_download_bytes: Option<u64>,
+    /// LIVE-caption readiness (`"ready"` / `"noModel"` / `"modelMissing"` / `"pinnedHeavy"`) — the
+    /// SAME classification `get_config` ships as `AppConfigDto::live_captions`, resolved here over
+    /// the ONE models-dir listing this DTO already took so the picker can offer a REPAIR affordance
+    /// without a second (and possibly disagreeing) probe. P2 (W2) added it because the picker is
+    /// where a user both discovers and fixes "live captions have nothing to run".
+    pub live_captions: String,
     /// The brain posture we would advise on this machine (advice only — it gates nothing).
     pub brain_advice: crate::reason::BrainAdvice,
 }
@@ -608,6 +614,21 @@ fn build_recommendation(
         },
         models,
         pending_download_bytes: pending_download_bytes(cfg, dir, &selected_id, present),
+        // The same classification `live_captions::dto_probe` performs, over the dir this DTO already
+        // listed. `selected_id` — not `cfg.model_size` — is passed on purpose: it is the ALREADY
+        // resolved size, so a blank config cannot send `resolve_in` off to `default_model_size_now()`
+        // to re-list the real models dir (which would break this function's purity and its headless
+        // tests, and could disagree with the listing every other field here was built from).
+        live_captions: super::live_captions::resolve_in(
+            dir,
+            configured,
+            &selected_id,
+            language,
+            &cfg.live_model_pin,
+            cfg.brain_live,
+        )
+        .dto_state()
+        .to_string(),
         selected_id,
         recommended_id: hardware.id.to_string(),
         auto_default_id: auto_default_id.to_string(),
@@ -950,6 +971,131 @@ mod recommendation_tests {
         let d = dto(&cfg, &dir, &[], &apple(64));
         assert!(d.custom_path_override);
         assert_eq!(d.pending_download_bytes, Some(0));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// P2 (W2) — THE WIRE FORMAT, asserted against the fixture the Playwright specs feed to the
+    /// mocked `whisper_recommendation`. Before this test the camelCase payload had never been
+    /// exercised against the backend at all: the FE's `WhisperRecommendationDto` interface was
+    /// hand-written, so a renamed / added / dropped Rust field would have surfaced only as a blank
+    /// area of the model picker in a shipped build.
+    ///
+    /// It compares the KEY SHAPE (top level, `machine`, every `models` row) and the closed
+    /// vocabularies (`reason`, `liveCaptions`, `brainAdvice`, `tier`), NOT the byte figures — the
+    /// figures are already pinned by `catalog`'s own tests, and duplicating them here would make the
+    /// fixture fight the catalog instead of the wire format.
+    #[test]
+    fn whisper_recommendation_wire_format_matches_the_e2e_fixture() {
+        let dir = tmp_dir("wire");
+        // Mirror the fixture's scenario: Sharp + Balanced already on disk. The files are really
+        // written because `resolve_in` / `companion_pending_size_in` read the filesystem, not the
+        // name list.
+        for f in ["ggml-large-v3-turbo-q8_0.bin", "ggml-small.bin"] {
+            std::fs::write(dir.join(f), b"MODEL").unwrap();
+        }
+        let cfg = AppConfig {
+            model_size: SHARP_ID.to_string(),
+            ..AppConfig::default()
+        };
+        let d = build_recommendation(
+            &cfg,
+            &dir,
+            &[
+                "ggml-large-v3-turbo-q8_0.bin".to_string(),
+                "ggml-small.bin".to_string(),
+            ],
+            &apple(64),
+            Some(200 * GIB),
+            Some("auto".to_string()),
+        );
+        let actual = serde_json::to_value(&d).expect("the DTO serializes");
+
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../e2e/fixtures/whisper-recommendation.json");
+        let fixture: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(&path).expect("the e2e fixture is checked in"),
+        )
+        .expect("the e2e fixture is valid JSON");
+
+        // `_`-prefixed keys are documentation for the fixture's human readers.
+        let keys = |v: &serde_json::Value| -> Vec<String> {
+            let mut k: Vec<String> = v
+                .as_object()
+                .expect("an object")
+                .keys()
+                .filter(|k| !k.starts_with('_'))
+                .cloned()
+                .collect();
+            k.sort();
+            k
+        };
+
+        assert_eq!(
+            keys(&actual),
+            keys(&fixture),
+            "the e2e fixture must carry EXACTLY the DTO's top-level camelCase keys — update \
+             e2e/fixtures/whisper-recommendation.json (and the FE interface in src/app/core/models.ts)"
+        );
+        assert_eq!(
+            keys(&actual["machine"]),
+            keys(&fixture["machine"]),
+            "machine profile keys drifted"
+        );
+        let actual_row = &actual["models"][0];
+        for row in fixture["models"].as_array().expect("models is an array") {
+            assert_eq!(keys(actual_row), keys(row), "a catalog row's keys drifted");
+        }
+
+        // The closed vocabularies: every fixture value must be one Rust can really emit.
+        let real_reasons: Vec<serde_json::Value> = [
+            RecommendReason::AlreadyDownloaded,
+            RecommendReason::FreshInstallAmpleRam,
+            RecommendReason::NotAppleSilicon,
+            RecommendReason::ArchUnknown,
+            RecommendReason::ModestRam,
+            RecommendReason::RamUnknown,
+            RecommendReason::ExistingInstall,
+        ]
+        .iter()
+        .map(|r| serde_json::to_value(r).unwrap())
+        .collect();
+        assert!(
+            real_reasons.contains(&fixture["reason"]),
+            "fixture reason {:?} is not a RecommendReason variant",
+            fixture["reason"]
+        );
+        assert_eq!(
+            actual["reason"], fixture["reason"],
+            "the fixture's scenario (Sharp already on disk) must produce the fixture's reason"
+        );
+        assert_eq!(actual["liveCaptions"], fixture["liveCaptions"]);
+        assert_eq!(actual["brainAdvice"], fixture["brainAdvice"]);
+        assert_eq!(actual["selectedId"], fixture["selectedId"]);
+        assert_eq!(actual["recommendedId"], fixture["recommendedId"]);
+        assert_eq!(actual["autoDefaultId"], fixture["autoDefaultId"]);
+        assert_eq!(actual["modelSizeSource"], fixture["modelSizeSource"]);
+        assert_eq!(actual["pendingDownloadBytes"], fixture["pendingDownloadBytes"]);
+
+        // Every fixture row is a real registry row, and every ladder label is a real tier label.
+        for row in fixture["models"].as_array().unwrap() {
+            let id = row["id"].as_str().expect("an id");
+            assert!(
+                crate::transcribe::catalog::model_by_id(id).is_some(),
+                "fixture row {id} is not in the registry"
+            );
+            if let Some(tier) = row["tier"].as_str() {
+                assert_eq!(
+                    crate::transcribe::catalog::tier_label(id),
+                    Some(tier),
+                    "fixture tier for {id} disagrees with the registry"
+                );
+            }
+        }
+        assert_eq!(
+            fixture["models"].as_array().unwrap().len(),
+            crate::transcribe::catalog::visible().count(),
+            "the fixture must list exactly the VISIBLE catalog (provisional rows stay hidden)"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -251,11 +251,42 @@ pub async fn provider_statuses(
 /// tick, so the default install had NO live captions). BEST-EFFORT: a companion failure never fails
 /// this command — the batch model is what gates recording, and the recorder surfaces the
 /// "live captions off" state from `get_config`.
+/// What a `download_model` call ended up doing.
+///
+/// A user-initiated CANCEL is `Ok(status: "cancelled")`, never an `Err`: cancelling is not a
+/// failure, and returning an error would force the FE to string-match a message to tell a cancel
+/// apart from a dead link — exactly the fragility a typed outcome removes. `path` is the batch
+/// model that IS on disk when the call returns, so a cancel that arrived after the batch model
+/// landed (i.e. during the live-caption companion) still reports the file the user now has.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelDownloadOutcomeDto {
+    /// `"ready"` or `"cancelled"`.
+    pub status: String,
+    /// The batch model's path when one is on disk, else `null`.
+    pub path: Option<String>,
+}
+
+impl ModelDownloadOutcomeDto {
+    fn ready(path: String) -> Self {
+        Self {
+            status: "ready".into(),
+            path: Some(path),
+        }
+    }
+    fn cancelled(path: Option<String>) -> Self {
+        Self {
+            status: "cancelled".into(),
+            path,
+        }
+    }
+}
+
 #[tauri::command]
 pub async fn download_model(
     app: AppHandle,
     state: State<'_, AppState>,
-) -> Result<String, AppError> {
+) -> Result<ModelDownloadOutcomeDto, AppError> {
     let (configured, size, language, live_model_pin, brain_live) = {
         let c = state
             .config
@@ -274,32 +305,13 @@ pub async fn download_model(
     // Throttle progress events to roughly every 8 MB so a multi-GB download doesn't flood the FE.
     const EMIT_EVERY: u64 = 8 * 1024 * 1024;
     let mut last_emit: u64 = 0;
-    let path = crate::transcribe::ensure_model(p, &size, &language, |downloaded, total| {
-        if downloaded - last_emit >= EMIT_EVERY {
-            last_emit = downloaded;
-            let _ = app.emit(
-                crate::events::EVENT_MODEL_DOWNLOAD,
-                crate::events::ModelDownloadPayload {
-                    downloaded,
-                    total,
-                    done: false,
-                },
-            );
-        }
-    })
-    .await?;
-
-    // The LIVE-caption companion, decided against the model that actually landed above (so a custom
-    // `whisper_model_path` is covered without re-deriving it). Progress rides the SAME throttled
-    // event stream — the FE bar restarts for the (much smaller) second file, which is honest: it is a
-    // second download. Nothing is fetched when the live tick already has something to run.
-    if let Some(live_size) =
-        super::live_captions::companion_size(&path, &language, &live_model_pin, brain_live)
-    {
-        let mut companion_emit: u64 = 0;
-        match crate::transcribe::ensure_model(None, &live_size, &language, |downloaded, total| {
-            if downloaded - companion_emit >= EMIT_EVERY {
-                companion_emit = downloaded;
+    let outcome = crate::transcribe::model::ensure_model_cancellable(
+        p,
+        &size,
+        &language,
+        |downloaded, total| {
+            if downloaded - last_emit >= EMIT_EVERY {
+                last_emit = downloaded;
                 let _ = app.emit(
                     crate::events::EVENT_MODEL_DOWNLOAD,
                     crate::events::ModelDownloadPayload {
@@ -309,14 +321,76 @@ pub async fn download_model(
                     },
                 );
             }
-        })
+        },
+    )
+    .await?;
+    let path = match outcome {
+        crate::transcribe::model::DownloadOutcome::Ready(p) => p,
+        crate::transcribe::model::DownloadOutcome::Cancelled => {
+            // Tell the FE the bar is over, then report the cancel as a normal outcome. Nothing was
+            // left on disk (`ensure_model_cancellable` removes its own `.part`), so there is no
+            // path to report and no companion to consider.
+            let _ = app.emit(
+                crate::events::EVENT_MODEL_DOWNLOAD,
+                crate::events::ModelDownloadPayload {
+                    downloaded: 0,
+                    total: None,
+                    done: true,
+                },
+            );
+            return Ok(ModelDownloadOutcomeDto::cancelled(None));
+        }
+    };
+
+    // The LIVE-caption companion, decided against the model that actually landed above (so a custom
+    // `whisper_model_path` is covered without re-deriving it). Progress rides the SAME throttled
+    // event stream — the FE bar restarts for the (much smaller) second file, which is honest: it is a
+    // second download. Nothing is fetched when the live tick already has something to run.
+    if let Some(live_size) =
+        super::live_captions::companion_size(&path, &language, &live_model_pin, brain_live)
+    {
+        let mut companion_emit: u64 = 0;
+        match crate::transcribe::model::ensure_model_cancellable(
+            None,
+            &live_size,
+            &language,
+            |downloaded, total| {
+                if downloaded - companion_emit >= EMIT_EVERY {
+                    companion_emit = downloaded;
+                    let _ = app.emit(
+                        crate::events::EVENT_MODEL_DOWNLOAD,
+                        crate::events::ModelDownloadPayload {
+                            downloaded,
+                            total,
+                            done: false,
+                        },
+                    );
+                }
+            },
+        )
         .await
         {
-            Ok(_) => tracing::info!(
+            Ok(crate::transcribe::model::DownloadOutcome::Ready(_)) => tracing::info!(
                 target: "transcribe",
                 size = %live_size,
                 "live-caption companion model ready beside the batch model"
             ),
+            Ok(crate::transcribe::model::DownloadOutcome::Cancelled) => {
+                // The batch model DID land before the cancel arrived, so report the file the user
+                // now has alongside the cancel — the recommendation refresh the FE runs next will
+                // show it as downloaded, and a `path: null` here would contradict that.
+                let _ = app.emit(
+                    crate::events::EVENT_MODEL_DOWNLOAD,
+                    crate::events::ModelDownloadPayload {
+                        downloaded: 0,
+                        total: None,
+                        done: true,
+                    },
+                );
+                return Ok(ModelDownloadOutcomeDto::cancelled(Some(
+                    path.to_string_lossy().to_string(),
+                )));
+            }
             Err(e) => tracing::warn!(
                 target: "transcribe",
                 size = %live_size,
@@ -334,7 +408,82 @@ pub async fn download_model(
             done: true,
         },
     );
-    Ok(path.to_string_lossy().to_string())
+    Ok(ModelDownloadOutcomeDto::ready(
+        path.to_string_lossy().to_string(),
+    ))
+}
+
+/// Cancel the whisper model download that is in flight RIGHT NOW.
+///
+/// Infallible and idempotent: with nothing running it simply moves the generation counter forward,
+/// which affects no future download (see `transcribe::model::cancel_model_downloads`). The
+/// in-flight `download_model` resolves with `status: "cancelled"` shortly after — a cancel is a
+/// normal outcome there, never an `Err`.
+#[tauri::command]
+pub fn cancel_model_download() -> Result<(), AppError> {
+    crate::transcribe::model::cancel_model_downloads();
+    Ok(())
+}
+
+/// Delete ONE downloaded whisper model file to reclaim disk.
+///
+/// Every refusal lives in `transcribe::model::deletable_model_file` (pure + unit-tested): a
+/// non-registry id, the EFFECTIVE model, and the LIVE-caption pin are all refused, and the one file
+/// this can ever remove is `model_filename`'s `ggml-<id>[.en].bin` inside the models dir — the VAD,
+/// diarization and parakeet files are unreachable by construction.
+///
+/// LIFECYCLE: gated by the SAME sequence `retry_transcription_prep` uses — the recording-priority
+/// flag, the recorder slot, AND the lifecycle mutex. `recording_has_priority()` alone is not enough:
+/// during a retry that flag is false, so a delete would sail straight through and could pull the
+/// model file out from under an ASR pass that is about to load it.
+///
+/// NOT a content path: model files carry no meeting content, so there is nothing here for the lock
+/// model to gate. Logs the model id only (no PII).
+#[tauri::command]
+pub fn delete_whisper_model(state: State<'_, AppState>, size: String) -> Result<(), AppError> {
+    if crate::perf::recording_has_priority() {
+        return Err(AppError::Audio(
+            "a recording is in progress — stop it before deleting a model".into(),
+        ));
+    }
+    {
+        let recorder = state
+            .recorder
+            .lock()
+            .map_err(|_| AppError::Audio("recorder mutex poisoned".into()))?;
+        if recorder.is_some() {
+            return Err(AppError::Audio(
+                "a recording is in progress — stop it before deleting a model".into(),
+            ));
+        }
+    }
+    // Serialize with Stop / retry / lock so a transcription cannot claim the file mid-delete. Taken
+    // only after the recorder mutex is dropped (same ordering as `retry_transcription_prep`).
+    let _lifecycle = super::lifecycle_guard(&state);
+
+    let (configured_size, language, live_pin, brain_live) = {
+        let c = state
+            .config
+            .lock()
+            .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
+        (
+            c.model_size.clone(),
+            c.language.clone().unwrap_or_default(),
+            c.live_model_pin.clone(),
+            c.brain_live,
+        )
+    };
+    let effective = crate::transcribe::effective_model_size(&configured_size);
+    let pin = crate::transcribe::model::live_pin_size(&live_pin, brain_live);
+    let file = crate::transcribe::model::deletable_model_file(
+        &size,
+        &effective,
+        pin.as_deref(),
+        &language,
+    )?;
+    let dir = crate::transcribe::models_dir()?;
+    crate::transcribe::model::delete_model_file_in(&dir, &file)?;
+    Ok(())
 }
 
 /// Download the OPTIONAL parakeet live-ASR engine's four int8 models (~600 MB) from the csukuangfj

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -390,6 +390,8 @@ pub fn run() {
             commands::clear_voiceprints,
             commands::model_present,
             commands::download_model,
+            commands::cancel_model_download,
+            commands::delete_whisper_model,
             commands::parakeet_models_present,
             commands::download_parakeet_models,
             commands::brain_model_present,

--- a/src-tauri/src/transcribe/model.rs
+++ b/src-tauri/src/transcribe/model.rs
@@ -10,6 +10,7 @@
 //! then hand it to `Transcriber::load`.
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::error::{AppError, Result};
 
@@ -328,6 +329,71 @@ pub fn is_live_heavy_model_file(path: &Path) -> bool {
     })
 }
 
+/// The FOUR refusals a "delete this downloaded model" request must survive, PURE over the facts
+/// that decide them, returning the one file it is then allowed to remove.
+///
+/// 1. **A non-registry id is refused.** This is also the refusal that keeps the VAD
+///    (`ggml-silero-*.bin`), diarization (`*.onnx`) and parakeet bundles out of reach — none of
+///    them is a whisper catalog id, so no request can name one — and it is why the returned name is
+///    always [`model_filename`]'s `ggml-<id>[.en].bin` rather than caller-supplied text.
+/// 2. **The EFFECTIVE model is refused** — it is what a recording would load right now, so deleting
+///    it strands transcription with nothing to run.
+/// 3. **The LIVE-caption pin is refused.** `live_model_pin` defaults to `small` while the batch
+///    default on a 12 GB+ Mac is the turbo quant, so the two DIFFER on the shipped default: without
+///    this refusal, deleting `small` (which is neither selected nor recommended, and looks like
+///    obvious junk in the "show every size" list) silently kills live captions, and the UI offers no
+///    way back because nothing re-fetches a companion for an already-downloaded batch model.
+/// 4. **Nothing outside the models dir, ever** — the returned value is a bare filename with no path
+///    separator, asserted here rather than trusted.
+///
+/// `effective_size` is `effective_model_size(cfg.model_size)` and `live_pin` is
+/// `live_pin_size(cfg.live_model_pin, cfg.brain_live)`, both resolved by the caller so this stays
+/// pure and headless-testable.
+pub fn deletable_model_file(
+    size: &str,
+    effective_size: &str,
+    live_pin: Option<&str>,
+    language: &str,
+) -> Result<String> {
+    let size = size.trim();
+    let Some(model) = crate::transcribe::catalog::model_by_id(size) else {
+        return Err(AppError::InvalidArg(format!(
+            "not a transcription model Murmur manages: {size}"
+        )));
+    };
+    if model.id == effective_size.trim() {
+        return Err(AppError::InvalidArg(
+            "this is the model your recordings use — switch to another size first".into(),
+        ));
+    }
+    if live_pin.map(str::trim) == Some(model.id) {
+        return Err(AppError::InvalidArg(
+            "this model powers live captions — change the live-caption model first".into(),
+        ));
+    }
+    let file = model_filename(model.id, language);
+    if file.contains('/') || file.contains('\\') {
+        return Err(AppError::InvalidArg(
+            "refusing a model filename that escapes the models directory".into(),
+        ));
+    }
+    Ok(file)
+}
+
+/// Remove exactly ONE file from `dir`. `Ok(false)` = it was already gone (delete is idempotent —
+/// a second click must not raise an error). Touches nothing else in the directory, which is what
+/// keeps the VAD / diarization / parakeet files intact.
+pub fn delete_model_file_in(dir: &Path, file: &str) -> Result<bool> {
+    let path = dir.join(file);
+    if !path.is_file() {
+        return Ok(false);
+    }
+    std::fs::remove_file(&path)
+        .map_err(|e| AppError::Transcribe(format!("delete model file: {e}")))?;
+    tracing::info!(target: "transcribe", file = %file, "deleted a downloaded whisper model");
+    Ok(true)
+}
+
 /// Hugging Face mirror of the official whisper.cpp GGML models (ggerganov/whisper.cpp).
 /// `resolve/main` serves the raw file; whisper-rs loads the GGML/GGUF binary directly.
 pub fn model_url(filename: &str) -> String {
@@ -459,12 +525,22 @@ where
             base = base.saturating_add(std::fs::metadata(&dest).map(|m| m.len()).unwrap_or(0));
             continue;
         }
-        download_model_streaming(&client, &parakeet_model_url(file), &dest, |d, _t| {
-            // The aggregate total is unknown across four files (mixed Content-Length availability),
-            // so report the running byte sum with `None` total — the FE shows an indeterminate/byte
-            // progress, consistent with the whisper multi-GB bar.
-            on_progress(base.saturating_add(d), None);
-        })
+        download_model_streaming(
+            &client,
+            &parakeet_model_url(file),
+            &dest,
+            |d, _t| {
+                // The aggregate total is unknown across four files (mixed Content-Length
+                // availability), so report the running byte sum with `None` total — the FE shows an
+                // indeterminate/byte progress, consistent with the whisper multi-GB bar.
+                on_progress(base.saturating_add(d), None);
+            },
+            // Parakeet is a SEPARATE command from the whisper download, so it deliberately does not
+            // observe the whisper cancellation generation: a cancelled whisper fetch must not abort
+            // a live Parakeet fetch. That cross-download bleed is exactly why the generation is a
+            // counter rather than a global bool.
+            None,
+        )
         .await?;
         base = base.saturating_add(std::fs::metadata(&dest).map(|m| m.len()).unwrap_or(0));
     }
@@ -498,6 +574,89 @@ pub fn resolve_model_path(
         return Ok(Some(derived));
     }
     Ok(None)
+}
+
+/// Monotonic GENERATION counter for user-cancellable whisper model downloads.
+///
+/// MODULE-PRIVATE and a COUNTER, deliberately not a global `AtomicBool`. A bool leaks across
+/// downloads: cancel a 3 GB fetch, immediately start a different one, and the still-set flag
+/// cancels the NEW download the instant it reads it (and whoever clears the flag races whoever
+/// sets it). A generation has no such window — an in-flight download captures the value it started
+/// under and aborts only while the CURRENT value differs from ITS OWN, so a cancel can never reach
+/// forward into a download that had not begun when the user pressed the button.
+static DOWNLOAD_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+/// The generation a cancellable download must capture at its start and carry for its lifetime.
+pub fn current_download_generation() -> u64 {
+    DOWNLOAD_GENERATION.load(Ordering::SeqCst)
+}
+
+/// Cancel every whisper model download that is in flight RIGHT NOW. Downloads started after this
+/// returns are unaffected (that is the whole point of the counter). Idempotent and infallible: a
+/// cancel with nothing running simply moves the counter forward.
+pub fn cancel_model_downloads() {
+    DOWNLOAD_GENERATION.fetch_add(1, Ordering::SeqCst);
+}
+
+/// Has the download watching `watch` been superseded? `None` = a non-cancellable fetch (the VAD /
+/// diarization first-use downloads on the pipeline path), which is never interrupted.
+fn download_superseded(watch: Option<u64>) -> bool {
+    matches!(watch, Some(generation) if DOWNLOAD_GENERATION.load(Ordering::SeqCst) != generation)
+}
+
+/// What a cancellable model download ended up doing. `Cancelled` is a NORMAL outcome, not an
+/// error: a user-initiated cancel is not a failure, and modelling it as `Err` would force every
+/// caller (and eventually the FE) to string-match an error message to tell the two apart.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DownloadOutcome {
+    /// The model is on disk at this path (it was downloaded, or already there).
+    Ready(PathBuf),
+    /// The user cancelled; nothing was left behind (the `.part` is removed by [`PartFileGuard`]).
+    Cancelled,
+}
+
+/// Outcome of ONE streamed body write. Mirrors [`DownloadOutcome`] minus the path, which the
+/// caller already knows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StreamOutcome {
+    Complete,
+    Cancelled,
+}
+
+/// [`ensure_model`], but INTERRUPTIBLE by [`cancel_model_downloads`]. Used only by the
+/// user-facing `download_model` command — the pipeline's first-use fetches stay uncancellable so a
+/// stray cancel can never wedge a transcription that is already running.
+pub async fn ensure_model_cancellable<F>(
+    configured: Option<&Path>,
+    size: &str,
+    language: &str,
+    on_progress: F,
+) -> Result<DownloadOutcome>
+where
+    F: FnMut(u64, Option<u64>),
+{
+    let size = effective_model_size(size);
+    if let Some(found) = resolve_model_path(configured, &size, language)? {
+        return Ok(DownloadOutcome::Ready(found));
+    }
+    let dir = models_dir()?;
+    let file = model_filename(&size, language);
+    let dest = dir.join(&file);
+    // Captured BEFORE the first byte: this download aborts only while the counter differs from the
+    // value it started under.
+    let watch = Some(current_download_generation());
+    match download_model_streaming(
+        &download_client(None),
+        &model_url(&file),
+        &dest,
+        on_progress,
+        watch,
+    )
+    .await?
+    {
+        StreamOutcome::Complete => Ok(DownloadOutcome::Ready(dest)),
+        StreamOutcome::Cancelled => Ok(DownloadOutcome::Cancelled),
+    }
 }
 
 /// Ensure a usable GGUF model exists on disk and return its path.
@@ -535,6 +694,9 @@ where
         &model_url(&file),
         &dest,
         on_progress,
+        // Uncancellable: this is the pipeline's first-use path, where an abort would wedge a
+        // transcription that is already running.
+        None,
     )
     .await?;
     Ok(dest)
@@ -609,20 +771,22 @@ fn download_client(total_timeout: Option<std::time::Duration>) -> reqwest::Clien
 /// progress instead of buffering the whole body in memory. Overwrites any stale partial. Verifies a
 /// non-empty body before the rename. NO PII is logged (model id / byte counts only). The `client`
 /// carries the caller's timeout posture (see [`download_client`]).
+///
+/// `watch` carries the caller's cancellation generation (see [`current_download_generation`]);
+/// `None` means "cannot be cancelled".
 async fn download_model_streaming<F>(
     client: &reqwest::Client,
     url: &str,
     dest: &Path,
-    mut on_progress: F,
-) -> Result<()>
+    on_progress: F,
+    watch: Option<u64>,
+) -> Result<StreamOutcome>
 where
     F: FnMut(u64, Option<u64>),
 {
-    use tokio::io::AsyncWriteExt;
-
     tracing::info!(target: "transcribe", file = %dest.display(), "downloading whisper model");
 
-    let mut resp = client
+    let resp = client
         .get(url)
         .send()
         .await
@@ -634,6 +798,54 @@ where
         )));
     }
     let total = resp.content_length();
+    write_body_to_dest(ResponseChunks(resp), dest, total, on_progress, watch).await
+}
+
+/// A source of response-body bytes for [`write_body_to_dest`].
+///
+/// This tiny seam is what makes the CANCEL + `.part`-cleanup path testable headless: the real
+/// implementation pulls from a `reqwest::Response`, and the unit tests drive the identical loop
+/// from an in-memory fake, so no test needs a network (or a loopback listener the sandbox may
+/// refuse). PRIVATE, so `async fn` in it is not publicly-reachable API.
+trait BodyChunks {
+    /// The next body chunk, or `None` at end of body.
+    async fn next_chunk(&mut self) -> Result<Option<Vec<u8>>>;
+}
+
+/// [`BodyChunks`] over a live HTTP response. The `to_vec` copies one ~16 kB chunk at a time —
+/// immaterial next to the network + disk write it sits between.
+struct ResponseChunks(reqwest::Response);
+
+impl BodyChunks for ResponseChunks {
+    async fn next_chunk(&mut self) -> Result<Option<Vec<u8>>> {
+        Ok(self
+            .0
+            .chunk()
+            .await
+            .map_err(|e| AppError::Transcribe(format!("model download body failed: {e}")))?
+            .map(|b| b.to_vec()))
+    }
+}
+
+/// Stream `source` into `<dest>.part` and atomically rename it onto `dest`.
+///
+/// Between chunks it asks [`download_superseded`] whether the user cancelled; on a cancel it
+/// returns EARLY, which unwinds through the armed [`PartFileGuard`] and removes the partial file —
+/// so a cancelled multi-GB download leaves nothing behind. Cancellation is checked between chunks
+/// rather than by dropping the future so the `.part` removal is guaranteed to have run before the
+/// caller observes the outcome.
+async fn write_body_to_dest<S, F>(
+    mut source: S,
+    dest: &Path,
+    total: Option<u64>,
+    mut on_progress: F,
+    watch: Option<u64>,
+) -> Result<StreamOutcome>
+where
+    S: BodyChunks,
+    F: FnMut(u64, Option<u64>),
+{
+    use tokio::io::AsyncWriteExt;
 
     let part = dest.with_extension("part");
     // R1: guard the `.part` so ANY early return below — a mid-stream body/write/flush error, a
@@ -647,11 +859,18 @@ where
         .await
         .map_err(|e| AppError::Transcribe(format!("create model temp file: {e}")))?;
     let mut downloaded: u64 = 0;
-    while let Some(chunk) = resp
-        .chunk()
-        .await
-        .map_err(|e| AppError::Transcribe(format!("model download body failed: {e}")))?
-    {
+    while let Some(chunk) = source.next_chunk().await? {
+        // Checked BEFORE the write so a cancel never grows the partial file it is about to remove.
+        if download_superseded(watch) {
+            tracing::info!(
+                target: "transcribe",
+                file = %dest.display(),
+                bytes = downloaded,
+                "whisper model download cancelled by the user"
+            );
+            // Early return ⇒ the armed guard removes the `.part`.
+            return Ok(StreamOutcome::Cancelled);
+        }
         file.write_all(&chunk)
             .await
             .map_err(|e| AppError::Transcribe(format!("write model chunk: {e}")))?;
@@ -681,7 +900,7 @@ where
         bytes = downloaded,
         "whisper model ready"
     );
-    Ok(())
+    Ok(StreamOutcome::Complete)
 }
 
 /// RAII guard that removes a partial `<model>.part` download file on drop unless [`disarm`]ed after
@@ -759,7 +978,9 @@ pub fn sweep_stale_model_parts(models_dir: &Path) {
 /// "others" label).
 async fn download_model(url: &str, dest: &Path) -> Result<()> {
     let client = download_client(Some(SMALL_MODEL_DOWNLOAD_TIMEOUT));
-    download_model_streaming(&client, url, dest, |_, _| {}).await
+    // `None` = uncancellable, so the returned outcome can only ever be `Complete`.
+    download_model_streaming(&client, url, dest, |_, _| {}, None).await?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -811,7 +1032,10 @@ mod tests {
         let dest = dir.join("ggml-tiny.bin");
         let url = format!("http://{addr}/model.bin");
 
-        let res = download_model_streaming(&download_client(None), &url, &dest, |_, _| {}).await;
+        // `None` watch: this regression is about a TRUNCATED BODY, not cancellation, so the
+        // download must fail on its own merits with no generation observed.
+        let res =
+            download_model_streaming(&download_client(None), &url, &dest, |_, _| {}, None).await;
         assert!(res.is_err(), "a truncated body must surface an error");
 
         // `with_extension("part")` maps `ggml-tiny.bin` → `ggml-tiny.part`.
@@ -869,7 +1093,9 @@ mod tests {
         let client = download_client(Some(std::time::Duration::from_millis(400)));
         let res = tokio::time::timeout(
             std::time::Duration::from_secs(10),
-            download_model_streaming(&client, &url, &dest, |_, _| {}),
+            // `None` watch: this regression pins the CLIENT TIMEOUT, so no cancellation generation
+            // is observed — the download must resolve on the timeout alone.
+            download_model_streaming(&client, &url, &dest, |_, _| {}, None),
         )
         .await
         .expect("a stalled download must RESOLVE (as Err) within the client timeout — not hang");
@@ -1436,5 +1662,233 @@ mod tests {
         assert_eq!(paths.decoder, dir.join(PARAKEET_DECODER));
         assert_eq!(paths.joiner, dir.join(PARAKEET_JOINER));
         assert_eq!(paths.tokens, dir.join(PARAKEET_TOKENS));
+    }
+
+    // ── P2 (W2): delete refusals + download cancellation ────────────────────────────────────────
+
+    use crate::transcribe::catalog::{BALANCED_ID, LIGHT_ID, MAXIMUM_ID, SHARP_ID};
+
+    /// REFUSAL 2 — the model a recording would load RIGHT NOW is never deletable, and this leg is
+    /// pinned ON ITS OWN: the live pin is a size that is not under test, so only the effective-model
+    /// term can be what refuses.
+    #[test]
+    fn delete_refuses_the_effective_model() {
+        let err = deletable_model_file(SHARP_ID, SHARP_ID, Some(LIGHT_ID), "")
+            .expect_err("the effective model must be refused");
+        assert!(matches!(err, AppError::InvalidArg(_)), "got {err:?}");
+        // …and the SAME id with a different effective model is allowed, so the assertion above
+        // pins the effective-model term rather than "delete refuses everything".
+        assert_eq!(
+            deletable_model_file(SHARP_ID, BALANCED_ID, Some(LIGHT_ID), "").unwrap(),
+            "ggml-large-v3-turbo-q8_0.bin"
+        );
+        // A blank configured size resolves to a real default upstream; the refusal compares the
+        // ALREADY-resolved effective size, so an empty one must not accidentally match anything.
+        assert!(deletable_model_file(SHARP_ID, "", Some(LIGHT_ID), "").is_ok());
+    }
+
+    /// REFUSAL 3 — the live-caption pin, on its own leg. This is the one that actually bites on the
+    /// shipped default: the batch default is the turbo quant while `live_model_pin` is `small`, so
+    /// `small` is neither selected nor recommended and looks like junk in the long-tail list.
+    #[test]
+    fn delete_refuses_the_live_caption_pin() {
+        let err = deletable_model_file(BALANCED_ID, SHARP_ID, Some(BALANCED_ID), "")
+            .expect_err("the live-caption pin must be refused");
+        assert!(matches!(err, AppError::InvalidArg(_)), "got {err:?}");
+        // Same size, same effective model, pin moved elsewhere ⇒ allowed. Only the pin term moved.
+        assert_eq!(
+            deletable_model_file(BALANCED_ID, SHARP_ID, Some(LIGHT_ID), "").unwrap(),
+            "ggml-small.bin"
+        );
+        // A DISABLED pin (`live_pin_size` → None) must not refuse anything either.
+        assert!(deletable_model_file(BALANCED_ID, SHARP_ID, None, "").is_ok());
+        // The pin the shipped config actually carries resolves to `small` — so the refusal above is
+        // about the real default, not a hypothetical.
+        assert_eq!(live_pin_size("small", false).as_deref(), Some(BALANCED_ID));
+    }
+
+    /// REFUSAL 1 — anything that is not a whisper CATALOG id is rejected outright, including ids
+    /// that would otherwise resolve a filename through `model_filename`'s permissive passthrough.
+    #[test]
+    fn delete_rejects_a_non_registry_id() {
+        for bogus in [
+            "",
+            "   ",
+            "not-a-model",
+            "ggml-small.bin",
+            "../../etc/passwd",
+            "silero-v5.1.2",
+        ] {
+            let err = deletable_model_file(bogus, SHARP_ID, Some(BALANCED_ID), "")
+                .expect_err("a non-registry id must be refused");
+            assert!(matches!(err, AppError::InvalidArg(_)), "{bogus:?} → {err:?}");
+        }
+        // A REAL registry id still passes, so the loop above is not just "everything is refused".
+        assert!(deletable_model_file(MAXIMUM_ID, SHARP_ID, Some(BALANCED_ID), "").is_ok());
+    }
+
+    /// REFUSAL 4 — a delete removes exactly the one whisper file it named and NOTHING else: the
+    /// VAD model, the diarization models and the whole parakeet bundle survive untouched. Driven
+    /// over a real temp dir, because "we only ever join a `ggml-*.bin`" is the kind of claim that
+    /// deserves a filesystem, not a comment.
+    #[test]
+    fn delete_never_touches_vad_or_parakeet() {
+        let dir = parts_tmp_dir("delete-scope");
+        let bystanders = [
+            VAD_MODEL_FILE,
+            DIARIZE_SEG_MODEL_FILE,
+            DIARIZE_EMB_MODEL_FILE,
+            "ggml-large-v3-turbo-q8_0.bin",
+        ];
+        for f in bystanders {
+            std::fs::write(dir.join(f), b"KEEP").unwrap();
+        }
+        let parakeet = dir.join(PARAKEET_SUBDIR);
+        std::fs::create_dir_all(&parakeet).unwrap();
+        for f in PARAKEET_FILES {
+            std::fs::write(parakeet.join(f), b"KEEP").unwrap();
+        }
+        std::fs::write(dir.join("ggml-large-v3.bin"), b"DELETE-ME").unwrap();
+
+        let file = deletable_model_file(MAXIMUM_ID, SHARP_ID, Some(BALANCED_ID), "").unwrap();
+        assert!(delete_model_file_in(&dir, &file).unwrap());
+
+        assert!(!dir.join("ggml-large-v3.bin").is_file(), "the named model goes");
+        for f in bystanders {
+            assert!(dir.join(f).is_file(), "{f} must survive a model delete");
+        }
+        for f in PARAKEET_FILES {
+            assert!(parakeet.join(f).is_file(), "parakeet {f} must survive");
+        }
+        // Idempotent: deleting again is a no-op success, never an error the UI has to explain.
+        assert!(!delete_model_file_in(&dir, &file).unwrap());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// `DOWNLOAD_GENERATION` is process-global, so the three cancellation tests below MUST NOT
+    /// interleave: one test's `cancel_model_downloads()` would land inside another's write loop and
+    /// cancel it. `cargo test` runs them on parallel threads, so they serialize on this lock rather
+    /// than on luck. Poison-tolerant (a panicking test must not cascade into a spurious failure).
+    static CANCEL_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn cancel_test_guard() -> std::sync::MutexGuard<'static, ()> {
+        CANCEL_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    /// A canned [`BodyChunks`] that runs `on_chunk` after handing out each chunk — the hook the
+    /// cancellation test uses to press Cancel mid-stream.
+    struct FakeChunks<F: FnMut(usize)> {
+        chunks: Vec<Vec<u8>>,
+        next: usize,
+        on_chunk: F,
+    }
+
+    impl<F: FnMut(usize)> BodyChunks for FakeChunks<F> {
+        async fn next_chunk(&mut self) -> Result<Option<Vec<u8>>> {
+            if self.next >= self.chunks.len() {
+                return Ok(None);
+            }
+            let chunk = self.chunks[self.next].clone();
+            self.next += 1;
+            (self.on_chunk)(self.next);
+            Ok(Some(chunk))
+        }
+    }
+
+    /// Cancelling mid-download leaves NOTHING behind: no `.part`, no half-written model, and the
+    /// outcome is `Cancelled` rather than an `Err` the FE would have to string-match.
+    ///
+    /// RED before GREEN: without the `download_superseded` check in the write loop this test fails
+    /// on its FIRST assertion (the outcome would be `Complete` and the finished file would exist).
+    #[tokio::test]
+    async fn download_cancel_removes_the_part_file() {
+        let _serial = cancel_test_guard();
+        let dir = parts_tmp_dir("cancel");
+        let dest = dir.join("ggml-tiny.bin");
+        let watch = Some(current_download_generation());
+        let out = write_body_to_dest(
+            FakeChunks {
+                chunks: vec![vec![1u8; 32], vec![2u8; 32], vec![3u8; 32]],
+                next: 0,
+                // The user presses Cancel while the body is still arriving.
+                on_chunk: |n| {
+                    if n == 1 {
+                        cancel_model_downloads();
+                    }
+                },
+            },
+            &dest,
+            Some(96),
+            |_, _| {},
+            watch,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(out, StreamOutcome::Cancelled);
+        assert!(!dest.is_file(), "a cancelled download leaves no model file");
+        assert!(
+            !dest.with_extension("part").is_file(),
+            "a cancelled download leaves no .part residue"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The control for the test above: the SAME fake body, without a cancel, completes and lands
+    /// the file. Without this, "no file on disk" could equally mean the write loop is simply broken.
+    #[tokio::test]
+    async fn download_without_cancel_lands_the_file() {
+        let _serial = cancel_test_guard();
+        let dir = parts_tmp_dir("no-cancel");
+        let dest = dir.join("ggml-tiny.bin");
+        let watch = Some(current_download_generation());
+        let out = write_body_to_dest(
+            FakeChunks {
+                chunks: vec![vec![1u8; 32], vec![2u8; 32]],
+                next: 0,
+                on_chunk: |_| {},
+            },
+            &dest,
+            Some(64),
+            |_, _| {},
+            watch,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(out, StreamOutcome::Complete);
+        assert_eq!(std::fs::metadata(&dest).unwrap().len(), 64);
+        assert!(!dest.with_extension("part").is_file());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The counter's whole reason for existing: a cancel must NOT leak into the next download. A
+    /// global `AtomicBool` would still be set when the second fetch starts and would kill it.
+    #[tokio::test]
+    async fn a_cancel_does_not_leak_into_the_next_download() {
+        let _serial = cancel_test_guard();
+        cancel_model_downloads();
+        // A download that starts AFTER the cancel captures the new generation and is unaffected.
+        let dir = parts_tmp_dir("no-leak");
+        let dest = dir.join("ggml-base.bin");
+        let out = write_body_to_dest(
+            FakeChunks {
+                chunks: vec![vec![7u8; 16]],
+                next: 0,
+                on_chunk: |_| {},
+            },
+            &dest,
+            Some(16),
+            |_, _| {},
+            Some(current_download_generation()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(out, StreamOutcome::Complete);
+        assert!(dest.is_file());
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/src/transcribe/model.rs
+++ b/src-tauri/src/transcribe/model.rs
@@ -1772,6 +1772,22 @@ mod tests {
     /// than on luck. Poison-tolerant (a panicking test must not cascade into a spurious failure).
     static CANCEL_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    /// Each holder keeps this guard across `.await`, which normally earns
+    /// `clippy::await_holding_lock` — and normally deserves it, because a std guard held across a
+    /// yield can deadlock an executor. It is sound HERE, and only here:
+    ///
+    ///  * every `#[tokio::test]` builds its OWN current-thread runtime, so no two holders ever
+    ///    share an executor and a blocked thread cannot starve another task that wants the lock;
+    ///  * the only lockers are the three cancellation tests in this module — nothing in production
+    ///    touches `CANCEL_TEST_LOCK`, so there is no lock-order cycle to construct;
+    ///  * BLOCKING the thread is precisely the intent. `DOWNLOAD_GENERATION` is process-global, so
+    ///    a second test entering while the first is mid-write-loop would cancel it; serialising on
+    ///    a std mutex is what makes that impossible.
+    ///
+    /// A `tokio::sync::Mutex` would silence the lint but NOT serialise `cargo test`'s parallel
+    /// threads, since each runs its own runtime — it would be a worse fix that merely reads better.
+    ///
+    /// The `#[allow]` therefore sits on each of the three holders, where the lint actually fires.
     fn cancel_test_guard() -> std::sync::MutexGuard<'static, ()> {
         CANCEL_TEST_LOCK
             .lock()
@@ -1803,6 +1819,8 @@ mod tests {
     ///
     /// RED before GREEN: without the `download_superseded` check in the write loop this test fails
     /// on its FIRST assertion (the outcome would be `Complete` and the finished file would exist).
+    // Holds CANCEL_TEST_LOCK across .await on purpose — see cancel_test_guard's doc.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn download_cancel_removes_the_part_file() {
         let _serial = cancel_test_guard();
@@ -1839,6 +1857,8 @@ mod tests {
 
     /// The control for the test above: the SAME fake body, without a cancel, completes and lands
     /// the file. Without this, "no file on disk" could equally mean the write loop is simply broken.
+    // Holds CANCEL_TEST_LOCK across .await on purpose — see cancel_test_guard's doc.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn download_without_cancel_lands_the_file() {
         let _serial = cancel_test_guard();
@@ -1867,6 +1887,8 @@ mod tests {
 
     /// The counter's whole reason for existing: a cancel must NOT leak into the next download. A
     /// global `AtomicBool` would still be set when the second fetch starts and would kill it.
+    // Holds CANCEL_TEST_LOCK across .await on purpose — see cancel_test_guard's doc.
+    #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn a_cancel_does_not_leak_into_the_next_download() {
         let _serial = cancel_test_guard();

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -27,6 +27,7 @@ import type {
   Posture,
   RetiredModelNudge,
   WhisperRecommendationDto,
+  ModelDownloadOutcome,
   WhisperCard,
   EmbedDownloadProgress,
   EgressLedger,
@@ -1951,9 +1952,37 @@ export class IpcService {
     return invoke<boolean>("model_present");
   }
 
-  /** Download the default Whisper model (~150 MB) if missing; resolves with its path. */
-  downloadModel(): Promise<string> {
-    return invoke<string>("download_model");
+  /**
+   * Download the Whisper model for the SAVED language + size (plus the live-caption
+   * companion when one is planned). Progress streams over {@link onModelDownload}.
+   *
+   * Resolves with a typed OUTCOME: `status: "cancelled"` when
+   * {@link cancelModelDownload} interrupted it. A cancel is NOT a rejection —
+   * the FE must never string-match an error message to tell a user-initiated
+   * cancel apart from a dead link.
+   */
+  downloadModel(): Promise<ModelDownloadOutcome> {
+    return invoke<ModelDownloadOutcome>("download_model");
+  }
+
+  /**
+   * Cancel the Whisper model download that is in flight right now. Idempotent
+   * and infallible — with nothing running it is a no-op, and it can never reach
+   * forward into a download that has not started yet (the backend watches a
+   * generation counter, not a global flag).
+   */
+  cancelModelDownload(): Promise<void> {
+    return invoke<void>("cancel_model_download");
+  }
+
+  /**
+   * Delete ONE downloaded Whisper model to reclaim disk. Rejects (with the
+   * backend's reason) when the size is the effective model, the live-caption
+   * pin, or not a catalog id — the backend owns every refusal, so the FE never
+   * re-implements them.
+   */
+  deleteWhisperModel(size: string): Promise<void> {
+    return invoke<void>("delete_whisper_model", { size });
   }
 
   /** Whether the OPTIONAL parakeet live-ASR engine's models are all present on disk. */

--- a/src/app/core/model-bytes.ts
+++ b/src/app/core/model-bytes.ts
@@ -1,0 +1,28 @@
+/**
+ * The ONE place the frontend turns a whisper-model byte figure into words.
+ *
+ * The figures themselves are authored in Rust (`transcribe/catalog.rs`) and reach
+ * the FE through `whisper_recommendation`. Before P2 the frontend carried its own
+ * hardcoded size tables in TWO places (`settings.store.ts`'s `hints` map and
+ * `onboarding.component.ts`'s `SIZE_HINTS`) which had already drifted from each
+ * other and from the `<option>` labels; both are gone, and this module only ever
+ * FORMATS what the backend states.
+ */
+
+/** Binary units, matching how the Rust catalog states the figures. */
+export function formatModelBytes(bytes: number): string {
+  const mb = bytes / (1024 * 1024);
+  if (mb < 1) return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+  if (mb < 1000) return `${Math.round(mb)} MB`;
+  return `${(mb / 1024).toFixed(1)} GB`;
+}
+
+/**
+ * A download size for a button/label. `null` means the backend states no figure for
+ * that size, and it renders as **"size unknown"** — NEVER as "free" or as an empty
+ * string that reads like nothing will be transferred. Under-disclosing a multi-GB
+ * download is precisely the dishonesty this workstream removes.
+ */
+export function modelSizeLabel(bytes: number | null): string {
+  return bytes === null ? "size unknown" : formatModelBytes(bytes);
+}

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -133,6 +133,25 @@ export interface AppConfigDto {
   audioAutoPrune: boolean;
   modelSize: string;
   /**
+   * WHO put {@link modelSize} there — `"auto"` (Murmur's recommendation was
+   * accepted as-is) or `"user"` (a deliberate pick). Mirrors Rust
+   * `AppConfigDto::model_size_source`, and it is deliberately OPTIONAL in both
+   * directions: OMITTING it means PRESERVE, so every existing save path (the
+   * whole Settings form, every onboarding write that is not about the model
+   * choice) leaves the stored value exactly as it is instead of clobbering it.
+   *
+   * It matters because the onboarding wizard PRESELECTS the recommendation and
+   * then persists it like any other field: without sending `"auto"` there, a
+   * fresh install that simply accepted the default would be recorded as a
+   * deliberate user choice, and the backfill/nudge logic that keys off "did
+   * they actually choose this?" would never be able to tell them apart.
+   *
+   * Read it back through `whisperRecommendation().modelSizeSource`, never from
+   * a config round-trip (`config_to_dto` leaves it null so a read-modify-write
+   * is a preserve).
+   */
+  modelSizeSource?: string | null;
+  /**
    * OPTIONAL live-caption ASR engine (mirrors Rust `live_asr_engine`): `"whisper"` (default) or
    * `"parakeet"`. When `"parakeet"` AND its models are downloaded, live captions decode on the
    * CPU-only NVIDIA parakeet engine (off the Metal GPU); whisper stays the batch authority and the
@@ -605,7 +624,37 @@ export interface WhisperRecommendationDto {
    * apart so an unmeasured id cannot promise a free multi-GB transfer.
    */
   pendingDownloadBytes: number | null;
+  /**
+   * LIVE-caption readiness, from the SAME classification `get_config` ships as
+   * `liveCaptions` — resolved over the one models-dir listing this DTO already
+   * took. `"noModel"` / `"modelMissing"` are what the picker's repair
+   * affordance keys off; `"pinnedHeavy"` is a deliberate configuration, not a
+   * failure, so it is NOT offered a repair.
+   */
+  liveCaptions: LiveCaptionsState;
   brainAdvice: BrainAdvice;
+}
+
+/**
+ * How the live-caption tick's model resolved. `""` = not probed yet.
+ * Mirrors the Rust `LiveCaptions::dto_state`.
+ */
+export type LiveCaptionsState =
+  | ""
+  | "ready"
+  | "noModel"
+  | "modelMissing"
+  | "pinnedHeavy";
+
+/**
+ * What a `download_model` call ended up doing. A user-initiated CANCEL is a
+ * NORMAL outcome (`status: "cancelled"`), never a rejected promise — the FE
+ * must never have to string-match an error message to tell a cancel apart from
+ * a dead link.
+ */
+export interface ModelDownloadOutcome {
+  status: "ready" | "cancelled";
+  path: string | null;
 }
 
 /**

--- a/src/app/design-system/meter/meter.component.html
+++ b/src/app/design-system/meter/meter.component.html
@@ -1,0 +1,9 @@
+<span class="meter-label">{{ label() }}</span>
+<span class="meter-pips" aria-hidden="true">
+  @for (i of pips(); track i) {
+    <span class="meter-pip" [class.is-on]="i < filled()"></span>
+  }
+</span>
+@if (detail(); as d) {
+  <span class="meter-detail">{{ d }}</span>
+}

--- a/src/app/design-system/meter/meter.component.scss
+++ b/src/app/design-system/meter/meter.component.scss
@@ -1,0 +1,36 @@
+:host {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.meter-label {
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+}
+
+.meter-pips {
+  display: inline-flex;
+  gap: 3px;
+}
+
+/* Structural pixel sizes only — no token names a 4px pip. */
+.meter-pip {
+  width: 14px;
+  height: 4px;
+  border-radius: var(--radius-pill);
+  background: var(--surface-input);
+  border: 1px solid var(--border);
+  transition: background var(--transition-fast);
+}
+
+.meter-pip.is-on {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.meter-detail {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}

--- a/src/app/design-system/meter/meter.component.ts
+++ b/src/app/design-system/meter/meter.component.ts
@@ -1,0 +1,66 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from "@angular/core";
+
+/**
+ * Design System — `<mur-meter>`: a tiny segmented indicator for a COARSE, ordinal
+ * quantity (accuracy, speed) where a percentage would be a lie.
+ *
+ * Deliberately not `<mur-progress>`: progress is a measured fraction of a known
+ * whole, and it announces `aria-valuenow`. This is a relative rating with no unit,
+ * so it announces a sentence ("Accuracy: 4 of 4") and nothing numeric that invites
+ * being read as a percentage.
+ *
+ * The pips are `aria-hidden` decoration; the HOST carries `role="img"` plus the
+ * label, so assistive tech hears one phrase instead of counting boxes.
+ *
+ * @example
+ *   <mur-meter label="Accuracy" [value]="4" [max]="4" detail="Same as Sharp" />
+ */
+@Component({
+  selector: "mur-meter",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: "./meter.component.html",
+  styleUrl: "./meter.component.scss",
+  host: {
+    role: "img",
+    "[attr.aria-label]": "ariaText()",
+  },
+})
+export class MurMeterComponent {
+  /** The quantity's name, shown and announced (e.g. `Accuracy`). */
+  readonly label = input("");
+
+  /** Filled pips, clamped into `0..max`. */
+  readonly value = input(0);
+
+  /** Total pips. */
+  readonly max = input(4);
+
+  /** Optional clarifying phrase, shown after the pips and announced with the label. */
+  readonly detail = input<string | null>(null);
+
+  /** Pip count, guarded so a bad `max` can never render a runaway (or empty) row. */
+  readonly pips = computed(() => {
+    const max = this.max();
+    const n = Number.isFinite(max) ? Math.round(max) : 0;
+    return Array.from({ length: Math.min(Math.max(n, 0), 10) }, (_, i) => i);
+  });
+
+  /** {@link value} clamped into the pip range — an out-of-range input never overfills. */
+  readonly filled = computed(() => {
+    const v = this.value();
+    if (!Number.isFinite(v)) return 0;
+    return Math.min(Math.max(Math.round(v), 0), this.pips().length);
+  });
+
+  /** The single phrase assistive tech hears. */
+  readonly ariaText = computed(() => {
+    const base = `${this.label()}: ${this.filled()} of ${this.pips().length}`;
+    const detail = this.detail();
+    return detail ? `${base}. ${detail}` : base;
+  });
+}

--- a/src/app/design-system/power-slider/power-slider.component.html
+++ b/src/app/design-system/power-slider/power-slider.component.html
@@ -1,0 +1,40 @@
+<div class="ps-wrap">
+  <!-- The painted track sits BEHIND the native input (which is transparent apart
+       from its thumb) so the fill can animate; the input stays the one real
+       control, so focus, keyboard and assistive tech are all native. -->
+  <div class="ps-track" aria-hidden="true">
+    <span class="ps-fill" [style.width.%]="fillPct()"></span>
+    @for (r of rungs(); track r.id; let i = $index) {
+      <span
+        class="ps-notch"
+        [class.is-reached]="i <= activeIndex() && !isOffLadder()"
+        [style.left.%]="maxIndex() > 0 ? (i / maxIndex()) * 100 : 0"
+      ></span>
+    }
+  </div>
+
+  <input
+    #rangeInput
+    class="mur-range ps-input"
+    type="range"
+    min="0"
+    step="1"
+    [max]="maxIndex()"
+    [value]="activeIndex()"
+    [disabled]="isDisabled()"
+    [attr.aria-label]="ariaLabel()"
+    [attr.aria-valuetext]="valueText()"
+    (input)="onInput($event)"
+    (change)="onChangeEvent($event)"
+    (keydown)="onKeydown($event)"
+  />
+
+  <!-- Decoration: the input above already announces the active rung by NAME. -->
+  <div class="ps-labels" aria-hidden="true">
+    @for (r of rungs(); track r.id; let i = $index) {
+      <span class="ps-label" [class.is-active]="i === activeIndex() && !isOffLadder()">
+        {{ r.name }}
+      </span>
+    }
+  </div>
+</div>

--- a/src/app/design-system/power-slider/power-slider.component.scss
+++ b/src/app/design-system/power-slider/power-slider.component.scss
@@ -1,0 +1,106 @@
+/* Every value here is a design token (angular-zoneless.md §6/§6b). The only raw
+   pixels are the structural geometry of the control itself — the track height and
+   the notch/thumb sizes — which have to line up with `.mur-range`'s own 22px box
+   and 18px thumb in `primitives.css`, and which no token names.
+
+   MOTION: the fill and the notches ride `var(--transition)` / `var(--transition-fast)`
+   only. There is deliberately NO @keyframes here, so there is nothing that could
+   start at `opacity: 0` and strand content invisible when the global
+   `prefers-reduced-motion` block in styles.css collapses animation durations to
+   0.01ms. A transition that is collapsed to nothing simply snaps to the final
+   state — which is exactly the reduced-motion behaviour we want. */
+:host {
+  display: block;
+  min-width: 0;
+}
+
+.ps-wrap {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+/* The painted track: the native input's own track is transparent (see `.ps-input`),
+   so this is what the user sees, and it is what animates between rungs. */
+.ps-track {
+  position: absolute;
+  top: 8px;
+  left: 0;
+  right: 0;
+  height: 5px;
+  border-radius: var(--radius-pill);
+  background: var(--surface-input);
+  border: 1px solid var(--border);
+  pointer-events: none;
+}
+
+.ps-fill {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  border-radius: var(--radius-pill);
+  background: var(--accent);
+  transition: width var(--transition);
+}
+
+.ps-notch {
+  position: absolute;
+  top: 50%;
+  width: 5px;
+  height: 5px;
+  margin-left: -2.5px;
+  border-radius: 50%;
+  background: var(--border-strong);
+  transform: translateY(-50%);
+  transition:
+    background var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.ps-notch.is-reached {
+  background: var(--text-on-accent);
+  transform: translateY(-50%) scale(1.2);
+}
+
+/* The real control, laid over the painted track. `.mur-range` gives it the shared
+   thumb; the track it would have drawn itself is suppressed so the animated
+   `.ps-track` above shows through. */
+.ps-input {
+  position: relative;
+  z-index: 1;
+}
+
+.ps-input::-webkit-slider-runnable-track {
+  background: transparent;
+  border-color: transparent;
+}
+
+.ps-labels {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.ps-label {
+  flex: 1 1 0;
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+  text-align: center;
+  transition: color var(--transition-fast);
+}
+
+/* The first and last labels sit under a thumb that is pinned to the track's ends,
+   so they are aligned to the edge rather than to their own centres. */
+.ps-label:first-child {
+  text-align: left;
+}
+.ps-label:last-child {
+  text-align: right;
+}
+
+.ps-label.is-active {
+  color: var(--text-primary);
+  font-weight: 600;
+}

--- a/src/app/design-system/power-slider/power-slider.component.ts
+++ b/src/app/design-system/power-slider/power-slider.component.ts
@@ -1,0 +1,211 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  computed,
+  effect,
+  forwardRef,
+  input,
+  model,
+  signal,
+  untracked,
+  viewChild,
+} from "@angular/core";
+import { NG_VALUE_ACCESSOR, type ControlValueAccessor } from "@angular/forms";
+
+/** One notch of the ladder. `id` is the committed value; `name` is what a screen reader says. */
+export interface PowerRung {
+  /** The value committed to the form / `[(value)]` when this rung is chosen. */
+  id: string;
+  /** The HUMAN rung name — never a raw id. This is what `aria-valuetext` announces. */
+  name: string;
+}
+
+/**
+ * Design System — `<mur-power-slider>`: a DISCRETE ladder as a range control.
+ *
+ * It owns its own `<input type="range">` and shares mur-slider's look through the
+ * `.mur-range` primitive (`design-system/primitives.css`). It deliberately does NOT
+ * wrap `<mur-slider>`: that would need six passthrough bindings (min/max/step/
+ * disabled/aria/value) and would make mur-slider's appearance depend on what a
+ * caller passes — a design-system component's whole job is the opposite.
+ *
+ * PREVIEW vs COMMIT. Dragging fires `input` continuously; only `change` (pointer
+ * released / keyboard settled) commits. So a drag moves the thumb and the visible
+ * rung, but `value` — and `onChange`, i.e. the form and any persistence the host
+ * hangs off it — updates ONCE, at the end. `<mur-select>`'s `onChangeEvent` is the
+ * in-repo precedent for the same split. Without it, dragging past Maximum would
+ * persist (and, in the model picker, could start downloading) every rung on the way.
+ *
+ * TWO ways to drive it, exactly like `<mur-select>`, and they must not fight:
+ *   - `formControlName` / `[formControl]` — the CVA path (`writeValue` /
+ *     `setDisabledState`);
+ *   - `[(value)]` + `[disabled]` — the signal path, for hosts with no reactive form
+ *     (the onboarding wizard is signals-only).
+ * `value` is a `model()` so both writers hit the SAME signal; `disabled` cannot be a
+ * plain input for the CVA (an input signal is read-only), so `setDisabledState`'s
+ * answer lives in a private signal and the two are OR-ed in {@link isDisabled}.
+ *
+ * ACCESSIBILITY is not decoration here:
+ *   - `aria-valuetext` reads the rung NAME ("Balanced"), because "2 of 4" tells a
+ *     screen-reader user nothing about what they just chose;
+ *   - PageUp / PageDown jump exactly ONE rung. Browsers move a range by ~10% of its
+ *     span on those keys, which silently stops being one rung the moment the ladder
+ *     grows past ten — so the jump is implemented rather than inherited;
+ *   - Home / End / arrows are the native range behaviour, untouched;
+ *   - the tick labels are `aria-hidden` decoration: the input already announces the
+ *     rung, and a second set of controls for the same value is a worse experience,
+ *     not a better one.
+ */
+@Component({
+  selector: "mur-power-slider",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: "./power-slider.component.html",
+  styleUrl: "./power-slider.component.scss",
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => MurPowerSliderComponent),
+      multi: true,
+    },
+  ],
+})
+export class MurPowerSliderComponent implements ControlValueAccessor {
+  /** The ladder, in display order (cheapest first). */
+  readonly rungs = input<readonly PowerRung[]>([]);
+
+  /** Accessible name for the control — required in practice. */
+  readonly ariaLabel = input<string | null>(null);
+
+  /** The COMMITTED rung id. Two-way (`[(value)]`) AND the CVA's model. */
+  readonly value = model("");
+
+  /** Caller-driven disable. Independent of — and OR-ed with — `setDisabledState`. */
+  readonly disabled = input(false);
+
+  /** `setDisabledState` from a disabled FormControl. Private: the input is read-only. */
+  private readonly cvaDisabled = signal(false);
+
+  /** The effective disabled state the `<input>` binds. */
+  readonly isDisabled = computed(() => this.disabled() || this.cvaDisabled());
+
+  private readonly range =
+    viewChild<ElementRef<HTMLInputElement>>("rangeInput");
+
+  /** In-flight drag position, or `null` when nothing is being previewed. */
+  private readonly _preview = signal<number | null>(null);
+
+  /** Highest valid index (never negative, so an empty ladder still renders a sane track). */
+  readonly maxIndex = computed(() => Math.max(0, this.rungs().length - 1));
+
+  /**
+   * Index of the COMMITTED value. An unknown id (a long-tail size chosen from "show
+   * every size", or a custom one) has no rung, and answers `-1` — the callers below
+   * clamp it to 0 for the thumb while {@link isOffLadder} keeps the UI honest about it.
+   */
+  readonly committedIndex = computed(() =>
+    this.rungs().findIndex((r) => r.id === this.value()),
+  );
+
+  /** The committed value is not one of the rungs (so no rung should read as active). */
+  readonly isOffLadder = computed(() => this.committedIndex() < 0);
+
+  /** What the control SHOWS right now: the drag preview if there is one, else the commit. */
+  readonly activeIndex = computed(() => {
+    const preview = this._preview();
+    if (preview !== null) return preview;
+    return Math.max(0, this.committedIndex());
+  });
+
+  /** The rung the control currently shows, or `null` for an empty ladder. */
+  readonly activeRung = computed<PowerRung | null>(
+    () => this.rungs()[this.activeIndex()] ?? null,
+  );
+
+  /** `aria-valuetext`: the human rung name, NEVER the index and never the raw id. */
+  readonly valueText = computed(() => this.activeRung()?.name ?? "");
+
+  /** Track fill, 0–100. A single-rung ladder is fully filled rather than 0/0 = NaN. */
+  readonly fillPct = computed(() => {
+    const max = this.maxIndex();
+    if (max <= 0) return 100;
+    return (this.activeIndex() / max) * 100;
+  });
+
+  private onChange: (v: string) => void = () => undefined;
+  private onTouched: () => void = () => undefined;
+
+  /**
+   * THE DISABLED-MID-DRAG TRAP (the signal-CVA revert-coalescing trap). When the
+   * host disables the control while a drag is in flight, the preview is abandoned
+   * and the thumb must snap back to the committed rung — but abandoning the preview
+   * is a NET-ZERO change to `activeIndex` (it was N because of the preview, and it
+   * is N again from the commit). A `[value]` binding compares against the last value
+   * IT wrote, sees no change, and never touches the element again, leaving the DOM
+   * showing the abandoned position. So the element's `value` PROPERTY is written
+   * directly here. Tracking `isDisabled()` is what makes this effect run at all: that
+   * IS a real signal change, unlike the preview it cleans up after.
+   */
+  private readonly _revertOnDisable = effect(() => {
+    if (!this.isDisabled()) return;
+    const el = this.range()?.nativeElement;
+    if (!el) return;
+    untracked(() => {
+      this._preview.set(null);
+      el.value = String(Math.max(0, this.committedIndex()));
+    });
+  });
+
+  writeValue(v: unknown): void {
+    this.value.set(v == null ? "" : String(v));
+  }
+  registerOnChange(fn: (v: string) => void): void {
+    this.onChange = fn;
+  }
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+  setDisabledState(d: boolean): void {
+    this.cvaDisabled.set(d);
+  }
+
+  /** Dragging: PREVIEW only — no commit, no `onChange`, nothing persisted. */
+  onInput(e: Event): void {
+    this._preview.set(this.clamp(Number((e.target as HTMLInputElement).value)));
+  }
+
+  /** Released / settled: COMMIT. This is the only place `onChange` is called. */
+  onChangeEvent(e: Event): void {
+    this.commit(this.clamp(Number((e.target as HTMLInputElement).value)));
+  }
+
+  /**
+   * PageUp / PageDown move exactly one rung. `preventDefault` stops the browser's
+   * own ~10%-of-span jump, which means the element's value is NOT updated by the
+   * browser — {@link commit} writes the signal, and the `[value]` binding (a real
+   * change) puts it on the element.
+   */
+  onKeydown(e: KeyboardEvent): void {
+    if (this.isDisabled()) return;
+    const step = e.key === "PageUp" ? 1 : e.key === "PageDown" ? -1 : 0;
+    if (step === 0) return;
+    e.preventDefault();
+    this.commit(this.clamp(this.activeIndex() + step));
+  }
+
+  /** Write the rung at `index` through both writers (signal + CVA) and end the preview. */
+  private commit(index: number): void {
+    const rung = this.rungs()[index];
+    this._preview.set(null);
+    if (!rung) return;
+    this.value.set(rung.id);
+    this.onChange(rung.id);
+    this.onTouched();
+  }
+
+  /** Clamp into `0..maxIndex`; a NaN (an empty / non-numeric element value) reads as 0. */
+  private clamp(index: number): number {
+    if (!Number.isFinite(index)) return 0;
+    return Math.min(Math.max(Math.round(index), 0), this.maxIndex());
+  }
+}

--- a/src/app/design-system/primitives.css
+++ b/src/app/design-system/primitives.css
@@ -447,6 +447,61 @@ legend { padding: 0 var(--space-2); color: var(--text-secondary); font-size: 0.8
 .menu-item-danger { color: var(--danger); }
 .menu-item-danger:hover:not(:disabled) { background: var(--danger-soft); }
 
+/* --- Range control: the ONE track + thumb ----------------------------------
+   Shared by <mur-slider> (a continuous value) and <mur-power-slider> (discrete
+   rungs). It lives here rather than inside either component so the two can never
+   drift into two different-looking sliders — exactly the drift a design system
+   exists to prevent. Both hosts put `mur-range` on their OWN native
+   `<input type="range">`; the power slider deliberately does NOT wrap
+   mur-slider, because wrapping would mean six passthrough bindings and would put
+   mur-slider's appearance guarantee at the mercy of a caller.
+   The `::-webkit-*` pseudo-elements are the WKWebView/Chromium pair Murmur ships
+   on; they cannot be shared FROM a component stylesheet, because Angular's
+   emulated encapsulation would scope them to one component's attribute. */
+.mur-range {
+  display: block;
+  width: 100%;
+  height: 22px;
+  margin: 0;
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  cursor: pointer;
+}
+.mur-range::-webkit-slider-runnable-track {
+  height: 5px;
+  border-radius: var(--radius-pill);
+  background: var(--surface-input);
+  border: 1px solid var(--border);
+}
+.mur-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  margin-top: -7.5px;
+  border-radius: 50%;
+  background: var(--text-on-accent);
+  border: none;
+  box-shadow:
+    0 0 0 1px var(--border-strong),
+    var(--shadow-sm);
+  transition: transform var(--transition-fast);
+}
+.mur-range::-webkit-slider-thumb:hover {
+  transform: scale(1.08);
+}
+.mur-range:focus,
+.mur-range:focus-visible {
+  outline: none;
+}
+.mur-range:focus-visible::-webkit-slider-thumb {
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+.mur-range:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 /* --- Empty / loading wells (shared across list + detail + analytics) -------- */
 .state-card { padding: var(--space-6); }
 .empty-state {

--- a/src/app/design-system/slider/slider.component.html
+++ b/src/app/design-system/slider/slider.component.html
@@ -1,5 +1,5 @@
 <input
-  class="mur-slider-input"
+  class="mur-range"
   type="range"
   [min]="min()"
   [max]="max()"

--- a/src/app/design-system/slider/slider.component.scss
+++ b/src/app/design-system/slider/slider.component.scss
@@ -1,48 +1,9 @@
+/* The track + thumb now live in `design-system/primitives.css` as `.mur-range`,
+   shared with <mur-power-slider> — the rules are byte-identical to the ones that
+   used to be here, only relocated, so the appearance is unchanged. Only the
+   host's LAYOUT is component-specific. */
 :host {
   display: block;
   flex: 1 1 auto;
   min-width: 0;
-}
-.mur-slider-input {
-  display: block;
-  width: 100%;
-  height: 22px;
-  margin: 0;
-  appearance: none;
-  -webkit-appearance: none;
-  background: transparent;
-  cursor: pointer;
-}
-.mur-slider-input::-webkit-slider-runnable-track {
-  height: 5px;
-  border-radius: var(--radius-pill);
-  background: var(--surface-input);
-  border: 1px solid var(--border);
-}
-.mur-slider-input::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  width: 18px;
-  height: 18px;
-  margin-top: -7.5px;
-  border-radius: 50%;
-  background: var(--text-on-accent);
-  border: none;
-  box-shadow:
-    0 0 0 1px var(--border-strong),
-    var(--shadow-sm);
-  transition: transform var(--transition-fast);
-}
-.mur-slider-input::-webkit-slider-thumb:hover {
-  transform: scale(1.08);
-}
-.mur-slider-input:focus,
-.mur-slider-input:focus-visible {
-  outline: none;
-}
-.mur-slider-input:focus-visible::-webkit-slider-thumb {
-  box-shadow: 0 0 0 3px var(--accent-ring);
-}
-.mur-slider-input:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
 }

--- a/src/app/features/onboarding/onboarding/onboarding.component.html
+++ b/src/app/features/onboarding/onboarding/onboarding.component.html
@@ -63,9 +63,14 @@
           <div class="field-grid">
             <label class="field">
               <span class="field-label">Language</span>
-              <select
+              <!-- The SIGNAL path of <mur-select>: no reactive form here, so
+                   `[value]`/`(valueChange)` + `[disabled]` drive it directly. The CVA's
+                   writeValue/setDisabledState are never invoked on this instance, which
+                   is exactly why the two ways of driving it must not fight. -->
+              <mur-select
+                ariaLabel="Transcription language"
                 [value]="language()"
-                (change)="onLanguage($event)"
+                (valueChange)="onLanguage($event)"
                 [disabled]="downloading()"
               >
                 <option value="">Auto-detect</option>
@@ -78,27 +83,18 @@
                 <option value="pt">Português</option>
                 <option value="uk">Українська</option>
                 <option value="nl">Nederlands</option>
-              </select>
-            </label>
-
-            <label class="field">
-              <span class="field-label">Quality</span>
-              <select
-                [value]="modelSize()"
-                (change)="onModelSize($event)"
-                [disabled]="downloading()"
-              >
-                <option value="tiny">Tiny — fastest (~75 MB)</option>
-                <option value="base">Base (~150 MB)</option>
-                <option value="small">Small — light (~470 MB)</option>
-                <option value="large-v3-turbo-q8_0">
-                  Large v3 Turbo (q8) — recommended on 12+ GB Macs (~875 MB)
-                </option>
-                <option value="medium">Medium — accurate (~1.5 GB)</option>
-                <option value="large-v3">Large — best (~3 GB)</option>
-              </select>
+              </mur-select>
             </label>
           </div>
+
+          <!-- The SAME picker Settings hosts. Fully controlled: the wizard owns the
+               size signal, the card only reports picks. -->
+          <app-model-power
+            [size]="modelSize()"
+            [disabled]="downloading()"
+            (sizeChange)="onModelSize($event)"
+            (repair)="downloadModel()"
+          />
 
           <div class="model-state">
             @if (modelPresent() === true) {
@@ -126,6 +122,15 @@
                     }
                   </span>
                 </div>
+                <!-- Cancelling is a NORMAL outcome, not a failure — the command
+                     resolves with status "cancelled" and leaves no partial file. -->
+                <button
+                  type="button"
+                  class="btn btn-ghost"
+                  (click)="cancelDownload()"
+                >
+                  Cancel download
+                </button>
                 <span class="text-muted model-note">
                   Fetching the model — large models can take a few minutes.
                 </span>
@@ -136,10 +141,21 @@
                   (click)="downloadModel()"
                 >
                   <span class="dl-arrow" aria-hidden="true">↓</span>
-                  Download model ({{ sizeHint() }})
+                  <!-- COLD CACHE: on a first launch the catalog may not have arrived
+                       (or the probe may have failed), and the size figure comes only
+                       from it. No figure ⇒ no figure — never a made-up one. -->
+                  @if (sizeHint()) {
+                    Download model ({{ sizeHint() }})
+                  } @else {
+                    Download model
+                  }
                 </button>
                 <span class="text-muted model-note">
-                  {{ sizeHint() }}, one time, on-device.
+                  @if (sizeHint()) {
+                    {{ sizeHint() }}, one time, on-device.
+                  } @else {
+                    One time, on-device.
+                  }
                 </span>
               }
             } @else {
@@ -159,6 +175,19 @@
           }
           @if (downloadError(); as derr) {
             <p class="ob-error text-danger">{{ derr }}</p>
+          }
+          <!-- The wizard's only unskippable step needs a way out when the thing it
+               demands cannot be obtained (no catalog, or a download that keeps
+               failing). Skipping leaves Murmur unable to transcribe, so this appears
+               only once something has actually gone wrong. -->
+          @if (canSkipModel()) {
+            <button type="button" class="btn btn-ghost ob-skip" (click)="skipModel()">
+              I’ll set this up later
+            </button>
+            <p class="text-muted model-note">
+              Murmur can’t transcribe until a model is downloaded — you can finish this
+              in Settings → Transcription.
+            </p>
           }
         }
 

--- a/src/app/features/onboarding/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding/onboarding.component.ts
@@ -12,9 +12,13 @@ import { open } from "@tauri-apps/plugin-dialog";
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import { IpcService } from "../../../core/ipc.service";
 import { hostIsLoopback } from "../../../core/loopback";
+import { modelSizeLabel } from "../../../core/model-bytes";
 import type { AppConfigDto, ProviderStatus } from "../../../core/models";
+import { MachineService } from "../../../services/machine.service";
 import { BrainEnableCardComponent } from "../../brain/brain-enable-card/brain-enable-card.component";
 import { MurProgressComponent } from "../../../design-system/progress/progress.component";
+import { MurSelectComponent } from "../../../design-system/select/select.component";
+import { ModelPowerComponent } from "../../settings/sections/settings-transcription-section/model-power/model-power.component";
 
 /** The wizard steps, in order. Drives the dot indicator + progress copy. */
 type Step = "welcome" | "model" | "provider" | "brain" | "vault" | "done";
@@ -70,16 +74,6 @@ function liveCompanionPendingOf(cfg: AppConfigDto): boolean {
     .liveCompanionPending === true;
 }
 
-/** Approx download size per Whisper quality (mirrors Settings). */
-const SIZE_HINTS: Record<string, string> = {
-  tiny: "~75 MB",
-  base: "~150 MB",
-  small: "~470 MB",
-  "large-v3-turbo-q8_0": "~875 MB",
-  medium: "~1.5 GB",
-  "large-v3": "~3 GB",
-};
-
 /**
  * First-run wizard — a full-bleed, focused glassmorphism flow that gets a fresh
  * macOS user from launch to a working recorder in five calm steps:
@@ -93,7 +87,12 @@ const SIZE_HINTS: Record<string, string> = {
 @Component({
   selector: "app-onboarding",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [BrainEnableCardComponent, MurProgressComponent],
+  imports: [
+    BrainEnableCardComponent,
+    MurProgressComponent,
+    MurSelectComponent,
+    ModelPowerComponent,
+  ],
   templateUrl: "./onboarding.component.html",
   styleUrl: "./onboarding.component.scss",
 })
@@ -101,6 +100,8 @@ export class OnboardingComponent implements OnInit {
   private readonly ipc = inject(IpcService);
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
+  /** The root-held catalog + machine answer (P1). Shared with Settings, never re-fetched per host. */
+  readonly machine = inject(MachineService);
 
   readonly steps = STEPS;
   readonly currentStep = signal<Step>("welcome");
@@ -115,7 +116,42 @@ export class OnboardingComponent implements OnInit {
   readonly modelPresent = signal<boolean | null>(null);
   readonly downloading = signal(false);
   readonly downloadError = signal<string | null>(null);
-  readonly sizeHint = computed(() => SIZE_HINTS[this.modelSize()] ?? "");
+  /**
+   * The chosen size's download figure, from the RUST CATALOG (the FE's own six-entry
+   * `SIZE_HINTS` table is gone — it had already drifted from Settings' nine-entry
+   * copy and from the backend). `""` when the catalog has not arrived, which is the
+   * NORMAL first-launch state: the button then says "Download model" with no figure
+   * rather than a made-up one.
+   */
+  readonly sizeHint = computed(() => {
+    const row = this.machine.models().find((m) => m.id === this.modelSize());
+    return row ? modelSizeLabel(row.approxDownloadBytes) : "";
+  });
+
+  /**
+   * COLD CACHE. This is first launch: nothing is cached, and `whisper_recommendation`
+   * is as fallible as any other IPC call. `loading()` keeps this false while the
+   * first probe is still in flight, so the escape hatch below cannot flash during a
+   * perfectly normal startup.
+   */
+  readonly catalogUnavailable = computed(
+    () => !this.machine.loading() && this.machine.models().length === 0,
+  );
+
+  /**
+   * The model step is the wizard's ONLY unskippable step (`canAdvance` demands a
+   * downloaded model), which is fine right up until the catalog never loads or the
+   * download keeps failing — at which point a first-run user is stranded on it with
+   * no way forward and no way out. This is the way out. It is deliberately NOT always
+   * visible: skipping leaves the app unable to transcribe, so it appears only once
+   * something has actually gone wrong.
+   */
+  readonly canSkipModel = computed(
+    () =>
+      this.modelPresent() !== true &&
+      !this.downloading() &&
+      (this.catalogUnavailable() || this.downloadError() !== null),
+  );
   /**
    * Will `download_model` ALSO fetch a small live-caption model beside the chosen one? Read
    * STRAIGHT FROM THE BACKEND (`AppConfigDto.liveCompanionPending`, filled in by `get_config` from
@@ -315,7 +351,12 @@ export class OnboardingComponent implements OnInit {
   /** Side-effects run when a step becomes visible (probe model / providers). */
   private async onEnterStep(step: Step): Promise<void> {
     if (step === "model") {
-      await this.persistConfig();
+      // Cold cache by definition — this is the first time anything asks the backend
+      // what this Mac is. `refresh()` swallows its own failures, so a dead probe
+      // leaves the catalog empty rather than throwing the wizard off the step.
+      await this.machine.refresh();
+      const source = this.preselectRecommended();
+      await this.persistConfig(false, source);
       this.modelPresent.set(await this.ipc.modelPresent());
       await this.refreshLiveCompanionPending();
     } else if (step === "provider") {
@@ -325,14 +366,49 @@ export class OnboardingComponent implements OnInit {
 
   // ── Model step ────────────────────────────────────────────────────────────
 
-  async onLanguage(event: Event): Promise<void> {
-    this.language.set((event.target as HTMLSelectElement).value);
+  /** Runs at most once per wizard: the preselect is an opening offer, not a policy. */
+  private preselectApplied = false;
+
+  /**
+   * Put Murmur's recommendation in front of the user instead of whatever the config
+   * happened to default to — and record that it got there AUTOMATICALLY.
+   *
+   * Returns `"auto"` when it applied, so the very write that persists the preselected
+   * size carries `modelSizeSource: "auto"`. Without that, a fresh install which simply
+   * accepted the recommendation would be stored as a DELIBERATE user choice, and
+   * nothing downstream could ever tell "they chose this" from "we chose this for them".
+   *
+   * It refuses to run when `modelSizeSource` is already recorded: that means an
+   * install with a history (including one the backfill marked `"user"`), and
+   * re-running setup must never relabel a real choice as an automatic one.
+   */
+  private preselectRecommended(): "auto" | undefined {
+    if (this.preselectApplied) return undefined;
+    const data = this.machine.data();
+    // No catalog yet (cold / failed probe) — stay unapplied so a later entry retries.
+    if (!data?.recommendedId) return undefined;
+    this.preselectApplied = true;
+    if (data.modelSizeSource) return undefined;
+    this.modelSize.set(data.recommendedId);
+    return "auto";
+  }
+
+  async onLanguage(language: string): Promise<void> {
+    this.language.set(language);
     await this.refreshModelPresence();
   }
 
-  async onModelSize(event: Event): Promise<void> {
-    this.modelSize.set((event.target as HTMLSelectElement).value);
-    await this.refreshModelPresence();
+  /** An explicit pick from the power slider / "show every size" list. */
+  async onModelSize(size: string): Promise<void> {
+    if (size === this.modelSize()) return;
+    this.modelSize.set(size);
+    // A DELIBERATE choice — the opposite of the preselect above.
+    await this.refreshModelPresence("user");
+  }
+
+  /** Move past the model step without one. See {@link canSkipModel}. */
+  async skipModel(): Promise<void> {
+    await this.next();
   }
 
   /**
@@ -347,10 +423,12 @@ export class OnboardingComponent implements OnInit {
   private modelPresenceRequestId = 0;
 
   /** Persist the chosen language + size, then re-check what's on disk. */
-  private async refreshModelPresence(): Promise<void> {
+  private async refreshModelPresence(
+    modelSizeSource?: "auto" | "user",
+  ): Promise<void> {
     const requestId = ++this.modelPresenceRequestId;
     this.modelPresent.set(null);
-    await this.persistConfig();
+    await this.persistConfig(false, modelSizeSource);
     if (requestId !== this.modelPresenceRequestId) return; // superseded mid-flight
     const present = await this.ipc.modelPresent();
     if (requestId !== this.modelPresenceRequestId) return; // superseded mid-flight
@@ -360,6 +438,10 @@ export class OnboardingComponent implements OnInit {
     const pending = await this.readLiveCompanionPending();
     if (requestId !== this.modelPresenceRequestId) return; // superseded mid-flight
     this.liveCompanionPending.set(pending);
+    // The picker's own facts (pendingDownloadBytes, per-row `downloaded`, the
+    // live-caption state) describe the SAVED selection too. Inside the same guard, so
+    // an abandoned selection's catalog never lands over the current one.
+    await this.machine.refresh();
   }
 
   /** Re-read the backend's companion decision for the currently SAVED language + size. */
@@ -383,14 +465,27 @@ export class OnboardingComponent implements OnInit {
     try {
       // The model is fetched for the SAVED language + size — persist first.
       await this.persistConfig();
+      // A CANCEL resolves normally (`status: "cancelled"`) and must not paint an
+      // error: the user asked for it. Presence is re-read either way.
       await this.ipc.downloadModel();
       this.modelPresent.set(await this.ipc.modelPresent());
       // The companion has landed (or was never needed) — stop promising a second transfer.
       await this.refreshLiveCompanionPending();
+      await this.machine.refresh();
     } catch (e) {
       this.downloadError.set(String(e));
     } finally {
       this.downloading.set(false);
+    }
+  }
+
+  /** Stop an in-flight download. Best-effort; the download reports its own outcome. */
+  async cancelDownload(): Promise<void> {
+    try {
+      await this.ipc.cancelModelDownload();
+    } catch {
+      // Nothing to cancel, or the command is unavailable — the download still
+      // resolves (or fails) on its own, and there is nothing useful to say here.
     }
   }
 
@@ -547,8 +642,17 @@ export class OnboardingComponent implements OnInit {
    * Save the current wizard choices, preserving every other config field from
    * the loaded snapshot. `markOnboarded` flips the first-run gate on the final
    * step. A tracked timeout is NOT needed here — these are awaited one-shots.
+   *
+   * `modelSizeSource` is OMITTED by default, and omitting it means PRESERVE (the
+   * backend leaves the stored row untouched). That default is what lets every other
+   * write here — provider, vault, finish — go through without opinions about a field
+   * they know nothing about. Only the two writes that genuinely decide the question
+   * pass it: the PRESELECT (`"auto"`) and an explicit pick (`"user"`).
    */
-  private async persistConfig(markOnboarded = false): Promise<void> {
+  private async persistConfig(
+    markOnboarded = false,
+    modelSizeSource?: "auto" | "user",
+  ): Promise<void> {
     const base = this.loadedConfig;
     const cfg: AppConfigDto = {
       providerId: this.provider(),
@@ -578,6 +682,9 @@ export class OnboardingComponent implements OnInit {
       audioStorageLimitGb: base?.audioStorageLimitGb ?? null,
       audioAutoPrune: base?.audioAutoPrune ?? false,
       modelSize: this.modelSize(),
+      // `null` is the WIRE spelling of "absent" for this field (Rust `Option<String>`
+      // with `#[serde(default)]`), i.e. preserve whatever is stored.
+      modelSizeSource: modelSizeSource ?? null,
       // Live-caption engine — preserve-only here (the Settings Transcription section owns the
       // toggle + the parakeet download); round-trip the snapshot, default "whisper".
       liveAsrEngine: base?.liveAsrEngine ?? "whisper",
@@ -661,7 +768,9 @@ export class OnboardingComponent implements OnInit {
       shareEgressConsented: base?.shareEgressConsented ?? false,
     };
     await this.ipc.saveConfig(cfg);
-    // Keep the snapshot current so successive saves don't clobber fresh choices.
-    this.loadedConfig = cfg;
+    // Keep the snapshot current so successive saves don't clobber fresh choices —
+    // but WITHOUT the one-shot `modelSizeSource`, so a later preserve-write cannot
+    // accidentally re-assert a decision this call already made.
+    this.loadedConfig = { ...cfg, modelSizeSource: null };
   }
 }

--- a/src/app/features/settings/sections/settings-transcription-section/model-power/model-power.component.html
+++ b/src/app/features/settings/sections/settings-transcription-section/model-power/model-power.component.html
@@ -1,0 +1,149 @@
+<div class="mp">
+  @if (catalogLoaded()) {
+    <div class="mp-slider">
+      <mur-power-slider
+        ariaLabel="Transcription model power"
+        [rungs]="rungs()"
+        [value]="size()"
+        [disabled]="disabled()"
+        (valueChange)="pick($event)"
+      />
+    </div>
+
+    <!-- The HEADLINE says what the rung DOES. The download size is secondary detail
+         below it, never the thing the user reads first. -->
+    <div class="mp-active">
+      <div class="mp-active-head">
+        <h4 class="mp-active-name">
+          {{ selected()?.tier ?? selected()?.id ?? size() }}
+        </h4>
+        @if (isRecommended()) {
+          <mur-pill kind="accent">Recommended for this Mac</mur-pill>
+        }
+      </div>
+
+      @if (selected(); as m) {
+        <p class="mp-headline">{{ m.headline }}</p>
+      } @else {
+        <p class="mp-headline text-muted">
+          This size isn’t one Murmur knows about — it stays selected until you pick
+          another.
+        </p>
+      }
+
+      @if (rating(); as r) {
+        <div class="mp-meters">
+          <mur-meter
+            label="Accuracy"
+            [value]="r.accuracy"
+            [max]="4"
+            [detail]="accuracyDetail()"
+          />
+          <mur-meter label="Speed" [value]="r.speed" [max]="4" />
+        </div>
+      }
+
+      <p class="field-help text-muted mp-download">{{ downloadCopy() }}</p>
+
+      @if (reasonCopy(); as why) {
+        <p class="field-help text-muted mp-reason">{{ why }}</p>
+      }
+
+      @if (!isRecommended() && recommendedTier(); as recTier) {
+        <button
+          type="button"
+          class="btn btn-ghost mp-use-rec"
+          [disabled]="disabled()"
+          (click)="useRecommended()"
+        >
+          Use {{ recTier }}, the recommendation for this Mac
+        </button>
+      }
+    </div>
+
+    @if (needsLiveRepair()) {
+      <div class="banner mp-repair" role="status">
+        <span>
+          Live captions have no model to run. Fetching the transcription model
+          brings the small live-caption model with it.
+        </span>
+        <button
+          type="button"
+          class="btn btn-primary"
+          [disabled]="disabled()"
+          (click)="repair.emit()"
+        >
+          Fix live captions
+        </button>
+      </div>
+    }
+  }
+
+  <!-- ALWAYS openable, even with no catalog: on a cold first launch the list is the
+       only place a user can see that Murmur simply hasn't heard back yet. -->
+  <mur-disclosure panelLabel="Every transcription model size">
+    <span murDisclosureSummary>Show every size</span>
+
+    @if (longTail().length) {
+      <ul class="mp-tail">
+        @for (m of longTail(); track m.id) {
+          <li class="mp-tail-row" [class.is-selected]="m.id === size()">
+            <button
+              type="button"
+              class="mp-tail-pick"
+              [disabled]="disabled()"
+              [attr.aria-pressed]="m.id === size()"
+              (click)="pick(m.id)"
+            >
+              <span class="mp-tail-headline">{{ m.headline }}</span>
+              <span class="mp-tail-meta">
+                <!-- The honest raw id, in muted mono — this is the string the model
+                     file is actually named after. -->
+                <code class="mp-tail-id">{{ m.id }}</code>
+                <span class="mp-tail-size">{{ sizeLabel(m) }}</span>
+                @if (m.downloaded) {
+                  <span class="mp-tail-on-disk">on this Mac</span>
+                }
+              </span>
+            </button>
+
+            @if (m.downloaded) {
+              @if (confirmDelete() === m.id) {
+                <span class="mp-tail-confirm">
+                  <button
+                    type="button"
+                    class="btn btn-ghost mp-danger"
+                    [disabled]="deleting()"
+                    (click)="remove(m.id)"
+                  >
+                    Delete for good
+                  </button>
+                  <button type="button" class="btn btn-ghost" (click)="cancelDelete()">
+                    Keep
+                  </button>
+                </span>
+              } @else {
+                <button
+                  type="button"
+                  class="btn btn-ghost mp-tail-delete"
+                  [disabled]="disabled() || deleting()"
+                  (click)="askDelete(m.id)"
+                >
+                  Delete
+                </button>
+              }
+            }
+          </li>
+        }
+      </ul>
+    } @else {
+      <p class="field-help text-muted">
+        Murmur hasn’t read this Mac’s model list yet.
+      </p>
+    }
+
+    @if (deleteError(); as err) {
+      <p class="field-help text-danger mp-delete-error" role="alert">{{ err }}</p>
+    }
+  </mur-disclosure>
+</div>

--- a/src/app/features/settings/sections/settings-transcription-section/model-power/model-power.component.scss
+++ b/src/app/features/settings/sections/settings-transcription-section/model-power/model-power.component.scss
@@ -1,0 +1,143 @@
+:host {
+  display: block;
+  min-width: 0;
+}
+
+.mp {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.mp-slider {
+  padding: var(--space-2) var(--space-1) 0;
+}
+
+.mp-active {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.mp-active-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.mp-active-name {
+  margin: 0;
+  font-size: 1.0625rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.mp-headline {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.mp-meters {
+  display: flex;
+  align-items: center;
+  gap: var(--space-5);
+  flex-wrap: wrap;
+}
+
+.mp-use-rec {
+  align-self: flex-start;
+}
+
+/* Rides the global `.banner` primitive; only the layout is local. */
+.mp-repair {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.mp-tail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mp-tail-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  border-radius: var(--radius-md);
+  transition: background var(--transition-fast);
+}
+
+.mp-tail-row.is-selected {
+  background: var(--surface-hover);
+}
+
+.mp-tail-pick {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  padding: var(--space-2) var(--space-3);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-md);
+  text-align: left;
+  color: inherit;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.mp-tail-pick:hover:not(:disabled) {
+  background: var(--surface-hover);
+}
+
+.mp-tail-pick:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-ring);
+}
+
+.mp-tail-pick:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.mp-tail-headline {
+  color: var(--text-primary);
+}
+
+.mp-tail-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+/* The raw checkpoint id, stated plainly rather than hidden behind a marketing name. */
+.mp-tail-id {
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+}
+
+.mp-tail-on-disk {
+  color: var(--success);
+}
+
+.mp-tail-confirm {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.mp-danger {
+  color: var(--danger);
+}

--- a/src/app/features/settings/sections/settings-transcription-section/model-power/model-power.component.ts
+++ b/src/app/features/settings/sections/settings-transcription-section/model-power/model-power.component.ts
@@ -1,0 +1,290 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  output,
+  signal,
+} from "@angular/core";
+import { IpcService } from "../../../../../core/ipc.service";
+import {
+  formatModelBytes,
+  modelSizeLabel,
+} from "../../../../../core/model-bytes";
+import type { RecommendReason, WhisperModelDto } from "../../../../../core/models";
+import { MachineService } from "../../../../../services/machine.service";
+import { MurDisclosureComponent } from "../../../../../design-system/disclosure/disclosure.component";
+import { MurMeterComponent } from "../../../../../design-system/meter/meter.component";
+import { MurPillComponent } from "../../../../../design-system/pill/pill.component";
+import {
+  MurPowerSliderComponent,
+  type PowerRung,
+} from "../../../../../design-system/power-slider/power-slider.component";
+
+/**
+ * The COARSE accuracy / speed rating per ladder rung.
+ *
+ * These are ORDINAL and deliberately blunt. Sharp and Maximum share the SAME
+ * accuracy rating on purpose: the measured turbo-vs-large-v3 delta is unpublished
+ * (see `transcribe/catalog.rs` — the registry's `power` is explicitly ranked by
+ * COST, "never a claim that it transcribes better"), so inventing a difference
+ * here would be exactly the dishonesty this workstream removes. Maximum still
+ * differs where we DO have evidence: it is much slower and much heavier.
+ */
+const RATINGS: Record<string, { accuracy: number; speed: number }> = {
+  Light: { accuracy: 1, speed: 4 },
+  Balanced: { accuracy: 2, speed: 3 },
+  Sharp: { accuracy: 4, speed: 3 },
+  Maximum: { accuracy: 4, speed: 1 },
+};
+
+/**
+ * The transcription-model picker, used by BOTH hosts (Settings → Transcription and
+ * the onboarding wizard's model step). ONE component, two hosts, no duplicated
+ * logic — the previous design had the ladder, the size table and the copy written
+ * out twice, and they had already drifted.
+ *
+ * FULLY CONTROLLED: `size` in, `sizeChange` out. It stores no selection of its own,
+ * so the reactive-form host (Settings) and the signals-only host (onboarding) drive
+ * it identically and neither can fall out of sync with what it displays.
+ *
+ * Everything it renders comes from Rust via {@link MachineService}: the rungs, the
+ * headlines, the byte figures, the recommendation and — critically — the REASON.
+ * The FE maps a `reason` variant to a sentence and never assembles the reasoning,
+ * because each variant is true about a DIFFERENT thing (see {@link reasonCopy}).
+ */
+@Component({
+  selector: "app-model-power",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    MurDisclosureComponent,
+    MurMeterComponent,
+    MurPillComponent,
+    MurPowerSliderComponent,
+  ],
+  templateUrl: "./model-power.component.html",
+  styleUrl: "./model-power.component.scss",
+})
+export class ModelPowerComponent {
+  private readonly ipc = inject(IpcService);
+  readonly machine = inject(MachineService);
+
+  /** The currently chosen size id. The host owns it; this component never writes it. */
+  readonly size = input.required<string>();
+
+  /** Disable every control (a download in flight, a recording in progress). */
+  readonly disabled = input(false);
+
+  /** A rung / long-tail row was chosen. The host persists it. */
+  readonly sizeChange = output<string>();
+
+  /**
+   * "Live captions have nothing to run — fix it." Emitted rather than handled here
+   * because both hosts ALREADY own a download flow with progress and error copy;
+   * a second downloader inside this card would race them.
+   */
+  readonly repair = output<void>();
+
+  /** Two-step delete confirmation — the id awaiting confirmation, or `null`. */
+  private readonly _confirmDelete = signal<string | null>(null);
+  readonly confirmDelete = this._confirmDelete.asReadonly();
+
+  /** Surfaced verbatim from the backend when a delete is refused. */
+  private readonly _deleteError = signal<string | null>(null);
+  readonly deleteError = this._deleteError.asReadonly();
+
+  private readonly _deleting = signal(false);
+  readonly deleting = this._deleting.asReadonly();
+
+  constructor() {
+    // Stale-while-revalidate: the root service keeps the last catalog on screen, so
+    // this refresh replaces it underneath rather than blanking the picker.
+    void this.machine.refresh();
+  }
+
+  /** True once the backend catalog has arrived. Everything size-related is gated on it. */
+  readonly catalogLoaded = computed(() => this.machine.models().length > 0);
+
+  /** The four ladder rungs, ascending by cost, straight from the Rust catalog. */
+  readonly ladder = computed<WhisperModelDto[]>(() =>
+    this.machine
+      .models()
+      .filter((m) => m.tier !== null)
+      .sort((a, b) => a.power - b.power),
+  );
+
+  /** The rungs as the slider wants them: the HUMAN name is what it announces. */
+  readonly rungs = computed<PowerRung[]>(() =>
+    this.ladder().map((m) => ({ id: m.id, name: m.tier ?? m.id })),
+  );
+
+  /** Every catalog row that is NOT a rung — the honest long tail. */
+  readonly longTail = computed<WhisperModelDto[]>(() =>
+    this.machine
+      .models()
+      .filter((m) => m.tier === null)
+      .sort((a, b) => a.power - b.power),
+  );
+
+  /** The catalog row for the current selection, or `null` for an unknown/custom id. */
+  readonly selected = computed<WhisperModelDto | null>(
+    () => this.machine.models().find((m) => m.id === this.size()) ?? null,
+  );
+
+  /** The selection is not one of the four rungs (a long-tail size, or something custom). */
+  readonly selectionOffLadder = computed(
+    () => this.selected()?.tier == null,
+  );
+
+  /** Accuracy / speed for the selected rung, or `null` off the ladder. */
+  readonly rating = computed(() => {
+    const tier = this.selected()?.tier;
+    return tier ? (RATINGS[tier] ?? null) : null;
+  });
+
+  /** Sharp and Maximum share the accuracy rating — say so rather than let it look like a bug. */
+  readonly accuracyDetail = computed(() => {
+    const tier = this.selected()?.tier;
+    return tier === "Sharp" || tier === "Maximum"
+      ? "Sharp and Maximum share this rating — the measured difference between them is unpublished."
+      : null;
+  });
+
+  /** The size this Mac's HARDWARE deserves (blind to what is on disk). */
+  readonly recommendedId = this.machine.recommendedId;
+
+  /** The recommended row's human tier label, when it has one. */
+  readonly recommendedTier = computed(
+    () =>
+      this.machine.models().find((m) => m.id === this.recommendedId())?.tier ??
+      null,
+  );
+
+  /** The current selection IS the hardware recommendation. */
+  readonly isRecommended = computed(
+    () => !!this.size() && this.size() === this.recommendedId(),
+  );
+
+  /**
+   * WHY the default is what it is. Every branch says EXACTLY what is true about
+   * itself and nothing a neighbouring branch could claim:
+   *
+   *  - `freshInstallAmpleRam` is the ONLY variant allowed to say "your Mac has N GB,
+   *    so…" — every other branch is presence-first or capped, so a RAM-causal
+   *    sentence there would be a fabricated explanation;
+   *  - `notAppleSilicon` is the ONLY variant allowed to name a chip family. It is
+   *    reached only when the arch probe ANSWERED and answered false;
+   *  - `archUnknown` and `ramUnknown` claim NOTHING about the hardware. A failed
+   *    probe is reached by a real Intel Mac AND by an Apple-Silicon Mac that could
+   *    not answer, so naming either would be a coin flip presented as a fact;
+   *  - `modestRam` is genuinely RAM-caused, but it is the "not enough" branch — it
+   *    states the consequence without quoting a figure, so it can never read as the
+   *    "your Mac has plenty" sentence;
+   *  - `existingInstall` is the only variant that may mention an existing model.
+   */
+  readonly reasonCopy = computed(() => {
+    const data = this.machine.data();
+    if (!data) return "";
+    const tier = this.recommendedTier() ?? "the lighter model";
+    const reason: RecommendReason = data.reason;
+    switch (reason) {
+      case "freshInstallAmpleRam": {
+        const ram = data.machine.totalRamBytes;
+        // The causal sentence needs the figure it is causal about. Without a
+        // measurement, fall back to a sentence that claims nothing.
+        if (ram == null) {
+          return `Murmur picked ${tier} for this Mac.`;
+        }
+        const gb = Math.round(ram / (1024 * 1024 * 1024));
+        return `Your Mac has ${gb} GB of memory, so Murmur picked ${tier}.`;
+      }
+      case "notAppleSilicon":
+        return "This is an Intel Mac, so Murmur stays with the lighter model — the heavier ones are tuned for Apple silicon.";
+      case "archUnknown":
+        return "Murmur couldn't read this Mac's processor, so it chose the lighter model rather than guess.";
+      case "modestRam":
+        return "This Mac's memory is below the threshold for the heavier model, so Murmur chose the lighter one.";
+      case "ramUnknown":
+        return "Murmur couldn't measure this Mac's memory, so it chose the lighter model rather than guess.";
+      case "existingInstall":
+        return "You already have a model downloaded, so Murmur kept using it instead of fetching another.";
+      case "alreadyDownloaded":
+        return "This model is already on this Mac, so Murmur kept it — nothing to download.";
+      default:
+        return "";
+    }
+  });
+
+  /**
+   * The download line. `0` and `null` mean DIFFERENT things and must never be
+   * collapsed: `0` is "nothing to fetch", `null` is "a download IS pending but its
+   * size is unknown". Rendering `null` as free would promise a free multi-GB
+   * transfer, which is the exact dishonesty this workstream exists to remove.
+   */
+  readonly downloadCopy = computed(() => {
+    const data = this.machine.data();
+    if (!data) return "";
+    const bytes = data.pendingDownloadBytes;
+    if (bytes === null) return "Needs a download — size unknown.";
+    if (bytes === 0) return "Already on this Mac — nothing to download.";
+    return `About ${formatModelBytes(bytes)} to download, once.`;
+  });
+
+  /**
+   * Live captions have nothing to run AND it is recoverable. `pinnedHeavy` is
+   * deliberately excluded: that is a configuration the user chose, not a failed
+   * download, so offering to "repair" it would be misleading.
+   */
+  readonly needsLiveRepair = computed(() => {
+    const state = this.machine.data()?.liveCaptions;
+    return state === "noModel" || state === "modelMissing";
+  });
+
+  /** A row's download size as SECONDARY detail. `null` renders as unknown, never free. */
+  sizeLabel(m: WhisperModelDto): string {
+    return modelSizeLabel(m.approxDownloadBytes);
+  }
+
+  pick(id: string): void {
+    if (this.disabled() || !id || id === this.size()) return;
+    this._deleteError.set(null);
+    this.sizeChange.emit(id);
+  }
+
+  /** Jump straight to what this Mac deserves. */
+  useRecommended(): void {
+    this.pick(this.recommendedId());
+  }
+
+  askDelete(id: string): void {
+    this._deleteError.set(null);
+    this._confirmDelete.set(id);
+  }
+
+  cancelDelete(): void {
+    this._confirmDelete.set(null);
+  }
+
+  /**
+   * Delete a downloaded model. EVERY refusal (the effective model, the live-caption
+   * pin, a non-registry id, a recording in progress) lives in the backend, so the
+   * message shown here is the backend's own — the FE never re-implements the rules
+   * and therefore cannot drift from them.
+   */
+  async remove(id: string): Promise<void> {
+    this._confirmDelete.set(null);
+    this._deleteError.set(null);
+    this._deleting.set(true);
+    try {
+      await this.ipc.deleteWhisperModel(id);
+    } catch (e) {
+      this._deleteError.set(String(e));
+    } finally {
+      this._deleting.set(false);
+      // Refresh either way: on success the row must stop claiming it is downloaded,
+      // and on a refusal the catalog is the proof that nothing changed.
+      await this.machine.refresh();
+    }
+  }
+}

--- a/src/app/features/settings/sections/settings-transcription-section/model-power/model-power.component.ts
+++ b/src/app/features/settings/sections/settings-transcription-section/model-power/model-power.component.ts
@@ -119,12 +119,19 @@ export class ModelPowerComponent {
     this.ladder().map((m) => ({ id: m.id, name: m.tier ?? m.id })),
   );
 
-  /** Every catalog row that is NOT a rung — the honest long tail. */
+  /**
+   * EVERY catalog row, rungs included — this list is also the only place a downloaded
+   * model can be DELETED.
+   *
+   * It deliberately no longer filters to `tier === null`. Doing so made the two
+   * biggest downloads the ladder actively invites — Sharp (~875 MB) and Maximum
+   * (~3 GB) — impossible to remove from any surface, so "reclaim disk" was
+   * unreachable for exactly the sizes that cost disk. The backend's four refusals
+   * (effective model, live-caption pin, non-registry id, never VAD/Parakeet) already
+   * make surfacing it safe.
+   */
   readonly longTail = computed<WhisperModelDto[]>(() =>
-    this.machine
-      .models()
-      .filter((m) => m.tier === null)
-      .sort((a, b) => a.power - b.power),
+    [...this.machine.models()].sort((a, b) => a.power - b.power),
   );
 
   /** The catalog row for the current selection, or `null` for an unknown/custom id. */

--- a/src/app/features/settings/sections/settings-transcription-section/settings-transcription-section.component.html
+++ b/src/app/features/settings/sections/settings-transcription-section/settings-transcription-section.component.html
@@ -12,7 +12,7 @@
             <div class="model-grid">
               <label class="field">
                 <span class="field-label">Language</span>
-                <select formControlName="language" (change)="onModelChoiceChange()">
+                <mur-select formControlName="language" ariaLabel="Transcription language">
                   <option value="">Auto-detect</option>
                   <option value="pl">Polski</option>
                   <option value="en">English</option>
@@ -23,48 +23,23 @@
                   <option value="pt">Português</option>
                   <option value="uk">Українська</option>
                   <option value="nl">Nederlands</option>
-                </select>
+                </mur-select>
                 <span class="field-help text-muted">
                   Force the transcription language. Polish recommended if you record
                   mostly in Polish (auto-detect can misfire on short clips).
                 </span>
               </label>
-
-              <label class="field">
-                <span class="field-label">Quality</span>
-                <select
-                  formControlName="modelSize"
-                  (change)="onModelChoiceChange()"
-                >
-                  <option value="tiny">Tiny — fastest (~75 MB)</option>
-                  <option value="base">Base (~150 MB)</option>
-                  <option value="small">Small (~470 MB)</option>
-                  <option value="small-q8_0">
-                    Small (q8) — Small accuracy, less RAM (~270 MB)
-                  </option>
-                  <option value="medium">Medium (~1.5 GB)</option>
-                  <option value="medium-q8_0">
-                    Medium (q8) — Medium accuracy, less RAM (~850 MB)
-                  </option>
-                  <option value="large-v3-turbo">
-                    Large v3 Turbo — fast &amp; accurate (~1.6 GB)
-                  </option>
-                  <option value="large-v3-turbo-q8_0">
-                    Large v3 Turbo (q8) — recommended: Turbo accuracy, less RAM (~875 MB)
-                  </option>
-                  <option value="large-v3">
-                    Large v3 — best accuracy, largest (~3 GB)
-                  </option>
-                </select>
-                <span class="field-help text-muted">
-                  Large v3 Turbo (q8) is the recommended default on Macs with 12 GB+
-                  RAM — near-Large accuracy at a one-time ~875 MB download. Small is
-                  the fallback default on smaller machines. The (q8) variants are
-                  quantized: near-identical accuracy with a smaller download and less
-                  RAM while transcribing.
-                </span>
-              </label>
             </div>
+
+            <!-- The quality ladder. FULLY CONTROLLED: the form owns `modelSize`, the
+                 picker only reports what was chosen. Every rung, headline, size figure
+                 and reason comes from the Rust catalog. -->
+            <app-model-power
+              [size]="modelSize()"
+              [disabled]="downloadingModel()"
+              (sizeChange)="onSizeChange($event)"
+              (repair)="downloadModel()"
+            />
 
             <div class="model-status-row">
               @if (modelPresent() === true) {
@@ -90,6 +65,15 @@
                       }
                     </span>
                   </div>
+                  <!-- Cancelling is a NORMAL outcome, not a failure: the command
+                       resolves with status "cancelled" and leaves no partial file. -->
+                  <button
+                    type="button"
+                    class="btn btn-ghost"
+                    (click)="cancelDownload()"
+                  >
+                    Cancel download
+                  </button>
                   <span class="text-muted model-note">
                     Fetching the model — large models can take a few minutes.
                   </span>
@@ -99,10 +83,18 @@
                     class="btn btn-primary"
                     (click)="downloadModel()"
                   >
-                    Download ({{ downloadHint() }})
+                    @if (downloadHint()) {
+                      Download ({{ downloadHint() }})
+                    } @else {
+                      Download the model
+                    }
                   </button>
                   <span class="text-muted model-note">
-                    {{ downloadHint() }}, one time, on-device.
+                    @if (downloadHint()) {
+                      {{ downloadHint() }}, one time, on-device.
+                    } @else {
+                      One time, on-device.
+                    }
                   </span>
                 }
               } @else {

--- a/src/app/features/settings/sections/settings-transcription-section/settings-transcription-section.component.ts
+++ b/src/app/features/settings/sections/settings-transcription-section/settings-transcription-section.component.ts
@@ -1,17 +1,26 @@
 import { ChangeDetectionStrategy, Component, inject } from "@angular/core";
 import { ReactiveFormsModule } from "@angular/forms";
+import { toSignal } from "@angular/core/rxjs-interop";
+import { startWith } from "rxjs";
 import { SettingsStore } from "../../settings.store";
 import { MurProgressComponent } from "../../../../design-system/progress/progress.component";
+import { MurSelectComponent } from "../../../../design-system/select/select.component";
+import { ModelPowerComponent } from "./model-power/model-power.component";
 
 /**
- * Settings → transcription section (Stage-1 split): the `@case ("transcription")` block of the
- * former settings.component.ts monolith, moved VERBATIM. State/actions live in
- * the shell-provided SettingsStore so section switches never drop them.
+ * Settings → transcription section. The quality `<select>` (nine hand-written
+ * `<option>` labels carrying their own size figures) is now `<app-model-power>` —
+ * the SAME picker the onboarding wizard hosts, driven here from the reactive form.
  */
 @Component({
   selector: "app-settings-transcription-section",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ReactiveFormsModule, MurProgressComponent],
+  imports: [
+    ReactiveFormsModule,
+    MurProgressComponent,
+    MurSelectComponent,
+    ModelPowerComponent,
+  ],
   templateUrl: "./settings-transcription-section.component.html",
   styleUrl: "./settings-transcription-section.component.scss",
 })
@@ -26,6 +35,18 @@ export class SettingsTranscriptionSectionComponent {
   readonly modelDownloadError = this.store.modelDownloadError;
   readonly downloadHint = this.store.downloadHint;
 
+  /**
+   * The picker is FULLY CONTROLLED, so it needs the form's current value as a
+   * signal. `valueChanges` is the store's own idiom for this (`_gatewayModelValue`);
+   * a plain field would never re-render under zoneless change detection.
+   */
+  readonly modelSize = toSignal(
+    this.form.controls.modelSize.valueChanges.pipe(
+      startWith(this.form.controls.modelSize.value),
+    ),
+    { initialValue: "" },
+  );
+
   // OPTIONAL parakeet live-ASR engine (off-GPU live captions).
   readonly parakeetPresent = this.store.parakeetPresent;
   readonly downloadingParakeet = this.store.downloadingParakeet;
@@ -33,12 +54,24 @@ export class SettingsTranscriptionSectionComponent {
   readonly parakeetPct = this.store.parakeetPct;
   readonly parakeetDownloadError = this.store.parakeetDownloadError;
 
-  onModelChoiceChange(): void {
-    this.store.onModelChoiceChange();
+  /**
+   * Write the picked size into the form. The debounced auto-save persists it and
+   * then refreshes the catalog — no direct save() here (a direct call produced a
+   * double save; adversarial-verify finding).
+   */
+  onSizeChange(size: string): void {
+    // A pick HERE is deliberate, so the next save records `modelSizeSource: "user"`
+    // — the counterpart to the onboarding wizard's `"auto"` preselect.
+    this.store.markModelSizeUserPick();
+    this.form.controls.modelSize.setValue(size);
   }
 
   downloadModel(): void {
     void this.store.downloadModel();
+  }
+
+  cancelDownload(): void {
+    void this.store.cancelModelDownload();
   }
 
   downloadParakeet(): void {

--- a/src/app/features/settings/sections/settings-transcription-section/settings-transcription-section.component.ts
+++ b/src/app/features/settings/sections/settings-transcription-section/settings-transcription-section.component.ts
@@ -64,6 +64,13 @@ export class SettingsTranscriptionSectionComponent {
     // — the counterpart to the onboarding wizard's `"auto"` preselect.
     this.store.markModelSizeUserPick();
     this.form.controls.modelSize.setValue(size);
+    // MANDATORY, and the reason the pick was SILENTLY DISCARDED before: `setValue` is a
+    // PROGRAMMATIC write, which does not mark the form dirty, and the store's debounced
+    // auto-save is gated on `form.dirty` (settings.store.ts). Without this the rung visibly
+    // moves and NOTHING is persisted — the picker looks like it worked. Every sibling that
+    // patches the form on the user's behalf does the same (role/posture picks, vault pickers);
+    // see the convention note in settings.store.ts.
+    this.form.markAsDirty();
   }
 
   downloadModel(): void {

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -6,6 +6,8 @@ import { Router } from "@angular/router";
 import { open } from "@tauri-apps/plugin-dialog";
 import { IpcService } from "../../core/ipc.service";
 import { hostIsLoopback } from "../../core/loopback";
+import { modelSizeLabel } from "../../core/model-bytes";
+import { MachineService } from "../../services/machine.service";
 import type {
   AiMapRow,
   AppConfigDto,
@@ -107,6 +109,12 @@ export class SettingsStore {
   private readonly fb = inject(FormBuilder);
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
+  /**
+   * The ROOT-held whisper catalog + machine answer (P1). Root-scoped, so the store
+   * reads the same cached snapshot the picker paints — never a second copy that can
+   * disagree with it.
+   */
+  private readonly machine = inject(MachineService);
 
   // ── About — product identity + shared update-check state ────────────────
 
@@ -489,9 +497,49 @@ export class SettingsStore {
   /** Release handle for the EVENT_MODEL_DOWNLOAD subscription. */
   private unlistenModelDownload: UnlistenFn | null = null;
 
-  /** Approx download size for the selected quality (shown on the Download button). */
-  private readonly _downloadHint = signal("~3 GB");
-  readonly downloadHint = this._downloadHint.asReadonly();
+  /**
+   * Latched by {@link markModelSizeUserPick} when the user changes the quality in the
+   * picker, consumed by the next `save()`. Without the latch, `modelSizeSource` would
+   * have to be sent on EVERY save — which would relabel an automatically-chosen size
+   * as a deliberate one the moment the user changed something unrelated.
+   */
+  private readonly _modelSizeUserPick = signal(false);
+
+  /** The picker reports a DELIBERATE quality choice; the next save records it. */
+  markModelSizeUserPick(): void {
+    this._modelSizeUserPick.set(true);
+  }
+
+  /**
+   * Live signal of the modelSize form control's value — same `toSignal(valueChanges)`
+   * shape as `_gatewayModelValue` below, so {@link downloadHint} can track the pick
+   * the user just made rather than the one the backend last saved.
+   */
+  private readonly _modelSizeValue = toSignal(
+    this.form.controls.modelSize.valueChanges.pipe(
+      startWith(this.form.controls.modelSize.value),
+    ),
+    { initialValue: "" },
+  );
+
+  /**
+   * Approx download size for the selected quality (shown on the Download button),
+   * read from the RUST CATALOG via {@link MachineService}.
+   *
+   * This used to be a nine-entry hardcoded `hints` map here, mirrored by a SIX-entry
+   * `SIZE_HINTS` in the onboarding wizard and by the `<option>` labels in the
+   * template — three copies that had already diverged. The catalog is now the single
+   * source; a size the catalog states no figure for renders "size unknown", never a
+   * blank that reads as "free" (see `core/model-bytes.ts`).
+   */
+  readonly downloadHint = computed(() => {
+    const size = this._modelSizeValue() || this.machine.selectedId();
+    const row = this.machine.models().find((m) => m.id === size);
+    // No catalog yet (a cold first read, or a failed probe) ⇒ say nothing rather
+    // than invent a figure; the button still works.
+    if (!row) return "";
+    return modelSizeLabel(row.approxDownloadBytes);
+  });
 
   /**
    * OPTIONAL parakeet live-ASR engine model presence + download state (mirrors the Whisper
@@ -1526,7 +1574,9 @@ export class SettingsStore {
       )) {
         void this.ensureModels(conn);
       }
-      this.updateDownloadHint();
+      // The download hint is a `computed` over the Rust catalog now, so nothing to
+      // push here — but the catalog itself has to be READ, and this is the load path.
+      void this.machine.refresh();
       this._inputDevices.set(await this.ipc.listInputDevices().catch(() => []));
       // Speaker voiceprints — the gated management list (best-effort; failure leaves it empty).
       this._voiceprints.set(await this.ipc.listVoiceprints().catch(() => []));
@@ -2187,6 +2237,11 @@ export class SettingsStore {
       })(),
       audioAutoPrune: v.audioAutoPrune,
       modelSize: v.modelSize,
+      // Only a save that FOLLOWS an explicit pick in the picker claims `"user"`;
+      // `null` is the wire spelling of "absent" and means PRESERVE, so saving the
+      // vault path (or anything else on this form) can never relabel how the model
+      // size got there. The flag is consumed below, once the save resolves.
+      modelSizeSource: this._modelSizeUserPick() ? "user" : null,
       liveAsrEngine: v.liveAsrEngine,
       // Brain-sidecar timeouts (seconds). Coerce to a finite positive number; a blank/invalid value
       // falls back to the default here AND the backend's `dto_to_config` re-defaults a 0 — belt and
@@ -2292,6 +2347,15 @@ export class SettingsStore {
       // re-check presence so the download hint stays honest (was previously done
       // by onModelChoiceChange's direct save, now retired).
       this._modelPresent.set(await this.ipc.modelPresent().catch(() => false));
+      // The `"user"` claim has now been persisted — clear it so the NEXT save (a
+      // vault path, a toggle) goes back to preserving whatever is stored.
+      this._modelSizeUserPick.set(false);
+      // …and re-read the catalog for the SAVED selection: `pendingDownloadBytes`,
+      // every row's `downloaded` flag and the live-caption state all describe what
+      // is stored, not what is typed, so the picker would otherwise keep describing
+      // the previous pick. Refreshed HERE (after the save resolves) rather than on
+      // the change event, which fires before the debounced save has stored anything.
+      await this.machine.refresh();
       // A save may have flipped `mcp_require_token` (or minted the token on first use) — re-fetch
       // the MCP config so the copy block never shows a stale token-bearing / tokenless snippet.
       await this.refreshMcpConfig();
@@ -2697,30 +2761,6 @@ export class SettingsStore {
     }
   }
 
-  /**
-   * React to the language/quality selects. NO direct save() — the select is a
-   * form control, so the debounced auto-save persists it (a direct call here
-   * produced a double save — adversarial-verify finding); save() itself
-   * refreshes the model-present indicator once the new choice is stored.
-   */
-  onModelChoiceChange(): void {
-    this.updateDownloadHint();
-  }
-
-  private updateDownloadHint(): void {
-    const hints: Record<string, string> = {
-      tiny: "~75 MB",
-      base: "~150 MB",
-      small: "~470 MB",
-      "small-q8_0": "~270 MB",
-      medium: "~1.5 GB",
-      "medium-q8_0": "~850 MB",
-      "large-v3-turbo": "~1.6 GB",
-      "large-v3-turbo-q8_0": "~875 MB",
-      "large-v3": "~3 GB",
-    };
-    this._downloadHint.set(hints[this.form.getRawValue().modelSize] ?? "");
-  }
 
   /**
    * Copy the Obsidian URL to the clipboard and briefly confirm.
@@ -2770,7 +2810,14 @@ export class SettingsStore {
     }
   }
 
-  /** Download the model for the chosen language + quality, then re-check presence. */
+  /**
+   * Download the model for the chosen language + quality, then re-check presence.
+   *
+   * A CANCEL resolves normally (`status: "cancelled"`) and must NOT set the error
+   * line — the user asked for it. Presence and the catalog are re-read either way,
+   * because a cancel during the live-caption companion still leaves the batch model
+   * on disk and the UI has to tell the truth about that.
+   */
   async downloadModel(): Promise<void> {
     this._modelDownloadError.set(null);
     this._modelDownloadFrac.set(0);
@@ -2779,10 +2826,25 @@ export class SettingsStore {
       await this.save(); // ensure the chosen language + size are persisted first
       await this.ipc.downloadModel();
       this._modelPresent.set(await this.ipc.modelPresent());
+      await this.machine.refresh();
     } catch (e) {
       this._modelDownloadError.set(String(e));
     } finally {
       this._downloadingModel.set(false);
+    }
+  }
+
+  /**
+   * Cancel the in-flight model download. Best-effort and never surfaced as an error:
+   * the download itself resolves with a "cancelled" outcome, which
+   * {@link downloadModel} already handles.
+   */
+  async cancelModelDownload(): Promise<void> {
+    try {
+      await this.ipc.cancelModelDownload();
+    } catch {
+      // Nothing to cancel (or the command is unavailable) — the download either
+      // finishes or fails on its own; there is nothing useful to tell the user here.
     }
   }
 


### PR DESCRIPTION
P2 of a five-workstream UX program. Builds on P0 (#466) and P1 (#468).

**You no longer pick a transcription model by filename.** The dropdown of codenames and megabytes
(`large-v3-turbo-q8_0`, "Medium — accurate (~1.5 GB)") becomes a four-rung power slider that says what
each level does for you, with the rung Murmur picked for *your* Mac badged and explained.

## What lands

| Piece | Detail |
|---|---|
| `mur-power-slider` (new) | Owns its own range input rather than wrapping `mur-slider` (wrapping needed six passthroughs and would have broken `mur-slider`'s appearance guarantee). Full `ControlValueAccessor`: previews on `input`, commits on `change` — the split `mur-select` already uses. `aria-valuetext` reads the rung name, not the number; PageUp/PageDown jump a rung. |
| `mur-meter` (new) | The accuracy/speed indicator. **Sharp and Maximum deliberately share an accuracy meter** — the real delta between them is unpublished, and inventing one is exactly the dishonesty this program exists to remove. |
| `model-power` card | One component, two hosts (onboarding + Settings → Transcription), fully controlled. Renders the ladder from `MachineService`, the "Recommended for this Mac" pill, and the reason line. |
| "Show every size" | A `mur-disclosure` with the long-tail sizes and their honest raw ids in muted mono. Provisional rows stay hidden. |
| Cancellable download + delete | `download_model_streaming` gains a cancellation **generation** (an `AtomicU64`, not a global bool — a bool leaks across downloads and would cancel the next one). |
| Three hardcoded size tables deleted | The Rust catalog from P1 is now the single source. |

## The reason line cannot lie

The copy is selected by the `RecommendReason` variant P1 ships, and the rules are binding: only
`freshInstallAmpleRam` may say "your Mac has N GB, so…"; only `notAppleSilicon` may name a chip
family; `archUnknown` and `ramUnknown` claim nothing about the hardware. Two review rounds removed
exactly this class of false claim from P1 — this PR consumes the corrected enum rather than
re-deriving copy in the frontend.

`pendingDownloadBytes` keeps its `0` vs `null` distinction end to end: `0` renders as nothing to
fetch, `null` renders "size unknown" and **never** "free".

## Verification

- `npx ng lint` — clean.
- `npx ng build` — clean, 16 kB per-component style budget green.
- `cargo test --lib` targeted (`model:: catalog:: live_captions::`) — **63 passed, 0 failed**.
- `cargo clippy --lib -- -D warnings` — clean.
- Full suite + E2E run on CI.

## Honest provenance

The harness writer session was **killed mid-round** for the second time in this program — 9 of 179
tool calls were refused, two of them heredocs blocked by the repo's own `secret-scan` and
`finish-guard` hooks. The work was salvaged rather than restarted. What the writer had not finished,
and what I completed by hand:

- `download_model_streaming` had been widened with the cancellation generation but three call sites
  still passed four arguments, so **the crate did not compile**. Fixed at all three, each with a
  comment stating why its `watch` value is what it is — notably the Parakeet download passes `None`
  deliberately, because a cancelled *whisper* fetch must not abort a live *Parakeet* fetch.

Because I am now a co-author of this diff, it goes to independent review before merge; I do not sign
off on my own work.

## The second commit fixes a systemic own-goal

`docs(program)` commits the 93 kB program spec that every task contract has been telling writers to
read — **and which was never committed, so it did not exist in any task worktree.** All three PRs so
far were written without it. The same commit carries the operating lessons this program has produced
into `.claude/skills/pr-program/SKILL.md`: always `--base origin/murmur` (a stale local trunk made
every PR's CI run twice), cleanup after a failed `init` must prune worktree registrations in **both**
paired repos, the instructions hash covers `.agents/harness/*`, and how to salvage a writer killed by
a permission denial rather than restarting from zero.

---

## Light lane, declared — not a bypass

The attestation gate that landed in #471 **refuses this PR**, and it is right to: all four commits on
this `agent/` branch were made by hand after the harness writer was killed mid-round, so none carries
a `Harness-Verdict` receipt. Rather than rename the branch to dodge the check, the choice is recorded
here.

**What verification actually happened**, since "no receipt" must not be read as "no review":

- **Two independent reviewers** (spec-conformance and adversarial, fresh sessions, no writer context)
  returned **FAIL** with 3 blockers and 3 majors. Every one is fixed in this branch.
- The spec reviewer **drove the running app under Playwright** and proved the worst finding with a
  controlled A/B: on a pristine Settings form a rung pick emitted **zero** `save_config` calls; after
  dirtying the form first, the identical pick saved. The picker looked like it worked and silently
  discarded the choice.
- Both regressions were proven **RED before GREEN** on live code — `markAsDirty()` removed → test
  fails; the `modelPresenceRequestId` guard removed → test fails; both restored byte-identically and
  verified with an empty diff.
- Gates: `cargo test --lib` targeted 63 passed, `cargo clippy --lib --tests -- -D warnings` clean,
  `ng lint` clean, `ng build` clean, 8 Playwright tests green on chromium **and** webkit. Both CI lanes
  are green on this run (rust 15m59s, web 8m21s).

The harness round itself could not be completed: the writer hit the shared 1800 s wall (fixed in
#471, which split the writer and reviewer budgets), and re-running the task from zero would have
discarded ~1250 lines of correct work rather than adding any assurance.

Harness-Lane: B

