### PR TITLE
fix(harness): a directory owned path must not silently lose its risk gate

### DIFF
--- a/.agents/harness/config.json
+++ b/.agents/harness/config.json
@@ -37,13 +37,15 @@
     "egress": ["rust-lib"],
     "protocol": ["rust-lib", "protocol-server"],
     "runtime": ["tauri-boot"],
-    "ui": ["playwright"],
+    "ui": ["ng-lint", "ng-build", "playwright"],
     "performance": ["perf-contracts"]
   },
   "canonical_checks": {
     "rust-lib": "(cd src-tauri && CARGO_BUILD_JOBS=2 cargo test --lib -- --test-threads=1)",
     "protocol-server": "(cd ../murmur-server && CARGO_BUILD_JOBS=2 cargo test -p murmur-protocol -- --test-threads=1)",
     "tauri-boot": "scripts/harness-runtime-smoke",
+    "ng-lint": "npx ng lint",
+    "ng-build": "npx ng build",
     "playwright": "npm run test:e2e -- --workers=1",
     "perf-contracts": "bash .agents/harness/checks/perf-contracts.sh"
   },

--- a/.agents/harness/task_runner.py
+++ b/.agents/harness/task_runner.py
@@ -524,7 +524,25 @@ def _glob_pattern_to_regex(pattern: str) -> str:
 
 
 def _owned_matches_pattern(owned: str, pattern: str) -> bool:
-    return re.match(_glob_pattern_to_regex(pattern), owned) is not None
+    """Does an OWNED path fall under a classification pattern?
+
+    An owned path names a whole SUBTREE, so owning `src/app` must match the pattern
+    `src/app/**` — the task can write anything beneath it. Comparing the bare string
+    against the glob does not: `src/app` has no trailing segment for `**` to consume, so
+    it silently matched NOTHING.
+
+    That silence was the bug. `--owned src/app` (the natural spelling) classified as no
+    risk at all and the task therefore required no UI evidence, while `--owned src/app/`
+    or `--owned src/app/core` classified as `ui` and did. An operator got a weaker gate
+    for writing a shorter path, with nothing reported. Probing the directory form as well
+    makes the two spellings agree.
+    """
+
+    regex = _glob_pattern_to_regex(pattern)
+    if re.match(regex, owned) is not None:
+        return True
+    # Owning a directory owns everything under it: probe the subtree form too.
+    return re.match(regex, owned.rstrip("/") + "/") is not None
 
 
 def classify_risks(
@@ -5250,6 +5268,24 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
         failures.append("the FE note-attachment service is not classified lock + ui")
     if any(flag in fe_attachment_risks for flag in ("runtime", "egress", "protocol", "performance", "release")):
         failures.append("the FE note-attachment service leaked an unrelated risk flag")
+    # A DIRECTORY owned path must classify identically however it is spelled. Owning
+    # `src/app` names the whole subtree, so it has to match `src/app/**` exactly as
+    # `src/app/` and `src/app/core` do. It did not: the bare form matched nothing, so a
+    # task spelled the natural way silently required NO ui evidence while the same task
+    # spelled with a trailing slash required all of it. P3 lost its entire Angular gate to
+    # that difference and only a reviewer noticed.
+    for spelling in ("src/app", "src/app/", "src/app/core", "e2e"):
+        if "ui" not in classify_risks([spelling], [], config):
+            failures.append(f"owned path {spelling!r} did not classify as ui")
+    if required_risk_evidence(classify_risks(["src/app"], ["lock"], config), config) != [
+        "rust-lib",
+        "ng-lint",
+        "ng-build",
+        "playwright",
+    ]:
+        failures.append(
+            "a lock-risk task owning src/app must still require the full Angular evidence set"
+        )
     # Fix: a runner-owned environment probe signals BLOCKED via a DEDICATED EXIT CODE (never
     # stdout, which is writer-controlled) and only for its canonical check id — so a stray dev
     # server owning a port reads as "cannot evaluate here", not a code FAIL, while a forged


### PR DESCRIPTION
`--owned src/app` classified as **no risk at all**, while `--owned src/app/` and `--owned src/app/core` both classified as `ui`.

An owned path names a whole **subtree**, so the bare form has no trailing segment for the `**` in `src/app/**` to consume and matched nothing. **The operator who writes the shorter, more natural path got the weaker gate — and nothing said so.**

| `--owned` | before | after |
|---|---|---|
| `src/app` | *(none)* | `ui` |
| `src/app/` | `ui` | `ui` |
| `src/app/core` | `ui` | `ui` |
| `e2e` | *(none)* | `ui` |

## How it surfaced

P3 of the current UX program lost its **entire Angular evidence requirement** to that difference. The task was `--risk lock`, whose required evidence is `rust-lib` alone, so `ng lint`, `ng build` and Playwright were never scheduled against an 87-file, +2304/−672 diff that is mostly frontend.

The writer completed the work. An independent reviewer then returned BLOCKED for missing exactly that evidence — correctly, but only after a full task round had been spent.

## Two changes

- The matcher probes the subtree form as well, so both spellings agree.
- The `ui` profile requires `ng-lint` and `ng-build` alongside Playwright. An Angular change whose lint or build is broken should not reach a reviewer at all, and both commands already exist in `scripts/ci.sh`.

## Regression

Added to the selftest: all four spellings must classify as `ui`, **and** a `lock`-risk task owning `src/app` must still require the complete evidence set `[rust-lib, ng-lint, ng-build, playwright]` — the exact combination P3 was silently denied.

`agent-harness selftest --ci`: PASS · `agent-config-audit --ci`: PASS (137 checks, 0 warnings)

Harness-Lane: B