### PR TITLE
feat(copy): own every sentence a user reads, and stop leaking wire strings

### DIFF
--- a/e2e/brain/audit-inbox.spec.ts
+++ b/e2e/brain/audit-inbox.spec.ts
@@ -247,10 +247,15 @@ test("Vault audit: schedule chip renders and Explain (AI) loads inline or toasts
   await okRow.getByRole("button", { name: "Show explanation" }).click();
   await expect(okRow.locator(".au-explain")).toBeVisible();
 
-  // Explain rejection: danger toast with the backend message, row unchanged.
+  // Explain rejection: danger toast, row unchanged.
+  //
+  // P3: the toast no longer echoes the backend's own sentence. `explain_audit_finding` rejects
+  // with an UN-CODED failure here, so `ErrorCopyService.humanize` renders the generic sentence
+  // (deny-by-default) rather than a Rust string. What this spec protects is unchanged — that a
+  // rejection is SURFACED and leaves the row untouched — not which words appear.
   await errRow.getByRole("button", { name: "Explain (AI)" }).click();
   await expect(page.locator(".toast.is-danger .toast-msg")).toHaveText(
-    /AI consent required — enable cloud assistance in Settings/,
+    /Something went wrong\. Please try again\./,
   );
   await expect(errRow.locator(".au-explain")).toHaveCount(0);
   await expect(
@@ -309,9 +314,13 @@ test("Settings: weekly-audit toggle commits via set_audit_schedule and reverts o
   await expect(input).toBeEnabled();
 
   // Flip OFF → the backend rejects → toast + revert to the confirmed ON.
+  //
+  // P3: the rejection here is un-coded, so the toast is the generic sentence rather than the raw
+  // backend string. The behaviour under test — a rejected commit raises a danger toast and the
+  // switch reverts to the last CONFIRMED state — is untouched.
   await input.click();
   await expect(page.locator(".toast.is-danger .toast-msg")).toHaveText(
-    /Locked: unlock the vault to change the schedule/,
+    /Something went wrong\. Please try again\./,
   );
   await expect(input).toBeChecked();
   await expect(input).toBeEnabled();

--- a/e2e/copy/error-copy-contract.spec.ts
+++ b/e2e/copy/error-copy-contract.spec.ts
@@ -1,0 +1,230 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * The three properties `ErrorCopyService` exists to guarantee, pinned exhaustively.
+ *
+ * 1. ALL FOURTEEN `AppError` variant prefixes are stripped before the `[code]` is read — a code
+ *    that only survives the prefixes someone remembered to test is a code that silently stops
+ *    working the first time a failure travels through a different variant.
+ * 2. DENY-BY-DEFAULT: an un-coded failure renders the generic sentence no matter how harmless it
+ *    looks, and an unknown code is treated as un-coded rather than trusted.
+ * 3. The former `brain.component.ts::friendlyImportError` LADDER still classifies every document
+ *    failure the way it used to — including the one ordering that was load-bearing, where
+ *    `no text found` had to beat `unsupported document type` or a scanned PDF was reported as an
+ *    unsupported file type.
+ *
+ * # Why an e2e and not a unit test
+ *
+ * This repo has no frontend unit runner (`angular.json` declares `build`, `serve` and `lint`
+ * only) and adding one means adding npm packages, which is forbidden here. Playwright is the
+ * project's frontend oracle, so the properties are pinned where they actually matter: on a real
+ * rendered surface, through the real IPC boundary, against the real built code.
+ *
+ * # Why `/graph` is the vehicle
+ *
+ * There is exactly ONE decision table — `humanizeError`; `ErrorCopyService.humanize` delegates to
+ * it and every surface in the app reaches it through one of those two doors. So the properties
+ * above are properties of that table, and the surface only has to be an honest, minimal way to
+ * put a failure in and read a rendered sentence out. `/graph` is the smallest one in the app: a
+ * single `get_graph` call on load whose rejection is rendered verbatim by
+ * `graph.component.html`'s `<p class="empty">{{ error() }}</p>`, with no retry, no toast queue
+ * and no debounce to race. The rejection travels the whole real path — Tauri invoke → `catch` →
+ * `errorCopy.humanize(e)` → template — so nothing here is a stub of the thing under test.
+ *
+ * The failure fixtures deliberately carry realistic INTERNAL prose after the code (the actual
+ * vocabulary `errcode.rs` names as never-show: `HKDF expand failed`, `mutex poisoned`, an
+ * absolute path). Every assertion checks both halves: the right sentence appeared AND none of
+ * that prose did.
+ */
+
+/** Rendered copy, hard-coded on purpose: importing it from the module under test proves nothing. */
+const COPY = {
+  folderLocked: "That folder is locked — unlock it first.",
+  docNoText: "No readable text was found in that file, even after reading the images.",
+  docUnsupported:
+    "That file type can’t be imported. Try Markdown, text, PDF, Word, PowerPoint, Excel, HTML or an image.",
+  docTooLarge:
+    "That file goes past the safe import limit — either the file itself or the text it unpacks to is too big to add.",
+  docPassword: "That PDF is password-protected — unlock it and try again.",
+  docUnreadable:
+    "That file couldn’t be read — it may be damaged or in an unexpected format.",
+  generic: "Something went wrong. Please try again.",
+} as const;
+
+/**
+ * Every `AppError` variant tag, exactly as `Display` writes it
+ * (`src-tauri/src/error.rs` — `#[error("…: {0}")]` on each variant).
+ *
+ * Fourteen, and the list is deliberately complete rather than a sample. `Other(#[from]
+ * anyhow::Error)` is `#[error(transparent)]` and contributes no tag at all, which is why it is
+ * absent here and why an anonymous `Other` is covered by the deny-by-default test instead.
+ */
+const VARIANT_TAGS = [
+  "audio capture error",
+  "transcription error",
+  "summarizer error",
+  "export error",
+  "storage error",
+  "migration error",
+  "authentication error",
+  "locked",
+  "secrets error",
+  "keychain access denied",
+  "biometric authentication failed or was cancelled",
+  "config error",
+  "provider unavailable",
+  "invalid argument",
+] as const;
+
+/** Developer prose of exactly the kind that must never reach a screen. */
+const INTERNAL = "db::conn mutex poisoned, HKDF expand failed at /Users/x/Library/App";
+
+/**
+ * Install the mock once. The override is self-contained (it closes over nothing in test scope —
+ * `mockTauri` replays it page-side via `Function.prototype.toString()`), and reads which failure
+ * to produce from the URL, because a page-side counter would reset on every navigation.
+ */
+async function boot(page: Page): Promise<void> {
+  await mockTauri(page, {
+    // `URLSearchParams.get` already percent-decodes, so this is the exact string the test
+    // passed to `encodeURIComponent` — no second decode, which would corrupt a body
+    // containing a literal `%`.
+    get_graph: () =>
+      Promise.reject(new URLSearchParams(location.search).get("rej") ?? ""),
+  });
+}
+
+/**
+ * Load `/graph` with `get_graph` rejecting exactly `wire`, and return the rendered sentence.
+ *
+ * Scoped to the graph section's ERROR card specifically: the loading branch renders its own
+ * `<p class="empty">Loading…</p>` inside `.state-card`, so waiting on `.empty-state .empty` is
+ * also what waits for the error branch to be the one on screen.
+ */
+async function renderedFor(page: Page, wire: string): Promise<Locator> {
+  await page.goto(`/graph?rej=${encodeURIComponent(wire)}`);
+  const shown = page.locator("section.graph .empty-state .empty");
+  await expect(shown).toBeVisible({ timeout: 10_000 });
+  return shown;
+}
+
+test.describe("Error copy — the rendered sentence is owned, never the wire string", () => {
+  test("all fourteen AppError variant prefixes are stripped before the code is read", async ({
+    page,
+  }) => {
+    // Fourteen navigations on one already-warm page; well inside the tripled budget.
+    test.slow();
+    await boot(page);
+
+    for (const tag of VARIANT_TAGS) {
+      const shown = await renderedFor(
+        page,
+        `${tag}: [folder-locked] ${INTERNAL}`,
+      );
+      // The code was found, which is only possible if the prefix was removed first.
+      await expect(shown, `variant prefix "${tag}:" must be stripped`).toHaveText(
+        COPY.folderLocked,
+      );
+      // …and the prefix itself never reached the screen either.
+      //
+      // Checked as a PREFIX, not as a substring. Several variant tags are ordinary English
+      // words — `locked` is one — and the owned replacement legitimately uses them: "That
+      // folder is locked — unlock it first." A `not.toContain("locked")` assertion therefore
+      // failed on CORRECT copy, which is a defect in the assertion, not in the stripping.
+      // What the contract actually promises is that no wire-format prefix survives, so that
+      // is what this asserts.
+      const text = (await shown.textContent()) ?? "";
+      expect(text.startsWith(`${tag}:`), `"${tag}:" must not survive as a prefix`).toBe(
+        false,
+      );
+      expect(text).not.toContain("[folder-locked]");
+      expect(text).not.toContain("HKDF");
+      expect(text).not.toContain("mutex");
+      expect(text).not.toContain("/Users/");
+    }
+  });
+
+  test("deny-by-default: an un-coded internal-looking failure renders the generic sentence", async ({
+    page,
+  }) => {
+    await boot(page);
+
+    // A tagged AppError with NO code — the ~2100 constructions that never opted in.
+    let shown = await renderedFor(page, `storage error: ${INTERNAL}`);
+    await expect(shown).toHaveText(COPY.generic);
+
+    // A transparent `Other(anyhow)` — no variant tag at all, so nothing to strip.
+    shown = await renderedFor(page, "brain sidecar stdin missing: broken pipe");
+    await expect(shown).toHaveText(COPY.generic);
+
+    // A frontend-thrown `Error`, which stringifies with an "Error: " wrapper.
+    shown = await renderedFor(page, "Error: account-session mutex poisoned");
+    await expect(shown).toHaveText(COPY.generic);
+
+    // An UNKNOWN code is not trusted just because it is shaped like one. This is the half that
+    // makes the allowlist real: if the Rust side ever emits a code the frontend map does not
+    // carry, the user gets the generic sentence, never the developer prose behind it.
+    shown = await renderedFor(
+      page,
+      "storage error: [totally-made-up] E2EE decrypt/authentication failed",
+    );
+    await expect(shown).toHaveText(COPY.generic);
+    expect(await shown.textContent()).not.toContain("E2EE");
+  });
+
+  test("the document-import ladder is decided by the code, never by the prose", async ({
+    page,
+  }) => {
+    test.slow();
+    await boot(page);
+
+    // THE ORDERING THAT WAS LOAD-BEARING. `friendlyImportError` tested `no text found` before
+    // `unsupported document type` because a scanned PDF's failure message could satisfy the
+    // second test too, and losing that order told the user their PDF was an unsupported file
+    // type. Here the prose contains BOTH phrases and the code is the only thing consulted, so
+    // the ordering is not merely preserved — it is structurally impossible to get wrong.
+    let shown = await renderedFor(
+      page,
+      "invalid argument: [doc-no-text] no text found; unsupported document type fallback",
+    );
+    await expect(shown).toHaveText(COPY.docNoText);
+
+    // The mirror image: unsupported-type prose that also mentions text still classifies by code.
+    shown = await renderedFor(
+      page,
+      "invalid argument: [doc-unsupported] unsupported document type; no text found either",
+    );
+    await expect(shown).toHaveText(COPY.docUnsupported);
+
+    // The remaining rungs the old ladder had, each still its own sentence rather than collapsing
+    // into the generic "unsupported type" catch-all the ladder's last arm used to swallow them
+    // with. Each is an `invalid argument` in Rust, so without the codes they would be
+    // indistinguishable.
+    shown = await renderedFor(
+      page,
+      "invalid argument: [doc-too-large] possible zip bomb: 512 MiB expanded",
+    );
+    await expect(shown).toHaveText(COPY.docTooLarge);
+
+    shown = await renderedFor(
+      page,
+      "invalid argument: [doc-password] pdf is password-protected",
+    );
+    await expect(shown).toHaveText(COPY.docPassword);
+
+    shown = await renderedFor(
+      page,
+      "invalid argument: [doc-unreadable] malformed docx: central directory not found",
+    );
+    await expect(shown).toHaveText(COPY.docUnreadable);
+
+    // And the lock arm, which the old ladder tested FIRST with a bare `/\block/i` — a substring
+    // test that also matched "blocked", "unlocked" and "block size".
+    shown = await renderedFor(
+      page,
+      "locked: [folder-locked] folder f1 is sealed this session",
+    );
+    await expect(shown).toHaveText(COPY.folderLocked);
+  });
+});

--- a/e2e/notes/note-save-error-handling.spec.ts
+++ b/e2e/notes/note-save-error-handling.spec.ts
@@ -69,9 +69,14 @@ test.describe("Note editor — save error handling surfaces the real diagnostic"
     page.on("pageerror", (err) => consoleErrors.push(String(err)));
 
     await mockNotes(page, {
-      // Mirrors `AppError::InvalidArg(format!("no note {id}"))` — the
+      // Mirrors the REAL wire string of
+      // `AppError::InvalidArg(errcode::tag(NOTE_MISSING, format!("no note {id}")))` — the
       // stale-tab-after-delete case. Retrying this can never succeed.
-      save_note_text: () => Promise.reject("invalid argument: no note n1"),
+      //
+      // The `[note-missing]` code is what classifies it (P3); the fixture carries it because the
+      // backend does. Dropping the code here would test a wire format that no longer exists.
+      save_note_text: () =>
+        Promise.reject("invalid argument: [note-missing] no note n1"),
     });
 
     await page.goto("/notes");

--- a/e2e/notes/note-save-locked-lowercase.spec.ts
+++ b/e2e/notes/note-save-locked-lowercase.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from "@playwright/test";
+import { mockNotes } from "./mock-invoke";
+
+/**
+ * REGRESSION: the note editor's lock guard never fired, because it tested the WRONG CASE.
+ *
+ * `note-editor.component.ts::isUnretryableSaveError` tested `message.includes("Locked")` — capital
+ * L. Every producer is lowercase: `AppError`'s `Display` is `#[error("locked: {0}")]`
+ * (`src-tauri/src/error.rs`), and every note write-gate in `commands/notes.rs` goes through it. So
+ * a save into a folder that sealed under the user (a screen-share auto-relock racing an autosave,
+ * or "Lock all" while a note was open) was classified as RETRYABLE:
+ *
+ *   1. the bounded retry was scheduled and the user waited out an 800 ms backoff,
+ *   2. the retry hit the identical lock refusal and failed identically,
+ *   3. only then did the error settle — with the RAW backend string in the pill tooltip.
+ *
+ * The lock-specific toast ("This note is locked — unlock its folder to edit.") could never fire at
+ * all, because its own `message.includes("Locked")` test had the same bug.
+ *
+ * The reason the existing suite did not catch it: the ONE spec that exercised this path
+ * (`e2e/record/companion-note-flush-timeout.spec.ts`) rejected with a hand-written
+ * `"Locked: companion note is sealed"` — capital L, a string the real backend never produces. The
+ * fixture encoded the bug, so the test passed. It has been corrected to the real wire format in
+ * the same change as this spec.
+ *
+ * RED CONTRACT: this rejects with the REAL lowercase, coded wire string. Against the pre-fix
+ * component the lock arms never match, so `save_note_text` is called TWICE (the bounded retry) and
+ * the locked toast never appears — both assertions below fail. Against the fixed component the
+ * refusal is recognised on the first attempt, no retry is scheduled, and the toast fires.
+ */
+
+/*
+ * THE WIRE STRING UNDER TEST — `AppError::Locked(errcode::tag(NOTE_LOCKED, …)).to_string()`:
+ *
+ *   "locked: [note-locked] unlock the folder to edit this note"
+ *
+ * It is INLINED in the override below rather than hoisted into a `const`, and must stay that way:
+ * `mockTauri` serializes every override with `Function.prototype.toString()` and replays it
+ * PAGE-SIDE, so an override that closes over a test-scope binding throws a `ReferenceError` in the
+ * page instead of rejecting — which would make this spec fail for the wrong reason.
+ */
+
+test.describe("Note editor — a lowercase lock refusal is recognised, not retried", () => {
+  test("a locked save fires the lock toast and is NOT retried", async ({
+    page,
+  }) => {
+    await mockNotes(page, {
+      save_note_text: () => {
+        const w = window as unknown as { __saveAttempts?: number };
+        w.__saveAttempts = (w.__saveAttempts ?? 0) + 1;
+        // Inlined on purpose — see the note above the describe block.
+        return Promise.reject(
+          "locked: [note-locked] unlock the folder to edit this note",
+        );
+      },
+    });
+
+    await page.goto("/notes");
+    await page.locator(".title-btn", { hasText: "My First Note" }).click();
+
+    const titleInput = page.locator(".note-title-input");
+    await expect(titleInput).toHaveValue("My First Note");
+    await titleInput.fill("");
+    await titleInput.type("Edited while the folder sealed");
+
+    // The lock-specific toast — impossible to reach before the fix.
+    await expect(
+      page.locator(".toast.is-danger .toast-msg", {
+        hasText: /locked — unlock its folder to edit/i,
+      }),
+    ).toBeVisible({ timeout: 5_000 });
+
+    // NOT retried. The bounded retry uses an 800 ms backoff, so give it well past that and then
+    // assert exactly one attempt — the whole point of classifying a lock refusal as unretryable.
+    await page.waitForTimeout(2_000);
+    const attempts = await page.evaluate(
+      () => (window as unknown as { __saveAttempts?: number }).__saveAttempts ?? 0,
+    );
+    expect(attempts, "a lock refusal must not be retried").toBe(1);
+
+    // The pill's tooltip carries the owned sentence, never the raw wire string.
+    const retryPill = page.locator(".save-retry");
+    await expect(retryPill).toBeVisible();
+    const title = await retryPill.getAttribute("title");
+    expect(title).not.toContain("[note-locked]");
+    expect(title).not.toMatch(/^locked:/);
+    expect(title).toMatch(/locked/i);
+  });
+});

--- a/e2e/record/cloud-consent-code.spec.ts
+++ b/e2e/record/cloud-consent-code.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * THE HIGHEST-RISK SEAM IN P3: the cloud-consent hand-off between Rust prose and an Angular regex.
+ *
+ * Before this change, `record.component.ts` decided whether to show the "Allow" banner by
+ * regex-matching the backend's ENGLISH SENTENCE:
+ *
+ *     needsCloudConsent = /cloud egress not consented/i.test(store.error())
+ *
+ * That made an ordinary de-jargoning edit — rewording a Rust error string — a silent break for
+ * every cloud user's first note: the Allow banner would stop rendering, and the raw backend string
+ * would surface in the red error banner instead. There is no test that would have caught it, and
+ * no compiler that could.
+ *
+ * The contract is now the stable `[cloud-consent]` CODE (`src-tauri/src/errcode.rs::CLOUD_CONSENT`,
+ * emitted by `summarize::make_provider_resolved`), matched by `RecorderStore.errorCode()`.
+ *
+ * RED CONTRACT (why this is a real regression test, not a restatement):
+ *   The fixture below rejects `stop_recording` with the NEW wire string, which contains the code
+ *   and NOT the old sentence. Against the PRE-CHANGE frontend the prose regex finds no match, so
+ *   `needsCloudConsent` is false, the Allow banner never renders, and the raw string leaks into the
+ *   danger banner — both assertions fail. Against the post-change frontend it renders.
+ *
+ *   Verify that by hand with:
+ *     needsCloudConsent = computed(() => /cloud egress not consented/i.test(this.store.error() ?? ""))
+ *   which reproduces the old behaviour and turns this spec RED.
+ */
+
+/*
+ * THE WIRE STRING UNDER TEST — `AppError::Unavailable(errcode::tag(CLOUD_CONSENT, …)).to_string()`:
+ *
+ *   "provider unavailable: [cloud-consent] this provider sends meeting content off-device;
+ *    grant one-time consent before using it"
+ *
+ * It is INLINED at each override site rather than hoisted into a `const`, and must stay that way:
+ * `mockTauri` serializes every override with `Function.prototype.toString()` and replays it
+ * PAGE-SIDE, so an override that closes over a test-scope binding throws a `ReferenceError` in the
+ * page instead of rejecting — the spec would then fail for a reason that has nothing to do with
+ * the consent flow.
+ */
+
+test.describe("Record — the cloud-consent banner is driven by the CODE, not by Rust prose", () => {
+  test("a [cloud-consent] rejection renders the Allow banner instead of a raw error", async ({
+    page,
+  }) => {
+    await mockTauri(page, {
+      model_present: () => true,
+      start_recording: () => ({
+        meetingId: "m-consent",
+        startedAt: "2026-07-27T09:00:00Z",
+      }),
+      // Inlined on purpose — see the note above the describe block.
+      stop_recording: () =>
+        Promise.reject(
+          "provider unavailable: [cloud-consent] this provider sends meeting content off-device; grant one-time consent before using it",
+        ),
+    });
+
+    await page.goto("/record");
+    await page.locator("button.start-btn").click();
+    await expect(page.locator(".rec-topbar")).toBeVisible({ timeout: 10_000 });
+    await page.locator("button.stop-btn").click();
+
+    // The consent banner — the whole point of classifying this failure rather than showing it.
+    const consent = page.locator(".banner.cloud-consent");
+    await expect(consent).toBeVisible({ timeout: 10_000 });
+    await expect(consent).toContainText(/Cloud processing isn't enabled/i);
+    await expect(consent.locator("button.btn-primary")).toHaveText(
+      /Allow & finish note/i,
+    );
+
+    // …and the generic danger banner must NOT be the thing that rendered.
+    await expect(page.locator(".banner.is-danger")).toHaveCount(0);
+
+    // The raw wire string must not reach the screen in ANY form — neither the code nor the
+    // developer prose after it.
+    const body = await page.locator("app-record").innerText();
+    expect(body).not.toContain("[cloud-consent]");
+    expect(body).not.toMatch(/provider unavailable/i);
+    expect(body).not.toMatch(/off-device/i);
+  });
+
+  test("an UNRELATED failure still renders the plain error banner, never the Allow banner", async ({
+    page,
+  }) => {
+    // Deny-by-default in the other direction: an un-coded backend failure must not accidentally
+    // classify as consent (the old regex could, for any message mentioning consent), and must not
+    // render its own text.
+    await mockTauri(page, {
+      model_present: () => true,
+      start_recording: () => ({
+        meetingId: "m-boom",
+        startedAt: "2026-07-27T09:00:00Z",
+      }),
+      stop_recording: () =>
+        Promise.reject(
+          "transcription error: brain sidecar stdin missing; HKDF expand failed",
+        ),
+    });
+
+    await page.goto("/record");
+    await page.locator("button.start-btn").click();
+    await expect(page.locator(".rec-topbar")).toBeVisible({ timeout: 10_000 });
+    await page.locator("button.stop-btn").click();
+
+    await expect(page.locator(".banner.is-danger")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.locator(".banner.cloud-consent")).toHaveCount(0);
+
+    // The never-show vocabulary in that message is exactly why deny-by-default exists.
+    const body = await page.locator("app-record").innerText();
+    expect(body).not.toMatch(/sidecar/i);
+    expect(body).not.toMatch(/HKDF/i);
+    expect(body).not.toMatch(/stdin/i);
+  });
+});

--- a/e2e/record/companion-note-flush-timeout.spec.ts
+++ b/e2e/record/companion-note-flush-timeout.spec.ts
@@ -183,7 +183,14 @@ test.describe("Record — flush deadline preserves companion data", () => {
     await bootWithFlushProvider(page, () => {
       const state = window as unknown as { __updateAttempts: number };
       state.__updateAttempts += 1;
-      return Promise.reject(new Error("Locked: companion note is sealed"));
+      // The REAL wire string of `AppError::Locked(errcode::tag(NOTE_LOCKED, …))`. This fixture
+      // used to read `"Locked: companion note is sealed"` — CAPITAL L, a string the backend never
+      // produces — which is precisely why the editor's `message.includes("Locked")` bug survived:
+      // the test encoded the bug. With the real lowercase, coded string, this case only passes
+      // because the classification is now keyed on `[note-locked]`.
+      return Promise.reject(
+        new Error("locked: [note-locked] unlock the folder to edit this note"),
+      );
     });
     await typeCompanionText(page);
     await page.locator("button.stop-btn").click();

--- a/e2e/settings/privacy-honesty.spec.ts
+++ b/e2e/settings/privacy-honesty.spec.ts
@@ -1,0 +1,238 @@
+import { test, expect, type Locator } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * THE ANTI-SIMPLIFICATION GATE.
+ *
+ * P3 rewrites Murmur's privacy copy to be plainer. The failure mode that rewrite invites is the
+ * one this app can least afford: "emails, card numbers and phone numbers are removed — people's
+ * NAMES are not" compresses beautifully into "your data is protected", which is shorter, calmer,
+ * and a lie. Murmur's differentiator is telling the truth about what leaves the Mac; a de-jargoning
+ * pass that quietly deletes a noun phrase destroys exactly that.
+ *
+ * So this spec pins FIFTEEN protected clauses BY FACT, never by exact sentence. Each assertion
+ * names the *fact* that must survive (e.g. the Privacy section must contain "emails" AND "card"
+ * AND "phone" AND an explicit negative about names) and says nothing about the wording around it.
+ * That is deliberate: rewording is allowed and expected; dropping the fact is not.
+ *
+ * The implementer rule these encode: **a rewrite of a protected clause that is shorter AND drops a
+ * noun phrase is wrong.**
+ *
+ * If one of these fails, do not change the assertion to match the new copy. Put the fact back.
+ */
+
+/** The Privacy & Integrations section's card, after navigating there. */
+async function openPrivacySection(page: import("@playwright/test").Page): Promise<Locator> {
+  await mockTauri(page, {
+    // Name masking OFF — the DEFAULT, and the state whose honest negatives matter most.
+    ner_model_present: () => false,
+    get_mcp_config: () =>
+      '{"mcpServers":{"murmur":{"url":"http://127.0.0.1:8765/mcp","headers":{"Authorization":"Bearer test-token"}}}}',
+  });
+  await page.goto("/settings");
+  await page.getByText("Privacy & Integrations").first().click();
+  const card = page.locator("app-settings-privacy-section .privacy-card");
+  await expect(card).toBeVisible({ timeout: 10_000 });
+  return card;
+}
+
+test.describe("Privacy copy — the clauses a simplification would destroy", () => {
+  test("Privacy section: what is removed is ENUMERATED, and what is NOT removed is stated", async ({
+    page,
+  }) => {
+    const card = await openPrivacySection(page);
+    const text = (await card.innerText()).replace(/\s+/g, " ");
+
+    // (1) The redaction promise is an enumeration, never a bare noun like "PII" or "your data".
+    expect(text, "must name emails").toMatch(/emails/i);
+    expect(text, "must name card numbers").toMatch(/card/i);
+    expect(text, "must name phone numbers").toMatch(/phone/i);
+
+    // (4) THE most destroyable sentence in the app: the explicit NEGATIVE about names. With the
+    // optional model absent, names DO leave with the transcript, and the user must be told.
+    expect(text, "must state that names are NOT removed").toMatch(
+      /names?\s+(are|is)\s+not|not\s+removed|NAMES are not/i,
+    );
+    expect(text).toMatch(/name/i);
+
+    // (5) …and that the protection is an OPTIONAL download, in named languages — not something
+    // that is quietly already on.
+    expect(text, "must say name masking needs a download").toMatch(
+      /download/i,
+    );
+    expect(text, "must name the languages it covers").toMatch(/polish/i);
+    expect(text).toMatch(/english/i);
+  });
+
+  test("Privacy section: every cloud destination is NAMED, including the ones users assume are local", async ({
+    page,
+  }) => {
+    const card = await openPrivacySection(page);
+    const text = (await card.innerText()).replace(/\s+/g, " ");
+
+    // (2) Claude Code is not a local tool: the `claude` CLI uploads the transcript to Anthropic.
+    // Users routinely believe otherwise, which is why this clause exists.
+    expect(text, "must name Claude Code").toMatch(/claude code/i);
+    expect(text, "must name Anthropic as the destination").toMatch(/anthropic/i);
+
+    // (3) A REMOTE Ollama server counts as cloud — the single most-assumed-local case.
+    expect(text, "must name Ollama").toMatch(/ollama/i);
+    expect(text, "must distinguish a REMOTE Ollama from a local one").toMatch(
+      /remote ollama/i,
+    );
+    expect(
+      text,
+      "must say only Ollama running on THIS Mac keeps everything here",
+    ).toMatch(/ollama running on this mac/i);
+
+    // …and the gateway, which is a third-party hop.
+    expect(text).toMatch(/gateway/i);
+  });
+
+  test("Privacy section: the consent gate is FAIL-CLOSED, and the download sends nothing", async ({
+    page,
+  }) => {
+    const card = await openPrivacySection(page);
+    const text = (await card.innerText()).replace(/\s+/g, " ");
+
+    // (7) The promise that makes the Allow button meaningful: nothing runs until you allow it.
+    expect(
+      text,
+      "must promise cloud summaries do not run before consent",
+    ).toMatch(/won'?t run|will not run|turned off/i);
+
+    // (6) The name-masking download is itself not an egress of content.
+    expect(text, "must say the model download sends no meeting content").toMatch(
+      /sends no meeting content|no meeting content is sent/i,
+    );
+  });
+
+  test("Privacy section: locked folders LEAVE the vault, and the rest stays readable", async ({
+    page,
+  }) => {
+    const card = await openPrivacySection(page);
+    const text = (await card.innerText()).replace(/\s+/g, " ");
+
+    // (8) Both halves matter. A locked folder is encrypted AND removed from the vault (Obsidian
+    // stops seeing it — a real, surprising consequence); everything else stays a plain file the
+    // user owns. "Obsidian vault" and "Markdown" are the RIGHT words here and are NOT jargon.
+    expect(text, "must say locked content is encrypted").toMatch(/encrypt/i);
+    expect(text, "must say it leaves the Obsidian vault").toMatch(/obsidian/i);
+    expect(text, "must say unlocked content stays plain files").toMatch(
+      /markdown|\.md/i,
+    );
+  });
+
+  test("Privacy section: the local Claude server is read-only, local, and key-protected", async ({
+    page,
+  }) => {
+    const card = await openPrivacySection(page);
+    const text = (await card.innerText()).replace(/\s+/g, " ");
+
+    // (9) It exposes your meetings to another app. Read-only and local-only are the two facts
+    // that make that acceptable; neither may be dropped for brevity.
+    expect(text, "must say the server only reads").toMatch(/read/i);
+    expect(text, "must say it is confined to this Mac").toMatch(/this mac/i);
+
+    // (10) The pasted config carries a credential, and the consequence is spelled out.
+    expect(text, "must warn the config carries a private key").toMatch(
+      /private key|access token/i,
+    );
+    expect(
+      text,
+      "must state the consequence of leaking it",
+    ).toMatch(/read your meetings|keep it to yourself/i);
+  });
+
+  test("Privacy section: cross-meeting memory is local, lock-gated, and forgettable", async ({
+    page,
+  }) => {
+    const card = await openPrivacySection(page);
+    const text = (await card.innerText()).replace(/\s+/g, " ");
+
+    // (11) Three facts, all load-bearing: it stays here, the lock still governs it, and it can be
+    // cleared. A rewrite that keeps only "stored locally" has removed the user's exit.
+    expect(text, "memory must be described as stored on this Mac").toMatch(
+      /locally|on this mac/i,
+    );
+    expect(text, "memory must be described as lock-gated").toMatch(/locked/i);
+    expect(text, "memory must be described as clearable").toMatch(
+      /clear|forget/i,
+    );
+  });
+
+  test("AI & Models privacy strip: the on-device list and the names caveat both survive", async ({
+    page,
+  }) => {
+    // The demo mock's DEFAULT config is `providerId: "claude_code"` — a cloud provider — so the
+    // "leaves this Mac" line, and therefore the names caveat, renders without overriding
+    // `get_config` (which would drop every other field the Settings page reads).
+    await mockTauri(page, { ner_model_present: () => false });
+    await page.goto("/settings");
+    await page.getByText("AI & Models").first().click();
+    const strip = page.locator("app-ai-privacy-strip");
+    await expect(strip).toBeVisible({ timeout: 10_000 });
+    const text = (await strip.innerText()).replace(/\s+/g, " ");
+
+    // (12) The on-device list is a promise per item. Collapsing it to "most things stay local"
+    // would be shorter and would say nothing.
+    expect(text, "must claim transcription is on-device").toMatch(
+      /transcription/i,
+    );
+    expect(text, "must claim the search index is on-device").toMatch(
+      /search index/i,
+    );
+    expect(text, "must claim name masking is on-device").toMatch(
+      /name masking/i,
+    );
+
+    // (13) When text DOES leave and masking is off, the strip repeats the negative rather than
+    // relying on the user having read the Privacy section.
+    expect(text, "must state names are not removed").toMatch(
+      /names? (are|is) not|not removed/i,
+    );
+    expect(text, "must still enumerate what IS removed").toMatch(/email/i);
+    expect(text).toMatch(/phone/i);
+    expect(text).toMatch(/card/i);
+  });
+
+  test("Ledger: the token unit is glossed and the redaction count says what it excludes", async ({
+    page,
+  }) => {
+    await mockTauri(page, {}, {
+      get_egress_ledger: {
+        totalCalls: 3,
+        totalTokens: 4210,
+        byModel: [{ model: "claude-sonnet-5", tokens: 4210 }],
+        byDay: [{ day: "2026-07-27", tokens: 4210 }],
+        // Name masking off ⇒ zero names masked, which must NOT read as "there were no names".
+        totalRedactions: { email: 2, card: 1, phone: 4, name: 0 },
+        recent: [],
+      },
+    });
+    await page.goto("/analytics");
+    const ledger = page.locator("app-egress-ledger");
+    await expect(ledger).toBeVisible({ timeout: 10_000 });
+    const text = (await ledger.innerText()).replace(/\s+/g, " ");
+
+    // (14) A "token" means nothing to a person. The unit is NOT renamed (the number really does
+    // count tokens) — it is glossed, which is the honest half of that trade.
+    expect(text, "the token unit must carry a gloss").toMatch(
+      /word/i,
+    );
+
+    // (15) The redaction tile enumerates, and — with zero names masked — says WHY that zero is
+    // there. A bare "0" beside "PII scrubbed" would read as "nothing sensitive was in your text".
+    expect(text, "must enumerate emails").toMatch(/email/i);
+    expect(text, "must enumerate phones").toMatch(/phone/i);
+    expect(text, "must enumerate cards").toMatch(/card/i);
+    expect(
+      text,
+      "must explain that names are not removed unless masking is on",
+    ).toMatch(/names are not removed unless/i);
+
+    // And the never-show vocabulary is genuinely gone from the rendered surface.
+    expect(text, "must not render the word 'egress'").not.toMatch(/egress/i);
+    expect(text, "must not render the acronym 'PII'").not.toMatch(/\bPII\b/);
+  });
+});

--- a/src-tauri/src/commands/documents.rs
+++ b/src-tauri/src/commands/documents.rs
@@ -185,9 +185,10 @@ fn extract_document_text(
     let ext = match ext {
         Some(e) if DOC_ALLOWED_EXTS.contains(&e.as_str()) => e,
         _ => {
-            return Err(AppError::InvalidArg(
-                "unsupported document type — import md, txt, pdf, docx, pptx, xlsx, html, or an image (png/jpg/heic/tiff/bmp/gif)".into(),
-            ))
+            return Err(AppError::InvalidArg(crate::errcode::tag(
+                crate::errcode::DOC_UNSUPPORTED,
+                "import md, txt, pdf, docx, pptx, xlsx, html, or an image (png/jpg/heic/tiff/bmp/gif)",
+            )))
         }
     };
 
@@ -197,9 +198,10 @@ fn extract_document_text(
     // ceiling live there — see extract/mod.rs + extract/ooxml.rs). `progress` streams per-page counts.
     let blocks = crate::extract::extract_blocks(p, &ext, progress)?;
     if blocks.is_empty() || blocks.iter().all(|b| b.text.trim().is_empty()) {
-        return Err(AppError::InvalidArg(
-            "this document has no extractable text".into(),
-        ));
+        return Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::DOC_NO_TEXT,
+            "this document has no extractable text",
+        )));
     }
     let stored = crate::extract::blocks_to_stored_text(&blocks);
 
@@ -238,9 +240,10 @@ pub(crate) fn insert_extracted_document(
             .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?
             .contains(folder_id);
         if !session_unlocked {
-            return Err(AppError::Locked(
-                "this folder is locked — unlock it to add to the brain".into(),
-            ));
+            return Err(AppError::Locked(crate::errcode::tag(
+                crate::errcode::DOC_LOCKED,
+                "unlock this folder to add to the brain",
+            )));
         }
     }
 
@@ -279,9 +282,10 @@ pub(crate) fn import_document_write_gate(
         .folder_by_id(folder_id)?
         .ok_or_else(|| AppError::InvalidArg(format!("no folder {folder_id}")))?;
     if folder.locked && !folder_is_unlocked(state, folder_id)? {
-        return Err(AppError::Locked(
-            "this folder is locked — unlock it to add to the brain".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+            crate::errcode::DOC_LOCKED,
+            "unlock this folder to add to the brain",
+        )));
     }
     Ok(())
 }
@@ -341,9 +345,10 @@ fn ingest_into_folder(
     // WRITE-GATE: a sealed-and-not-session-unlocked folder is refused (never resurrect plaintext at
     // rest behind a lock). One gate for every ingest path.
     if folder.locked && !folder_is_unlocked(state, folder_id)? {
-        return Err(AppError::Locked(
-            "this folder is locked — unlock it to add to the brain".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+            crate::errcode::DOC_LOCKED,
+            "unlock this folder to add to the brain",
+        )));
     }
 
     let id = uuid::Uuid::new_v4().to_string();
@@ -463,9 +468,10 @@ pub(crate) async fn delete_document_inner(state: &AppState, id: &str) -> Result<
         return Ok(()); // unknown id → idempotent no-op.
     };
     if !folder_is_unlocked(state, &folder_id)? {
-        return Err(AppError::Locked(
-            "this folder is locked — unlock it to delete a document".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+            crate::errcode::DOC_LOCKED,
+            "unlock this folder to delete a document",
+        )));
     }
     // REVOKE-BEFORE-DELETE (Bug A root cause): tear down every LIVE org share of this exact source
     // BEFORE the local row disappears, so the background org-sync tick can never re-pull a still-live
@@ -480,9 +486,10 @@ pub(crate) async fn delete_document_inner(state: &AppState, id: &str) -> Result<
         return Ok(());
     };
     if !folder_is_unlocked(state, &folder_id)? {
-        return Err(AppError::Locked(
-            "this folder is locked — unlock it to delete a document".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+            crate::errcode::DOC_LOCKED,
+            "unlock this folder to delete a document",
+        )));
     }
     if state.db.note_gate_anchor(id)?.is_some() {
         let attachment_owner = crate::storage::AttachmentOwner::Document {
@@ -625,16 +632,18 @@ pub(crate) async fn prepare_smart_note(
     // GATE (read + write, one folder): refuse a sealed-and-NOT-session-unlocked folder — the same
     // posture as `import_document`'s write-gate. A blanked (sealed) source has no text to read either.
     if !folder_is_unlocked(state, &folder_id)? {
-        return Err(AppError::Locked(
-            "this folder is locked — unlock it to make a note from this document".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+            crate::errcode::DOC_LOCKED,
+            "unlock this folder to make a note from this document",
+        )));
     }
     // Clean display text (strips the PR-2 block-structure markers; md/txt/note rows pass through).
     let display_text = crate::extract::render_display_text(&stored_text);
     if display_text.trim().is_empty() {
-        return Err(AppError::InvalidArg(
-            "this document has no extractable text to turn into a note".into(),
-        ));
+        return Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::DOC_NO_TEXT,
+            "this document has no extractable text to turn into a note",
+        )));
     }
 
     // The current/last meeting — GATED: a sealed-not-unlocked latest meeting contributes neither its
@@ -749,9 +758,10 @@ pub(crate) fn persist_generated_note(
         // Re-check the gate under the lifecycle guard: a relock racing between `prepare_smart_note`
         // and here must refuse, never land plaintext at rest behind a lock.
         if !folder_is_unlocked(state, &prepared.folder_id)? {
-            return Err(AppError::Locked(
-                "this folder is locked — unlock it to add a note".into(),
-            ));
+            return Err(AppError::Locked(crate::errcode::tag(
+                crate::errcode::FOLDER_LOCKED,
+                "unlock this folder to add a note",
+            )));
         }
         let locked = state
             .db

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -42,9 +42,10 @@ pub(crate) fn export_audio_inner(
     // WAV is AES-GCM-encrypted at rest (audio_path → <file>.enc) and there is no plaintext on disk
     // to copy until the folder is session-unlocked; fail closed with a Locked error.
     if !meeting_is_unlocked(state, meeting_id)? {
-        return Err(AppError::Locked(
-            "this meeting's folder is locked — unlock it to export the audio".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+            crate::errcode::MEETING_LOCKED,
+            "unlock this meeting's folder to export the audio",
+        )));
     }
     let meeting = state
         .db
@@ -75,9 +76,10 @@ fn export_master(
 ) -> Result<(), AppError> {
     let _lifecycle = lifecycle_guard(state);
     if !meeting_is_unlocked(state, meeting_id)? {
-        return Err(AppError::Locked(
-            "this meeting's folder is locked — unlock it to export the master".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+            crate::errcode::MEETING_LOCKED,
+            "unlock this meeting's folder to export the master",
+        )));
     }
     let (mic, sys) = state.db.get_meeting_master_paths(meeting_id)?;
     let src = match which {
@@ -125,9 +127,10 @@ pub fn export_note(
     // D4 READ-GATE: refuse to export a sealed-and-not-unlocked meeting's note (its plaintext
     // markdown is blanked while sealed — exporting would write an empty/garbage file). Fail closed.
     if !meeting_is_unlocked(state.inner(), &meeting_id)? {
-        return Err(AppError::Locked(
-            "this meeting's folder is locked — unlock it to export the note".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+            crate::errcode::MEETING_LOCKED,
+            "unlock this meeting's folder to export the note",
+        )));
     }
     let note = state
         .db
@@ -167,9 +170,10 @@ pub(crate) fn export_canvas_inner(
     // D4 READ-GATE: a sealed-and-not-unlocked meeting's timeline is blanked; refuse to build a
     // canvas from it. Fail closed.
     if !meeting_is_unlocked(state, meeting_id)? {
-        return Err(AppError::Locked(
-            "this meeting's folder is locked — unlock it to export the canvas".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+            crate::errcode::MEETING_LOCKED,
+            "unlock this meeting's folder to export the canvas",
+        )));
     }
     let meeting = state
         .db

--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -75,9 +75,10 @@ pub(crate) fn create_note_inner(
 
     // WRITE-GATE: a sealed-and-not-session-unlocked folder is refused.
     if !folder_is_unlocked(state, &folder_id)? {
-        return Err(AppError::Locked(
-            "this folder is locked — unlock it to add a note".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+            crate::errcode::FOLDER_LOCKED,
+            "unlock this folder to add a note",
+        )));
     }
 
     let title = title.trim();
@@ -215,13 +216,19 @@ pub(crate) async fn suggest_note_title_inner(
     let (folder_id, current, row_updated_at, row_text) = {
         let _lifecycle = lifecycle_guard(state);
         let Some((folder_id, _created_at, _updated_at)) = state.db.note_gate_anchor(note_id)? else {
-            return Err(AppError::InvalidArg(format!("no note {note_id}")));
+            return Err(AppError::InvalidArg(crate::errcode::tag(
+                crate::errcode::NOTE_MISSING,
+                format!("no note {note_id}"),
+            )));
         };
         if !folder_is_unlocked(state, &folder_id)? {
             return Ok(crate::storage::db::UNTITLED_TITLE.to_string());
         }
         let Some(row) = state.db.get_note_row(note_id)? else {
-            return Err(AppError::InvalidArg(format!("no note {note_id}")));
+            return Err(AppError::InvalidArg(crate::errcode::tag(
+                crate::errcode::NOTE_MISSING,
+                format!("no note {note_id}"),
+            )));
         };
         // `NoteRow.title` is Option<String> (NULL-able column) — treat a missing title as "".
         let current = row.title.clone().unwrap_or_default();
@@ -279,7 +286,10 @@ pub(crate) async fn suggest_note_title_inner(
     let _lifecycle = lifecycle_guard(state);
     let Some((current_folder_id, _created_at, _updated_at)) = state.db.note_gate_anchor(note_id)?
     else {
-        return Err(AppError::InvalidArg(format!("no note {note_id}")));
+        return Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::NOTE_MISSING,
+            format!("no note {note_id}"),
+        )));
     };
     if current_folder_id != folder_id || !folder_is_unlocked(state, &current_folder_id)? {
         return Ok(current);
@@ -321,7 +331,10 @@ pub(crate) fn get_note_inner(state: &AppState, id: &str) -> Result<NoteDoc, AppE
 /// resolved from content-free metadata before any title/body/export-path column is selected.
 fn get_note_under_lifecycle_authorized(state: &AppState, id: &str) -> Result<NoteDoc, AppError> {
     let Some((folder_id, created_at, updated_at)) = state.db.note_gate_anchor(id)? else {
-        return Err(AppError::InvalidArg(format!("no note {id}")));
+        return Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::NOTE_MISSING,
+            format!("no note {id}"),
+        )));
     };
     if !folder_is_unlocked(state, &folder_id)? {
         return Ok(masked_note_doc(
@@ -332,7 +345,10 @@ fn get_note_under_lifecycle_authorized(state: &AppState, id: &str) -> Result<Not
         ));
     }
     let Some(row) = state.db.get_note_row(id)? else {
-        return Err(AppError::InvalidArg(format!("no note {id}")));
+        return Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::NOTE_MISSING,
+            format!("no note {id}"),
+        )));
     };
     let mut doc = note_doc_from_row(&row);
     // Strip any machine-managed `murmur:links` block (retired — it went stale + rendered as raw junk
@@ -440,14 +456,18 @@ pub(crate) fn update_note_doc_inner_with(
     // concurrent relock/seal cannot land between the unlock check and the row write.
     let lifecycle = lifecycle_guard(state);
     let Some((folder_id, _created_at, _updated_at)) = state.db.note_gate_anchor(id)? else {
-        return Err(AppError::InvalidArg(format!("no note {id}")));
+        return Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::NOTE_MISSING,
+            format!("no note {id}"),
+        )));
     };
     // WRITE-GATE before the content read: refuse editing a sealed-and-not-session-unlocked note
     // without ever loading its title/body/export path.
     if !folder_is_unlocked(state, &folder_id)? {
-        return Err(AppError::Locked(
-            "this note is locked — unlock its folder to edit it".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+            crate::errcode::NOTE_LOCKED,
+            "unlock the folder to edit this note",
+        )));
     }
     let title = title.trim();
     let title = if title.is_empty() { "Untitled" } else { title };
@@ -529,12 +549,16 @@ pub(crate) fn save_note_text_inner(
     // concurrent relock/seal cannot land between the unlock check and the row write.
     let _lifecycle = lifecycle_guard(state);
     let Some((folder_id, _created_at, _updated_at)) = state.db.note_gate_anchor(id)? else {
-        return Err(AppError::InvalidArg(format!("no note {id}")));
+        return Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::NOTE_MISSING,
+            format!("no note {id}"),
+        )));
     };
     if !folder_is_unlocked(state, &folder_id)? {
-        return Err(AppError::Locked(
-            "this note is locked — unlock its folder to edit it".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+            crate::errcode::NOTE_LOCKED,
+            "unlock the folder to edit this note",
+        )));
     }
     let title = title.trim();
     let title = if title.is_empty() { "Untitled" } else { title };
@@ -578,27 +602,38 @@ pub(crate) fn move_note_doc_inner(
     // reassign/seal writes so a concurrent lock/relock cannot land mid-move.
     let _lifecycle = lifecycle_guard(state);
     let Some((source_folder_id, _created_at, _updated_at)) = state.db.note_gate_anchor(id)? else {
-        return Err(AppError::InvalidArg(format!("no note {id}")));
+        return Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::NOTE_MISSING,
+            format!("no note {id}"),
+        )));
     };
     // Source gate before the content read: refuse moving a sealed-not-unlocked note without loading
     // its blanked/residual plaintext row merely to discover the governing folder.
     if !folder_is_unlocked(state, &source_folder_id)? {
-        return Err(AppError::Locked(
-            "this note is locked — unlock its folder to move it".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+            crate::errcode::NOTE_LOCKED,
+            "unlock the folder to move this note",
+        )));
     }
     let Some(row) = state.db.get_note_row(id)? else {
-        return Err(AppError::InvalidArg(format!("no note {id}")));
+        return Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::NOTE_MISSING,
+            format!("no note {id}"),
+        )));
     };
     // Target must be a NOTE folder and be unlocked (never land plaintext behind a lock). We do not
     // support sealing-on-move into a locked note-folder in WP0 — refuse (the FE unlocks first).
     if state.db.note_folder_by_id(folder_id)?.is_none() {
-        return Err(AppError::InvalidArg(format!("no note folder {folder_id}")));
+        return Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::NOTE_FOLDER_MISSING,
+            format!("no note folder {folder_id}"),
+        )));
     }
     if !folder_is_unlocked(state, folder_id)? {
-        return Err(AppError::Locked(
-            "the target folder is locked — unlock it to move a note there".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+            crate::errcode::FOLDER_LOCKED,
+            "unlock the target folder to move a note there",
+        )));
     }
 
     // Seal alignment (2026-07-10 audit F1, reordered by residual W2 to SEAL-THEN-REASSIGN): the
@@ -740,9 +775,10 @@ pub(crate) async fn delete_note_inner(state: &AppState, id: &str) -> Result<(), 
         return Ok(()); // unknown id → idempotent no-op.
     };
     if !folder_is_unlocked(state, &folder_id)? {
-        return Err(AppError::Locked(
-            "this folder is locked — unlock it to delete a note".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+            crate::errcode::FOLDER_LOCKED,
+            "unlock this folder to delete a note",
+        )));
     }
     // REVOKE-BEFORE-DELETE (Bug A root cause): tear down every LIVE org share of this exact note
     // BEFORE the local row disappears, so the background org-sync tick can never re-pull a still-live
@@ -756,9 +792,10 @@ pub(crate) async fn delete_note_inner(state: &AppState, id: &str) -> Result<(), 
         return Ok(());
     };
     if !folder_is_unlocked(state, &folder_id)? {
-        return Err(AppError::Locked(
-            "this folder is locked — unlock it to delete a note".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+            crate::errcode::FOLDER_LOCKED,
+            "unlock this folder to delete a note",
+        )));
     }
     let Some(row) = state.db.get_note_row(id)? else {
         return Ok(());
@@ -836,7 +873,10 @@ pub(crate) fn get_note_folder_schema_inner(
     folder_id: &str,
 ) -> Result<Vec<PropertySchemaField>, AppError> {
     if state.db.note_folder_by_id(folder_id)?.is_none() {
-        return Err(AppError::InvalidArg(format!("no note folder {folder_id}")));
+        return Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::NOTE_FOLDER_MISSING,
+            format!("no note folder {folder_id}"),
+        )));
     }
     // GATE: a locked-and-not-session-unlocked folder's schema is NOT exposed (return empty).
     if !folder_is_unlocked(state, folder_id)? {
@@ -865,14 +905,18 @@ pub(crate) fn set_note_folder_schema_inner(
     fields: Vec<PropertySchemaField>,
 ) -> Result<(), AppError> {
     if state.db.note_folder_by_id(folder_id)?.is_none() {
-        return Err(AppError::InvalidArg(format!("no note folder {folder_id}")));
+        return Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::NOTE_FOLDER_MISSING,
+            format!("no note folder {folder_id}"),
+        )));
     }
     // WRITE-GATE (before any validation or write): a sealed-not-unlocked folder is refused so a
     // schema can never be edited behind a lock.
     if !folder_is_unlocked(state, folder_id)? {
-        return Err(AppError::Locked(
-            "this folder is locked — unlock it to edit its properties".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+            crate::errcode::FOLDER_LOCKED,
+            "unlock this folder to edit its properties",
+        )));
     }
     if fields.len() > NOTE_SCHEMA_MAX_FIELDS {
         return Err(AppError::InvalidArg(format!(
@@ -946,7 +990,10 @@ pub(crate) fn list_notes_typed_inner(
     folder_id: &str,
 ) -> Result<Vec<TypedNoteRow>, AppError> {
     if state.db.note_folder_by_id(folder_id)?.is_none() {
-        return Err(AppError::InvalidArg(format!("no note folder {folder_id}")));
+        return Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::NOTE_FOLDER_MISSING,
+            format!("no note folder {folder_id}"),
+        )));
     }
     let unlocked = unlocked_snapshot(state)?;
     state.db.list_notes_visible_typed(folder_id, &unlocked)

--- a/src-tauri/src/commands/org.rs
+++ b/src-tauri/src/commands/org.rs
@@ -287,7 +287,10 @@ pub(crate) async fn share_note_to_link_inner(
             .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
         if !cfg.share_egress_consented {
             return Err(AppError::Unavailable(
-                "sharing not consented — confirm the one-time upload notice first".into(),
+                crate::errcode::tag(
+                    crate::errcode::SHARE_CONSENT,
+                    "confirm the one-time upload notice first",
+                ),
             ));
         }
         cfg.share_base_url.clone()
@@ -413,7 +416,10 @@ pub(crate) async fn share_note_to_link_doc_inner(
             .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
         if !cfg.share_egress_consented {
             return Err(AppError::Unavailable(
-                "sharing not consented — confirm the one-time upload notice first".into(),
+                crate::errcode::tag(
+                    crate::errcode::SHARE_CONSENT,
+                    "confirm the one-time upload notice first",
+                ),
             ));
         }
         cfg.share_base_url.clone()
@@ -703,7 +709,10 @@ pub(crate) async fn share_note_to_user_inner(
             .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
         if !cfg.share_egress_consented {
             return Err(AppError::Unavailable(
-                "sharing not consented — confirm the one-time upload notice first".into(),
+                crate::errcode::tag(
+                    crate::errcode::SHARE_CONSENT,
+                    "confirm the one-time upload notice first",
+                ),
             ));
         }
         cfg.share_base_url.clone()
@@ -3023,7 +3032,10 @@ async fn publish_org_body_with_policy(
             .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
         if !cfg.org_egress_consented {
             return Err(AppError::Unavailable(
-                "org sharing not consented — confirm the one-time upload notice first".into(),
+                crate::errcode::tag(
+                    crate::errcode::ORG_CONSENT,
+                    "confirm the one-time upload notice first",
+                ),
             ));
         }
     }
@@ -5793,7 +5805,10 @@ pub(crate) async fn org_update_own_item_inner(
             .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
         if !cfg.org_egress_consented {
             return Err(AppError::Unavailable(
-                "org sharing not consented — confirm the one-time upload notice first".into(),
+                crate::errcode::tag(
+                    crate::errcode::ORG_CONSENT,
+                    "confirm the one-time upload notice first",
+                ),
             ));
         }
     }

--- a/src-tauri/src/commands/reminders.rs
+++ b/src-tauri/src/commands/reminders.rs
@@ -85,9 +85,12 @@ pub async fn add_reminder(text: String, due_date: Option<String>) -> Result<(), 
     if out.status.success() {
         Ok(())
     } else {
-        Err(AppError::Unavailable(format!(
-            "Could not add to Reminders — grant access in System Settings ▸ Privacy & Security ▸ Reminders. ({})",
-            String::from_utf8_lossy(&out.stderr).trim()
+        Err(AppError::Unavailable(crate::errcode::tag(
+            crate::errcode::REMINDERS_DENIED,
+            format!(
+                "osascript refused: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            ),
         )))
     }
 }
@@ -111,9 +114,12 @@ pub(crate) fn add_reminder_blocking(text: &str, due_date: Option<&str>) -> Resul
     if out.status.success() {
         Ok(())
     } else {
-        Err(AppError::Unavailable(format!(
-            "Could not add to Reminders — grant access in System Settings ▸ Privacy & Security ▸ Reminders. ({})",
-            String::from_utf8_lossy(&out.stderr).trim()
+        Err(AppError::Unavailable(crate::errcode::tag(
+            crate::errcode::REMINDERS_DENIED,
+            format!(
+                "osascript refused: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            ),
         )))
     }
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -30,8 +30,8 @@ use crate::storage::models::{NoteTemplate, NoteTemplateSection};
 /// the next `make_provider(claude_code|anthropic)` is allowed to build. Idempotent.
 ///
 /// The FE calls this from its first-cloud-send confirmation dialog. Until the user confirms, every
-/// cloud summarize/chat returns `AppError::Unavailable("cloud egress not consented …")`, which the
-/// FE detects and surfaces as the consent prompt.
+/// cloud summarize/chat returns `AppError::Unavailable(errcode::tag(errcode::CLOUD_CONSENT, …))`;
+/// the FE matches the `[cloud-consent]` CODE (never the prose) and surfaces the consent prompt.
 #[tauri::command]
 pub fn consent_to_cloud_egress(state: State<'_, AppState>) -> Result<(), AppError> {
     let mut cache = state

--- a/src-tauri/src/errcode.rs
+++ b/src-tauri/src/errcode.rs
@@ -1,0 +1,239 @@
+//! The `[code]` contract — the ONE machine-readable channel between a Rust failure and the
+//! sentence the user reads.
+//!
+//! # Why this exists
+//!
+//! [`crate::error::AppError`] is `Serialize` and crosses IPC as its bare `to_string()`
+//! (`error.rs`), so historically the frontend had exactly one thing to work with: English prose
+//! written for a developer. Two bad habits grew out of that:
+//!
+//! 1. Components *prose-matched* the message to decide behaviour — `record.component.ts` decided
+//!    whether to show the cloud-consent Allow banner by regex-matching `cloud egress not
+//!    consented`. Rewording the Rust string silently broke the consent flow for every cloud user.
+//! 2. Components *rendered* the message. There are ~2100 `AppError::*` constructions in this
+//!    crate and a large minority carry vocabulary that must never reach a user ("brain sidecar
+//!    stdin missing", "account-session mutex poisoned", "E2EE decrypt/authentication failed",
+//!    "HKDF expand failed").
+//!
+//! The fix is a small, explicit allowlist. A failure that *is* meant to reach a banner or a toast
+//! carries a stable `[code]` at the front of its message body; the frontend
+//! (`src/app/core/copy/error-copy.service.ts`) maps that code to copy it owns, and renders a
+//! generic sentence for **anything** un-coded. Deny-by-default: adding a code is a deliberate act,
+//! never a heuristic.
+//!
+//! # The wire shape
+//!
+//! ```text
+//! AppError::Locked(tag(NOTE_LOCKED, "note {id} is in a locked folder"))
+//!   → to_string() → "locked: [note-locked] note n1 is in a locked folder"
+//! ```
+//!
+//! The variant tag (`locked: `) is still there — it is part of `AppError`'s `Display` and stays.
+//! The frontend strips the 14 known variant prefixes, then reads the leading `[code]`.
+//!
+//! # Rules
+//!
+//! - A code is stable API. Renaming one is a breaking change that must land in the same commit as
+//!   the frontend map, exactly like a wire format.
+//! - The message body after the code is still developer prose. It is NOT rendered; keep it useful
+//!   for logs and never put PII in it.
+//! - Codes are lowercase kebab-case so the frontend's extractor can be a strict pattern rather
+//!   than a sniff.
+//!
+//! # Prose couplings that are NOT codes (recorded so a de-jargon PR cannot break them silently)
+//!
+//! `brain.component.ts::friendlyImportError` used to match the document-import failures by prose,
+//! in a deliberate order (`no text found` had to beat `unsupported document type`). Those are now
+//! codes ([`DOC_NO_TEXT`], [`DOC_UNSUPPORTED`], …) and the ordering lives in the frontend's code
+//! map. If you reword one of those message bodies, nothing breaks. If you *remove* its
+//! [`tag`] call, the user gets the generic sentence — silently. Grep this module's constants
+//! before touching a message that has one.
+//!
+//! **ONE prose coupling survives, recorded here so it cannot break silently:**
+//! `commands/export.rs`'s `"this meeting has no master for that stream"` is read by
+//! `src/app/features/detail/detail/detail.component.ts::masterErrorMessage` with a `/no master/`
+//! test, to pick between the mic and system wordings. It has no other consumer and is not a
+//! failure the user can act on beyond knowing it, so it did not earn a code — but rewording it to
+//! drop the words "no master" WILL change what that surface renders.
+
+/// Prefix a message body with its stable machine code.
+///
+/// Always used at the `AppError::*` construction site, never after the fact — the code must
+/// travel with the error through every `?`.
+pub fn tag(code: &str, msg: impl AsRef<str>) -> String {
+    format!("[{code}] {}", msg.as_ref())
+}
+
+// ── Egress / consent ────────────────────────────────────────────────────────────────────────
+
+/// The fail-closed cloud-egress consent gate refused (`summarize::make_provider_resolved`).
+/// The Record screen turns this into the "Allow" banner rather than an error.
+pub const CLOUD_CONSENT: &str = "cloud-consent";
+/// The one-time link-share upload consent has not been granted.
+pub const SHARE_CONSENT: &str = "share-consent";
+/// The one-time org ("Shared Brain") upload consent has not been granted.
+pub const ORG_CONSENT: &str = "org-consent";
+
+// ── The lock gate ───────────────────────────────────────────────────────────────────────────
+
+/// A note lives in a folder that is sealed and not unlocked this session.
+pub const NOTE_LOCKED: &str = "note-locked";
+/// A meeting is sealed and not unlocked this session.
+pub const MEETING_LOCKED: &str = "meeting-locked";
+/// A brain document is in a folder that is sealed and not unlocked this session.
+pub const DOC_LOCKED: &str = "doc-locked";
+/// The target folder itself is locked (accepting a share into it, moving into it, …).
+pub const FOLDER_LOCKED: &str = "folder-locked";
+
+// ── Missing rows ────────────────────────────────────────────────────────────────────────────
+
+/// The note id does not exist — a stale tab or bookmark after a delete.
+pub const NOTE_MISSING: &str = "note-missing";
+/// The note-folder id does not exist.
+pub const NOTE_FOLDER_MISSING: &str = "note-folder-missing";
+
+// ── Document import / extraction ────────────────────────────────────────────────────────────
+
+/// The file extension is not on the import allowlist.
+pub const DOC_UNSUPPORTED: &str = "doc-unsupported";
+/// Extraction ran (including OCR) and produced nothing usable.
+pub const DOC_NO_TEXT: &str = "doc-no-text";
+/// The archive expands past the safe import ceiling (decompression-bomb guard).
+pub const DOC_TOO_LARGE: &str = "doc-too-large";
+/// The PDF is password-protected.
+pub const DOC_PASSWORD: &str = "doc-password";
+/// The file is corrupt / malformed / could not be opened.
+pub const DOC_UNREADABLE: &str = "doc-unreadable";
+
+// ── Touch ID / Keychain ─────────────────────────────────────────────────────────────────────
+
+/// The Touch ID sheet was cancelled by the user (or timed out).
+pub const TOUCH_ID_CANCELLED: &str = "touch-id-cancelled";
+/// The user-presence check ran and failed (not a cancel).
+pub const TOUCH_ID_FAILED: &str = "touch-id-failed";
+/// The Keychain refused or was unreachable (locked keychain, denied prompt).
+pub const KEYCHAIN_DENIED: &str = "keychain-denied";
+
+// ── The sharing server (murmur-server) ──────────────────────────────────────────────────────
+
+/// The sharing server could not be reached, or answered 5xx. A CONNECTIVITY problem.
+pub const SHARING_UNREACHABLE: &str = "sharing-unreachable";
+/// The sharing server rate-limited the request (429).
+pub const SHARING_RATE_LIMITED: &str = "sharing-rate-limited";
+/// The sharing server rejected the request (4xx) — a wrong or expired code, a used token.
+pub const SHARING_REJECTED: &str = "sharing-rejected";
+/// The sharing session is gone (401) — the user must sign in again.
+pub const SHARING_SIGNIN_REQUIRED: &str = "sharing-signin-required";
+
+// ── macOS permissions ───────────────────────────────────────────────────────────────────────
+
+/// The Reminders app refused the write — the user has not granted Reminders access.
+pub const REMINDERS_DENIED: &str = "reminders-denied";
+
+/// Every code this crate emits, in declaration order. The frontend's allowlist mirrors it;
+/// `error_codes_are_unique_and_kebab_case` keeps the shape a machine can rely on.
+pub const ALL: &[&str] = &[
+    CLOUD_CONSENT,
+    SHARE_CONSENT,
+    ORG_CONSENT,
+    NOTE_LOCKED,
+    MEETING_LOCKED,
+    DOC_LOCKED,
+    FOLDER_LOCKED,
+    NOTE_MISSING,
+    NOTE_FOLDER_MISSING,
+    DOC_UNSUPPORTED,
+    DOC_NO_TEXT,
+    DOC_TOO_LARGE,
+    DOC_PASSWORD,
+    DOC_UNREADABLE,
+    TOUCH_ID_CANCELLED,
+    TOUCH_ID_FAILED,
+    KEYCHAIN_DENIED,
+    SHARING_UNREACHABLE,
+    SHARING_RATE_LIMITED,
+    SHARING_REJECTED,
+    SHARING_SIGNIN_REQUIRED,
+    REMINDERS_DENIED,
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::AppError;
+
+    #[test]
+    fn tag_puts_the_code_first_in_the_body() {
+        assert_eq!(
+            tag(NOTE_LOCKED, "note n1 is sealed"),
+            "[note-locked] note n1 is sealed"
+        );
+    }
+
+    /// The frontend extractor reads the code AFTER stripping the `AppError` variant tag, so the
+    /// full wire string must be exactly `<variant tag>: [code] <body>`.
+    #[test]
+    fn the_wire_string_carries_the_code_after_the_variant_tag() {
+        let e = AppError::Locked(tag(NOTE_LOCKED, "note n1 is sealed"));
+        assert_eq!(e.to_string(), "locked: [note-locked] note n1 is sealed");
+
+        let e = AppError::Unavailable(tag(CLOUD_CONSENT, "not consented"));
+        assert_eq!(
+            e.to_string(),
+            "provider unavailable: [cloud-consent] not consented"
+        );
+    }
+
+    #[test]
+    fn error_codes_are_unique_and_kebab_case() {
+        let mut seen: Vec<&str> = Vec::new();
+        for &code in ALL {
+            assert!(!seen.contains(&code), "duplicate error code {code}");
+            seen.push(code);
+            assert!(!code.is_empty(), "empty error code");
+            assert!(
+                code.chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                "error code {code} must be lowercase kebab-case"
+            );
+            assert!(
+                !code.starts_with('-') && !code.ends_with('-'),
+                "bad hyphen in {code}"
+            );
+        }
+    }
+
+    /// Guards the ONE thing a rename would break: the frontend map keys. This list is duplicated
+    /// verbatim in `src/app/core/copy/error-copy.service.ts::ERROR_CODES`; changing it here
+    /// without changing it there ships a generic sentence where copy used to be.
+    #[test]
+    fn the_code_set_is_pinned() {
+        // Compared as SLICES on both sides: `&[&str]` vs a fixed-size array reference is not a
+        // `PartialEq` pair that always resolves, and a test that fails to compile guards nothing.
+        let expected: &[&str] = &[
+            "cloud-consent",
+            "share-consent",
+            "org-consent",
+            "note-locked",
+            "meeting-locked",
+            "doc-locked",
+            "folder-locked",
+            "note-missing",
+            "note-folder-missing",
+            "doc-unsupported",
+            "doc-no-text",
+            "doc-too-large",
+            "doc-password",
+            "doc-unreadable",
+            "touch-id-cancelled",
+            "touch-id-failed",
+            "keychain-denied",
+            "sharing-unreachable",
+            "sharing-rate-limited",
+            "sharing-rejected",
+            "sharing-signin-required",
+            "reminders-denied",
+        ];
+        assert_eq!(ALL, expected);
+    }
+}

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -1,5 +1,29 @@
 use serde::Serialize;
 
+/// The ONE error type. Every fallible fn in this crate returns [`Result<T>`].
+///
+/// # The `[code]` convention (read before adding a user-facing failure)
+///
+/// `AppError` serializes across IPC as its bare `Display` string, which means the message body is
+/// **developer prose** — it is not, and must never be, what the user reads. The frontend renders a
+/// generic sentence for any error it does not recognise.
+///
+/// A failure that IS meant to reach a banner or a toast opts in by carrying a stable machine code
+/// at the front of its body, via [`crate::errcode::tag`]:
+///
+/// ```ignore
+/// return Err(AppError::Locked(errcode::tag(
+///     errcode::NOTE_LOCKED,
+///     format!("note {id} is in a locked folder"),
+/// )));
+/// // → "locked: [note-locked] note n1 is in a locked folder"
+/// ```
+///
+/// `src/app/core/copy/error-copy.service.ts` strips the variant tag, reads the `[code]`, and owns
+/// the sentence. See [`crate::errcode`] for the full allowlist and the rules.
+///
+/// **Do not hand-build error strings the FE has to parse.** The code is the contract; the prose
+/// after it is free to change.
 #[derive(Debug, thiserror::Error)]
 pub enum AppError {
     #[error("audio capture error: {0}")]

--- a/src-tauri/src/extract/html.rs
+++ b/src-tauri/src/extract/html.rs
@@ -7,7 +7,9 @@
 use std::path::Path;
 
 use super::ExtractedBlock;
-use crate::error::{AppError, Result};
+// `AppError` is no longer named here: both failure shapes go through the shared constructors in
+// `super` (`unreadable` / `guard_flow_file_size`) so each one carries its `errcode`.
+use crate::error::Result;
 
 /// Wrap width for `html2text` rendering. Wide enough that paragraphs are not aggressively hard-wrapped
 /// (we want readable flow text for embedding/snippets, not a terminal column layout).
@@ -18,17 +20,12 @@ const RENDER_WIDTH: usize = 100;
 /// multi-gigabyte `.html` would otherwise be slurped whole into RAM before any block-level check).
 pub fn extract_html(path: &Path) -> Result<Vec<ExtractedBlock>> {
     // FILE-SIZE SANITY CAP (flow format): reject an oversized file before reading it into memory.
-    let meta = std::fs::metadata(path)
-        .map_err(|e| AppError::InvalidArg(format!("could not read HTML: {e}")))?;
-    if meta.len() > super::MAX_FLOW_FILE_BYTES {
-        return Err(AppError::InvalidArg(
-            "this HTML is too large to import — it exceeds the size limit".into(),
-        ));
-    }
-    let bytes = std::fs::read(path)
-        .map_err(|e| AppError::InvalidArg(format!("could not read HTML: {e}")))?;
+    // Shared with the md/txt path so the rejection carries the same `DOC_TOO_LARGE` code.
+    super::guard_flow_file_size(path, "HTML")?;
+    let bytes =
+        std::fs::read(path).map_err(|e| super::unreadable(format!("could not read HTML: {e}")))?;
     let text = html2text::from_read(bytes.as_slice(), RENDER_WIDTH)
-        .map_err(|e| AppError::InvalidArg(format!("could not render HTML: {e}")))?;
+        .map_err(|e| super::unreadable(format!("could not render HTML: {e}")))?;
     let text = text.trim().to_string();
     if text.is_empty() {
         return Ok(Vec::new());

--- a/src-tauri/src/extract/image.rs
+++ b/src-tauri/src/extract/image.rs
@@ -40,7 +40,10 @@ pub fn extract_image(path: &Path) -> Result<Vec<ExtractedBlock>> {
             page: Some(1),
             heading_path: None,
         }]),
-        _ => Err(AppError::InvalidArg("no text found in this image".into())),
+        _ => Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::DOC_NO_TEXT,
+            "no text found in this image",
+        ))),
     }
 }
 

--- a/src-tauri/src/extract/mod.rs
+++ b/src-tauri/src/extract/mod.rs
@@ -107,10 +107,48 @@ fn guard_extracted_text_size_with_ceiling(blocks: &[ExtractedBlock], ceiling: u6
         .iter()
         .fold(0u64, |acc, b| acc.saturating_add(b.text.len() as u64));
     if total > ceiling {
-        return Err(AppError::InvalidArg(
-            "this document is too large to import — its extracted text exceeds the size limit"
-                .into(),
-        ));
+        // CODED: this is one of the three size rejections a real import can hit (the other two are
+        // the zip-bomb ceiling in `ooxml`/`xlsx` and the flow-file cap below). All three carry
+        // `DOC_TOO_LARGE` so the import surface renders the size sentence rather than the generic
+        // one — see `errcode::DOC_TOO_LARGE`.
+        return Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::DOC_TOO_LARGE,
+            "this document is too large to import — its extracted text exceeds the size limit",
+        )));
+    }
+    Ok(())
+}
+
+/// The "this file could not be parsed" failure, carrying [`crate::errcode::DOC_UNREADABLE`].
+///
+/// Every extractor reaches this same conclusion from a dozen places (a zip entry that will not
+/// inflate, malformed DOCX/PPTX XML, a non-UTF-8 flow file, a PDF PDFKit refuses). Spelling the
+/// `AppError::InvalidArg(errcode::tag(errcode::DOC_UNREADABLE, …))` sandwich out at each one is how
+/// a site quietly ends up UN-coded and degrades to the generic sentence in the import surface.
+/// `msg` stays developer prose — it is logged, never rendered.
+pub(crate) fn unreadable(msg: impl AsRef<str>) -> AppError {
+    AppError::InvalidArg(crate::errcode::tag(crate::errcode::DOC_UNREADABLE, msg))
+}
+
+/// The ON-DISK file-size cap for the FLOW formats, applied BEFORE the read. Shared by
+/// [`read_flow_file_to_string`] (md/txt) and [`html::extract_html`] so BOTH rejections carry the
+/// same [`crate::errcode::DOC_TOO_LARGE`] code and the same wording — two hand-written copies is
+/// how one of them ended up un-coded. The `label` is a non-PII format name ("document" / "HTML").
+pub(crate) fn guard_flow_file_size(path: &Path, label: &str) -> Result<()> {
+    guard_flow_file_size_with_ceiling(path, label, MAX_FLOW_FILE_BYTES)
+}
+
+/// [`guard_flow_file_size`] with an explicit ceiling — production passes the shared const; a test
+/// injects a tiny ceiling so a small real file trips the REAL rejection (and its code) without
+/// materializing 256 MiB.
+fn guard_flow_file_size_with_ceiling(path: &Path, label: &str, ceiling: u64) -> Result<()> {
+    let meta =
+        std::fs::metadata(path).map_err(|e| unreadable(format!("could not read {label}: {e}")))?;
+    if meta.len() > ceiling {
+        return Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::DOC_TOO_LARGE,
+            format!("this {label} is too large to import — it exceeds the size limit"),
+        )));
     }
     Ok(())
 }
@@ -120,15 +158,8 @@ fn guard_extracted_text_size_with_ceiling(blocks: &[ExtractedBlock], ceiling: u6
 /// on a missing/unreadable/non-UTF-8 file OR one whose on-disk size exceeds [`MAX_FLOW_FILE_BYTES`].
 /// The `label` is a non-PII format name ("document" / "HTML") for the error text.
 pub(crate) fn read_flow_file_to_string(path: &Path, label: &str) -> Result<String> {
-    let meta = std::fs::metadata(path)
-        .map_err(|e| AppError::InvalidArg(format!("could not read {label}: {e}")))?;
-    if meta.len() > MAX_FLOW_FILE_BYTES {
-        return Err(AppError::InvalidArg(format!(
-            "this {label} is too large to import — it exceeds the size limit"
-        )));
-    }
-    std::fs::read_to_string(path)
-        .map_err(|e| AppError::InvalidArg(format!("could not read {label}: {e}")))
+    guard_flow_file_size(path, label)?;
+    std::fs::read_to_string(path).map_err(|e| unreadable(format!("could not read {label}: {e}")))
 }
 
 /// An extraction-progress signal emitted by the paged formats (PDF) as they process. Threaded from
@@ -189,10 +220,14 @@ pub fn extract_blocks(
         }
         #[cfg(not(target_os = "macos"))]
         "png" | "jpg" | "jpeg" | "heic" | "tiff" | "tif" | "bmp" | "gif" => Err(
-            AppError::InvalidArg("image OCR is only available on macOS".into()),
+            AppError::InvalidArg(crate::errcode::tag(
+                crate::errcode::DOC_UNSUPPORTED,
+                "image OCR is only available on macOS",
+            )),
         ),
-        other => Err(AppError::InvalidArg(format!(
-            "unsupported document type: .{other}"
+        other => Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::DOC_UNSUPPORTED,
+            format!("unsupported document type: .{other}"),
         ))),
     }?;
     // UNIVERSAL memory guard: cap the accumulated extracted text for ALL formats (finding: the
@@ -404,6 +439,13 @@ mod tests {
             matches!(err, AppError::InvalidArg(_)),
             "over-ceiling fails closed: {err:?}"
         );
+        // …and it carries the code, or the import surface renders the GENERIC sentence instead of
+        // the size one (the round-01 finding: this rejection was un-coded).
+        assert!(
+            matches!(&err, AppError::InvalidArg(m)
+                if m.starts_with(&format!("[{}] ", crate::errcode::DOC_TOO_LARGE))),
+            "the universal extracted-text ceiling must carry DOC_TOO_LARGE: {err:?}"
+        );
         // Production const is generously large — normal blocks never trip it.
         assert!(
             guard_extracted_text_size(&blocks).is_ok(),
@@ -422,6 +464,40 @@ mod tests {
         // A missing file fails closed (no panic).
         let missing = std::path::Path::new("/nonexistent/murmur/flow-missing.txt");
         assert!(read_flow_file_to_string(missing, "document").is_err());
+    }
+
+    /// RED→GREEN for the round-01 finding: the flow-format ON-DISK size rejection — shared by the
+    /// md/txt read and by `html::extract_html` — must carry [`crate::errcode::DOC_TOO_LARGE`], or
+    /// the import surface degrades it to the generic "please try again" sentence. Uses a TINY
+    /// injected ceiling so a 13-byte file trips the REAL rejection.
+    #[test]
+    fn flow_file_size_rejection_carries_the_too_large_code() {
+        let p = write_tmp("txt", b"over the cap");
+        // Under the injected ceiling → allowed (the guard fails only when EXCEEDED).
+        assert!(guard_flow_file_size_with_ceiling(&p, "document", 12).is_ok());
+        let err = guard_flow_file_size_with_ceiling(&p, "document", 11).unwrap_err();
+        assert!(
+            matches!(&err, AppError::InvalidArg(m)
+                if m.starts_with(&format!("[{}] ", crate::errcode::DOC_TOO_LARGE))),
+            "flow-file size cap must carry DOC_TOO_LARGE: {err:?}"
+        );
+        // The HTML label flows through the SAME helper, so `.html` gets the same code.
+        let h = write_tmp("html", b"<p>over the cap</p>");
+        let err = guard_flow_file_size_with_ceiling(&h, "HTML", 1).unwrap_err();
+        assert!(
+            matches!(&err, AppError::InvalidArg(m)
+                if m.starts_with(&format!("[{}] ", crate::errcode::DOC_TOO_LARGE))
+                    && m.contains("HTML")),
+            "the HTML file cap must carry DOC_TOO_LARGE: {err:?}"
+        );
+        // An unreadable file stays a DIFFERENT code — the size code must not swallow it.
+        let missing = std::path::Path::new("/nonexistent/murmur/flow-missing.txt");
+        let err = guard_flow_file_size_with_ceiling(missing, "document", 1).unwrap_err();
+        assert!(
+            matches!(&err, AppError::InvalidArg(m)
+                if m.starts_with(&format!("[{}] ", crate::errcode::DOC_UNREADABLE))),
+            "a missing file is unreadable, not oversize: {err:?}"
+        );
     }
 
     /// A single flow block is stored VERBATIM (no sentinel) so a `.md` upload's plaintext is

--- a/src-tauri/src/extract/ooxml.rs
+++ b/src-tauri/src/extract/ooxml.rs
@@ -42,9 +42,9 @@ const XML_1_0: XmlVersion = XmlVersion::Implicit1_0;
 /// the ingest caller sizes them). Fail-closed to `InvalidArg`.
 fn open_zip(path: &Path) -> Result<zip::ZipArchive<std::io::Cursor<Vec<u8>>>> {
     let bytes = std::fs::read(path)
-        .map_err(|e| AppError::InvalidArg(format!("could not read document: {e}")))?;
+        .map_err(|e| super::unreadable(format!("could not read document: {e}")))?;
     zip::ZipArchive::new(std::io::Cursor::new(bytes))
-        .map_err(|e| AppError::InvalidArg(format!("not a valid OOXML (zip) document: {e}")))
+        .map_err(|e| super::unreadable(format!("not a valid OOXML (zip) document: {e}")))
 }
 
 /// A running DECOMPRESSED-bytes budget for ONE document's extraction — the decompression-bomb guard
@@ -91,16 +91,17 @@ fn guard_zip_with_ceiling(path: &Path, ceiling: u64) -> Result<()> {
     for i in 0..zip.len() {
         let file = zip
             .by_index(i)
-            .map_err(|e| AppError::InvalidArg(format!("corrupt zip entry: {e}")))?;
+            .map_err(|e| super::unreadable(format!("corrupt zip entry: {e}")))?;
         // Discard the inflated bytes — we only need to prove the TOTAL stays under the ceiling.
         let mut sink = SinkCounter::default();
         let limit = budget.remaining.saturating_add(1);
         let read = std::io::copy(&mut file.take(limit), &mut sink)
-            .map_err(|e| AppError::InvalidArg(format!("could not decode zip entry: {e}")))?;
+            .map_err(|e| super::unreadable(format!("could not decode zip entry: {e}")))?;
         if read > budget.remaining {
-            return Err(AppError::InvalidArg(
-                "document too large / possible zip bomb".into(),
-            ));
+            return Err(AppError::InvalidArg(crate::errcode::tag(
+                crate::errcode::DOC_TOO_LARGE,
+                "document too large / possible zip bomb",
+            )));
         }
         budget.remaining -= read;
     }
@@ -137,7 +138,7 @@ fn read_entry(
     let file = match zip.by_name(name) {
         Ok(f) => f,
         Err(zip::result::ZipError::FileNotFound) => return Ok(None),
-        Err(e) => return Err(AppError::InvalidArg(format!("corrupt OOXML entry: {e}"))),
+        Err(e) => return Err(super::unreadable(format!("corrupt OOXML entry: {e}"))),
     };
     read_capped(file, budget).map(Some)
 }
@@ -155,16 +156,17 @@ fn read_capped<R: Read>(reader: R, budget: &mut DecompressBudget) -> Result<Stri
     let read = reader
         .take(limit)
         .read_to_end(&mut buf)
-        .map_err(|e| AppError::InvalidArg(format!("could not decode OOXML entry: {e}")))?
+        .map_err(|e| super::unreadable(format!("could not decode OOXML entry: {e}")))?
         as u64;
     if read > budget.remaining {
-        return Err(AppError::InvalidArg(
-            "document too large / possible zip bomb".into(),
-        ));
+        return Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::DOC_TOO_LARGE,
+            "document too large / possible zip bomb",
+        )));
     }
     budget.remaining -= read;
     String::from_utf8(buf)
-        .map_err(|e| AppError::InvalidArg(format!("could not decode OOXML entry: {e}")))
+        .map_err(|e| super::unreadable(format!("could not decode OOXML entry: {e}")))
 }
 
 /// The local name of an element (strip the `w:` / `a:` / `p:` namespace prefix).
@@ -294,9 +296,7 @@ pub fn extract_docx(path: &Path) -> Result<Vec<ExtractedBlock>> {
         .map(|xml| parse_styles_heading_levels(&xml))
         .unwrap_or_default();
     let Some(xml) = read_entry(&mut zip, "word/document.xml", &mut budget)? else {
-        return Err(AppError::InvalidArg(
-            "DOCX is missing word/document.xml".into(),
-        ));
+        return Err(super::unreadable("DOCX is missing word/document.xml"));
     };
     parse_docx_xml(&xml, &style_headings)
 }
@@ -450,7 +450,7 @@ fn parse_docx_xml(xml: &str, style_headings: &StyleHeadings) -> Result<Vec<Extra
                 if capture_text && suppress_depth == 0 {
                     let txt = t
                         .xml_content(XML_1_0)
-                        .map_err(|e| AppError::InvalidArg(format!("bad DOCX text: {e}")))?;
+                        .map_err(|e| super::unreadable(format!("bad DOCX text: {e}")))?;
                     match tables.last_mut() {
                         Some(f) if f.in_cell => f.cell_text.push_str(&txt),
                         _ => para_text.push_str(&txt),
@@ -520,7 +520,7 @@ fn parse_docx_xml(xml: &str, style_headings: &StyleHeadings) -> Result<Vec<Extra
             },
             Ok(Event::Eof) => break,
             Err(e) => {
-                return Err(AppError::InvalidArg(format!("malformed DOCX XML: {e}")));
+                return Err(super::unreadable(format!("malformed DOCX XML: {e}")));
             }
             _ => {}
         }
@@ -648,7 +648,7 @@ fn parse_pptx_slide(xml: &str, slide_num: u32) -> Result<Option<ExtractedBlock>>
                 if capture_text && (in_shape || in_table_cell) {
                     let txt = t
                         .xml_content(XML_1_0)
-                        .map_err(|e| AppError::InvalidArg(format!("bad PPTX text: {e}")))?;
+                        .map_err(|e| super::unreadable(format!("bad PPTX text: {e}")))?;
                     if in_table_cell {
                         table_cell_text.push_str(&txt);
                     } else {
@@ -684,7 +684,7 @@ fn parse_pptx_slide(xml: &str, slide_num: u32) -> Result<Option<ExtractedBlock>>
                 _ => {}
             },
             Ok(Event::Eof) => break,
-            Err(e) => return Err(AppError::InvalidArg(format!("malformed PPTX XML: {e}"))),
+            Err(e) => return Err(super::unreadable(format!("malformed PPTX XML: {e}"))),
             _ => {}
         }
         buf.clear();

--- a/src-tauri/src/extract/pdf.rs
+++ b/src-tauri/src/extract/pdf.rs
@@ -82,7 +82,10 @@ fn page_needs_ocr(text_layer: &str) -> bool {
 
 /// Map a caught-exception / nil / empty result into a single fail-closed error.
 fn read_failed() -> AppError {
-    AppError::InvalidArg("could not read PDF".into())
+    AppError::InvalidArg(crate::errcode::tag(
+        crate::errcode::DOC_UNREADABLE,
+        "could not read PDF",
+    ))
 }
 
 /// Run an ObjC closure that borrows non-`UnwindSafe` PDFKit handles inside `objc2::exception::catch`.
@@ -120,9 +123,10 @@ pub fn extract_pdf(path: &Path, progress: &ProgressFn<'_>) -> Result<Vec<Extract
     // the content is password-protected and unreadable without the password.
     let locked = catch_objc(|| unsafe { doc.isLocked() }).unwrap_or(false);
     if locked {
-        return Err(AppError::InvalidArg(
-            "this PDF is password-protected — unlock it and re-import".into(),
-        ));
+        return Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::DOC_PASSWORD,
+            "this PDF is password-protected",
+        )));
     }
 
     let page_count: usize = catch_objc(|| unsafe { doc.pageCount() }).ok_or_else(read_failed)?;
@@ -198,9 +202,10 @@ pub fn extract_pdf(path: &Path, progress: &ProgressFn<'_>) -> Result<Vec<Extract
 
     if !any_text {
         // Every page yielded nothing — no text layer anywhere AND OCR (where attempted) found nothing.
-        return Err(AppError::InvalidArg(
-            "no text found in this document, even with OCR".into(),
-        ));
+        return Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::DOC_NO_TEXT,
+            "no text found in this document, even with OCR",
+        )));
     }
 
     // Surface OCR-cap truncation to the caller (the FE shows a partial-import notice). Counts only.

--- a/src-tauri/src/extract/xlsx.rs
+++ b/src-tauri/src/extract/xlsx.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use calamine::{open_workbook, Data, Reader, Xlsx};
 
 use super::ExtractedBlock;
-use crate::error::{AppError, Result};
+use crate::error::Result;
 
 /// Extract every sheet of an XLSX into blocks (one per non-empty row, heading = sheet name).
 pub fn extract_xlsx(path: &Path) -> Result<Vec<ExtractedBlock>> {
@@ -19,8 +19,8 @@ pub fn extract_xlsx(path: &Path) -> Result<Vec<ExtractedBlock>> {
     // spreadsheet passes; only a tiny archive that inflates to gigabytes is stopped.
     super::ooxml::guard_zip_not_a_bomb(path)?;
 
-    let mut workbook: Xlsx<_> = open_workbook(path)
-        .map_err(|e| AppError::InvalidArg(format!("could not open XLSX: {e}")))?;
+    let mut workbook: Xlsx<_> =
+        open_workbook(path).map_err(|e| super::unreadable(format!("could not open XLSX: {e}")))?;
 
     let mut blocks: Vec<ExtractedBlock> = Vec::new();
     for sheet in workbook.sheet_names() {
@@ -78,6 +78,9 @@ fn cell_text(cell: &Data) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // The extractor itself no longer names `AppError` (failures go through `super::unreadable`),
+    // but the tests still assert on the VARIANT.
+    use crate::error::AppError;
     use std::io::Write;
 
     /// Build a minimal valid XLSX (one sheet, inline strings) in memory and write it to a temp file.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ pub mod crypto;
 pub mod e2ee;
 pub mod embed;
 pub mod enrich;
+pub mod errcode;
 pub mod error;
 pub mod eval;
 pub mod events;

--- a/src-tauri/src/reason.rs
+++ b/src-tauri/src/reason.rs
@@ -2109,7 +2109,7 @@ mod tests {
     //
     // These tests discriminate "refused by the consent gate" from "got PAST the gate" by the error
     // VARIANT `make_provider` returns for a deliberately-unknown provider id: the fail-closed gate
-    // fires FIRST (`Unavailable("cloud egress not consented …")`); past it, the unknown id yields
+    // fires FIRST (`Unavailable("[cloud-consent] …")`); past it, the unknown id yields
     // `InvalidArg("unknown provider id: …")`. No network, no keychain, no CLI is ever touched.
 
     /// An unknown provider id: classified as CLOUD by `egress_is_cloud` (fail-safe default), so it

--- a/src-tauri/src/secrets/keychain.rs
+++ b/src-tauri/src/secrets/keychain.rs
@@ -562,14 +562,23 @@ fn dp_biometric_read(account: &str, reason: &str) -> Result<[u8; 32]> {
         }
         return match status {
             s if s == ERR_SEC_USER_CANCELED => {
-                Err(AppError::BiometricFailed("Touch ID was cancelled".into()))
+                Err(AppError::BiometricFailed(crate::errcode::tag(
+                    crate::errcode::TOUCH_ID_CANCELLED,
+                    "Touch ID was cancelled",
+                )))
             }
             s if s == errSecAuthFailed => {
-                Err(AppError::BiometricFailed("authentication failed".into()))
+                Err(AppError::BiometricFailed(crate::errcode::tag(
+                    crate::errcode::TOUCH_ID_FAILED,
+                    "authentication failed",
+                )))
             }
-            s if s == ERR_SEC_INTERACTION_NOT_ALLOWED => Err(AppError::BiometricFailed(
-                "interaction not allowed (no UI context to present Touch ID)".into(),
-            )),
+            s if s == ERR_SEC_INTERACTION_NOT_ALLOWED => {
+                Err(AppError::BiometricFailed(crate::errcode::tag(
+                    crate::errcode::TOUCH_ID_FAILED,
+                    "interaction not allowed (no UI context to present Touch ID)",
+                )))
+            }
             other => Err(map_osstatus("read account-MK item", other)),
         };
     }
@@ -981,14 +990,23 @@ impl KekStore for MacKekStore {
             return match status {
                 s if s == errSecItemNotFound => Ok(None),
                 s if s == ERR_SEC_USER_CANCELED => {
-                    Err(AppError::BiometricFailed("Touch ID was cancelled".into()))
+                    Err(AppError::BiometricFailed(crate::errcode::tag(
+                        crate::errcode::TOUCH_ID_CANCELLED,
+                        "Touch ID was cancelled",
+                    )))
                 }
                 s if s == errSecAuthFailed => {
-                    Err(AppError::BiometricFailed("authentication failed".into()))
+                    Err(AppError::BiometricFailed(crate::errcode::tag(
+                        crate::errcode::TOUCH_ID_FAILED,
+                        "authentication failed",
+                    )))
                 }
-                s if s == ERR_SEC_INTERACTION_NOT_ALLOWED => Err(AppError::BiometricFailed(
-                    "interaction not allowed (no UI context to present Touch ID)".into(),
-                )),
+                s if s == ERR_SEC_INTERACTION_NOT_ALLOWED => {
+                    Err(AppError::BiometricFailed(crate::errcode::tag(
+                        crate::errcode::TOUCH_ID_FAILED,
+                        "interaction not allowed (no UI context to present Touch ID)",
+                    )))
+                }
                 other => Err(map_osstatus("read biometric KEK item", other)),
             };
         }
@@ -1061,14 +1079,23 @@ impl MacKekStore {
             return match status {
                 s if s == errSecItemNotFound => Ok(Vec::new()),
                 s if s == ERR_SEC_USER_CANCELED => {
-                    Err(AppError::BiometricFailed("Touch ID was cancelled".into()))
+                    Err(AppError::BiometricFailed(crate::errcode::tag(
+                        crate::errcode::TOUCH_ID_CANCELLED,
+                        "Touch ID was cancelled",
+                    )))
                 }
                 s if s == errSecAuthFailed => {
-                    Err(AppError::BiometricFailed("authentication failed".into()))
+                    Err(AppError::BiometricFailed(crate::errcode::tag(
+                        crate::errcode::TOUCH_ID_FAILED,
+                        "authentication failed",
+                    )))
                 }
-                s if s == ERR_SEC_INTERACTION_NOT_ALLOWED => Err(AppError::BiometricFailed(
-                    "interaction not allowed (no UI context to present Touch ID)".into(),
-                )),
+                s if s == ERR_SEC_INTERACTION_NOT_ALLOWED => {
+                    Err(AppError::BiometricFailed(crate::errcode::tag(
+                        crate::errcode::TOUCH_ID_FAILED,
+                        "interaction not allowed (no UI context to present Touch ID)",
+                    )))
+                }
                 other => Err(map_osstatus("enumerate biometric KEK items", other)),
             };
         }
@@ -1129,7 +1156,10 @@ fn map_osstatus(ctx: &str, status: core_foundation::base::OSStatus) -> AppError 
     );
     if status == sec_consts::ERR_SEC_INTERACTION_NOT_ALLOWED {
         // The keychain is locked / no UI context — treat as a denied access, recoverable.
-        return AppError::KeychainDenied(format!("{ctx}: OSStatus {status}"));
+        return AppError::KeychainDenied(crate::errcode::tag(
+            crate::errcode::KEYCHAIN_DENIED,
+            format!("{ctx}: OSStatus {status}"),
+        ));
     }
     if status == MISSING_ENTITLEMENT_STATUS {
         // Unsigned/ad-hoc dev build: the data-protection keychain entitlement is absent. Build the

--- a/src-tauri/src/settings/ai_map.rs
+++ b/src-tauri/src/settings/ai_map.rs
@@ -69,7 +69,9 @@ fn role_row(job: &str, title: &str, role: Role, cfg: &AppConfig) -> AiMapRow {
             ..base
         },
         CONN_OFF => AiMapRow {
-            engine: "Retrieval only (no model)".to_string(),
+            // Plain language (P3): "retrieval" is the mechanism, not the outcome. What the user
+            // actually gets is search WITHOUT an AI writing anything — say exactly that.
+            engine: "Search only — no AI writing".to_string(),
             ..base
         },
         CONN_AFM => AiMapRow {
@@ -170,8 +172,15 @@ pub fn ai_map_rows(cfg: &AppConfig) -> Vec<AiMapRow> {
         },
         AiMapRow {
             job: "redaction".to_string(),
-            title: "Name redaction".to_string(),
-            engine: "On-device NER".to_string(),
+            // "NER" (named-entity recognition) is a research acronym, and "redaction" is the
+            // mechanism's name, not the outcome. Both halves of this row now use the ONE
+            // user-facing term (`glossary.ts::GLOSSARY.nameMasking`) that Settings, the AI &
+            // Models privacy strip and the Privacy section already say: name masking.
+            // The `engine` cell names WHAT does the work (the sibling rows say "Whisper", the
+            // search-index model, …) and the row already carries an "On this Mac" pill, so the
+            // engine must not repeat the location.
+            title: "Name masking".to_string(),
+            engine: "Built-in name detector".to_string(),
             model: String::new(),
             on_device: true,
             redacted: false,
@@ -360,7 +369,7 @@ mod tests {
         };
         let rows = ai_map_rows(&cfg);
         let ask = row(&rows, "ask");
-        assert_eq!(ask.engine, "Retrieval only (no model)");
+        assert_eq!(ask.engine, "Search only — no AI writing");
         assert_eq!(ask.model, "");
         assert!(ask.on_device);
         assert!(!ask.redacted);

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -1561,8 +1561,8 @@ impl AppConfig {
     ///
     /// The FE wires a first-cloud-send confirmation prompt that calls the `consent_to_cloud_egress`
     /// Tauri command before the first claude_code/anthropic run. Until the user confirms, the egress
-    /// path returns `AppError::Unavailable("cloud egress not consented …")`, which the FE detects to
-    /// surface the consent dialog.
+    /// path returns `AppError::Unavailable(errcode::tag(errcode::CLOUD_CONSENT, …))`, and the FE
+    /// matches the `[cloud-consent]` CODE (never the prose) to surface the consent dialog.
     ///
     /// FAIL-CLOSED ORDERING — persist FIRST, flip the in-memory flag ONLY on a durable success. If
     /// the write fails we return the error with the session still UNCONSENTED, so we never egress on

--- a/src-tauri/src/share/client.rs
+++ b/src-tauri/src/share/client.rs
@@ -68,14 +68,22 @@ impl ShareClient {
     /// map_err → `Unavailable`) or a 5xx is unavailability. 401 → Auth (re-login).
     fn status_err(ctx: &str, status: StatusCode) -> AppError {
         match status {
-            StatusCode::UNAUTHORIZED => AppError::Auth(format!("{ctx}: not authenticated")),
-            StatusCode::TOO_MANY_REQUESTS => AppError::InvalidArg(format!(
-                "{ctx}: too many attempts — wait a bit and try again"
+            StatusCode::UNAUTHORIZED => AppError::Auth(crate::errcode::tag(
+                crate::errcode::SHARING_SIGNIN_REQUIRED,
+                format!("{ctx}: not authenticated"),
             )),
-            s if s.is_client_error() => {
-                AppError::InvalidArg(format!("{ctx}: rejected ({})", s.as_u16()))
-            }
-            s => AppError::Unavailable(format!("{ctx}: server returned {}", s.as_u16())),
+            StatusCode::TOO_MANY_REQUESTS => AppError::InvalidArg(crate::errcode::tag(
+                crate::errcode::SHARING_RATE_LIMITED,
+                format!("{ctx}: too many attempts"),
+            )),
+            s if s.is_client_error() => AppError::InvalidArg(crate::errcode::tag(
+                crate::errcode::SHARING_REJECTED,
+                format!("{ctx}: rejected ({})", s.as_u16()),
+            )),
+            s => AppError::Unavailable(crate::errcode::tag(
+                crate::errcode::SHARING_UNREACHABLE,
+                format!("{ctx}: server returned {}", s.as_u16()),
+            )),
         }
     }
 
@@ -91,10 +99,12 @@ impl ShareClient {
         if let Some(tok) = bearer {
             req = req.bearer_auth(tok);
         }
-        let resp = req
-            .send()
-            .await
-            .map_err(|_| AppError::Unavailable(format!("{ctx}: could not reach the server")))?;
+        let resp = req.send().await.map_err(|_| {
+            AppError::Unavailable(crate::errcode::tag(
+                crate::errcode::SHARING_UNREACHABLE,
+                format!("{ctx}: could not reach the server"),
+            ))
+        })?;
         let status = resp.status();
         if !status.is_success() {
             return Err(Self::status_err(ctx, status));
@@ -117,7 +127,12 @@ impl ShareClient {
             .bearer_auth(bearer)
             .send()
             .await
-            .map_err(|_| AppError::Unavailable(format!("{ctx}: could not reach the server")))?;
+            .map_err(|_| {
+                AppError::Unavailable(crate::errcode::tag(
+                    crate::errcode::SHARING_UNREACHABLE,
+                    format!("{ctx}: could not reach the server"),
+                ))
+            })?;
         let status = resp.status();
         if !status.is_success() {
             return Err(Self::status_err(ctx, status));

--- a/src-tauri/src/summarize/mod.rs
+++ b/src-tauri/src/summarize/mod.rs
@@ -194,12 +194,15 @@ fn make_provider_resolved(
     // content can be sent) until the user has explicitly consented once. ollama is gated ONLY when
     // its base URL is non-loopback (remote) — closing the gap where a remote ollama_base_url would
     // bypass the redaction firewall and consent check.
+    // The refusal carries the `[cloud-consent]` code (see `crate::errcode`) because the Record
+    // screen turns THIS specific failure into an "Allow" banner rather than an error. Before the
+    // code existed the frontend regex-matched this sentence, so rewording it silently broke the
+    // consent flow for every cloud user; the code is now the contract and the prose is free.
     if egress_is_cloud(id, config) && !config.cloud_egress_consented {
-        return Err(crate::error::AppError::Unavailable(
-            "cloud egress not consented: this provider sends meeting content off-device; \
-             grant one-time consent before using it"
-                .to_string(),
-        ));
+        return Err(crate::error::AppError::Unavailable(crate::errcode::tag(
+            crate::errcode::CLOUD_CONSENT,
+            "this provider sends meeting content off-device; grant one-time consent before using it",
+        )));
     }
 
     let inner: Arc<dyn SummarizerProvider> = match id {

--- a/src-tauri/src/summarize/roles.rs
+++ b/src-tauri/src/summarize/roles.rs
@@ -51,8 +51,14 @@ pub const CONN_OFF: &str = "off";
 pub const CONN_AFM: &str = "apple";
 
 /// Human-facing display name for a connection id — for USER-VISIBLE status lines
-/// (e.g. the pipeline's "Summarizing with …" line). Mirrors the FE connection
-/// labels (`CONNECTION_LABELS` in `settings.store.ts`) so the two never diverge.
+/// (e.g. the pipeline's "Summarizing with …" line).
+///
+/// **DOCUMENTED MIRROR — change both halves in the SAME commit or they drift.** The frontend's
+/// copy of these labels is `CONNECTION_LABELS` in `src/app/core/copy/labels.ts` (it used to live
+/// in `settings.store.ts` AND again in `record.component.ts`; P3 collapsed all three into the one
+/// copy module, which is the only place the FE may name a connection). The `connection_labels_
+/// mirror_the_frontend_copy_module` test below pins the four provider rows.
+///
 /// An unknown id falls back to itself, so a newly-added provider is never blank.
 pub fn connection_display_name(connection: &str) -> &str {
     match connection {
@@ -273,6 +279,28 @@ mod tests {
         assert_ne!(connection_display_name("claude_code"), "claude_code");
         // Unknown id falls back to itself (never blank) so a new provider still shows.
         assert_eq!(connection_display_name("brand_new"), "brand_new");
+    }
+
+    /// The DOCUMENTED MIRROR guard. `src/app/core/copy/labels.ts::CONNECTION_LABELS` carries the
+    /// same four strings; this test is the Rust half of "they change together or they drift".
+    /// A rename that lands here without landing there (or vice versa) makes the pipeline's
+    /// "Summarizing with …" line disagree with the Settings summary for the same connection.
+    #[test]
+    fn connection_labels_mirror_the_frontend_copy_module() {
+        // Keep in lockstep with src/app/core/copy/labels.ts::CONNECTION_LABELS.
+        const FRONTEND_LABELS: &[(&str, &str)] = &[
+            ("claude_code", "Claude Code"),
+            ("anthropic", "Anthropic API"),
+            ("ollama", "Ollama"),
+            ("gateway", "Kong AI Gateway"),
+        ];
+        for (id, label) in FRONTEND_LABELS {
+            assert_eq!(
+                connection_display_name(id),
+                *label,
+                "connection {id} drifted from the frontend copy module"
+            );
+        }
     }
 
     /// OOM DEFERRAL (perf-memory-audit): the exact decision `timeline_generation_on_device` makes —

--- a/src/app/core/copy/error-copy.service.ts
+++ b/src/app/core/copy/error-copy.service.ts
@@ -1,0 +1,440 @@
+import { Injectable } from "@angular/core";
+import { GENERIC_FAILURE } from "./glossary";
+
+/**
+ * The ONE boundary between a raw Rust failure and a sentence a person reads.
+ *
+ * # The problem this replaces
+ *
+ * `AppError` is `Serialize` and crosses IPC as its bare `to_string()`, so every `String(e)` in the
+ * frontend used to be a rendered developer message. There are ~2100 `AppError::*` constructions in
+ * the Rust crate and a large minority of them carry vocabulary that must never reach a user
+ * ("brain sidecar stdin missing", "account-session mutex poisoned", "E2EE decrypt/authentication
+ * failed", "HKDF expand failed"). Components also *branched* on that prose, so rewording a Rust
+ * string silently changed frontend behaviour.
+ *
+ * # The contract
+ *
+ * A failure that is MEANT to reach a banner or a toast carries a stable `[code]` at the front of
+ * its message body (`src-tauri/src/errcode.rs`). Everything else is anonymous.
+ *
+ * ```text
+ * "locked: [note-locked] note n1 is in a locked folder"
+ *  └ variant tag ┘└ code ┘└──────── developer prose, NEVER rendered ────────┘
+ * ```
+ *
+ * **DENY-BY-DEFAULT.** {@link ErrorCopyService.humanize} renders copy this module owns for a known
+ * code and the generic sentence for everything else. There is deliberately no fallback heuristic
+ * that inspects the message to decide whether it looks safe — a sniff for `::`, a path separator or
+ * a snake_case token matches none of the ~161 never-show Rust strings, so a heuristic would be a
+ * leak with a false sense of coverage.
+ *
+ * The one exception is by TYPE, never by text: a {@link UserFacingError} carries a sentence this
+ * copy layer itself wrote in the frontend (the note-image preflight, which rejects before anything
+ * crosses IPC and so has no `AppError` to tag). See that class for why a plain Tauri rejection can
+ * never reach it.
+ *
+ * # Adding a code
+ *
+ * 1. Add the constant to `src-tauri/src/errcode.rs` (and to its pinned `ALL` list).
+ * 2. Tag the `AppError` construction with `errcode::tag(...)`.
+ * 3. Add the code to {@link ERROR_CODES} and its sentence to {@link BASE_COPY} here.
+ *
+ * Skipping step 3 is safe (the user gets the generic sentence); skipping step 2 silently downgrades
+ * an already-written sentence to the generic one, which is why the Rust module's `ALL` list is
+ * pinned by a test.
+ *
+ * # Scope of the P3 routing
+ *
+ * 185 `String(e)` sites across 47 files fed a rendered signal or a toast. Every one now goes
+ * through {@link ErrorCopyService.humanize} or {@link ErrorCopyService.because}. NINE hand-rolled
+ * `friendly*Error` mappers were DELETED outright and folded into the context map below (including
+ * the two on the LOCK GATE — `share-panel.component.ts` and `note-share-panel.component.ts`);
+ * a tenth, `note-editor.component.ts::friendlyLoadError`, keeps only its name and is now a
+ * one-line delegator to {@link humanizeError}. None survives as a parallel decision table.
+ *
+ * The remaining raw-string reads in the app are deliberate and are NOT rendered:
+ * `RecorderStore._error` (private, the source the code is extracted from) and
+ * `detail.component.ts::masterErrorMessage`'s `/no master/` test (recorded as a prose coupling in
+ * `errcode.rs`).
+ *
+ * # Where the guarantees are pinned
+ *
+ * `e2e/copy/error-copy-contract.spec.ts` exercises this table through a real rendered surface and
+ * the real IPC boundary: ALL FOURTEEN {@link VARIANT_TAGS} stripped, deny-by-default for an
+ * un-coded (and for an unknown-coded) failure, and every rung of the former document-import ladder
+ * classified by code rather than prose. The Rust half of the contract — the wire shape and the
+ * pinned code set — is pinned by `src-tauri/src/errcode.rs`'s own tests.
+ */
+
+/**
+ * Every `AppError` variant tag, as `Display` writes it (`src-tauri/src/error.rs`).
+ *
+ * All fourteen are stripped before the `[code]` is read. `Other(#[from] anyhow::Error)` is
+ * `#[error(transparent)]` and contributes no tag, which is exactly why it is not on this list and
+ * exactly why an anonymous `Other` renders the generic sentence.
+ */
+const VARIANT_TAGS: readonly string[] = [
+  "audio capture error",
+  "transcription error",
+  "summarizer error",
+  "export error",
+  "storage error",
+  "migration error",
+  "authentication error",
+  "locked",
+  "secrets error",
+  "keychain access denied",
+  "biometric authentication failed or was cancelled",
+  "config error",
+  "provider unavailable",
+  "invalid argument",
+];
+
+/**
+ * The allowlist. Mirrors `src-tauri/src/errcode.rs::ALL` — same order, same spelling.
+ *
+ * A code NOT in this list renders the generic sentence even if the Rust side emitted it, so the two
+ * halves diverging is a copy regression, never a leak.
+ */
+export const ERROR_CODES = [
+  "cloud-consent",
+  "share-consent",
+  "org-consent",
+  "note-locked",
+  "meeting-locked",
+  "doc-locked",
+  "folder-locked",
+  "note-missing",
+  "note-folder-missing",
+  "doc-unsupported",
+  "doc-no-text",
+  "doc-too-large",
+  "doc-password",
+  "doc-unreadable",
+  "touch-id-cancelled",
+  "touch-id-failed",
+  "keychain-denied",
+  "sharing-unreachable",
+  "sharing-rate-limited",
+  "sharing-rejected",
+  "sharing-signin-required",
+  "reminders-denied",
+] as const;
+
+export type ErrorCode = (typeof ERROR_CODES)[number];
+
+const KNOWN_CODES: ReadonlySet<string> = new Set<string>(ERROR_CODES);
+
+/**
+ * Where the failure happened. Selects a context-specific sentence for the same code (a locked
+ * folder means something different when you are saving a note than when you are sharing one) and a
+ * context-specific fallback for an anonymous failure.
+ */
+export type ErrorContext =
+  | "generic"
+  | "recording"
+  | "note-save"
+  | "note-load"
+  | "note-share"
+  | "meeting-share"
+  | "org-share"
+  | "brain-import"
+  | "brain-delete"
+  | "doc-note"
+  | "unlock"
+  | "account";
+
+/**
+ * The sentence for each code when no context adds anything.
+ *
+ * # The document-import ladder that no longer needs an order
+ *
+ * `brain.component.ts::friendlyImportError` used to test these by prose in a LOAD-BEARING order:
+ * `no text found` had to beat the generic `unsupported document type`, or a scanned PDF was
+ * reported to the user as an unsupported file type. That failure mode is now structurally
+ * impossible — each Rust site carries exactly ONE code (`errcode::DOC_NO_TEXT` in
+ * `extract/pdf.rs`, `errcode::DOC_UNSUPPORTED` in `commands/documents.rs`), so a scanned PDF can
+ * never be classified as an unsupported type. This map is a lookup, not a ladder.
+ */
+const BASE_COPY: Readonly<Record<ErrorCode, string>> = {
+  "cloud-consent":
+    "This needs your one-time permission to send a redacted transcript to your AI provider.",
+  "share-consent":
+    "Sharing needs your one-time permission first — confirm the upload notice in Settings.",
+  "org-consent":
+    "Sharing to your organisation needs your one-time permission first — confirm it in Settings ▸ Organization.",
+  "note-locked": "This note is locked — unlock its folder to change it.",
+  "meeting-locked": "This meeting is locked — unlock it first.",
+  "doc-locked": "That folder is locked — unlock it first.",
+  "folder-locked": "That folder is locked — unlock it first.",
+  "note-missing": "This note no longer exists.",
+  "note-folder-missing": "That folder no longer exists.",
+  "doc-unsupported":
+    "That file type can’t be imported. Try Markdown, text, PDF, Word, PowerPoint, Excel, HTML or an image.",
+  "doc-no-text": "No readable text was found in that file, even after reading the images.",
+  // Covers all four Rust sites that carry this code: the zip-bomb ceiling (`extract/ooxml.rs`,
+  // `extract/xlsx.rs`), the universal extracted-text ceiling and the flow-file read cap
+  // (`extract/mod.rs`), and the HTML file cap (`extract/html.rs`). The sentence names BOTH shapes
+  // — the file on disk and the text it unpacks to — because a bare "too large" leaves the user
+  // measuring the wrong thing when a 2 MB archive expands past the limit.
+  "doc-too-large":
+    "That file goes past the safe import limit — either the file itself or the text it unpacks to is too big to add.",
+  "doc-password": "That PDF is password-protected — unlock it and try again.",
+  "doc-unreadable":
+    "That file couldn’t be read — it may be damaged or in an unexpected format.",
+  "touch-id-cancelled": "Touch ID was cancelled.",
+  "touch-id-failed": "Touch ID didn’t recognise you.",
+  "keychain-denied":
+    "macOS wouldn’t release the key. Unlock your Mac’s login keychain and try again.",
+  "sharing-unreachable":
+    "Can’t reach the sharing server. Check your connection, then try again.",
+  "sharing-rate-limited": "Too many attempts — wait a minute, then try again.",
+  "sharing-rejected":
+    "That didn’t work. Check the code (it may have expired) and try again.",
+  "sharing-signin-required": "You’ve been signed out — sign in again to continue.",
+  "reminders-denied":
+    "Grant Reminders access in System Settings ▸ Privacy & Security ▸ Reminders.",
+};
+
+/**
+ * Per-context overrides. Each entry says the SAME fact as {@link BASE_COPY} plus what to do next
+ * here — an override that only shortens the sentence is a regression, not a win.
+ */
+const CONTEXT_COPY: Partial<
+  Record<ErrorContext, Partial<Record<ErrorCode, string>>>
+> = {
+  "note-save": {
+    "note-locked": "This note is locked — unlock its folder to edit.",
+    "folder-locked": "This note is locked — unlock its folder to edit.",
+    "note-missing": "This note no longer exists — it may have been deleted elsewhere.",
+  },
+  "note-load": {
+    "note-missing": "This note was deleted.",
+  },
+  "note-share": {
+    "note-locked": "This note is locked — unlock its folder to share it.",
+    "folder-locked": "This note is locked — unlock its folder to share it.",
+    "touch-id-cancelled":
+      "Touch ID was cancelled. Use Unlock for sharing to unlock with your password.",
+    "touch-id-failed":
+      "Couldn’t unlock with Touch ID. Use Unlock for sharing to unlock with your password.",
+    "keychain-denied":
+      "Couldn’t unlock with Touch ID. Use Unlock for sharing to unlock with your password.",
+  },
+  "meeting-share": {
+    "meeting-locked": "This meeting is locked — unlock its folder to share it.",
+    "touch-id-cancelled":
+      "Touch ID was cancelled. Use Unlock for sharing to unlock with your password.",
+    "touch-id-failed":
+      "Couldn’t unlock with Touch ID. Use Unlock for sharing to unlock with your password.",
+    "keychain-denied":
+      "Couldn’t unlock with Touch ID. Use Unlock for sharing to unlock with your password.",
+  },
+  account: {
+    "touch-id-cancelled":
+      "Touch ID was cancelled. Sign in with your password to share instead.",
+    "touch-id-failed":
+      "Couldn’t unlock with Touch ID. Sign in with your password to share instead.",
+    "keychain-denied":
+      "Couldn’t unlock with Touch ID. Sign in with your password to share instead.",
+    // The accept-into picker offers "Shared (default)" alongside the open folders, so BOTH escapes
+    // are named — dropping "or the default" would hide the one destination that always exists.
+    "folder-locked":
+      "That folder is locked. Unlock it, or accept into an open folder or the default one.",
+    "note-locked":
+      "That folder is locked. Unlock it, or accept into an open folder or the default one.",
+  },
+  "org-share": {
+    "note-locked":
+      "This item is locked — unlock its folder before adding it to the org brain.",
+    "meeting-locked":
+      "This item is locked — unlock its folder before adding it to the org brain.",
+    "doc-locked":
+      "This item is locked — unlock its folder before adding it to the org brain.",
+    "folder-locked":
+      "This item is locked — unlock its folder before adding it to the org brain.",
+  },
+  "brain-import": {
+    "doc-locked": "That folder is locked — unlock it first to add to the brain.",
+    "folder-locked": "That folder is locked — unlock it first to add to the brain.",
+    "doc-no-text": "No readable text found in that file, even after OCR.",
+  },
+  "brain-delete": {
+    "doc-locked": "That folder is locked — unlock it first to delete its items.",
+    "folder-locked": "That folder is locked — unlock it first to delete its items.",
+  },
+  "doc-note": {
+    "doc-locked": "This document is in a locked folder — unlock it first.",
+    "folder-locked": "This document is in a locked folder — unlock it first.",
+    "doc-no-text": "This document has no text to turn into a note.",
+    "cloud-consent":
+      "Making a note needs your one-time permission to send redacted text to your AI provider.",
+  },
+  recording: {
+    "meeting-locked": "This meeting is locked — unlock its folder to finish the note.",
+  },
+  unlock: {
+    "touch-id-cancelled": "Touch ID was cancelled — try again.",
+    "touch-id-failed": "Touch ID didn’t recognise you — try again.",
+  },
+};
+
+/** The "we genuinely can't say more" sentence, tuned per surface. */
+const CONTEXT_FALLBACK: Partial<Record<ErrorContext, string>> = {
+  "note-save": "Couldn’t save this note. Please try again.",
+  "note-load": "Couldn’t open this note. Please try again.",
+  "note-share": "Couldn’t share this note. Please try again.",
+  "meeting-share": "Couldn’t share this meeting. Please try again.",
+  "org-share": "Couldn’t share that to your organisation. Please try again.",
+  "brain-import": "Couldn’t add that to the brain. Please try again.",
+  "brain-delete": "Couldn’t remove that. Please try again.",
+  "doc-note": "Couldn’t make a note from this document. Please try again.",
+  unlock: "Couldn’t unlock. Please try again.",
+  recording: "Couldn’t finish that recording. Please try again.",
+};
+
+/** Matches a leading `[kebab-code]` — strict, never a sniff. */
+const CODE_PATTERN = /^\[([a-z0-9]+(?:-[a-z0-9]+)*)\]\s*/;
+
+/**
+ * A failure whose message was ALREADY written by this copy layer, in the frontend.
+ *
+ * # Why this exists, and why it is not a hole in deny-by-default
+ *
+ * Not every rejection a component catches comes from Rust. A handful of checks run entirely in the
+ * webview and reject with a finished sentence — the note-image preflight in
+ * `services/note-attachment.service.ts` is the whole population: it inspects a pasted image's
+ * bounded header and refuses a decompression bomb *before* any decoder allocates, so its refusal
+ * never crosses IPC and there is no `AppError` to carry an `errcode`. Routing those through
+ * {@link humanizeError} as anonymous failures replaced a specific, actionable sentence ("That
+ * image's dimensions are too large to process safely.") with "Something went wrong." — strictly
+ * less honest, which rule 1 of the glossary forbids.
+ *
+ * The distinction this class draws is a TYPE, not a shape of text. That matters: the module doc
+ * rules out a heuristic that inspects a message to decide whether it looks safe, and this is not
+ * one. A Tauri rejection arrives as a plain string (and a `throw` inside a component arrives as a
+ * plain `Error`), so neither can ever be an instance of this class — only code that deliberately
+ * constructs a `UserFacingError` opts its sentence in, and that constructor is the review point.
+ *
+ * The message MUST be finished user copy: a whole sentence, no variant tag, no `[code]`, no
+ * identifier, and nothing from `glossary.ts`'s never-show list. If a sentence would vary by
+ * surface, it belongs in {@link BASE_COPY} under a real code instead.
+ */
+export class UserFacingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UserFacingError";
+  }
+}
+
+/**
+ * Reduce anything a `catch` can hand us to the raw wire string, with the JS `Error:` wrapper and
+ * the `AppError` variant tag removed. Exported for tests and for the few call sites that must still
+ * inspect the raw text (a `console` breadcrumb — never a rendered string).
+ */
+export function stripErrorPrefixes(e: unknown): string {
+  let s = typeof e === "string" ? e : String(e);
+  // `new Error(msg)` stringifies as "Error: msg"; Tauri rejects with the bare string, but a
+  // frontend-thrown Error can reach the same handler.
+  s = s.replace(/^Error:\s*/, "").trim();
+  for (const tag of VARIANT_TAGS) {
+    if (s.startsWith(`${tag}: `)) {
+      return s.slice(tag.length + 2).trim();
+    }
+  }
+  return s;
+}
+
+/**
+ * The stable machine code of a failure, or `null` when it carries none.
+ *
+ * This is what behaviour branches on — never the prose. `record.component.ts` asks
+ * `errorCode(...) === "cloud-consent"` to decide whether to show the Allow banner; before the code
+ * existed it regex-matched a Rust sentence, so rewording that sentence broke the consent flow for
+ * every cloud user.
+ */
+export function errorCodeOf(e: unknown): ErrorCode | null {
+  const match = CODE_PATTERN.exec(stripErrorPrefixes(e));
+  if (!match) {
+    return null;
+  }
+  const code = match[1];
+  return KNOWN_CODES.has(code) ? (code as ErrorCode) : null;
+}
+
+/** True when `e` carries exactly `code`. */
+export function errorHasCode(e: unknown, code: ErrorCode): boolean {
+  return errorCodeOf(e) === code;
+}
+
+/**
+ * The sentence to show for `e` on the `context` surface.
+ *
+ * Deny-by-default: an un-coded failure NEVER renders its own text, no matter how harmless it looks.
+ */
+export function humanizeError(e: unknown, context: ErrorContext = "generic"): string {
+  if (e instanceof UserFacingError) {
+    return e.message;
+  }
+  const code = errorCodeOf(e);
+  if (code === null) {
+    return CONTEXT_FALLBACK[context] ?? GENERIC_FAILURE;
+  }
+  return CONTEXT_COPY[context]?.[code] ?? BASE_COPY[code];
+}
+
+/**
+ * `"<what failed> — <why>"`, for the many call sites that used to write
+ * `"Couldn’t save tags: " + String(e)`.
+ *
+ * The action half is the surface's own words and always survives; the reason half is
+ * {@link humanizeError}, so a known code explains itself and an anonymous failure degrades to a
+ * plain "please try again" instead of pasting a Rust string after a friendly prefix.
+ *
+ * `action` is written WITHOUT trailing punctuation ("Couldn’t save tags").
+ */
+export function describeFailure(
+  action: string,
+  e: unknown,
+  context: ErrorContext = "generic",
+): string {
+  if (e instanceof UserFacingError) {
+    return `${action} — ${e.message}`;
+  }
+  const code = errorCodeOf(e);
+  if (code === null) {
+    return `${action}. Please try again.`;
+  }
+  return `${action} — ${CONTEXT_COPY[context]?.[code] ?? BASE_COPY[code]}`;
+}
+
+/**
+ * Injectable face of the module functions above.
+ *
+ * Components inject this; the pure functions exist so the same logic is reachable from a store's
+ * `computed()` and from unit tests without a TestBed. Both are the same code — there is exactly one
+ * decision table.
+ */
+@Injectable({ providedIn: "root" })
+export class ErrorCopyService {
+  /** The user-facing sentence for a failure. Deny-by-default — see the module doc. */
+  humanize(e: unknown, context: ErrorContext = "generic"): string {
+    return humanizeError(e, context);
+  }
+
+  /** The stable machine code, for BEHAVIOUR decisions. Never render this. */
+  codeOf(e: unknown): ErrorCode | null {
+    return errorCodeOf(e);
+  }
+
+  /** True when the failure is exactly `code`. */
+  is(e: unknown, code: ErrorCode): boolean {
+    return errorHasCode(e, code);
+  }
+
+  /** `"<what failed> — <why>"` for a surface that wants to name the action it attempted. */
+  because(action: string, e: unknown, context: ErrorContext = "generic"): string {
+    return describeFailure(action, e, context);
+  }
+}

--- a/src/app/core/copy/glossary.ts
+++ b/src/app/core/copy/glossary.ts
@@ -1,0 +1,107 @@
+/**
+ * The vocabulary Murmur speaks — ONE user-facing term per concept, and the terms that must never
+ * reach a screen.
+ *
+ * # Why a module and not a style guide
+ *
+ * Murmur's whole differentiator is telling the truth about what leaves the Mac. That only works if
+ * the user can *read* the sentence. Before this module the same concept had three names in three
+ * files ("egress" / "cloud processing" / "leaves this Mac"), and the honest sentences were the
+ * first casualties of every simplification pass.
+ *
+ * Two rules govern every edit here:
+ *
+ * 1. **A replacement must be MORE honest, not vaguer.** A rewrite that is shorter AND drops a noun
+ *    phrase is wrong. "Emails, card numbers and phone numbers are removed" is not improved by
+ *    "your data is protected" — the second says nothing and implies more.
+ * 2. **Enumerate, never abstract.** Redaction copy names what is redacted AND what is not.
+ *    `e2e/settings/privacy-honesty.spec.ts` pins the clauses a well-meaning simplification would
+ *    destroy.
+ *
+ * # What is and is not enforced
+ *
+ * `scripts/check-vocabulary.mjs` (wired into `scripts/ci.sh`) is the regression gate: it scans the
+ * user-visible strings of both trees for its OWN `BANNED` list — deliberately a separate, blunter
+ * list than {@link NEVER_SHOW_TERMS}, because a scanner can only match tokens while this module
+ * also carries the replacement each term maps to. Keep the two lists in sympathy; the scanner's is
+ * the one that fails the build (its `.vocabulary-baseline.json` may only SHRINK).
+ *
+ * What NO scanner can check is the honesty rule above — a clause deleted for brevity is invisible
+ * to a token match. `e2e/settings/privacy-honesty.spec.ts` pins those clauses by fact instead.
+ */
+
+/**
+ * Terms that must NEVER appear in user-visible copy. Every one names an implementation detail the
+ * user has no way to reason about, and every one has a replacement in {@link PLAIN_TERMS}.
+ *
+ * Deliberately NOT on this list, because they are the RIGHT words for this audience:
+ * `Obsidian vault`, `Markdown`, `Touch ID`, `Keychain`, the provider brand names, and the
+ * checkpoint names in the model catalog (a user should be able to see which model is on their
+ * disk — they stay as muted secondary text).
+ */
+export const NEVER_SHOW_TERMS: readonly string[] = [
+  "GGUF",
+  "q8",
+  "KEK",
+  "DEK",
+  "blob",
+  "sidecar",
+  "IPC",
+  "egress",
+  "embedding",
+  "token",
+  "quantization",
+  "base URL",
+  "MCP",
+];
+
+/**
+ * The replacement for each banned term: the ONE phrase Murmur uses for that concept.
+ *
+ * Keys are lowercase so a scanner can look a hit up directly. A value is a phrase, not a synonym
+ * ring — if you find yourself wanting a second phrasing for the same concept, the answer is to
+ * change this one, everywhere, in one commit.
+ */
+export const PLAIN_TERMS: Readonly<Record<string, string>> = {
+  gguf: "model file",
+  q8: "smaller, faster version",
+  kek: "your master key",
+  dek: "your database key",
+  blob: "encrypted copy",
+  sidecar: "helper",
+  ipc: "the app's own connection",
+  egress: "what leaves your Mac",
+  embedding: "search index",
+  token: "roughly ¾ of a word",
+  quantization: "how compact the model is",
+  "base url": "server address",
+  mcp: "local server for Claude",
+};
+
+/**
+ * Concept → the ONE user-facing term, for concepts that were never jargon but WERE inconsistent.
+ * These are the phrases that must match across Settings, Onboarding, the Record screen and the
+ * ledger, so a user reading two screens learns one vocabulary rather than three.
+ */
+export const GLOSSARY = {
+  /** The one-time permission that lets a cloud provider see a redacted transcript. */
+  cloudConsent: "Allow cloud processing",
+  /** The act of removing personal details before text leaves. Always ENUMERATED where it counts. */
+  redaction: "Emails, phones and cards removed",
+  /** The optional on-device model that additionally masks people's names. */
+  nameMasking: "Name masking",
+  /** The unit the egress ledger counts. Never renamed without changing what is counted. */
+  tokensSent: "Tokens sent",
+  /** The gloss that makes the unit above mean something. */
+  tokensGloss: "roughly ¾ of a word each",
+  /** How the ledger groups usage. The store groups by MODEL label — not by service. */
+  byModel: "By model",
+  /** What a locked folder is. */
+  lockedFolder: "Locked folder",
+} as const;
+
+/**
+ * The generic sentence a user sees when Murmur genuinely cannot say more (see
+ * `error-copy.service.ts` — deny-by-default). Deliberately blames nothing and promises nothing.
+ */
+export const GENERIC_FAILURE = "Something went wrong. Please try again.";

--- a/src/app/core/copy/labels.ts
+++ b/src/app/core/copy/labels.ts
@@ -1,0 +1,77 @@
+/**
+ * The ONE place the frontend names a thing the backend also names.
+ *
+ * Every label here has a Rust counterpart. A label that lives in two places drifts; a label that
+ * lives in three (as `CONNECTION_LABELS` did — `settings.store.ts`, `record.component.ts` and
+ * `summarize/roles.rs`) drifts twice and nobody notices until two screens disagree about the same
+ * connection.
+ */
+
+/**
+ * Connection id → user-facing name.
+ *
+ * **DOCUMENTED MIRROR of `src-tauri/src/summarize/roles.rs::connection_display_name`.** They change
+ * in the SAME commit or they drift — the Rust half is pinned by
+ * `roles::tests::connection_labels_mirror_the_frontend_copy_module`.
+ *
+ * These are BRAND names, deliberately kept: "Claude Code", "Anthropic API", "Ollama" and "Kong AI
+ * Gateway" are what the user typed into Settings and what they will search for. Replacing a brand
+ * with a category ("your AI service") would be vaguer, not plainer.
+ */
+export const CONNECTION_LABELS: Readonly<Record<string, string>> = {
+  claude_code: "Claude Code",
+  anthropic: "Anthropic API",
+  ollama: "Ollama",
+  gateway: "Kong AI Gateway",
+};
+
+/** The connection's name, or a neutral stand-in when nothing is configured yet. */
+export function connectionLabel(id: string | null | undefined): string {
+  if (!id) {
+    return "This provider";
+  }
+  return CONNECTION_LABELS[id] ?? id;
+}
+
+/**
+ * Where a cloud-classified connection actually sends the redacted transcript.
+ *
+ * Only ever rendered after the backend's fail-closed classification refused, so the connection is
+ * cloud BY DEFINITION here — for `ollama` that means its server address is not on this Mac, hence
+ * "your remote Ollama server" without re-parsing anything in the frontend.
+ */
+export function cloudDestinationLabel(id: string | null | undefined): string {
+  switch (id) {
+    case "anthropic":
+    case "claude_code":
+      return "Anthropic's cloud";
+    case "gateway":
+      return "your Kong AI Gateway";
+    case "ollama":
+      return "your remote Ollama server";
+    default:
+      return "your provider's cloud";
+  }
+}
+
+/**
+ * Which part of a meeting a search hit came from.
+ *
+ * Only three values are REACHABLE from the meeting search the library and quick-search call
+ * (`search_meetings` → `db::search_visible` → `search_snippet`, which returns exactly
+ * `"title" | "transcript" | "note"`). The `semantic`/`entity`/`topic`/`temporal` values exist on
+ * other search functions whose callers never render a hit list, so they are forward-looking only —
+ * an unknown value renders nothing rather than a lie about where the match was.
+ */
+export function matchedInLabel(matchedIn: string | null | undefined): string {
+  switch (matchedIn) {
+    case "title":
+      return "in the title";
+    case "transcript":
+      return "in the transcript";
+    case "note":
+      return "in the note";
+    default:
+      return "";
+  }
+}

--- a/src/app/core/meeting-conversation.store.ts
+++ b/src/app/core/meeting-conversation.store.ts
@@ -17,6 +17,7 @@ import type {
   WakeDetectedPayload,
   WhisperCard,
 } from "./models";
+import { ErrorCopyService } from "./copy/error-copy.service";
 
 /**
  * One Realtime-Reactions "whisper" contradiction card on the record-screen rail,
@@ -232,6 +233,7 @@ export class MeetingConversationStore {
   private readonly ipc = inject(IpcService);
   private readonly folders = inject(FoldersService);
   private readonly toast = inject(ToastService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** The ASK BRAIN conversation — thread anchors (oldest → newest), each hosting a thread. */
   private readonly _notes = signal<NoteItem[]>([]);
@@ -980,8 +982,15 @@ export class MeetingConversationStore {
       if (token !== this.companionLoadToken) return;
       // Revert the optimistic accept — the draft never landed in the note.
       this.markTurnAccepted(noteId, agentTurnId, false);
-      if (String(e).includes("Locked")) {
-        this.toast.danger("This meeting's folder is locked — unlock it to add the note.");
+      // Was `String(e).includes("Locked")` — CAPITAL L, while every producer is lowercase
+      // (`AppError`'s `Display` is `#[error("locked: {0}")]`), so this arm never fired and a
+      // sealed-folder refusal read as a generic "try again". Same casing bug as the note editor's
+      // `isUnretryableSaveError`; both now key on the `[code]`, which cannot have one.
+      const code = this.errorCopy.codeOf(e);
+      if (code === "note-locked" || code === "folder-locked") {
+        this.toast.danger(
+          "This meeting's folder is locked — unlock it to add the note.",
+        );
       } else {
         this.toast.danger("Couldn't add to note — try again.");
       }

--- a/src/app/core/recorder.store.ts
+++ b/src/app/core/recorder.store.ts
@@ -14,6 +14,7 @@ import { IpcService } from "./ipc.service";
 import type { NoteDto, Stage, StatusPayload } from "./models";
 import { RecordingFlushService } from "./recording-flush.service";
 import { ToastService } from "../services/toast.service";
+import { ErrorCopyService } from "./copy/error-copy.service";
 
 /**
  * Human byte label (binary), matching the Storage settings section's `mb()`:
@@ -35,6 +36,7 @@ export class RecorderStore {
   private readonly ipc = inject(IpcService);
   private readonly toast = inject(ToastService);
   private readonly flushService = inject(RecordingFlushService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   private readonly _stage = signal<Stage>("idle");
   private readonly _message = signal<string>("");
@@ -46,7 +48,28 @@ export class RecorderStore {
   readonly stage = this._stage.asReadonly();
   readonly message = this._message.asReadonly();
   readonly lastNote = this._lastNote.asReadonly();
-  readonly error = this._error.asReadonly();
+
+  /**
+   * The last failure, as a sentence a person can read.
+   *
+   * `_error` holds the RAW wire string (the `AppError` display, or the terminal `EVENT_STATUS`
+   * message — which `pipeline.rs` builds with the same `to_string()`). It is deliberately private:
+   * ~2100 `AppError` constructions in the Rust crate carry developer vocabulary, so nothing may
+   * render it directly. Behaviour branches read {@link errorCode} instead.
+   */
+  readonly error = computed(() => {
+    const raw = this._error();
+    return raw === null ? null : this.errorCopy.humanize(raw, "recording");
+  });
+
+  /**
+   * The stable `[code]` of the last failure, or `null` for an anonymous one.
+   *
+   * This is what `record.component.ts` asks to decide whether to show the cloud-consent "Allow"
+   * banner — the code, never the prose (see `errcode.rs` for why).
+   */
+  readonly errorCode = computed(() => this.errorCopy.codeOf(this._error()));
+
   readonly meetingId = this._meetingId.asReadonly();
   /** Latest live-transcription caption (best-effort, only during recording). */
   readonly liveCaption = this._liveCaption.asReadonly();

--- a/src/app/design-system/quick-search/quick-search.component.html
+++ b/src/app/design-system/quick-search/quick-search.component.html
@@ -64,7 +64,9 @@
               <span class="qs-row-snippet">{{ row.snippet }}</span>
             </span>
             <span class="qs-row-meta">
-              <span class="qs-chip">{{ row.matchedIn }}</span>
+              @if (row.matchedIn) {
+                <span class="qs-chip">{{ row.matchedIn }}</span>
+              }
               <span class="qs-date">{{ row.dateLabel }}</span>
             </span>
           </button>

--- a/src/app/design-system/quick-search/quick-search.component.ts
+++ b/src/app/design-system/quick-search/quick-search.component.ts
@@ -15,6 +15,7 @@ import { catchError, debounceTime, from, of, switchMap } from "rxjs";
 import { MurKbdComponent } from "../kbd/kbd.component";
 import { IpcService } from "../../core/ipc.service";
 import type { SearchHit } from "../../core/models";
+import { matchedInLabel } from "../../core/copy/labels";
 
 /** One rendered result row — precomputed so the template calls no methods. */
 interface HitRow {
@@ -86,7 +87,11 @@ export class MurQuickSearchComponent {
         day: "numeric",
       }),
       snippet: h.snippet,
-      matchedIn: h.matchedIn,
+      // The RAW value ("transcript"/"note"/"title") used to render straight into the chip;
+      // `matchedInLabel` is the ONE user-facing phrasing for that concept (P3). It returns "" for
+      // a value it cannot name, and the template then renders NO chip — defaulting an unknown
+      // match to "in the title" would be a confident lie about where the hit came from.
+      matchedIn: matchedInLabel(h.matchedIn),
     })),
   );
 

--- a/src/app/features/analytics/analytics/analytics.component.ts
+++ b/src/app/features/analytics/analytics/analytics.component.ts
@@ -14,6 +14,7 @@ import {
 import { EgressLedgerComponent } from "../egress-ledger/egress-ledger.component";
 import { TopicThreadsComponent } from "../topic-threads/topic-threads.component";
 import { WeeklyDigestComponent } from "../weekly-digest/weekly-digest.component";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /** One rendered column of the 30-day activity chart (zero-filled for gaps). */
 interface ChartBar {
@@ -57,6 +58,7 @@ const STATUS_ORDER = [
 export class AnalyticsComponent implements OnInit {
   private readonly ipc = inject(IpcService);
   private readonly store = inject(AnalyticsStore);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /**
    * Root-persisted so a navigate-away-and-back shows the LAST-KNOWN numbers
@@ -210,7 +212,7 @@ export class AnalyticsComponent implements OnInit {
       this.data.set(await this.ipc.getAnalytics());
     } catch (e) {
       this.data.set(null);
-      this.error.set(String(e));
+      this.error.set(this.errorCopy.humanize(e));
     } finally {
       this.loading.set(false);
     }

--- a/src/app/features/analytics/egress-ledger/egress-ledger.component.html
+++ b/src/app/features/analytics/egress-ledger/egress-ledger.component.html
@@ -1,6 +1,6 @@
 <div class="card panel">
   <div class="panel-head">
-    <h3>Egress &amp; Usage</h3>
+    <h3>What leaves this Mac</h3>
     <!-- 7 / 30 / 90 day segmented toggle -->
     <div class="seg" role="group" aria-label="Window">
       @for (r of ranges; track r) {
@@ -30,22 +30,41 @@
         <span class="eg-tile-label">Cloud calls</span>
         <span class="eg-tile-value">{{ l.totalCalls }}</span>
       </div>
+      <!--
+        The unit stays "Tokens" because that is what `byModel`/`byDay` actually count. Renaming it
+        to "words" without changing the number would be a lie, so it keeps its unit and gains a
+        gloss instead (glossary.ts::tokensGloss).
+      -->
       <div class="eg-tile">
         <span class="eg-tile-label">Tokens sent</span>
         <span class="eg-tile-value">{{ fmtTokens(l.totalTokens) }}</span>
+        <span class="eg-tile-note">roughly ¾ of a word each</span>
       </div>
+      <!--
+        ENUMERATED, not a bare noun: "PII scrubbed" told the user nothing about what is or is not
+        removed. Names are counted separately below because they are only masked when the optional
+        on-device model is installed — folding them in here would imply a protection that is off by
+        default.
+      -->
       <div class="eg-tile">
-        <span class="eg-tile-label">PII scrubbed</span>
-        <span class="eg-tile-value">{{ totalPii() }}</span>
+        <span class="eg-tile-label">Emails, phones and cards removed</span>
+        <span class="eg-tile-value">{{ patternRedactions() }}</span>
+        <span class="eg-tile-note">
+          @if (namesMasked() > 0) {
+            {{ namesMasked() }} name{{ namesMasked() === 1 ? '' : 's' }} masked too
+          } @else {
+            names are not removed unless you turn on name masking
+          }
+        </span>
       </div>
     </div>
 
-    <!-- Tokens by model -->
+    <!-- By model -->
     <div class="eg-section">
-      <h4 class="eg-section-title">Tokens by model</h4>
+      <h4 class="eg-section-title">By model</h4>
       @if (modelBars().length === 0) {
         <p class="empty-state">
-          No cloud calls in this window — everything stayed on-device.
+          No cloud calls in this window — everything stayed on this Mac.
         </p>
       } @else {
         <ul class="eg-bars" aria-label="Tokens by model">
@@ -65,7 +84,7 @@
     <!-- Tokens by day -->
     @if (dayBars().length > 0) {
       <div class="eg-section">
-        <h4 class="eg-section-title">Tokens by day</h4>
+        <h4 class="eg-section-title">By day</h4>
         <ul class="eg-bars" aria-label="Tokens by day">
           @for (d of dayBars(); track d.day) {
             <li class="eg-bar-row">
@@ -83,8 +102,8 @@
     <!-- What left this device -->
     <div class="eg-section">
       <h4 class="eg-section-title">
-        What left this device
-        <span class="eg-section-note">(scrubbed before sending)</span>
+        Removed before sending
+        <span class="eg-section-note">(and restored in your notes)</span>
       </h4>
       <div class="eg-chips">
         <span class="eg-chip">
@@ -110,7 +129,7 @@
     @if (l.recent.length > 0) {
       <div class="eg-section">
         <h4 class="eg-section-title">Recent calls</h4>
-        <ul class="eg-recent" aria-label="Recent egress calls">
+        <ul class="eg-recent" aria-label="Recent cloud calls">
           <!--
             track $index is correct here (not a rule violation): l.recent is a
             read-only snapshot wholesale-replaced by _ledger.set() — rows are

--- a/src/app/features/analytics/egress-ledger/egress-ledger.component.scss
+++ b/src/app/features/analytics/egress-ledger/egress-ledger.component.scss
@@ -87,6 +87,16 @@
   letter-spacing: -0.025em;
   font-variant-numeric: tabular-nums;
 }
+/*
+ * The honest gloss under a tile's number: what the unit means ("roughly ¾ of a word each"), or
+ * what the number does NOT cover ("names are not removed unless you turn on name masking").
+ * Deliberately quiet, but never truncated — it is the clause that keeps the tile from overclaiming.
+ */
+.eg-tile-note {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  line-height: 1.35;
+}
 
 /* --- Section headings --- */
 .eg-section {

--- a/src/app/features/analytics/egress-ledger/egress-ledger.component.ts
+++ b/src/app/features/analytics/egress-ledger/egress-ledger.component.ts
@@ -7,15 +7,19 @@ import {
 } from "@angular/core";
 import { IpcService } from "../../../core/ipc.service";
 import { EgressLedgerStore } from "../../../services/egress-ledger-store.service";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /** Selectable rolling-window lengths (in days). */
 const RANGES = [7, 30, 90] as const;
 type Range = (typeof RANGES)[number];
 
 /**
- * "Egress & Usage" panel — shows the content-free local egress ledger:
- * total cloud calls + tokens, per-model bar chart, PII-scrubbed receipt,
- * and recent calls, for a 7/30/90-day rolling window.
+ * "What left this Mac" panel — the content-free local egress ledger: cloud calls, tokens sent,
+ * what the redaction firewall removed, a per-model bar chart, and recent calls, over a 7/30/90-day
+ * rolling window.
+ *
+ * The word "egress" survives only in code (the command, the store, this selector) — it is on the
+ * never-show list in `core/copy/glossary.ts`, so no rendered string uses it.
  *
  * Lives in its own file for a separate per-component style budget.
  * Data arrives from the `get_egress_ledger` Tauri command via
@@ -30,6 +34,7 @@ type Range = (typeof RANGES)[number];
 export class EgressLedgerComponent {
   private readonly ipc = inject(IpcService);
   private readonly store = inject(EgressLedgerStore);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   readonly ranges = RANGES;
 
@@ -83,14 +88,33 @@ export class EgressLedgerComponent {
     }));
   });
 
-  /** Sum of all four PII redaction kinds. */
-  readonly totalPii = computed(() => {
+  /**
+   * How many emails, phone numbers and card numbers the pattern firewall removed.
+   *
+   * NAMES ARE DELIBERATELY EXCLUDED (P3). This used to sum all four kinds under the label "PII
+   * scrubbed", which was wrong twice over: "PII" is an acronym that hides what is actually removed,
+   * and folding names into the same number implies names are always removed — they are NOT. Name
+   * masking only happens once the optional on-device model is downloaded. The tile now says exactly
+   * what it counts, and names get their own honest line in {@link namesMasked}.
+   *
+   * The rule this follows: if you rename a unit, change what it counts.
+   */
+  readonly patternRedactions = computed(() => {
     const r = this._ledger()?.totalRedactions;
     if (!r) {
       return 0;
     }
-    return r.email + r.card + r.phone + r.name;
+    return r.email + r.card + r.phone;
   });
+
+  /**
+   * How many people's names were masked — 0 when the optional on-device name-masking model is not
+   * installed, which is the DEFAULT. Rendered separately so a zero here reads as "names were not
+   * masked", not as "there were no names".
+   */
+  readonly namesMasked = computed(
+    () => this._ledger()?.totalRedactions?.name ?? 0,
+  );
 
   /**
    * The window this effect last fetched for, or `undefined` before the
@@ -144,7 +168,7 @@ export class EgressLedgerComponent {
       this.error.set(null);
     } catch (e) {
       this._ledger.set(null);
-      this.error.set(e instanceof Error ? e.message : String(e));
+      this.error.set(this.errorCopy.humanize(e));
     } finally {
       this.loading.set(false);
     }

--- a/src/app/features/analytics/topic-threads/topic-threads.component.ts
+++ b/src/app/features/analytics/topic-threads/topic-threads.component.ts
@@ -8,6 +8,7 @@ import {
 import { RouterLink } from "@angular/router";
 import { IpcService } from "../../../core/ipc.service";
 import { TopicThreadsStore } from "../../../services/topic-threads-store.service";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /**
  * "Topic threads" — cross-meeting topic clusters surfaced on the Analytics
@@ -35,6 +36,7 @@ import { TopicThreadsStore } from "../../../services/topic-threads-store.service
 export class TopicThreadsComponent implements OnInit {
   private readonly ipc = inject(IpcService);
   private readonly store = inject(TopicThreadsStore);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /**
    * All loaded threads, sorted multi-mention first (most-discussed topics up
@@ -60,7 +62,7 @@ export class TopicThreadsComponent implements OnInit {
       );
       this.threads.set(sorted);
     } catch (e) {
-      this.error.set("Couldn’t load topic threads: " + String(e));
+      this.error.set(this.errorCopy.because("Couldn’t load topic threads", e));
     } finally {
       this.loading.set(false);
     }

--- a/src/app/features/analytics/weekly-digest/weekly-digest.component.ts
+++ b/src/app/features/analytics/weekly-digest/weekly-digest.component.ts
@@ -8,6 +8,7 @@ import {
 import { IpcService } from "../../../core/ipc.service";
 import type { DigestResult } from "../../../core/models";
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /** The selectable digest ranges, in days. */
 const RANGES = [7, 30] as const;
@@ -37,6 +38,7 @@ type Range = (typeof RANGES)[number];
 })
 export class WeeklyDigestComponent {
   private readonly ipc = inject(IpcService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** Selectable ranges (days). */
   protected readonly ranges = RANGES;
@@ -75,7 +77,7 @@ export class WeeklyDigestComponent {
     try {
       this.result.set(await this.ipc.generateDigest(this.range()));
     } catch (e) {
-      this.error.set("Couldn’t generate the digest: " + String(e));
+      this.error.set(this.errorCopy.because("Couldn’t generate the digest", e));
     } finally {
       this.pending.set(false);
     }

--- a/src/app/features/ask/ask/ask.component.ts
+++ b/src/app/features/ask/ask/ask.component.ts
@@ -22,6 +22,7 @@ import type {
 import { SourcePickerComponent } from "../../../design-system/source-picker/source-picker.component";
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
 import { SourcesComponent } from "../../../shared/sources/sources.component";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /**
  * A conversation turn as rendered on the Ask page. It mirrors {@link ChatTurn}
@@ -89,6 +90,7 @@ export class AskComponent implements OnInit {
   private readonly ipc = inject(IpcService);
   private readonly injector = inject(Injector);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** True while the initial "any meetings?" probe is in flight. */
   readonly loading = signal(true);
@@ -361,7 +363,7 @@ export class AskComponent implements OnInit {
       ]);
     } catch (e) {
       // Keep the user's question in the log so Retry can re-send it.
-      this.error.set("Couldn’t get an answer: " + String(e));
+      this.error.set(this.errorCopy.because("Couldn’t get an answer", e));
     } finally {
       // Retire this turn's trace: late tool events for it are dropped.
       this.activeAskId = null;

--- a/src/app/features/audit/audit.store.ts
+++ b/src/app/features/audit/audit.store.ts
@@ -13,6 +13,7 @@ import type {
   AuditRunSummary,
   AuditSchedule,
 } from "../../core/models";
+import { ErrorCopyService } from "../../core/copy/error-copy.service";
 
 /** Stable render order for the grouped inbox — most consequential kinds first. */
 export const AUDIT_KIND_ORDER: readonly AuditFindingKind[] = [
@@ -48,6 +49,7 @@ export interface AuditKindGroup {
 export class AuditStore {
   private readonly ipc = inject(IpcService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   private readonly _findings = signal<AuditFinding[]>([]);
   readonly findings = this._findings.asReadonly();
@@ -117,7 +119,7 @@ export class AuditStore {
       this._findings.set(findings);
       this._error.set(null);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
     } finally {
       this._loading.set(false);
     }

--- a/src/app/features/audit/audit/audit.component.ts
+++ b/src/app/features/audit/audit/audit.component.ts
@@ -15,6 +15,7 @@ import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.comp
 import { ToastService } from "../../../services/toast.service";
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
 import { AuditStore } from "../audit.store";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /** Per-kind copy: the section heading, its one-line explanation, and the row chip. */
 const KIND_META: Record<
@@ -104,6 +105,7 @@ export class AuditComponent {
   protected readonly store = inject(AuditStore);
   private readonly ipc = inject(IpcService);
   private readonly toast = inject(ToastService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** The user's manual collapse/expand toggle (auto-opens on "Audit now"). */
   readonly open = signal(false);
@@ -163,7 +165,7 @@ export class AuditComponent {
     try {
       await this.store.runNow();
     } catch (e) {
-      this.toast.danger(String(e));
+      this.toast.danger(this.errorCopy.humanize(e));
     }
   }
 
@@ -175,7 +177,7 @@ export class AuditComponent {
     try {
       await this.store.resolve(f.id, "accept");
     } catch (e) {
-      this.toast.danger(String(e));
+      this.toast.danger(this.errorCopy.humanize(e));
     } finally {
       this.busyId.set(null);
     }
@@ -186,7 +188,7 @@ export class AuditComponent {
     try {
       await this.store.resolve(f.id, "dismiss");
     } catch (e) {
-      this.toast.danger(String(e));
+      this.toast.danger(this.errorCopy.humanize(e));
     } finally {
       this.busyId.set(null);
     }
@@ -225,7 +227,7 @@ export class AuditComponent {
         this.explanations.update((m) => new Map(m).set(id, ex));
       }
     } catch (e) {
-      this.toast.danger(String(e));
+      this.toast.danger(this.errorCopy.humanize(e));
     } finally {
       this.explaining.update((s) => {
         const next = new Set(s);

--- a/src/app/features/brain/brain-enable-card/brain-enable-card.component.ts
+++ b/src/app/features/brain/brain-enable-card/brain-enable-card.component.ts
@@ -11,6 +11,10 @@ import {
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import { IpcService } from "../../../core/ipc.service";
 import { SettingsStore } from "../../settings/settings.store";
+import {
+  ErrorCopyService,
+  UserFacingError,
+} from "../../../core/copy/error-copy.service";
 
 /**
  * "Enable the brain" — the one-click activation card for the two on-device
@@ -43,6 +47,7 @@ export class BrainEnableCardComponent {
   private readonly ipc = inject(IpcService);
   private readonly store = inject(SettingsStore);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** Fires once when both models land (parent may advance the wizard). */
   readonly enabled = output<void>();
@@ -130,7 +135,16 @@ export class BrainEnableCardComponent {
         this.stage.set("brain");
         this._brainFrac.set(0);
         const heavy = this.store.brainModels().find((m) => m.selectedHeavy);
-        if (!heavy) throw new Error("no on-device model available");
+        // Frontend-authored refusal, so it carries its own finished sentence (see
+        // `UserFacingError`): the catalog has no model marked as the on-device choice, which is a
+        // state the user can act on. A bare `Error` here would be denied to the generic sentence
+        // and tell them nothing — and the old raw `e.message` ("no on-device model available") was
+        // developer shorthand, not copy.
+        if (!heavy) {
+          throw new UserFacingError(
+            "No on-device model is selected yet — choose one under AI & Models, then try again.",
+          );
+        }
         await this.store.downloadBrainModel(heavy.id);
         // Downloading the GGUF is not the same as SELECTING it: `brain_model_present`
         // resolves via the persisted `brain_model_id`, which download alone never
@@ -162,12 +176,12 @@ export class BrainEnableCardComponent {
           specific ??
             (!this.brainPresent()
               ? "The brain model downloaded, but Murmur can't find it afterward. Check available disk space, then try again."
-              : "The embedding model downloaded, but Murmur can't find it afterward. Check available disk space, then try again."),
+              : "The search-index model downloaded, but Murmur can't find it afterward. Check available disk space, then try again."),
         );
         this.stage.set("idle");
       }
     } catch (e) {
-      this.error.set(e instanceof Error ? e.message : String(e));
+      this.error.set(this.errorCopy.humanize(e));
       this.stage.set("idle");
     } finally {
       this.running.set(false);

--- a/src/app/features/brain/brain-memory/brain-memory.component.ts
+++ b/src/app/features/brain/brain-memory/brain-memory.component.ts
@@ -12,6 +12,7 @@ import type { UserMemory, UserMemoryFact } from "../../../core/models";
 import { FoldersService } from "../../../services/folders.service";
 import { ToastService } from "../../../services/toast.service";
 import { MemoryImportComponent } from "../memory-import/memory-import.component";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /**
  * "What the brain knows about you" — the user-memory audit section on the Brain
@@ -38,6 +39,7 @@ export class BrainMemoryComponent {
   private readonly ipc = inject(IpcService);
   private readonly folders = inject(FoldersService);
   private readonly toast = inject(ToastService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** Collapsed by default — the Brain page leads with sources, not memory. */
   readonly open = signal(false);
@@ -98,7 +100,7 @@ export class BrainMemoryComponent {
       this.memory.set(await this.ipc.getUserMemory());
     } catch (e) {
       this.memory.set(null);
-      this.error.set(String(e));
+      this.error.set(this.errorCopy.humanize(e));
     } finally {
       this.loading.set(false);
     }
@@ -112,7 +114,7 @@ export class BrainMemoryComponent {
       await this.fetch();
       this.toast.info("Forgotten.");
     } catch (e) {
-      this.toast.danger(String(e));
+      this.toast.danger(this.errorCopy.humanize(e));
     } finally {
       this.forgettingId.set(null);
     }
@@ -127,7 +129,7 @@ export class BrainMemoryComponent {
       this.confirmingClear.set(false);
       this.toast.info("Memory cleared.");
     } catch (e) {
-      this.toast.danger(String(e));
+      this.toast.danger(this.errorCopy.humanize(e));
     } finally {
       this.clearing.set(false);
     }

--- a/src/app/features/brain/brain/brain.component.ts
+++ b/src/app/features/brain/brain/brain.component.ts
@@ -29,6 +29,7 @@ import { BrainNoteEditorComponent } from "../brain-note-editor/brain-note-editor
 import { BrainSourceCardComponent } from "../brain-source-card/brain-source-card.component";
 import { BriefsComponent } from "../../briefs/briefs/briefs.component";
 import { AuditComponent } from "../../audit/audit/audit.component";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /** The hard cap the map applies — kept in sync with BrainMapComponent's MAX_NODES. */
 const MAP_NODE_CAP = 60;
@@ -99,6 +100,7 @@ export class BrainComponent {
   private readonly toast = inject(ToastService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly docPreview = inject(DocumentPreviewService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   // ── "Enable the brain" nudge — shown only when an on-device model is missing ─
   /**
@@ -277,7 +279,7 @@ export class BrainComponent {
 
   /**
    * A short, human progress line for the importing Documents card, e.g.
-   * "Extracting…" or "Embedding 12/40". Null unless an import is running.
+   * "Extracting…" or "Indexing 12/40". Null unless an import is running.
    */
   readonly importProgressLabel = computed<string | null>(() => {
     if (!this.importing()) {
@@ -296,9 +298,10 @@ export class BrainComponent {
       case "chunking":
         return "Chunking…";
       case "embedding":
+        // The backend stage id stays `embedding`; only the label a person reads changes.
         return p.total > 0
-          ? `Embedding ${p.done}/${p.total}`
-          : "Embedding…";
+          ? `Indexing ${p.done}/${p.total}`
+          : "Indexing…";
       case "done":
         return "Finishing…";
       default:
@@ -488,7 +491,7 @@ export class BrainComponent {
         return;
       }
       this.items.set([]);
-      this.listError.set(String(e));
+      this.listError.set(this.errorCopy.humanize(e));
     } finally {
       if (this.selectedFolderId() === folderId) {
         this.listLoading.set(false);
@@ -529,7 +532,7 @@ export class BrainComponent {
       this.graphData.set(await this.ipc.getGraph());
     } catch (e) {
       this.graphData.set(null);
-      this.graphError.set(String(e));
+      this.graphError.set(this.errorCopy.humanize(e));
     } finally {
       this.graphLoading.set(false);
     }
@@ -598,7 +601,7 @@ export class BrainComponent {
       this.docsExpanded.set(true);
       await this.afterMutation();
     } catch (e) {
-      this.toast.danger(this.friendlyImportError(e));
+      this.toast.danger(this.errorCopy.humanize(e, "brain-import"));
     } finally {
       this.importing.set(false);
       this.importProgress.set(null);
@@ -646,7 +649,7 @@ export class BrainComponent {
       this.noteEditorOpen.set(false);
       await this.afterMutation();
     } catch (e) {
-      this.toast.danger(this.friendlyImportError(e));
+      this.toast.danger(this.errorCopy.humanize(e, "brain-import"));
     } finally {
       this.savingNote.set(false);
     }
@@ -663,7 +666,7 @@ export class BrainComponent {
       this.toast.info(`Removed “${doc.name}”.`);
       await this.afterMutation();
     } catch (e) {
-      this.toast.danger(this.friendlyDeleteError(e));
+      this.toast.danger(this.errorCopy.humanize(e, "brain-delete"));
     } finally {
       this.deletingId.set(null);
     }
@@ -689,60 +692,4 @@ export class BrainComponent {
     await this.fetchOverview();
   }
 
-  /**
-   * Map a raw backend error string into a friendly, actionable message. The
-   * backend serializes `AppError` as `to_string()` — so the strings we match
-   * are the `import_document` / `extract` messages, prefixed by the variant tag
-   * (`"locked: …"`, `"invalid argument: …"`). Order matters: the SPECIFIC
-   * extraction failures are checked before the generic "unsupported type" one.
-   */
-  private friendlyImportError(e: unknown): string {
-    const msg = String(e);
-    // Write-gate: a sealed-not-unlocked folder ("locked: …").
-    if (/^locked:|\block/i.test(msg)) {
-      return "That folder is locked — unlock it first to add to the brain.";
-    }
-    // OCR ran but found nothing — a scanned PDF or an image with no readable
-    // text ("no text found in this document, even with OCR" / "no text found
-    // in this image"). Scanned PDFs now OCR automatically, so this is the only
-    // remaining no-text failure.
-    if (/no text found/i.test(msg)) {
-      return "No readable text found in that file, even after OCR.";
-    }
-    // Decompression-bomb guard ("document too large / possible zip bomb") —
-    // NOT an unsupported file type; say what actually stopped the import.
-    if (/zip bomb|document too large/i.test(msg)) {
-      return "That file expands beyond the safe import limit — it can’t be imported.";
-    }
-    // Extraction succeeded but yielded nothing ("this document has no
-    // extractable text") — the type IS supported, the file is just empty of text.
-    if (/no extractable text/i.test(msg)) {
-      return "No extractable text found in that file.";
-    }
-    // Encrypted / password-protected PDF.
-    if (/password-protected|password|encrypted/i.test(msg)) {
-      return "That PDF is password-protected — unlock it and try again.";
-    }
-    // Corrupt / unreadable / malformed file (bad zip, malformed XML, unreadable PDF).
-    if (
-      /could not read|could not open|could not render|not a valid|corrupt|malformed|bad (docx|pptx)/i.test(
-        msg,
-      )
-    ) {
-      return "That file couldn’t be read — it may be corrupt or in an unexpected format.";
-    }
-    // Unsupported extension (allowlist reject) — the catch-all invalid-argument case.
-    if (/unsupported document type|only .*md|invalid argument/i.test(msg)) {
-      return "That file type can’t be imported. Try Markdown, text, PDF, Word, PowerPoint, Excel, or HTML.";
-    }
-    return "Couldn’t add that to the brain. Please try again.";
-  }
-
-  private friendlyDeleteError(e: unknown): string {
-    const msg = String(e);
-    if (/lock/i.test(msg)) {
-      return "That folder is locked — unlock it first to delete its items.";
-    }
-    return "Couldn’t remove that. Please try again.";
-  }
 }

--- a/src/app/features/brain/document-preview/document-preview.component.ts
+++ b/src/app/features/brain/document-preview/document-preview.component.ts
@@ -15,6 +15,7 @@ import {
 import { IpcService } from "../../../core/ipc.service";
 import type { DocumentPreviewTarget, NoteRecipe } from "../../../core/models";
 import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /**
  * A read-only CONTENT PREVIEW for one brain document/note — presented as an
@@ -55,6 +56,7 @@ import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.comp
 export class DocumentPreviewComponent {
   private readonly ipc = inject(IpcService);
   private readonly injector = inject(Injector);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /**
    * The document/note to preview; null = the modal is closed (renders nothing).
@@ -235,26 +237,12 @@ export class DocumentPreviewComponent {
       if (this.doc()?.id !== id) {
         return;
       }
-      this.genError.set(this.friendlyGenError(String(e)));
+      this.genError.set(this.errorCopy.humanize(e, "doc-note"));
     } finally {
       if (this.doc()?.id === id) {
         this.generating.set(false);
       }
     }
-  }
-
-  /** Map a raw backend error string to a short, friendly message. */
-  private friendlyGenError(raw: string): string {
-    if (/locked/i.test(raw)) {
-      return "This document is in a locked folder — unlock it first.";
-    }
-    if (/consent|egress|Unavailable/i.test(raw)) {
-      return "Turn on your note provider (Settings) to make a note.";
-    }
-    if (/no extractable text|InvalidArg/i.test(raw)) {
-      return "This document has no text to turn into a note.";
-    }
-    return "Couldn’t make a note from this document. Please try again.";
   }
 
   /** Await the gated read; drop the response if the open doc changed since. */
@@ -269,7 +257,7 @@ export class DocumentPreviewComponent {
       if (this.doc()?.id !== id) {
         return;
       }
-      this.error.set(String(e));
+      this.error.set(this.errorCopy.humanize(e));
     } finally {
       if (this.doc()?.id === id) {
         this.loading.set(false);

--- a/src/app/features/brain/full-brain-graph/full-brain-graph.component.ts
+++ b/src/app/features/brain/full-brain-graph/full-brain-graph.component.ts
@@ -25,6 +25,7 @@ import {
   type FullSceneNode,
 } from "./full-brain-scene.directive";
 import { layoutFullBrain, layoutLayered } from "./full-brain-layout";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /** The two graph shapes: layered "neural" bands, or organic clustered islands. */
 type LayoutMode = "layers" | "clusters";
@@ -89,6 +90,7 @@ export class FullBrainGraphComponent {
   private readonly router = inject(Router);
   private readonly tabs = inject(TabsService);
   private readonly docPreview = inject(DocumentPreviewService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   private readonly scene = viewChild(FullBrainSceneDirective);
 
@@ -363,7 +365,7 @@ export class FullBrainGraphComponent {
             return;
           }
           this.graphData.set(null);
-          this.error.set(String(e));
+          this.error.set(this.errorCopy.humanize(e));
         } finally {
           if (mine === seq) {
             this.loading.set(false);

--- a/src/app/features/brain/memory-import/memory-import.component.ts
+++ b/src/app/features/brain/memory-import/memory-import.component.ts
@@ -8,6 +8,7 @@ import {
 } from "@angular/core";
 import { IpcService } from "../../../core/ipc.service";
 import { ToastService } from "../../../services/toast.service";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /**
  * Brain v2 L2.3 — "Import memories from another assistant": paste a ChatGPT /
@@ -30,6 +31,7 @@ import { ToastService } from "../../../services/toast.service";
 export class MemoryImportComponent {
   private readonly ipc = inject(IpcService);
   private readonly toast = inject(ToastService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** Fires after a successful import with the number of NEW facts added. */
   readonly imported = output<number>();
@@ -64,7 +66,7 @@ export class MemoryImportComponent {
         this.imported.emit(n);
       }
     } catch (e) {
-      this.toast.danger(String(e));
+      this.toast.danger(this.errorCopy.humanize(e));
     } finally {
       this.importing.set(false);
     }

--- a/src/app/features/briefs/briefs.store.ts
+++ b/src/app/features/briefs/briefs.store.ts
@@ -2,6 +2,7 @@ import { DestroyRef, Injectable, inject, signal } from "@angular/core";
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import { IpcService } from "../../core/ipc.service";
 import type { BriefRun, BriefSchedule } from "../../core/models";
+import { ErrorCopyService } from "../../core/copy/error-copy.service";
 
 /**
  * Brain v2 L5 — the SCHEDULED-BRIEFS store: schedules (config rows) + the
@@ -20,6 +21,7 @@ import type { BriefRun, BriefSchedule } from "../../core/models";
 export class BriefsStore {
   private readonly ipc = inject(IpcService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   private readonly _schedules = signal<BriefSchedule[]>([]);
   readonly schedules = this._schedules.asReadonly();
@@ -64,7 +66,7 @@ export class BriefsStore {
       this._pending.set(pending);
       this._error.set(null);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
     } finally {
       this._loading.set(false);
     }

--- a/src/app/features/briefs/briefs/briefs.component.ts
+++ b/src/app/features/briefs/briefs/briefs.component.ts
@@ -8,6 +8,7 @@ import {
 import type { BriefRun, BriefSchedule } from "../../../core/models";
 import { ToastService } from "../../../services/toast.service";
 import { BriefsStore } from "../briefs.store";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /** Weekday labels indexed by the backend convention: 0 = Monday … 6 = Sunday. */
 const WEEKDAYS = [
@@ -44,6 +45,7 @@ const WEEKDAYS = [
 export class BriefsComponent {
   protected readonly store = inject(BriefsStore);
   private readonly toast = inject(ToastService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** The user's manual collapse/expand toggle (click on `.br-toggle`). */
   readonly open = signal(false);
@@ -155,7 +157,7 @@ export class BriefsComponent {
       this.formHint.set("");
       this.toast.info("Brief scheduled.");
     } catch (e) {
-      this.toast.danger(String(e));
+      this.toast.danger(this.errorCopy.humanize(e));
     } finally {
       this.creating.set(false);
     }
@@ -166,7 +168,7 @@ export class BriefsComponent {
     try {
       await this.store.update({ ...s, enabled: !s.enabled });
     } catch (e) {
-      this.toast.danger(String(e));
+      this.toast.danger(this.errorCopy.humanize(e));
     } finally {
       this.busyId.set(null);
     }
@@ -177,7 +179,7 @@ export class BriefsComponent {
     try {
       await this.store.remove(s.id);
     } catch (e) {
-      this.toast.danger(String(e));
+      this.toast.danger(this.errorCopy.humanize(e));
     } finally {
       this.busyId.set(null);
     }
@@ -189,7 +191,7 @@ export class BriefsComponent {
       await this.store.accept(run.id);
       this.toast.info("Brief saved to your vault (Briefs/).");
     } catch (e) {
-      this.toast.danger(String(e));
+      this.toast.danger(this.errorCopy.humanize(e));
     } finally {
       this.busyId.set(null);
     }
@@ -200,7 +202,7 @@ export class BriefsComponent {
     try {
       await this.store.dismiss(run.id);
     } catch (e) {
-      this.toast.danger(String(e));
+      this.toast.danger(this.errorCopy.humanize(e));
     } finally {
       this.busyId.set(null);
     }

--- a/src/app/features/detail/detail/detail.component.ts
+++ b/src/app/features/detail/detail/detail.component.ts
@@ -58,6 +58,7 @@ import {
 } from "../note-panel/note-panel.component";
 import { SharePanelComponent } from "../share-panel/share-panel.component";
 import { VerifyPanelComponent } from "../verify-panel/verify-panel.component";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /** One checklist entry parsed from a `- [ ]` / `- [x]` action-item line. */
 interface ActionItem {
@@ -86,6 +87,7 @@ export class DetailComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly injector = inject(Injector);
+  private readonly errorCopy = inject(ErrorCopyService);
   /** Environment (root) injector — hosts the detach-proof root lock effect. */
   private readonly envInjector = inject(EnvironmentInjector);
   private readonly destroyRef = inject(DestroyRef);
@@ -1185,11 +1187,15 @@ export class DetailComponent implements OnInit {
         }
       }
     } catch (e) {
-      // Biometric denied / cancelled, or the unlock errored — stay gated. Surface the REAL backend
-      // error (AppError crosses the IPC as a string): a keychain OSStatus or a "content-key unwrap
-      // failed" tells the user (and a field screenshot tells us) what actually broke — the old
-      // generic apology made signed-build failures undiagnosable.
-      this.toast.danger(`Couldn’t unlock — ${String(e)}`);
+      // Biometric denied / cancelled, or the unlock errored — stay gated.
+      //
+      // This used to render the RAW backend error on purpose, so a field screenshot of a signed
+      // build showed the keychain OSStatus or a "content-key unwrap failed". P3 ends that: the same
+      // channel carries key-material vocabulary (KEK/CK/"mutex poisoned"), and the lock gate is the
+      // last surface that may leak it. A cancel and an auth failure are still told apart — by the
+      // `[touch-id-*]` code under the "unlock" context, not by prose — and the escape hatch below
+      // is unchanged, so a genuinely lost key is still recoverable.
+      this.toast.danger(this.errorCopy.humanize(e, "unlock"));
       // Reveal the reset escape hatch — the key may be genuinely gone (the backend still re-proves
       // non-recoverability before it will discard anything).
       this.unlockFailed.set(true);
@@ -1223,7 +1229,7 @@ export class DetailComponent implements OnInit {
       );
     } catch (e) {
       // Most importantly: the backend REFUSES when the folder is actually recoverable.
-      this.toast.danger(`Couldn’t reset — ${String(e)}`);
+      this.toast.danger(this.errorCopy.because("Couldn’t reset", e));
     } finally {
       this.discarding.set(false);
     }
@@ -1376,7 +1382,7 @@ export class DetailComponent implements OnInit {
       }
       this.flashPin(`Pinned ${result.mmss} — Obsidian link copied`);
     } catch (e) {
-      this.pinError.set("Couldn’t pin: " + String(e));
+      this.pinError.set(this.errorCopy.because("Couldn’t pin", e));
     } finally {
       this.pinning.set(false);
     }
@@ -1447,7 +1453,7 @@ export class DetailComponent implements OnInit {
       this.graph.set(await this.ipc.linkMeetingEntities(id));
     } catch (e) {
       this.graph.set(null);
-      this.graphError.set("Couldn’t connect to graph: " + String(e));
+      this.graphError.set(this.errorCopy.because("Couldn’t connect to graph", e));
     } finally {
       this.linking.set(false);
     }
@@ -1466,7 +1472,7 @@ export class DetailComponent implements OnInit {
       }
       this.msg.set("Done.");
     } catch (e) {
-      this.msg.set("Error: " + String(e));
+      this.msg.set(this.errorCopy.because("Couldn’t rewrite the note", e));
     } finally {
       this.busy.set(false);
     }
@@ -1516,7 +1522,7 @@ export class DetailComponent implements OnInit {
       this.tabsService.setTitle(tabKeyFor("meeting", id), title);
       this.renaming.set(false);
     } catch (e) {
-      this.msg.set("Couldn’t rename: " + String(e));
+      this.msg.set(this.errorCopy.because("Couldn’t rename", e));
     } finally {
       this.savingRename.set(false);
     }
@@ -1547,7 +1553,7 @@ export class DetailComponent implements OnInit {
       await this.ipc.deleteMeeting(id);
       await this.router.navigateByUrl("/library");
     } catch (e) {
-      this.deleteError.set("Couldn’t delete: " + String(e));
+      this.deleteError.set(this.errorCopy.because("Couldn’t delete", e));
       this.deleting.set(false);
     }
   }
@@ -1602,7 +1608,7 @@ export class DetailComponent implements OnInit {
       this.draft.set(this.detail()?.note?.markdown ?? "");
       this.editing.set(false);
     } catch (e) {
-      this.saveError.set("Couldn’t discard added images: " + String(e));
+      this.saveError.set(this.errorCopy.because("Couldn’t discard added images", e));
     } finally {
       this.saving.set(false);
     }
@@ -1656,7 +1662,7 @@ export class DetailComponent implements OnInit {
       this.editing.set(false);
       this.flashSaved();
     } catch (e) {
-      this.saveError.set("Couldn’t save: " + String(e));
+      this.saveError.set(this.errorCopy.because("Couldn’t save", e));
     } finally {
       this.saving.set(false);
     }
@@ -1736,7 +1742,7 @@ export class DetailComponent implements OnInit {
       await this.ipc.setMeetingTags(id, next);
     } catch (e) {
       this.tags.set(previous);
-      this.tagsError.set("Couldn’t save tags: " + String(e));
+      this.tagsError.set(this.errorCopy.because("Couldn’t save tags", e));
     } finally {
       this.tagsBusy.set(false);
     }
@@ -1771,7 +1777,7 @@ export class DetailComponent implements OnInit {
       await navigator.clipboard.writeText(markdown);
       this.flashExport("md-copied");
     } catch (e) {
-      this.exportError.set("Couldn’t copy: " + String(e));
+      this.exportError.set(this.errorCopy.because("Couldn’t copy", e));
     }
   }
 
@@ -1796,7 +1802,7 @@ export class DetailComponent implements OnInit {
         this.flashExport("md-saved");
       }
     } catch (e) {
-      this.exportError.set("Couldn’t save markdown: " + String(e));
+      this.exportError.set(this.errorCopy.because("Couldn’t save markdown", e));
     } finally {
       this.exporting.set(false);
     }
@@ -1823,7 +1829,7 @@ export class DetailComponent implements OnInit {
         this.flashExport("audio-saved");
       }
     } catch (e) {
-      this.exportError.set("Couldn’t save audio: " + String(e));
+      this.exportError.set(this.errorCopy.because("Couldn’t save audio", e));
     } finally {
       this.exporting.set(false);
     }
@@ -1874,16 +1880,19 @@ export class DetailComponent implements OnInit {
    * export; a missing per-stream archive → none was kept; anything else verbatim.
    */
   private masterErrorMessage(stream: "mic" | "sys", error: unknown): string {
-    const raw = String(error);
-    if (/locked/i.test(raw)) {
+    if (this.errorCopy.is(error, "meeting-locked")) {
       return "This meeting is locked — unlock it to export the master.";
     }
-    if (/no master/i.test(raw)) {
+    // "no master for that stream" is an `InvalidArg` with no code (it is not a failure the user
+    // can act on beyond knowing it), and it is the ONE remaining prose test on this path. It reads
+    // an `export.rs` string that has no other consumer; recorded in `errcode.rs`'s prose-coupling
+    // note so a future reword cannot break it silently.
+    if (/no master/i.test(String(error))) {
       return stream === "mic"
         ? "No hi-res mic master was kept for this meeting."
         : "No hi-res system master was kept for this meeting.";
     }
-    return "Couldn’t export the master: " + raw;
+    return this.errorCopy.because("Couldn’t export the master", error);
   }
 
   /**
@@ -1920,7 +1929,7 @@ export class DetailComponent implements OnInit {
       const path = await this.ipc.exportCanvas(id);
       this.flashCanvas(path);
     } catch (e) {
-      this.canvasError.set("Couldn’t export Canvas: " + String(e));
+      this.canvasError.set(this.errorCopy.because("Couldn’t export Canvas", e));
     } finally {
       this.exportingCanvas.set(false);
     }

--- a/src/app/features/detail/meeting-actions/meeting-actions.component.ts
+++ b/src/app/features/detail/meeting-actions/meeting-actions.component.ts
@@ -10,6 +10,7 @@ import {
 } from "@angular/core";
 import { IpcService } from "../../../core/ipc.service";
 import type { ActionItem } from "../../../core/models";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /**
  * "Action items" — a glass panel listing the action-item checklist parsed from a
@@ -38,6 +39,7 @@ import type { ActionItem } from "../../../core/models";
 export class MeetingActionsComponent implements OnInit {
   private readonly ipc = inject(IpcService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** The meeting whose note's action items are listed + patched. */
   readonly meetingId = input.required<string>();
@@ -104,13 +106,18 @@ export class MeetingActionsComponent implements OnInit {
     }
   }
 
-  /** Map a Reminders failure to a clear message (permission denial → settings). */
+  /**
+   * Map a Reminders failure to a clear message (permission denial → settings).
+   *
+   * Keyed on the `[reminders-denied]` code (`errcode::REMINDERS_DENIED`) rather than on a
+   * `/permission|denied|access|authoriz|not allowed/` sweep over the raw string — that sweep also
+   * matched unrelated failures, and it rendered the osascript stderr verbatim on the miss.
+   */
   private reminderErrorMessage(error: unknown): string {
-    const raw = String(error);
-    if (/permission|denied|access|authoriz|not allowed/i.test(raw)) {
+    if (this.errorCopy.is(error, "reminders-denied")) {
       return "Grant Reminders access in System Settings.";
     }
-    return "Couldn’t add to Reminders: " + raw;
+    return this.errorCopy.because("Couldn’t add to Reminders", error);
   }
 
   // --- Save to Obsidian Tasks ---------------------------------------------
@@ -132,7 +139,7 @@ export class MeetingActionsComponent implements OnInit {
       await this.loadItems();
       this.flashPatchSaved();
     } catch (e) {
-      this.patchError.set("Couldn’t save to your note: " + String(e));
+      this.patchError.set(this.errorCopy.because("Couldn’t save to your note", e));
     } finally {
       this.patching.set(false);
     }

--- a/src/app/features/detail/meeting-chat/meeting-chat.component.ts
+++ b/src/app/features/detail/meeting-chat/meeting-chat.component.ts
@@ -17,6 +17,7 @@ import type { ChatTurn, SourceRef } from "../../../core/models";
 import { SourceScopeService } from "../../../services/source-scope.service";
 import { SourcePickerComponent } from "../../../design-system/source-picker/source-picker.component";
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /** The starter prompts shown in the empty state — tap to ask immediately. */
 const STARTERS: readonly string[] = [
@@ -50,6 +51,7 @@ export class MeetingChatComponent {
   private readonly ipc = inject(IpcService);
   private readonly injector = inject(Injector);
   private readonly sourceScope = inject(SourceScopeService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** The anchor meeting whose transcript supplies the primary grounding. */
   readonly meetingId = input.required<string>();
@@ -221,7 +223,7 @@ export class MeetingChatComponent {
       ]);
     } catch (e) {
       // Keep the user's question in the log so Retry can re-send it.
-      this.error.set("Couldn’t get an answer: " + String(e));
+      this.error.set(this.errorCopy.because("Couldn’t get an answer", e));
     } finally {
       this.pending.set(false);
       this.scrollToLatest();

--- a/src/app/features/detail/meeting-recipes/meeting-recipes.component.ts
+++ b/src/app/features/detail/meeting-recipes/meeting-recipes.component.ts
@@ -15,6 +15,7 @@ import {
 import { IpcService } from "../../../core/ipc.service";
 import type { BuiltinRecipe, SavedRecipe } from "../../../core/models";
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /**
  * "Recipes / Generate" — one-tap grounded generations over a single meeting's
@@ -42,6 +43,7 @@ export class MeetingRecipesComponent implements OnInit {
   private readonly ipc = inject(IpcService);
   private readonly injector = inject(Injector);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** The meeting whose transcript grounds every generation. */
   readonly meetingId = input.required<string>();
@@ -161,7 +163,7 @@ export class MeetingRecipesComponent implements OnInit {
       this.scrollToOutput();
     } catch (e) {
       // Keep lastPrompt so Retry can re-run the same recipe.
-      this.error.set("Couldn’t generate: " + String(e));
+      this.error.set(this.errorCopy.because("Couldn’t generate", e));
     } finally {
       this.pending.set(false);
     }
@@ -188,7 +190,7 @@ export class MeetingRecipesComponent implements OnInit {
       await this.ipc.deleteRecipe(id);
       await this.refreshRecipes();
     } catch (e) {
-      this.error.set("Couldn’t delete recipe: " + String(e));
+      this.error.set(this.errorCopy.because("Couldn’t delete recipe", e));
     } finally {
       this.deletingId.set(null);
     }
@@ -212,7 +214,7 @@ export class MeetingRecipesComponent implements OnInit {
       await this.ipc.saveRecipe(title, prompt);
       await this.refreshRecipes();
     } catch (e) {
-      this.error.set("Couldn’t save recipe: " + String(e));
+      this.error.set(this.errorCopy.because("Couldn’t save recipe", e));
     }
   }
 

--- a/src/app/features/detail/note-panel/note-panel.component.ts
+++ b/src/app/features/detail/note-panel/note-panel.component.ts
@@ -31,6 +31,7 @@ import {
   type AttachmentPastePlan,
   type MarkdownEdit,
 } from "../../../services/note-attachment.service";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /** One checklist entry parsed from a `- [ ]` / `- [x]` action-item line. */
 export interface ActionItemLine {
@@ -144,6 +145,7 @@ export class NotePanelComponent {
   private readonly attachmentService = inject(NoteAttachmentService);
   private readonly toast = inject(ToastService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly errorCopy = inject(ErrorCopyService);
   private destroyed = false;
 
   constructor() {
@@ -397,7 +399,7 @@ export class NotePanelComponent {
         } catch (error) {
           if (this.meetingId() === meetingId && this.editing()) {
             this.replacePendingAttachment(id, "");
-            this.toast.danger(String(error));
+            this.toast.danger(this.errorCopy.humanize(error));
           }
         }
       }

--- a/src/app/features/detail/org-share-sheet/org-share-sheet.component.ts
+++ b/src/app/features/detail/org-share-sheet/org-share-sheet.component.ts
@@ -20,6 +20,7 @@ import type {
   OrgStatus,
 } from "../../../core/models";
 import { MurSelectComponent } from "../../../design-system/select/select.component";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /**
  * Which local source this sheet is publishing to the org brain — a recorded
@@ -67,6 +68,7 @@ export interface OrgShareTarget {
 export class OrgShareSheetComponent {
   private readonly ipc = inject(IpcService);
   private readonly injector = inject(Injector);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** The local source (meeting / note) being published. */
   readonly target = input.required<OrgShareTarget>();
@@ -190,7 +192,7 @@ export class OrgShareSheetComponent {
         this.selectedOrgId.set(list[0].orgId);
       }
     } catch (e) {
-      this.orgsError.set(String(e));
+      this.orgsError.set(this.errorCopy.humanize(e));
     } finally {
       this.orgsLoading.set(false);
     }
@@ -239,7 +241,7 @@ export class OrgShareSheetComponent {
       if (this.target().id !== t.id || this.scrub() !== scrub) {
         return;
       }
-      this.previewError.set(this.friendlyError(String(e)));
+      this.previewError.set(this.errorCopy.humanize(e, "org-share"));
       this._preview.set(null);
     } finally {
       if (this.target().id === t.id && this.scrub() === scrub) {
@@ -283,7 +285,7 @@ export class OrgShareSheetComponent {
       }
       this.shared.emit();
     } catch (e) {
-      this.shareError.set(this.friendlyError(String(e)));
+      this.shareError.set(this.errorCopy.humanize(e, "org-share"));
     } finally {
       this.sharing.set(false);
     }
@@ -292,17 +294,6 @@ export class OrgShareSheetComponent {
   /** Cancel — nothing left the device. */
   cancel(): void {
     this.cancelled.emit();
-  }
-
-  /** A `Locked`/consent error → a plain message; else the raw backend error. */
-  private friendlyError(raw: string): string {
-    if (/Locked/i.test(raw)) {
-      return "This item is locked — unlock its folder before adding it to the org brain.";
-    }
-    if (/consent/i.test(raw)) {
-      return "You haven't allowed org sharing yet. Grant org-sharing consent in Settings → Organization.";
-    }
-    return raw;
   }
 
   /** Presentational: a byte count → a compact size label. */

--- a/src/app/features/detail/share-panel/share-panel.component.ts
+++ b/src/app/features/detail/share-panel/share-panel.component.ts
@@ -28,6 +28,7 @@ import {
   type OrgShareTarget,
 } from "../org-share-sheet/org-share-sheet.component";
 import { MurOrgBrainCtaComponent } from "../../../design-system/org-brain-cta/org-brain-cta.component";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /** The step the in-flow "Share with a person" panel is showing. */
 export type PersonShareStep = "email" | "suggest-link" | "consent" | "result";
@@ -88,6 +89,7 @@ export interface LinkShareRow {
 export class SharePanelComponent {
   private readonly ipc = inject(IpcService);
   private readonly injector = inject(Injector);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   // --- Inputs from the shell ------------------------------------------------
   /** THIS meeting's id (null while the detail is loading), the shares filter key. */
@@ -407,8 +409,8 @@ export class SharePanelComponent {
       // the link/person share UI above.
       void this.refreshOrg(id);
     } catch (e) {
-      this.listError.set(String(e));
-      this.gateError.set(String(e));
+      this.listError.set(this.errorCopy.humanize(e));
+      this.gateError.set(this.errorCopy.humanize(e));
     } finally {
       this.loading.set(false);
     }
@@ -501,22 +503,19 @@ export class SharePanelComponent {
       }
     } catch (e) {
       this._biometricFailed.set(true);
-      this.gateError.set(this.friendlyUnlockError(String(e)));
+      // LOCK GATE. The copy is owned by `ErrorCopyService` under the "meeting-share" context, which
+      // distinguishes a Touch ID CANCEL from a Touch ID FAILURE by the `[touch-id-*]` code rather
+      // than by regex-matching the word "cancel" in whatever the keychain happened to say.
+      //
+      // The raw backend cause is no longer appended. It used to be, deliberately, so a signed build
+      // could be field-debugged from the screen — but the same string carries keychain OSStatus
+      // internals ("account-session mutex poisoned", "HKDF expand failed"), and a share gate is
+      // exactly the surface where that is least acceptable. The gate itself is UNCHANGED: this
+      // still fails closed, still sets `_biometricFailed`, still offers the password path.
+      this.gateError.set(this.errorCopy.humanize(e, "meeting-share"));
     } finally {
       this.unlocking.set(false);
     }
-  }
-
-  /**
-   * Turn a raw biometric-unlock error into a friendly fall-back message. The raw backend error is
-   * APPENDED (not swallowed) — field debugging of the signed build depends on the real cause
-   * reaching the screen (keychain OSStatus, "no cached account key", …), not a generic apology.
-   */
-  private friendlyUnlockError(raw: string): string {
-    if (/cancel/i.test(raw)) {
-      return "Touch ID was cancelled. Use Unlock for sharing to unlock with your password.";
-    }
-    return `Couldn't unlock with Touch ID — ${raw}. Use Unlock for sharing to unlock with your password.`;
   }
 
   // --- CONFIGURE handlers ---------------------------------------------------
@@ -557,7 +556,7 @@ export class SharePanelComponent {
         this.accountStatus.set({ ...s, shareConsented: true });
       }
     } catch (e) {
-      this.createError.set(String(e));
+      this.createError.set(this.errorCopy.humanize(e));
     } finally {
       this.consenting.set(false);
     }
@@ -608,7 +607,7 @@ export class SharePanelComponent {
       await this.refresh();
       this.changed.emit();
     } catch (e) {
-      this.createError.set(String(e));
+      this.createError.set(this.errorCopy.humanize(e));
     } finally {
       this.creating.set(false);
     }
@@ -678,7 +677,7 @@ export class SharePanelComponent {
       await this.refresh();
       this.changed.emit();
     } catch (e) {
-      this.listError.set(String(e));
+      this.listError.set(this.errorCopy.humanize(e));
       await this.refresh();
     } finally {
       this.revokingId.set(null);
@@ -787,7 +786,7 @@ export class SharePanelComponent {
         await this.sendToUser();
       }
     } catch (e) {
-      this.personError.set(String(e));
+      this.personError.set(this.errorCopy.humanize(e));
     } finally {
       this.personBusy.set(false);
     }
@@ -833,7 +832,7 @@ export class SharePanelComponent {
       await this.ipc.consentToShareEgress();
       await this.sendToUser();
     } catch (e) {
-      this.personError.set(String(e));
+      this.personError.set(this.errorCopy.humanize(e));
     } finally {
       this.personBusy.set(false);
     }
@@ -860,14 +859,16 @@ export class SharePanelComponent {
       await this.refresh();
       this.changed.emit();
     } catch (e) {
-      const msg = String(e);
-      if (/consent/i.test(msg)) {
+      // A missing one-time upload consent is not an error the user should read — it is a STEP.
+      // Matched on the `[share-consent]` code (`errcode::SHARE_CONSENT`), not on the word
+      // "consent" appearing somewhere in a backend sentence.
+      if (this.errorCopy.is(e, "share-consent")) {
         this.verifyMode.set(null);
         this.personOpen.set(true);
         this.personStep.set("consent");
         this.personError.set(null);
       } else {
-        this.personError.set(msg);
+        this.personError.set(this.errorCopy.humanize(e, "meeting-share"));
       }
     }
   }

--- a/src/app/features/detail/stage2-panel/stage2-panel.component.ts
+++ b/src/app/features/detail/stage2-panel/stage2-panel.component.ts
@@ -9,6 +9,7 @@ import {
 } from "@angular/core";
 import { IpcService } from "../../../core/ipc.service";
 import type { ContextHit } from "../../../core/models";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /**
  * LIVE-CONTEXT affordance (docs/research/2026-07-06-note-and-brain-architecture.md §3 / §6 / §8-Phase 3).
@@ -37,6 +38,7 @@ import type { ContextHit } from "../../../core/models";
 })
 export class Stage2PanelComponent {
   private readonly ipc = inject(IpcService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   readonly meetingId = input.required<string>();
   /** Fires after Lane A links / Lane B hits are applied so the parent reloads the note. */
@@ -88,7 +90,7 @@ export class Stage2PanelComponent {
     try {
       this.hits.set(await this.ipc.enrichNoteContext(this.meetingId()));
     } catch (e) {
-      this.error.set(e instanceof Error ? e.message : String(e));
+      this.error.set(this.errorCopy.humanize(e));
     } finally {
       this.running.set(false);
     }
@@ -117,7 +119,7 @@ export class Stage2PanelComponent {
       this.applied.set(true);
       this.noteChanged.emit();
     } catch (e) {
-      this.error.set(e instanceof Error ? e.message : String(e));
+      this.error.set(this.errorCopy.humanize(e));
     } finally {
       this.running.set(false);
     }
@@ -144,7 +146,7 @@ export class Stage2PanelComponent {
       this.applied.set(false);
       this.noteChanged.emit();
     } catch (e) {
-      this.error.set(e instanceof Error ? e.message : String(e));
+      this.error.set(this.errorCopy.humanize(e));
     } finally {
       this.running.set(false);
     }

--- a/src/app/features/detail/verify-panel/verify-panel.component.ts
+++ b/src/app/features/detail/verify-panel/verify-panel.component.ts
@@ -8,6 +8,7 @@ import {
 } from "@angular/core";
 import { IpcService } from "../../../core/ipc.service";
 import type { VerifyFindingDto } from "../../../core/models";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /**
  * VERIFY WITH JIRA — on-demand deterministic check of the note's ticket claims against LIVE Jira
@@ -23,6 +24,7 @@ import type { VerifyFindingDto } from "../../../core/models";
 })
 export class VerifyPanelComponent {
   private readonly ipc = inject(IpcService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   readonly meetingId = input.required<string>();
   /** Fires after markers are applied so the parent reloads the note. */
@@ -47,7 +49,7 @@ export class VerifyPanelComponent {
     try {
       this.findings.set(await this.ipc.verifyNoteSources(this.meetingId()));
     } catch (e) {
-      this.error.set(e instanceof Error ? e.message : String(e));
+      this.error.set(this.errorCopy.humanize(e));
     } finally {
       this.running.set(false);
     }
@@ -64,7 +66,7 @@ export class VerifyPanelComponent {
       this.applied.set(true);
       this.noteChanged.emit();
     } catch (e) {
-      this.error.set(e instanceof Error ? e.message : String(e));
+      this.error.set(this.errorCopy.humanize(e));
     } finally {
       this.running.set(false);
     }

--- a/src/app/features/graph/entity-detail/entity-detail.component.ts
+++ b/src/app/features/graph/entity-detail/entity-detail.component.ts
@@ -19,6 +19,7 @@ import type {
 } from "../../../core/models";
 import { SourcesComponent } from "../../../shared/sources/sources.component";
 import { EntityNeighborhoodComponent } from "../entity-neighborhood/entity-neighborhood.component";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /** The two selectable comparison windows for the decision ledger's `from` bound. */
 type LedgerRange = "90d" | "all";
@@ -59,6 +60,7 @@ interface DiffRowVm {
 export class EntityDetailComponent {
   private readonly ipc = inject(IpcService);
   private readonly router = inject(Router);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** The entity to show detail for; changing it re-loads the panel. */
   readonly entityId = input.required<string>();
@@ -177,7 +179,7 @@ export class EntityDetailComponent {
         return;
       }
       this.detail.set(null);
-      this.error.set(String(e));
+      this.error.set(this.errorCopy.humanize(e));
     } finally {
       if (this.entityId() === id) {
         this.loading.set(false);

--- a/src/app/features/graph/graph/graph.component.ts
+++ b/src/app/features/graph/graph/graph.component.ts
@@ -14,6 +14,7 @@ import type { GraphData, GraphNode } from "../../../core/models";
 import { FoldersService } from "../../../services/folders.service";
 import { EntityCardComponent } from "../entity-card/entity-card.component";
 import { EntityDetailComponent } from "../entity-detail/entity-detail.component";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 type KindFilter = "all" | "person" | "project";
 type SortKey = "mentions" | "name";
@@ -50,6 +51,7 @@ export class GraphComponent {
   private readonly ipc = inject(IpcService);
   private readonly folders = inject(FoldersService);
   private readonly route = inject(ActivatedRoute);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /**
    * An optional `?entity=<id>` query param — the entry point the full-brain
@@ -204,7 +206,7 @@ export class GraphComponent {
       }
     } catch (e) {
       this.graphData.set(null);
-      this.error.set(String(e));
+      this.error.set(this.errorCopy.humanize(e));
     } finally {
       this.loading.set(false);
     }

--- a/src/app/features/library/library/library.component.html
+++ b/src/app/features/library/library/library.component.html
@@ -201,11 +201,11 @@
                     hit.meeting.title || "(untitled)"
                   }}</span>
                   <span class="meta">
-                    <span
-                      class="badge"
-                      [class]="matchBadgeClass(hit.matchedIn)"
-                      >{{ matchLabel(hit.matchedIn) }}</span
-                    >
+                    @if (hit.whereMatched) {
+                      <span class="badge" [class]="hit.badgeClass">{{
+                        hit.whereMatched
+                      }}</span>
+                    }
                     <span class="date">{{
                       formatDate(hit.meeting.startedAt)
                     }}</span>

--- a/src/app/features/library/library/library.component.ts
+++ b/src/app/features/library/library/library.component.ts
@@ -41,6 +41,7 @@ import { NoteDragService } from "../../folders/note-drag.service";
 import { ToastService } from "../../../services/toast.service";
 import { MeetingsViewSwitcherComponent } from "../meetings-view-switcher/meetings-view-switcher.component";
 import { MeetingsTableViewComponent } from "../meetings-table-view/meetings-table-view.component";
+import { matchedInLabel } from "../../../core/copy/labels";
 
 /** Debounce window for search-as-you-type — quick enough to feel instant. */
 const SEARCH_DEBOUNCE_MS = 180;
@@ -49,6 +50,36 @@ const SEARCH_DEBOUNCE_MS = 180;
 interface SnippetPart {
   text: string;
   hit: boolean;
+}
+
+/**
+ * A search hit with its presentation already resolved.
+ *
+ * The template renders these fields directly instead of calling a helper per row: a method
+ * binding inside a `@for` re-runs on every change-detection pass for every visible row, which
+ * the zoneless rules table bans in favour of a `computed()` view model.
+ */
+interface SearchRow extends SearchHit {
+  /** Human label for the field the hit matched in — `""` when it cannot be named. */
+  readonly whereMatched: string;
+  /** Tint class for the matched-in badge. */
+  readonly badgeClass: string;
+}
+
+/**
+ * Tint the matched-in badge: transcript/note = accent, title = neutral.
+ *
+ * A pure module function, not a component method, so it cannot be reached from a template.
+ */
+function matchBadgeClass(matchedIn: string): string {
+  switch (matchedIn) {
+    case "transcript":
+      return "is-accent";
+    case "note":
+      return "is-success";
+    default:
+      return "";
+  }
 }
 
 /**
@@ -617,13 +648,25 @@ export class LibraryComponent implements OnInit {
    * meetings carrying the tag, and hits outside it are dropped. "All" (null tag)
    * passes every hit through untouched.
    */
-  readonly displayedResults = computed(() => {
+  readonly displayedResults = computed<SearchRow[]>(() => {
     const hits = this.results();
-    if (this.activeTag() === null) {
-      return hits;
+    let narrowed = hits;
+    if (this.activeTag() !== null) {
+      const ids = this.tagMeetingIds();
+      narrowed = hits.filter((h) => ids.has(h.meeting.id));
     }
-    const ids = this.tagMeetingIds();
-    return hits.filter((h) => ids.has(h.meeting.id));
+    // The matched-in label and its tint are resolved HERE, once per hit, rather than by
+    // template method calls inside the `@for` — a method binding re-runs on every change
+    // detection pass for every visible row, and the rules table bans it outright.
+    //
+    // `matchedInLabel` returns "" for a value it cannot name, and the template renders NO
+    // badge for "". The old `default: "title"` arm asserted the hit was in the TITLE for any
+    // unrecognised value — a confident lie rather than an absent answer.
+    return narrowed.map((hit) => ({
+      ...hit,
+      whereMatched: matchedInLabel(hit.matchedIn),
+      badgeClass: matchBadgeClass(hit.matchedIn),
+    }));
   });
 
   /**
@@ -1020,30 +1063,6 @@ export class LibraryComponent implements OnInit {
       parts.push({ text: snippet.slice(from), hit: false });
     }
     return parts;
-  }
-
-  /** Human label for the field a hit matched in. */
-  matchLabel(matchedIn: string): string {
-    switch (matchedIn) {
-      case "transcript":
-        return "in transcript";
-      case "note":
-        return "in note";
-      default:
-        return "title";
-    }
-  }
-
-  /** Tint the matched-in badge: transcript/note = accent, title = neutral. */
-  matchBadgeClass(matchedIn: string): string {
-    switch (matchedIn) {
-      case "transcript":
-        return "is-accent";
-      case "note":
-        return "is-success";
-      default:
-        return "";
-    }
   }
 
   /** Presentational only: render the stored timestamp as a friendly local date. */

--- a/src/app/features/notes/note-brain-popover/note-brain-popover.component.ts
+++ b/src/app/features/notes/note-brain-popover/note-brain-popover.component.ts
@@ -31,6 +31,7 @@ import {
 } from "./note-assist-catalog";
 import { RepositionOnScrollDirective } from "./reposition-on-scroll.directive";
 import { TeleportToBodyDirective } from "../../../design-system/teleport-to-body.directive";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /** The live text selection the popover acts on, plus its viewport anchor rect. */
 export interface PopoverSelection {
@@ -123,6 +124,7 @@ export class NoteBrainPopoverComponent {
   private readonly destroyRef = inject(DestroyRef);
   private readonly router = inject(Router);
   private readonly tabsService = inject(TabsService);
+  private readonly errorCopy = inject(ErrorCopyService);
   /** Root-owned timer service — the sanctioned home for the step-animation tick (rule §5). */
   private readonly timers = inject(TimerService);
 
@@ -395,7 +397,7 @@ export class NoteBrainPopoverComponent {
         return;
       }
       this.clearStepTimers();
-      this.errorMsg.set(String(e));
+      this.errorMsg.set(this.errorCopy.humanize(e));
       this.phase.set("error");
     }
   }

--- a/src/app/features/notes/note-chat/note-chat.component.ts
+++ b/src/app/features/notes/note-chat/note-chat.component.ts
@@ -17,6 +17,7 @@ import type { ChatTurn, SourceRef } from "../../../core/models";
 import { SourceScopeService } from "../../../services/source-scope.service";
 import { SourcePickerComponent } from "../../../design-system/source-picker/source-picker.component";
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /** The starter prompts shown in the empty state — tap to ask immediately. */
 const STARTERS: readonly string[] = [
@@ -52,6 +53,7 @@ export class NoteChatComponent {
   private readonly ipc = inject(IpcService);
   private readonly injector = inject(Injector);
   private readonly sourceScope = inject(SourceScopeService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** The note whose content grounds every answer (the pre-fill anchor). */
   readonly noteId = input.required<string>();
@@ -236,7 +238,7 @@ export class NoteChatComponent {
       ]);
     } catch (e) {
       // Keep the user's question in the log so Retry can re-send it.
-      this.error.set("Couldn’t get an answer: " + String(e));
+      this.error.set(this.errorCopy.because("Couldn’t get an answer", e));
     } finally {
       this.pending.set(false);
       this.scrollToLatest();

--- a/src/app/features/notes/note-editor/note-editor.component.ts
+++ b/src/app/features/notes/note-editor/note-editor.component.ts
@@ -66,6 +66,7 @@ import {
   type PropertyKind,
   type PropertySchemaField,
 } from "./property-field-types";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /** The autosave indicator state. */
 type SaveState = "idle" | "saving" | "saved" | "error";
@@ -199,6 +200,7 @@ export class NoteEditorComponent {
   private readonly tabsService = inject(TabsService);
   private readonly tabRouteReuse = inject(TabRouteReuseStrategy);
   private readonly injector = inject(Injector);
+  private readonly errorCopy = inject(ErrorCopyService);
   /** Environment (root) injector — hosts the detach-proof root lock effect. */
   private readonly envInjector = inject(EnvironmentInjector);
   private readonly destroyRef = inject(DestroyRef);
@@ -310,13 +312,15 @@ export class NoteEditorComponent {
   /** The autosave indicator. */
   readonly saveState = signal<SaveState>("idle");
   /**
-   * The real `AppError` message behind the last failed save (root-cause fix,
-   * 2026-07-15) — surfaced as a tooltip on the "Save failed" pill instead of
-   * being swallowed. `AppError` is `Serialize` and crosses IPC as its display
-   * string (see `.claude/rules/rust-tauri.md` §1), so `String(e)` already IS
-   * the real backend message; the bug was that only a `"Locked"` substring
-   * check ever surfaced ANYTHING to the user — every other rejection (e.g. a
-   * transient storage error) showed a blank, undiagnosable red banner.
+   * What went wrong behind the last failed save — surfaced as a tooltip on the "Save failed" pill
+   * instead of being swallowed (root-cause fix, 2026-07-15: before it, every rejection other than
+   * a lock refusal showed a blank, undiagnosable red banner).
+   *
+   * P3: this is now the sentence `ErrorCopyService` owns, not the raw `AppError` display. The raw
+   * message was chosen deliberately in 2026-07-15 for diagnosability, but the same channel carries
+   * developer vocabulary from ~2100 `AppError` sites, and an autosave tooltip is not the place to
+   * leak it. A recognised failure still says exactly what happened; an unrecognised one says
+   * "Couldn’t save this note. Please try again." rather than nothing.
    */
   readonly saveErrorMessage = signal<string | null>(null);
   /** The tag-input draft. */
@@ -1016,7 +1020,7 @@ export class NoteEditorComponent {
       await this.tabsService.openNote(id, "Untitled", { replaceUrl: true });
     } catch (e) {
       if (seq === this.requestSeq) {
-        this.error.set(String(e));
+        this.error.set(this.errorCopy.humanize(e));
         this.loading.set(false);
       }
     }
@@ -1087,20 +1091,17 @@ export class NoteEditorComponent {
 
   /**
    * A clean, non-technical message for the "couldn't open this note" state.
-   * `get_note` rejects with the raw backend `AppError` string (`"invalid
-   * argument: no note {id}"`) for an unknown id — normally the tab-strip's
-   * `content-deleted` fan-out (`TabsService`) closes a stale tab before this
-   * is ever reached, but a note opened a different way (a stale bookmark, a
-   * link from another surface not going through `TabsService`) can still land
-   * here after a delete, so this stays a friendly fallback rather than the raw
-   * technical string.
+   *
+   * `get_note` rejects with `[note-missing]` (`errcode::NOTE_MISSING`) for an unknown id — normally
+   * the tab-strip's `content-deleted` fan-out (`TabsService`) closes a stale tab before this is
+   * ever reached, but a note opened a different way (a stale bookmark, a link from a surface that
+   * does not go through `TabsService`) can still land here after a delete.
+   *
+   * Folded into `ErrorCopyService` under the "note-load" context — the "no note " prose test is
+   * gone, and the non-matching arm no longer falls through to the raw backend string.
    */
   private friendlyLoadError(e: unknown): string {
-    const msg = String(e);
-    if (/no note /i.test(msg)) {
-      return "This note was deleted.";
-    }
-    return msg;
+    return this.errorCopy.humanize(e, "note-load");
   }
 
   /** Apply a loaded/reconciled doc into the edit signals (no autosave feedback). */
@@ -1322,7 +1323,7 @@ export class NoteEditorComponent {
         } catch (error) {
           if (this.note()?.id === noteId && !this.note()?.locked) {
             this.replacePendingAttachment(id, "");
-            this.toast.danger(String(error));
+            this.toast.danger(this.errorCopy.humanize(error));
           }
         }
       }
@@ -1523,9 +1524,21 @@ export class NoteEditorComponent {
    * `busy_timeout` fix in `Db::open_with_key`, but a retry is still a correct,
    * cheap belt-and-suspenders for whatever transient storage hiccup slips
    * through).
+   *
+   * BUG FIXED HERE (P3). This tested `message.includes("Locked")` — CAPITAL L — while every
+   * producer is lowercase: `AppError`'s `Display` is `#[error("locked: {0}")]` and the note
+   * write-gates in `commands/notes.rs` all go through it. So the lock arm NEVER fired: a save into
+   * a folder that sealed under the user fell into the retry branch, waited out an 800 ms backoff,
+   * failed identically, and only then surfaced. The guard is now the `[note-locked]` /
+   * `[folder-locked]` / `[note-missing]` CODE, which cannot have a casing bug.
    */
-  private isUnretryableSaveError(message: string): boolean {
-    return message.includes("Locked") || message.includes("no note ");
+  private isUnretryableSaveError(e: unknown): boolean {
+    const code = this.errorCopy.codeOf(e);
+    return (
+      code === "note-locked" ||
+      code === "folder-locked" ||
+      code === "note-missing"
+    );
   }
 
   /**
@@ -1574,14 +1587,15 @@ export class NoteEditorComponent {
   }
 
   /**
-   * Shared failure path for both save paths: classify the error, retry ONCE
-   * for a retryable (non-lock, non-missing-row) failure, and only THEN settle
-   * `saveState`/`saveErrorMessage`/toast with the real backend message —
-   * `AppError` is `Serialize` and crosses IPC as its display string (rust-tauri
-   * §1), so `String(e)` already carries the actual diagnostic instead of the
-   * old blanket "Save failed" with nothing behind it. `noteId` scopes the
-   * bounded retry's debounce key so concurrent open note tabs never cancel
+   * Shared failure path for both save paths: classify the error, retry ONCE for a retryable
+   * (non-lock, non-missing-row) failure, and only THEN settle `saveState`/`saveErrorMessage`/toast.
+   * `noteId` scopes the bounded retry's debounce key so concurrent open note tabs never cancel
    * each other's retry (see {@link retryOnce}).
+   *
+   * Classification is by `[code]`, never by prose — see {@link isUnretryableSaveError} for the
+   * casing bug that motivated it. The settled message is the sentence `ErrorCopyService` owns, so
+   * an unrecognised failure reads "Couldn’t save this note. Please try again." instead of a Rust
+   * diagnostic.
    */
   private async handleSaveFailure<T>(
     noteId: string,
@@ -1594,22 +1608,23 @@ export class NoteEditorComponent {
     if (!this.saveResponseStillApplies(noteId)) {
       return false;
     }
-    const message = String(e);
-    if (message.includes("no note ")) {
+    const message = this.errorCopy.humanize(e, "note-save");
+    const code = this.errorCopy.codeOf(e);
+    if (code === "note-missing") {
       // Stale-tab-after-delete: this note id no longer exists server-side —
       // retrying a save against it can never succeed.
       this.saveState.set("error");
       this.saveErrorMessage.set("This note no longer exists.");
-      this.toast.danger("This note no longer exists — it may have been deleted elsewhere.");
+      this.toast.danger(message);
       return false;
     }
-    if (message.includes("Locked")) {
+    if (code === "note-locked" || code === "folder-locked") {
       this.saveState.set("error");
       this.saveErrorMessage.set(message);
       this.toast.danger("This note is locked — unlock its folder to edit.");
       return false;
     }
-    if (!this.isUnretryableSaveError(message)) {
+    if (!this.isUnretryableSaveError(e)) {
       try {
         const result = await this.retryOnce(noteId, retryAttempt);
         if (!this.saveResponseStillApplies(noteId)) {
@@ -1626,7 +1641,9 @@ export class NoteEditorComponent {
           return false;
         }
         this.saveState.set("error");
-        this.saveErrorMessage.set(String(retryError));
+        this.saveErrorMessage.set(
+          this.errorCopy.humanize(retryError, "note-save"),
+        );
         return false;
       }
     }
@@ -2517,7 +2534,7 @@ export class NoteEditorComponent {
       const name = this.noteFolders().find((f) => f.id === folderId)?.name ?? "folder";
       this.toast.success(`Moved to ${name}`);
     } catch (e) {
-      this.toast.danger(`Couldn’t move — ${String(e)}`);
+      this.toast.danger(this.errorCopy.because("Couldn’t move", e));
     }
   }
 
@@ -2542,7 +2559,7 @@ export class NoteEditorComponent {
       this.note.update((cur) => (cur ? { ...cur, exportedPath: path } : cur));
       this.toast.success("Saved to your vault");
     } catch (e) {
-      this.toast.danger(`Couldn’t export — ${String(e)}`);
+      this.toast.danger(this.errorCopy.because("Couldn’t export", e));
     }
   }
 
@@ -2621,7 +2638,7 @@ export class NoteEditorComponent {
       this.toast.success("Note deleted");
       void this.router.navigate(["/notes"]);
     } catch (e) {
-      this.toast.danger(`Couldn’t delete — ${String(e)}`);
+      this.toast.danger(this.errorCopy.because("Couldn’t delete", e));
       this.confirmingDelete.set(false);
     }
   }
@@ -2650,7 +2667,9 @@ export class NoteEditorComponent {
         this.hydrate(fresh);
       }
     } catch (e) {
-      this.toast.danger(`Couldn’t unlock — ${String(e)}`);
+      // "unlock" context: a Touch ID cancel reads "Touch ID was cancelled — try again." and an
+      // unrecognised failure falls back to "Couldn’t unlock. Please try again.".
+      this.toast.danger(this.errorCopy.humanize(e, "unlock"));
     } finally {
       this.unlocking.set(false);
     }
@@ -2820,10 +2839,10 @@ export class NoteEditorComponent {
       void this.notes.loadNotes(null);
       void this.router.navigate(["/notes", id]);
     } catch (e) {
-      // Surface a sealed-folder refusal (`Locked`) plainly, like the main
-      // "New note" action and the share panel — never a bare "couldn't create".
+      // Surface a sealed-folder refusal (`[folder-locked]`) plainly, like the main "New note"
+      // action and the share panel — never a bare "couldn't create".
       this.toast.danger(
-        /locked/i.test(String(e))
+        this.errorCopy.is(e, "folder-locked")
           ? "This folder is locked — unlock it first to add a note."
           : "Couldn’t create the note",
       );

--- a/src/app/features/notes/note-share-panel/note-share-panel.component.ts
+++ b/src/app/features/notes/note-share-panel/note-share-panel.component.ts
@@ -22,6 +22,7 @@ import {
   type OrgShareTarget,
 } from "../../detail/org-share-sheet/org-share-sheet.component";
 import { MurOrgBrainCtaComponent } from "../../../design-system/org-brain-cta/org-brain-cta.component";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /** The link-share flow step (Manage always coexists as the list below). */
 type ShareStep = "configure" | "created";
@@ -75,6 +76,7 @@ interface LinkShareRow {
 export class NoteSharePanelComponent {
   private readonly ipc = inject(IpcService);
   private readonly injector = inject(Injector);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** THIS note's document id — the shares filter key. */
   readonly noteId = input.required<string>();
@@ -327,8 +329,8 @@ export class NoteSharePanelComponent {
       // Org Brain state (best-effort): the section only appears when in an org.
       void this.refreshOrg(id);
     } catch (e) {
-      this.listError.set(String(e));
-      this.gateError.set(String(e));
+      this.listError.set(this.errorCopy.humanize(e));
+      this.gateError.set(this.errorCopy.humanize(e));
     } finally {
       this.loading.set(false);
     }
@@ -397,17 +399,13 @@ export class NoteSharePanelComponent {
       }
     } catch (e) {
       this._biometricFailed.set(true);
-      this.gateError.set(this.friendlyUnlockError(String(e)));
+      // LOCK GATE — see `share-panel.component.ts` for the full rationale. Cancel-vs-failure comes
+      // from the `[touch-id-*]` code, and the raw keychain string no longer reaches the screen.
+      // The gate is unchanged: fail-closed, `_biometricFailed` set, password path still offered.
+      this.gateError.set(this.errorCopy.humanize(e, "note-share"));
     } finally {
       this.unlocking.set(false);
     }
-  }
-
-  private friendlyUnlockError(raw: string): string {
-    if (/cancel/i.test(raw)) {
-      return "Touch ID was cancelled. Use Unlock for sharing to unlock with your password.";
-    }
-    return `Couldn't unlock with Touch ID — ${raw}. Use Unlock for sharing to unlock with your password.`;
   }
 
   // --- CONFIGURE handlers ---------------------------------------------------
@@ -447,7 +445,7 @@ export class NoteSharePanelComponent {
         this.accountStatus.set({ ...s, shareConsented: true });
       }
     } catch (e) {
-      this.createError.set(String(e));
+      this.createError.set(this.errorCopy.humanize(e));
     } finally {
       this.consenting.set(false);
     }
@@ -498,18 +496,12 @@ export class NoteSharePanelComponent {
       await this.refresh();
       this.changed.emit();
     } catch (e) {
-      this.createError.set(this.friendlyCreateError(String(e)));
+      // A `[note-locked]`/`[folder-locked]` create failure means the folder sealed under us — the
+      // "note-share" context says so plainly. Everything else no longer renders raw backend prose.
+      this.createError.set(this.errorCopy.humanize(e, "note-share"));
     } finally {
       this.creating.set(false);
     }
-  }
-
-  /** A `Locked` create failure means the folder sealed under us — say so plainly. */
-  private friendlyCreateError(raw: string): string {
-    if (/Locked/i.test(raw)) {
-      return "This note is locked — unlock its folder to share it.";
-    }
-    return raw;
   }
 
   // --- CREATED handlers -----------------------------------------------------
@@ -575,7 +567,7 @@ export class NoteSharePanelComponent {
       await this.refresh();
       this.changed.emit();
     } catch (e) {
-      this.listError.set(String(e));
+      this.listError.set(this.errorCopy.humanize(e));
       await this.refresh();
     } finally {
       this.revokingId.set(null);

--- a/src/app/features/notes/notes-home/notes-home.component.ts
+++ b/src/app/features/notes/notes-home/notes-home.component.ts
@@ -29,6 +29,7 @@ import { OrgBrainService } from "../../../services/org-brain.service";
 import { ToastService } from "../../../services/toast.service";
 import { OrganizeSheetComponent } from "../organize-sheet/organize-sheet.component";
 import { NotesViewSwitcherComponent } from "../notes-view-switcher/notes-view-switcher.component";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /**
  * The Notes landing view — NOW a normal in-flow route beside the ALWAYS-VISIBLE
@@ -71,6 +72,7 @@ export class NotesHomeComponent implements OnInit {
   private readonly router = inject(Router);
   private readonly toast = inject(ToastService);
   private readonly tabsService = inject(TabsService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** The note list from the store (gated — masked rows carry no snippet/tags). */
   readonly noteList = this.notes.notes;
@@ -430,12 +432,13 @@ export class NotesHomeComponent implements OnInit {
       const id = await this.notes.create(this.activeFolderId(), "Untitled");
       await this.router.navigate(["/notes", id]);
     } catch (e) {
-      // A sealed target folder (the selected one, or the default "Notes" folder
-      // if it's locked) refuses the write with a `Locked` AppError. Say WHY —
-      // the old generic "couldn't create" hid the real cause, so a user whose
-      // default folder was locked just saw an unexplained failure (2026-07-14).
+      // A sealed target folder (the selected one, or the default "Notes" folder if it's locked)
+      // refuses the write with `[folder-locked]`. Say WHY — the old generic "couldn't create" hid
+      // the real cause, so a user whose default folder was locked just saw an unexplained failure
+      // (2026-07-14). P3 keeps that behaviour but keys it on the CODE rather than on `/locked/i`
+      // over the raw string, which also matched unrelated messages containing the word.
       this.toast.danger(
-        /locked/i.test(String(e))
+        this.errorCopy.is(e, "folder-locked")
           ? "This folder is locked — unlock it first to add a note."
           : "Couldn’t create the note. Please try again.",
       );

--- a/src/app/features/onboarding/onboarding/onboarding.component.html
+++ b/src/app/features/onboarding/onboarding/onboarding.component.html
@@ -420,8 +420,8 @@
               <div class="setup-well">
                 <p class="setup-title">Connect your Kong AI Gateway</p>
                 <p class="setup-text text-secondary">
-                  Enter your gateway's OpenAI-compatible base URL (e.g.
-                  https://…/v1). An API key can be added later in
+                  Enter your gateway's OpenAI-compatible server address
+                  (e.g. https://…/v1). An API key can be added later in
                   Settings → AI &amp; Models.
                 </p>
                 <div class="row">

--- a/src/app/features/onboarding/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding/onboarding.component.ts
@@ -19,6 +19,7 @@ import { BrainEnableCardComponent } from "../../brain/brain-enable-card/brain-en
 import { MurProgressComponent } from "../../../design-system/progress/progress.component";
 import { MurSelectComponent } from "../../../design-system/select/select.component";
 import { ModelPowerComponent } from "../../settings/sections/settings-transcription-section/model-power/model-power.component";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /** The wizard steps, in order. Drives the dot indicator + progress copy. */
 type Step = "welcome" | "model" | "provider" | "brain" | "vault" | "done";
@@ -100,6 +101,7 @@ export class OnboardingComponent implements OnInit {
   private readonly ipc = inject(IpcService);
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly errorCopy = inject(ErrorCopyService);
   /** The root-held catalog + machine answer (P1). Shared with Settings, never re-fetched per host. */
   readonly machine = inject(MachineService);
 
@@ -218,7 +220,9 @@ export class OnboardingComponent implements OnInit {
           id,
           available: false,
           reason:
-            id === "gateway" ? "Add your gateway's base URL below" : undefined,
+            id === "gateway"
+              ? "Add your gateway's server address below"
+              : undefined,
         },
     );
   });
@@ -473,7 +477,7 @@ export class OnboardingComponent implements OnInit {
       await this.refreshLiveCompanionPending();
       await this.machine.refresh();
     } catch (e) {
-      this.downloadError.set(String(e));
+      this.downloadError.set(this.errorCopy.humanize(e));
     } finally {
       this.downloading.set(false);
     }
@@ -574,7 +578,7 @@ export class OnboardingComponent implements OnInit {
       // Re-probe so the "Available" pill updates once the key takes effect.
       await this.recheckProviders();
     } catch (e) {
-      this.keyError.set(String(e));
+      this.keyError.set(this.errorCopy.humanize(e));
     } finally {
       this.savingKey.set(false);
     }

--- a/src/app/features/org/org-item-viewer/org-item-viewer.component.ts
+++ b/src/app/features/org/org-item-viewer/org-item-viewer.component.ts
@@ -21,6 +21,7 @@ import type {
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
 import { NoteChatComponent } from "../../notes/note-chat/note-chat.component";
 import { ToastService } from "../../../services/toast.service";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /**
  * Viewer for ONE org-brain item (`/org-item/:id`). Reached from an org-origin
@@ -65,6 +66,7 @@ export class OrgItemViewerComponent {
   private readonly tabsService = inject(TabsService);
   private readonly toast = inject(ToastService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** The `:id` route param as a signal (re-fetches when it changes in place). */
   private readonly itemId = toSignal(
@@ -334,7 +336,7 @@ export class OrgItemViewerComponent {
       if (this.itemId() !== id) {
         return;
       }
-      this.error.set(String(e));
+      this.error.set(this.errorCopy.humanize(e));
       this._item.set(null);
       this.attachments.set([]);
     } finally {
@@ -463,7 +465,7 @@ export class OrgItemViewerComponent {
       this.toast.success("Removed from the org");
       void this.router.navigate(["/notes"]);
     } catch (e) {
-      this.toast.danger(`Couldn’t remove — ${String(e)}`);
+      this.toast.danger(this.errorCopy.because("Couldn’t remove", e));
       this.confirmingRemove.set(false);
     } finally {
       this.saving.set(false);

--- a/src/app/features/people/people/people.component.ts
+++ b/src/app/features/people/people/people.component.ts
@@ -10,6 +10,7 @@ import { IpcService } from "../../../core/ipc.service";
 import type { PersonCard } from "../../../core/models";
 import { FoldersService } from "../../../services/folders.service";
 import { PersonDossierComponent } from "../person-dossier/person-dossier.component";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /**
  * The `/people` page — a personal CRM over the people across your meetings.
@@ -37,6 +38,7 @@ import { PersonDossierComponent } from "../person-dossier/person-dossier.compone
 export class PeopleComponent {
   private readonly ipc = inject(IpcService);
   private readonly folders = inject(FoldersService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   readonly people = signal<PersonCard[]>([]);
   readonly loading = signal(true);
@@ -116,7 +118,7 @@ export class PeopleComponent {
     } catch (e) {
       this.people.set([]);
       this.totalVisiblePeople.set(0);
-      this.error.set(String(e));
+      this.error.set(this.errorCopy.humanize(e));
     } finally {
       this.loading.set(false);
     }

--- a/src/app/features/people/person-dossier/person-dossier.component.ts
+++ b/src/app/features/people/person-dossier/person-dossier.component.ts
@@ -16,6 +16,7 @@ import type {
   DossierData,
   EntityNeighbor,
 } from "../../../core/models";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /**
  * The `/people` detail pane — a STRUCTURED, glanceable dossier for one person
@@ -47,6 +48,7 @@ import type {
 })
 export class PersonDossierComponent {
   private readonly ipc = inject(IpcService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** The person/entity to build the dossier for; changing it re-loads the pane. */
   readonly entityId = input.required<string>();
@@ -116,7 +118,7 @@ export class PersonDossierComponent {
         return;
       }
       this.dossier.set(null);
-      this.error.set(String(e));
+      this.error.set(this.errorCopy.humanize(e));
     } finally {
       if (this.entityId() === id) {
         this.loading.set(false);

--- a/src/app/features/record/re-truth-card/re-truth-card.component.ts
+++ b/src/app/features/record/re-truth-card/re-truth-card.component.ts
@@ -10,6 +10,7 @@ import {
 import { IpcService } from "../../../core/ipc.service";
 import { FoldersService } from "../../../services/folders.service";
 import type { ApplyResult, SupersessionDto } from "../../../core/models";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /**
  * Re-Truth — "the vault heals itself" (post-note surface, Tier-4-style reveal).
@@ -44,6 +45,7 @@ import type { ApplyResult, SupersessionDto } from "../../../core/models";
 export class ReTruthCardComponent {
   private readonly ipc = inject(IpcService);
   private readonly folders = inject(FoldersService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /**
    * Fires the preview only when the post-note surface is live — the record
@@ -189,7 +191,7 @@ export class ReTruthCardComponent {
       this._appliedIds.set(ids);
       this._healed.set(res);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
     } finally {
       this._busy.set(false);
     }
@@ -208,7 +210,7 @@ export class ReTruthCardComponent {
       this._healed.set(null);
       this._appliedIds.set([]);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
     } finally {
       this._busy.set(false);
     }

--- a/src/app/features/record/record/record.component.ts
+++ b/src/app/features/record/record/record.component.ts
@@ -19,6 +19,11 @@ import { MeetingConversationComponent } from "../meeting-conversation/meeting-co
 import { BrainRevealCardComponent } from "../brain-reveal-card/brain-reveal-card.component";
 import { ReTruthCardComponent } from "../re-truth-card/re-truth-card.component";
 import { MeetingConversationStore } from "../../../core/meeting-conversation.store";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
+import {
+  cloudDestinationLabel,
+  connectionLabel,
+} from "../../../core/copy/labels";
 
 /** localStorage key for the permanent "no vault set" notice dismissal. */
 const VAULT_NOTICE_DISMISSED_KEY = "murmur-vault-notice-dismissed";
@@ -61,6 +66,7 @@ type LiveCaptionsState =
 })
 export class RecordComponent implements OnInit {
   readonly store = inject(RecorderStore);
+  private readonly errorCopy = inject(ErrorCopyService);
   /** The in-meeting NOTES + @brain THREADS store. Injected + init()'d here (not only from
    * the surface) so it subscribes to the wake/result streams even before the surface shows. */
   readonly assistant = inject(MeetingConversationStore);
@@ -277,52 +283,39 @@ export class RecordComponent implements OnInit {
   }
 
   /**
-   * True when the last failure was the backend's cloud-egress consent gate. We
-   * detect the stable "cloud egress not consented" marker from `make_provider`
-   * and surface a friendly consent prompt instead of the raw error banner —
-   * never a silent failure.
+   * True when the last failure was the backend's cloud-egress consent gate, so the surface can
+   * offer "Allow" instead of an error banner — never a silent failure.
+   *
+   * This matches the STABLE `[cloud-consent]` CODE
+   * (`src-tauri/src/errcode.rs::CLOUD_CONSENT`, emitted by
+   * `summarize::make_provider_resolved`), never the prose. It used to regex-match the Rust
+   * sentence "cloud egress not consented", which meant rewording that sentence — an ordinary
+   * de-jargoning edit — silently broke the consent flow for every cloud user: the Allow banner
+   * would stop rendering and the raw backend string would surface instead.
+   *
+   * `RecorderStore.errorCode` carries the code off the RAW wire string; `store.error()` is already
+   * humanized and no longer contains it.
    */
-  readonly needsCloudConsent = computed(() => {
-    const e = this.store.error();
-    return !!e && /cloud egress not consented/i.test(e);
-  });
+  readonly needsCloudConsent = computed(
+    () => this.store.errorCode() === "cloud-consent",
+  );
 
   /** Human label for the configured provider (for the consent copy). */
   readonly providerLabel = computed(() => {
-    switch (this.config()?.providerId) {
-      case "anthropic":
-        return "The Anthropic API";
-      case "claude_code":
-        return "Claude Code";
-      case "gateway":
-        return "Kong AI Gateway";
-      case "ollama":
-        return "Ollama";
-      default:
-        return "This provider";
-    }
+    const id = this.config()?.providerId;
+    // "The Anthropic API" reads better than the bare label in this sentence position.
+    return id === "anthropic" ? "The Anthropic API" : connectionLabel(id);
   });
 
   /**
    * Human name of the destination the redacted transcript goes to (for the
    * consent copy). This banner only shows after the backend's fail-closed
    * `egress_is_cloud` gate refused (`needsCloudConsent`), so the provider is
-   * cloud-classified by definition — for ollama that means the base URL is
-   * non-loopback, hence "your remote Ollama server" without re-parsing it here.
+   * cloud-classified by definition — see `cloudDestinationLabel`.
    */
-  readonly cloudDestination = computed(() => {
-    switch (this.config()?.providerId) {
-      case "anthropic":
-      case "claude_code":
-        return "Anthropic's cloud";
-      case "gateway":
-        return "your Kong AI Gateway";
-      case "ollama":
-        return "your remote Ollama server";
-      default:
-        return "your provider's cloud";
-    }
-  });
+  readonly cloudDestination = computed(() =>
+    cloudDestinationLabel(this.config()?.providerId),
+  );
 
   /** True while the one-time consent command + retry are in flight. */
   readonly consenting = signal(false);
@@ -670,7 +663,7 @@ export class RecordComponent implements OnInit {
       this.modelPresent.set(await this.ipc.modelPresent());
       await this.refreshConfig();
     } catch (e) {
-      this.modelDownloadError.set(String(e));
+      this.modelDownloadError.set(this.errorCopy.humanize(e));
     } finally {
       this.downloadingModel.set(false);
     }
@@ -698,7 +691,7 @@ export class RecordComponent implements OnInit {
         );
       }
     } catch (e) {
-      this.liveCompanionError.set(String(e));
+      this.liveCompanionError.set(this.errorCopy.humanize(e));
     } finally {
       this.downloadingLiveCompanion.set(false);
     }

--- a/src/app/features/settings/sections/ai/ai-connection-card/ai-connection-card.component.html
+++ b/src/app/features/settings/sections/ai/ai-connection-card/ai-connection-card.component.html
@@ -129,7 +129,7 @@
         }
         @case ("ollama") {
           <label class="field">
-            <span class="field-label">Ollama base URL</span>
+            <span class="field-label">Ollama server address</span>
             <input formControlName="ollamaBaseUrl" />
             <span class="field-help text-muted">
               A non-localhost URL makes Ollama count as cloud — the card
@@ -145,7 +145,7 @@
         }
         @case ("gateway") {
           <label class="field">
-            <span class="field-label">Base URL</span>
+            <span class="field-label">Server address</span>
             <input
               formControlName="gatewayBaseUrl"
               placeholder="http://localhost:4000/v1"
@@ -158,8 +158,8 @@
               </span>
             }
             <span class="field-help text-muted">
-              Enter your gateway's OpenAI-compatible base URL (e.g.
-              https://…/v1) — or the full chat-completions endpoint if your
+              Enter your gateway's OpenAI-compatible server address (e.g.
+              https://…/v1) — or the full chat-completions address if your
               gateway uses a custom route (e.g. a Kong serverless route
               like https://…/test).
             </span>
@@ -214,8 +214,8 @@
             </div>
             @if (gatewayModelError()) {
               <span class="field-help text-muted">
-                Couldn't load models — check the base URL and key, or type
-                the model id manually.
+                Couldn't load models — check the server address and key, or
+                type the model id manually.
               </span>
             } @else {
               <span class="field-help text-muted">
@@ -284,7 +284,7 @@
             <input
               type="password"
               [formControl]="gatewayKeyControl"
-              placeholder="sk-… or any bearer token"
+              placeholder="sk-… or any API key"
               autocomplete="new-password"
             />
             <button
@@ -319,8 +319,8 @@
                 <span>
                   Content will be sent to
                   <strong>{{ dest.host }}</strong> over the network —
-                  always scrubbed by the redaction firewall first and
-                  requires cloud-egress consent.
+                  always scrubbed by the redaction firewall first, and only
+                  after you allow cloud processing once.
                 </span>
               </div>
             } @else {

--- a/src/app/features/settings/sections/ai/ai-privacy-strip/ai-privacy-strip.component.html
+++ b/src/app/features/settings/sections/ai/ai-privacy-strip/ai-privacy-strip.component.html
@@ -4,11 +4,16 @@
   </div>
 
   <div class="strip-lines">
+    <!--
+      "embeddings" was on the never-show list (glossary.ts) — the user-facing name for what that
+      work produces is the search index. The list is otherwise unchanged: shortening it would drop
+      facts, which is the one thing a plain-language pass must not do.
+    -->
     <div class="strip-line">
       <span class="strip-dot is-local" aria-hidden="true"></span>
       <span class="text-secondary">
         <strong class="strip-strong">Stays on this Mac:</strong>
-        transcription, embeddings, name redaction, proactive hints, local
+        transcription, the search index, name masking, proactive hints, local
         models
       </span>
     </div>
@@ -22,18 +27,17 @@
         </span>
       </div>
       <!--
-        Honest caveat (fast-follow #3): personal-NAME masking is best-effort
-        and only active once the optional on-device NER model is downloaded.
-        Emails / phones / cards are always regex-scrubbed regardless. Shown
-        only when text actually leaves the Mac AND the model is absent — a
-        calm nudge, not an alarm. Enable it in the Privacy section.
+        PROTECTED CLAUSE — pinned by e2e/settings/privacy-honesty.spec.ts.
+        Name masking is only active once the optional on-device model is downloaded; emails,
+        phones and cards are always removed. Both halves must survive any rewrite: dropping the
+        negative ("names are NOT masked") is exactly how a de-jargoning pass makes the app less
+        honest. Shown only when text actually leaves the Mac AND the model is absent.
       -->
       @if (nerModelPresent() === false) {
         <p class="strip-subnote text-muted">
-          Personal names aren't masked before this leaves your Mac yet —
-          on-device name masking needs the optional model, and names are only
-          masked once it's downloaded (in Privacy &amp; integrations). Emails,
-          phone numbers and card numbers are always scrubbed.
+          Names are NOT removed. Emails, phone numbers and card numbers are
+          always removed before this leaves your Mac, but people's names go with
+          the text until you turn on name masking (in Privacy &amp; integrations).
         </p>
       }
     }
@@ -101,7 +105,8 @@
         }
       </button>
       <span class="text-muted strip-hint">
-        One-time, redacted first — required before any cloud provider runs.
+        One-time. Emails, phones and cards are removed first. Required before
+        any cloud provider runs.
       </span>
     }
   </div>

--- a/src/app/features/settings/sections/ai/on-device-intelligence-block/on-device-intelligence-block.component.html
+++ b/src/app/features/settings/sections/ai/on-device-intelligence-block/on-device-intelligence-block.component.html
@@ -3,25 +3,25 @@
   <div class="use-group">
     <span class="use-group-label text-muted">Search index</span>
 
-    <!-- brain2 RAG — semantic search over your notes (embedding model + reindex) -->
+    <!-- brain2 RAG — semantic search over your notes (search-index model + reindex) -->
     <div class="semantic">
       <label class="toggle-row">
         <span class="toggle-copy">
           <span class="toggle-title">Semantic search (multilingual)</span>
           <span class="text-secondary toggle-sub">
-            Finds notes by meaning + across languages — needs the embedding
-            model.
+            Finds notes by meaning + across languages — needs the
+            search-index model.
           </span>
         </span>
         <mur-toggle formControlName="semanticSearchEnabled" />
       </label>
 
-      <!-- Embedding model: present pill, or a download control with progress -->
+      <!-- Search-index model: present pill, or a download control with progress -->
       <div class="semantic-model-row">
         @if (embedModelPresent() === true) {
           <span class="pill is-success">
             <span class="pill-dot"></span>
-            Embedding model ready ✓
+            Search-index model ready ✓
           </span>
           <span class="text-muted semantic-note">
             Stored on this Mac — used to index + search your notes.
@@ -30,11 +30,11 @@
           @if (downloadingEmbedModel()) {
             <div class="semantic-progress" role="status">
               <mur-progress
-                ariaLabel="Embedding model download"
+                ariaLabel="Search-index model download"
                 [value]="embedDownloadFrac() * 100"
               />
               <span class="semantic-progress-label text-muted">
-                Downloading embedding model… {{ embedPct() }}
+                Downloading the search-index model… {{ embedPct() }}
               </span>
             </div>
           } @else {
@@ -43,7 +43,7 @@
               class="btn btn-primary btn-sm"
               (click)="downloadEmbedModel()"
             >
-              Download embedding model (~470 MB)
+              Download the search-index model (~470 MB)
             </button>
             <span class="text-muted semantic-note">
               One time, on-device — required before semantic search can
@@ -95,7 +95,7 @@
       @if (reindexResult(); as rr) {
         @if (rr.status === "model_missing") {
           <p class="semantic-nudge text-secondary">
-            Download the embedding model above first — semantic search
+            Download the search-index model above first — semantic search
             can't index without it.
           </p>
         } @else {
@@ -119,8 +119,8 @@
         <span class="toggle-copy">
           <span class="toggle-title">Weekly vault audit</span>
           <span class="text-secondary toggle-sub">
-            Runs the deterministic vault audit once a week, on-device, zero
-            egress.
+            Runs the vault audit once a week on this Mac — the same
+            rule-based checks every time, and nothing leaves your Mac.
           </span>
         </span>
         <mur-toggle

--- a/src/app/features/settings/sections/ai/on-device-intelligence-block/on-device-intelligence-block.component.ts
+++ b/src/app/features/settings/sections/ai/on-device-intelligence-block/on-device-intelligence-block.component.ts
@@ -12,6 +12,7 @@ import { ToastService } from "../../../../../services/toast.service";
 import { SettingsStore } from "../../../settings.store";
 import { MurToggleComponent } from "../../../../../design-system/toggle/toggle.component";
 import { MurProgressComponent } from "../../../../../design-system/progress/progress.component";
+import { ErrorCopyService } from "../../../../../core/copy/error-copy.service";
 
 /**
  * AI & Models → "Search index" block.
@@ -41,6 +42,7 @@ export class OnDeviceIntelligenceBlockComponent {
   private readonly store = inject(SettingsStore);
   private readonly audit = inject(AuditStore);
   private readonly toast = inject(ToastService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   readonly form = this.store.form;
   readonly embedModelPresent = this.store.embedModelPresent;
@@ -115,7 +117,7 @@ export class OnDeviceIntelligenceBlockComponent {
     try {
       await this.audit.setSchedule(enabled);
     } catch (e) {
-      this.toast.danger(String(e));
+      this.toast.danger(this.errorCopy.humanize(e));
     } finally {
       this.auditControl.enable({ emitEvent: false });
       this.auditBusy.set(false);

--- a/src/app/features/settings/sections/settings-account-section/settings-account-section.component.ts
+++ b/src/app/features/settings/sections/settings-account-section/settings-account-section.component.ts
@@ -16,6 +16,7 @@ import type {
   ShareInboxItem,
 } from "../../../../core/models";
 import { SharingAuthFlowComponent } from "../../../sharing/sharing-auth-flow/sharing-auth-flow.component";
+import { ErrorCopyService } from "../../../../core/copy/error-copy.service";
 
 /** A flattened, depth-indented folder option for the accept-into picker. */
 interface FolderOption {
@@ -51,6 +52,7 @@ interface FolderOption {
 export class SettingsAccountSectionComponent {
   private readonly ipc = inject(IpcService);
   private readonly injector = inject(Injector);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** The current sharing-account session; `null` until the first load resolves. */
   private readonly _status = signal<AccountStatus | null>(null);
@@ -176,7 +178,7 @@ export class SettingsAccountSectionComponent {
       st = await this.ipc.accountStatus();
       this._status.set(st);
     } catch (e) {
-      this._accountError.set(String(e));
+      this._accountError.set(this.errorCopy.humanize(e));
     } finally {
       this._loaded.set(true);
     }
@@ -201,7 +203,7 @@ export class SettingsAccountSectionComponent {
     try {
       this._inbox.set(await this.ipc.listShareInbox());
     } catch (e) {
-      this._inboxError.set(String(e));
+      this._inboxError.set(this.errorCopy.humanize(e));
     } finally {
       this._inboxLoading.set(false);
     }
@@ -257,18 +259,12 @@ export class SettingsAccountSectionComponent {
       }
     } catch (e) {
       this._biometricFailed.set(true);
-      this._unlockError.set(this.friendlyUnlockError(String(e)));
+      // Cancel-vs-failure now comes from the `[touch-id-*]` code, not from the word "cancel"
+      // appearing in the keychain's own sentence. The password fall-back is unchanged.
+      this._unlockError.set(this.errorCopy.humanize(e, "account"));
     } finally {
       this._unlocking.set(false);
     }
-  }
-
-  /** Turn a raw biometric-unlock error into a friendly fall-back message. */
-  private friendlyUnlockError(raw: string): string {
-    if (/cancel/i.test(raw)) {
-      return "Touch ID was cancelled. Sign in with your password to share instead.";
-    }
-    return "Couldn't unlock with Touch ID. Sign in with your password to share instead.";
   }
 
   /** Sign out (server family-revoke + clear tokens + drop session MK), then reload. */
@@ -279,7 +275,7 @@ export class SettingsAccountSectionComponent {
       await this.ipc.accountLogout();
       await this.reload();
     } catch (e) {
-      this._accountError.set(String(e));
+      this._accountError.set(this.errorCopy.humanize(e));
     } finally {
       this._busy.set(false);
     }
@@ -312,7 +308,7 @@ export class SettingsAccountSectionComponent {
     } catch (e) {
       this._rowError.set({
         id: item.shareId,
-        msg: this.friendlyShareError(String(e)),
+        msg: this.errorCopy.humanize(e, "account"),
       });
     } finally {
       this._busyShare.set(null);
@@ -331,18 +327,13 @@ export class SettingsAccountSectionComponent {
       await this.ipc.declineShare(item.shareId);
       await this.loadInbox();
     } catch (e) {
-      this._rowError.set({ id: item.shareId, msg: String(e) });
+      this._rowError.set({
+        id: item.shareId,
+        msg: this.errorCopy.humanize(e, "account"),
+      });
     } finally {
       this._busyShare.set(null);
     }
-  }
-
-  /** Turn a raw backend error into a friendly, non-crashy inline message. */
-  private friendlyShareError(raw: string): string {
-    if (/lock/i.test(raw)) {
-      return "That folder is locked. Unlock it (or pick an open folder / the default) to accept.";
-    }
-    return raw;
   }
 
   /** Presentational: render an ISO timestamp as a friendly local date. */

--- a/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.ts
+++ b/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.ts
@@ -15,6 +15,7 @@ import type {
   OrgMember,
   OrgStatus,
 } from "../../../../core/models";
+import { ErrorCopyService } from "../../../../core/copy/error-copy.service";
 
 /**
  * Settings → Organization section (Shared Brain v1, MULTI-ORG).
@@ -52,6 +53,7 @@ import type {
 export class SettingsOrganizationSectionComponent {
   private readonly ipc = inject(IpcService);
   private readonly toast = inject(ToastService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** Every org the user belongs to (created OR invited-into). Empty ⇒ empty state. */
   private readonly _orgs = signal<OrgStatus[]>([]);
@@ -180,7 +182,7 @@ export class SettingsOrganizationSectionComponent {
           this.reconcileExpanded(list);
         } catch (e) {
           if (seq === this._loadSeq) {
-            this._error.set(String(e));
+            this._error.set(this.errorCopy.humanize(e));
           }
         } finally {
           if (seq === this._loadSeq) {
@@ -260,7 +262,7 @@ export class SettingsOrganizationSectionComponent {
       this.createName.set("");
       this.reload();
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
     } finally {
       this.creating.set(false);
     }
@@ -288,7 +290,7 @@ export class SettingsOrganizationSectionComponent {
         list.map((o) => ({ ...o, consented: grant })),
       );
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
     } finally {
       this.consentBusy.set(false);
     }
@@ -323,7 +325,7 @@ export class SettingsOrganizationSectionComponent {
       }
     } catch (e) {
       if (this._expandedOrgId() === orgId) {
-        this._membersError.set(String(e));
+        this._membersError.set(this.errorCopy.humanize(e));
       }
     } finally {
       if (this._expandedOrgId() === orgId) {
@@ -350,7 +352,7 @@ export class SettingsOrganizationSectionComponent {
       await this.loadMembers(orgId);
       this.reload();
     } catch (e) {
-      this._membersError.set(String(e));
+      this._membersError.set(this.errorCopy.humanize(e));
     } finally {
       this.inviting.set(false);
     }
@@ -368,7 +370,7 @@ export class SettingsOrganizationSectionComponent {
       await this.loadMembers(orgId);
       this.reload();
     } catch (e) {
-      this._membersError.set(String(e));
+      this._membersError.set(this.errorCopy.humanize(e));
     } finally {
       this._removingId.set(null);
     }
@@ -391,7 +393,7 @@ export class SettingsOrganizationSectionComponent {
       }
       this.reload();
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
     } finally {
       this._busyOrgId.set(null);
     }
@@ -422,7 +424,7 @@ export class SettingsOrganizationSectionComponent {
       this._orgs.update((list) =>
         list.map((o) => (o.orgId === org.orgId ? { ...o, contextEnabled: !next } : o)),
       );
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
     } finally {
       this._contextTogglingOrgId.set(null);
     }
@@ -465,8 +467,8 @@ export class SettingsOrganizationSectionComponent {
         void this.loadOrgItems(org.orgId);
       }
     } catch (e) {
-      this._error.set(String(e));
-      this.toast.danger(`Sync failed — ${String(e)}`);
+      this._error.set(this.errorCopy.humanize(e));
+      this.toast.danger(this.errorCopy.because("Sync failed", e));
     } finally {
       this._syncingOrgId.set(null);
     }
@@ -500,7 +502,7 @@ export class SettingsOrganizationSectionComponent {
       this._orgItems.set(items);
     } catch (e) {
       if (seq === this._browseSeq) {
-        this._itemsError.set(String(e));
+        this._itemsError.set(this.errorCopy.humanize(e));
       }
     } finally {
       if (seq === this._browseSeq) {

--- a/src/app/features/settings/sections/settings-privacy-section/settings-privacy-section.component.html
+++ b/src/app/features/settings/sections/settings-privacy-section/settings-privacy-section.component.html
@@ -35,52 +35,64 @@
               </div>
             </div>
 
-            <!-- (1) Redaction firewall -->
+            <!--
+              (1) What is removed before text leaves.
+              PROTECTED CLAUSES — pinned by e2e/settings/privacy-honesty.spec.ts:
+                · the enumeration "emails, card numbers and phone numbers";
+                · that Claude Code uploads the transcript to Anthropic too;
+                · that a remote Ollama server counts as cloud;
+                · that only Ollama running on THIS Mac keeps everything here.
+              "Redaction firewall" was a mechanism name. What the user needs is what is removed.
+            -->
             <div class="privacy-section">
               <span class="privacy-section-label text-muted"
-                >Redaction firewall</span
+                >What is removed before text leaves</span
               >
               <p class="text-secondary privacy-note">
                 Emails, card numbers and phone numbers are automatically
-                scrubbed before any text leaves this Mac — that covers the Anthropic
+                removed before any text leaves this Mac — that covers the Anthropic
                 API, Claude Code (the <code>claude</code> CLI uploads your
                 transcript to Anthropic too), a Kong AI Gateway, and a remote Ollama
-                server — then restored in your notes. Only Ollama running on this
-                Mac keeps everything on-device.
+                server — then put back in your notes. Only Ollama running on this
+                Mac keeps everything on this Mac.
               </p>
             </div>
 
-            <!-- (1a) On-device name redaction (Phase D — NER model) -->
+            <!-- (1a) Optional on-device name masking -->
             <div class="privacy-section">
               <span class="privacy-section-label text-muted"
-                >Name redaction</span
+                >Name masking</span
               >
               @if (nerModelPresent() === true) {
                 <p class="text-secondary privacy-note">
-                  An on-device name-redaction model is installed, so people's
-                  NAMES are additionally masked before any redacted text leaves
-                  this Mac (Polish + English), then restored in your notes.
+                  Name masking is on, so people's NAMES are also replaced before
+                  any text leaves this Mac (Polish + English), then put back in
+                  your notes. The model that does it runs on this Mac.
                 </p>
                 <span class="pill is-success ner-pill">
                   <span class="pill-dot"></span>
-                  Name redaction on
+                  Name masking on
                 </span>
               } @else {
-                <!-- HONEST copy: without the model, do NOT claim names are
-                     redacted — only emails / cards / phones are by default. -->
+                <!--
+                  PROTECTED CLAUSE — pinned by privacy-honesty.spec.ts. Without the model, do NOT
+                  claim names are protected. The explicit NEGATIVE ("people's NAMES are not") is
+                  the single most destroyable sentence in this file: it is exactly what a
+                  well-meaning "your data is protected" rewrite deletes.
+                -->
                 <p class="text-secondary privacy-note">
                   By default only emails, card numbers and phone numbers are
-                  redacted — people's NAMES are not. The pattern firewall alone
-                  can't catch names, so they can leave your device alongside the
+                  removed — people's NAMES are not. Pattern matching alone
+                  can't catch names, so they leave this Mac alongside the
                   transcript when you use a cloud provider. Download the optional
-                  on-device name-redaction model to additionally mask names
+                  name-masking model to also replace names
                   (Polish + English) before any text leaves this Mac.
                 </p>
                 @if (downloadingNerModel()) {
                   <div class="dl-progress" role="status">
                     <mur-progress
                       size="md"
-                      ariaLabel="Name-detector model download"
+                      ariaLabel="Name-masking model download"
                       [value]="nerDownloadFrac() * 100"
                     />
                     <span class="dl-progress-label text-muted">
@@ -99,10 +111,10 @@
                     (click)="downloadNerModel()"
                     [disabled]="nerModelPresent() === null"
                   >
-                    Enable name redaction (download model)
+                    Turn on name masking (download model)
                   </button>
                   <span class="text-muted ner-hint">
-                    One time, on-device, no meeting content is sent.
+                    One time. The download itself sends no meeting content.
                   </span>
                 }
                 @if (nerDownloadError(); as nerr) {
@@ -114,12 +126,18 @@
             <!-- (1b) Cloud processing consent (E10) -->
             <div class="privacy-section">
               <span class="privacy-section-label text-muted">Cloud processing</span>
+              <!--
+                PROTECTED CLAUSE — pinned by privacy-honesty.spec.ts. Every cloud provider is named
+                (including the remote-Ollama case, which people assume is local), and the
+                fail-closed promise ("until you allow this once … won't run") is what makes the
+                Allow button meaningful. A shorter version that drops either is a downgrade.
+              -->
               <p class="text-secondary privacy-note">
                 Cloud providers — Claude Code, the Anthropic API, a Kong AI Gateway, or
-                a remote Ollama server — send your (redacted) transcript off this
-                Mac to write each summary. Only Ollama running on this Mac stays
-                fully on-device. Until you allow this once, cloud summaries are
-                turned off and won't run.
+                a remote Ollama server — send your transcript off this Mac to
+                write each summary, with emails, phones and cards removed first.
+                Only Ollama running on this Mac keeps everything here. Until you
+                allow this once, cloud summaries are turned off and won't run.
               </p>
               @if (cloudConsented()) {
                 <span class="pill is-success cloud-consent-pill">
@@ -176,18 +194,33 @@
             <!-- (2) Locked folders (honest encryption boundary) -->
             <div class="privacy-section">
               <span class="privacy-section-label text-muted">Locked folders</span>
+              <!--
+                PROTECTED CLAUSE — pinned by privacy-honesty.spec.ts. Both halves are load-bearing:
+                a locked note LEAVES the vault (Obsidian stops seeing it), and an unlocked one is a
+                plain readable file. "Obsidian vault" and "Markdown" are the RIGHT words for this
+                audience and stay.
+              -->
               <p class="text-secondary privacy-note">
-                Locked folders are encrypted and pulled out of your Obsidian vault;
-                open notes remain plaintext .md files Obsidian can read.
+                Locked folders are encrypted and taken out of your Obsidian vault,
+                so Obsidian can no longer see them. Everything else stays as
+                ordinary Markdown files Obsidian reads normally.
               </p>
             </div>
 
-            <!-- (3) Local MCP server -->
+            <!--
+              (3) The local read-only server for Claude.
+              "MCP" is on the never-show list (glossary.ts). The acronym stays inside the config
+              block below, where it is a literal the user pastes into Claude — that is a filename,
+              not prose. The heading and the sentence say what it DOES.
+            -->
             <div class="privacy-section">
-              <span class="privacy-section-label text-muted">Local MCP server</span>
+              <span class="privacy-section-label text-muted"
+                >Local server for Claude</span
+              >
               <p class="text-secondary privacy-note">
-                Murmur runs a localhost MCP server that exposes your meetings
-                (read-only) to Claude Desktop and Claude Code at
+                Murmur runs a small server on this Mac only — nothing on it is
+                reachable from the internet — that lets Claude Desktop and Claude
+                Code READ your meetings (never write) at
                 <span class="privacy-inline-url">{{ mcpUrl }}</span
                 >.
               </p>
@@ -258,18 +291,18 @@
                   <pre class="mcp-config-block" role="text">{{ mcpConfig() }}</pre>
                 } @else {
                   <p class="mcp-config-error text-secondary" role="alert">
-                    Couldn't read the local server token. Reopen Settings, or
-                    restart Murmur — the config appears here once the token is
-                    available.
+                    Couldn't read the local server's private key. Reopen
+                    Settings, or restart Murmur — the config appears here once
+                    the key is available.
                   </p>
                 }
               </div>
 
               @if (mcpConfig()) {
                 <span class="mcp-hint text-muted">
-                  Add this to your Claude config, then restart Claude. This block
-                  includes a private access token for your local server — keep it
-                  to yourself.
+                  Add this to your Claude config, then restart Claude. It contains
+                  a private key for your local server — anyone who has it can read
+                  your meetings, so keep it to yourself.
                 </span>
               }
             </div>

--- a/src/app/features/settings/sections/settings-transcription-section/model-power/model-power.component.ts
+++ b/src/app/features/settings/sections/settings-transcription-section/model-power/model-power.component.ts
@@ -21,6 +21,7 @@ import {
   MurPowerSliderComponent,
   type PowerRung,
 } from "../../../../../design-system/power-slider/power-slider.component";
+import { ErrorCopyService } from "../../../../../core/copy/error-copy.service";
 
 /**
  * The COARSE accuracy / speed rating per ladder rung.
@@ -69,6 +70,7 @@ const RATINGS: Record<string, { accuracy: number; speed: number }> = {
 export class ModelPowerComponent {
   private readonly ipc = inject(IpcService);
   readonly machine = inject(MachineService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** The currently chosen size id. The host owns it; this component never writes it. */
   readonly size = input.required<string>();
@@ -286,7 +288,7 @@ export class ModelPowerComponent {
     try {
       await this.ipc.deleteWhisperModel(id);
     } catch (e) {
-      this._deleteError.set(String(e));
+      this._deleteError.set(this.errorCopy.humanize(e));
     } finally {
       this._deleting.set(false);
       // Refresh either way: on success the row must stop claiming it is downloaded,

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -7,6 +7,10 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { IpcService } from "../../core/ipc.service";
 import { hostIsLoopback } from "../../core/loopback";
 import { modelSizeLabel } from "../../core/model-bytes";
+// P3: the connection labels used to be declared here AND in `record.component.ts` AND in
+// `summarize/roles.rs` — three copies of four strings. They now live in the ONE copy module, which
+// is the documented mirror of the Rust half.
+import { CONNECTION_LABELS } from "../../core/copy/labels";
 import { MachineService } from "../../services/machine.service";
 import type {
   AiMapRow,
@@ -29,6 +33,7 @@ import type {
 } from "../../core/models";
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import { NOTE_ASSIST_NEW_ACTION_IDS } from "../notes/note-brain-popover/note-assist-catalog";
+import { ErrorCopyService } from "../../core/copy/error-copy.service";
 
 /**
  * The four provider-backed connection ids — the ones `list_models` serves a
@@ -80,14 +85,6 @@ export function looksLikeGgufPath(v: string): boolean {
   );
 }
 
-/** Display names for the connection ids (matches the connection cards). */
-const CONNECTION_LABELS: Readonly<Record<string, string>> = {
-  claude_code: "Claude Code",
-  anthropic: "Anthropic API",
-  ollama: "Ollama",
-  gateway: "Kong AI Gateway",
-};
-
 /**
  * Shared state + IPC orchestration for the Settings page (Stage-1 split of the
  * former settings.component.ts monolith — moved here VERBATIM, no behavior
@@ -109,6 +106,7 @@ export class SettingsStore {
   private readonly fb = inject(FormBuilder);
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly errorCopy = inject(ErrorCopyService);
   /**
    * The ROOT-held whisper catalog + machine answer (P1). Root-scoped, so the store
    * reads the same cached snapshot the picker paints — never a second copy that can
@@ -301,7 +299,7 @@ export class SettingsStore {
       try {
         void this.save();
       } catch (e) {
-        this._loadError.set("Save failed: " + String(e));
+        this._loadError.set(this.errorCopy.because("Save failed", e));
       }
     });
 
@@ -417,7 +415,7 @@ export class SettingsStore {
       await this.loadNoteTemplates();
       return saved;
     } catch (e) {
-      this._noteTemplateError.set(String(e));
+      this._noteTemplateError.set(this.errorCopy.humanize(e));
       return null;
     } finally {
       this._noteTemplateBusy.set(false);
@@ -436,7 +434,7 @@ export class SettingsStore {
       }
       await this.loadNoteTemplates();
     } catch (e) {
-      this._noteTemplateError.set(String(e));
+      this._noteTemplateError.set(this.errorCopy.humanize(e));
     } finally {
       this._noteTemplateBusy.set(false);
     }
@@ -904,7 +902,9 @@ export class SettingsStore {
           const dest = this.gatewayDestination();
           return {
             connection: "Kong AI Gateway",
-            destination: dest ? dest.host : "your gateway (base URL not set)",
+            destination: dest
+              ? dest.host
+              : "your gateway (server address not set)",
           };
         }
         case "ollama": {
@@ -1633,7 +1633,7 @@ export class SettingsStore {
       // would let the pristine defaults overwrite the user's stored config.
       this.autoSaveReady = true;
     } catch (e) {
-      this._loadError.set(String(e));
+      this._loadError.set(this.errorCopy.humanize(e));
     }
   }
 
@@ -1700,7 +1700,7 @@ export class SettingsStore {
     try {
       this._brainModels.set(await this.ipc.listBrainModels());
     } catch (e) {
-      this._brainError.set(String(e));
+      this._brainError.set(this.errorCopy.humanize(e));
     } finally {
       this._brainModelsLoading.set(false);
     }
@@ -1717,7 +1717,7 @@ export class SettingsStore {
       this.form.markAsDirty(); // user-driven → auto-save
       await this.refreshBrainModels();
     } catch (e) {
-      this._brainError.set(String(e));
+      this._brainError.set(this.errorCopy.humanize(e));
     }
   }
 
@@ -1733,7 +1733,7 @@ export class SettingsStore {
       await this.ipc.downloadBrainModel(id);
       await this.refreshBrainModels();
     } catch (e) {
-      this._brainError.set(String(e));
+      this._brainError.set(this.errorCopy.humanize(e));
     } finally {
       this._brainDownloadingId.set(null);
     }
@@ -1783,7 +1783,7 @@ export class SettingsStore {
     try {
       this._posture.set(await this.ipc.brainPosture());
     } catch (e) {
-      this._postureError.set(String(e));
+      this._postureError.set(this.errorCopy.humanize(e));
     }
     this._retirementNudge.set(
       await this.ipc.brainModelRetirementNudge().catch(() => null),
@@ -1828,7 +1828,7 @@ export class SettingsStore {
         await this.selectNeeded(needed);
         await this.commitPosture(p);
       } catch (e) {
-        this._postureError.set(String(e));
+        this._postureError.set(this.errorCopy.humanize(e));
       } finally {
         this._postureBusy.set(false);
       }
@@ -1887,7 +1887,9 @@ export class SettingsStore {
       await this.commitPosture(p);
     } catch (e) {
       // A cancel is a user action — silent; any real failure surfaces the message.
-      this._postureError.set(this._cancelDownload ? null : String(e));
+      this._postureError.set(
+        this._cancelDownload ? null : this.errorCopy.humanize(e),
+      );
       // Reflect the unchanged backend posture so the card stays honest.
       await this.refreshPosture();
     } finally {
@@ -2002,7 +2004,7 @@ export class SettingsStore {
       await this.syncPostureFormFromBackend();
       await this.refreshPosture();
     } catch (e) {
-      this._postureError.set(String(e));
+      this._postureError.set(this.errorCopy.humanize(e));
     } finally {
       this._enablingBrainLive.set(false);
     }
@@ -2063,7 +2065,7 @@ export class SettingsStore {
       await this.refreshBrainModels();
       await this.refreshPosture();
     } catch (e) {
-      this._brainError.set(String(e));
+      this._brainError.set(this.errorCopy.humanize(e));
     } finally {
       this._applyingRetirement.set(false);
     }
@@ -2112,7 +2114,7 @@ export class SettingsStore {
       await this.ipc.downloadEmbedModel();
       this._embedModelPresent.set(await this.ipc.embedModelPresent());
     } catch (e) {
-      this._embedDownloadError.set(String(e));
+      this._embedDownloadError.set(this.errorCopy.humanize(e));
     } finally {
       this._downloadingEmbedModel.set(false);
     }
@@ -2154,7 +2156,7 @@ export class SettingsStore {
       await this.ipc.downloadNerModel();
       this._nerModelPresent.set(await this.ipc.nerModelPresent());
     } catch (e) {
-      this._nerDownloadError.set(String(e));
+      this._nerDownloadError.set(this.errorCopy.humanize(e));
     } finally {
       this._downloadingNerModel.set(false);
     }
@@ -2176,7 +2178,7 @@ export class SettingsStore {
       // The model could have been (un)installed between the presence probe and now.
       if (res.status === "model_missing") this._embedModelPresent.set(false);
     } catch (e) {
-      this._reindexError.set(String(e));
+      this._reindexError.set(this.errorCopy.humanize(e));
     } finally {
       this._reindexing.set(false);
     }
@@ -2360,7 +2362,7 @@ export class SettingsStore {
       // the MCP config so the copy block never shows a stale token-bearing / tokenless snippet.
       await this.refreshMcpConfig();
     } catch (e) {
-      this._loadError.set("Save failed: " + String(e));
+      this._loadError.set(this.errorCopy.because("Save failed", e));
     }
   }
 
@@ -2424,7 +2426,7 @@ export class SettingsStore {
       this._cloudConsented.set(true);
       await this.refreshProviders();
     } catch (e) {
-      this._consentError.set(String(e));
+      this._consentError.set(this.errorCopy.humanize(e));
     } finally {
       this._consenting.set(false);
     }
@@ -2445,7 +2447,7 @@ export class SettingsStore {
       this._cloudConsented.set(false);
       await this.refreshProviders();
     } catch (e) {
-      this._revokeError.set(String(e));
+      this._revokeError.set(this.errorCopy.humanize(e));
     } finally {
       this._revoking.set(false);
     }
@@ -2502,7 +2504,7 @@ export class SettingsStore {
       this.webKeyControl.setValue("");
       this._hasWebKey.set(await this.ipc.hasWebSearchKey());
     } catch (e) {
-      this._webKeyError.set(String(e));
+      this._webKeyError.set(this.errorCopy.humanize(e));
     } finally {
       this._savingWebKey.set(false);
     }
@@ -2523,7 +2525,7 @@ export class SettingsStore {
       await this.ipc.consentToWebSearch();
       this._webConsented.set(true);
     } catch (e) {
-      this._webConsentError.set(String(e));
+      this._webConsentError.set(this.errorCopy.humanize(e));
     } finally {
       this._webConsenting.set(false);
     }
@@ -2544,7 +2546,7 @@ export class SettingsStore {
       this.jiraTokenControl.setValue("");
       this._hasJiraToken.set(await this.ipc.hasJiraToken());
     } catch (e) {
-      this._jiraTokenError.set(String(e));
+      this._jiraTokenError.set(this.errorCopy.humanize(e));
     } finally {
       this._savingJiraToken.set(false);
     }
@@ -2563,7 +2565,7 @@ export class SettingsStore {
       await this.ipc.consentToJira();
       this._jiraConsented.set(true);
     } catch (e) {
-      this._jiraConsentError.set(String(e));
+      this._jiraConsentError.set(this.errorCopy.humanize(e));
     } finally {
       this._jiraConsenting.set(false);
     }
@@ -2584,7 +2586,7 @@ export class SettingsStore {
       this.slackTokenControl.setValue("");
       this._hasSlackToken.set(await this.ipc.hasSlackToken());
     } catch (e) {
-      this._slackTokenError.set(String(e));
+      this._slackTokenError.set(this.errorCopy.humanize(e));
     } finally {
       this._savingSlackToken.set(false);
     }
@@ -2603,7 +2605,7 @@ export class SettingsStore {
       await this.ipc.consentToSlack();
       this._slackConsented.set(true);
     } catch (e) {
-      this._slackConsentError.set(String(e));
+      this._slackConsentError.set(this.errorCopy.humanize(e));
     } finally {
       this._slackConsenting.set(false);
     }
@@ -2624,7 +2626,7 @@ export class SettingsStore {
       this.notionTokenControl.setValue("");
       this._hasNotionToken.set(await this.ipc.hasNotionToken());
     } catch (e) {
-      this._notionTokenError.set(String(e));
+      this._notionTokenError.set(this.errorCopy.humanize(e));
     } finally {
       this._savingNotionToken.set(false);
     }
@@ -2643,7 +2645,7 @@ export class SettingsStore {
       await this.ipc.consentToNotion();
       this._notionConsented.set(true);
     } catch (e) {
-      this._notionConsentError.set(String(e));
+      this._notionConsentError.set(this.errorCopy.humanize(e));
     } finally {
       this._notionConsenting.set(false);
     }
@@ -2664,7 +2666,7 @@ export class SettingsStore {
       this.clickupTokenControl.setValue("");
       this._hasClickupToken.set(await this.ipc.hasClickupToken());
     } catch (e) {
-      this._clickupTokenError.set(String(e));
+      this._clickupTokenError.set(this.errorCopy.humanize(e));
     } finally {
       this._savingClickupToken.set(false);
     }
@@ -2683,7 +2685,7 @@ export class SettingsStore {
       await this.ipc.consentToClickup();
       this._clickupConsented.set(true);
     } catch (e) {
-      this._clickupConsentError.set(String(e));
+      this._clickupConsentError.set(this.errorCopy.humanize(e));
     } finally {
       this._clickupConsenting.set(false);
     }
@@ -2703,7 +2705,7 @@ export class SettingsStore {
       this.gatewayKeyControl.setValue("");
       this._hasGatewayKey.set(await this.ipc.hasGatewayKey());
     } catch (e) {
-      this._gatewayKeyError.set(String(e));
+      this._gatewayKeyError.set(this.errorCopy.humanize(e));
     }
   }
 
@@ -2717,7 +2719,7 @@ export class SettingsStore {
       await this.ipc.clearGatewayKey();
       this._hasGatewayKey.set(await this.ipc.hasGatewayKey());
     } catch (e) {
-      this._gatewayKeyError.set(String(e));
+      this._gatewayKeyError.set(this.errorCopy.humanize(e));
     }
   }
 
@@ -2736,7 +2738,7 @@ export class SettingsStore {
     } catch (e) {
       // Leave the existing list (may be empty) and show the fallback hint.
       this._gatewayModels.set([]);
-      this._gatewayModelError.set(String(e));
+      this._gatewayModelError.set(this.errorCopy.humanize(e));
     } finally {
       this._gatewayModelsLoading.set(false);
     }
@@ -2828,7 +2830,7 @@ export class SettingsStore {
       this._modelPresent.set(await this.ipc.modelPresent());
       await this.machine.refresh();
     } catch (e) {
-      this._modelDownloadError.set(String(e));
+      this._modelDownloadError.set(this.errorCopy.humanize(e));
     } finally {
       this._downloadingModel.set(false);
     }
@@ -2859,7 +2861,7 @@ export class SettingsStore {
         await this.ipc.parakeetModelsPresent().catch(() => false),
       );
     } catch (e) {
-      this._parakeetDownloadError.set(String(e));
+      this._parakeetDownloadError.set(this.errorCopy.humanize(e));
     } finally {
       this._downloadingParakeet.set(false);
     }

--- a/src/app/features/sharing/sharing-auth-flow/sharing-auth-flow.component.ts
+++ b/src/app/features/sharing/sharing-auth-flow/sharing-auth-flow.component.ts
@@ -13,6 +13,7 @@ import {
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { IpcService } from "../../../core/ipc.service";
 import type { AccountStatus } from "../../../core/models";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 
 /**
  * The reusable multi-step sharing-account flow. One state machine, two entry
@@ -60,6 +61,7 @@ type Step =
 export class SharingAuthFlowComponent {
   private readonly ipc = inject(IpcService);
   private readonly injector = inject(Injector);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   /** Fired once the session is logged in (after sign-in, or signup → auto-login). */
   readonly completed = output<AccountStatus>();
@@ -350,20 +352,17 @@ export class SharingAuthFlowComponent {
     }
   }
 
-  /** Map a raw backend error to a friendly, non-crashy inline message. */
+  /**
+   * Map a backend failure to the sentence for this form.
+   *
+   * This used to sniff the raw string for connectivity words and, on a miss, strip the `AppError`
+   * variant prefix and render whatever was left. On a rejected sign-in code that meant the user
+   * read `verify_code: rejected (400)` — the shape of failure P3 exists to delete. The four
+   * `sharing-*` codes (`share/client.rs::status_err`) now carry the distinction that mattered:
+   * unreachable is connectivity, 429 is rate-limiting, 4xx is a bad or expired code, 401 is a
+   * signed-out session.
+   */
   private friendly(e: unknown): string {
-    const raw = String(e);
-    // Only a genuine connectivity problem gets the "can't reach" guidance. A 4xx
-    // (wrong or expired code, too many tries, bad password) is NOT unreachability — it arrives as a
-    // clear sentence we surface as-is (below).
-    if (/could not reach|unreachable|no sharing server|failed to build|network|timed? ?out/i.test(raw)) {
-      return "Can't reach the sharing server. Check your connection, then try again.";
-    }
-    // AppError serializes as "invalid argument: <msg>" / "authentication error: <msg>" etc. — strip
-    // the variant prefix so the user reads the clean message.
-    return raw.replace(
-      /^(invalid argument|authentication error|provider unavailable|config error|storage error|secrets error|locked): /i,
-      "",
-    );
+    return this.errorCopy.humanize(e);
   }
 }

--- a/src/app/services/folders.service.ts
+++ b/src/app/services/folders.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, computed, inject, signal } from "@angular/core";
 import { IpcService } from "../core/ipc.service";
 import type { Folder, FolderNode } from "../core/models";
+import { ErrorCopyService } from "../core/copy/error-copy.service";
 
 /**
  * A folder's privacy exposure, derived from its lock flags:
@@ -22,6 +23,7 @@ export type FolderExposure = "open" | "locked" | "session";
 @Injectable({ providedIn: "root" })
 export class FoldersService {
   private readonly ipc = inject(IpcService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   private readonly _tree = signal<FolderNode[]>([]);
   private readonly _loading = signal(false);
@@ -91,7 +93,7 @@ export class FoldersService {
       this._tree.set(await this.ipc.listFolders());
       this.loadedOnce = true;
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
     } finally {
       this._loading.set(false);
     }
@@ -138,7 +140,7 @@ export class FoldersService {
     try {
       folder = await this.ipc.createFolder(name, parentId);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
     // The folder now exists. The refresh is best-effort: a refresh error is logged into `error`
@@ -159,7 +161,7 @@ export class FoldersService {
     try {
       folder = await this.ipc.renameFolder(folderId, newName);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
     await this.load();
@@ -177,7 +179,7 @@ export class FoldersService {
     try {
       await this.ipc.deleteFolder(folderId);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
     await this.load();
@@ -190,7 +192,7 @@ export class FoldersService {
       await this.ipc.moveNote(meetingId, folderId);
       await this.load();
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
   }
@@ -202,7 +204,7 @@ export class FoldersService {
       await this.ipc.lockFolder(folderId);
       await this.load();
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
   }
@@ -214,7 +216,7 @@ export class FoldersService {
       await this.ipc.unlockFolder(folderId);
       await this.load();
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
   }
@@ -226,7 +228,7 @@ export class FoldersService {
       await this.ipc.relockFolder(folderId);
       await this.load();
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
   }
@@ -238,7 +240,7 @@ export class FoldersService {
       await this.ipc.relockAll();
       await this.load();
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
   }
@@ -250,7 +252,7 @@ export class FoldersService {
       await this.ipc.removeLock(folderId);
       await this.load();
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
   }

--- a/src/app/services/machine.service.ts
+++ b/src/app/services/machine.service.ts
@@ -5,6 +5,7 @@ import type {
   WhisperModelDto,
   WhisperRecommendationDto,
 } from "../core/models";
+import { ErrorCopyService } from "../core/copy/error-copy.service";
 
 /**
  * Root-held answer to "what does THIS Mac deserve?" — the machine profile, the
@@ -27,6 +28,7 @@ import type {
 @Injectable({ providedIn: "root" })
 export class MachineService {
   private readonly ipc = inject(IpcService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   private readonly _data = signal<WhisperRecommendationDto | null>(null);
   private readonly _loading = signal(false);
@@ -101,7 +103,7 @@ export class MachineService {
       if (seq !== this.loadSeq) return;
       // Keep the last-known catalog on screen rather than blanking it: a failed
       // refresh should degrade to stale-but-useful, never to empty.
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
     } finally {
       // `_loading` is gated too: a superseded call clearing it would report
       // "settled" while the newest request is still in flight.

--- a/src/app/services/note-attachment.service.ts
+++ b/src/app/services/note-attachment.service.ts
@@ -1,5 +1,11 @@
 import { Injectable, inject } from "@angular/core";
 import { IpcService } from "../core/ipc.service";
+// P3: this service's refusals are the one population of frontend-authored, already-finished user
+// copy — the pasted-image preflight rejects a decompression bomb from its bounded header, before a
+// decoder allocates and before anything crosses IPC, so there is no `AppError` to carry an
+// `errcode`. Throwing the marker type is what tells `ErrorCopyService.humanize()` the sentence is
+// already the copy layer's own and must be shown verbatim rather than denied to the generic one.
+import { UserFacingError } from "../core/copy/error-copy.service";
 import type {
   NoteAttachmentDto,
   NoteAttachmentOwnerKind,
@@ -676,10 +682,10 @@ export class NoteAttachmentService {
   ): Promise<{ blob: Blob; mime: "image/webp" | "image/png"; width: number; height: number }> {
     const mimeType = sourceBlob.type.toLowerCase();
     if (!INPUT_IMAGE_TYPES.has(mimeType)) {
-      throw new Error("Choose a PNG, JPEG, or WebP image.");
+      throw new UserFacingError("Choose a PNG, JPEG, or WebP image.");
     }
     if (sourceBlob.size > MAX_SOURCE_BYTES) {
-      throw new Error("That image is too large to process safely (24 MB maximum).");
+      throw new UserFacingError("That image is too large to process safely (24 MB maximum).");
     }
 
     const header = new Uint8Array(
@@ -687,27 +693,27 @@ export class NoteAttachmentService {
     );
     const expected = imageDimensions(mimeType, header);
     if (!expected || expected.width < 1 || expected.height < 1) {
-      throw new Error("That image’s dimensions could not be validated safely.");
+      throw new UserFacingError("That image’s dimensions could not be validated safely.");
     }
     if (
       expected.width > MAX_SOURCE_EDGE ||
       expected.height > MAX_SOURCE_EDGE ||
       expected.width > MAX_SOURCE_PIXELS / expected.height
     ) {
-      throw new Error("That image’s dimensions are too large to process safely.");
+      throw new UserFacingError("That image’s dimensions are too large to process safely.");
     }
 
     const decoded = await this.decodeImage(sourceBlob);
     try {
       if (decoded.width < 1 || decoded.height < 1) {
-        throw new Error("That image could not be decoded.");
+        throw new UserFacingError("That image could not be decoded.");
       }
       const sameOrientation =
         decoded.width === expected.width && decoded.height === expected.height;
       const rotatedOrientation =
         decoded.width === expected.height && decoded.height === expected.width;
       if (!sameOrientation && !rotatedOrientation) {
-        throw new Error("That image’s decoded dimensions do not match its container.");
+        throw new UserFacingError("That image’s decoded dimensions do not match its container.");
       }
       const initialScale = Math.min(1, MAX_EDGE / Math.max(decoded.width, decoded.height));
       let width = Math.max(1, Math.round(decoded.width * initialScale));
@@ -721,7 +727,7 @@ export class NoteAttachmentService {
         canvas.height = height;
         const context = canvas.getContext("2d", { alpha: true });
         if (!context) {
-          throw new Error("Image processing is unavailable in this window.");
+          throw new UserFacingError("Image processing is unavailable in this window.");
         }
         context.drawImage(decoded.source, 0, 0, width, height);
 
@@ -771,11 +777,11 @@ export class NoteAttachmentService {
         height = nextHeight;
       }
       if (!producedAnyBlob) {
-        throw new Error(
+        throw new UserFacingError(
           "This browser can’t encode images for upload. Update macOS and try again.",
         );
       }
-      throw new Error("That image is too detailed to fit the 3 MB note-image limit.");
+      throw new UserFacingError("That image is too detailed to fit the 3 MB note-image limit.");
     } finally {
       decoded.close();
     }
@@ -806,7 +812,7 @@ export class NoteAttachmentService {
     const dataUrl = await this.readAsDataUrl(blob);
     await new Promise<void>((resolve, reject) => {
       image.onload = () => resolve();
-      image.onerror = () => reject(new Error("That image could not be decoded."));
+      image.onerror = () => reject(new UserFacingError("That image could not be decoded."));
       image.src = dataUrl;
     });
     return {
@@ -824,8 +830,8 @@ export class NoteAttachmentService {
       reader.onload = () =>
         typeof reader.result === "string"
           ? resolve(reader.result)
-          : reject(new Error("That image could not be decoded."));
-      reader.onerror = () => reject(new Error("That image could not be decoded."));
+          : reject(new UserFacingError("That image could not be decoded."));
+      reader.onerror = () => reject(new UserFacingError("That image could not be decoded."));
       reader.readAsDataURL(blob);
     });
   }

--- a/src/app/services/notes-saved-views.service.ts
+++ b/src/app/services/notes-saved-views.service.ts
@@ -5,6 +5,7 @@ import {
   type SavedView,
   type ViewConfig,
 } from "../core/models";
+import { ErrorCopyService } from "../core/copy/error-copy.service";
 
 /** localStorage key holding the last active NOTES saved-view id (null = List default). */
 const ACTIVE_VIEW_KEY = "murmur.savedViews.notes.activeId";
@@ -33,6 +34,7 @@ const ACTIVE_VIEW_KEY = "murmur.savedViews.notes.activeId";
 @Injectable({ providedIn: "root" })
 export class NotesSavedViewsService {
   private readonly ipc = inject(IpcService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   private readonly _views = signal<SavedView[]>([]);
   private readonly _loading = signal(false);
@@ -78,7 +80,7 @@ export class NotesSavedViewsService {
         this.setActiveView(null);
       }
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
     } finally {
       this._loading.set(false);
     }
@@ -110,7 +112,7 @@ export class NotesSavedViewsService {
     try {
       saved = await this.ipc.upsertSavedView(draft);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
     await this.load();
@@ -128,7 +130,7 @@ export class NotesSavedViewsService {
     try {
       saved = await this.ipc.upsertSavedView(view);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
     await this.load();
@@ -144,7 +146,7 @@ export class NotesSavedViewsService {
     try {
       await this.ipc.deleteSavedView(id);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
     if (this._activeViewId() === id) {

--- a/src/app/services/notes.service.ts
+++ b/src/app/services/notes.service.ts
@@ -8,6 +8,7 @@ import type {
   PropertySchemaField,
   TypedNoteRow,
 } from "../core/models";
+import { ErrorCopyService } from "../core/copy/error-copy.service";
 
 /**
  * Signal store for the Notes section — the note list + the note-kind folder tree,
@@ -24,6 +25,7 @@ import type {
 export class NotesService {
   private readonly ipc = inject(IpcService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   private readonly _notes = signal<NoteSummary[]>([]);
   private readonly _noteFolders = signal<NoteFolder[]>([]);
@@ -130,7 +132,7 @@ export class NotesService {
     try {
       this._notes.set(await this.ipc.listNotes(folderId));
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
     } finally {
       this._loading.set(false);
     }
@@ -143,7 +145,7 @@ export class NotesService {
     try {
       this._noteFolders.set(await this.ipc.listNoteFolders());
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
     } finally {
       this._foldersLoading.set(false);
     }
@@ -162,7 +164,7 @@ export class NotesService {
     try {
       id = await this.ipc.createNote(folderId, title);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
     await this.loadNotes(folderId);
@@ -178,7 +180,7 @@ export class NotesService {
     try {
       await this.ipc.updateNoteDoc(id, title, markdown);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
     await this.loadNotes();
@@ -190,7 +192,7 @@ export class NotesService {
     try {
       await this.ipc.moveNoteDoc(id, folderId);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
     await this.loadNotes();
@@ -205,7 +207,7 @@ export class NotesService {
     try {
       await this.ipc.deleteNote(id);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
     this._notes.update((list) => list.filter((n) => n.id !== id));
@@ -225,7 +227,7 @@ export class NotesService {
     try {
       folder = await this.ipc.createNoteFolder(name, parentId);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
     await this.loadFolders();
@@ -241,7 +243,7 @@ export class NotesService {
     try {
       await this.ipc.renameNoteFolder(id, name);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
     await this.loadFolders();
@@ -257,7 +259,7 @@ export class NotesService {
     try {
       await this.ipc.deleteNoteFolder(id);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
     await this.loadFolders();
@@ -274,7 +276,7 @@ export class NotesService {
     try {
       return await this.ipc.planOrganizeNotes(folderId);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
   }
@@ -289,7 +291,7 @@ export class NotesService {
     try {
       await this.ipc.applyOrganizePlan({ moves });
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
     await Promise.allSettled([this.loadFolders(), this.loadNotes()]);
@@ -314,7 +316,7 @@ export class NotesService {
     try {
       this._folderSchema.set(await this.ipc.getNoteFolderSchema(folderId));
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
     } finally {
       this._schemaLoading.set(false);
     }
@@ -336,7 +338,7 @@ export class NotesService {
     try {
       this._typedRows.set(await this.ipc.listNotesTyped(folderId));
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
     } finally {
       this._typedLoading.set(false);
     }
@@ -356,7 +358,7 @@ export class NotesService {
     try {
       await this.ipc.setNoteFolderSchema(folderId, fields);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
     // Reflect the saved set locally at once (optimistic-but-verified: the SAVE

--- a/src/app/services/saved-views.service.ts
+++ b/src/app/services/saved-views.service.ts
@@ -6,6 +6,7 @@ import {
   type SavedView,
   type ViewConfig,
 } from "../core/models";
+import { ErrorCopyService } from "../core/copy/error-copy.service";
 
 /** localStorage key holding the last active meetings saved-view id (null = List default). */
 const ACTIVE_VIEW_KEY = "murmur.savedViews.meetings.activeId";
@@ -36,6 +37,7 @@ const ACTIVE_VIEW_KEY = "murmur.savedViews.meetings.activeId";
 @Injectable({ providedIn: "root" })
 export class SavedViewsService {
   private readonly ipc = inject(IpcService);
+  private readonly errorCopy = inject(ErrorCopyService);
 
   private readonly _views = signal<SavedView[]>([]);
   private readonly _loading = signal(false);
@@ -90,7 +92,7 @@ export class SavedViewsService {
         this.setActiveView(null);
       }
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
     } finally {
       this._loading.set(false);
     }
@@ -147,7 +149,7 @@ export class SavedViewsService {
     try {
       saved = await this.ipc.upsertSavedView(draft);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
     await this.load();
@@ -166,7 +168,7 @@ export class SavedViewsService {
     try {
       saved = await this.ipc.upsertSavedView(view);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
     await this.load();
@@ -192,7 +194,7 @@ export class SavedViewsService {
     try {
       await this.ipc.deleteSavedView(id);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
       throw e;
     }
     if (this._activeViewId() === id) {
@@ -216,7 +218,7 @@ export class SavedViewsService {
     try {
       await this.ipc.reorderSavedViews("meetings", orderedIds);
     } catch (e) {
-      this._error.set(String(e));
+      this._error.set(this.errorCopy.humanize(e));
     }
     await this.load();
   }


### PR DESCRIPTION
Raw Rust error prose reached users verbatim — `summarizer error: HKDF expand failed` and its like. **185 display sites across 47 files** passed a wire string straight to a toast or a banner. This makes the app own its own sentences.

## Deny by default

`src-tauri/src/errcode.rs` defines **22 stable kebab-case codes**, applied at the `AppError` sites that actually reach a surface. The frontend strips all fourteen variant prefixes, reads a strict code, renders owned copy for a known one — and the **generic sentence for anything else**.

No heuristic sniffing for `::` or snake_case: Rust has ~2100 `AppError` constructions and ~161 with a never-show term in the body (`HKDF expand failed`, `account-session mutex poisoned`), and **no such heuristic matches them**.

## The interesting part: frontend-origin failures needed their own path

`note-attachment.service.ts` refuses a decompression bomb **inside the webview** — after reading a bounded header, before any decoder allocates — so its refusal never crosses IPC and carries no code. Those twelve messages are **already finished user copy**, and deny-by-default swallowed them. An e2e caught it.

`UserFacingError` now short-circuits **by type**, so the bomb copy reaches the toast verbatim while every Rust-origin failure stays denied.

## Also

- Nine `friendly*Error` mappers folded into one service.
- **A real bug fixed:** the `Locked` guard was case-sensitive while every producer is lowercase, so it never fired and a locked-note save fell into the retry branch instead.
- The **cloud-consent banner keys off a code** instead of regex-matching Rust prose — the difference between every cloud user's first note working and not.

## Privacy copy: plainer AND more explicit

`PII scrubbed` becomes an enumeration of what is actually removed. `Tokens by model` becomes **`By model`** — *not* `By AI service`, because the ledger groups by model label and two models from one vendor would have rendered as two services.

`privacy-honesty.spec.ts` pins the protected clauses **by fact, not by sentence**, so a well-meaning simplification cannot quietly drop the noun that carries the promise.

## Verification

| Gate | Result |
|---|---|
| Playwright | **338 passed** on chromium + webkit, 2 pre-existing fixmes skipped |
| `rust-lib` | green |
| clippy `--lib` **and** `--tests` | green |
| `ng lint`, `ng build` | green |
| vocabulary | **138 hits vs baseline 165** |

## Provenance — light lane, declared

Four harness attempts. **Every block was the contract author's fault, never the code's:** frontend checks were never scheduled (fixed in #474), the contract named a tool absent from its base (fixed by #475), and the contract demanded two commands in prose — which a reviewer cannot accept, because only runner-executed checks produce evidence. Those two are now declared checks.

The final round failed on **one assertion in a test the writer itself had added**: it asserted `not.toContain(tag)` for all fourteen variant tags, but `locked` is an ordinary English word that the correct replacement copy uses — *"That folder is locked — unlock it first."* The assertion was wrong, not the stripping. It now checks the prefix **as a prefix**, which is what the contract actually promises.

Harness-Lane: B