### PR TITLE
fix(mcp): stop discarding diarized speakers and f64 noise in the transcript

### DIFF
--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -1865,21 +1865,60 @@ fn page_text_disclosed(text: &str, offset: usize, max_chars: usize) -> (String, 
     (body, Some(header))
 }
 
+/// Render one wall-clock offset in seconds at ONE decimal. Upstream offsetting is f64 arithmetic
+/// (`pipeline.rs` `segment.start_s += offset_s`, `audio/merge.rs` `start_s: seg.start_s + offset_s`),
+/// so essentially every offset-shifted segment carries ~16 significant digits — 37 chars per
+/// timestamp pair where 16 suffice, ≈28k wasted chars (≈7k tokens) on a 1h/1355-segment meeting.
+/// A whole second collapses to an integer (`12`, not `12.0`) so short/fixture transcripts render
+/// exactly as before; sub-second precision below 0.1s is below ASR segment resolution anyway.
+fn secs(v: f64) -> String {
+    let r = (v * 10.0).round() / 10.0;
+    if r.fract() == 0.0 {
+        format!("{}", r as i64)
+    } else {
+        format!("{r:.1}")
+    }
+}
+
 /// Feature D — render a meeting's transcript segments as a STRUCTURED, one-line-per-segment block:
 /// `[<start_s>–<end_s>] <Speaker>: <text>`. RAW SECONDS (never MM:SS) so a 2h+ meeting can never
-/// wrap/clip a minutes field. Speaker maps the cheap 2-way stream attribution
-/// (`Segment.speaker`): `Some("me")` → `Me`, `Some("others")` → `Others`, `None`/anything else →
-/// `Unknown`. Empty-text segments are skipped (they carry no content, only silence bounds).
+/// wrap/clip a minutes field, rounded by [`secs`] to one decimal.
+///
+/// Speaker maps the raw `Segment.speaker` tag the SAME way the summarizer does
+/// (`summarize/template.rs`, `summarize/timeline.rs`): `me` → `Me`, plain `others` → `Others`, and a
+/// DIARIZED `others-{N}` (written by `transcribe::diarize::relabel_others` when sherpa-onnx finds
+/// more than one remote speaker) → `Speaker {N+1}`, one label per distinct person. Collapsing those to
+/// `Unknown` — as this renderer used to — meant ENABLING diarization strictly DEGRADED the MCP
+/// transcript while the note/timeline consumers of the same tag read it correctly. An absent tag, an
+/// unknown tag, or a malformed index (`others--1`) stays `Unknown` rather than inventing a
+/// `Speaker 0`. Empty-text segments are skipped (they carry no content, only silence bounds).
 fn format_structured_transcript(segs: &[crate::transcribe::types::Segment]) -> String {
+    use crate::audio::merge::{SPEAKER_ME, SPEAKER_OTHERS};
+    use std::borrow::Cow;
     segs.iter()
         .filter(|s| !s.text.trim().is_empty())
         .map(|s| {
-            let speaker = match s.speaker.as_deref() {
-                Some("me") => "Me",
-                Some("others") => "Others",
-                _ => "Unknown",
+            let speaker: Cow<'static, str> = match s.speaker.as_deref() {
+                Some(SPEAKER_ME) => Cow::Borrowed("Me"),
+                Some(SPEAKER_OTHERS) => Cow::Borrowed("Others"),
+                // Plain `others` is already handled above, so ask the shared parser for the
+                // NUMBERED branch only (`has_numbered: true`). Reject a negative/overflowing index
+                // so a corrupt tag can never render as `Speaker 0` or panic on `n + 1`.
+                Some(tag) => match crate::transcribe::diarize::cluster_index_of_tag(tag, true)
+                    .filter(|n| *n >= 0)
+                    .and_then(|n| n.checked_add(1))
+                {
+                    Some(label_n) => Cow::Owned(format!("Speaker {label_n}")),
+                    None => Cow::Borrowed("Unknown"),
+                },
+                None => Cow::Borrowed("Unknown"),
             };
-            format!("[{}–{}] {speaker}: {}", s.start_s, s.end_s, s.text.trim())
+            format!(
+                "[{}–{}] {speaker}: {}",
+                secs(s.start_s),
+                secs(s.end_s),
+                s.text.trim()
+            )
         })
         .collect::<Vec<_>>()
         .join("\n")
@@ -4587,6 +4626,145 @@ mod tests {
         assert_eq!(
             out, expected,
             "plain format must be byte-identical to the legacy join"
+        );
+    }
+
+    /// R1-A — DIARIZED tags must not collapse to `Unknown`. Murmur ships real N-way diarization
+    /// (`transcribe::diarize::relabel_others` rewrites system-stream segments to `others-{N}`), which
+    /// the summarizer already consumes as DISTINCT people. The MCP renderer must agree: each
+    /// `others-{N}` gets its own `Speaker {N+1}` label, plain `others` stays `Others`, and a
+    /// MALFORMED tag (`others--1`) degrades to `Unknown` rather than leaking a bogus `Speaker 0`.
+    #[test]
+    fn get_meeting_structured_transcript_labels_diarized_speakers() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        seed_meeting(&db, "m-diar", "Diarized", "the note", None);
+        db.insert_segments(
+            "m-diar",
+            &[
+                Segment {
+                    idx: 0,
+                    start_s: 0.0,
+                    end_s: 2.0,
+                    text: "opening".into(),
+                    speaker: Some("me".into()),
+                    confidence: None,
+                },
+                Segment {
+                    idx: 1,
+                    start_s: 2.0,
+                    end_s: 4.0,
+                    text: "first guest".into(),
+                    speaker: Some("others-0".into()),
+                    confidence: None,
+                },
+                Segment {
+                    idx: 2,
+                    start_s: 4.0,
+                    end_s: 6.0,
+                    text: "second guest".into(),
+                    speaker: Some("others-1".into()),
+                    confidence: None,
+                },
+                Segment {
+                    idx: 3,
+                    start_s: 6.0,
+                    end_s: 8.0,
+                    text: "undiarized guest".into(),
+                    speaker: Some("others".into()),
+                    confidence: None,
+                },
+                Segment {
+                    idx: 4,
+                    start_s: 8.0,
+                    end_s: 10.0,
+                    text: "malformed tag".into(),
+                    speaker: Some("others--1".into()),
+                    confidence: None,
+                },
+            ],
+        )
+        .unwrap();
+
+        let out = execute_tool(
+            &ToolCall::GetMeeting {
+                meeting_id: "m-diar".into(),
+                transcript_format: "structured".into(),
+                offset: 0,
+                max_chars: 0,
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            !out.contains("Unknown: first guest") && !out.contains("Unknown: second guest"),
+            "a diarized others-N tag must NOT render as Unknown: {out}"
+        );
+        assert!(
+            out.contains("Speaker 1: first guest"),
+            "others-0 → Speaker 1: {out}"
+        );
+        assert!(
+            out.contains("Speaker 2: second guest"),
+            "others-1 → Speaker 2 (distinct from others-0): {out}"
+        );
+        assert!(
+            out.contains("Others: undiarized guest"),
+            "plain others still renders as Others: {out}"
+        );
+        assert!(
+            out.contains("Unknown: malformed tag") && !out.contains("Speaker 0"),
+            "a malformed others--1 tag degrades to Unknown, never Speaker 0: {out}"
+        );
+    }
+
+    /// R1-B — timestamps render at ONE decimal, not full f64 precision. Upstream wall-clock
+    /// offsetting (`pipeline.rs` `segment.start_s += offset_s`, `audio/merge.rs`) leaves essentially
+    /// every offset-shifted segment carrying ~16 significant digits, which is pure token waste in the
+    /// MCP payload (~28k wasted chars on a 1h meeting).
+    #[test]
+    fn get_meeting_structured_transcript_rounds_timestamps() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        seed_meeting(&db, "m-prec", "Long meeting", "the note", None);
+        db.insert_segments(
+            "m-prec",
+            &[Segment {
+                idx: 0,
+                start_s: 3659.3188999159997,
+                end_s: 3668.198899916,
+                text: "wrapping up".into(),
+                speaker: Some("me".into()),
+                confidence: None,
+            }],
+        )
+        .unwrap();
+
+        let out = execute_tool(
+            &ToolCall::GetMeeting {
+                meeting_id: "m-prec".into(),
+                transcript_format: "structured".into(),
+                offset: 0,
+                max_chars: 0,
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            out.contains("[3659.3"),
+            "start must round to one decimal: {out}"
+        );
+        assert!(
+            !out.contains("3659.3188"),
+            "full f64 precision must not reach the payload: {out}"
+        );
+        assert!(
+            out.contains("[3659.3–3668.2]"),
+            "both bounds round to one decimal: {out}"
         );
     }
 

--- a/src-tauri/src/transcribe/diarize.rs
+++ b/src-tauri/src/transcribe/diarize.rs
@@ -166,7 +166,13 @@ fn tag_is_numbered_cluster(tag: &str) -> bool {
 /// `others` → 0 ONLY when the meeting is single-cluster 1:1 — inferred from the tags PRESENT on the
 /// segments (`has_numbered == false`), NOT from the stored-voiceprint set. `me`, an unknown tag, or a
 /// stray plain `others` inside a multi-cluster meeting → None (never a fabricated cluster).
-fn cluster_index_of_tag(tag: &str, has_numbered: bool) -> Option<i64> {
+///
+/// `pub(crate)` so the MCP transcript renderer (`tools.rs::format_structured_transcript`) parses the
+/// tag with the SAME parser the reconciler uses — two consumers of one tag must never disagree. That
+/// caller handles plain `others` itself and passes `has_numbered: true` to get only the numbered
+/// branch. NOTE: the returned index is unvalidated (`others--1` → `Some(-1)`); a caller that turns it
+/// into a user-visible label must range-check it.
+pub(crate) fn cluster_index_of_tag(tag: &str, has_numbered: bool) -> Option<i64> {
     if let Some(rest) = tag
         .strip_prefix(SPEAKER_OTHERS)
         .and_then(|r| r.strip_prefix('-'))


### PR DESCRIPTION
First batch of the MCP + note-pipeline repair program (defects #2b and #12 of 21).

## What was wrong

**Diarized speakers were thrown away.** `format_structured_transcript` matched `me` and `others` and sent *everything else* to `"Unknown"`. Murmur ships real N-way diarization — `transcribe/diarize.rs` relabels system-stream segments to `others-{N}` — so those labels landed in the catch-all and N distinct people collapsed into one anonymous blob. Turning diarization **on** therefore made the MCP transcript strictly *worse* than leaving it off, while `summarize/template.rs` and `summarize/timeline.rs` read the identical tag correctly. Two consumers of one tag disagreeing is what made this invisible.

**Timestamps shipped raw `f64` Display.** Upstream wall-clock offsetting (`pipeline.rs` `segment.start_s += offset_s`, `audio/merge.rs`) means nearly every shifted segment carries float noise, so segments printed as `[3659.3188999159997–3668.198899916]` where `[3659.3–3668.2]` conveys the same thing. On a 1h meeting (~1355 segments) that is roughly 28k wasted characters of context for precision no consumer can use.

## The fix

- `others-{N}` → `Speaker {N+1}`, with the parse **delegated to `diarize::cluster_index_of_tag`** so the tag keeps exactly one parser. A second, drifting copy of that parse is what caused this class of defect in the first place. A malformed or negative index is rejected rather than rendered as `Speaker 0`.
- Timestamps round to one decimal via a private `secs()` helper.

The `fract() == 0.0` integer-collapse branch is load-bearing rather than cosmetic: it keeps whole-second fixtures rendering `[12–15]` / `[5–8]` exactly as `{}` Display did, so the pinned assertions stay green **with no test edits**.

## Verification

Two new tests, driven end-to-end through `execute_tool` rather than the private helper:

- `get_meeting_structured_transcript_labels_diarized_speakers`
- `get_meeting_structured_transcript_rounds_timestamps`

Both were **proven RED empirically**, not by argument — the fix hunk was neutered back to trunk behavior, both tests failed, and the tree was restored byte-identically (verified: tree SHA matches the harness attestation).

```
tools::tests::get_meeting_structured_transcript_default              ... ok   (pinned, unedited)
tools::tests::get_meeting_structured_transcript_labels_diarized...   ... FAILED (neutered)
tools::tests::get_meeting_structured_transcript_rounds_timestamps    ... FAILED (neutered)
```

Restored → `cargo test --lib tools::tests` 64 passed, `mcp::tests` 24 passed, `cargo clippy --lib -- -D warnings` clean. The `plain` branch is untouched, so `get_meeting_transcript_format_plain_is_byte_identical` holds.

## Behavior change

`TOTAL_CHARS` shrinks roughly 24% on a long meeting, so an MCP client holding a cached char offset across the upgrade will land elsewhere. Self-correcting, since `TOTAL_CHARS` is re-disclosed on every call.

## Known follow-up (not in scope here)

`Speaker {N+1}` is a *different label space* from the timeline's display labels, which can resolve to a **real name** once a voiceprint is enrolled (`diarize::reconcile_speakers` exists to bridge cluster ↔ display label). So a meeting whose timeline resolved cluster 0 to "Anna" will read `Speaker 1` over MCP and "Anna" in the note. Strictly better than `Unknown` — distinct people are now distinguishable — but routing the MCP renderer through the stored reconciliation, and emitting a `SPEAKERS:` map, is tracked as the next step toward defect #2's `speakerMap` ask.
