### PR TITLE
fix(harness): expose the pinned sherpa archive to check SCRIPTS

### DIFF
--- a/.agents/harness/task_runner.py
+++ b/.agents/harness/task_runner.py
@@ -1306,6 +1306,14 @@ def command_needs_sherpa_archive(command: str, worktree: Optional[Path] = None) 
             "scripts/e2e-core.sh",
             "scripts/e2e-mix.sh",
             "scripts/harness-runtime-smoke",
+            # A harness check SCRIPT compiles the tree from inside itself, so the marker never
+            # appears in the command string the runner matches on. `perf-contracts.sh` runs
+            # `cd src-tauri && cargo test --lib …`, but its command is only
+            # `bash .agents/harness/checks/perf-contracts.sh` — so without this marker the pinned
+            # archive stayed unexposed and the network-isolated build tried to DOWNLOAD
+            # sherpa-onnx, which can never succeed under `network_mode: none`. Match the checks
+            # directory so any future check script inherits the offline archive too.
+            ".agents/harness/checks/",
             "npm run dev",
             "npm run tauri",
             "npx tauri",


### PR DESCRIPTION
A network-isolated check that requires a network download can never pass. That is the state `perf-contracts` was in.

## The bug

`command_needs_sherpa_archive` decides whether a check may compile the client-side sherpa-onnx dependency by **substring-matching the command string** against markers like `src-tauri` and `scripts/ci.sh`.

A check that runs as a *script* compiles the tree from inside itself, so the marker never appears in the command the runner matches on. `perf-contracts` is exactly that shape — its command is only:

```
bash .agents/harness/checks/perf-contracts.sh
```

while the `cd src-tauri` and the `cargo test --lib` invocations live in the script body. So `expose_sherpa_archive` stayed false, `SHERPA_ONNX_ARCHIVE_DIR` was never set, and `sherpa-onnx-sys`'s build script fell back to downloading the archive — under `network_mode: none`.

It surfaced as a DNS failure, with the pinned 19 MB archive sitting on disk the whole time:

```
Downloading sherpa-onnx libs from https://github.com/k2-fsa/sherpa-onnx/...
Dns Failed: resolve dns name 'github.com:443'
```

This blocks **every** task carrying the `performance` risk flag, which is auto-inferred for most `src-tauri` changes — so it is not a corner case.

## The fix

Match the checks *directory* rather than one script name, so any future check script inherits the offline archive too.

## Verification

Empirical, not theoretical — `perf-contracts` failed on DNS before this change and passed after it in two separate harness tasks (87s in one, clean in the other). `ng lint` still resolves to `false`, so no unrelated check gains the variable:

```
'bash .agents/harness/checks/perf-contracts.sh' -> True
'(cd src-tauri && cargo test --lib)'            -> True
'npx ng lint'                                    -> False
```

Found while running the MCP + note-pipeline repair program; it is independent of that work and worth landing on its own.