### PR TITLE
fix(e2e): retry flaky tests on CI so one timing blip stops failing the lane

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,21 @@ export default defineConfig({
   timeout: 30_000,
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
-  retries: 0,
+  // CI retries flaky tests; LOCAL stays 0 so a flake you just wrote fails loudly.
+  //
+  // This does NOT hide failures: a test that only passes on a retry is reported as
+  // `flaky`, not `passed`, so the signal is preserved and quantified rather than
+  // swallowed. What it removes is the all-or-nothing coupling — with `retries: 0`
+  // a single timing-sensitive assertion anywhere in the ~330-test webkit project
+  // fails the whole lane, and the shared macOS runner produces exactly that: three
+  // consecutive runs of unrelated diffs (one Rust-only, one Python-only) each failed
+  // a DIFFERENT webkit test, every one dying on an assertion timeout around 12-13s
+  // rather than the 30s test timeout. That is runner timing noise, not a defect the
+  // gate should be attributing to whichever PR happens to be passing through.
+  //
+  // A test that goes flaky PERSISTENTLY is still a bug to fix at the source — the
+  // flaky count in the report is where to look for it.
+  retries: process.env.CI ? 2 : 0,
   reporter: [["list"]],
   use: {
     baseURL: `http://127.0.0.1:${PORT}`,


### PR DESCRIPTION
## The evidence

Three consecutive CI runs, three **different** webkit tests, always exactly `1 failed`:

| Run | Diff under test | Failing test |
|---|---|---|
| #477 | Rust-only (`tools.rs`, `diarize.rs`) | `settings-ai/model-power.spec.ts` — slider drag |
| #477 rerun | same | `detail/receipts.spec.ts` — receipt chip seek |
| #478 | **Python-only** (`task_runner.py`) | `notes/note-save-locked-lowercase.spec.ts` — lock toast |

A Python-only harness change cannot affect a webkit slider test. Different test every run, always exactly one, every one dying on an **assertion timeout at ~12–13s** rather than the 30s test timeout. That is shared-runner timing noise, and `retries: 0` was attributing it to whichever PR happened to be passing through.

## The change

`retries: process.env.CI ? 2 : 0`

Local stays at 0, so a flake you just wrote still fails loudly on your own machine.

## This does not hide failures

Playwright reports a test that only passes on retry as **`flaky`**, not `passed`. The signal is quantified rather than swallowed — and a persistently flaky test remains a bug to fix at the source, with the flaky count in the report being where to look for it.

What it removes is the all-or-nothing coupling: one timing-sensitive assertion out of ~330 webkit tests should not be able to fail a lane that is otherwise green.

Found while running the MCP + note-pipeline repair program, where it was blocking every PR.