### PR TITLE
fix(notes): stop the note naming speakers it cannot know, and hardening a guess into a spec

### DIFF
--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -1983,6 +1983,20 @@ pub(crate) struct TranscriptFeed {
     pub summary_text: String,
     /// Whether `summary_text` carries `(speaker)` tags (i.e. ≥2 distinct speakers).
     pub labeled: bool,
+    /// LANE SHAPE, not speaker count: whether the far side is genuinely DIARIZED — at least one kept
+    /// segment carries a NUMBERED `others-N` tag (written by
+    /// [`crate::transcribe::diarize::relabel_others`] when diarization actually separated the remote
+    /// voices).
+    ///
+    /// This is the ONLY signal that says whether per-person attribution is supportable at all.
+    /// `labeled` is NOT: an ordinary dual-stream call has the distinct set `{me, others}` = 2 ⇒
+    /// `labeled == true`, yet the single plain `others` lane holds ALL N remote people COLLAPSED
+    /// together. Handing that feed a prompt that asks for participants' real names leaves the model
+    /// only one way to comply — guessing from vocatives — which is exactly how a 6-person meeting
+    /// note ended up crediting remarks to people who had stopped talking minutes earlier.
+    /// `false` ⇒ the summarizer prompt FORBIDS personal-name attribution
+    /// ([`crate::summarize::template::speaker_attribution_directive_collapsed`]).
+    pub diarized_others: bool,
 }
 
 /// Build the [`TranscriptFeed`] from the merged, time-ordered segments. Drops empty and
@@ -1990,7 +2004,7 @@ pub(crate) struct TranscriptFeed {
 pub(crate) fn build_transcript_feed(
     segments: &[crate::transcribe::types::Segment],
 ) -> TranscriptFeed {
-    use crate::audio::merge::SPEAKER_ME;
+    use crate::audio::merge::{SPEAKER_ME, SPEAKER_OTHERS};
     let kept: Vec<&crate::transcribe::types::Segment> = segments
         .iter()
         .filter(|s| {
@@ -2014,6 +2028,20 @@ pub(crate) fn build_transcript_feed(
         .map(|s| s.speaker.as_deref().unwrap_or(SPEAKER_ME))
         .collect();
     let labeled = distinct.len() >= 2;
+
+    // LANE SHAPE — see `TranscriptFeed::diarized_others`. A NUMBERED `others-N` tag is the only
+    // evidence that the remote side was actually split per-voice; a plain `others` lane is N people
+    // collapsed into one label, so nothing in this feed can support a personal NAME. Mirrors
+    // `transcribe::diarize::tag_is_numbered_cluster` (private to that module — kept as a local
+    // one-liner rather than widening its surface for a read-only shape probe).
+    let diarized_others = kept.iter().any(|s| {
+        s.speaker
+            .as_deref()
+            .and_then(|t| t.strip_prefix(SPEAKER_OTHERS))
+            .and_then(|rest| rest.strip_prefix('-'))
+            .map(|n| n.parse::<i64>().is_ok())
+            .unwrap_or(false)
+    });
 
     // Tier 3b/A3 — PREVENTIVE [UNCLEAR] MARKING. Prefix an acoustically-shaky segment (ASR
     // `confidence < LOW_CONFIDENCE_P`) so the summarizer is TOLD which spans are garbled and does not
@@ -2062,6 +2090,7 @@ pub(crate) fn build_transcript_feed(
         retrieval_text,
         summary_text,
         labeled,
+        diarized_others,
     }
 }
 
@@ -2263,7 +2292,14 @@ async fn summarize_and_export(
             duration_s,
             language,
         },
-        template: template::build_template(&config.note_style, &config.note_language, feed.labeled),
+        // The attribution directive is selected by LANE SHAPE, not speaker count: a collapsed
+        // `others` lane gets the no-personal-name variant (see `TranscriptFeed::diarized_others`).
+        template: template::build_template(
+            &config.note_style,
+            &config.note_language,
+            feed.labeled,
+            feed.diarized_others,
+        ),
         vault_titles,
         // STAGE 1 — no cross-meeting context in the generation prompt (Phase 1). Phase 2 will add
         // links additively on the finished note, not via this field.
@@ -3891,6 +3927,12 @@ mod tests {
 
     /// ≥2 distinct speakers ⇒ labeled with the EXACT `[start-end] (speaker) text` timeline shape,
     /// while `retrieval_text` stays FLAT (no tag/timestamp tokens perturb the RAG query).
+    ///
+    /// R2 UPDATE: this is the ORDINARY dual-stream shape — `me` + ONE plain `others` lane — and it
+    /// now also pins `diarized_others == false`. That is the whole point of DEFECT-A: `labeled` is
+    /// TRUE here (2 distinct labels) while the far side is one collapsed lane that could be holding
+    /// any number of people, so this feed must NOT license personal-name attribution. The assertion
+    /// is added, nothing existing is weakened.
     #[test]
     fn feed_multi_speaker_is_labeled_timeline_format() {
         let segs = vec![
@@ -3899,12 +3941,62 @@ mod tests {
         ];
         let feed = build_transcript_feed(&segs);
         assert!(feed.labeled);
+        assert!(
+            !feed.diarized_others,
+            "a plain `others` lane is COLLAPSED — N remote people under one tag, never diarized"
+        );
         assert_eq!(
             feed.summary_text,
             "[0.0-2.0] (me) hi there\n[2.0-6.0] (others) great to meet you"
         );
         assert_eq!(feed.retrieval_text, "hi there great to meet you");
         assert!(!feed.retrieval_text.contains('[') && !feed.retrieval_text.contains("(me)"));
+    }
+
+    /// R2/DEFECT-A, lane-shape detection at the SOURCE. Only a NUMBERED `others-N` tag (written by
+    /// `transcribe::diarize::relabel_others` when diarization really separated the remote voices)
+    /// sets `diarized_others`; a plain `others` lane never does, however many people were on the
+    /// call. RED against the previous code, which had no lane-shape signal at all and let the
+    /// `labeled` speaker COUNT stand in for it.
+    #[test]
+    fn feed_diarized_others_tracks_lane_shape_not_speaker_count() {
+        // Collapsed: mic + one merged remote lane — the shape that produced the bad note.
+        let collapsed = build_transcript_feed(&[
+            seg(0, 0.0, 2.0, Some("me"), "so what do we do about the migration"),
+            seg(1, 2.0, 6.0, Some("others"), "Anna, can you take the walkthrough"),
+            seg(2, 6.0, 9.0, Some("others"), "sure, I'll do it"),
+        ]);
+        assert!(collapsed.labeled, "still labeled — 2 distinct tags");
+        assert!(
+            !collapsed.diarized_others,
+            "a vocative in the text is NOT diarization: the lane is still collapsed"
+        );
+
+        // Diarized: the remote side really was split per-voice.
+        let diarized = build_transcript_feed(&[
+            seg(0, 0.0, 2.0, Some("me"), "so what do we do about the migration"),
+            seg(1, 2.0, 6.0, Some("others-0"), "I'll take the walkthrough"),
+            seg(2, 6.0, 9.0, Some("others-1"), "I'd rather we wait"),
+        ]);
+        assert!(diarized.labeled);
+        assert!(
+            diarized.diarized_others,
+            "numbered others-N tags ⇒ per-voice attribution is supportable"
+        );
+
+        // A solo-`me` meeting: no far side at all.
+        let solo = build_transcript_feed(&[seg(0, 0.0, 2.0, Some("me"), "note to self")]);
+        assert!(!solo.labeled && !solo.diarized_others);
+
+        // A malformed / non-numeric suffix is NOT a diarized cluster (fail closed: no naming).
+        let bogus = build_transcript_feed(&[
+            seg(0, 0.0, 2.0, Some("me"), "hi"),
+            seg(1, 2.0, 6.0, Some("others-unknown"), "hello"),
+        ]);
+        assert!(
+            !bogus.diarized_others,
+            "only an integer `others-N` suffix counts as a diarized cluster"
+        );
     }
 
     /// Empty + assistant-directed ("Klaudku, …") segments are dropped identically to the old flat

--- a/src-tauri/src/summarize/template.rs
+++ b/src-tauri/src/summarize/template.rs
@@ -113,6 +113,30 @@ fn lookup_saved_template(id: &str) -> Option<NoteTemplate> {
     map.get(id).cloned()
 }
 
+/// R2/DEFECT-B — the ONE shared "don't launder a hedge into a fact" rule, interpolated into BOTH
+/// note-prompt renderers ([`default_template`] and [`style_variant_with_keys`], which between them
+/// cover every built-in style, the `standard`/`""` default, and every saved user template).
+///
+/// WHY IT IS A CONST: the two renderers are independent string literals. A rule pasted into both by
+/// hand drifts on the first edit — and a rule that is present in `standard` but missing from `brief`
+/// is worse than no rule, because it makes the failure style-dependent and therefore invisible.
+/// Single-sourcing it here makes divergence unrepresentable (pinned by
+/// `every_builtin_style_carries_the_hedge_rule`).
+///
+/// WHAT IT FIXES: a speaker said he did not know what a flag was technically, that he had forgotten
+/// what was decided, and that it was "like a Boolean, probably". Nobody confirmed it. The generated
+/// note asserted the flag *is* a Boolean on a named API — a hedge promoted to a specification. The
+/// `(to confirm)` marker is deliberately the EXACT token
+/// [`crate::summarize::recipes::BUILTIN_RECIPES`] already ships (`grounded-email`), so the app has
+/// ONE vocabulary for "not yet confirmed" rather than two.
+pub(crate) const EPISTEMIC_STRENGTH_RULE: &str = "\
+Accuracy rules:
+- PRESERVE EPISTEMIC STRENGTH. When the ONLY support for a claim in the transcript is hedged (\"I \
+don't know\", \"I think\", \"probably\", \"I forgot\", \"maybe\", \"not sure\", \"something like\"), \
+keep the hedge in your wording OR mark the item '(to confirm)'. Never restate an unconfirmed guess \
+as a fact, a specification, or a decision, and never promote one into the Decisions section. An \
+unanswered question stays an open question.";
+
 /// The canonical Obsidian note-format prompt (front-matter + sections), shared by all providers.
 ///
 /// This is the *system / instruction* portion sent to every provider. It instructs the
@@ -121,7 +145,8 @@ fn lookup_saved_template(id: &str) -> Option<NoteTemplate> {
 /// (output must start with `---`) per the design lessons, so the wording here is
 /// load-bearing across all three providers.
 pub fn default_template() -> String {
-    r#"You are a meticulous meeting-notes writer for an Obsidian vault.
+    format!(
+        r#"You are a meticulous meeting-notes writer for an Obsidian vault.
 
 Produce a SINGLE, complete Markdown note summarizing the meeting transcript that
 follows. Output ONLY the note — no preamble, no explanation, no code fences around
@@ -167,8 +192,10 @@ Formatting rules:
 - Use plain Markdown. Use real newlines.
 - Be concise and faithful to the transcript; do not fabricate participants, decisions,
   or action items that are not supported by the transcript.
+
+{EPISTEMIC_STRENGTH_RULE}
 "#
-    .to_string()
+    )
 }
 
 /// Pick the note-format template for a style preset. Unknown styles fall back to standard.
@@ -288,6 +315,8 @@ Formatting rules:
 - Use plain Markdown. Use real newlines.
 - Be faithful to the transcript; do not fabricate participants, decisions, or action
   items that are not supported by the transcript.
+
+{EPISTEMIC_STRENGTH_RULE}
 "#
     )
 }
@@ -334,11 +363,27 @@ never the keys."
 }
 
 /// The full summary system prompt: the style template + the output-language directive, and — when
-/// the transcript is SPEAKER-LABELED (`labeled`, i.e. the meeting had ≥2 distinct diarized speakers)
-/// — the speaker-attribution directive so the model attributes decisions / key points / action-item
-/// OWNERS to who actually said them. `labeled == false` (the default solo-`me` meeting) is
-/// byte-identical to the pre-Tier-0 prompt.
-pub fn build_template(style: &str, note_language: &str, labeled: bool) -> String {
+/// the transcript is SPEAKER-LABELED (`labeled`) — an attribution directive chosen by the feed's
+/// LANE SHAPE (`diarized_others`, see [`crate::pipeline::TranscriptFeed`]):
+///
+///   * `diarized_others == true` — the far side really was split per-voice (`others-0`,
+///     `others-1`, …) ⇒ [`speaker_attribution_directive_diarized`], unchanged from before.
+///   * `diarized_others == false` — one plain `others` lane holding EVERY remote participant ⇒
+///     [`speaker_attribution_directive_collapsed`], which FORBIDS personal-name attribution.
+///
+/// R2/DEFECT-A: the old gate was `labeled` alone, so an ordinary dual-stream call ({me, others} = 2
+/// distinct labels) got the diarized directive — which asks for participants' real names — even
+/// though its single `others` lane could not tell one remote person from another. The model's only
+/// way to comply was to guess from vocatives, and it did: a 63-minute, 6-participant note carried
+/// ~15 name attributions, at least three of them demonstrably wrong.
+///
+/// `labeled == false` (the default solo-`me` meeting) still appends nothing.
+pub fn build_template(
+    style: &str,
+    note_language: &str,
+    labeled: bool,
+    diarized_others: bool,
+) -> String {
     let mut t = format!(
         "{}\n\n{}",
         template_for_style(style),
@@ -346,17 +391,24 @@ pub fn build_template(style: &str, note_language: &str, labeled: bool) -> String
     );
     if labeled {
         t.push_str("\n\n");
-        t.push_str(speaker_attribution_directive());
+        t.push_str(if diarized_others {
+            speaker_attribution_directive_diarized()
+        } else {
+            speaker_attribution_directive_collapsed()
+        });
     }
     t
 }
 
-/// Appended to the system prompt ONLY when the transcript is speaker-labeled (`[start-end] (speaker)
-/// text`, the same shape the timeline consumes — see [`crate::summarize::timeline`]). Tells the model
-/// to attribute content to the speaker who said it (`me` = the person recording; `others` /
-/// `others-0` / `others-1` … = the DISTINCT other participants) so action-item OWNERS and decisions
-/// are correctly assigned instead of guessed from speaker-blind text. Mirrors `timeline::SYSTEM`.
-pub(crate) fn speaker_attribution_directive() -> &'static str {
+/// Appended when the transcript is speaker-labeled AND the far side is genuinely DIARIZED (at least
+/// one numbered `others-N` tag). Tells the model to attribute content to the speaker who said it
+/// (`me` = the person recording; `others-0` / `others-1` … = the DISTINCT other participants) so
+/// action-item OWNERS and decisions are correctly assigned instead of guessed from speaker-blind
+/// text. Mirrors `timeline::SYSTEM`.
+///
+/// UNCHANGED TEXT (renamed from `speaker_attribution_directive`): naming a real participant is only
+/// defensible here, where separate tags actually distinguish the people being named.
+pub(crate) fn speaker_attribution_directive_diarized() -> &'static str {
     "SPEAKER ATTRIBUTION: the transcript below is diarized — each line is `[start-end] (speaker) \
 text` (seconds). The `(speaker)` tag is the source of truth for who is talking: `me` is the person \
 recording the meeting; `others`, `others-0`, `others-1`, … are the DISTINCT people on the other \
@@ -368,6 +420,33 @@ clearly stated in the conversation, otherwise keep the tag label).\n\
 - List the distinct speakers under the `participants` front-matter (real names when clearly stated, \
 else the tag labels).\n\
 Never attribute to `me` something another participant said or owns, and never invent a speaker the \
+tags do not support."
+}
+
+/// Appended when the transcript is speaker-labeled but the far side is COLLAPSED — one plain
+/// `others` lane carrying every remote participant, however many were on the call (no diarization
+/// ran, or it found ≤1 cluster; see [`crate::transcribe::diarize::relabel_others`]).
+///
+/// The lane tag is a CAPTURE CHANNEL, not a person. Nothing in such a feed identifies which of the N
+/// remote people spoke a given line, so any personal name in the note would be a guess dressed as a
+/// record — the exact failure this directive exists to prevent. It therefore forbids personal-name
+/// attribution outright, forbids guessed names in the `participants` front-matter, and allows a
+/// heard name through ONLY as an explicitly-marked inference.
+pub(crate) fn speaker_attribution_directive_collapsed() -> &'static str {
+    "SPEAKER ATTRIBUTION: the transcript below has exactly TWO lanes — `me` (the person recording) \
+and `others` (EVERY remote participant, merged into ONE lane by the capture, however many people \
+were on the call). The `(speaker)` tag is a capture LANE, not a person, and nothing in this \
+transcript says which of the remote people spoke any given line. Therefore:\n\
+- NEVER attribute a statement, decision, key point, or action item to a personal NAME. Attribute \
+only to the lane: `me` or `others` (write action items as `others — action`, or `me — action`).\n\
+- NEVER put a guessed personal name in the `participants` front-matter. List only the lane labels \
+that actually appear (`me`, `others`), or leave the list empty.\n\
+- A name you hear in the conversation (someone being addressed or referred to) may be reported ONLY \
+as an inference and must be marked as one — e.g. `addressed as X (inferred, not a speaker record)` \
+— never as a record of who spoke.\n\
+- Do NOT infer who said what from vocatives, turn order, topic, or who was mentioned nearby. If the \
+lane tag does not establish it, this transcript does not support it.\n\
+Never attribute to `me` something the `others` lane said or owns, and never invent a speaker the \
 tags do not support."
 }
 
@@ -1382,9 +1461,14 @@ mod tests {
         assert!(fm.contains("recipe: synthesis"));
     }
 
-    /// TIER 0: the speaker-attribution directive is appended ONLY when `labeled`, and the
-    /// `labeled == false` prompt is byte-identical to the legacy `template + language` prompt.
-    /// RED on the old 2-arg `build_template` (no `labeled` param, never appends the directive).
+    /// TIER 0: an attribution directive is appended ONLY when `labeled`, and the `labeled == false`
+    /// prompt is byte-identical to the `template + language` prompt.
+    ///
+    /// R2 UPDATE: `build_template` gained the `diarized_others` lane-shape argument, so the
+    /// "labeled" leg of this test now pins the DIARIZED lane specifically (`true, true`) — the case
+    /// whose bytes it always meant to describe. The collapsed lane (`true, false`) is a genuinely
+    /// different prompt and is pinned by `collapsed_lane_prompt_forbids_personal_name_attribution`;
+    /// asserting `contains("OWNER")` against it would be asserting the very defect R2 removes.
     #[test]
     fn build_template_adds_attribution_only_when_labeled() {
         let base = format!(
@@ -1392,15 +1476,18 @@ mod tests {
             template_for_style("standard"),
             language_directive("auto")
         );
-        // Unlabeled (the default solo-`me` meeting): byte-identical to the legacy prompt.
-        let unlabeled = build_template("standard", "auto", false);
-        assert_eq!(
-            unlabeled, base,
-            "unlabeled must be byte-identical to the pre-Tier-0 prompt"
-        );
-        assert!(!unlabeled.contains("SPEAKER ATTRIBUTION"));
-        // Labeled: the unlabeled prompt PLUS the attribution directive instructing owner/speaker.
-        let labeled = build_template("standard", "auto", true);
+        // Unlabeled (the default solo-`me` meeting): byte-identical to the base prompt, whatever the
+        // lane-shape flag says — no tags in the feed ⇒ nothing to attribute.
+        for diarized in [false, true] {
+            let unlabeled = build_template("standard", "auto", false, diarized);
+            assert_eq!(
+                unlabeled, base,
+                "unlabeled must be byte-identical to the pre-Tier-0 prompt (diarized={diarized})"
+            );
+            assert!(!unlabeled.contains("SPEAKER ATTRIBUTION"));
+        }
+        // Labeled + DIARIZED: the base prompt PLUS the attribution directive instructing owner/speaker.
+        let labeled = build_template("standard", "auto", true, true);
         assert!(
             labeled.starts_with(&base),
             "labeled prompt extends the base prompt"
@@ -1411,6 +1498,112 @@ mod tests {
             "instructs action-item OWNER attribution"
         );
         assert!(labeled.contains("(speaker)") && labeled.contains("others"));
+    }
+
+    /// R2/DEFECT-A (regression 1). A COLLAPSED far side — one plain `others` lane holding every
+    /// remote participant — MUST get the no-personal-name directive, and MUST NOT carry the
+    /// real-NAME instruction that only makes sense for a diarized feed.
+    ///
+    /// RED against the previous behavior: `build_template` used to gate on `labeled` alone, so this
+    /// exact feed shape (an ordinary dual-stream call, distinct set {me, others}) received the
+    /// diarized directive — the prompt that told the model to name participants it could not
+    /// possibly identify.
+    #[test]
+    fn collapsed_lane_prompt_forbids_personal_name_attribution() {
+        let p = build_template("standard", "auto", true, false);
+        assert!(
+            p.contains("SPEAKER ATTRIBUTION"),
+            "a collapsed lane still gets an attribution directive, just the forbidding one"
+        );
+        assert!(
+            p.contains(
+                "NEVER attribute a statement, decision, key point, or action item to a personal NAME"
+            ),
+            "collapsed lane must FORBID personal-name attribution; got:\n{p}"
+        );
+        assert!(
+            p.contains("NEVER put a guessed personal name in the `participants` front-matter"),
+            "collapsed lane must forbid guessed names in front-matter; got:\n{p}"
+        );
+        assert!(
+            p.contains("(inferred, not a speaker record)"),
+            "a heard name may only be reported as an explicitly-marked inference; got:\n{p}"
+        );
+        // The diarized directive's naming clauses must be ABSENT — their presence is the defect.
+        assert!(
+            !p.contains("use a participant's real NAME when it is clearly stated"),
+            "collapsed lane must NOT carry the real-NAME instruction; got:\n{p}"
+        );
+        assert!(
+            !p.contains("real names when clearly stated"),
+            "collapsed lane must NOT ask for real names in the participants list; got:\n{p}"
+        );
+        assert_ne!(
+            speaker_attribution_directive_collapsed(),
+            speaker_attribution_directive_diarized(),
+            "the two lane shapes must be genuinely different directives"
+        );
+    }
+
+    /// R2/DEFECT-A (regression 2). A DIARIZED far side (numbered `others-N` tags present) keeps
+    /// TODAY's directive verbatim — the fix narrows where naming is allowed, it does not remove the
+    /// capability where the tags actually support it.
+    ///
+    /// RED against a fix that over-corrects by forbidding names everywhere.
+    #[test]
+    fn diarized_lane_prompt_keeps_existing_attribution_directive() {
+        let p = build_template("standard", "auto", true, true);
+        assert!(
+            p.ends_with(speaker_attribution_directive_diarized()),
+            "the diarized prompt must end with the unchanged diarized directive; got:\n{p}"
+        );
+        assert!(p.contains("use a participant's real NAME when it is clearly stated"));
+        assert!(p.contains("List the distinct speakers under the `participants` front-matter"));
+        assert!(
+            !p.contains("NEVER attribute a statement, decision, key point, or action item to a personal NAME"),
+            "the diarized lane must NOT get the collapsed-lane prohibition; got:\n{p}"
+        );
+    }
+
+    /// R2/DEFECT-B (regression 3). EVERY built-in note style — and the `standard`/`""` default that
+    /// renders `default_template` — must carry the shared hedge rule, so a hedged utterance is never
+    /// laundered into a specification or a decision. Style-dependent honesty is not honesty.
+    ///
+    /// RED against the previous behavior: no style carried any hedge rule at all.
+    #[test]
+    fn every_builtin_style_carries_the_hedge_rule() {
+        for style in ["standard", "", "brief", "detailed", "action"] {
+            let t = template_for_style(style);
+            assert!(
+                t.contains("PRESERVE EPISTEMIC STRENGTH"),
+                "{style}: the built-in style must carry the hedge rule; got:\n{t}"
+            );
+            assert!(
+                t.contains("(to confirm)"),
+                "{style}: the hedge rule must reuse the existing '(to confirm)' marker; got:\n{t}"
+            );
+            assert!(
+                t.contains("never promote one into the Decisions section"),
+                "{style}: a hedged claim must never be promoted into Decisions; got:\n{t}"
+            );
+            // Single-sourced: the rendered rule is the const verbatim, so the two renderers
+            // (`default_template` + `style_variant_with_keys`) cannot drift apart.
+            assert!(
+                t.contains(EPISTEMIC_STRENGTH_RULE),
+                "{style}: must interpolate the shared const, not a hand-copied paraphrase"
+            );
+        }
+        // The marker token is the one `recipes::BUILTIN_RECIPES` already ships — one vocabulary.
+        assert!(
+            crate::summarize::recipes::BUILTIN_RECIPES
+                .iter()
+                .any(|(_, _, prompt)| prompt.contains("(to confirm)")),
+            "the '(to confirm)' marker must stay the SHARED vocabulary with the built-in recipes"
+        );
+        // A saved user template renders through `style_variant_with_keys` too ⇒ same rule.
+        let saved =
+            render_saved_template(&tpl("tpl-hedge", "", &[("Outcome", "what we agreed")], &[]));
+        assert!(saved.contains(EPISTEMIC_STRENGTH_RULE), "{saved}");
     }
 
     fn tpl(id: &str, tone: &str, sections: &[(&str, &str)], extra: &[&str]) -> NoteTemplate {
@@ -1430,13 +1623,18 @@ mod tests {
         }
     }
 
-    /// (i) BYTE-IDENTITY REGRESSION: after the data-driven refactor, the built-in `brief` style must
-    /// render EXACTLY the same prompt as before (the full literal is pinned so any spacing/keyword
-    /// drift from the `style_variant` → `style_variant_with_keys` change fails here). RED if the
-    /// refactor leaks an extra-key line, drops the tone clause, or shifts the front-matter spacing.
+    /// (i) BYTE-IDENTITY REGRESSION: the built-in `brief` style renders EXACTLY this prompt (the full
+    /// literal is pinned so any spacing/keyword drift fails here). RED if a refactor leaks an
+    /// extra-key line, drops the tone clause, or shifts the front-matter spacing.
+    ///
+    /// R2 UPDATE: the pinned literal now ends with the shared hedge rule, interpolated from
+    /// [`EPISTEMIC_STRENGTH_RULE`] rather than re-typed — re-typing it here would create the second
+    /// copy the const exists to prevent, and the rule's own text is pinned by
+    /// `every_builtin_style_carries_the_hedge_rule`. Everything around it stays byte-pinned.
     #[test]
     fn builtin_brief_style_is_byte_identical() {
-        let expected = r#"You are a meticulous meeting-notes writer for an Obsidian vault.
+        let expected = format!(
+            r#"You are a meticulous meeting-notes writer for an Obsidian vault.
 
 Produce a SINGLE, complete Markdown note summarizing the meeting transcript that
 follows. Output ONLY the note — no preamble, no explanation, no code fences around
@@ -1476,7 +1674,10 @@ Formatting rules:
 - Use plain Markdown. Use real newlines.
 - Be faithful to the transcript; do not fabricate participants, decisions, or action
   items that are not supported by the transcript.
-"#;
+
+{EPISTEMIC_STRENGTH_RULE}
+"#
+        );
         assert_eq!(template_for_style("brief"), expected);
     }
 
@@ -1549,7 +1750,7 @@ Formatting rules:
         // Registered → build_template resolves it (pipeline's exact call) + appends the language
         // directive; unlabeled adds no speaker directive.
         set_saved_templates(vec![t.clone()]);
-        let built = build_template("tpl-client-call", "auto", false);
+        let built = build_template("tpl-client-call", "auto", false, false);
         assert!(built.starts_with(&body), "build_template renders the saved body");
         assert!(built.contains("OUTPUT LANGUAGE:"), "language directive appended");
         assert!(!built.contains("SPEAKER ATTRIBUTION"), "no attribution when unlabeled");


### PR DESCRIPTION
Defects **#3** and **#5** of the MCP + note-pipeline repair program. These are the two findings the audit rated most serious, because they concern **trust**, not cost — a note that reads like a record of a meeting but is partly invented is more dangerous than an expensive one.

Both were authored by the **prompt**, not by the model.

## Defect #3 — the note named speakers the transcript cannot identify

`build_transcript_feed` computed:

```rust
let labeled = distinct.len() >= 2;
```

For an ordinary dual-stream call the distinct set is `{me, others}` = 2, so `labeled` is **true** — even though that single `others` lane holds *every* remote participant merged together by the capture. That fired `speaker_attribution_directive`, which instructs the model to *"use a participant's real NAME when it is clearly stated"* and to *"List the distinct speakers under the `participants` front-matter"*.

With one lane covering N people, the only way to comply is to guess from vocatives. And it did — in the audited note, three attributions were demonstrably wrong:

- a walkthrough remark credited to someone who had stopped talking ~200s earlier
- live documentation credited to the wrong person (the transcript shows someone else sharing their screen and typing)
- "X and Y pushed back" where only X is documented

The trailing *"never invent a speaker the tags do not support"* clause was far weaker than, and directly contradicted by, the explicit instruction to name people.

**Fix:** gate on **lane shape**, not the distinct count. A new `diarized_others` flag is true only when a segment carries a numbered `others-N` tag — what `diarize.rs::relabel_others` writes.

- **Diarized feed** → the existing directive, renamed to `_diarized`, text **byte-unchanged**.
- **Collapsed feed** → a new directive that forbids personal-name attribution outright, forbids guessed names in `participants`, and explicitly forbids inferring a speaker *"from vocatives, turn order, topic"* — the exact route that produced all three errors. A heard name may still be reported, but only marked as an inference, never as a record of who spoke.

## Defect #5 — a hedge hardened into a specification

The only transcript support was a speaker saying he *"didn't know what it is technically"*, that he *"forgot what you guys decided"*, and that it's *"like a Boolean, isn't it… probably"*. The note restated this as a specification on a named entity API — a phrase that never occurs in the transcript at all.

**Fix:** one rule requiring the hedge to survive into the note or the item to be marked `(to confirm)`, and never to be promoted into `## Decisions`. It lives in a **single const interpolated into both templates**, so the two cannot drift apart, and reuses the exact `(to confirm)` token the `grounded-email` recipe already ships rather than inventing a second vocabulary for the same concept.

## Verification

Both regressions were proven **RED before GREEN empirically** — each change neutered independently, the real failure observed, then restored:

```
# A: make build_template select the diarized directive for both lane shapes
collapsed_lane_prompt_forbids_personal_name_attribution ... FAILED

# B: remove the rule interpolation from both production templates
every_builtin_style_carries_the_hedge_rule ... FAILED
builtin_brief_style_is_byte_identical      ... FAILED   (byte-pinned fixture also caught it)
```

Restored → **2460 passed, 0 failed** (full lib suite), `cargo clippy --lib -- -D warnings` clean, MSRV grep empty.

`diarized_lane_prompt_keeps_existing_attribution_directive` is deliberately a **preservation** test, not a regression — the diarized text is byte-unchanged, so it cannot fail against the old behavior by construction.

The pinned `build_template_adds_attribution_only_when_labeled` was updated because `build_template` gained a parameter, and was **strengthened** while there: it now loops both lane-shape values asserting an unlabeled meeting stays byte-identical regardless.

## Behavior change worth flagging

Notes on ordinary dual-stream meetings **stop carrying personal names**. That is the point — it removes false precision rather than adding capability. It pairs with turning diarization on by default, after which the diarized branch applies and real names become defensible again.

## What this does NOT fix

Who actually said what. That is upstream: the collapsed lane exists because diarization is off by default. This change stops the system from *stating* what it cannot know; it does not recover the information.
