### PR TITLE
fix(facts): a tool id can no longer become a durable owner, and junk facts became forgettable

### DIFF
--- a/src-tauri/src/commands/facts.rs
+++ b/src-tauri/src/commands/facts.rs
@@ -76,6 +76,24 @@ pub(crate) fn forget_user_fact_inner(state: &AppState, id: &str) -> Result<(), A
     Ok(())
 }
 
+/// Forget ONE ENTITY fact (bitemporal invalidate — the row is CLOSED, never silently deleted, so
+/// history is preserved). The entity twin of [`forget_user_fact`]: until this existed an entity fact
+/// could only be superseded by a later meeting asserting a different object for the same key, so a
+/// junk row nobody would ever restate stayed CURRENT forever and kept surfacing through
+/// `get_entity_dossier` as truth. Idempotent. Content-free logging (the fact id only).
+#[tauri::command]
+pub fn forget_entity_fact(state: State<'_, AppState>, id: String) -> Result<(), AppError> {
+    forget_entity_fact_inner(state.inner(), &id)
+}
+
+/// Inner of [`forget_entity_fact`] taking `&AppState` (unit-testable).
+pub(crate) fn forget_entity_fact_inner(state: &AppState, id: &str) -> Result<(), AppError> {
+    let at = chrono::Utc::now().to_rfc3339();
+    let closed = state.db.forget_entity_fact(id, &at)?;
+    tracing::info!(target: "facts", fact_id = %id, closed, "entity fact forgotten (invalidated)");
+    Ok(())
+}
+
 /// Clear ALL user memory: bitemporal-close every currently-open user fact (invalidate, never delete —
 /// closed history stays). After this `get_user_memory` and the brief are empty. Content-free logging
 /// (a count only).

--- a/src-tauri/src/facts.rs
+++ b/src-tauri/src/facts.rs
@@ -640,6 +640,55 @@ pub fn extract_fact_candidates(
 /// Map raw extracted triples to [`FactCandidate`]s: resolve each `entity` name to a known
 /// `entity_id` (case-insensitive), use the canonical entity name as the subject, drop unresolved or
 /// empty triples. Pure + headless-testable (no reasoner needed).
+/// Predicates whose OBJECT is supposed to name a person. EN + PL, matching the extractor prompt's
+/// own examples (`owner`, `role`) and the Polish forms the language-pinned variant emits.
+const PERSON_VALUED_PREDICATES: &[&str] = &[
+    "owner",
+    "assignee",
+    "role",
+    "właściciel",
+    "wlasciciel",
+    "odpowiedzialny",
+    "rola",
+];
+
+/// Tool / provider identifiers that are NEVER a person, and so may never be written as one.
+///
+/// This is not hypothetical. A real vault ended up with the durable, un-forgettable fact
+/// `M1 Advanced Mode · owner: claude_code`, which then surfaced through `get_entity_dossier` as a
+/// CURRENT FACT — so every agent reading that dossier reported a provider id as the product's owner.
+///
+/// The route in is ordinary: `pipeline.rs::fold_manual_notes` folds the user's typed companion-note
+/// text (which routinely contains pasted CLI/agent output) into the markdown the extractor reads,
+/// and `candidates_from_triples` validated only the ENTITY — `predicate` and `object` were taken
+/// verbatim. The guard belongs HERE rather than in the note writer, because
+/// `commands/links.rs::link_meeting_entities` re-feeds stored note markdown to this same extractor,
+/// so any writer-side filter would be bypassed on re-ingest.
+///
+/// Kept deliberately narrow: these are exact ids we KNOW are machinery. A broader "does this look
+/// like a person" heuristic would silently drop legitimate owners who did not attend the meeting
+/// ("Anna owns it, she will pick it up"), and losing a true fact is worse than the junk it prevents.
+fn object_is_never_a_person(object: &str) -> bool {
+    let o = object.trim().to_lowercase();
+    let o = o.strip_prefix('+').unwrap_or(&o).trim();
+    [
+        crate::summarize::PROVIDER_CLAUDE_CODE,
+        crate::summarize::PROVIDER_ANTHROPIC,
+        crate::summarize::PROVIDER_OLLAMA,
+        crate::summarize::PROVIDER_GATEWAY,
+        "claude",
+        "claude code",
+        "chatgpt",
+        "openai",
+        "copilot",
+        "assistant",
+        "ai",
+        "llm",
+        "bot",
+    ]
+    .contains(&o)
+}
+
 fn candidates_from_triples(
     triples: Vec<RawTriple>,
     entities: &[(String, String)],
@@ -650,6 +699,13 @@ fn candidates_from_triples(
         let predicate = t.predicate.trim();
         let object = t.object.trim();
         if ent.is_empty() || predicate.is_empty() || object.is_empty() {
+            continue;
+        }
+        // A person-valued predicate may never take a tool/provider id as its object. Dropping the
+        // CANDIDATE (rather than the whole triple set) keeps every other fact from this note.
+        if PERSON_VALUED_PREDICATES.contains(&predicate.to_lowercase().as_str())
+            && object_is_never_a_person(object)
+        {
             continue;
         }
         let Some((id, name)) = entities
@@ -672,6 +728,93 @@ fn candidates_from_triples(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn raw(entity: &str, predicate: &str, object: &str) -> RawTriple {
+        RawTriple {
+            entity: entity.to_string(),
+            predicate: predicate.to_string(),
+            object: object.to_string(),
+        }
+    }
+
+    /// R4/#17 (regression). A tool/provider id may NEVER be written as a person-valued object.
+    ///
+    /// RED against the previous behavior: `candidates_from_triples` validated only the ENTITY and
+    /// took `predicate`/`object` verbatim, so `(M1 Advanced Mode, owner, claude_code)` became a
+    /// durable fact and surfaced through `get_entity_dossier` as a CURRENT one — every agent
+    /// reading that dossier then reported a provider id as the product's owner.
+    #[test]
+    fn a_provider_id_is_never_accepted_as_an_owner() {
+        let entities = vec![("e1".to_string(), "M1 Advanced Mode".to_string())];
+        for junk in [
+            "claude_code",
+            "Claude Code",
+            "+ claude_code",
+            "anthropic",
+            "ollama",
+            "gateway",
+            "ChatGPT",
+            "assistant",
+        ] {
+            let got =
+                candidates_from_triples(vec![raw("M1 Advanced Mode", "owner", junk)], &entities);
+            assert!(
+                got.is_empty(),
+                "a person-valued predicate must reject the tool id {junk:?}, got {got:?}"
+            );
+        }
+        // Polish predicate forms the language-pinned extractor emits are gated too.
+        assert!(
+            candidates_from_triples(
+                vec![raw("M1 Advanced Mode", "właściciel", "claude_code")],
+                &entities
+            )
+            .is_empty(),
+            "the Polish owner predicate must be gated as well"
+        );
+    }
+
+    /// The guard must stay NARROW. A real person is still accepted, a real person who never spoke
+    /// in the meeting is still accepted (dropping them would silently lose a true fact, which is
+    /// worse than the junk this prevents), and a NON-person predicate may still carry any object —
+    /// `deployed_on: gateway` is a legitimate statement about infrastructure.
+    #[test]
+    fn the_owner_guard_does_not_swallow_legitimate_facts() {
+        let entities = vec![("e1".to_string(), "M1 Advanced Mode".to_string())];
+        for (predicate, object) in [
+            ("owner", "Anna"),
+            ("owner", "Jakub Gawronski"),
+            ("status", "shipped"),
+            // NOT a person-valued predicate ⇒ the blocklist must not apply at all.
+            ("deployed_on", "gateway"),
+            ("runs_on", "ollama"),
+        ] {
+            let got = candidates_from_triples(
+                vec![raw("M1 Advanced Mode", predicate, object)],
+                &entities,
+            );
+            assert_eq!(
+                got.len(),
+                1,
+                "({predicate}, {object}) is legitimate and must survive"
+            );
+        }
+    }
+
+    /// One junk triple must not take the whole note's facts down with it.
+    #[test]
+    fn a_rejected_owner_does_not_drop_the_other_facts() {
+        let entities = vec![("e1".to_string(), "M1 Advanced Mode".to_string())];
+        let got = candidates_from_triples(
+            vec![
+                raw("M1 Advanced Mode", "owner", "claude_code"),
+                raw("M1 Advanced Mode", "status", "in review"),
+            ],
+            &entities,
+        );
+        assert_eq!(got.len(), 1, "the sibling fact survives");
+        assert_eq!(got[0].predicate, "status");
+    }
 
     fn fact(
         id: &str,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -210,6 +210,7 @@ pub fn run() {
             commands::delete_document,
             commands::get_user_memory,
             commands::forget_user_fact,
+            commands::forget_entity_fact,
             commands::clear_user_memory,
             commands::import_memories,
             // Re-Truth (the vault heals itself) — supersession review + one-tap stamp + undo.

--- a/src-tauri/src/storage/db_tests/lock_tests.rs
+++ b/src-tauri/src/storage/db_tests/lock_tests.rs
@@ -1660,6 +1660,80 @@ fn list_user_facts_visible_excludes_sealed_meeting() {
     );
 }
 
+/// R4/#17 (regression). An ENTITY fact must be FORGETTABLE.
+///
+/// Until `forget_entity_fact` existed, the store exposed forget/clear for USER facts only, so the
+/// only way to close a wrong entity fact was for a later meeting to assert a different object for
+/// the same key. A junk row nobody would ever restate — the real `owner: claude_code` that reached
+/// a dossier as a current fact — therefore stayed CURRENT forever.
+///
+/// Same bitemporal contract as the user-fact twin: CLOSE, never delete, and idempotent.
+#[test]
+fn forget_entity_fact_closes_the_row_and_is_idempotent() {
+    use crate::facts::{FactOp, NewFact};
+    use crate::storage::models::EntityKind;
+    let db = file_db("entity-facts-forget");
+    seed_note(&db, "m1", "note", None);
+    // `facts.entity_id` is a real FK — the entity has to exist before a fact can reference it.
+    let entity = db
+        .upsert_entity("M1 Advanced Mode", EntityKind::Project)
+        .unwrap();
+    let new_fact = |predicate: &str, object: &str| {
+        FactOp::Add(NewFact {
+            entity_id: entity.clone(),
+            subject: "M1 Advanced Mode".into(),
+            predicate: predicate.into(),
+            object: object.into(),
+            valid_from: "2026-06-01T00:00:00Z".into(),
+            recorded_at: "2026-06-01T00:00:00Z".into(),
+            confidence: 1.0,
+            meeting_id: Some("m1".into()),
+        })
+    };
+    db.apply_fact_ops(&[new_fact("owner", "claude_code"), new_fact("status", "open")])
+        .unwrap();
+
+    let visible = db.list_facts_visible(&entity, &HashSet::new()).unwrap();
+    assert_eq!(visible.len(), 2, "both facts start current");
+    let junk = visible
+        .iter()
+        .find(|f| f.predicate == "owner")
+        .expect("the junk owner row")
+        .id
+        .clone();
+
+    assert!(
+        db.forget_entity_fact(&junk, "2026-06-02T00:00:00Z").unwrap(),
+        "closed the open junk fact"
+    );
+    assert!(
+        !db.forget_entity_fact(&junk, "2026-06-02T00:00:00Z").unwrap(),
+        "re-forget is a no-op (idempotent)"
+    );
+
+    // `list_facts_visible` deliberately returns the FULL bitemporal ledger (open + closed), because
+    // knowledge_diff needs the history. What must change is which facts are still OPEN — that is
+    // what `dossier::render_structured` filters on (`valid_to.is_none()`) to print CURRENT FACTS,
+    // and therefore what an agent reads as true.
+    let after = db.list_facts_visible(&entity, &HashSet::new()).unwrap();
+    assert_eq!(after.len(), 2, "history is preserved, never deleted");
+    let open: Vec<_> = after.iter().filter(|f| f.valid_to.is_none()).collect();
+    assert_eq!(open.len(), 1, "only one fact is still current");
+    assert_eq!(
+        open[0].predicate, "status",
+        "the SIBLING stays current; the junk owner is no longer a current fact"
+    );
+    let closed = after
+        .iter()
+        .find(|f| f.predicate == "owner")
+        .expect("the owner row still exists as history");
+    assert_eq!(
+        closed.valid_to.as_deref(),
+        Some("2026-06-02T00:00:00Z"),
+        "closed AT the requested instant, not deleted"
+    );
+}
+
 /// FORGET (task C5.iii): forget_user_fact bitemporally CLOSES the row (never deletes) so it drops
 /// out of the gated read; a second forget is a no-op. clear_user_facts closes ALL open facts.
 #[test]

--- a/src-tauri/src/storage/facts_store.rs
+++ b/src-tauri/src/storage/facts_store.rs
@@ -634,6 +634,29 @@ impl Db {
         Ok(n > 0)
     }
 
+    /// FORGET one ENTITY fact by id — the `facts` twin of [`Db::forget_user_fact`] above.
+    ///
+    /// Until this existed, entity facts were effectively UNCORRECTABLE: the store exposed
+    /// forget/clear for *user* facts only, so the sole way to close a wrong entity fact was for a
+    /// LATER meeting to happen to assert a different object for the same
+    /// `(entity_id, subject, predicate)` key. A junk row nobody would ever restate — the real
+    /// `owner: claude_code` that reached a dossier as a current fact — therefore stayed current
+    /// forever, and kept being reported as truth by every agent reading that dossier.
+    ///
+    /// Same bitemporal contract as the user-fact twin: INVALIDATE by closing the row at `at`, never
+    /// delete, so the history stays on the record and only the CURRENT view changes. Idempotent —
+    /// an already-closed row is untouched. Returns `true` iff this call closed a row.
+    pub fn forget_entity_fact(&self, id: &str, at: &str) -> Result<bool> {
+        let conn = self.lock();
+        let n = conn
+            .execute(
+                "UPDATE facts SET valid_to = ?2 WHERE id = ?1 AND valid_to IS NULL",
+                rusqlite::params![id, at],
+            )
+            .map_err(map_err)?;
+        Ok(n > 0)
+    }
+
     /// CLEAR all user memory: bitemporal-close EVERY currently-open user fact at `at` (invalidate,
     /// never delete — closed history stays for the record). After this the brief regenerates empty and
     /// the audit view is empty. Returns the number of facts closed.


### PR DESCRIPTION
Defect **#17** of the MCP + note-pipeline repair program.

## What was wrong

A real vault ended up with the fact `M1 Advanced Mode · owner: claude_code`, and it surfaced through `get_entity_dossier` as a **CURRENT FACT**:

```
M1 Advanced Mode owner: claude_code (since 2026-07-09)
```

So every agent reading that dossier reported a provider id as the product's owner — a tool artifact promoted into the durable knowledge layer and restated as truth.

The route in is completely ordinary. `pipeline.rs::fold_manual_notes` folds the user's typed companion-note text — which routinely contains pasted CLI/agent output — into the markdown the fact extractor reads. `facts.rs::candidates_from_triples` then validated **only the entity** (resolved against the meeting's known set, "never invent"); `predicate` and `object` were taken verbatim with a `trim()` and a non-empty check. No roster check, no allowlist, no blocklist anywhere.

## Two halves, because the guard alone is not enough

**1. Junk can no longer get in.** Reject a tool/provider id as the object of a person-valued predicate (`owner`, `assignee`, `role`, plus the Polish forms the language-pinned extractor emits).

The guard belongs in the **extractor**, not the note writer: `commands/links.rs::link_meeting_entities` re-feeds stored note markdown to this same extractor, so any writer-side filter would be bypassed on re-ingest.

**2. Junk already stored can now be removed.** `facts_store.rs` exposed forget/clear for **user** facts only. An entity fact could be closed *only* by a later meeting asserting a different object for the same `(entity, subject, predicate)` key — so a junk row nobody would ever restate stayed current **forever**. New `forget_entity_fact` is the bitemporal twin of `forget_user_fact`: close the row, never delete, idempotent, registered in `generate_handler!` so the frontend can reach it.

## The risk I deliberately did not take

An obvious "does this look like a person?" heuristic would **silently drop a legitimate owner who did not attend** — "Anna owns it, she'll pick it up" is a true fact the meeting never had a speaker for. Losing a true fact is worse than the junk it prevents.

So the blocklist is deliberately narrow: an exact list of ids we *know* are machinery. And only the offending **candidate** is dropped, not the triple set — the rest of the note's facts survive.

A test pins this explicitly:

```rust
("owner", "Anna")           // a real person → kept
("owner", "Jakub Gawronski")// a real person → kept
("deployed_on", "gateway")  // NOT person-valued → blocklist must not apply
("runs_on", "ollama")       // ditto
```

## Verification

RED before GREEN, proven empirically by disabling the guard:

```
a_provider_id_is_never_accepted_as_an_owner   ... FAILED
a_rejected_owner_does_not_drop_the_other_facts ... FAILED
the_owner_guard_does_not_swallow_legitimate_facts ... ok   (a safety test, correctly still passing)
```

Restored → full lib suite green, `cargo clippy --lib -- -D warnings` clean (it caught a `manual_contains` that `cargo test` does not see), MSRV grep empty.

One correction worth recording: my first `forget_entity_fact` test asserted the forgotten row would **disappear** from `list_facts_visible`. It does not, and should not — that read deliberately returns the full bitemporal ledger (open + closed, `ORDER BY (valid_to IS NULL) DESC`) because `knowledge_diff` needs the history. What changes is which facts are still **open**, which is exactly what `dossier::render_structured` filters on (`valid_to.is_none()`) to print CURRENT FACTS. The test now asserts the real contract: history preserved, the junk closed at the requested instant, the sibling fact still current.

## What this does NOT fix

The extractor still assigns `confidence: 1.0` to everything, and there is still no roster validation — an invented person-name owner would pass. That needs the participant roster plumbed through, and is deliberately out of scope here to keep the blocklist's zero-false-positive property.
