### PR TITLE
fix(notes): a note section that records the meeting may only contain the meeting

### DIFF
--- a/src-tauri/src/summarize/grounding.rs
+++ b/src-tauri/src/summarize/grounding.rs
@@ -455,10 +455,20 @@ fn is_skipped_heading(trimmed_heading: &str) -> bool {
     const KEYS: &[&str] = &[
         // English
         "my notes",
+        // The provenance sections the enhance-mode prompt now emits for note items the transcript
+        // never covers. They exist PRECISELY to hold unsupported-by-the-recording material, so
+        // flagging their lines `> unverified` would mark every line of a section whose whole purpose
+        // is to be honest about that — noise that trains the reader to ignore the marker where it
+        // matters. NOTE these need their own keys: `starts_with` on the lowercased title does NOT
+        // match "from my notes" via the "my notes" key above.
+        "from my notes",
+        "from attached materials",
         "related prior notes",
         "also discussed",
         // Polish
         "moje notatki",
+        "z moich notatek",
+        "z załączonych materiałów",
         "powiązane notatki",
         "pozostałe",
     ];
@@ -560,6 +570,43 @@ mod tests {
     /// RED-before-GREEN: an action item the transcript never supports gets a following `> unverified`
     /// line, while a SUPPORTED summary sentence stays clean. Reverting `annotate_unverified` to a
     /// no-op drops the marker (RED). The marker here is the PLAIN variant (no overlapping segment).
+    #[test]
+    /// R3/#4 (regression). `## From my notes` is the provenance section the enhance-mode prompt now
+    /// emits for note material the transcript never covered. Flagging its lines `> unverified` would
+    /// mark every line of a section whose entire purpose is to be honest about exactly that — pure
+    /// noise that trains a reader to ignore the marker where it matters.
+    ///
+    /// RED against the previous behavior: `is_skipped_heading` knew only `my notes`, and its
+    /// `starts_with` test does NOT match `from my notes`, so the whole section was flagged.
+    #[test]
+    fn the_provenance_section_is_never_flagged_unverified() {
+        let segments = vec![seg("we shipped the login page this week", None)];
+        for heading in [
+            "## From my notes",
+            "## From attached materials",
+            "## Z moich notatek",
+        ] {
+            let note = format!(
+                "## Summary\n\nThe team shipped the login page.\n\n{heading}\n\n- rename the servers to interfaces\n- a 50 tool limit per interface\n"
+            );
+            let out = annotate_unverified(&note, &segments);
+            assert!(
+                !out.contains("> unverified"),
+                "{heading} must be exempt from the grounding pass; got:\n{out}"
+            );
+        }
+        // Control: the SAME uncovered lines under a meeting-record heading ARE still flagged, so the
+        // exemption is scoped to the provenance section and has not disarmed the pass generally.
+        let under_decisions = annotate_unverified(
+            "## Decisions\n\n- rename the servers to interfaces\n",
+            &segments,
+        );
+        assert!(
+            under_decisions.contains("> unverified"),
+            "the same claim under Decisions must still be flagged; got:\n{under_decisions}"
+        );
+    }
+
     #[test]
     fn unsupported_action_item_gets_unverified() {
         let segments = vec![

--- a/src-tauri/src/summarize/grounding.rs
+++ b/src-tauri/src/summarize/grounding.rs
@@ -567,10 +567,6 @@ mod tests {
         }
     }
 
-    /// RED-before-GREEN: an action item the transcript never supports gets a following `> unverified`
-    /// line, while a SUPPORTED summary sentence stays clean. Reverting `annotate_unverified` to a
-    /// no-op drops the marker (RED). The marker here is the PLAIN variant (no overlapping segment).
-    #[test]
     /// R3/#4 (regression). `## From my notes` is the provenance section the enhance-mode prompt now
     /// emits for note material the transcript never covered. Flagging its lines `> unverified` would
     /// mark every line of a section whose entire purpose is to be honest about exactly that — pure
@@ -607,6 +603,9 @@ mod tests {
         );
     }
 
+    /// RED-before-GREEN: an action item the transcript never supports gets a following `> unverified`
+    /// line, while a SUPPORTED summary sentence stays clean. Reverting `annotate_unverified` to a
+    /// no-op drops the marker (RED). The marker here is the PLAIN variant (no overlapping segment).
     #[test]
     fn unsupported_action_item_gets_unverified() {
         let segments = vec![

--- a/src-tauri/src/summarize/template.rs
+++ b/src-tauri/src/summarize/template.rs
@@ -534,16 +534,26 @@ pub fn render_user_content(req: &SummarizeRequest) -> String {
             out.push_str(
                 "\n## The user's own in-meeting notes (SKELETON — build the note around these)\n\
                  The user typed these during the meeting, one item per line, in order. They are \
-                 the strongest signal of what mattered. Requirements:\n\
+                 the strongest signal of what mattered. They may also contain material that was \
+                 NEVER discussed — pasted from a document, an agenda, or a plan. Requirements:\n\
                  - Use them as the outline: cover EVERY item, in the user's order, keeping the \
                  user's wording (fix only obvious typos).\n\
                  - Expand each item with concrete detail from the transcript — decisions, owners, \
                  dates, numbers.\n\
+                 - PROVENANCE (this overrides every other instruction): `## Summary`, \
+                 `## Key points`, `## Decisions`, `## Action items` and `## Risks & open questions` \
+                 record THE MEETING. Put a statement there ONLY if the TRANSCRIPT supports it. A \
+                 note item the transcript never covers — however important it looks — does NOT go \
+                 in those sections.\n\
+                 - Put every such uncovered item under ONE section headed exactly \
+                 `## From my notes`, placed after the meeting sections, keeping the user's wording. \
+                 Omit that section when the transcript covers everything.\n\
+                 - An OPEN QUESTION in a document is not a decision. Never promote one into \
+                 `## Decisions` because the notes stated it as a plan.\n\
                  - After covering every item, add one section headed exactly `## Also discussed` \
                  for significant transcript topics the notes missed; omit it when nothing \
                  significant remains.\n\
-                 - Never invent content that is not grounded in the transcript or these notes.\n\
-                 - Never output a section titled `My notes`.\n\
+                 - Never invent content grounded in neither the transcript nor these notes.\n\
                  - Never repeat a section heading; keep every formatting requirement from the \
                  instructions above (front-matter first, section structure, wikilinks).\n\
                  USER NOTES:\n",
@@ -1397,9 +1407,46 @@ mod tests {
             s.contains("## Also discussed"),
             "instructs the Also discussed section"
         );
+        // R3/#4 — DELIBERATE CHANGE. This used to assert the prompt forbade a notes-derived
+        // section outright ("Never output a section titled `My notes`"). That instruction was the
+        // defect: with no home of its own, note material the transcript never covered had to be
+        // distributed into the meeting sections, and a pasted PRD's open question landed under
+        // `## Decisions` where a reader takes it for a team decision. The section is now REQUIRED
+        // and named, so the forbidding clause is gone on purpose.
         assert!(
-            s.contains("Never output a section titled"),
-            "forbids a My notes section"
+            s.contains("## From my notes"),
+            "gives uncovered note material its own named home"
+        );
+    }
+
+    /// R3/#4 (regression). The enhance-mode block must state a PROVENANCE contract: the
+    /// meeting-record sections carry only transcript-supported statements, and anything from the
+    /// user's notes the transcript never covered goes to its own section instead.
+    ///
+    /// RED against the previous behavior: the old block said "Never invent content that is not
+    /// grounded in the transcript OR THESE NOTES", which explicitly WIDENED the grounding set to
+    /// the pasted document, and named no section to hold uncovered material.
+    #[test]
+    fn enhance_mode_prompt_states_a_provenance_contract() {
+        let mut r = req(None);
+        r.user_notes = Some("rename the servers\n50 tools per interface".to_string());
+        let s = render_user_content(&r);
+        assert!(
+            s.contains("## From my notes"),
+            "names the section that holds uncovered note material"
+        );
+        assert!(
+            s.contains("ONLY if the TRANSCRIPT supports it"),
+            "binds the meeting sections to transcript support"
+        );
+        assert!(
+            s.contains("OPEN QUESTION in a document is not a decision"),
+            "blocks the exact failure that put a PRD open question under Decisions"
+        );
+        // The old wording legitimised the notes as a grounding source for the meeting sections.
+        assert!(
+            !s.contains("grounded in the transcript or these notes"),
+            "must not widen the grounding set for the meeting-record sections"
         );
     }
 


### PR DESCRIPTION
Defect **#4** — the audit rated this the single most serious finding, because it concerns **trust rather than cost**. A note that is expensive to read is annoying. A note that *looks like* a record of a meeting but is half something else is dangerous.

## What was observed

Roughly **half** of a real 63-minute note had no coverage in the transcript at all: a PRD overview, numbered requirements, a Skills/FastMCP section, a 50/30s/100MB limits table, and an open-questions list.

None of the distinguishing terms — `Interfaces`, `Skills`, `SKILL.md`, `blocklist`, `Code Mode`, `FastMCP`, `sandbox`, `50`, `30s`, `100MB` — occur **even once** in 63 minutes of transcript. The topic was announced at the start and never reached.

The damage is not the extra text. It is **where the text landed**:

> `Rename MCP Servers → Interfaces … (me / PRD)` — under `## Decisions`

A reader and an agent both take that section as the record of what the team agreed. In the source document it was an **open question**.

## Why the model did it — this is a prompt defect

The enhance-mode block told the model to *"cover EVERY item"* from the user's typed notes, and then:

```
- Never invent content that is not grounded in the transcript or these notes.
- Never output a section titled `My notes`.
```

Those two instructions together **guarantee** the observed failure:

1. The first explicitly **widens the grounding set** to whatever was pasted into the notes — so document material is legitimised as note content.
2. The second denies that material any **home of its own**, so it must be distributed into the meeting sections.

There is even an `## Also discussed` section for the *inverse* case (transcript topics the notes missed), but nothing for notes material the transcript never covered. And `enhance` is the **default** notes mode, so this is the normal path, not an edge case.

## The fix

**Prompt — a provenance contract.** `## Summary`, `## Key points`, `## Decisions`, `## Action items` and `## Risks & open questions` record THE MEETING, and may carry a statement only if the transcript supports it. Anything from the notes the transcript never covered goes under one named section, `## From my notes`, placed after them. An open question in a document is explicitly **not** a decision.

**Deterministic backstop.** `grounding.rs::is_skipped_heading` must exempt that section. It exists precisely to hold material the recording does not support, so flagging every one of its lines `> unverified` would be pure noise — and noise is how you train a reader to ignore a marker where it *does* matter. Note the exemption needs its own keys: `starts_with` on the lowercased title does **not** match `from my notes` via the existing `my notes` key.

## Verification

RED before GREEN, proven empirically by removing the exemption keys:

```
the_provenance_section_is_never_flagged_unverified ... FAILED
```

The test also carries a **control assertion** so the exemption stays scoped rather than quietly disarming the grounding pass: the same uncovered claim under `## Decisions` must *still* be flagged.

Restored → **2465 passed, 0 failed**, `cargo clippy --lib -- -D warnings` clean.

One existing assertion was changed **deliberately**: `user_notes_block_renders_before_transcript` pinned `"Never output a section titled"`. That instruction *was* the defect, so the test now asserts the opposite — that the section is named and required.

## What this does NOT fix

The model is still asked to obey a prompt. The deterministic half only *exempts* the new section; it does not verify that the model actually routed uncovered material into it. Enforcing that — annotating below-coverage lines under a meeting-record heading with `> from your notes, not the recording` — is the next step, and it depends on `ground_summary`, which is still opt-in and whose thresholds are documented as needing calibration on real data.
