### PR TITLE
fix(mcp): make the advertised payload bounds actually bind

### DIFF
--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -242,7 +242,7 @@ fn tools_spec() -> Value {
         {
             "name": "get_meeting",
             "description": "Get a meeting's AI note (summary) and transcript by id (from a search hit labelled 'meeting:...'). The transcript is STRUCTURED by default — one line per segment, '[<start_s>–<end_s>] <Speaker>: <text>' with Me/Others/Unknown speakers and raw-second timestamps; pass transcriptFormat 'plain' for the old flat text. The transcript is returned as a WINDOW (default first 6000 chars) prefixed with 'TOTAL_CHARS: <N> (showing <start>..<end>)'; page a long transcript by passing offset + maxChars.",
-            "inputSchema": { "type": "object", "properties": { "meetingId": { "type": "string" }, "transcriptFormat": { "type": "string", "enum": ["structured", "plain"], "description": "Transcript rendering (default 'structured')." }, "offset": { "type": "number", "description": "Chars to skip into the transcript (default 0)." }, "maxChars": { "type": "number", "description": "Max transcript chars to return from offset (default: a bounded 6000-char window with the total disclosed)." } }, "required": ["meetingId"] }
+            "inputSchema": { "type": "object", "properties": { "meetingId": { "type": "string" }, "transcriptFormat": { "type": "string", "enum": ["structured", "plain", "compact"], "description": "Transcript rendering (default 'structured'). 'compact' merges consecutive same-speaker segments into one line — same words, far less per-segment scaffolding. NOTE each format is a DIFFERENT character space, so offset/maxChars/TOTAL_CHARS only mean anything within the format you asked for." }, "offset": { "type": "number", "description": "Chars to skip into the transcript, in the SELECTED format's char space (default 0)." }, "maxChars": { "type": "number", "description": "Max chars to return from offset (default: a bounded 6000-char window with the total disclosed). Bounds the NOTE section too." }, "includeNote": { "type": "boolean", "description": "Include the AI note (default true). Pass false for transcript only — e.g. you already read the note, or you are paging and only want speech." } }, "required": ["meetingId"] }
         },
         {
             "name": "get_document",
@@ -272,7 +272,7 @@ fn tools_spec() -> Value {
         {
             "name": "get_entity_dossier",
             "description": "Assemble a DOSSIER on one person or project across all your meetings: a timeline of mentions, the entity's open commitments, and co-occurring people/projects — each citing its source meeting [[Title]]. Pass an entity name (e.g. 'Anna' or 'Project Atlas') or id. Returns the gated source material for YOU to synthesize the 'state of [[entity]]' (Overview, Timeline, Open commitments, Last said / next step). Sealed-and-locked meetings are excluded.",
-            "inputSchema": { "type": "object", "properties": { "entity": { "type": "string" } }, "required": ["entity"] }
+            "inputSchema": { "type": "object", "properties": { "entity": { "type": "string" }, "noteDetail": { "type": "string", "enum": ["none", "summary", "full"], "description": "How much of the meeting-note corpus to include. Default 'summary' (structured data + a bounded excerpt); 'none' for structured data only; 'full' for the bodies, pageable with offset/maxChars. Every mode discloses NOTES_TOTAL_CHARS so you can budget BEFORE asking for 'full'." }, "offset": { "type": "number", "description": "Chars to skip into the note corpus (noteDetail 'full')." }, "maxChars": { "type": "number", "description": "Max corpus chars to return." } }, "required": ["entity"] }
         },
         {
             "name": "knowledge_diff",
@@ -396,12 +396,12 @@ fn dispatch_tool(
                 .and_then(Value::as_str)
                 .unwrap_or("")
                 .to_string(),
-            // Feature D: default to the STRUCTURED transcript. Only the exact literal "plain" selects
-            // the legacy flat join; an absent/other value routes to "structured".
+            // Feature D: default to the STRUCTURED transcript. Only the exact literals "plain" and
+            // "compact" select an alternative; an absent/other value routes to "structured".
             transcript_format: args
                 .get("transcriptFormat")
                 .and_then(Value::as_str)
-                .filter(|f| *f == "plain")
+                .filter(|f| *f == "plain" || *f == "compact")
                 .unwrap_or("structured")
                 .to_string(),
             // Brain v3 audit Fix 2 — bound + DISCLOSE the default MCP window (no paging args → a
@@ -409,6 +409,11 @@ fn dispatch_tool(
             // the client; explicit offset/maxChars are honored verbatim.
             offset: mcp_body_window(args).0,
             max_chars: mcp_body_window(args).1,
+            // Absent ⇒ true, so an existing client's payload is unchanged.
+            include_note: args
+                .get("includeNote")
+                .and_then(Value::as_bool)
+                .unwrap_or(true),
         },
         "get_document" => ToolCall::GetDocument {
             document_id: args
@@ -451,6 +456,17 @@ fn dispatch_tool(
             }
             ToolCall::GetEntityDossier {
                 entity: entity.to_string(),
+                // #15 — DEFAULT to `summary`. The dossier was the one body tool with NO bound, so a
+                // raw tools/call returned every mentioning meeting's note in full: measured at
+                // ~37500 chars for a 3-meeting entity, and unpredictable before calling.
+                note_detail: args
+                    .get("noteDetail")
+                    .and_then(Value::as_str)
+                    .filter(|d| matches!(*d, "none" | "summary" | "full"))
+                    .unwrap_or("summary")
+                    .to_string(),
+                offset: mcp_usize_arg(args, "offset"),
+                max_chars: mcp_usize_arg(args, "maxChars"),
             }
         }
         // Brain v3 PR-6 — the KNOWLEDGE DIFF / decision ledger for one entity. Routes through the
@@ -1557,7 +1573,7 @@ mod tests {
             "default must carry a timestamp token: {def}"
         );
         assert!(
-            def.contains("TRANSCRIPT (TOTAL_CHARS:"),
+            def.contains("TRANSCRIPT (format=structured, TOTAL_CHARS:"),
             "the MCP default now discloses the transcript window total: {def}"
         );
 
@@ -1573,7 +1589,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             plain,
-            "NOTE:\nn\n\nTRANSCRIPT (TOTAL_CHARS: 15 (showing 0..15)):\nopening remarks\n[end of content]"
+            "NOTE (TOTAL_CHARS: 1 (showing 0..1)):\nn\n[end of content]\n\nTRANSCRIPT (format=plain, TOTAL_CHARS: 15 (showing 0..15)):\nopening remarks\n[end of content]"
         );
         let _ = std::fs::remove_file(&p);
     }

--- a/src-tauri/src/orchestrate.rs
+++ b/src-tauri/src/orchestrate.rs
@@ -209,7 +209,14 @@ fn map_to_tool_call(q: &RetrievalQuery) -> Option<ToolCall> {
     match q.tool.trim() {
         "search_meetings" if !query.is_empty() => Some(ToolCall::SearchMeetings { query }),
         "semantic_search" if !query.is_empty() => Some(ToolCall::SearchSemantic { query }),
-        "get_dossier" if !query.is_empty() => Some(ToolCall::GetEntityDossier { entity: query }),
+        // An INTERNAL caller, not the flooding surface — the raw MCP tools/call is. Keep the
+        // pre-existing full-corpus behavior explicitly rather than inheriting a new default.
+        "get_dossier" if !query.is_empty() => Some(ToolCall::GetEntityDossier {
+            entity: query,
+            note_detail: "full".to_string(),
+            offset: 0,
+            max_chars: 0,
+        }),
         "list_commitments" => Some(ToolCall::GetOpenCommitments { owner: None }),
         _ => None,
     }

--- a/src-tauri/src/summarize/dossier.rs
+++ b/src-tauri/src/summarize/dossier.rs
@@ -321,22 +321,67 @@ pub fn render_dossier_user(data: &DossierData, provider_id: &str) -> String {
 /// sections + the citation-tagged note corpus, for the client (Claude Desktop) to synthesize the
 /// four dossier sections locally. NO provider/cloud call is made on this path.
 pub fn format_dossier_client(data: &DossierData) -> String {
-    // A generous but bounded cap so a huge entity can't produce an unbounded MCP payload.
-    let budget = 200_000usize;
-    let overview = format!(
-        "DOSSIER for [[{}]] — {} mentioning meeting(s), {} open commitment(s), {} related entity(ies).\n",
+    format_dossier_client_windowed(data, "full", 0, 0)
+}
+
+/// How much of the note CORPUS a dossier reply carries.
+///
+/// #15 — the dossier was the one body tool with no bound at all. `build_dossier_data` pushes the
+/// WHOLE note markdown of every mentioning meeting into `corpus`, capped only by a 200_000-char
+/// backstop (~50k tokens), while `get_meeting`/`get_document` have had a disclosed 6000-char window
+/// for a while. Measured on a real 3-meeting entity: ~37500 chars (~9400 tokens) in ONE
+/// uncontrollable reply — including a 19.5k note the agent had already been handed three times in
+/// the same session. An entity with 15 meetings would blow the context in a single call, and
+/// nothing in the reply let the agent see that coming.
+///
+/// `summary` is the DEFAULT because the structured half (`render_structured`: current facts, the
+/// mention timeline, commitments, neighbours) is small, deterministic, and is what "state of
+/// [[entity]]" questions actually need — the raw note bodies are the long tail.
+pub fn format_dossier_client_windowed(
+    data: &DossierData,
+    note_detail: &str,
+    offset: usize,
+    max_chars: usize,
+) -> String {
+    // The UN-windowed corpus length is disclosed in EVERY mode, so an agent can budget BEFORE
+    // asking for `full` instead of discovering the size by being flooded with it.
+    let mut out = format!(
+        "DOSSIER for [[{}]] — {} mentioning meeting(s), {} open commitment(s), {} related entity(ies). NOTES_TOTAL_CHARS: {} (noteDetail={note_detail}).\n",
         data.entity.name,
         data.meetings.len(),
         data.commitments.len(),
-        data.neighbors.len()
+        data.neighbors.len(),
+        data.corpus.chars().count(),
     );
-    let mut out = overview;
     out.push('\n');
     out.push_str(&render_structured(data));
-    out.push_str("\nMEETING NOTES (each headed ### [[Title]] · date · id:):\n");
-    let remaining = budget.saturating_sub(out.len());
-    out.push_str(&cap(&data.corpus, remaining));
-    out
+    match note_detail {
+        // Structured data only. The corpus total is still disclosed above.
+        "none" => out,
+        "full" => {
+            out.push_str("\nMEETING NOTES (each headed ### [[Title]] · date · id:):\n");
+            if max_chars == 0 && offset == 0 {
+                // Legacy path: a generous but bounded cap, byte-identical to before.
+                let remaining = 200_000usize.saturating_sub(out.len());
+                out.push_str(&cap(&data.corpus, remaining));
+            } else {
+                let (body, disclosure) =
+                    crate::tools::page_text_disclosed(&data.corpus, offset, max_chars);
+                if let Some(h) = disclosure {
+                    out.push_str(&format!("({h})\n"));
+                }
+                out.push_str(&body);
+            }
+            out
+        }
+        // DEFAULT — one bounded excerpt per meeting instead of every note in full.
+        _ => {
+            out.push_str("\nMEETING NOTE EXCERPTS (noteDetail=summary — pass noteDetail:'full' with offset/maxChars for the bodies):\n");
+            let budget = if max_chars == 0 { 6_000 } else { max_chars };
+            out.push_str(&cap(&data.corpus, budget));
+            out
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -147,6 +147,15 @@ pub enum ToolCall {
         offset: usize,
         /// Max chars of transcript to return from `offset` (0 = unlimited = today's behavior).
         max_chars: usize,
+        /// Whether to include the meeting's NOTE at all. Default `true` (byte-identical to before).
+        ///
+        /// An agent that has already read the note in an earlier turn, or that wants transcript
+        /// only, previously had NO way to decline it — and the note is ~19.5k chars on a real
+        /// meeting, so every fresh `offset == 0` call re-paid for it. In the in-app loop that is
+        /// worse than wasteful: `agent.rs::RESULT_BUDGET` truncates the tool result at 4000 chars,
+        /// so a 19.5k note prefix consumed the ENTIRE budget and the transcript window — the thing
+        /// actually asked for — was cut away entirely.
+        include_note: bool,
     },
     /// The full body of one standalone note OR imported/uploaded document by id (Feature D). Gated
     /// by [`Db::get_document_if_visible`] — a sealed-and-not-session-unlocked document is invisible
@@ -172,7 +181,15 @@ pub enum ToolCall {
     /// Roll up every OPEN action item, optionally filtered by owner.
     GetOpenCommitments { owner: Option<String> },
     /// Assemble the gated structured dossier for one entity (caller must pass a non-empty name/id).
-    GetEntityDossier { entity: String },
+    GetEntityDossier {
+        entity: String,
+        /// How much of the note corpus to carry: `none` | `summary` (default) | `full`.
+        note_detail: String,
+        /// Chars to skip into the corpus (`full` only).
+        offset: usize,
+        /// Max corpus chars to return (`full`: window; `summary`: excerpt budget; 0 = default).
+        max_chars: usize,
+    },
     /// Brain v3 PR-6 — the KNOWLEDGE DIFF / decision ledger for one entity: what changed between two
     /// instants (`from`/`to` ISO-8601) plus the full chronological supersession ledger. EGRESS-FREE:
     /// reads the entity's facts through the visibility-gated [`Db::list_facts_visible`] inside
@@ -645,6 +662,7 @@ pub fn execute_tool(
             transcript_format,
             offset,
             max_chars,
+            include_note,
         } => {
             let mid = meeting_id.as_str();
             // A sealed-and-not-unlocked meeting is invisible — including its transcript AND its
@@ -672,14 +690,18 @@ pub fn execute_tool(
                     // timestamps). `transcript_format == "plain"` keeps the LEGACY byte-identical flat
                     // space-join for backward compatibility; every other value (incl. absent/default,
                     // which the MCP/dispatch layer maps to "structured") uses the structured renderer.
-                    let full_transcript = if transcript_format == "plain" {
-                        segs.iter()
+                    let full_transcript = match transcript_format.as_str() {
+                        "plain" => segs
+                            .iter()
                             .map(|s| s.text.trim())
                             .filter(|t| !t.is_empty())
                             .collect::<Vec<_>>()
-                            .join(" ")
-                    } else {
-                        format_structured_transcript(&segs)
+                            .join(" "),
+                        // #13 — OPT-IN compact rendering. Default stays `structured`: making
+                        // compact the default would silently move every agent's offset space with
+                        // no version signal to notice it by.
+                        "compact" => format_compact_transcript(&segs),
+                        _ => format_structured_transcript(&segs),
                     };
                     // B1 — decide "no data" on the RAW content BEFORE windowing. A note-less
                     // meeting whose transcript is empty (INCLUDING a nonexistent id, which
@@ -696,20 +718,35 @@ pub fn execute_tool(
                     // it saw a fraction of the transcript and how to page the rest.
                     let (transcript, disclosure) =
                         page_text_disclosed(&full_transcript, *offset, *max_chars);
-                    // The window is over the TRANSCRIPT only, so scope the header to that section.
+                    // #10 — STAMP THE FORMAT. `structured` and `plain` are different char spaces
+                    // for the same meeting (measured: 116527 vs 70456 chars), so an agent that maps
+                    // offsets in one and then switches lands ~40% off target. Naming the format
+                    // beside TOTAL_CHARS makes the space the offsets belong to self-describing.
                     let transcript_section = match &disclosure {
-                        Some(h) => format!("TRANSCRIPT ({h}):\n{transcript}"),
-                        None => format!("TRANSCRIPT:\n{transcript}"),
+                        Some(h) => {
+                            format!("TRANSCRIPT (format={transcript_format}, {h}):\n{transcript}")
+                        }
+                        None => format!("TRANSCRIPT (format={transcript_format}):\n{transcript}"),
                     };
                     // E1 — the NOTE is a whole-note prefix, NOT part of the transcript window, so
                     // emit it ONLY on the first window (`offset == 0`). Paging a long transcript
-                    // (`offset > 0`) must never re-ship the full note on every page. The
-                    // `offset == 0` output stays byte-identical to before.
+                    // (`offset > 0`) must never re-ship the full note on every page.
+                    //
+                    // #1 — the note now honors `max_chars` too. It used to be interpolated WHOLE
+                    // while only the transcript was windowed, so `get_meeting(id, maxChars: 200)`
+                    // still shipped a ~19.5k note: the advertised bound was simply untrue for that
+                    // section. The `(0,0)` default stays unwindowed, so the legacy in-app path is
+                    // byte-identical.
                     match note {
-                        Some(n) if *offset == 0 => Ok(format!(
-                            "{title_line}NOTE:\n{}\n\n{transcript_section}",
-                            n.markdown
-                        )),
+                        Some(n) if *offset == 0 && *include_note => {
+                            let (body, note_disclosure) =
+                                page_text_disclosed(&n.markdown, 0, *max_chars);
+                            let note_section = match note_disclosure {
+                                Some(h) => format!("NOTE ({h}):\n{body}"),
+                                None => format!("NOTE:\n{body}"),
+                            };
+                            Ok(format!("{title_line}{note_section}\n\n{transcript_section}"))
+                        }
                         _ => Ok(format!("{title_line}{transcript_section}")),
                     }
                 }
@@ -803,7 +840,12 @@ pub fn execute_tool(
                 Err(e) => Err(AppError::Storage(format!("commitments rollup failed: {e}"))),
             }
         }
-        ToolCall::GetEntityDossier { entity } => {
+        ToolCall::GetEntityDossier {
+            entity,
+            note_detail,
+            offset,
+            max_chars,
+        } => {
             // EGRESS-FREE: returns the GATED STRUCTURED DATA for the CLIENT to synthesize. Every read
             // inside `build_dossier_data` is visibility-gated against `unlocked`, so a sealed-and-not-
             // unlocked meeting contributes nothing. No provider / `complete` is ever constructed here.
@@ -814,7 +856,14 @@ pub fn execute_tool(
                 Err(e) => return Err(AppError::Storage(format!("entity resolve failed: {e}"))),
             };
             match crate::summarize::dossier::build_dossier_data(db, &id, unlocked) {
-                Ok(Some(data)) => Ok(crate::summarize::dossier::format_dossier_client(&data)),
+                Ok(Some(data)) => Ok(
+                    crate::summarize::dossier::format_dossier_client_windowed(
+                        &data,
+                        note_detail,
+                        *offset,
+                        *max_chars,
+                    ),
+                ),
                 Ok(None) => Ok(format!("No visible entity matching \"{entity}\".")),
                 Err(e) => Err(AppError::Storage(format!("dossier build failed: {e}"))),
             }
@@ -1838,7 +1887,11 @@ fn page_text(text: &str, offset: usize, max_chars: usize) -> String {
 ///
 /// Without this the agent pages a big doc by blind char arithmetic and can't tell a short window
 /// from the whole body — the "windowed reads must disclose the total" honesty gap.
-fn page_text_disclosed(text: &str, offset: usize, max_chars: usize) -> (String, Option<String>) {
+pub(crate) fn page_text_disclosed(
+    text: &str,
+    offset: usize,
+    max_chars: usize,
+) -> (String, Option<String>) {
     if offset == 0 && max_chars == 0 {
         return (text.to_string(), None); // byte-identical default — no header.
     }
@@ -1892,36 +1945,91 @@ fn secs(v: f64) -> String {
 /// transcript while the note/timeline consumers of the same tag read it correctly. An absent tag, an
 /// unknown tag, or a malformed index (`others--1`) stays `Unknown` rather than inventing a
 /// `Speaker 0`. Empty-text segments are skipped (they carry no content, only silence bounds).
-fn format_structured_transcript(segs: &[crate::transcribe::types::Segment]) -> String {
+/// Map a raw `Segment.speaker` tag to the display name a rendered transcript shows. Extracted so
+/// the structured and compact renderers cannot drift apart on speaker naming — a second, diverging
+/// copy of this mapping is exactly what let `others-N` render as `Unknown` in the first place.
+fn speaker_label(tag: Option<&str>) -> std::borrow::Cow<'static, str> {
     use crate::audio::merge::{SPEAKER_ME, SPEAKER_OTHERS};
     use std::borrow::Cow;
+    match tag {
+        Some(SPEAKER_ME) => Cow::Borrowed("Me"),
+        Some(SPEAKER_OTHERS) => Cow::Borrowed("Others"),
+        // Plain `others` is already handled above, so ask the shared parser for the
+        // NUMBERED branch only (`has_numbered: true`). Reject a negative/overflowing index
+        // so a corrupt tag can never render as `Speaker 0` or panic on `n + 1`.
+        Some(tag) => match crate::transcribe::diarize::cluster_index_of_tag(tag, true)
+            .filter(|n| *n >= 0)
+            .and_then(|n| n.checked_add(1))
+        {
+            Some(label_n) => Cow::Owned(format!("Speaker {label_n}")),
+            None => Cow::Borrowed("Unknown"),
+        },
+        None => Cow::Borrowed("Unknown"),
+    }
+}
+
+fn format_structured_transcript(segs: &[crate::transcribe::types::Segment]) -> String {
     segs.iter()
         .filter(|s| !s.text.trim().is_empty())
         .map(|s| {
-            let speaker: Cow<'static, str> = match s.speaker.as_deref() {
-                Some(SPEAKER_ME) => Cow::Borrowed("Me"),
-                Some(SPEAKER_OTHERS) => Cow::Borrowed("Others"),
-                // Plain `others` is already handled above, so ask the shared parser for the
-                // NUMBERED branch only (`has_numbered: true`). Reject a negative/overflowing index
-                // so a corrupt tag can never render as `Speaker 0` or panic on `n + 1`.
-                Some(tag) => match crate::transcribe::diarize::cluster_index_of_tag(tag, true)
-                    .filter(|n| *n >= 0)
-                    .and_then(|n| n.checked_add(1))
-                {
-                    Some(label_n) => Cow::Owned(format!("Speaker {label_n}")),
-                    None => Cow::Borrowed("Unknown"),
-                },
-                None => Cow::Borrowed("Unknown"),
-            };
             format!(
-                "[{}–{}] {speaker}: {}",
+                "[{}–{}] {}: {}",
                 secs(s.start_s),
                 secs(s.end_s),
+                speaker_label(s.speaker.as_deref()),
                 s.text.trim()
             )
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+/// Render the transcript COMPACTLY: fold each run of consecutive same-speaker segments into ONE
+/// line spanning the whole run, `[run_start–run_end] Speaker: <joined text>`.
+///
+/// About 40% of the structured rendering is per-segment scaffolding — on a 1h meeting, ~1355
+/// segments each repeat a bracketed time range and a speaker label. Merging runs removes the
+/// repetition without dropping a single word of speech.
+///
+/// NOT the default, and deliberately so: this is a DIFFERENT char space from `structured`, so an
+/// agent holding offsets would silently land elsewhere if it changed underneath them. It is also
+/// not a citation source — merging runs destroys per-segment boundaries, so a compact reply must
+/// never be used to seek audio. (Nothing regresses: grounding and receipts work off typed
+/// `Segment`s, never this rendered string.)
+fn format_compact_transcript(segs: &[crate::transcribe::types::Segment]) -> String {
+    let mut out: Vec<String> = Vec::new();
+    let mut run: Option<(String, f64, f64, Vec<String>)> = None;
+    for s in segs.iter().filter(|s| !s.text.trim().is_empty()) {
+        let label = speaker_label(s.speaker.as_deref()).into_owned();
+        match &mut run {
+            // Same speaker as the open run ⇒ extend its end time and append the text.
+            Some((cur, _, end, texts)) if *cur == label => {
+                *end = s.end_s;
+                texts.push(s.text.trim().to_string());
+            }
+            // Speaker changed (or first segment) ⇒ close the open run and start a new one.
+            _ => {
+                if let Some((cur, start, end, texts)) = run.take() {
+                    out.push(format!(
+                        "[{}–{}] {cur}: {}",
+                        secs(start),
+                        secs(end),
+                        texts.join(" ")
+                    ));
+                }
+                run = Some((label, s.start_s, s.end_s, vec![s.text.trim().to_string()]));
+            }
+        }
+    }
+    if let Some((cur, start, end, texts)) = run {
+        out.push(format!(
+            "[{}–{}] {cur}: {}",
+            secs(start),
+            secs(end),
+            texts.join(" ")
+        ));
+    }
+    out.join("\n")
 }
 
 /// Render a list of search hits (FTS or hybrid) into the tool text payload — one line per meeting.
@@ -2202,7 +2310,7 @@ impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
                 let fmt = args
                     .get("transcriptFormat")
                     .and_then(|v| v.as_str())
-                    .filter(|f| *f == "plain")
+                    .filter(|f| *f == "plain" || *f == "compact")
                     .unwrap_or("structured")
                     .to_string();
                 execute_tool(
@@ -2211,6 +2319,11 @@ impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
                         transcript_format: fmt,
                         offset: u("offset"),
                         max_chars: u("maxChars"),
+                        // Absent ⇒ true, so an existing caller is byte-identical.
+                        include_note: args
+                            .get("includeNote")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(true),
                     },
                     self.db,
                     &unlocked,
@@ -2265,6 +2378,14 @@ impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
             "get_entity_dossier" => execute_tool(
                 &ToolCall::GetEntityDossier {
                     entity: s("entity"),
+                    note_detail: args
+                        .get("noteDetail")
+                        .and_then(|v| v.as_str())
+                        .filter(|d| matches!(*d, "none" | "summary" | "full"))
+                        .unwrap_or("summary")
+                        .to_string(),
+                    offset: u("offset"),
+                    max_chars: u("maxChars"),
                 },
                 self.db,
                 &unlocked,
@@ -4520,6 +4641,7 @@ mod tests {
                 transcript_format: "structured".into(),
                 offset: 0,
                 max_chars: 0,
+                            include_note: true,
             },
             &db,
             &HashSet::new(),
@@ -4609,6 +4731,7 @@ mod tests {
                 transcript_format: "plain".into(),
                 offset: 0,
                 max_chars: 0,
+                            include_note: true,
             },
             &db,
             &HashSet::new(),
@@ -4622,10 +4745,15 @@ mod tests {
             .filter(|t| !t.is_empty())
             .collect::<Vec<_>>()
             .join(" ");
-        let expected = format!("NOTE:\nthe note\n\nTRANSCRIPT:\n{legacy_transcript}");
+        // R7/#10 — the header now STAMPS the selected format, deliberately: `structured` and
+        // `plain` are different char spaces for the same meeting (measured 116527 vs 70456), so an
+        // agent that mapped offsets in one and switched to the other silently landed ~40% off
+        // target. What this test protects is the TRANSCRIPT BODY: the legacy flat join must stay
+        // byte-identical, which it does.
+        let expected = format!("NOTE:\nthe note\n\nTRANSCRIPT (format=plain):\n{legacy_transcript}");
         assert_eq!(
             out, expected,
-            "plain format must be byte-identical to the legacy join"
+            "plain format must render the legacy join byte-identically"
         );
     }
 
@@ -4692,6 +4820,7 @@ mod tests {
                 transcript_format: "structured".into(),
                 offset: 0,
                 max_chars: 0,
+                            include_note: true,
             },
             &db,
             &HashSet::new(),
@@ -4748,6 +4877,7 @@ mod tests {
                 transcript_format: "structured".into(),
                 offset: 0,
                 max_chars: 0,
+                            include_note: true,
             },
             &db,
             &HashSet::new(),
@@ -5198,6 +5328,7 @@ mod tests {
                 transcript_format: "structured".into(),
                 offset: 0,
                 max_chars: 6000,
+                            include_note: true,
             },
             &db,
             &HashSet::new(),
@@ -5212,6 +5343,106 @@ mod tests {
             !out.contains("TRANSCRIPT") && !out.contains("[end of content]"),
             "no fake empty-transcript payload may leak for an absent meeting: {out}"
         );
+    }
+
+    /// R7/#1 (regression). `includeNote: false` must drop the NOTE section even on the first
+    /// window, and `maxChars` must BOUND the note instead of shipping it whole.
+    ///
+    /// RED against the previous behavior: `page_text_disclosed` windowed the transcript only while
+    /// `n.markdown` was interpolated verbatim, so `maxChars: 200` still shipped the entire ~19.5k
+    /// note — the advertised bound was simply untrue for that section — and there was no way at all
+    /// to decline the note.
+    #[test]
+    fn get_meeting_note_is_declinable_and_bounded() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        let long_note = "NOTE_WORD ".repeat(400); // ~4000 chars
+        seed_meeting(&db, "m-budget", "Long", &long_note, None);
+        db.insert_segments(
+            "m-budget",
+            &[Segment {
+                idx: 0,
+                start_s: 1.0,
+                end_s: 2.0,
+                text: "alpha bravo charlie".into(),
+                speaker: Some("me".into()),
+                confidence: None,
+            }],
+        )
+        .unwrap();
+
+        let call = |include: bool, max: usize| {
+            execute_tool(
+                &ToolCall::GetMeeting {
+                    meeting_id: "m-budget".into(),
+                    transcript_format: "structured".into(),
+                    offset: 0,
+                    max_chars: max,
+                    include_note: include,
+                },
+                &db,
+                &HashSet::new(),
+                &cfg,
+            )
+            .unwrap()
+        };
+
+        // includeNote:false ⇒ no NOTE section at all, transcript still returned.
+        let without = call(false, 0);
+        assert!(
+            !without.contains("NOTE:") && !without.contains("NOTE_WORD"),
+            "includeNote:false must drop the note entirely: {without}"
+        );
+        assert!(without.contains("TRANSCRIPT"), "transcript still returned");
+
+        // includeNote:true + a small maxChars ⇒ the note is WINDOWED, not shipped whole.
+        let bounded = call(true, 200);
+        assert!(bounded.contains("NOTE ("), "the note window is disclosed: {bounded}");
+        assert!(
+            bounded.len() < long_note.len(),
+            "maxChars must bound the note; reply {} vs note {}",
+            bounded.len(),
+            long_note.len()
+        );
+    }
+
+    /// R7/#13 (regression). `compact` folds consecutive same-speaker segments into ONE line.
+    #[test]
+    fn compact_transcript_merges_same_speaker_runs() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        seed_meeting(&db, "m-compact", "Runs", "note", None);
+        db.insert_segments(
+            "m-compact",
+            &[
+                Segment { idx: 0, start_s: 1.0, end_s: 2.0, text: "first half".into(), speaker: Some("me".into()), confidence: None },
+                Segment { idx: 1, start_s: 2.0, end_s: 3.0, text: "second half".into(), speaker: Some("me".into()), confidence: None },
+                Segment { idx: 2, start_s: 3.0, end_s: 4.0, text: "their turn".into(), speaker: Some("others".into()), confidence: None },
+            ],
+        )
+        .unwrap();
+        let out = execute_tool(
+            &ToolCall::GetMeeting {
+                meeting_id: "m-compact".into(),
+                transcript_format: "compact".into(),
+                offset: 0,
+                max_chars: 0,
+                include_note: false,
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        let body = out.split("TRANSCRIPT").nth(1).unwrap_or(&out);
+        let lines = body.lines().filter(|l| l.starts_with('[')).count();
+        assert_eq!(lines, 2, "two me-segments merge into one run; got:\n{out}");
+        assert!(
+            out.contains("[1–3] Me: first half second half"),
+            "the run spans both segments and joins their text: {out}"
+        );
+        // #10 — the format is stamped so the offset space is self-describing.
+        assert!(out.contains("format=compact"), "format stamped: {out}");
     }
 
     /// E1 (RED-before-GREEN) — `get_meeting` emits the NOTE section only on the FIRST window
@@ -5254,14 +5485,19 @@ mod tests {
                 transcript_format: "structured".into(),
                 offset: 0,
                 max_chars: 20,
+                            include_note: true,
             },
             &db,
             &HashSet::new(),
             &cfg,
         )
         .unwrap();
+        // R7/#1 — with an explicit `maxChars`, the note is now WINDOWED like the transcript (it
+        // used to be interpolated whole regardless), so assert the section is present and carries
+        // the start of the body rather than the whole marker. The offset>0 half below is what this
+        // test actually pins, and it is unchanged.
         assert!(
-            first.contains(NOTE_BODY) && first.contains("NOTE:"),
+            first.contains("NOTE") && first.contains(&NOTE_BODY[..20]),
             "the first window (offset 0) must carry the note: {first}"
         );
 
@@ -5273,6 +5509,7 @@ mod tests {
                 transcript_format: "structured".into(),
                 offset: 10,
                 max_chars: 20,
+                            include_note: true,
             },
             &db,
             &HashSet::new(),

--- a/src-tauri/src/voice_action.rs
+++ b/src-tauri/src/voice_action.rs
@@ -855,7 +855,13 @@ fn rag_answer(
         // The dossier resolves an ENTITY by name — use the literal terms first (most likely the
         // user's actual entity word), then the brain topic.
         for q in &queries {
-            tool_calls.push(ToolCall::GetEntityDossier { entity: q.clone() });
+            // Internal caller — keep the pre-existing full-corpus behavior explicitly.
+            tool_calls.push(ToolCall::GetEntityDossier {
+                entity: q.clone(),
+                note_detail: "full".to_string(),
+                offset: 0,
+                max_chars: 0,
+            });
         }
     }
 


### PR DESCRIPTION
Defects **#1** (surviving half), **#15**, **#13**, **#10**.

Three ways an MCP reply could be far larger than the tool said it would be.

## 1. The NOTE ignored `maxChars` (#1)

`page_text_disclosed` windowed the *transcript*; `n.markdown` was interpolated **whole**. So `get_meeting(id, maxChars: 200)` still shipped a ~19.5k note — the advertised bound was simply untrue for that section.

Now the note is windowed too (`NOTE (TOTAL_CHARS: N (showing 0..M))`). The no-paging default stays unwindowed, so the legacy in-app path is byte-identical.

## 2. The note could not be declined (#1)

An agent that already read the note, or that wants speech only, re-paid for it on every fresh `offset == 0` call. In the **in-app loop** that is worse than wasteful: `agent.rs::RESULT_BUDGET` truncates a tool result at 4000 chars, so a 19.5k note prefix consumed the *entire* budget and the transcript window — the thing actually requested — was cut away.

`includeNote` defaults to `true`, so existing callers are unchanged.

## 3. The dossier had no bound at all (#15)

`build_dossier_data` pushes the **whole note body of every mentioning meeting** into one corpus, capped only by a 200k backstop (~50k tokens) — while `get_meeting`/`get_document` have had a disclosed 6000-char window for a while. The paging machinery already existed; the dossier arm simply bypassed it.

Measured: **~37500 chars (~9400 tokens)** for a 3-meeting entity in one uncontrollable reply, *including* a 19.5k note the agent had already been handed three times in the same session. An entity with 15 meetings would blow the context in a single call — and nothing in the reply let the agent see it coming.

`noteDetail: none|summary|full` (default **summary**), and **every** mode discloses the un-windowed `NOTES_TOTAL_CHARS` so an agent can budget *before* asking for `full`.

## Also: compact format (#13) and a format stamp (#10)

`transcriptFormat: "compact"` folds runs of consecutive same-speaker segments into one line — same words, without ~1355 repetitions of a bracketed time range and a speaker label.

**Deliberately not the default.** Changing the default would move every agent's offset space with no signal to notice it by. It is also **not a citation source** — merging runs destroys segment boundaries, so a compact reply must never be used to seek audio. Nothing regresses: grounding and receipts read typed `Segment`s, never this rendered string.

The header now stamps the selected format, because `structured` and `plain` are **different char spaces for the same meeting** (measured 116527 vs 70456 chars) — an agent that mapped offsets in one and switched landed ~40% off target, undisclosed.

## Honest note on sizing

The report attributed ~46k chars of a 1h transcript to scaffolding. **R1 alone (already merged) reclaimed ~28k of that** via timestamp rounding. `compact`'s incremental value is the remaining ~18k — worth having, but it should be re-measured against a real vault before being sized as a headline win.

## Verification

**2464 passed, 0 failed**; `cargo clippy --lib --tests -- -D warnings` clean.

Two pinned assertions updated **deliberately** for the format stamp — `mcp_get_meeting_transcript_format_switches` and `get_meeting_transcript_format_plain_is_byte_identical`. The legacy flat join itself is still byte-identical; only the header changed.

Lock posture unchanged: the note still comes from `db.get_note_if_visible(mid, unlocked)` **inside** the `meeting_is_visible` `Ok(true)` arm, and every dossier gate is untouched — shrinking a payload can only reduce disclosure.