### PR TITLE
feat(facts): the note's written decisions become first-class, queryable rows

### DIFF
--- a/src-tauri/src/commands/facts.rs
+++ b/src-tauri/src/commands/facts.rs
@@ -129,6 +129,19 @@ pub(crate) fn persist_facts_for_meeting(
     recording_model_token: Option<&crate::perf::RecordingSessionToken>,
     visibility: &MeetingContentSnapshot,
 ) -> Result<(), AppError> {
+    // R6/#6 — mirror the note's `## Decisions` / `## Risks & open questions` bullets into their own
+    // table BEFORE the entity gate below. This is a DETERMINISTIC parse of text the model was
+    // already instructed to write, so unlike the LLM triple extraction it works with no model at
+    // all — and it must not be skipped just because this meeting produced no entities.
+    let bullets = crate::summarize::note_sections::parse_labeled_bullets(markdown);
+    if !bullets.is_empty() {
+        let at = chrono::Utc::now().to_rfc3339();
+        if let Err(e) = state.db.replace_note_decisions(meeting_id, &bullets, &at) {
+            // Best-effort, exactly like the extraction below: a decisions hiccup must NEVER block
+            // the note pipeline. Content-free logging (a count only).
+            tracing::warn!(target: "facts", count = bullets.len(), error = %e, "note decisions not persisted");
+        }
+    }
     if entity_refs.is_empty() {
         return Ok(());
     }

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -539,6 +539,22 @@ impl Db {
              );
              CREATE INDEX IF NOT EXISTS idx_facts_entity ON facts(entity_id);
              CREATE INDEX IF NOT EXISTS idx_facts_meeting ON facts(meeting_id);
+             -- R6/#6 — the note's `## Decisions` / `## Risks & open questions` bullets as
+             -- FIRST-CLASS rows. Deliberately a SEPARATE table rather than more `facts` rows: a
+             -- decision is a SENTENCE, and routing free text through `reconcile_facts` would mint
+             -- a spurious supersession on every re-wording under the same (subject, predicate) key,
+             -- fabricating bitemporal history. It also keeps the `status`/`owner` key space clean.
+             -- `meeting_id` is the provenance + gating + purge anchor, exactly like `facts`:
+             -- PURGED on seal in the same atomic tx and visibility-gated on every read.
+             CREATE TABLE IF NOT EXISTS note_decisions (
+               id TEXT PRIMARY KEY,
+               meeting_id TEXT NOT NULL,
+               kind TEXT NOT NULL,
+               text TEXT NOT NULL,
+               recorded_at TEXT NOT NULL,
+               FOREIGN KEY (meeting_id) REFERENCES meetings(id) ON DELETE CASCADE
+             );
+             CREATE INDEX IF NOT EXISTS idx_note_decisions_meeting ON note_decisions(meeting_id);
              -- CROSS-MEETING USER MEMORY (Phase 3). The SAME bitemporal shape as `facts`
              -- (subject·predicate·object with valid_from/valid_to — invalidate-not-delete via
              -- reconcile) but USER-SCOPED, not entity-scoped: these are durable facts/preferences/
@@ -3016,6 +3032,9 @@ impl Db {
         // drop them in the SAME seal tx so a sealed meeting contributes no fact — same purge-on-seal
         // contract as corrections / chunks / assistant interactions.
         Self::purge_facts_tx(&tx, meeting_ids)?;
+        // R6/#6: parsed DECISION / RISK bullets are derived note content anchored to the meeting;
+        // drop them in the SAME seal tx under the identical purge-on-seal contract as `facts`.
+        Self::purge_note_decisions_tx(&tx, meeting_ids)?;
         // Phase 3 CROSS-MEETING USER MEMORY: user-scoped facts are DERIVED content tied to the source
         // meeting (plaintext at rest); drop them in the SAME seal tx so a sealed meeting contributes
         // no user memory — identical purge-on-seal contract as `facts` above. The injected brief is

--- a/src-tauri/src/storage/db_tests/lock_tests.rs
+++ b/src-tauri/src/storage/db_tests/lock_tests.rs
@@ -1660,6 +1660,65 @@ fn list_user_facts_visible_excludes_sealed_meeting() {
     );
 }
 
+/// R6/#6 (regression + LOCK GATE). The note's `## Decisions` bullets become first-class rows — and
+/// they carry the SAME purge-on-seal + visibility-gate contract as `facts`.
+///
+/// A decision bullet is note CONTENT. If it were merely stored and read back, sealing the folder
+/// would leave it readable at rest and queryable through knowledge_diff — a straight sealed-content
+/// leak. Both halves are asserted here: the gated read hides it, and the seal tx deletes it.
+#[test]
+fn note_decisions_are_gated_and_purged_on_seal() {
+    use crate::summarize::note_sections::LabeledBullet;
+    let db = file_db("note-decisions-lock");
+    seed_folder(&db, "f-lock", "Secret");
+    seed_note(&db, "open", "## Decisions\n- open decision\n", None);
+    seed_note(&db, "sealed", "## Decisions\n- secret decision\n", Some("f-lock"));
+    let bullet = |t: &str| LabeledBullet {
+        kind: "decision",
+        text: t.to_string(),
+    };
+    db.replace_note_decisions("open", &[bullet("open decision")], "2026-07-01T00:00:00Z")
+        .unwrap();
+    db.replace_note_decisions("sealed", &[bullet("secret decision")], "2026-07-01T00:00:00Z")
+        .unwrap();
+
+    let ids = vec!["open".to_string(), "sealed".to_string()];
+    // Both visible while the folder is open.
+    assert_eq!(
+        db.list_note_decisions_visible(&ids, &HashSet::new())
+            .unwrap()
+            .len(),
+        2
+    );
+
+    db.set_folder_locked("f-lock", true, None).unwrap();
+
+    // GATE: the sealed meeting's decision text must not come back.
+    let after = db
+        .list_note_decisions_visible(&ids, &HashSet::new())
+        .unwrap();
+    assert_eq!(after.len(), 1, "only the open meeting's decision: {after:?}");
+    assert!(
+        !after.iter().any(|(_, _, t)| t.contains("secret")),
+        "a sealed decision must never surface: {after:?}"
+    );
+
+    // PURGE-ON-SEAL: not merely hidden — GONE from the table at rest, so even a future ungated
+    // reader cannot find it. `set_folder_locked` above only flips the flag; the derived-content
+    // purge is the seal transaction itself, which is what `lock_folder` runs.
+    db.purge_chunks_for_meetings(&["sealed".to_string()]).unwrap();
+    let unlocked: HashSet<String> = ["f-lock".to_string()].into_iter().collect();
+    let even_unlocked = db.list_note_decisions_visible(&ids, &unlocked).unwrap();
+    assert!(
+        !even_unlocked.iter().any(|(_, _, t)| t.contains("secret")),
+        "the sealed row must be purged by the seal tx, so unlocking cannot resurrect it: {even_unlocked:?}"
+    );
+    assert!(
+        even_unlocked.iter().any(|(_, _, t)| t.contains("open")),
+        "the OPEN meeting's decision must survive the purge of an unrelated meeting"
+    );
+}
+
 /// R4/#17 (regression). An ENTITY fact must be FORGETTABLE.
 ///
 /// Until `forget_entity_fact` existed, the store exposed forget/clear for USER facts only, so the

--- a/src-tauri/src/storage/facts_store.rs
+++ b/src-tauri/src/storage/facts_store.rs
@@ -619,6 +619,101 @@ impl Db {
         Ok(())
     }
 
+    /// Replace this meeting's parsed DECISION / RISK bullets (R6/#6).
+    ///
+    /// Replace-not-append, keyed on `meeting_id`, so re-summarizing a meeting cannot accumulate
+    /// duplicate decisions — the note is the source of truth and this table mirrors it.
+    pub fn replace_note_decisions(
+        &self,
+        meeting_id: &str,
+        bullets: &[crate::summarize::note_sections::LabeledBullet],
+        recorded_at: &str,
+    ) -> Result<()> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        tx.execute(
+            "DELETE FROM note_decisions WHERE meeting_id = ?1",
+            rusqlite::params![meeting_id],
+        )
+        .map_err(map_err)?;
+        for b in bullets {
+            tx.execute(
+                "INSERT INTO note_decisions (id, meeting_id, kind, text, recorded_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                rusqlite::params![
+                    uuid::Uuid::new_v4().to_string(),
+                    meeting_id,
+                    b.kind,
+                    b.text,
+                    recorded_at
+                ],
+            )
+            .map_err(map_err)?;
+        }
+        tx.commit().map_err(map_err)?;
+        Ok(())
+    }
+
+    /// GATED read of the decision/risk rows for a set of meetings.
+    ///
+    /// LOCK MODEL: a decision bullet is note CONTENT, so this carries the same `visibility_clause`
+    /// predicate as `list_facts_visible` — keep a meeting iff it has NO note rows, OR at least one
+    /// VISIBLE note row. Purge-on-seal (below) is defense-in-depth BENEATH this gate, not the gate.
+    pub fn list_note_decisions_visible(
+        &self,
+        meeting_ids: &[String],
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<(String, String, String)>> {
+        if meeting_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let placeholders = (1..=meeting_ids.len())
+            .map(|i| format!("?{i}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!(
+            "SELECT d.meeting_id, d.kind, d.text \
+               FROM note_decisions d \
+               JOIN meetings m ON m.id = d.meeting_id \
+              WHERE d.meeting_id IN ({placeholders}) \
+                AND (NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id) \
+                 OR EXISTS ( \
+                      SELECT 1 FROM notes n \
+                       LEFT JOIN folders f ON f.id = n.folder_id \
+                       WHERE n.meeting_id = m.id AND {visible} \
+                    )) \
+              ORDER BY d.kind ASC, d.rowid ASC"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params_from_iter(meeting_ids.iter()), |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// Seal-time purge of the decision rows, called from the SAME atomic tx as `purge_facts_tx`.
+    pub(crate) fn purge_note_decisions_tx(
+        tx: &rusqlite::Transaction<'_>,
+        meeting_ids: &[String],
+    ) -> Result<()> {
+        for mid in meeting_ids {
+            tx.execute(
+                "DELETE FROM note_decisions WHERE meeting_id = ?1",
+                rusqlite::params![mid],
+            )
+            .map_err(map_err)?;
+        }
+        Ok(())
+    }
+
     /// FORGET one user fact by id (bitemporal INVALIDATE, never a silent delete): close the row at
     /// `at` if it is still open. Idempotent (a already-closed row is untouched). History is preserved
     /// — the fact simply stops being current, so it drops out of `list_user_facts_visible` and the

--- a/src-tauri/src/storage/seal_store.rs
+++ b/src-tauri/src/storage/seal_store.rs
@@ -550,6 +550,9 @@ impl Db {
             // re-diarized voiceprints) survived the relock at rest. Same purge-on-seal contract,
             // same meeting scope, same atomic unit as the plaintext re-blank above.
             Self::purge_facts_tx(&tx, &meeting_ids)?;
+            // R6/#6: the RELOCK path must purge decisions too — rows re-derived during a session
+            // unlock would otherwise survive the relock at rest (the exact 2026-07-10 F5 class).
+            Self::purge_note_decisions_tx(&tx, &meeting_ids)?;
             Self::purge_user_facts_tx(&tx, &meeting_ids)?;
             Self::purge_assistant_interactions_tx(&tx, &meeting_ids)?;
             Self::purge_speaker_voiceprints_tx(&tx, &meeting_ids)?;

--- a/src-tauri/src/summarize/mod.rs
+++ b/src-tauri/src/summarize/mod.rs
@@ -19,6 +19,7 @@ pub mod graph;
 /// transcript segments. Pure, on-device, zero-egress; annotates unsupported summary units with a
 /// non-destructive `> unverified` marker.
 pub mod grounding;
+pub mod note_sections;
 pub mod local;
 pub mod meta;
 /// The REAL on-device PERSON-name NER redactor (Phase D). ALWAYS compiled; the real impl is selected

--- a/src-tauri/src/summarize/note_sections.rs
+++ b/src-tauri/src/summarize/note_sections.rs
@@ -1,0 +1,181 @@
+//! Deterministic parser for the note's LABELLED BULLET sections — `## Decisions` and
+//! `## Risks & open questions`.
+//!
+//! #6 — the knowledge layer never read the most structured thing the app itself produces. A note
+//! with five decisions, nine key points and seven open risks reported `0 total decision(s) on
+//! record`, because the ONLY writer into the fact registry is the LLM triple extractor, and
+//! `facts.rs::EXTRACT_SYSTEM` narrows it by design to short key-value attributes ("predicate is a
+//! short, stable attribute (e.g. \"status\", \"owner\", \"deadline\", \"role\")"). A decision is a
+//! SENTENCE, not an attribute, so it was never a candidate. Grepping `Decisions` across the crate
+//! found only prompt-authoring sites — zero parsers.
+//!
+//! Pure and dependency-free, like `action_items::parse_action_items`: the note already carries the
+//! headings, so this reads what the model was told to write rather than asking a model again.
+
+/// One parsed bullet, tagged with the section heading it came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LabeledBullet {
+    /// A stable machine key for the section: `decision` | `risk`.
+    pub kind: &'static str,
+    pub text: String,
+}
+
+/// Section headings that carry DECISIONS, lowercased. EN + PL, matching every built-in note style
+/// (`template.rs::template_for_style`) and the Polish notes a real vault contains.
+const DECISION_HEADINGS: &[&str] = &["decisions", "decyzje", "ustalenia"];
+
+/// Section headings that carry RISKS / open questions.
+const RISK_HEADINGS: &[&str] = &[
+    "risks & open questions",
+    "risks and open questions",
+    "risks",
+    "open questions",
+    "follow-ups",
+    "ryzyka",
+    "otwarte pytania",
+    "ryzyka i otwarte pytania",
+];
+
+/// Parse `## Decisions` / `## Risks & open questions` bullets out of a note.
+///
+/// Only genuine list items count — a prose paragraph under the heading is not a decision. The
+/// model is explicitly instructed to write "None recorded" when there were none, so that exact
+/// placeholder (EN + PL) is dropped rather than stored as a decision that reads like one.
+pub fn parse_labeled_bullets(markdown: &str) -> Vec<LabeledBullet> {
+    let mut out = Vec::new();
+    let mut kind: Option<&'static str> = None;
+    let mut in_fence = false;
+    for line in markdown.lines() {
+        let t = line.trim();
+        if t.starts_with("```") || t.starts_with("~~~") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+        if let Some(title) = t.strip_prefix('#') {
+            let title = title.trim_start_matches('#').trim().to_lowercase();
+            // A heading always RESETS the section, so a bullet can never be attributed to a
+            // section that ended several headings ago.
+            kind = if DECISION_HEADINGS.iter().any(|h| title.starts_with(h)) {
+                Some("decision")
+            } else if RISK_HEADINGS.iter().any(|h| title.starts_with(h)) {
+                Some("risk")
+            } else {
+                None
+            };
+            continue;
+        }
+        let Some(kind) = kind else { continue };
+        let Some(body) = t
+            .strip_prefix("- ")
+            .or_else(|| t.strip_prefix("* "))
+            .or_else(|| t.strip_prefix("+ "))
+        else {
+            continue;
+        };
+        // Skip a checklist item — that is an ACTION, already owned by `parse_action_items`.
+        let body = body.trim();
+        if body.starts_with("[ ]") || body.starts_with("[x]") || body.starts_with("[X]") {
+            continue;
+        }
+        if is_none_placeholder(body) {
+            continue;
+        }
+        if body.is_empty() {
+            continue;
+        }
+        out.push(LabeledBullet {
+            kind,
+            text: body.to_string(),
+        });
+    }
+    out
+}
+
+/// The "nothing to record" placeholder the templates instruct the model to emit. Storing it would
+/// create a decision whose text says there were no decisions.
+fn is_none_placeholder(body: &str) -> bool {
+    let b = body.trim_matches(|c: char| !c.is_alphanumeric()).to_lowercase();
+    matches!(
+        b.as_str(),
+        "none" | "none recorded" | "n/a" | "brak" | "brak ustaleń" | "brak decyzji"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// R6/#6 (regression). A note with three `## Decisions` bullets must report three, not zero.
+    #[test]
+    fn decisions_and_risks_are_parsed_from_their_sections() {
+        let md = "# Title\n\
+                  \n## Summary\nsome prose that is not a decision\n\
+                  \n## Decisions\n\
+                  - Rename the servers to interfaces\n\
+                  - Ship the operator in hybrid mode\n\
+                  - Keep the control plane authoritative\n\
+                  \n## Action items\n\
+                  - [ ] Anna — write the migration\n\
+                  \n## Risks & open questions\n\
+                  - The version bump may break older clients\n";
+        let got = parse_labeled_bullets(md);
+        let decisions: Vec<_> = got.iter().filter(|b| b.kind == "decision").collect();
+        let risks: Vec<_> = got.iter().filter(|b| b.kind == "risk").collect();
+        assert_eq!(decisions.len(), 3, "three decisions: {got:?}");
+        assert_eq!(risks.len(), 1, "one risk: {got:?}");
+        assert_eq!(decisions[0].text, "Rename the servers to interfaces");
+    }
+
+    /// An ACTION item lives under its own heading and belongs to `parse_action_items`; a checklist
+    /// bullet that happens to sit under Decisions must not be double-counted as one.
+    #[test]
+    fn checklist_items_are_not_decisions() {
+        let md = "## Decisions\n- [ ] Anna — do the thing\n- A real decision\n";
+        let got = parse_labeled_bullets(md);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].text, "A real decision");
+    }
+
+    /// The templates instruct the model to write "None recorded" when there were none. Storing that
+    /// would create a decision whose text says there were no decisions.
+    #[test]
+    fn the_none_placeholder_is_not_a_decision() {
+        for md in [
+            "## Decisions\n- None recorded\n",
+            "## Decisions\n- None\n",
+            "## Decyzje\n- Brak\n",
+        ] {
+            assert!(parse_labeled_bullets(md).is_empty(), "{md:?}");
+        }
+    }
+
+    /// A heading RESETS the section, so a later bullet is never attributed to a section that ended.
+    #[test]
+    fn a_following_heading_ends_the_section() {
+        let md = "## Decisions\n- kept\n\n## Notes\n- not a decision\n";
+        let got = parse_labeled_bullets(md);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].text, "kept");
+    }
+
+    /// Polish notes are a real case in this vault, not a hypothetical.
+    #[test]
+    fn polish_headings_are_recognised() {
+        let md = "## Decyzje\n- Zmieniamy nazwę serwerów\n\n## Ryzyka\n- Może zepsuć starsze klienty\n";
+        let got = parse_labeled_bullets(md);
+        assert_eq!(got.iter().filter(|b| b.kind == "decision").count(), 1);
+        assert_eq!(got.iter().filter(|b| b.kind == "risk").count(), 1);
+    }
+
+    /// A fenced code block is never content.
+    #[test]
+    fn code_fences_are_skipped() {
+        let md = "## Decisions\n```\n- not a decision, just sample markdown\n```\n- a real one\n";
+        let got = parse_labeled_bullets(md);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].text, "a real one");
+    }
+}

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -880,7 +880,27 @@ pub fn execute_tool(
                 Err(e) => return Err(AppError::Storage(format!("entity resolve failed: {e}"))),
             };
             match crate::facts::build_knowledge_diff(db, &id, from, to, unlocked) {
-                Ok(kd) => Ok(format_knowledge_diff(entity, &kd)),
+                Ok(kd) => {
+                    // R6/#6 — the note's OWN `## Decisions` / `## Risks` bullets, which the triple
+                    // extractor could never produce (a decision is a sentence, not a short
+                    // attribute) and which is why a 5-decision note reported "0 total decisions".
+                    // GATED: `list_note_decisions_visible` carries the same visibility predicate as
+                    // `list_facts_visible`, over the meetings this diff already resolved.
+                    let meeting_ids: Vec<String> = kd
+                        .ledger
+                        .iter()
+                        .chain(kd.diff.changed.iter())
+                        .chain(kd.diff.added.iter())
+                        .chain(kd.diff.removed.iter())
+                        .filter_map(|c| c.source_meeting_id.clone())
+                        .collect::<HashSet<_>>()
+                        .into_iter()
+                        .collect();
+                    let recorded = db
+                        .list_note_decisions_visible(&meeting_ids, unlocked)
+                        .unwrap_or_default();
+                    Ok(format_knowledge_diff(entity, &kd, &recorded))
+                }
                 Err(e) => Err(AppError::Storage(format!("knowledge diff failed: {e}"))),
             }
         }
@@ -1516,7 +1536,11 @@ fn format_org_hits(hits: &[crate::storage::models::OrgChunkHit]) -> String {
 /// `<subject> · <predicate>: <old> → <new>` (or `+ <new>` / `- <old>`), with the effective date and
 /// the `source:<meetingId>` provenance so the client can cite. No entity/predicate/object is logged —
 /// this is the RETURNED payload, not a log line.
-fn format_knowledge_diff(entity: &str, kd: &crate::facts::EntityKnowledgeDiff) -> String {
+fn format_knowledge_diff(
+    entity: &str,
+    kd: &crate::facts::EntityKnowledgeDiff,
+    recorded: &[(String, String, String)],
+) -> String {
     fn line(c: &crate::facts::FactStateChange) -> String {
         let val = match (&c.old_object, &c.new_object) {
             (Some(o), Some(n)) => format!("{o} → {n}"),
@@ -1535,15 +1559,23 @@ fn format_knowledge_diff(entity: &str, kd: &crate::facts::EntityKnowledgeDiff) -
         )
     }
     let d = &kd.diff;
+    // R6/#6 — the count used to be `kd.ledger.len()` ALONE, i.e. supersessions of extracted
+    // attribute triples. A note carrying five written decisions therefore reported "0 total
+    // decision(s) on record", which reads as "this project has made no decisions" rather than
+    // "this registry never looked at the Decisions section". Report both, named for what they are.
+    let decisions = recorded.iter().filter(|(_, k, _)| k == "decision").count();
+    let risks = recorded.iter().filter(|(_, k, _)| k == "risk").count();
     let mut out = format!(
-        "KNOWLEDGE DIFF for \"{}\" — {} vs {}: {} changed, {} added, {} removed; {} total decision(s) on record.\n",
+        "KNOWLEDGE DIFF for \"{}\" — {} vs {}: {} changed, {} added, {} removed; {} attribute supersession(s), {} recorded decision(s), {} open risk(s).\n",
         entity,
         kd.from,
         kd.to,
         d.changed.len(),
         d.added.len(),
         d.removed.len(),
-        kd.ledger.len()
+        kd.ledger.len(),
+        decisions,
+        risks
     );
     let mut section = |title: &str, rows: &[crate::facts::FactStateChange]| {
         if !rows.is_empty() {
@@ -1558,7 +1590,29 @@ fn format_knowledge_diff(entity: &str, kd: &crate::facts::EntityKnowledgeDiff) -
     section("ADDED", &d.added);
     section("REMOVED", &d.removed);
     section("DECISION LEDGER (oldest → newest)", &kd.ledger);
-    if d.changed.is_empty() && d.added.is_empty() && d.removed.is_empty() && kd.ledger.is_empty() {
+    // The decisions the note actually WROTE, as opposed to attribute supersessions inferred from it.
+    for (title, want) in [
+        ("RECORDED DECISIONS (from the note)", "decision"),
+        ("OPEN RISKS & QUESTIONS (from the note)", "risk"),
+    ] {
+        let rows: Vec<&String> = recorded
+            .iter()
+            .filter(|(_, k, _)| k == want)
+            .map(|(_, _, text)| text)
+            .collect();
+        if !rows.is_empty() {
+            out.push_str(&format!("\n{title}:\n"));
+            for text in rows {
+                out.push_str(&format!("- {text}\n"));
+            }
+        }
+    }
+    if d.changed.is_empty()
+        && d.added.is_empty()
+        && d.removed.is_empty()
+        && kd.ledger.is_empty()
+        && recorded.is_empty()
+    {
         out.push_str("\nNo tracked facts in this window.\n");
     }
     out


### PR DESCRIPTION
Defect **#6**.

## What was measured

A note containing **5 decisions, 9 key points and 7 open risks** produced:

```
knowledge_diff('M1 Advanced Mode', 2026-07-01..07-28)
  → 2 facts, "0 total decision(s) on record"
```

That reads as *"this project has made no decisions"*. The truth was *"this registry never looked at the Decisions section"*.

## The cause is structural, not a bug in the extractor

The **only** writer into the fact registry is the LLM triple extractor, and `facts.rs::EXTRACT_SYSTEM` narrows it **by design**:

> predicate is a short, stable attribute (e.g. "status", "owner", "deadline", "role")

A decision is a **sentence**, not an attribute — so it was never a candidate. Grepping `Decisions` across the crate found only prompt-authoring sites and **zero parsers**: the app instructs the model to write the section, then never reads it back.

## Parse it deterministically

The note already carries the headings, so this reads what the model was *told* to write rather than asking a model again. Two consequences worth noting:

- it works with **no model installed at all**, unlike the triple extraction;
- it runs **before** the entity gate, so a meeting that produced no entities still records its decisions.

Handles EN + PL headings (real in this vault), skips checklist items (those are actions, owned by `parse_action_items`), skips code fences, and drops the `None recorded` placeholder the templates instruct the model to emit — otherwise you get a decision whose text says there were no decisions.

## A separate table, not more `facts` rows

Routing free-text bullets through `reconcile_facts` would mint a **spurious supersession on every re-wording** under the same `(subject, predicate)` key — fabricating bitemporal history that never happened — and would pollute the `status`/`owner` key space.

## Lock model — all three requirements

| requirement | how |
|---|---|
| provenance / gating / purge anchor | table carries `meeting_id`, FK CASCADE |
| gated read | **identical** `visibility_clause` predicate as `list_facts_visible` |
| purge on seal | same atomic tx as `purge_facts_tx`, on **both** the lock and relock paths |

The relock path matters independently: rows re-derived **during a session unlock** would otherwise survive the relock at rest — precisely the 2026-07-10 F5 class of bug the surrounding comments document.

The regression asserts both halves:

```
GATE   → a sealed meeting's decision never surfaces
PURGE  → the seal tx deletes it, so unlocking cannot resurrect it
         (while an unrelated open meeting's decision survives)
```

Worth recording: my first version of that test used `set_folder_locked`, which only flips the flag — the derived-content purge is the seal transaction itself. The test now exercises the real path.

## Header wording changed deliberately

The count was `kd.ledger.len()` alone, which counts **attribute supersessions**. It now names all three — attribute supersessions, recorded decisions, open risks — so a zero is attributable to the right thing.

## Verification

**2480 passed, 0 failed**; `cargo clippy --lib --tests -- -D warnings` clean. Migration is additive (`CREATE TABLE IF NOT EXISTS` + guarded index) per the rust-tauri rules.

## Does NOT solve

Decision *quality*. This makes whatever the note says durable and queryable — which is why it is sequenced **after** the attribution contract and provenance demarcation, both already merged.
