### PR TITLE
feat(mcp): expose the chapter map the app already computes

### DIFF
--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -245,6 +245,11 @@ fn tools_spec() -> Value {
             "inputSchema": { "type": "object", "properties": { "meetingId": { "type": "string" }, "transcriptFormat": { "type": "string", "enum": ["structured", "plain", "compact"], "description": "Transcript rendering (default 'structured'). 'compact' merges consecutive same-speaker segments into one line — same words, far less per-segment scaffolding. NOTE each format is a DIFFERENT character space, so offset/maxChars/TOTAL_CHARS only mean anything within the format you asked for." }, "offset": { "type": "number", "description": "Chars to skip into the transcript, in the SELECTED format's char space (default 0)." }, "maxChars": { "type": "number", "description": "Max chars to return from offset (default: a bounded 6000-char window with the total disclosed). Bounds the NOTE section too." }, "includeNote": { "type": "boolean", "description": "Include the AI note (default true). Pass false for transcript only — e.g. you already read the note, or you are paging and only want speech." } }, "required": ["meetingId"] }
         },
         {
+            "name": "get_meeting_chapters",
+            "description": "The CHAPTER MAP of one meeting: each topic span with its title, start/end time, and the CHARACTER OFFSET range it occupies in the structured transcript. Read this BEFORE paging a long meeting — take the chapter you want and pass its offset/maxChars straight to get_meeting instead of scanning blindly. Chapters are built with the meeting timeline (not during recording), so a meeting may legitimately have none yet. Sealed-and-locked meetings return no map.",
+            "inputSchema": { "type": "object", "properties": { "meetingId": { "type": "string" } }, "required": ["meetingId"] }
+        },
+        {
             "name": "get_document",
             "description": "Get the body of one standalone note or imported/uploaded document by id (from a search hit labelled 'document:...'). Use this — not get_meeting — for ids from the DOCUMENTS section of a search result. The body is returned as a WINDOW (default first 6000 chars) prefixed with 'TOTAL_CHARS: <N> (showing <start>..<end>)'; page a big document by passing offset + maxChars.",
             "inputSchema": { "type": "object", "properties": { "documentId": { "type": "string" }, "offset": { "type": "number", "description": "Chars to skip into the body (default 0)." }, "maxChars": { "type": "number", "description": "Max body chars to return from offset (default: a bounded 6000-char window with the total disclosed)." } }, "required": ["documentId"] }
@@ -386,6 +391,13 @@ fn dispatch_tool(
         "search_semantic" => ToolCall::SearchSemantic {
             query: args
                 .get("query")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string(),
+        },
+        "get_meeting_chapters" => ToolCall::GetMeetingChapters {
+            meeting_id: args
+                .get("meetingId")
                 .and_then(Value::as_str)
                 .unwrap_or("")
                 .to_string(),
@@ -572,10 +584,12 @@ mod tests {
     }
 
     #[test]
-    fn tools_list_has_eleven_tools() {
+    fn tools_list_has_twelve_tools() {
         let r = rpc(r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#).unwrap();
         let tools = r["result"]["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 11);
+        assert_eq!(tools.len(), 12);
+        // #8 — the chapter map the app already computes but never exposed.
+        assert!(tools.iter().any(|t| t["name"] == "get_meeting_chapters"));
         // The Phase 2b semantic tool is advertised.
         assert!(tools.iter().any(|t| t["name"] == "search_semantic"));
         // The Phase 5a open-commitments rollup tool is advertised.
@@ -801,6 +815,67 @@ mod tests {
         assert!(
             out.contains("Budget"),
             "flag-off fallback must still surface the gated keyword hit, got: {out}"
+        );
+        let _ = std::fs::remove_file(&p);
+    }
+
+    /// R9/#8 (regression + LOCK GATE). The chapter map reaches MCP with usable char offsets, and a
+    /// sealed-and-not-unlocked meeting leaks NO topic label.
+    ///
+    /// Topic labels are LLM-derived note CONTENT, so this is a new content read path. Relying on
+    /// `timelines.data` being blanked while sealed would be exactly the mistake the masked-DTO
+    /// discipline warns about — the gate is what makes it safe.
+    #[test]
+    fn meeting_chapters_carry_offsets_and_are_visibility_gated() {
+        use crate::storage::models::Folder;
+        use crate::transcribe::types::Segment;
+        let (db, p) = temp_db();
+        db.insert_folder(&Folder {
+            id: "f-lock".to_string(),
+            name: "Secret".to_string(),
+            path: "Secret".to_string(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-06-26T00:00:00Z".to_string(),
+        })
+        .unwrap();
+        seed(&db, "open", "Open", "a note", None);
+        seed(&db, "sealed", "Sealed", "a note", Some("f-lock"));
+        let segs = vec![
+            Segment { idx: 0, start_s: 0.0, end_s: 10.0, text: "kickoff talk".into(), speaker: Some("me".into()), confidence: None },
+            Segment { idx: 1, start_s: 60.0, end_s: 70.0, text: "the deep dive".into(), speaker: Some("others".into()), confidence: None },
+        ];
+        let timeline = r#"{"speakers":[],"topics":[
+            {"label":"Kickoff","start_s":0.0,"end_s":30.0},
+            {"label":"SECRET Deep Dive","start_s":55.0,"end_s":90.0}]}"#;
+        for mid in ["open", "sealed"] {
+            db.insert_segments(mid, &segs).unwrap();
+            db.set_timeline_data(mid, timeline).unwrap();
+        }
+        db.set_folder_locked("f-lock", true, None).unwrap();
+
+        let open = dispatch_tool(
+            &db,
+            "get_meeting_chapters",
+            &json!({ "meetingId": "open" }),
+            &HashSet::new(),
+        )
+        .unwrap();
+        assert!(open.contains("Kickoff"), "chapter titles surface: {open}");
+        assert!(open.contains("offset 0.."), "with a usable char offset: {open}");
+        assert!(open.contains("01:30"), "and a human timestamp: {open}");
+
+        // GATE: the sealed meeting must leak no label at all.
+        let sealed = dispatch_tool(
+            &db,
+            "get_meeting_chapters",
+            &json!({ "meetingId": "sealed" }),
+            &HashSet::new(),
+        )
+        .unwrap();
+        assert!(
+            !sealed.contains("SECRET") && !sealed.contains("Kickoff"),
+            "a sealed meeting must leak no topic label: {sealed}"
         );
         let _ = std::fs::remove_file(&p);
     }

--- a/src-tauri/src/orchestrate.rs
+++ b/src-tauri/src/orchestrate.rs
@@ -228,6 +228,7 @@ fn tool_label(call: &ToolCall) -> &'static str {
         ToolCall::SearchMeetings { .. } => "Related meetings",
         ToolCall::SearchSemantic { .. } => "Semantically related",
         ToolCall::GetEntityDossier { .. } => "Entity dossier",
+        ToolCall::GetMeetingChapters { .. } => "Meeting chapters",
         // Brain v3 PR-6 — knowledge diff / decision ledger (explicit tool; label for completeness).
         ToolCall::KnowledgeDiff { .. } => "Knowledge diff",
         ToolCall::GetOpenCommitments { .. } => "Open commitments",

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -5011,6 +5011,24 @@ impl Db {
 
     // ── timelines (AI-derived speaker + topic spans; JSON blob per meeting) ──────
 
+    /// GATED read of a meeting's timeline JSON — the chapter/topic map (#8).
+    ///
+    /// LOCK MODEL: topic LABELS and speaker names are LLM-derived note CONTENT, so this is a new
+    /// content read path and must be gated, not merely rely on `timelines.data` being blanked while
+    /// sealed. Relying on blanking alone is exactly the mistake the masked-DTO comment in
+    /// `get_meeting_detail` warns about. `get_timeline_data` below is the RAW, UNGATED reader —
+    /// never call it from `execute_tool`.
+    pub fn get_timeline_data_visible(
+        &self,
+        meeting_id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Option<String>> {
+        if !self.meeting_is_visible(meeting_id, unlocked)? {
+            return Ok(None);
+        }
+        self.get_timeline_data(meeting_id)
+    }
+
     pub fn get_timeline_data(&self, meeting_id: &str) -> Result<Option<String>> {
         let conn = self.lock();
         conn.query_row(

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -181,6 +181,10 @@ pub enum ToolCall {
     /// Roll up every OPEN action item, optionally filtered by owner.
     GetOpenCommitments { owner: Option<String> },
     /// Assemble the gated structured dossier for one entity (caller must pass a non-empty name/id).
+    /// #8 — the CHAPTER map. The app computes topic spans (`summarize::timeline`) and persists them;
+    /// the desktop UI renders them as a chapter list. None of the tools exposed them, so an agent
+    /// navigated a 116k-char transcript blind even though the map already existed.
+    GetMeetingChapters { meeting_id: String },
     GetEntityDossier {
         entity: String,
         /// How much of the note corpus to carry: `none` | `summary` (default) | `full`.
@@ -839,6 +843,29 @@ pub fn execute_tool(
                 Ok(items) => Ok(format_commitments(&items)),
                 Err(e) => Err(AppError::Storage(format!("commitments rollup failed: {e}"))),
             }
+        }
+        ToolCall::GetMeetingChapters { meeting_id } => {
+            let mid = meeting_id.as_str();
+            // GATED by `get_timeline_data_visible`. A sealed-and-not-unlocked meeting returns the
+            // SAME masking sentinel shape as `get_meeting`, so a topic label — which is LLM-derived
+            // content — can never leak, and locked is indistinguishable from absent.
+            let Ok(Some(raw)) = db.get_timeline_data_visible(mid, unlocked) else {
+                // AVAILABILITY HONESTY: `commands::get_timeline` is read-only cached-or-empty and
+                // never GENERATES (generation moved behind an explicit action for on-device
+                // providers, per the OOM fix). So "no chapters" usually means "not generated yet",
+                // NOT "this meeting has no structure" — say so rather than implying the latter.
+                return Ok(format!(
+                    "No chapter map for meeting {mid}. It may not have been generated yet (chapters \
+                     are built with the meeting timeline, not during recording), or the meeting may \
+                     be locked or absent. The transcript is still readable with get_meeting."
+                ));
+            };
+            let Ok(timeline) = serde_json::from_str::<crate::storage::models::MeetingTimeline>(&raw)
+            else {
+                return Ok(format!("No chapter map for meeting {mid}."));
+            };
+            let segs = db.get_segments(mid).unwrap_or_default();
+            Ok(format_chapters(&timeline, &segs))
         }
         ToolCall::GetEntityDossier {
             entity,
@@ -1957,6 +1984,79 @@ fn secs(v: f64) -> String {
 /// Map a raw `Segment.speaker` tag to the display name a rendered transcript shows. Extracted so
 /// the structured and compact renderers cannot drift apart on speaker naming — a second, diverging
 /// copy of this mapping is exactly what let `others-N` render as `Unknown` in the first place.
+/// Render the chapter map, mapping each topic span to its CHAR OFFSET in the structured transcript.
+///
+/// The offset is what makes this actionable rather than decorative: an agent reads a chapter title,
+/// then passes the matching `offset`/`maxChars` straight to `get_meeting` and lands on that section
+/// instead of paging a 116k-char transcript blind.
+///
+/// Offsets are computed by prefix-summing the SAME per-segment rendering `format_structured_transcript`
+/// produces, so they address the `structured` char space exactly — the one the tool defaults to.
+fn format_chapters(
+    timeline: &crate::storage::models::MeetingTimeline,
+    segs: &[crate::transcribe::types::Segment],
+) -> String {
+    if timeline.topics.is_empty() {
+        return "No chapters recorded for this meeting.".to_string();
+    }
+    // Prefix-sum the rendered length of each non-empty segment, mirroring the renderer's own
+    // filter and its "\n" join, so an offset here is byte-for-byte the offset get_meeting expects.
+    let rendered: Vec<(f64, f64, usize, usize)> = {
+        let mut acc = 0usize;
+        let mut out = Vec::new();
+        for s in segs.iter().filter(|s| !s.text.trim().is_empty()) {
+            let line = format!(
+                "[{}–{}] {}: {}",
+                secs(s.start_s),
+                secs(s.end_s),
+                speaker_label(s.speaker.as_deref()),
+                s.text.trim()
+            );
+            let len = line.chars().count();
+            out.push((s.start_s, s.end_s, acc, acc + len));
+            acc += len + 1; // the join's newline
+        }
+        out
+    };
+
+    let mut out = String::from(
+        "CHAPTERS (offsets address the 'structured' transcript — pass them to get_meeting as offset/maxChars):\n",
+    );
+    for (i, t) in timeline.topics.iter().enumerate() {
+        // First and last segment OVERLAPPING the span; a chapter with no overlapping segment
+        // (a hallucinated or out-of-range span) reports no offsets rather than a wrong one.
+        let overlap: Vec<&(f64, f64, usize, usize)> = rendered
+            .iter()
+            .filter(|(a, b, _, _)| *b > t.start_s && *a < t.end_s)
+            .collect();
+        let span = match (overlap.first(), overlap.last()) {
+            (Some(f), Some(l)) => {
+                let (start, end) = (f.2, l.3);
+                format!(
+                    " · offset {start}..{end} ({} chars)",
+                    end.saturating_sub(start)
+                )
+            }
+            _ => String::new(),
+        };
+        out.push_str(&format!(
+            "- [{}] {} — {}–{}{}\n",
+            i,
+            t.label.trim(),
+            mmss(t.start_s),
+            mmss(t.end_s),
+            span
+        ));
+    }
+    out
+}
+
+/// `mm:ss` for a human reading the reply; raw seconds ride alongside for machine seeking.
+fn mmss(v: f64) -> String {
+    let total = v.max(0.0).round() as i64;
+    format!("{:02}:{:02}", total / 60, total % 60)
+}
+
 fn speaker_label(tag: Option<&str>) -> std::borrow::Cow<'static, str> {
     use crate::audio::merge::{SPEAKER_ME, SPEAKER_OTHERS};
     use std::borrow::Cow;


### PR DESCRIPTION
Defect **#8**.

## The map already existed

The desktop UI shows a chapter list for every meeting with a timeline:

```
Meeting Kickoff 0:01 · Advanced Config Walkthrough 0:54 · Undeploy & Mapping Logic 5:39
Basic Mode Journey 9:24 · Advanced Mode Concepts 22:39 · Hybrid Mode Feasibility 32:09
```

It is built from the topic spans `summarize::timeline` computes and persists to the `timelines` table. **None of the tools exposed any of it** — so an agent navigated a 116k-char transcript blind while the map sat in the database.

## Offsets are what make it actionable

Each chapter carries its **character-offset range** in the structured transcript, so an agent reads a title and passes that offset straight to `get_meeting` rather than scanning:

```
CHAPTERS (offsets address the 'structured' transcript — pass them to get_meeting as offset/maxChars):
- [0] Kickoff — 00:00–00:30 · offset 0..23 (23 chars)
- [1] Hybrid Mode Feasibility — 32:09–41:02 · offset 84120..99341 (15221 chars)
```

Offsets are prefix-summed from the **same** per-segment rendering `format_structured_transcript` produces — same filter, same `\n` join — so they address exactly the char space the tool defaults to. A span with no overlapping segment (a hallucinated or out-of-range topic) reports **no** offset rather than a wrong one.

## Lock model

Topic labels are **LLM-derived note content**, so this is a new content read path and gets its own gated reader. `get_timeline_data` is a raw, ungated `SELECT` and must never be called from `execute_tool`.

Relying instead on `timelines.data` being blanked while sealed would be precisely the mistake the masked-DTO comment in `get_meeting_detail` warns about — blanking is defense-in-depth, not the gate.

Proven by neutering the gate:

```
a sealed meeting must leak no topic label:
  CHAPTERS (offsets address the 'structured' transcript…)   ← FAILED
```

Restored → the sealed meeting returns the same "no chapter map" sentinel as an absent one.

## Availability honesty — a UX contract, not a bug

`commands::get_timeline` is **read-only cached-or-empty and never generates**; generation moved behind an explicit action for on-device providers after the OOM fix. So "no chapters" usually means **not generated yet**, not "this meeting has no structure".

The reply says exactly that, and points at `get_meeting` as still usable — rather than implying the meeting is featureless.

## Verification

**2474 passed, 0 failed**; `cargo clippy --lib --tests -- -D warnings` clean. Catalog grows to 12 tools.
