### PR TITLE
feat(notes): a workspace glossary, so a mis-heard proper noun stops becoming a permanent entity

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -592,6 +592,9 @@ pub struct AppConfigDto {
     #[serde(default)]
     pub note_assist_actions_off: Vec<String>,
     pub note_language: String,
+    /// R14/#18 — workspace domain glossary (canonical spellings + aliases), user-authored.
+    #[serde(default)]
+    pub glossary: String,
     /// E3/security: default true (matches AppConfig::default) when the FE omits it on an older
     /// payload — an omitted flag must FAIL CLOSED (require a token), never silently disable MCP
     /// auth. Was `#[serde(default)]` (=false), which let a partial save flip the token requirement
@@ -4926,6 +4929,7 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         note_assist_enhance: c.note_assist_enhance,
         note_assist_actions_off: c.note_assist_actions_off.clone(),
         note_language: c.note_language.clone(),
+        glossary: c.glossary.clone(),
         mcp_require_token: c.mcp_require_token,
         lock_require_biometric: c.lock_require_biometric,
         relock_on_screenshare: c.relock_on_screenshare,
@@ -5094,6 +5098,7 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         } else {
             d.note_language
         },
+        glossary: d.glossary,
         mcp_require_token: d.mcp_require_token,
         lock_require_biometric: d.lock_require_biometric,
         relock_on_screenshare: d.relock_on_screenshare,

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -2310,6 +2310,9 @@ async fn summarize_and_export(
             None
         },
         live_bullets: live_bullets.clone(),
+        // R14/#18 — the workspace glossary. Plain user-authored config, never derived from sealed
+        // content, so it is safe to carry into the prompt whatever is locked.
+        glossary: Some(config.glossary.clone()).filter(|g| !g.trim().is_empty()),
     };
 
     let (generated, call_meta) = provider.summarize_with_meta(&request).await?;

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -250,6 +250,23 @@ pub struct AppConfig {
     pub note_assist_actions_off: Vec<String>,
     /// Summary note language: "auto" (match the meeting) | "en" | "pl" | "de" | ... .
     pub note_language: String,
+    /// R14/#18 — the workspace DOMAIN GLOSSARY: canonical spellings of the proper nouns this vault
+    /// actually uses, one per line, optionally `Canonical = alias, alias`.
+    ///
+    /// ASR mangles domain proper nouns it has never seen — a real transcript rendered "Konnect" as
+    /// "Kanak" and "Kinect", "control plane" as "control plan", "Danny" as "Dani". That would be
+    /// survivable if it stayed in the transcript, but it does not: the NOTE then writes "Connect"
+    /// and "Fast MCP", and entities are extracted from the note's text, so a mangling becomes a
+    /// DURABLE entity row that no later meeting will merge back.
+    ///
+    /// Plain user-authored config, never derived from sealed content, so it is safe to carry into
+    /// a prompt regardless of which folders are locked.
+    ///
+    /// `serde(default)` is load-bearing, not decoration: every config JSON written before this
+    /// field existed omits it, and without the default those installs would fail to deserialize
+    /// their settings outright.
+    #[serde(default)]
+    pub glossary: String,
     /// Require an `Authorization: Bearer <token>` on EVERY MCP method (E3) — including
     /// initialize / tools/list / ping, not just tools/call. Default ON (fail-closed): an
     /// unauthenticated localhost process must not be able to even enumerate the meeting tools.
@@ -689,6 +706,7 @@ impl Default for AppConfig {
             note_assist_actions_off: Vec::new(),
             auto_organize: false,
             note_language: "auto".to_string(),
+            glossary: String::new(),
             mcp_require_token: true,
             lock_require_biometric: true,
             relock_on_screenshare: true,
@@ -787,6 +805,7 @@ const K_NOTE_ASSIST_ENHANCE: &str = "note_assist_enhance";
 const K_NOTE_ASSIST_ACTIONS_OFF: &str = "note_assist_actions_off";
 const K_AUTO_ORGANIZE: &str = "auto_organize";
 const K_NOTE_LANGUAGE: &str = "note_language";
+const K_GLOSSARY: &str = "glossary";
 const K_MCP_REQUIRE_TOKEN: &str = "mcp_require_token";
 const K_LOCK_REQUIRE_BIOMETRIC: &str = "lock_require_biometric";
 const K_RELOCK_ON_SCREENSHARE: &str = "relock_on_screenshare";
@@ -998,6 +1017,9 @@ impl AppConfig {
         // empty list (all actions enabled) rather than erroring the whole config load.
         if let Some(v) = db.get_setting(K_NOTE_ASSIST_ACTIONS_OFF)? {
             cfg.note_assist_actions_off = serde_json::from_str(&v).unwrap_or_default();
+        }
+        if let Some(v) = db.get_setting(K_GLOSSARY)? {
+            cfg.glossary = v;
         }
         if let Some(v) = db.get_setting(K_NOTE_LANGUAGE)? {
             if !v.is_empty() {
@@ -1303,6 +1325,7 @@ impl AppConfig {
             &serde_json::to_string(&self.note_assist_actions_off).unwrap_or_else(|_| "[]".into()),
         )?;
         db.set_setting(K_NOTE_LANGUAGE, &self.note_language)?;
+        db.set_setting(K_GLOSSARY, &self.glossary)?;
         db.set_setting(
             K_MCP_REQUIRE_TOKEN,
             if self.mcp_require_token {

--- a/src-tauri/src/summarize/ollama.rs
+++ b/src-tauri/src/summarize/ollama.rs
@@ -872,6 +872,7 @@ mod tests {
             related_context: None,
             user_notes: None,
             live_bullets: None,
+            glossary: None,
         };
         let res =
             tokio::time::timeout(std::time::Duration::from_secs(10), provider.summarize(&req))

--- a/src-tauri/src/summarize/provider.rs
+++ b/src-tauri/src/summarize/provider.rs
@@ -53,6 +53,9 @@ pub struct SummarizeRequest {
     /// this string EGRESSES to the provider in the prompt — `RedactingProvider` MUST scrub it
     /// alongside the transcript (summarize/redact.rs) before egress.
     pub live_bullets: Option<String>,
+    /// R14/#18 — the workspace DOMAIN GLOSSARY, verbatim from settings. Absent/blank renders a
+    /// byte-identical prompt, so an install without one is unchanged.
+    pub glossary: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -283,6 +286,7 @@ mod tests {
             related_context: None,
             user_notes: None,
             live_bullets: None,
+            glossary: None,
         };
         let (text, meta) = p.summarize_with_meta(&req).await.unwrap();
         assert_eq!(text, "note body");

--- a/src-tauri/src/summarize/redact.rs
+++ b/src-tauri/src/summarize/redact.rs
@@ -727,6 +727,16 @@ impl SummarizerProvider for RedactingProvider {
         // Brain v2 L4: the running live bullets ride the prompt as the "Live notes (auto)"
         // section — scrub them through the SAME shared map as the transcript they were derived
         // from, so a value redacted anywhere restores consistently in the reply.
+        // R14/#18: the workspace GLOSSARY rides the prompt as CANONICAL SPELLINGS and therefore
+        // egresses. It is user-authored config rather than meeting content, but it is exactly the
+        // place someone writes a colleague's name to fix a mis-transcription ("Danny", not "Dani"),
+        // so it gets the SAME firewall as everything else — through the shared map, so a value
+        // redacted anywhere restores consistently. Product terms (Konnect, FastMCP) are not PII and
+        // survive; a person's name does not, which is the correct trade for the privacy promise.
+        let red_glossary = req
+            .glossary
+            .as_ref()
+            .map(|c| redact_into(c, &mut map, &mut rev));
         let red_bullets = req
             .live_bullets
             .as_ref()
@@ -824,6 +834,7 @@ impl SummarizerProvider for RedactingProvider {
         r.related_context = red_related;
         r.user_notes = red_notes;
         r.live_bullets = red_bullets;
+        r.glossary = red_glossary;
         r.template = red_template;
         r.meta.title_hint = red_title_hint;
         r.vault_titles = red_titles;
@@ -1137,6 +1148,7 @@ mod tests {
             related_context: None,
             user_notes: None,
             live_bullets: None,
+            glossary: None,
         }
     }
 
@@ -2116,6 +2128,10 @@ mod tests {
             related_context: Some("s-related@leak.example".to_string()), // SCRUBBED (regex + NER)
             user_notes: Some("s-notes@leak.example".to_string()),        // SCRUBBED (regex + NER)
             live_bullets: Some("s-bullets@leak.example".to_string()),    // SCRUBBED (regex + NER)
+            // R14/#18 — user-authored config rather than meeting content, but it is exactly where
+            // someone writes a colleague's name to fix a mis-transcription, and it EGRESSES in the
+            // prompt as CANONICAL SPELLINGS. So: SCRUBBED, like everything else that leaves.
+            glossary: Some("s-glossary@leak.example".to_string()), // SCRUBBED (regex + NER)
         };
         let inner = std::sync::Arc::new(CapturingInner(std::sync::Mutex::new(None)));
         let provider = RedactingProvider::new(inner.clone());
@@ -2130,6 +2146,7 @@ mod tests {
             "s-related@leak.example",
             "s-notes@leak.example",
             "s-bullets@leak.example",
+            "s-glossary@leak.example",
         ] {
             assert!(
                 !egress.contains(sentinel),

--- a/src-tauri/src/summarize/template.rs
+++ b/src-tauri/src/summarize/template.rs
@@ -509,6 +509,23 @@ pub fn render_user_content(req: &SummarizeRequest) -> String {
         out.push_str(&format!("- language: {lang}\n"));
     }
 
+    // R14/#18 — CANONICAL SPELLINGS, before the titles and the transcript so the model has them in
+    // hand while reading mangled ASR. This is the half of the glossary that actually protects the
+    // knowledge layer: ASR mangling would be survivable if it stayed in the transcript, but the
+    // NOTE inherits it ("Connect" for "Konnect", "Fast MCP" for "FastMCP"), and entities are
+    // extracted from the note's text — so one mis-transcription becomes a DURABLE entity row that
+    // no later meeting will ever merge back.
+    if let Some(glossary) = req.glossary.as_deref().map(str::trim).filter(|g| !g.is_empty()) {
+        out.push_str(
+            "\nCANONICAL SPELLINGS (this workspace's own terms; the transcript may mis-hear them)\n\
+             The speech-to-text has not seen these names before and often mangles them. When a \
+             transcript word is clearly one of these, WRITE THE CANONICAL SPELLING BELOW — do not \
+             copy the mangled form, and do not invent a term that is not listed.\n",
+        );
+        out.push_str(glossary);
+        out.push('\n');
+    }
+
     out.push_str("\nEXISTING NOTE TITLES (valid [[wikilink]] targets — link only these):\n");
     if req.vault_titles.is_empty() {
         out.push_str("(none)\n");
@@ -1275,7 +1292,47 @@ mod tests {
             related_context: related,
             user_notes: None,
             live_bullets: None,
+            glossary: None,
         }
+    }
+
+    /// R14/#18 (regression). The workspace glossary reaches the note prompt as CANONICAL
+    /// SPELLINGS, and an install without one renders a BYTE-IDENTICAL prompt.
+    ///
+    /// This is the half of the glossary that protects the knowledge layer. ASR mangling would be
+    /// survivable if it stayed in the transcript, but the NOTE inherits it ("Connect" for
+    /// "Konnect", "Fast MCP" for "FastMCP"), and entities are extracted from the note's text — so
+    /// one mis-transcription becomes a durable entity row no later meeting merges back.
+    #[test]
+    fn the_glossary_reaches_the_prompt_and_is_absent_when_unset() {
+        let base = render_user_content(&req(None));
+        assert!(
+            !base.contains("CANONICAL SPELLINGS"),
+            "no glossary ⇒ the prompt is unchanged: {base}"
+        );
+
+        let mut r = req(None);
+        r.glossary = Some("Konnect = Kanak, Kinect\nFastMCP\nKong Operator = KO".to_string());
+        let with = render_user_content(&r);
+        assert!(with.contains("CANONICAL SPELLINGS"), "{with}");
+        assert!(with.contains("Konnect = Kanak, Kinect"), "verbatim terms: {with}");
+        assert!(
+            with.contains("WRITE THE CANONICAL SPELLING"),
+            "instructs the model to prefer the canonical form: {with}"
+        );
+        assert!(
+            with.contains("do not invent a term that is not listed"),
+            "and forbids inventing terms outside the list: {with}"
+        );
+        // The glossary must precede the transcript, so the model holds it while reading mangled ASR.
+        let g = with.find("CANONICAL SPELLINGS").unwrap();
+        let t = with.find("\nTRANSCRIPT").unwrap();
+        assert!(g < t, "glossary before transcript");
+
+        // A blank glossary is treated as no glossary — byte-identical, not an empty section.
+        let mut blank = req(None);
+        blank.glossary = Some("   \n  ".to_string());
+        assert_eq!(render_user_content(&blank), base);
     }
 
     /// No-regression proof: with `related_context = None` (the default + flag-OFF case) the rendered


### PR DESCRIPTION
Defect **#18**, and the upstream cause of **#7**. Stage 1 of the glossary program — the **note** half.

## Why this is not just a transcription-quality nit

Speech-to-text mangles domain proper nouns it has never seen. The audited transcript rendered:

| spoken | transcribed |
|---|---|
| Konnect | **Kanak**, **Kinect** |
| control plane | control plan |
| Danny | Dani |
| advanced gateway configuration | advanced Q configuration |

39 domain-term defects across eight windows. That would be survivable **if it stayed in the transcript**. It does not:

1. the **note** inherits the mangling — it consistently writes `Connect` for `Konnect`, `Fast MCP` for `FastMCP`;
2. **entities are extracted from the note's text**;
3. so one mis-transcription becomes a **durable entity row** that no later meeting merges back.

That is the direct upstream cause of the alias failures in #7 — `Konnect` and `Connect` are two permanent rows for one thing, and `knowledge_diff('Kong Operator')` found nothing because the note had written `KO`.

## Ordering: the note half first, deliberately

The report asked for ASR biasing via whisper's `initial_prompt`. That seam genuinely exists and is unused — `whisper.rs::build_params` never calls `set_initial_prompt`, and a doc comment in `audio/wake.rs` records that the wiring was contemplated and never landed.

But it is also the half that **cannot be verified without a signed build and real recordings**. Canonical spellings in the note prompt are testable today, and they protect the layer where the damage becomes *permanent*. Shipping the untestable half first would have meant claiming a fix I could not demonstrate.

## Design details worth reviewing

- The glossary sits **before** the transcript, so the model holds it while reading mangled ASR.
- It explicitly **forbids inventing a term that is not listed** — otherwise it would license the same fabrication it exists to prevent.
- Absent or blank renders a **byte-identical** prompt (asserted).

## Privacy — the field-coverage test forced a decision

`every_string_field_of_summarize_request_is_scrubbed_or_exempt` requires every string field to be classified as scrubbed or explicitly exempt. The glossary **egresses in the prompt**, so it had to be one or the other.

It is user-authored *config* rather than meeting content — but it is exactly where someone writes a colleague's name to fix a mis-transcription (`Danny`, not `Dani`). So it goes through the **same redaction firewall** as the transcript, sharing the map so a value redacted anywhere restores consistently.

Product terms (`Konnect`, `FastMCP`) are not PII and survive. A person's name does not. That is the correct trade for the privacy promise, and the test now pins it with its own sentinel.

## Compatibility

`#[serde(default)]` on the field is **load-bearing, not decoration**: every config JSON written before this field existed omits it, and without the default those installs would fail to deserialize their settings outright. Ten existing tests caught that immediately.

## Verification

**2474 passed, 0 failed**; `cargo clippy --lib --tests -- -D warnings` clean.

## Remaining stages (not in this PR)

- **ASR biasing** — wire `set_initial_prompt` to the glossary. Needs a signed build and real recordings to show it actually changes WER on these terms.
- **Entity canonicalization** — apply the glossary at extraction time so existing split rows (`Konnect` / `Connect`) can be merged rather than merely prevented going forward.
