### PR TITLE
fix(harness): allow isolated task worktrees in Claude sandbox

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,9 @@
     "MURMUR_AUTOFMT": "0"
   },
   "permissions": {
+    "additionalDirectories": [
+      "../.murmur-agent-tasks"
+    ],
     "deny": [
       "Read(~/.ssh/**)",
       "Read(~/.aws/**)",
@@ -28,6 +31,15 @@
     "failIfUnavailable": true,
     "autoAllowBashIfSandboxed": true,
     "allowUnsandboxedCommands": false,
+    "filesystem": {
+      "allowWrite": [
+        "../.murmur-agent-tasks"
+      ],
+      "denyWrite": [
+        "../meetnotes/.git",
+        "../murmur-server/.git"
+      ]
+    },
     "network": {
       "allowLocalBinding": true
     }


### PR DESCRIPTION
## What changed

- grants Claude file access and sandboxed write access only to the sibling .murmur-agent-tasks root used by Harness v2
- explicitly denies writes to the user primary checkout Git metadata and sibling server Git metadata
- preserves strict sandboxing, credential denies, network policy, and the disabled unsandboxed escape hatch

## Verification

- protected v1 harness task harness-driver-sandbox-20260728: PASS
- runner-owned sandbox policy assertion: PASS
- agent config audit: PASS
- official Claude settings JSON schema validation: PASS
- independent spec and adversarial reviews: PASS