### PR TITLE
feat(harness): add verifier v2 engine

### DIFF
--- a/.agents/harness/cli.py
+++ b/.agents/harness/cli.py
@@ -1,0 +1,3888 @@
+#!/usr/bin/env python3
+"""Generation-aware dispatcher and lifecycle for Murmur Harness v2.
+
+Legacy v1 commands continue to execute in ``task_runner.py``.  V2 is a separate,
+verifier-only lifecycle: a developer edits the isolated worktree, then ``plan``
+and ``verify`` bind checks/reviews to the exact diff.  There is no writer or
+repair loop in this module.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import copy
+import datetime as dt
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import signal
+import stat
+import subprocess
+import sys
+import time
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+import task_runner as legacy
+import verifier
+
+
+V1_COMMANDS = {
+    "init",
+    "run",
+    "seal-prepared",
+    "verify-attestation",
+    "reap",
+    "gc",
+    "eval",
+    "close",
+}
+DUAL_COMMANDS = {"status", "commit", "guard-commit", "doctor", "selftest"}
+STANDALONE_DRIVER_NAME = ".murmur-agent-driver"
+CLIENT_WORKTREE_NAME = "meetnotes"
+CANONICAL_MURMUR_ORIGINS = frozenset(
+    {
+        "https://github.com/murmur-io/murmur.git",
+        "git@github.com:murmur-io/murmur.git",
+        "ssh://git@github.com/murmur-io/murmur.git",
+    }
+)
+
+
+def v2_store(common: Path) -> Path:
+    return common / "agent-harness" / "v2"
+
+
+def v2_tasks(common: Path) -> Path:
+    return v2_store(common) / "tasks"
+
+
+def v2_task_dir(common: Path, task_id: str) -> Path:
+    return v2_tasks(common) / task_id
+
+
+def v1_task_dir(common: Path, task_id: str) -> Path:
+    return common / "agent-harness" / "tasks" / task_id
+
+
+def _single_write_jsonl(path: Path, document: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = legacy.canonical_json(document) + b"\n"
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    try:
+        written = os.write(descriptor, payload)
+        if written != len(payload):
+            raise legacy.HarnessError(f"short append to {path}")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def set_v2_state(task_dir: Path, status: str, **details: Any) -> Dict[str, Any]:
+    if status not in verifier.V2_STATES:
+        raise legacy.HarnessError(f"invalid v2 state: {status}")
+    prior: Dict[str, Any] = {}
+    state_path = task_dir / "state.json"
+    if (task_dir / "events.jsonl").is_file():
+        prior = load_v2_state(task_dir)
+    elif state_path.is_file():
+        raise legacy.HarnessError(
+            "v2 state projection exists without its authoritative event ledger"
+        )
+    if prior:
+        if prior.get("status") in verifier.V2_TERMINAL_STATES:
+            raise legacy.HarnessError(
+                f"v2 task is terminal ({prior.get('status')}); state cannot change"
+            )
+    state = {
+        "schema_version": 2,
+        "task_id": task_dir.name,
+        "status": status,
+        "updated_at": legacy.utc_now(),
+        **{
+            key: value
+            for key, value in prior.items()
+            if key not in {"schema_version", "task_id", "status", "updated_at"}
+        },
+        **details,
+    }
+    # The append-only event is authoritative.  The projection follows it, so a
+    # crash between writes is repaired by load_v2_state instead of losing the
+    # transition.
+    _single_write_jsonl(
+        task_dir / "events.jsonl",
+        {
+            "at": state["updated_at"],
+            "event": "state",
+            "state": state,
+        },
+    )
+    if (
+        os.environ.get("MURMUR_HARNESS_SELFTEST") == "1"
+        and os.environ.get("MURMUR_HARNESS_SELFTEST_KILL_AFTER_STATE_EVENT")
+        == status
+    ):
+        os.kill(os.getpid(), signal.SIGKILL)
+    legacy.atomic_write_json(state_path, state)
+    return state
+
+
+def _last_state_event(task_dir: Path) -> Optional[Dict[str, Any]]:
+    return verifier.last_state_event(task_dir)
+
+
+def load_v2_state(task_dir: Path) -> Dict[str, Any]:
+    return verifier.load_v2_state(task_dir)
+
+
+def _valid_task_id(task_id: str) -> None:
+    if not legacy.TASK_ID_RE.fullmatch(task_id):
+        raise legacy.HarnessError(
+            "task id must match [a-z0-9][a-z0-9._-]{1,63}"
+        )
+
+
+def load_v2_task(
+    task_id: str, cwd: Path
+) -> Tuple[Dict[str, Any], Path, Path]:
+    _valid_task_id(task_id)
+    primary, common = legacy.repo_context(cwd)
+    task_dir = v2_task_dir(common, task_id)
+    contract = legacy.load_json(task_dir / "task.json")
+    contract_schema: Optional[Mapping[str, Any]] = None
+    if (task_dir / "events.jsonl").is_file():
+        state = load_v2_state(task_dir)
+        receipt_path = task_dir / "commit.json"
+        if state.get("status") in {"COMMITTED", "CLOSED"} and receipt_path.is_file():
+            receipt = legacy.load_json(receipt_path)
+            attested_commit = str(receipt.get("commit_sha", ""))
+            if not legacy.SHA1_RE.fullmatch(attested_commit):
+                raise legacy.HarnessError("v2 committed receipt commit is malformed")
+            if receipt.get("task_id") != task_id:
+                raise legacy.HarnessError(
+                    "v2 committed receipt task differs from its task store"
+                )
+            if receipt.get("contract_sha256") != contract.get(
+                "contract_sha256"
+            ):
+                raise legacy.HarnessError(
+                    "v2 committed receipt contract binding is stale"
+                )
+            contract_schema = verifier.attested_schema(
+                primary, attested_commit, "v2-task"
+            )
+    verifier.validate_hashed_document(
+        contract,
+        "v2-task",
+        "contract_sha256",
+        "v2 task",
+        schema=contract_schema,
+    )
+    if Path(str(contract["git_common_dir"])).resolve() != common.resolve():
+        raise legacy.HarnessError("v2 task belongs to another Git common directory")
+    return contract, task_dir, common
+
+
+def _legacy_contract(common: Path, task_id: str) -> Optional[Dict[str, Any]]:
+    path = v1_task_dir(common, task_id) / "task.json"
+    if not path.is_file():
+        return None
+    contract = legacy.load_json(path)
+    legacy.validate_schema(contract, legacy.load_schema("task"), label="v1 task")
+    if legacy.contract_hash(contract) != contract.get("contract_sha256"):
+        raise legacy.HarnessError("v1 task contract hash is stale")
+    return contract
+
+
+def resolve_generation(task_id: str, cwd: Path) -> Tuple[int, Dict[str, Any], Path]:
+    """Resolve an ID without ever falling back from a malformed v2 claim."""
+
+    _valid_task_id(task_id)
+    _, common = legacy.repo_context(cwd)
+    v2_dir = v2_task_dir(common, task_id)
+    legacy_contract = _legacy_contract(common, task_id)
+    if v2_dir.exists():
+        contract, task_dir, _ = load_v2_task(task_id, cwd)
+        if legacy_contract is not None:
+            supersedes = contract.get("supersedes")
+            expected = {
+                "generation": 1,
+                "task_id": task_id,
+                "contract_sha256": legacy_contract["contract_sha256"],
+            }
+            if supersedes != expected:
+                raise legacy.HarnessError(
+                    "v1/v2 task id collision is ambiguous; v2 has no exact supersedes binding"
+                )
+        return 2, contract, task_dir
+    if legacy_contract is not None:
+        return 1, legacy_contract, v1_task_dir(common, task_id)
+    raise legacy.HarnessError(f"no v1 or v2 task exists: {task_id}")
+
+
+def _fetch_base(cwd: Path, requested: Optional[str]) -> str:
+    if requested:
+        return legacy.git(
+            cwd,
+            "rev-parse",
+            "--verify",
+            "--end-of-options",
+            f"{requested}^{{commit}}",
+        )
+    config = legacy.load_config()
+    default = str(config.get("default_base", "origin/murmur"))
+    remote, separator, branch = default.partition("/")
+    try:
+        if separator and remote and branch:
+            subprocess.run(
+                ["git", "fetch", "--quiet", remote, branch],
+                cwd=str(cwd),
+                check=True,
+                capture_output=True,
+                timeout=int(config.get("base_fetch_timeout_seconds", 30)),
+                env={
+                    **os.environ,
+                    "GIT_TERMINAL_PROMPT": "0",
+                    "GIT_ASKPASS": "",
+                    "SSH_ASKPASS": "",
+                },
+            )
+        return legacy.git(
+            cwd,
+            "rev-parse",
+            "--verify",
+            "--end-of-options",
+            f"{default}^{{commit}}",
+        )
+    except Exception as exc:  # noqa: BLE001 - explicit offline fallback
+        print(
+            f"agent-harness: WARNING — could not resolve {default} "
+            f"({type(exc).__name__}); using local HEAD",
+            file=sys.stderr,
+        )
+        return legacy.git(cwd, "rev-parse", "HEAD")
+
+
+def _read_description(args: argparse.Namespace) -> str:
+    prompt = getattr(args, "prompt", None)
+    prompt_file = getattr(args, "prompt_file", None)
+    if bool(prompt) == bool(prompt_file):
+        raise legacy.HarnessError("provide exactly one of --prompt or --prompt-file")
+    if prompt_file:
+        path = Path(prompt_file)
+        try:
+            prompt = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise legacy.HarnessError(f"cannot read prompt file {path}: {exc}") from exc
+    result = str(prompt).strip()
+    if not result:
+        raise legacy.HarnessError("task prompt must not be empty")
+    return result
+
+
+def _protected_v2_paths(
+    owned: Sequence[str], config: Optional[Mapping[str, Any]] = None
+) -> List[str]:
+    protected = [
+        legacy.normalize_owned_path(path)
+        for path in (config or legacy.load_config()).get("protected_paths", [])
+    ]
+    return sorted(
+        path
+        for path in owned
+        if any(legacy.path_overlaps(path, guard) for guard in protected)
+    )
+
+
+def _link_node_modules(primary: Path, worktree: Path) -> Optional[str]:
+    source = primary / "node_modules"
+    target = worktree / "node_modules"
+    if not source.is_dir() or source.is_symlink():
+        return None
+    ignored = legacy.run_capture(
+        ["git", "check-ignore", "--quiet", "--no-index", "--", "node_modules/"],
+        worktree,
+        check=False,
+    )
+    if ignored.returncode != 0:
+        raise legacy.HarnessError("node_modules is not ignored in the v2 worktree")
+    target.symlink_to(source.resolve(), target_is_directory=True)
+    return str(source.resolve())
+
+
+def _local_branch_oid(primary: Path, branch: str) -> Optional[str]:
+    branch_ref = f"refs/heads/{branch}"
+    result = legacy.run_capture(
+        [
+            "git",
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            "--end-of-options",
+            branch_ref,
+        ],
+        primary,
+        check=False,
+    )
+    if result.returncode == 1:
+        return None
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise legacy.HarnessError(
+            f"cannot inspect local branch {branch}: {detail}"
+        )
+    oid = result.stdout.strip()
+    if not legacy.SHA1_RE.fullmatch(oid):
+        raise legacy.HarnessError(f"local branch {branch} has an invalid OID")
+    return oid
+
+
+def _create_open_branch(primary: Path, branch: str, base_sha: str) -> str:
+    branch_ref = f"refs/heads/{branch}"
+    result = legacy.run_capture(
+        ["git", "update-ref", "--no-deref", branch_ref, base_sha, "0" * 40],
+        primary,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise legacy.HarnessError(
+            f"could not create task branch {branch}: {detail}"
+        )
+    return base_sha
+
+
+def _delete_open_branch_if_unchanged(
+    primary: Path, branch: str, expected_oid: str
+) -> None:
+    branch_ref = f"refs/heads/{branch}"
+    legacy.run_capture(
+        ["git", "update-ref", "--no-deref", "-d", branch_ref, expected_oid],
+        primary,
+        check=False,
+    )
+
+
+def _standalone_driver_urls(driver: Path, *, push: bool) -> List[str]:
+    argv = ["git", "remote", "get-url"]
+    if push:
+        argv.append("--push")
+    argv.extend(["--all", "origin"])
+    result = legacy.run_capture(argv, driver, check=False)
+    urls = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if result.returncode != 0 or not urls:
+        raise legacy.HarnessError(
+            "standalone driver origin must be canonical GitHub "
+            "murmur-io/murmur HTTPS or SSH; local/file origins are forbidden"
+        )
+    return urls
+
+
+def _standalone_driver_context(cwd: Path) -> Tuple[Path, Path]:
+    top = Path(
+        legacy.git(
+            cwd,
+            "rev-parse",
+            "--path-format=absolute",
+            "--show-toplevel",
+        )
+    ).resolve()
+    primary, common = legacy.repo_context(cwd)
+    if top.name != STANDALONE_DRIVER_NAME:
+        raise legacy.HarnessError(
+            "Harness v2 open requires the dedicated "
+            f"{STANDALONE_DRIVER_NAME} standalone clone"
+        )
+    if top != primary:
+        raise legacy.HarnessError(
+            "standalone driver must be the primary worktree of its own "
+            "Git common directory; linked driver worktrees are forbidden"
+        )
+
+    expected_common = top / ".git"
+    git_dir = Path(
+        legacy.git(
+            cwd,
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-dir",
+        )
+    ).resolve()
+    try:
+        common_metadata = expected_common.lstat()
+    except OSError as exc:
+        raise legacy.HarnessError(
+            "standalone driver Git common directory is missing"
+        ) from exc
+    if (
+        stat.S_ISLNK(common_metadata.st_mode)
+        or not stat.S_ISDIR(common_metadata.st_mode)
+        or common != expected_common
+        or git_dir != expected_common
+    ):
+        raise legacy.HarnessError(
+            "standalone driver Git common directory must be exactly "
+            f"{expected_common}"
+        )
+
+    symbolic_head = legacy.run_capture(
+        ["git", "symbolic-ref", "--quiet", "HEAD"],
+        top,
+        check=False,
+    )
+    if symbolic_head.returncode == 0:
+        raise legacy.HarnessError("standalone driver HEAD must be detached")
+    if symbolic_head.returncode != 1:
+        detail = (symbolic_head.stderr or symbolic_head.stdout).strip()
+        raise legacy.HarnessError(
+            f"cannot prove standalone driver HEAD is detached: {detail}"
+        )
+    legacy.git(top, "rev-parse", "--verify", "HEAD^{commit}")
+
+    if legacy.git_bytes(
+        top,
+        "status",
+        "--porcelain=v1",
+        "--untracked-files=all",
+    ).strip():
+        raise legacy.HarnessError("standalone driver must be clean before open")
+
+    alternates = expected_common / "objects" / "info" / "alternates"
+    try:
+        alternates_metadata = alternates.lstat()
+    except FileNotFoundError:
+        alternates_metadata = None
+    except OSError as exc:
+        raise legacy.HarnessError(
+            "cannot inspect standalone driver objects/info/alternates"
+        ) from exc
+    if alternates_metadata is not None:
+        if (
+            stat.S_ISLNK(alternates_metadata.st_mode)
+            or not stat.S_ISREG(alternates_metadata.st_mode)
+        ):
+            raise legacy.HarnessError(
+                "standalone driver objects/info/alternates must be absent "
+                "or empty"
+            )
+        try:
+            nonempty_alternates = bool(alternates.read_bytes())
+        except OSError as exc:
+            raise legacy.HarnessError(
+                "cannot inspect standalone driver objects/info/alternates"
+            ) from exc
+        if nonempty_alternates:
+            raise legacy.HarnessError(
+                "standalone driver objects/info/alternates must be absent "
+                "or empty"
+            )
+
+    origin_urls = _standalone_driver_urls(top, push=False)
+    push_urls = _standalone_driver_urls(top, push=True)
+    if any(
+        url not in CANONICAL_MURMUR_ORIGINS
+        for url in [*origin_urls, *push_urls]
+    ):
+        raise legacy.HarnessError(
+            "standalone driver origin must be canonical GitHub "
+            "murmur-io/murmur HTTPS or SSH; local/file origins are forbidden"
+        )
+    return top, common
+
+
+def _require_safe_new_task_root(driver: Path, task_root: Path) -> None:
+    task_parent = driver.parent / ".murmur-agent-tasks"
+    expected = task_parent / "v2" / task_root.name
+    if task_root != expected:
+        raise legacy.HarnessError("v2 task root escaped its dedicated parent")
+
+    for component in (driver.parent, task_parent, task_parent / "v2"):
+        try:
+            metadata = component.lstat()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            raise legacy.HarnessError(
+                f"cannot inspect v2 task root component: {component}"
+            ) from exc
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+            raise legacy.HarnessError(
+                f"v2 task root component is unsafe or symlinked: {component}"
+            )
+
+    try:
+        root_metadata = task_root.lstat()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise legacy.HarnessError(
+            f"cannot inspect v2 task root: {task_root}"
+        ) from exc
+    if stat.S_ISLNK(root_metadata.st_mode) or not stat.S_ISDIR(
+        root_metadata.st_mode
+    ):
+        raise legacy.HarnessError(
+            f"v2 task root is unsafe or symlinked: {task_root}"
+        )
+    raise legacy.HarnessError(f"v2 task root already exists: {task_root}")
+
+
+def cmd_open(args: argparse.Namespace) -> int:
+    cwd = Path.cwd()
+    primary, common = _standalone_driver_context(cwd)
+    _valid_task_id(args.task_id)
+    task_dir = v2_task_dir(common, args.task_id)
+    task_root = primary.parent / ".murmur-agent-tasks" / "v2" / args.task_id
+    _require_safe_new_task_root(primary, task_root)
+    if task_dir.exists() or v1_task_dir(common, args.task_id).exists():
+        raise legacy.HarnessError(
+            f"task id already exists in a harness generation: {args.task_id}"
+        )
+    description = _read_description(args)
+    owned = sorted(
+        set(legacy.normalize_owned_path(path) for path in args.owned)
+    )
+    protected = _protected_v2_paths(owned)
+    if protected:
+        raise legacy.HarnessError(
+            "Harness v2 is not allowed to certify its own protected control plane "
+            f"({', '.join(protected)}); use a v1 --kind harness task with "
+            "seal-prepared until an externally anchored v2 bootstrap replaces it"
+        )
+    claims = sorted(set(args.claim or []))
+    reviewer = args.reviewer or str(legacy.load_config()["default_reviewer"])
+    if reviewer not in legacy.REAL_MODEL_VENDORS:
+        raise legacy.HarnessError("v2 reviewer must be codex or claude")
+    if "runtime" in claims:
+        legacy.runtime_preflight(primary)
+    base_sha = _fetch_base(cwd, args.base)
+    if not legacy.SHA1_RE.fullmatch(base_sha):
+        raise legacy.HarnessError("v2 base did not resolve to a commit")
+    branch = args.branch or f"agent/v2/{args.task_id}"
+    if branch in {"murmur", "main", "master"}:
+        raise legacy.HarnessError("v2 task cannot use a protected branch")
+    if (
+        legacy.run_capture(
+            ["git", "check-ref-format", "--branch", branch], cwd, check=False
+        ).returncode
+        != 0
+    ):
+        raise legacy.HarnessError(f"invalid task branch: {branch}")
+    if _local_branch_oid(primary, branch) is not None:
+        raise legacy.HarnessError(f"branch already exists: {branch}")
+    worktree = task_root / CLIENT_WORKTREE_NAME
+    server_worktree = task_root / "murmur-server"
+    contract: Dict[str, Any] = {
+        "schema_version": 2,
+        "task_id": args.task_id,
+        "description": description,
+        "kind": args.kind,
+        "base_sha": base_sha,
+        "contract_sha256": "",
+        "repo_realpath": str(primary.resolve()),
+        "git_common_dir": str(common.resolve()),
+        "worktree_path": str(worktree.resolve()),
+        "branch": branch,
+        "owned_paths": owned,
+        "claims": claims,
+        "reviewer": reviewer,
+        "expected_change": bool(args.expected_change),
+        "degraded_provenance": [],
+        "created_at": legacy.utc_now(),
+    }
+    branch_created = False
+    branch_expected_oid: Optional[str] = None
+    task_dir_created = False
+    task_root_created = False
+    try:
+        task_root.mkdir(parents=True)
+        task_root_created = True
+        task_dir.mkdir(parents=True)
+        task_dir_created = True
+        legacy.run_capture(["git", "worktree", "prune"], primary)
+        branch_expected_oid = _create_open_branch(primary, branch, base_sha)
+        branch_created = True
+        legacy.run_capture(
+            ["git", "worktree", "add", str(worktree), branch],
+            primary,
+        )
+        unsafe = [
+            path
+            for path in owned
+            if legacy.path_has_symlink_component(worktree, path)
+        ]
+        if unsafe:
+            raise legacy.HarnessError(
+                "owned paths traverse symlinks: " + ", ".join(unsafe)
+            )
+        shared_node_modules = _link_node_modules(primary, worktree)
+        contract["contract_sha256"] = verifier.document_hash(
+            contract, "contract_sha256"
+        )
+        legacy.validate_schema(
+            contract, legacy.load_schema("v2-task"), label="v2 task"
+        )
+        legacy.atomic_write_json(task_dir / "task.json", contract)
+        legacy.atomic_write_json(
+            task_dir / "runtime.json",
+            {
+                "schema_version": 2,
+                "task_root": str(task_root),
+                "shared_node_modules": shared_node_modules,
+                "server_worktree": None,
+                "server_source": str(primary.parent / "murmur-server"),
+                "server_revision": None,
+                "server_checkout_mode": None,
+            },
+        )
+        set_v2_state(task_dir, "OPEN", phase="open")
+    except Exception:
+        if server_worktree.exists():
+            server_source = primary.parent / "murmur-server"
+            if server_source.is_dir():
+                legacy.run_capture(
+                    ["git", "worktree", "remove", "--force", str(server_worktree)],
+                    server_source,
+                    check=False,
+                )
+        if worktree.exists():
+            legacy.run_capture(
+                ["git", "worktree", "remove", "--force", str(worktree)],
+                primary,
+                check=False,
+            )
+        if branch_created and branch_expected_oid is not None:
+            _delete_open_branch_if_unchanged(
+                primary, branch, branch_expected_oid
+            )
+        if task_dir_created:
+            shutil.rmtree(task_dir, ignore_errors=True)
+        if task_root_created:
+            try:
+                task_root.rmdir()
+                task_root.parent.rmdir()
+            except OSError:
+                pass
+        raise
+    print(
+        json.dumps(
+            {
+                "task_id": args.task_id,
+                "generation": 2,
+                "status": "OPEN",
+                "base_sha": base_sha,
+                "worktree": str(worktree),
+                "server_worktree": None,
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+def prepare_plan(
+    contract: Mapping[str, Any], task_dir: Path
+) -> Tuple[Dict[str, Any], Path, bytes]:
+    worktree = Path(str(contract["worktree_path"]))
+    if "runtime" in contract.get("claims", []):
+        legacy.runtime_preflight(worktree)
+    state = load_v2_state(task_dir)
+    if state.get("status") in verifier.V2_TERMINAL_STATES | {"COMMITTED"}:
+        raise legacy.HarnessError(
+            f"cannot plan v2 task in state {state.get('status')}"
+        )
+    paths, diff, tree_sha = verifier.snapshot_scoped_diff(
+        worktree, contract, task_dir
+    )
+    if not paths or not diff:
+        raise legacy.HarnessError(
+            "Harness v2 verifies changes only; the exact diff is empty"
+        )
+    plan, bundle = verifier.build_plan(
+        contract, worktree, paths, diff, tree_sha, legacy.load_config()
+    )
+    current_id = verifier.attempt_id(plan)
+    attempt_dir = task_dir / "attempts" / current_id
+    attempt_dir.mkdir(parents=True, exist_ok=True)
+    plan_path = attempt_dir / "plan.json"
+    if plan_path.is_file():
+        existing = legacy.load_json(plan_path)
+        verifier.validate_hashed_document(
+            existing, "v2-plan", "plan_sha256", "v2 plan"
+        )
+        if existing != plan:
+            raise legacy.HarnessError(
+                "attempt-key collision: existing plan differs from the exact profile"
+            )
+    else:
+        legacy.atomic_write_json(plan_path, plan)
+        legacy.atomic_write_json(attempt_dir / "protocol.json", bundle)
+        legacy.atomic_write_bytes(attempt_dir / "diff.patch", diff)
+    set_v2_state(
+        task_dir,
+        "OPEN",
+        phase="planned",
+        attempt_id=current_id,
+        plan_path=str(plan_path),
+        diff_sha256=plan["diff_sha256"],
+        plan_sha256=plan["plan_sha256"],
+        protocol_sha256=plan["protocol_sha256"],
+    )
+    return plan, attempt_dir, diff
+
+
+def _verification_snapshot_path(
+    contract: Mapping[str, Any], attempt_dir: Path
+) -> Path:
+    worktree = Path(str(contract["worktree_path"])).resolve()
+    attempts_dir = attempt_dir.parent
+    if attempts_dir.name != "attempts":
+        raise legacy.HarnessError("v2 attempt directory layout is malformed")
+    if re.fullmatch(r"[0-9a-f]{64}", attempt_dir.name) is None:
+        raise legacy.HarnessError("v2 attempt id is malformed")
+    return worktree.parent / f"verify-{attempt_dir.name}"
+
+
+def _verification_snapshot_ref(task_id: str, attempt_id: str) -> str:
+    safe = re.sub(r"[^a-zA-Z0-9._-]+", "-", task_id).strip(".-")
+    safe = safe.replace("..", "-") or "task"
+    suffix = legacy.sha256_bytes(task_id.encode("utf-8"))[:12]
+    return (
+        f"refs/agent-harness/v2/snapshots/{safe}-{suffix}/{attempt_id}"
+    )
+
+
+def _anchor_verification_tree(
+    contract: Mapping[str, Any],
+    plan: Mapping[str, Any],
+    attempt_dir: Path,
+) -> Tuple[str, str]:
+    """Keep private-index objects reachable across crashes and concurrent GC."""
+
+    primary = Path(str(contract["repo_realpath"])).resolve()
+    reference = _verification_snapshot_ref(
+        str(contract["task_id"]), attempt_dir.name
+    )
+    current = legacy.git(
+        primary, "rev-parse", "--verify", reference, check=False
+    )
+    if current:
+        commit_sha = current
+    else:
+        identity = legacy.load_config()["commit_identity"]
+        environment = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": str(identity["name"]),
+            "GIT_AUTHOR_EMAIL": str(identity["email"]),
+            "GIT_COMMITTER_NAME": str(identity["name"]),
+            "GIT_COMMITTER_EMAIL": str(identity["email"]),
+            "GIT_AUTHOR_DATE": str(contract["created_at"]),
+            "GIT_COMMITTER_DATE": str(contract["created_at"]),
+        }
+        completed = subprocess.run(
+            [
+                "git",
+                "commit-tree",
+                plan["tree_sha"],
+                "-p",
+                plan["base_sha"],
+                "-m",
+                f"harness v2 immutable snapshot: {contract['task_id']}",
+            ],
+            cwd=str(primary),
+            env=environment,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise legacy.HarnessError(
+                "could not anchor v2 verification tree: "
+                + completed.stderr.strip()
+            )
+        commit_sha = completed.stdout.strip()
+        if not legacy.SHA1_RE.fullmatch(commit_sha):
+            raise legacy.HarnessError(
+                "v2 verification anchor did not produce a commit"
+            )
+        # Create-only publication. A concurrent publisher may only win with
+        # the same deterministic commit; otherwise update-ref fails closed.
+        legacy.run_capture(
+            ["git", "update-ref", reference, commit_sha, "0" * 40],
+            primary,
+        )
+    if legacy.git(primary, "rev-parse", f"{commit_sha}^{{tree}}") != plan["tree_sha"]:
+        raise legacy.HarnessError("v2 verification anchor tree is stale")
+    parents = legacy.git(
+        primary, "show", "-s", "--format=%P", commit_sha
+    ).split()
+    if parents != [plan["base_sha"]]:
+        raise legacy.HarnessError("v2 verification anchor parent is stale")
+    return reference, commit_sha
+
+
+def _snapshot_manifest(
+    contract: Mapping[str, Any],
+    plan: Mapping[str, Any],
+    snapshot: Path,
+    snapshot_ref: str,
+    snapshot_commit: str,
+) -> Dict[str, Any]:
+    document: Dict[str, Any] = {
+        "schema_version": 2,
+        "task_id": contract["task_id"],
+        "contract_sha256": contract["contract_sha256"],
+        "plan_sha256": plan["plan_sha256"],
+        "base_sha": plan["base_sha"],
+        "tree_sha": plan["tree_sha"],
+        "diff_sha256": plan["diff_sha256"],
+        "path": str(snapshot),
+        "snapshot_ref": snapshot_ref,
+        "snapshot_commit": snapshot_commit,
+        "created_at": contract["created_at"],
+        "snapshot_sha256": "",
+    }
+    document["snapshot_sha256"] = verifier.document_hash(
+        document, "snapshot_sha256"
+    )
+    return document
+
+
+def _validate_verification_snapshot(
+    contract: Mapping[str, Any],
+    task_dir: Path,
+    plan: Mapping[str, Any],
+    attempt_dir: Path,
+    snapshot: Path,
+) -> None:
+    if not snapshot.is_dir() or snapshot.is_symlink():
+        raise legacy.HarnessError("v2 verification snapshot is missing or unsafe")
+    if snapshot.resolve() != _verification_snapshot_path(contract, attempt_dir):
+        raise legacy.HarnessError("v2 verification snapshot escaped its task root")
+    common = Path(
+        legacy.git(
+            snapshot,
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-common-dir",
+        )
+    ).resolve()
+    if common != (snapshot / ".git").resolve():
+        raise legacy.HarnessError(
+            "v2 verification snapshot unexpectedly shares mutable Git metadata"
+        )
+    if (
+        Path(legacy.git(snapshot, "rev-parse", "--show-toplevel")).resolve()
+        != snapshot.resolve()
+    ):
+        raise legacy.HarnessError("v2 verification snapshot is not its Git root")
+    if legacy.git(snapshot, "rev-parse", "HEAD") != plan["base_sha"]:
+        raise legacy.HarnessError("v2 verification snapshot parent changed")
+    paths, diff, tree_sha = verifier.snapshot_scoped_diff(
+        snapshot, contract, task_dir
+    )
+    if paths != plan["changed_paths"]:
+        raise legacy.HarnessError("v2 verification snapshot paths changed")
+    if legacy.sha256_bytes(diff) != plan["diff_sha256"]:
+        raise legacy.HarnessError("v2 verification snapshot diff changed")
+    if tree_sha != plan["tree_sha"]:
+        raise legacy.HarnessError("v2 verification snapshot tree changed")
+
+
+def _discard_claimed_verification_snapshot(
+    contract: Mapping[str, Any], attempt_dir: Path, snapshot: Path
+) -> None:
+    if snapshot.resolve() != _verification_snapshot_path(contract, attempt_dir):
+        raise legacy.HarnessError(
+            "refusing to discard a verification snapshot outside its task root"
+        )
+    if not snapshot.exists() and not snapshot.is_symlink():
+        return
+    if not snapshot.is_dir() or snapshot.is_symlink():
+        raise legacy.HarnessError(
+            "claimed verification snapshot path became unsafe"
+        )
+    shutil.rmtree(snapshot)
+
+
+def _ensure_verification_snapshot(
+    contract: Mapping[str, Any],
+    task_dir: Path,
+    plan: Mapping[str, Any],
+    attempt_dir: Path,
+) -> Path:
+    """Materialize the exact planned tree in a runner-owned standalone clone.
+
+    Checks and reviewers never read the concurrently editable developer
+    worktree.  The standalone clone keeps its own index/HEAD while borrowing
+    immutable objects from the primary repository.
+    """
+
+    snapshot = _verification_snapshot_path(contract, attempt_dir)
+    snapshot_ref, snapshot_commit = _anchor_verification_tree(
+        contract, plan, attempt_dir
+    )
+    manifest_path = attempt_dir / "snapshot.json"
+    expected_manifest = _snapshot_manifest(
+        contract,
+        plan,
+        snapshot,
+        snapshot_ref,
+        snapshot_commit,
+    )
+    if manifest_path.is_file():
+        manifest = legacy.load_json(manifest_path)
+        if manifest != expected_manifest:
+            raise legacy.HarnessError(
+                "v2 verification snapshot manifest differs from the exact plan"
+            )
+        try:
+            _validate_verification_snapshot(
+                contract, task_dir, plan, attempt_dir, snapshot
+            )
+            return snapshot
+        except legacy.HarnessError:
+            # The durable manifest was published before clone creation. A
+            # parent crash may leave a partial clone; discard only that exact
+            # runner-claimed path and reconstruct from the anchored tree.
+            _discard_claimed_verification_snapshot(
+                contract, attempt_dir, snapshot
+            )
+    else:
+        if snapshot.exists() or snapshot.is_symlink():
+            raise legacy.HarnessError(
+                "unclaimed v2 verification snapshot path already exists"
+            )
+        legacy.atomic_write_json(manifest_path, expected_manifest)
+    primary = Path(str(contract["repo_realpath"])).resolve()
+    if not primary.is_dir() or primary.is_symlink():
+        raise legacy.HarnessError("v2 primary repository is missing or unsafe")
+    try:
+        legacy.run_capture(
+            [
+                "git",
+                "clone",
+                "--quiet",
+                "--shared",
+                "--no-checkout",
+                str(primary),
+                str(snapshot),
+            ],
+            snapshot.parent,
+        )
+        legacy.run_capture(
+            ["git", "checkout", "--quiet", "--detach", plan["base_sha"]],
+            snapshot,
+        )
+        legacy.run_capture(
+            ["git", "read-tree", "--reset", "-u", plan["tree_sha"]],
+            snapshot,
+        )
+        _validate_verification_snapshot(
+            contract, task_dir, plan, attempt_dir, snapshot
+        )
+        _link_node_modules(primary, snapshot)
+        shared_target = primary / "target"
+        snapshot_target = snapshot / "target"
+        if (
+            shared_target.is_dir()
+            and not shared_target.is_symlink()
+            and not snapshot_target.exists()
+            and not snapshot_target.is_symlink()
+        ):
+            snapshot_target.symlink_to(
+                shared_target.resolve(), target_is_directory=True
+            )
+    except Exception:
+        # The manifest is a durable ownership intent, so a later resume can
+        # safely reconstruct even when this process dies mid-clone.
+        _discard_claimed_verification_snapshot(
+            contract, attempt_dir, snapshot
+        )
+        raise
+    return snapshot
+
+
+def cmd_plan(args: argparse.Namespace) -> int:
+    contract, task_dir, _ = load_v2_task(args.task_id, Path.cwd())
+    lock = acquire_v2_run_lock(task_dir, "plan")
+    try:
+        plan, attempt_dir, _ = prepare_plan(contract, task_dir)
+    finally:
+        release_v2_run_lock(lock)
+    print(
+        json.dumps(
+            {
+                "task_id": contract["task_id"],
+                "attempt_id": attempt_dir.name,
+                "changed_paths": plan["changed_paths"],
+                "claims": plan["claims"],
+                "actual_risk_flags": plan["actual_risk_flags"],
+                "checks": [item["id"] for item in plan["checks"]],
+                "reviews": plan["reviews"],
+                "server_required": plan["server_required"],
+                "diff_sha256": plan["diff_sha256"],
+                "plan_sha256": plan["plan_sha256"],
+                "protocol_sha256": plan["protocol_sha256"],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def acquire_v2_run_lock(
+    task_dir: Path, command: str
+) -> legacy.TaskRunLock:
+    """Use the one hardened create-only lock protocol for both generations.
+
+    ``command`` remains part of the call-site API so diagnostics can name the
+    attempted operation without inventing a second, weaker on-disk protocol.
+    """
+
+    del command
+    return legacy.acquire_run_lock(task_dir)
+
+
+def release_v2_run_lock(lock: legacy.TaskRunLock) -> None:
+    legacy.release_run_lock(lock)
+
+
+def _ensure_server_worktree(
+    contract: Mapping[str, Any],
+    task_dir: Path,
+    plan: Mapping[str, Any],
+    *,
+    verification_worktree: Optional[Path] = None,
+) -> Optional[Path]:
+    if not plan.get("server_required"):
+        return None
+    worktree = verification_worktree or Path(str(contract["worktree_path"]))
+    runtime_path = task_dir / "runtime.json"
+    runtime = legacy.load_json(runtime_path)
+    server_worktree = worktree.parent / "murmur-server"
+    server_source = Path(str(runtime.get("server_source", "")))
+    expected_source = Path(str(contract["repo_realpath"])).parent / "murmur-server"
+    if server_source.resolve() != expected_source.resolve():
+        raise legacy.HarnessError("v2 server source is not the canonical sibling repository")
+    revision_path = worktree / ".murmur-server-revision"
+    try:
+        revision = revision_path.read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeError) as exc:
+        raise legacy.HarnessError("v2 Rust/protocol check needs .murmur-server-revision") from exc
+    if not legacy.SHA1_RE.fullmatch(revision):
+        raise legacy.HarnessError(".murmur-server-revision is malformed")
+    if not server_source.is_dir():
+        raise legacy.HarnessError(f"pinned sibling server repository is missing: {server_source}")
+    resolved = legacy.git(
+        server_source,
+        "rev-parse",
+        "--verify",
+        "--end-of-options",
+        f"{revision}^{{commit}}",
+    )
+    if resolved != revision:
+        raise legacy.HarnessError("pinned server revision did not resolve exactly")
+    if server_worktree.exists():
+        if not server_worktree.is_dir() or server_worktree.is_symlink():
+            raise legacy.HarnessError("v2 server worktree path is unsafe")
+        if legacy.git_bytes(server_worktree, "status", "--porcelain").strip():
+            raise legacy.HarnessError("existing v2 server worktree is dirty")
+        checkout_mode = str(
+            runtime.get("server_checkout_mode") or "linked-worktree"
+        )
+        if legacy.git(server_worktree, "rev-parse", "HEAD") != revision:
+            if checkout_mode != "local-shared-clone":
+                raise legacy.HarnessError(
+                    "existing linked v2 server worktree is at another revision"
+                )
+            common = Path(
+                legacy.git(
+                    server_worktree,
+                    "rev-parse",
+                    "--path-format=absolute",
+                    "--git-common-dir",
+                )
+            ).resolve()
+            if common != (server_worktree / ".git").resolve():
+                raise legacy.HarnessError(
+                    "existing v2 server clone shares mutable Git metadata"
+                )
+            shutil.rmtree(server_worktree)
+    if not server_worktree.exists():
+        # Do not register a linked worktree in the sibling repository. Agent
+        # sandboxes correctly deny that cross-workspace .git mutation. A local
+        # shared clone writes only inside the task root while reusing objects.
+        legacy.run_capture(
+            [
+                "git",
+                "clone",
+                "--quiet",
+                "--shared",
+                "--no-checkout",
+                str(server_source),
+                str(server_worktree),
+            ],
+            worktree.parent,
+        )
+        legacy.run_capture(
+            ["git", "checkout", "--quiet", "--detach", revision],
+            server_worktree,
+        )
+        checkout_mode = "local-shared-clone"
+    runtime.update(
+        {
+            "server_worktree": str(server_worktree),
+            "server_source": str(server_source.resolve()),
+            "server_revision": revision,
+            "server_checkout_mode": checkout_mode,
+        }
+    )
+    legacy.atomic_write_json(runtime_path, runtime)
+    return server_worktree
+
+
+def _checkpoint_event(
+    task_dir: Path, event: str, **details: Any
+) -> None:
+    _single_write_jsonl(
+        task_dir / "events.jsonl",
+        {"at": legacy.utc_now(), "event": event, **details},
+    )
+
+
+def _load_bound_record(
+    path: Path, plan: Mapping[str, Any]
+) -> Optional[Dict[str, Any]]:
+    if not path.is_file():
+        return None
+    try:
+        record = legacy.load_json(path)
+    except (legacy.HarnessError, OSError, UnicodeError):
+        return None
+    if not verifier.binding_matches(record, plan):
+        return None
+    return record
+
+
+def _snapshot_still_matches(
+    contract: Mapping[str, Any],
+    task_dir: Path,
+    plan: Mapping[str, Any],
+) -> bool:
+    paths, diff, tree_sha = verifier.snapshot_scoped_diff(
+        Path(str(contract["worktree_path"])), contract, task_dir
+    )
+    return (
+        paths == plan["changed_paths"]
+        and legacy.sha256_bytes(diff) == plan["diff_sha256"]
+        and tree_sha == plan["tree_sha"]
+    )
+
+
+def _run_or_resume_check(
+    contract: Mapping[str, Any],
+    task_dir: Path,
+    plan: Mapping[str, Any],
+    attempt_dir: Path,
+    declared: Mapping[str, Any],
+    verification_worktree: Path,
+    *,
+    checkpoint_number: int,
+) -> Tuple[Dict[str, Any], bool]:
+    record_path = attempt_dir / "checks" / f"{declared['id']}.json"
+    record = _load_bound_record(record_path, plan)
+    if record is not None:
+        try:
+            verifier.validate_check_checkpoint(
+                record, declared, plan, task_dir
+            )
+        except legacy.HarnessError:
+            record = None
+    if record is not None:
+        prior_evidence = record.get("evidence", {})
+        # A successful or deterministic failed check is a reusable exact-diff
+        # checkpoint. Environmental BLOCKED/timeout records are pause markers.
+        if not (
+            prior_evidence.get("outcome") == "BLOCKED"
+            or prior_evidence.get("timed_out")
+        ):
+            return record, False
+    evidence = legacy.run_check(
+        verification_worktree,
+        task_dir,
+        declared,
+        f"v2-{attempt_dir.name[:12]}",
+    )
+    if not _snapshot_still_matches(
+        {**contract, "worktree_path": str(verification_worktree)},
+        task_dir,
+        plan,
+    ):
+        evidence = {
+            **evidence,
+            "passed": False,
+            "outcome": "FAIL",
+            "tree_mutated": True,
+            "blocked_reason": "runner-owned check changed the exact task diff",
+        }
+    record = verifier.check_record(declared, plan, evidence)
+    legacy.atomic_write_json(record_path, record)
+    _checkpoint_event(
+        task_dir,
+        "check-checkpoint",
+        attempt_id=attempt_dir.name,
+        check_id=declared["id"],
+        record_path=str(record_path),
+        passed=bool(evidence.get("passed")),
+    )
+    if (
+        os.environ.get("MURMUR_HARNESS_SELFTEST") == "1"
+        and os.environ.get("MURMUR_HARNESS_SELFTEST_KILL_AFTER_CHECK")
+        == str(checkpoint_number)
+    ):
+        os.kill(os.getpid(), signal.SIGKILL)
+    return record, True
+
+
+def verify_task(
+    contract: Mapping[str, Any],
+    task_dir: Path,
+    *,
+    allow_test_adapter: bool = False,
+) -> str:
+    lock = acquire_v2_run_lock(task_dir, "verify")
+    try:
+        state = load_v2_state(task_dir)
+        if state.get("status") in verifier.V2_TERMINAL_STATES | {"COMMITTED"}:
+            raise legacy.HarnessError(
+                f"cannot verify v2 task in state {state.get('status')}"
+            )
+        plan, attempt_dir, diff = prepare_plan(contract, task_dir)
+        verification_worktree = _ensure_verification_snapshot(
+            contract, task_dir, plan, attempt_dir
+        )
+        set_v2_state(
+            task_dir,
+            "VERIFYING",
+            phase="checks",
+            attempt_id=attempt_dir.name,
+            plan_path=str(attempt_dir / "plan.json"),
+            diff_sha256=plan["diff_sha256"],
+            plan_sha256=plan["plan_sha256"],
+            protocol_sha256=plan["protocol_sha256"],
+        )
+        _ensure_server_worktree(
+            contract,
+            task_dir,
+            plan,
+            verification_worktree=verification_worktree,
+        )
+        worktree = verification_worktree
+        check_dir = attempt_dir / "checks"
+        check_dir.mkdir(parents=True, exist_ok=True)
+        check_records: List[Dict[str, Any]] = []
+        ran_checks = 0
+        for declared in plan["checks"]:
+            record, did_run = _run_or_resume_check(
+                contract,
+                task_dir,
+                plan,
+                attempt_dir,
+                declared,
+                verification_worktree,
+                checkpoint_number=ran_checks + 1,
+            )
+            if did_run:
+                ran_checks += 1
+            check_records.append(record)
+            if not _snapshot_still_matches(contract, task_dir, plan):
+                set_v2_state(
+                    task_dir,
+                    "NEEDS_FIX",
+                    phase="checks",
+                    reason=(
+                        "developer worktree changed during verification; "
+                        "the completed snapshot checkpoint was preserved and "
+                        "a new exact-diff attempt is required"
+                    ),
+                    attempt_id=attempt_dir.name,
+                    plan_path=str(attempt_dir / "plan.json"),
+                )
+                return "NEEDS_FIX"
+
+        check_state: Optional[str] = None
+        check_reason = ""
+        resource_wait_ms = sum(
+            int(record.get("evidence", {}).get("resource_wait_ms", 0) or 0)
+            for record in check_records
+        )
+        for record in check_records:
+            evidence = record.get("evidence", {})
+            if evidence.get("outcome") == "BLOCKED" or evidence.get("timed_out"):
+                check_state = "PAUSED_RETRYABLE"
+                check_reason = f"check {record.get('id')} is retryable"
+                break
+            if not evidence.get("passed"):
+                check_state = "NEEDS_FIX"
+                check_reason = f"check {record.get('id')} failed"
+                break
+        if check_state is not None:
+            set_v2_state(
+                task_dir,
+                check_state,
+                phase="checks",
+                reason=check_reason,
+                resource_wait_ms=resource_wait_ms,
+                attempt_id=attempt_dir.name,
+                plan_path=str(attempt_dir / "plan.json"),
+            )
+            return check_state
+
+        set_v2_state(
+            task_dir,
+            "VERIFYING",
+            phase="reviews",
+            attempt_id=attempt_dir.name,
+            plan_path=str(attempt_dir / "plan.json"),
+            resource_wait_ms=resource_wait_ms,
+        )
+        reviews_dir = attempt_dir / "reviews"
+        reviews_dir.mkdir(parents=True, exist_ok=True)
+        probes_dir = attempt_dir / "probes"
+        probes_dir.mkdir(parents=True, exist_ok=True)
+        probe_records: List[Dict[str, Any]] = []
+        for path in sorted(probes_dir.glob("*.json")):
+            record = _load_bound_record(path, plan)
+            if record is None:
+                continue
+            try:
+                declared_probe = verifier.canonical_check(
+                    str(record.get("id")), legacy.load_config()
+                )
+                verifier.validate_check_checkpoint(
+                    record, declared_probe, plan, task_dir
+                )
+            except legacy.HarnessError:
+                continue
+            prior = record.get("evidence", {})
+            if prior.get("outcome") == "BLOCKED" or prior.get("timed_out"):
+                continue
+            probe_records.append(record)
+        probe_records.sort(key=lambda item: str(item.get("id", "")))
+        probe_hash = verifier.probe_evidence_hash(probe_records)
+        records_by_kind: Dict[str, Dict[str, Any]] = {}
+        missing: List[Mapping[str, str]] = []
+        for declared in plan["reviews"]:
+            record_path = reviews_dir / f"{declared['kind']}.json"
+            record = _load_bound_record(record_path, plan)
+            if record is not None:
+                prompt = verifier.combined_review_prompt(
+                    contract,
+                    plan,
+                    diff,
+                    [*check_records, *probe_records],
+                    str(declared["kind"]),
+                    worktree,
+                )
+                try:
+                    verifier.validate_review_checkpoint(
+                        record,
+                        declared,
+                        plan,
+                        task_dir,
+                        expected_prompt_sha256=legacy.sha256_bytes(
+                            prompt.encode("utf-8")
+                        ),
+                        allow_test_adapter=allow_test_adapter,
+                    )
+                except legacy.HarnessError:
+                    record = None
+            if (
+                record is None
+                or record.get("probe_evidence_sha256") != probe_hash
+            ):
+                missing.append(declared)
+            else:
+                records_by_kind[declared["kind"]] = record
+
+        retry_pauses: List[Tuple[str, verifier.ReviewPaused]] = []
+        permanent_errors: List[Tuple[str, Exception]] = []
+        if missing:
+            max_workers = max(
+                1,
+                min(
+                    3,
+                    int(legacy.load_config().get("v2_max_parallel_reviews", 3)),
+                    len(missing),
+                ),
+            )
+
+            def run_review(declared: Mapping[str, str]) -> Dict[str, Any]:
+                run_dir = attempt_dir / "review-runs" / declared["kind"]
+                run_dir.mkdir(parents=True, exist_ok=True)
+                return verifier.invoke_readonly_review(
+                    contract=contract,
+                    plan=plan,
+                    worktree=worktree,
+                    attempt_dir=run_dir,
+                    diff=diff,
+                    checks=[*check_records, *probe_records],
+                    review=declared,
+                    probe_evidence_sha256=probe_hash,
+                    allow_test_adapter=allow_test_adapter,
+                )
+
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=max_workers,
+                thread_name_prefix="murmur-v2-review",
+            ) as pool:
+                future_map = {
+                    pool.submit(run_review, declared): declared for declared in missing
+                }
+                # Consume every future: specialist failures never short-circuit
+                # another independent review.
+                for future in concurrent.futures.as_completed(future_map):
+                    declared = future_map[future]
+                    kind = declared["kind"]
+                    try:
+                        record = future.result()
+                    except verifier.ReviewPaused as exc:
+                        retry_pauses.append((kind, exc))
+                        continue
+                    except Exception as exc:  # noqa: BLE001 - persist all reviewer failures
+                        permanent_errors.append((kind, exc))
+                        continue
+                    record_path = reviews_dir / f"{kind}.json"
+                    legacy.atomic_write_json(record_path, record)
+                    records_by_kind[kind] = record
+                    _checkpoint_event(
+                        task_dir,
+                        "review-checkpoint",
+                        attempt_id=attempt_dir.name,
+                        review_kind=kind,
+                        record_path=str(record_path),
+                        verdict=record["result"]["verdict"],
+                    )
+        if (
+            not _snapshot_still_matches(contract, task_dir, plan)
+            or not _snapshot_still_matches(
+                {**contract, "worktree_path": str(verification_worktree)},
+                task_dir,
+                plan,
+            )
+        ):
+            set_v2_state(
+                task_dir,
+                "NEEDS_FIX",
+                phase="reviews",
+                reason="review phase changed the exact diff",
+                attempt_id=attempt_dir.name,
+            )
+            return "NEEDS_FIX"
+        if retry_pauses:
+            reason = "; ".join(
+                f"{kind}: {exc}" for kind, exc in sorted(retry_pauses)
+            )
+            set_v2_state(
+                task_dir,
+                "PAUSED_RETRYABLE",
+                phase="reviews",
+                reason=reason,
+                attempt_id=attempt_dir.name,
+            )
+            return "PAUSED_RETRYABLE"
+        if permanent_errors:
+            reason = "; ".join(
+                f"{kind}: {type(exc).__name__}: {exc}"
+                for kind, exc in sorted(permanent_errors)
+            )
+            set_v2_state(
+                task_dir,
+                "NEEDS_EVIDENCE",
+                phase="reviews",
+                reason=reason,
+                attempt_id=attempt_dir.name,
+            )
+            return "NEEDS_EVIDENCE"
+
+        review_records = [
+            records_by_kind[item["kind"]] for item in plan["reviews"]
+        ]
+        requested_probe_ids = sorted(
+            {
+                str(request["probe_id"])
+                for review in review_records
+                for request in review.get("result", {}).get("probe_requests", [])
+            }
+        )
+        existing_probe_ids = {
+            str(record.get("id")) for record in probe_records
+        }
+        passed_checks = {
+            str(record.get("id")): record
+            for record in check_records
+            if record.get("evidence", {}).get("passed")
+        }
+        aliased_probe_ids = [
+            probe_id
+            for probe_id in requested_probe_ids
+            if probe_id not in existing_probe_ids and probe_id in passed_checks
+        ]
+        for probe_id in aliased_probe_ids:
+            record_path = probes_dir / f"{probe_id}.json"
+            alias = {
+                **passed_checks[probe_id],
+                "source": "planned-check",
+                "created_at": legacy.utc_now(),
+            }
+            legacy.atomic_write_json(record_path, alias)
+            _checkpoint_event(
+                task_dir,
+                "probe-alias-checkpoint",
+                attempt_id=attempt_dir.name,
+                probe_id=probe_id,
+                record_path=str(record_path),
+                source="planned-check",
+            )
+        missing_probe_ids = [
+            probe_id
+            for probe_id in requested_probe_ids
+            if probe_id not in existing_probe_ids
+            and probe_id not in passed_checks
+        ]
+        if missing_probe_ids:
+            if any(
+                probe_id in {"rust-lib", "protocol-server"}
+                for probe_id in missing_probe_ids
+            ):
+                _ensure_server_worktree(
+                    contract,
+                    task_dir,
+                    {**plan, "server_required": True},
+                    verification_worktree=verification_worktree,
+                )
+            config = legacy.load_config()
+            probe_pause = False
+            probe_failure = False
+            for probe_id in missing_probe_ids:
+                declared = verifier.canonical_check(probe_id, config)
+                record_path = probes_dir / f"{probe_id}.json"
+                evidence = legacy.run_check(
+                    worktree,
+                    task_dir,
+                    declared,
+                    f"v2-{attempt_dir.name[:12]}-probe",
+                )
+                if not _snapshot_still_matches(
+                    {
+                        **contract,
+                        "worktree_path": str(verification_worktree),
+                    },
+                    task_dir,
+                    plan,
+                ):
+                    evidence = {
+                        **evidence,
+                        "passed": False,
+                        "outcome": "FAIL",
+                        "tree_mutated": True,
+                        "blocked_reason": "runner-owned probe changed the exact task diff",
+                    }
+                record = verifier.check_record(declared, plan, evidence)
+                legacy.atomic_write_json(record_path, record)
+                _checkpoint_event(
+                    task_dir,
+                    "probe-checkpoint",
+                    attempt_id=attempt_dir.name,
+                    probe_id=probe_id,
+                    record_path=str(record_path),
+                    passed=bool(evidence.get("passed")),
+                )
+                if not _snapshot_still_matches(contract, task_dir, plan):
+                    set_v2_state(
+                        task_dir,
+                        "NEEDS_FIX",
+                        phase="probes",
+                        reason=(
+                            "developer worktree changed while a snapshot probe "
+                            "ran; checkpoint preserved for the old attempt"
+                        ),
+                        attempt_id=attempt_dir.name,
+                    )
+                    return "NEEDS_FIX"
+                if evidence.get("outcome") == "BLOCKED" or evidence.get("timed_out"):
+                    probe_pause = True
+                elif not evidence.get("passed"):
+                    probe_failure = True
+            if probe_failure:
+                set_v2_state(
+                    task_dir,
+                    "NEEDS_FIX",
+                    phase="probes",
+                    reason="a runner-owned reviewer probe failed",
+                    attempt_id=attempt_dir.name,
+                )
+                return "NEEDS_FIX"
+            if probe_pause:
+                set_v2_state(
+                    task_dir,
+                    "PAUSED_RETRYABLE",
+                    phase="probes",
+                    reason="a runner-owned reviewer probe is retryable",
+                    attempt_id=attempt_dir.name,
+                )
+                return "PAUSED_RETRYABLE"
+            set_v2_state(
+                task_dir,
+                "NEEDS_EVIDENCE",
+                phase="probes",
+                reason=(
+                    "allowlisted probe evidence collected; resume will run fresh "
+                    "reviews against it"
+                ),
+                attempt_id=attempt_dir.name,
+            )
+            return "NEEDS_EVIDENCE"
+        if aliased_probe_ids:
+            set_v2_state(
+                task_dir,
+                "NEEDS_EVIDENCE",
+                phase="probes",
+                reason=(
+                    "reviewer-requested proof was already a planned green "
+                    "check; a bound alias was recorded and resume will run a "
+                    "fresh review without repeating the command"
+                ),
+                attempt_id=attempt_dir.name,
+            )
+            return "NEEDS_EVIDENCE"
+        if requested_probe_ids:
+            set_v2_state(
+                task_dir,
+                "NEEDS_EVIDENCE",
+                phase="probes",
+                reason=(
+                    "review still requests a probe it already saw; no arbitrary "
+                    "or repeated command was executed"
+                ),
+                attempt_id=attempt_dir.name,
+            )
+            return "NEEDS_EVIDENCE"
+        evidence = verifier.build_evidence(
+            contract,
+            plan,
+            worktree,
+            check_records,
+            probe_records,
+            review_records,
+        )
+        evidence_path = attempt_dir / "evidence.json"
+        legacy.atomic_write_json(evidence_path, evidence)
+        _checkpoint_event(
+            task_dir,
+            "evidence-checkpoint",
+            attempt_id=attempt_dir.name,
+            evidence_path=str(evidence_path),
+            verdict=evidence["verdict"],
+            evidence_sha256=evidence["evidence_sha256"],
+            resource_wait_ms=resource_wait_ms
+            + sum(
+                int(record.get("evidence", {}).get("resource_wait_ms", 0) or 0)
+                for record in probe_records
+            ),
+        )
+        new_state = evidence["verdict"]
+        set_v2_state(
+            task_dir,
+            new_state,
+            phase="complete",
+            reason=evidence["reason"],
+            attempt_id=attempt_dir.name,
+            plan_path=str(attempt_dir / "plan.json"),
+            evidence_path=str(evidence_path),
+            diff_sha256=evidence["diff_sha256"],
+            plan_sha256=evidence["plan_sha256"],
+            protocol_sha256=evidence["protocol_sha256"],
+            evidence_sha256=evidence["evidence_sha256"],
+        )
+        if new_state == "PASSED":
+            try:
+                verifier.verify_v2_evidence(
+                    contract,
+                    task_dir,
+                    allow_test_adapter=allow_test_adapter,
+                )
+            except Exception as exc:
+                set_v2_state(
+                    task_dir,
+                    "NEEDS_EVIDENCE",
+                    phase="receipt",
+                    reason=f"exact evidence verification failed: {exc}",
+                )
+                raise
+        return new_state
+    except (KeyboardInterrupt, legacy.HarnessCancellation):
+        current = load_v2_state(task_dir)
+        if current.get("status") not in verifier.V2_TERMINAL_STATES:
+            set_v2_state(
+                task_dir,
+                "INTERRUPTED",
+                phase=current.get("phase", "verify"),
+                reason="verifier interrupted; resume preserves completed checkpoints",
+            )
+        raise
+    except legacy.HarnessError as exc:
+        current = load_v2_state(task_dir)
+        if current.get("status") == "VERIFYING":
+            set_v2_state(
+                task_dir,
+                "NEEDS_EVIDENCE",
+                phase=current.get("phase", "verify"),
+                reason=str(exc),
+            )
+        raise
+    finally:
+        release_v2_run_lock(lock)
+
+
+def cmd_verify(args: argparse.Namespace) -> int:
+    contract, task_dir, _ = load_v2_task(args.task_id, Path.cwd())
+    result = verify_task(contract, task_dir)
+    print(json.dumps(v2_status(contract, task_dir), indent=2, sort_keys=True))
+    return 0 if result == "PASSED" else 1
+
+
+def cmd_resume(args: argparse.Namespace) -> int:
+    contract, task_dir, _ = load_v2_task(args.task_id, Path.cwd())
+    result = verify_task(contract, task_dir)
+    print(json.dumps(v2_status(contract, task_dir), indent=2, sort_keys=True))
+    return 0 if result == "PASSED" else 1
+
+
+def _legacy_degraded_provenance(task_dir: Path) -> List[Dict[str, Any]]:
+    values: List[Dict[str, Any]] = []
+    provenance_known = False
+    attestation_rounds = 0
+    attestation_path = task_dir / "attestation.json"
+    if attestation_path.is_file():
+        attestation = legacy.load_json(attestation_path)
+        provenance_known = attestation.get("provenance_schema_version") == 2
+        attestation_rounds = int(attestation.get("rounds", 0) or 0)
+        for item in attestation.get("degraded_provenance", []):
+            if isinstance(item, dict):
+                values.append({"source": "attestation", **item})
+        writer = attestation.get("writer", {})
+        if isinstance(writer, dict) and (
+            writer.get("degraded") or writer.get("timed_out")
+        ):
+            values.append(
+                {
+                    "source": "attestation-writer",
+                    "round": writer.get("round"),
+                    "label": writer.get("label"),
+                    "degraded": writer.get("degraded"),
+                    "timed_out": bool(writer.get("timed_out")),
+                }
+            )
+    model_exit_events = 0
+    events_path = task_dir / "events.jsonl"
+    if events_path.is_file():
+        with events_path.open("r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                if event.get("event") == "model-process-exit":
+                    model_exit_events += 1
+                if event.get("event") in {
+                    "writer-timed-out-recovered",
+                    "writer-report-degraded",
+                } or (
+                    event.get("event") == "model-process-exit"
+                    and event.get("role") == "writer"
+                    and event.get("timed_out")
+                ):
+                    values.append(
+                        {
+                            "source": "event",
+                            "event": event.get("event"),
+                            "label": event.get("label"),
+                            "degraded": (
+                                "timeout"
+                                if event.get("timed_out")
+                                or event.get("event") == "writer-timed-out-recovered"
+                                else "unparseable-report"
+                            ),
+                            "timed_out": bool(event.get("timed_out")),
+                            "at": event.get("at"),
+                        }
+                    )
+    state_missing = not (task_dir / "state.json").is_file()
+    raw_model_logs = len(
+        [
+            path
+            for path in (task_dir / "logs").glob("*.jsonl")
+            if path.is_file() and not path.is_symlink()
+        ]
+    ) if (task_dir / "logs").is_dir() else 0
+    if (
+        state_missing
+        or (not provenance_known and attestation_rounds > 1)
+        or raw_model_logs > model_exit_events
+        or (raw_model_logs > 0 and not provenance_known)
+    ):
+        values.append(
+            {
+                "source": "legacy-import",
+                "degraded": "legacy-provenance-unknown",
+                "state_missing": state_missing,
+                "attestation_rounds": attestation_rounds,
+                "raw_model_logs": raw_model_logs,
+                "model_exit_events": model_exit_events,
+            }
+        )
+    unique: Dict[bytes, Dict[str, Any]] = {}
+    for item in values:
+        unique[legacy.canonical_json(item)] = item
+    return [unique[key] for key in sorted(unique)]
+
+
+def _directory_digest(root: Path) -> str:
+    digest = hashlib.sha256()
+    if not root.is_dir() or root.is_symlink():
+        raise legacy.HarnessError(f"unsafe legacy task directory: {root}")
+    for path in sorted(root.rglob("*"), key=lambda item: item.as_posix()):
+        relative = path.relative_to(root).as_posix()
+        # The import holds this ephemeral liveness lock for the whole
+        # byte-preserving adoption. Its PID/timestamp are not v1 evidence and
+        # would otherwise make every later idempotency digest differ.
+        if relative == "run.lock":
+            continue
+        metadata = path.lstat()
+        digest.update(relative.encode("utf-8", "surrogateescape"))
+        digest.update(b"\x00")
+        digest.update(str(stat.S_IFMT(metadata.st_mode)).encode("ascii"))
+        digest.update(b"\x00")
+        if path.is_symlink():
+            digest.update(os.readlink(path).encode("utf-8", "surrogateescape"))
+        elif path.is_file():
+            with path.open("rb") as handle:
+                for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                    digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _legacy_state_for_import(
+    source_dir: Path,
+) -> Tuple[Dict[str, Any], Optional[str]]:
+    state_path = source_dir / "state.json"
+    if state_path.is_file():
+        return legacy.load_json(state_path), legacy.sha256_file(state_path)
+    status = "UNKNOWN"
+    last_event: Dict[str, Any] = {}
+    events_path = source_dir / "events.jsonl"
+    if events_path.is_file():
+        with events_path.open("r", encoding="utf-8", errors="strict") as handle:
+            for line in handle:
+                event = json.loads(line)
+                if (
+                    isinstance(event, dict)
+                    and event.get("event") == "state"
+                    and isinstance(event.get("status"), str)
+                ):
+                    last_event = event
+                    status = event["status"]
+    return {
+        "task_id": source_dir.name,
+        "status": status,
+        "round": last_event.get("round", 0),
+        "phase": last_event.get("phase", "ghost-import"),
+        "reason": "v1 state.json is missing; status recovered from append-only events",
+        "ghost": True,
+    }, None
+
+
+def _private_visible_tree(worktree: Path, runtime_dir: Path) -> str:
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    import tempfile
+
+    descriptor, raw_index = tempfile.mkstemp(
+        prefix="v1-import-tree-", dir=str(runtime_dir)
+    )
+    os.close(descriptor)
+    index = Path(raw_index)
+    environment = {**os.environ, "GIT_INDEX_FILE": str(index)}
+    try:
+        index.unlink(missing_ok=True)
+        subprocess.run(
+            ["git", "read-tree", "HEAD"],
+            cwd=str(worktree),
+            env=environment,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "add", "-A", "--", "."],
+            cwd=str(worktree),
+            env=environment,
+            check=True,
+            capture_output=True,
+        )
+        return subprocess.run(
+            ["git", "write-tree"],
+            cwd=str(worktree),
+            env=environment,
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+    except subprocess.CalledProcessError as exc:
+        detail = (
+            exc.stderr.decode("utf-8", "replace")
+            if isinstance(exc.stderr, bytes)
+            else str(exc.stderr)
+        )
+        raise legacy.HarnessError(
+            f"could not reconstruct v1 visible tree: {detail}"
+        ) from exc
+    finally:
+        index.unlink(missing_ok=True)
+
+
+def _restore_v1_worktree(
+    primary: Path,
+    source: Mapping[str, Any],
+    source_dir: Path,
+    target_runtime: Path,
+) -> bool:
+    worktree = Path(str(source["worktree_path"])).resolve()
+    if worktree.exists():
+        return worktree.is_dir() and not worktree.is_symlink()
+    archive: Dict[str, Any] = {}
+    if (source_dir / "archive.json").is_file():
+        archive = legacy.load_json(source_dir / "archive.json")
+    candidates = [
+        str(archive.get("snapshot_sha", "")),
+        legacy.git(
+            primary,
+            "show-ref",
+            "--verify",
+            "--hash",
+            f"refs/heads/{source['branch']}",
+            check=False,
+        ),
+        legacy.git(
+            primary,
+            "rev-parse",
+            "--verify",
+            legacy.task_archive_ref(source),
+            check=False,
+        ),
+    ]
+    snapshot = next(
+        (
+            candidate
+            for candidate in candidates
+            if isinstance(candidate, str)
+            and legacy.SHA1_RE.fullmatch(candidate)
+            and legacy.run_capture(
+                ["git", "cat-file", "-e", f"{candidate}^{{commit}}"],
+                primary,
+                check=False,
+            ).returncode
+            == 0
+        ),
+        None,
+    )
+    if snapshot is None:
+        return False
+    snapshot_tree = legacy.git(primary, "rev-parse", f"{snapshot}^{{tree}}")
+    recorded_tree = archive.get("tree_sha")
+    if recorded_tree and recorded_tree != snapshot_tree:
+        raise legacy.HarnessError(
+            "v1 archive snapshot tree differs from its recorded tree"
+        )
+    base = str(source["base_sha"])
+    if (
+        legacy.run_capture(
+            ["git", "cat-file", "-e", f"{base}^{{commit}}"],
+            primary,
+            check=False,
+        ).returncode
+        != 0
+    ):
+        raise legacy.HarnessError("v1 base commit is unavailable for reconstruction")
+    archive_ref = legacy.task_archive_ref(source)
+    legacy.git(primary, "update-ref", archive_ref, snapshot)
+    worktree.parent.mkdir(parents=True, exist_ok=True)
+    legacy._prune_worktree_registrations(primary)
+    legacy.run_capture(
+        [
+            "git",
+            "worktree",
+            "add",
+            "-B",
+            str(source["branch"]),
+            str(worktree),
+            base,
+        ],
+        primary,
+    )
+    try:
+        legacy.git(worktree, "read-tree", "--reset", "-u", snapshot)
+        legacy.git(worktree, "reset", "--quiet", "HEAD", "--", ".")
+        if legacy.git(worktree, "rev-parse", "HEAD") != base:
+            raise legacy.HarnessError("reconstructed v1 worktree is not at task base")
+        if _private_visible_tree(worktree, target_runtime) != snapshot_tree:
+            raise legacy.HarnessError(
+                "reconstructed v1 worktree bytes differ from archived tree"
+            )
+    except Exception:
+        # The archive ref remains the lossless recovery point.  Do not silently
+        # adopt a partial reconstruction.
+        raise
+    return True
+
+
+def cmd_import_v1(args: argparse.Namespace) -> int:
+    _primary, common = legacy.repo_context(Path.cwd())
+    _valid_task_id(args.task_id)
+    source_dir = v1_task_dir(common, args.task_id)
+    if not (source_dir / "task.json").is_file():
+        raise legacy.HarnessError(f"v1 task does not exist: {args.task_id}")
+    lock = legacy.acquire_run_lock(source_dir)
+    try:
+        return _cmd_import_v1_locked(args)
+    finally:
+        legacy.release_run_lock(lock)
+
+
+def _cmd_import_v1_locked(args: argparse.Namespace) -> int:
+    cwd = Path.cwd()
+    primary, common = legacy.repo_context(cwd)
+    _valid_task_id(args.task_id)
+    source_dir = v1_task_dir(common, args.task_id)
+    source_path = source_dir / "task.json"
+    if not source_path.is_file():
+        raise legacy.HarnessError(f"v1 task does not exist: {args.task_id}")
+    source = legacy.load_json(source_path)
+    legacy.validate_schema(source, legacy.load_schema("task"), label="v1 task")
+    source_hash = legacy.contract_hash(source)
+    if source.get("contract_sha256") != source_hash:
+        raise legacy.HarnessError("cannot import a stale v1 task contract")
+    if not source.get("expected_change", True):
+        raise legacy.HarnessError(
+            "Harness v2 does not import no-change tasks; retain the v1 record"
+        )
+    protected = _protected_v2_paths(list(source.get("owned_paths", [])))
+    if protected:
+        raise legacy.HarnessError(
+            "protected v1 control-plane work cannot be imported into the "
+            "self-verifying v2 candidate; finish it through v1 seal-prepared "
+            f"({', '.join(protected)})"
+        )
+    source_bytes_before = _directory_digest(source_dir)
+    target_dir = v2_task_dir(common, args.task_id)
+    expected_supersedes = {
+        "generation": 1,
+        "task_id": args.task_id,
+        "contract_sha256": source_hash,
+    }
+    if target_dir.exists():
+        existing, _, _ = load_v2_task(args.task_id, cwd)
+        if existing.get("supersedes") != expected_supersedes:
+            raise legacy.HarnessError("v2 import collision does not supersede this exact v1 contract")
+        imported = legacy.load_json(target_dir / "imports" / "v1.json")
+        if imported.get("source_directory_sha256") != source_bytes_before:
+            raise legacy.HarnessError(
+                "v1 source artifacts changed after import; idempotent adoption refused"
+            )
+        print(
+            json.dumps(
+                {
+                    "task_id": args.task_id,
+                    "generation": 2,
+                    "status": load_v2_state(target_dir)["status"],
+                    "idempotent": True,
+                    "source_unchanged": True,
+                },
+                indent=2,
+            )
+        )
+        return 0
+    source_state, source_state_sha256 = _legacy_state_for_import(source_dir)
+    if source_state.get("status") in {"PASSED", "COMMITTED"} and not args.invalidate_pass:
+        raise legacy.HarnessError(
+            "PASSED/COMMITTED v1 tasks should finish in v1; pass --invalidate-pass to resume in v2"
+        )
+    worktree = Path(str(source["worktree_path"]))
+    worktree_present = worktree.is_dir() and not worktree.is_symlink()
+    if not worktree_present:
+        import_runtime = v2_store(common) / "runtime" / f"import-{args.task_id}"
+        try:
+            worktree_present = _restore_v1_worktree(
+                primary,
+                source,
+                source_dir,
+                import_runtime,
+            )
+        finally:
+            shutil.rmtree(import_runtime, ignore_errors=True)
+    if worktree_present:
+        if Path(legacy.git(worktree, "rev-parse", "--show-toplevel")).resolve() != worktree.resolve():
+            raise legacy.HarnessError("v1 worktree path is not its Git root")
+        actual_base = legacy.git(worktree, "rev-parse", "HEAD")
+        actual_branch = legacy.git(worktree, "branch", "--show-current")
+        if actual_branch != source["branch"]:
+            raise legacy.HarnessError("v1 worktree branch changed before import")
+        if actual_base != source["base_sha"]:
+            raise legacy.HarnessError(
+                "v1 worktree HEAD moved beyond its contracted base; refusing "
+                "to hide committed bytes as a new v2 base. Preserve/archive the "
+                "branch, restore the original base with its visible tree, then import."
+            )
+    else:
+        actual_base = source["base_sha"]
+        actual_branch = source["branch"]
+    reviewer = args.reviewer or source.get("reviewer")
+    if reviewer not in legacy.REAL_MODEL_VENDORS and not (
+        reviewer == "fake" and os.environ.get("MURMUR_HARNESS_SELFTEST") == "1"
+    ):
+        raise legacy.HarnessError("imported v2 reviewer must be codex or claude")
+    contract: Dict[str, Any] = {
+        "schema_version": 2,
+        "task_id": args.task_id,
+        "description": str(source["description"]),
+        "kind": "import",
+        "base_sha": actual_base,
+        "contract_sha256": "",
+        "repo_realpath": str(primary.resolve()),
+        "git_common_dir": str(common.resolve()),
+        "worktree_path": str(worktree.resolve()),
+        "branch": actual_branch,
+        "owned_paths": list(source["owned_paths"]),
+        "claims": sorted(set(args.claim or [])),
+        "reviewer": reviewer,
+        "expected_change": bool(source["expected_change"]),
+        "degraded_provenance": _legacy_degraded_provenance(source_dir),
+        "supersedes": expected_supersedes,
+        "created_at": legacy.utc_now(),
+    }
+    contract["contract_sha256"] = verifier.document_hash(
+        contract, "contract_sha256"
+    )
+    legacy.validate_schema(
+        contract, legacy.load_schema("v2-task"), label="imported v2 task"
+    )
+    target_dir.mkdir(parents=True)
+    try:
+        legacy.atomic_write_json(target_dir / "task.json", contract)
+        source_runtime = (
+            legacy.load_json(source_dir / "runtime.json")
+            if (source_dir / "runtime.json").is_file()
+            else {}
+        )
+        legacy.atomic_write_json(
+            target_dir / "runtime.json",
+            {
+                "schema_version": 2,
+                "task_root": str(worktree.parent),
+                "shared_node_modules": source_runtime.get("shared_node_modules"),
+                "server_worktree": source_runtime.get("server_worktree"),
+                "server_source": source_runtime.get(
+                    "server_source", str(primary.parent / "murmur-server")
+                ),
+                "server_revision": source.get("dependency_revisions", {}).get(
+                    "murmur-server.expected"
+                ),
+                # Missing means an imported legacy linked worktree.
+                "server_checkout_mode": source_runtime.get(
+                    "server_checkout_mode"
+                ),
+            },
+        )
+        legacy.atomic_write_json(
+            target_dir / "imports" / "v1.json",
+            {
+                "schema_version": 2,
+                "task_id": args.task_id,
+                "source_contract_sha256": source_hash,
+                "source_task_path": str(source_path),
+                "source_state_sha256": source_state_sha256,
+                "source_events_sha256": (
+                    legacy.sha256_file(source_dir / "events.jsonl")
+                    if (source_dir / "events.jsonl").is_file()
+                    else None
+                ),
+                "source_directory_sha256": source_bytes_before,
+                "source_worktree_present": worktree_present,
+                "imported_at": legacy.utc_now(),
+            },
+        )
+        set_v2_state(
+            target_dir,
+            "OPEN" if worktree_present else "NEEDS_EVIDENCE",
+            phase="import",
+            reason=(
+                "v1 worktree adopted without re-running a writer"
+                if worktree_present
+                else "v1 worktree is missing; import is history-only and cannot PASS"
+            ),
+        )
+        if _directory_digest(source_dir) != source_bytes_before:
+            raise legacy.HarnessError(
+                "v1 source artifacts changed during import; refusing adoption"
+            )
+    except Exception:
+        shutil.rmtree(target_dir, ignore_errors=True)
+        raise
+    print(
+        json.dumps(
+            {
+                "task_id": args.task_id,
+                "generation": 2,
+                "status": load_v2_state(target_dir)["status"],
+                "worktree_present": worktree_present,
+                "source_unchanged": True,
+                "degraded_attempts": len(contract["degraded_provenance"]),
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+def _stage_v2_commit(
+    contract: Mapping[str, Any], task_dir: Path, evidence: Mapping[str, Any]
+) -> None:
+    worktree = Path(str(contract["worktree_path"]))
+    # This is the one intentional real-index mutation in v2.  It happens only
+    # after exact evidence is verified, immediately before commit.
+    legacy.git(worktree, "reset", "--quiet", "HEAD", "--", ".")
+    if evidence["changed_paths"]:
+        legacy.git(worktree, "add", "-A", "--", *contract["owned_paths"])
+    diff = legacy.staged_diff(worktree)
+    if legacy.sha256_bytes(diff) != evidence["diff_sha256"]:
+        raise legacy.HarnessError("real staged index differs from v2 evidence")
+    if legacy.git(worktree, "write-tree") != evidence["tree_sha"]:
+        raise legacy.HarnessError("real staged tree differs from v2 evidence")
+
+
+def _v2_commit_message(message: str, evidence: Mapping[str, Any]) -> str:
+    subject = message.strip()
+    if not subject or "\x00" in subject:
+        raise legacy.HarnessError("commit message must be non-empty and contain no NUL")
+    if re.search(
+        r"(?im)^\s*(?:Harness-(?:Version|Task|Verdict|Base|Diff-Sha256|"
+        r"Evidence-Sha256|Attestation-Sha256)|Co-Authored-By):",
+        subject,
+    ):
+        raise legacy.HarnessError(
+            "commit message must not contain receipt or co-author trailers"
+        )
+    degraded = evidence.get("degraded_provenance", [])
+    trailers = [
+        "Harness-Version: 2",
+        f"Harness-Task: {evidence['task_id']}",
+        "Harness-Verdict: PASS",
+        f"Harness-Base: {evidence['parent_sha']}",
+        f"Harness-Diff-Sha256: {evidence['diff_sha256']}",
+        f"Harness-Evidence-Sha256: {evidence['evidence_sha256']}",
+        # Transitional alias so an older presence-only gate sees a receipt;
+        # strict v2 verification requires the alias to equal Evidence.
+        f"Harness-Attestation-Sha256: {evidence['evidence_sha256']}",
+    ]
+    if degraded:
+        labels = sorted(
+            {
+                str(item.get("degraded") or item.get("event") or "degraded")
+                for item in degraded
+                if isinstance(item, Mapping)
+            }
+        )
+        trailers.insert(3, "Harness-Writer-Degraded: " + ",".join(labels))
+    return subject + "\n\n" + "\n".join(trailers)
+
+
+def _strict_v2_receipt_trailers(
+    message: str, evidence: Mapping[str, Any]
+) -> Dict[str, str]:
+    keys = {
+        "Harness-Version",
+        "Harness-Task",
+        "Harness-Verdict",
+        "Harness-Base",
+        "Harness-Diff-Sha256",
+        "Harness-Evidence-Sha256",
+        "Harness-Attestation-Sha256",
+        "Harness-Writer-Degraded",
+    }
+    values: Dict[str, str] = {}
+    for line in message.splitlines():
+        match = re.fullmatch(r"(Harness-[A-Za-z0-9-]+): ([^\r\n]+)", line)
+        if match is None:
+            if re.match(r"(?i)^\s*Harness-", line):
+                raise legacy.HarnessError(
+                    "v2 commit contains a malformed receipt trailer"
+                )
+            continue
+        key, value = match.groups()
+        if key not in keys:
+            raise legacy.HarnessError(
+                f"v2 commit contains an unknown receipt trailer: {key}"
+            )
+        if key in values:
+            raise legacy.HarnessError(
+                f"v2 commit contains duplicate receipt trailer: {key}"
+            )
+        values[key] = value
+    expected = {
+        "Harness-Version": "2",
+        "Harness-Task": str(evidence["task_id"]),
+        "Harness-Verdict": "PASS",
+        "Harness-Base": str(evidence["parent_sha"]),
+        "Harness-Diff-Sha256": str(evidence["diff_sha256"]),
+        "Harness-Evidence-Sha256": str(evidence["evidence_sha256"]),
+        "Harness-Attestation-Sha256": str(evidence["evidence_sha256"]),
+    }
+    degraded = evidence.get("degraded_provenance", [])
+    if degraded:
+        labels = sorted(
+            {
+                str(item.get("degraded") or item.get("event") or "degraded")
+                for item in degraded
+                if isinstance(item, Mapping)
+            }
+        )
+        expected["Harness-Writer-Degraded"] = ",".join(labels)
+    if values != expected:
+        raise legacy.HarnessError(
+            "v2 commit trailers do not exactly match the attested evidence"
+        )
+    return values
+
+
+def cmd_v2_guard_commit(
+    contract: Mapping[str, Any],
+    task_dir: Path,
+    *,
+    allow_test_adapter: bool = False,
+) -> Dict[str, Any]:
+    evidence = verifier.verify_v2_evidence(
+        contract, task_dir, allow_test_adapter=allow_test_adapter
+    )
+    _stage_v2_commit(contract, task_dir, evidence)
+    return evidence
+
+
+def _commit_intent(
+    contract: Mapping[str, Any],
+    task_dir: Path,
+    evidence: Mapping[str, Any],
+    message: str,
+) -> Dict[str, Any]:
+    intent: Dict[str, Any] = {
+        "schema_version": 2,
+        "task_id": contract["task_id"],
+        "contract_sha256": contract["contract_sha256"],
+        "evidence_sha256": evidence["evidence_sha256"],
+        "parent_sha": evidence["parent_sha"],
+        "tree_sha": evidence["tree_sha"],
+        "diff_sha256": evidence["diff_sha256"],
+        "message": message,
+        "message_sha256": legacy.sha256_bytes(message.encode("utf-8")),
+        # Intent is deterministically bound to the immutable PASS evidence so
+        # retrying before/after git commit reproduces the exact same artifact.
+        "created_at": evidence["created_at"],
+        "intent_sha256": "",
+    }
+    intent["intent_sha256"] = verifier.document_hash(intent, "intent_sha256")
+    path = task_dir / "commit-intent.json"
+    if path.is_file():
+        existing = legacy.load_json(path)
+        verifier.validate_hashed_document(
+            existing,
+            "v2-commit-intent",
+            "intent_sha256",
+            "v2 commit intent",
+        )
+        if existing != intent:
+            raise legacy.HarnessError(
+                "existing v2 commit intent differs; resume with the exact original message"
+            )
+        return existing
+    legacy.validate_schema(
+        intent,
+        legacy.load_schema("v2-commit-intent"),
+        label="v2 commit intent",
+    )
+    legacy.atomic_write_json(path, intent)
+    return intent
+
+
+def _validate_v2_commit_head(
+    worktree: Path,
+    evidence: Mapping[str, Any],
+    intent: Mapping[str, Any],
+    expected_identity: Mapping[str, str],
+) -> Dict[str, Any]:
+    commit_sha = legacy.git(worktree, "rev-parse", "HEAD")
+    parent_sha = legacy.git(worktree, "rev-parse", "HEAD^")
+    tree_sha = legacy.git(worktree, "rev-parse", "HEAD^{tree}")
+    actual_diff = legacy.git_bytes(
+        worktree,
+        "diff",
+        "--binary",
+        "--full-index",
+        "--no-ext-diff",
+        "--no-renames",
+        parent_sha,
+        commit_sha,
+        "--",
+    )
+    author = {
+        "name": legacy.git(worktree, "log", "-1", "--format=%an"),
+        "email": legacy.git(worktree, "log", "-1", "--format=%ae"),
+    }
+    committer = {
+        "name": legacy.git(worktree, "log", "-1", "--format=%cn"),
+        "email": legacy.git(worktree, "log", "-1", "--format=%ce"),
+    }
+    actual_message = legacy.git(
+        worktree, "log", "-1", "--format=%B"
+    ).rstrip("\n")
+    if parent_sha != evidence["parent_sha"] or parent_sha != intent["parent_sha"]:
+        raise legacy.HarnessError("v2 commit actual parent differs from evidence/intent")
+    if tree_sha != evidence["tree_sha"] or tree_sha != intent["tree_sha"]:
+        raise legacy.HarnessError("v2 commit tree differs from evidence/intent")
+    diff_sha = legacy.sha256_bytes(actual_diff)
+    if diff_sha != evidence["diff_sha256"] or diff_sha != intent["diff_sha256"]:
+        raise legacy.HarnessError("v2 commit diff differs from evidence/intent")
+    if actual_message != intent["message"]:
+        raise legacy.HarnessError("v2 commit message differs from the durable intent")
+    if legacy.sha256_bytes(actual_message.encode("utf-8")) != intent["message_sha256"]:
+        raise legacy.HarnessError("v2 commit message hash differs from the durable intent")
+    if author != expected_identity or committer != expected_identity:
+        raise legacy.HarnessError("v2 commit author/committer is not QueaT")
+    if legacy.git_bytes(worktree, "status", "--porcelain").strip():
+        raise legacy.HarnessError("v2 committed worktree/index is not clean")
+    return {
+        "commit_sha": commit_sha,
+        "parent_sha": parent_sha,
+        "tree_sha": tree_sha,
+        "diff_sha256": diff_sha,
+        "author": author,
+        "committer": committer,
+        "message": actual_message,
+    }
+
+
+def cmd_v2_commit(args: argparse.Namespace) -> int:
+    contract, task_dir, _ = load_v2_task(args.task_id, Path.cwd())
+    lock = acquire_v2_run_lock(task_dir, "commit")
+    try:
+        return _cmd_v2_commit_locked(args, contract, task_dir)
+    finally:
+        release_v2_run_lock(lock)
+
+
+def _cmd_v2_commit_locked(
+    args: argparse.Namespace,
+    contract: Mapping[str, Any],
+    task_dir: Path,
+) -> int:
+    allow_test_adapter = bool(
+        getattr(args, "_allow_test_adapter", False)
+    )
+    state = load_v2_state(task_dir)
+    if state.get("status") == "COMMITTED":
+        receipt = verify_v2_committed(
+            contract,
+            task_dir,
+            allow_test_adapter=allow_test_adapter,
+        )
+        print(
+            json.dumps(
+                {
+                    "task_id": contract["task_id"],
+                    "generation": 2,
+                    "status": "COMMITTED",
+                    "commit_sha": receipt["commit_sha"],
+                    "idempotent": True,
+                },
+                indent=2,
+            )
+        )
+        return 0
+    if state.get("status") != "PASSED":
+        raise legacy.HarnessError("only a PASSED v2 task can be committed")
+    worktree = Path(str(contract["worktree_path"]))
+    identity = legacy.load_config().get("commit_identity", {})
+    name = identity.get("name") if isinstance(identity, Mapping) else None
+    email = identity.get("email") if isinstance(identity, Mapping) else None
+    if (name, email) != ("QueaT", "kgm004a@gmail.com"):
+        raise legacy.HarnessError("v2 commit identity contract changed")
+    expected_identity = {"name": name, "email": email}
+    current_head = legacy.git(worktree, "rev-parse", "HEAD")
+    if current_head == contract["base_sha"]:
+        evidence = cmd_v2_guard_commit(
+            contract,
+            task_dir,
+            allow_test_adapter=allow_test_adapter,
+        )
+        message = _v2_commit_message(args.message, evidence)
+        intent = _commit_intent(contract, task_dir, evidence, message)
+        legacy.run_capture(
+            [
+                "git",
+                "-c",
+                f"user.name={name}",
+                "-c",
+                f"user.email={email}",
+                "commit",
+                "-m",
+                message,
+            ],
+            worktree,
+        )
+        if (
+            os.environ.get("MURMUR_HARNESS_SELFTEST") == "1"
+            and os.environ.get("MURMUR_HARNESS_SELFTEST_KILL_AFTER_GIT_COMMIT")
+            == "1"
+        ):
+            os.kill(os.getpid(), signal.SIGKILL)
+    else:
+        intent = legacy.load_json(task_dir / "commit-intent.json")
+        verifier.validate_hashed_document(
+            intent,
+            "v2-commit-intent",
+            "intent_sha256",
+            "v2 commit intent",
+        )
+        evidence = verifier.verify_v2_evidence(
+            contract,
+            task_dir,
+            allow_test_adapter=allow_test_adapter,
+            allow_committed_head=True,
+        )
+        message = _v2_commit_message(args.message, evidence)
+        if intent.get("message") != message:
+            raise legacy.HarnessError(
+                "commit recovery requires the exact original commit message"
+            )
+    committed = _validate_v2_commit_head(
+        worktree, evidence, intent, expected_identity
+    )
+    commit_sha = committed["commit_sha"]
+    parent_sha = committed["parent_sha"]
+    tree_sha = committed["tree_sha"]
+    author = committed["author"]
+    committer = committed["committer"]
+    receipt = {
+        "schema_version": 2,
+        "task_id": contract["task_id"],
+        "contract_sha256": contract["contract_sha256"],
+        "evidence_sha256": evidence["evidence_sha256"],
+        "commit_sha": commit_sha,
+        "parent_sha": parent_sha,
+        "tree_sha": tree_sha,
+        "diff_sha256": evidence["diff_sha256"],
+        "author": author,
+        "committer": committer,
+        "message": committed["message"],
+        "authored_at": legacy.git(worktree, "log", "-1", "--format=%aI"),
+        "committed_at": legacy.git(worktree, "log", "-1", "--format=%cI"),
+        "recorded_at": legacy.utc_now(),
+    }
+    legacy.validate_schema(
+        receipt, legacy.load_schema("v2-commit"), label="v2 commit receipt"
+    )
+    legacy.atomic_write_json(task_dir / "commit.json", receipt)
+    set_v2_state(
+        task_dir,
+        "COMMITTED",
+        phase="commit",
+        commit_sha=commit_sha,
+        parent_sha=parent_sha,
+        tree_sha=tree_sha,
+        evidence_path=load_v2_state(task_dir).get("evidence_path"),
+        evidence_sha256=evidence["evidence_sha256"],
+    )
+    print(
+        json.dumps(
+            {
+                "task_id": contract["task_id"],
+                "generation": 2,
+                "status": "COMMITTED",
+                "commit_sha": commit_sha,
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+def _v2_archive_ref(task_id: str) -> str:
+    safe = re.sub(r"[^a-zA-Z0-9._-]+", "-", task_id).strip(".-")
+    safe = safe.replace("..", "-") or "task"
+    suffix = legacy.sha256_bytes(task_id.encode("utf-8"))[:12]
+    return f"refs/agent-harness/v2/archive/{safe}-{suffix}"
+
+
+def _archive_all_visible_bytes(
+    primary: Path,
+    worktree: Path,
+    contract: Mapping[str, Any],
+    task_dir: Path,
+) -> Tuple[str, str, str]:
+    """Archive HEAD plus every tracked/untracked byte via a private index."""
+
+    runtime = task_dir / "runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    import tempfile
+
+    descriptor, raw_index = tempfile.mkstemp(prefix="v2-clean-index-", dir=str(runtime))
+    os.close(descriptor)
+    index_path = Path(raw_index)
+    environment = {**os.environ, "GIT_INDEX_FILE": str(index_path)}
+    head = legacy.git(worktree, "rev-parse", "HEAD")
+    try:
+        index_path.unlink(missing_ok=True)
+        subprocess.run(
+            ["git", "read-tree", "HEAD"],
+            cwd=str(worktree),
+            env=environment,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "add", "-A", "--", "."],
+            cwd=str(worktree),
+            env=environment,
+            check=True,
+            capture_output=True,
+        )
+        tree = subprocess.run(
+            ["git", "write-tree"],
+            cwd=str(worktree),
+            env=environment,
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout.strip()
+    except subprocess.CalledProcessError as exc:
+        detail = (
+            exc.stderr.decode("utf-8", "replace")
+            if isinstance(exc.stderr, bytes)
+            else str(exc.stderr)
+        )
+        raise legacy.HarnessError(
+            "could not archive every Git-visible v2 byte: " + detail
+        ) from exc
+    finally:
+        index_path.unlink(missing_ok=True)
+    if tree == legacy.git(worktree, "rev-parse", "HEAD^{tree}"):
+        snapshot = head
+    else:
+        identity = legacy.load_config()["commit_identity"]
+        snapshot = legacy.git(
+            worktree,
+            "-c",
+            f"user.name={identity['name']}",
+            "-c",
+            f"user.email={identity['email']}",
+            "commit-tree",
+            tree,
+            "-p",
+            head,
+            "-m",
+            f"harness v2 archive: {contract['task_id']}",
+        )
+    archive_ref = _v2_archive_ref(str(contract["task_id"]))
+    legacy.git(primary, "update-ref", archive_ref, snapshot)
+    if legacy.git(primary, "rev-parse", archive_ref) != snapshot:
+        raise legacy.HarnessError("v2 archive ref verification failed")
+    if legacy.git(primary, "rev-parse", f"{snapshot}^{{tree}}") != tree:
+        raise legacy.HarnessError("v2 archive tree verification failed")
+    legacy.atomic_write_json(
+        task_dir / "archive.json",
+        {
+            "schema_version": 2,
+            "task_id": contract["task_id"],
+            "archive_ref": archive_ref,
+            "snapshot_sha": snapshot,
+            "original_head_sha": head,
+            "tree_sha": tree,
+            "created_at": legacy.utc_now(),
+        },
+    )
+    return archive_ref, snapshot, tree
+
+
+def _non_disposable_ignored_paths(worktree: Path) -> List[str]:
+    raw = legacy.git_bytes(
+        worktree,
+        "ls-files",
+        "--others",
+        "--ignored",
+        "--exclude-standard",
+        "-z",
+        "--",
+    )
+    values = sorted(
+        item.decode("utf-8", "surrogateescape")
+        for item in raw.split(b"\x00")
+        if item
+    )
+    if legacy.managed_node_modules_link(worktree):
+        values = [
+            path
+            for path in values
+            if path != "node_modules" and not path.startswith("node_modules/")
+        ]
+    return values
+
+
+def _clean_intent_document(
+    contract: Mapping[str, Any],
+    *,
+    final_status: str,
+    previous_status: str,
+    archive_ref: str,
+    snapshot_sha: str,
+    tree_sha: str,
+    server: Tuple[Optional[Path], Optional[Path], Optional[str]],
+    verification_snapshots: Sequence[Tuple[Path, str, str]],
+) -> Dict[str, Any]:
+    server_worktree, server_source, server_mode = server
+    document: Dict[str, Any] = {
+        "schema_version": 2,
+        "task_id": contract["task_id"],
+        "contract_sha256": contract["contract_sha256"],
+        "final_status": final_status,
+        "previous_status": previous_status,
+        "archive_ref": archive_ref,
+        "snapshot_sha": snapshot_sha,
+        "tree_sha": tree_sha,
+        "worktree_path": contract["worktree_path"],
+        "branch": contract["branch"],
+        "server_worktree": (
+            str(server_worktree) if server_worktree is not None else None
+        ),
+        "server_source": str(server_source) if server_source is not None else None,
+        "server_mode": server_mode,
+        "verification_snapshots": [
+            {
+                "path": str(path),
+                "snapshot_ref": reference,
+                "snapshot_commit": commit,
+            }
+            for path, reference, commit in verification_snapshots
+        ],
+        "created_at": legacy.utc_now(),
+        "intent_sha256": "",
+    }
+    document["intent_sha256"] = verifier.document_hash(
+        document, "intent_sha256"
+    )
+    return document
+
+
+def _load_clean_intent(
+    contract: Mapping[str, Any], task_dir: Path
+) -> Optional[Dict[str, Any]]:
+    path = task_dir / "clean-intent.json"
+    if not path.is_file():
+        return None
+    document = legacy.load_json(path)
+    if document.get("intent_sha256") != verifier.document_hash(
+        document, "intent_sha256"
+    ):
+        raise legacy.HarnessError("v2 clean intent hash mismatch")
+    for key, expected in (
+        ("schema_version", 2),
+        ("task_id", contract["task_id"]),
+        ("contract_sha256", contract["contract_sha256"]),
+        ("worktree_path", contract["worktree_path"]),
+        ("branch", contract["branch"]),
+    ):
+        if document.get(key) != expected:
+            raise legacy.HarnessError(f"v2 clean intent {key} is stale")
+    if document.get("final_status") not in {"CLOSED", "ABANDONED"}:
+        raise legacy.HarnessError("v2 clean intent final status is malformed")
+    return document
+
+
+def _server_cleanup_preflight(
+    contract: Mapping[str, Any], task_dir: Path
+) -> Tuple[Optional[Path], Optional[Path], Optional[str]]:
+    runtime = legacy.load_json(task_dir / "runtime.json")
+    raw_worktree = runtime.get("server_worktree")
+    raw_source = runtime.get("server_source")
+    if not raw_worktree:
+        return None, None, None
+    server_worktree = Path(str(raw_worktree))
+    server_source = Path(str(raw_source))
+    expected = Path(str(contract["worktree_path"])).parent / "murmur-server"
+    if server_worktree.resolve() != expected.resolve():
+        raise legacy.HarnessError("recorded v2 server worktree escapes the task root")
+    if not server_worktree.is_dir() or server_worktree.is_symlink():
+        raise legacy.HarnessError("recorded v2 server worktree is missing or unsafe")
+    if legacy.git_bytes(server_worktree, "status", "--porcelain").strip():
+        raise legacy.HarnessError(
+            "refusing clean: pinned server worktree is dirty; nothing was removed"
+        )
+    mode = str(runtime.get("server_checkout_mode") or "linked-worktree")
+    if mode not in {"linked-worktree", "local-shared-clone"}:
+        raise legacy.HarnessError(
+            f"recorded v2 server checkout mode is unsupported: {mode}"
+        )
+    if mode == "local-shared-clone":
+        common = Path(
+            legacy.git(
+                server_worktree,
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-common-dir",
+            )
+        ).resolve()
+        if common != (server_worktree / ".git").resolve():
+            raise legacy.HarnessError(
+                "local v2 server clone unexpectedly shares mutable Git metadata"
+            )
+    return server_worktree, server_source, mode
+
+
+def _verification_snapshots_for_cleanup(
+    contract: Mapping[str, Any], task_dir: Path
+) -> List[Tuple[Path, str, str]]:
+    values: List[Tuple[Path, str, str]] = []
+    attempts = task_dir / "attempts"
+    if not attempts.is_dir():
+        return values
+    primary = Path(str(contract["repo_realpath"])).resolve()
+    for attempt_dir in sorted(attempts.iterdir()):
+        manifest_path = attempt_dir / "snapshot.json"
+        if not manifest_path.is_file():
+            continue
+        manifest = legacy.load_json(manifest_path)
+        if (
+            manifest.get("snapshot_sha256")
+            != verifier.document_hash(manifest, "snapshot_sha256")
+        ):
+            raise legacy.HarnessError(
+                f"v2 snapshot manifest is corrupt: {manifest_path}"
+            )
+        expected_path = _verification_snapshot_path(contract, attempt_dir)
+        snapshot = Path(str(manifest.get("path", "")))
+        reference = str(manifest.get("snapshot_ref", ""))
+        commit_sha = str(manifest.get("snapshot_commit", ""))
+        if snapshot.resolve() != expected_path:
+            raise legacy.HarnessError("v2 cleanup snapshot path is stale")
+        if reference != _verification_snapshot_ref(
+            str(contract["task_id"]), attempt_dir.name
+        ):
+            raise legacy.HarnessError("v2 cleanup snapshot ref is stale")
+        if not legacy.SHA1_RE.fullmatch(commit_sha):
+            raise legacy.HarnessError("v2 cleanup snapshot commit is malformed")
+        current_ref = legacy.git(
+            primary, "rev-parse", "--verify", reference, check=False
+        )
+        if current_ref and current_ref != commit_sha:
+            raise legacy.HarnessError("v2 cleanup snapshot ref moved")
+        if snapshot.exists() or snapshot.is_symlink():
+            if not snapshot.is_dir() or snapshot.is_symlink():
+                raise legacy.HarnessError(
+                    "v2 cleanup snapshot path is not a safe directory"
+                )
+            common = Path(
+                legacy.git(
+                    snapshot,
+                    "rev-parse",
+                    "--path-format=absolute",
+                    "--git-common-dir",
+                )
+            ).resolve()
+            if common != (snapshot / ".git").resolve():
+                raise legacy.HarnessError(
+                    "v2 cleanup snapshot shares mutable Git metadata"
+                )
+        values.append((snapshot, reference, commit_sha))
+    return values
+
+
+def _v2_clean_catchup_merges(
+    worktree: Path,
+    attested_commit: str,
+    current_head: str,
+    *,
+    default_base: str,
+) -> List[str]:
+    """Validate only clean base-branch merges after an immutable task commit.
+
+    The task commit and its receipt never move.  A branch that became stale may
+    merge the configured base branch, but every first-parent descendant must be
+    a two-parent merge whose side parent is contained by that base branch and
+    whose tree is exactly Git's automatic merge tree.  This rejects rebases,
+    extra branch-authored commits, conflict resolutions, and merge smuggling.
+    """
+
+    if current_head == attested_commit:
+        return []
+    if (
+        legacy.run_capture(
+            [
+                "git",
+                "merge-base",
+                "--is-ancestor",
+                attested_commit,
+                current_head,
+            ],
+            worktree,
+            check=False,
+        ).returncode
+        != 0
+    ):
+        raise legacy.HarnessError(
+            "v2 task commit is not an ancestor of the current branch tip; "
+            "rebases and replacement commits require fresh verification"
+        )
+    base_tip = legacy.git(
+        worktree,
+        "rev-parse",
+        "--verify",
+        "--end-of-options",
+        f"{default_base}^{{commit}}",
+        check=False,
+    )
+    if not base_tip:
+        raise legacy.HarnessError(
+            f"cannot validate v2 catch-up merges: fetch {default_base} first"
+        )
+
+    merges: List[str] = []
+    cursor = current_head
+    seen: set[str] = set()
+    while cursor != attested_commit:
+        if cursor in seen:
+            raise legacy.HarnessError("cycle detected in v2 first-parent history")
+        seen.add(cursor)
+        raw = legacy.git(worktree, "show", "-s", "--format=%P", cursor)
+        parents = raw.split()
+        if len(parents) != 2:
+            raise legacy.HarnessError(
+                "v2 branch contains a non-merge commit after its attested task "
+                f"commit ({cursor[:12]}); re-verify branch-authored content"
+            )
+        first_parent, side_parent = parents
+        if (
+            legacy.run_capture(
+                [
+                    "git",
+                    "merge-base",
+                    "--is-ancestor",
+                    side_parent,
+                    base_tip,
+                ],
+                worktree,
+                check=False,
+            ).returncode
+            != 0
+        ):
+            raise legacy.HarnessError(
+                f"v2 catch-up merge {cursor[:12]} has a side parent outside "
+                f"{default_base}"
+            )
+        completed = subprocess.run(
+            [
+                "git",
+                "merge-tree",
+                "--write-tree",
+                "--no-messages",
+                first_parent,
+                side_parent,
+            ],
+            cwd=str(worktree),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise legacy.HarnessError(
+                f"v2 catch-up merge {cursor[:12]} had conflicts or manual "
+                "resolution; verify the resulting diff as a new task"
+            )
+        output = completed.stdout.strip().splitlines()
+        expected_tree = output[0] if output else ""
+        actual_tree = legacy.git(worktree, "rev-parse", f"{cursor}^{{tree}}")
+        if not expected_tree or expected_tree != actual_tree:
+            raise legacy.HarnessError(
+                f"v2 catch-up merge {cursor[:12]} contains unverified "
+                "resolution content"
+            )
+        merges.append(cursor)
+        cursor = first_parent
+    return merges
+
+
+def verify_v2_committed(
+    contract: Mapping[str, Any],
+    task_dir: Path,
+    *,
+    allow_test_adapter: bool = False,
+) -> Dict[str, Any]:
+    receipt = legacy.load_json(task_dir / "commit.json")
+    worktree = Path(str(contract["worktree_path"]))
+    if not worktree.is_dir() or worktree.is_symlink():
+        raise legacy.HarnessError("v2 committed worktree is missing or unsafe")
+    if (
+        Path(legacy.git(worktree, "rev-parse", "--show-toplevel")).resolve()
+        != worktree.resolve()
+    ):
+        raise legacy.HarnessError("v2 committed worktree path is not its Git root")
+    if legacy.git(worktree, "branch", "--show-current") != contract["branch"]:
+        raise legacy.HarnessError("v2 committed task branch changed")
+    if legacy.git_bytes(worktree, "status", "--porcelain").strip():
+        raise legacy.HarnessError("v2 committed worktree/index is not clean")
+
+    attested_commit = str(receipt.get("commit_sha", ""))
+    if not legacy.SHA1_RE.fullmatch(attested_commit):
+        raise legacy.HarnessError("v2 committed receipt commit is malformed")
+    legacy.validate_schema(
+        receipt,
+        verifier.attested_schema(worktree, attested_commit, "v2-commit"),
+        label="v2 commit receipt",
+    )
+    attested_config = verifier.attested_json_object(
+        worktree,
+        attested_commit,
+        ".agents/harness/config.json",
+        "harness config",
+    )
+    default_base = attested_config.get("default_base", "origin/murmur")
+    if not isinstance(default_base, str) or not default_base:
+        raise legacy.HarnessError("v2 attested default_base is malformed")
+    current_head = legacy.git(worktree, "rev-parse", "HEAD")
+    _v2_clean_catchup_merges(
+        worktree,
+        attested_commit,
+        current_head,
+        default_base=default_base,
+    )
+    parents = legacy.git(
+        worktree, "show", "-s", "--format=%P", attested_commit
+    ).split()
+    if len(parents) != 1:
+        raise legacy.HarnessError("v2 attested task commit must have exactly one parent")
+    parent = parents[0]
+    tree = legacy.git(worktree, "rev-parse", f"{attested_commit}^{{tree}}")
+    diff = legacy.git_bytes(
+        worktree,
+        "diff",
+        "--binary",
+        "--full-index",
+        "--no-ext-diff",
+        "--no-renames",
+        parent,
+        attested_commit,
+        "--",
+    )
+    for key, value in (
+        ("task_id", contract["task_id"]),
+        ("contract_sha256", contract["contract_sha256"]),
+        ("commit_sha", attested_commit),
+        ("parent_sha", parent),
+        ("tree_sha", tree),
+        ("diff_sha256", legacy.sha256_bytes(diff)),
+    ):
+        if receipt.get(key) != value:
+            raise legacy.HarnessError(f"v2 committed receipt {key} is stale")
+    state = load_v2_state(task_dir)
+    for key, value in (
+        ("commit_sha", attested_commit),
+        ("parent_sha", parent),
+        ("tree_sha", tree),
+        ("evidence_sha256", receipt["evidence_sha256"]),
+    ):
+        if state.get(key) != value:
+            raise legacy.HarnessError(
+                f"v2 committed state {key} differs from its receipt"
+            )
+    evidence = verifier.verify_v2_evidence(
+        contract,
+        task_dir,
+        allow_test_adapter=allow_test_adapter,
+        attested_commit_sha=attested_commit,
+    )
+    if receipt.get("evidence_sha256") != evidence.get("evidence_sha256"):
+        raise legacy.HarnessError("v2 commit no longer binds its exact evidence")
+    if receipt.get("author") != {
+        "name": "QueaT",
+        "email": "kgm004a@gmail.com",
+    } or receipt.get("committer") != {
+        "name": "QueaT",
+        "email": "kgm004a@gmail.com",
+    }:
+        raise legacy.HarnessError("v2 committed receipt identity is invalid")
+    actual_author = {
+        "name": legacy.git(worktree, "show", "-s", "--format=%an", attested_commit),
+        "email": legacy.git(worktree, "show", "-s", "--format=%ae", attested_commit),
+    }
+    actual_committer = {
+        "name": legacy.git(worktree, "show", "-s", "--format=%cn", attested_commit),
+        "email": legacy.git(worktree, "show", "-s", "--format=%ce", attested_commit),
+    }
+    actual_message = legacy.git(
+        worktree, "show", "-s", "--format=%B", attested_commit
+    ).rstrip("\n")
+    _strict_v2_receipt_trailers(actual_message, evidence)
+    if receipt.get("author") != actual_author or receipt.get("committer") != actual_committer:
+        raise legacy.HarnessError("v2 committed receipt identity is stale")
+    if receipt.get("message") != actual_message:
+        raise legacy.HarnessError("v2 committed receipt message is stale")
+    if receipt.get("authored_at") != legacy.git(
+        worktree, "show", "-s", "--format=%aI", attested_commit
+    ):
+        raise legacy.HarnessError("v2 committed receipt authored_at is stale")
+    if receipt.get("committed_at") != legacy.git(
+        worktree, "show", "-s", "--format=%cI", attested_commit
+    ):
+        raise legacy.HarnessError("v2 committed receipt committed_at is stale")
+    return receipt
+
+
+def _execute_clean_intent(
+    contract: Mapping[str, Any],
+    task_dir: Path,
+    intent: Mapping[str, Any],
+) -> None:
+    primary = Path(str(contract["repo_realpath"])).resolve()
+    worktree = Path(str(contract["worktree_path"]))
+    archive_ref = str(intent["archive_ref"])
+    snapshot_sha = str(intent["snapshot_sha"])
+    tree_sha = str(intent["tree_sha"])
+    if legacy.git(
+        primary, "rev-parse", "--verify", archive_ref, check=False
+    ) != snapshot_sha:
+        raise legacy.HarnessError("v2 clean archive ref is missing or moved")
+    if legacy.git(primary, "rev-parse", f"{snapshot_sha}^{{tree}}") != tree_sha:
+        raise legacy.HarnessError("v2 clean archive tree is stale")
+
+    expected_snapshots = [
+        {
+            "path": str(path),
+            "snapshot_ref": reference,
+            "snapshot_commit": commit,
+        }
+        for path, reference, commit in _verification_snapshots_for_cleanup(
+            contract, task_dir
+        )
+    ]
+    if intent.get("verification_snapshots") != expected_snapshots:
+        raise legacy.HarnessError(
+            "v2 clean intent snapshot set differs from task evidence"
+        )
+
+    server_raw = intent.get("server_worktree")
+    source_raw = intent.get("server_source")
+    server_mode = intent.get("server_mode")
+    if server_raw is not None:
+        server_worktree = Path(str(server_raw))
+        server_source = Path(str(source_raw))
+        expected_server = worktree.parent / "murmur-server"
+        if server_worktree.resolve() != expected_server.resolve():
+            raise legacy.HarnessError("v2 clean server path escaped task root")
+        if server_worktree.exists() or server_worktree.is_symlink():
+            if not server_worktree.is_dir() or server_worktree.is_symlink():
+                raise legacy.HarnessError("v2 clean server path is unsafe")
+            if legacy.git_bytes(
+                server_worktree, "status", "--porcelain"
+            ).strip():
+                raise legacy.HarnessError(
+                    "refusing clean: pinned server checkout became dirty"
+                )
+            if server_mode == "local-shared-clone":
+                common = Path(
+                    legacy.git(
+                        server_worktree,
+                        "rev-parse",
+                        "--path-format=absolute",
+                        "--git-common-dir",
+                    )
+                ).resolve()
+                if common != (server_worktree / ".git").resolve():
+                    raise legacy.HarnessError(
+                        "v2 clean server clone shares mutable Git metadata"
+                    )
+                shutil.rmtree(server_worktree)
+            elif server_mode == "linked-worktree":
+                legacy.run_capture(
+                    ["git", "worktree", "remove", str(server_worktree)],
+                    server_source,
+                )
+            else:
+                raise legacy.HarnessError(
+                    "v2 clean intent server mode is unsupported"
+                )
+
+    for entry in expected_snapshots:
+        snapshot = Path(entry["path"])
+        if snapshot.exists() or snapshot.is_symlink():
+            if not snapshot.is_dir() or snapshot.is_symlink():
+                raise legacy.HarnessError(
+                    "v2 verification snapshot became unsafe before cleanup"
+                )
+            common = Path(
+                legacy.git(
+                    snapshot,
+                    "rev-parse",
+                    "--path-format=absolute",
+                    "--git-common-dir",
+                )
+            ).resolve()
+            if common != (snapshot / ".git").resolve():
+                raise legacy.HarnessError(
+                    "v2 verification snapshot shares mutable Git metadata"
+                )
+            shutil.rmtree(snapshot)
+
+    if worktree.exists() or worktree.is_symlink():
+        if not worktree.is_dir() or worktree.is_symlink():
+            raise legacy.HarnessError("v2 clean client worktree is unsafe")
+        ignored = _non_disposable_ignored_paths(worktree)
+        if ignored:
+            shown = ", ".join(ignored[:20])
+            suffix = "" if len(ignored) <= 20 else f" (+{len(ignored) - 20} more)"
+            raise legacy.HarnessError(
+                "refusing clean: ignored task bytes are not archived: "
+                + shown
+                + suffix
+            )
+        current_tree = _private_visible_tree(worktree, task_dir / "runtime")
+        if current_tree != tree_sha:
+            raise legacy.HarnessError(
+                "refusing clean: task bytes changed after the durable archive"
+            )
+        node_modules = worktree / "node_modules"
+        if legacy.managed_node_modules_link(worktree):
+            node_modules.unlink()
+        legacy.run_capture(
+            ["git", "worktree", "remove", "--force", str(worktree)], primary
+        )
+
+    legacy.delete_local_task_branch(
+        primary,
+        str(contract["branch"]),
+        snapshot_sha,
+        archive_ref,
+    )
+    for entry in expected_snapshots:
+        reference = entry["snapshot_ref"]
+        commit_sha = entry["snapshot_commit"]
+        current = legacy.git(
+            primary, "rev-parse", "--verify", reference, check=False
+        )
+        if current:
+            if current != commit_sha:
+                raise legacy.HarnessError(
+                    "v2 verification snapshot ref moved before cleanup"
+                )
+            legacy.run_capture(
+                ["git", "update-ref", "-d", reference, commit_sha],
+                primary,
+            )
+
+
+def cmd_clean(args: argparse.Namespace) -> int:
+    contract, task_dir, _ = load_v2_task(args.task_id, Path.cwd())
+    lock = acquire_v2_run_lock(task_dir, "clean")
+    try:
+        state = load_v2_state(task_dir)
+        if state.get("status") in verifier.V2_TERMINAL_STATES:
+            print(
+                f"{contract['task_id']}: {state['status']} "
+                "(cleanup already complete)"
+            )
+            return 0
+        worktree = Path(str(contract["worktree_path"]))
+        intent = _load_clean_intent(contract, task_dir)
+        if intent is None:
+            if not worktree.is_dir() or worktree.is_symlink():
+                raise legacy.HarnessError(
+                    "v2 task lost its worktree before a durable clean intent"
+                )
+            ignored = _non_disposable_ignored_paths(worktree)
+            if ignored:
+                shown = ", ".join(ignored[:20])
+                suffix = (
+                    "" if len(ignored) <= 20 else f" (+{len(ignored) - 20} more)"
+                )
+                raise legacy.HarnessError(
+                    "refusing clean: ignored task bytes are not archived: "
+                    + shown
+                    + suffix
+                )
+            dirty_after_commit = bool(legacy.changed_paths(worktree))
+            clean_close = (
+                state.get("status") == "COMMITTED" and not dirty_after_commit
+            )
+            if clean_close:
+                verify_v2_committed(
+                    contract,
+                    task_dir,
+                    allow_test_adapter=bool(
+                        getattr(args, "_allow_test_adapter", False)
+                    ),
+                )
+            if not clean_close and not args.abandon:
+                raise legacy.HarnessError(
+                    "uncommitted/dirty v2 clean requires explicit --abandon"
+                )
+            server = _server_cleanup_preflight(contract, task_dir)
+            verification_snapshots = _verification_snapshots_for_cleanup(
+                contract, task_dir
+            )
+            primary = Path(str(contract["repo_realpath"])).resolve()
+            archive_ref, snapshot, tree = _archive_all_visible_bytes(
+                primary, worktree, contract, task_dir
+            )
+            intent = _clean_intent_document(
+                contract,
+                final_status="CLOSED" if clean_close else "ABANDONED",
+                previous_status=str(state.get("status")),
+                archive_ref=archive_ref,
+                snapshot_sha=snapshot,
+                tree_sha=tree,
+                server=server,
+                verification_snapshots=verification_snapshots,
+            )
+            legacy.atomic_write_json(task_dir / "clean-intent.json", intent)
+            _checkpoint_event(
+                task_dir,
+                "clean-intent",
+                final_status=intent["final_status"],
+                archive_ref=archive_ref,
+                snapshot_sha=snapshot,
+                tree_sha=tree,
+                intent_sha256=intent["intent_sha256"],
+            )
+        _execute_clean_intent(contract, task_dir, intent)
+        final = str(intent["final_status"])
+        set_v2_state(
+            task_dir,
+            final,
+            phase="clean",
+            archive_ref=intent["archive_ref"],
+            snapshot_sha=intent["snapshot_sha"],
+            tree_sha=intent["tree_sha"],
+            previous_status=intent["previous_status"],
+            clean_intent_sha256=intent["intent_sha256"],
+        )
+    finally:
+        release_v2_run_lock(lock)
+    print(
+        f"{contract['task_id']}: {load_v2_state(task_dir)['status']} "
+        f"(snapshot preserved: {intent['archive_ref']})"
+    )
+    return 0
+
+
+def _v2_task_for_worktree(cwd: Path) -> Tuple[Dict[str, Any], Path]:
+    top = Path(legacy.git(cwd, "rev-parse", "--show-toplevel")).resolve()
+    _, common = legacy.repo_context(cwd)
+    root = v2_tasks(common)
+    matches: List[Tuple[Dict[str, Any], Path]] = []
+    malformed_claim = False
+    if root.is_dir():
+        for task_dir in sorted(root.iterdir()):
+            manifest = task_dir / "task.json"
+            if not manifest.is_file():
+                continue
+            try:
+                contract = legacy.load_json(manifest)
+                verifier.validate_hashed_document(
+                    contract, "v2-task", "contract_sha256", "v2 task"
+                )
+            except Exception:
+                # A manifest physically claiming this path may be malformed in
+                # the very field needed for discovery. Fail closed whenever a
+                # v2 task dir exists but cannot be validated.
+                malformed_claim = True
+                continue
+            if Path(str(contract["worktree_path"])).resolve() == top:
+                matches.append((contract, task_dir))
+    if malformed_claim and not matches:
+        raise legacy.HarnessError(
+            "malformed v2 task claim exists; refusing no-task fallback"
+        )
+    if len(matches) != 1:
+        raise legacy.HarnessError(
+            f"expected exactly one v2 task for {top}, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def cmd_v2_guard(args: argparse.Namespace) -> int:
+    if args.task_id:
+        contract, task_dir, _ = load_v2_task(args.task_id, Path.cwd())
+    else:
+        contract, task_dir = _v2_task_for_worktree(Path.cwd())
+    lock = acquire_v2_run_lock(task_dir, "guard-commit")
+    try:
+        evidence = cmd_v2_guard_commit(contract, task_dir)
+    finally:
+        release_v2_run_lock(lock)
+    if not getattr(args, "quiet", False):
+        print(
+            f"agent-harness: v2 commit gate PASS for {contract['task_id']} "
+            f"({evidence['diff_sha256'][:12]}…)"
+        )
+    return 0
+
+
+def lock_liveness(task_dir: Path) -> Tuple[str, Optional[Dict[str, Any]]]:
+    lock_path = task_dir / "run.lock"
+    flags = os.O_RDWR
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(lock_path, flags)
+    except FileNotFoundError:
+        return "ABSENT", None
+    except OSError as exc:
+        raise legacy.HarnessError(
+            f"refusing unsafe v2 task lock: {lock_path}"
+        ) from exc
+    handle = os.fdopen(descriptor, "r+b", buffering=0)
+    try:
+        opened = os.fstat(handle.fileno())
+        if not stat.S_ISREG(opened.st_mode):
+            raise legacy.HarnessError(
+                f"v2 task lock is not a regular file: {lock_path}"
+            )
+        current = os.stat(lock_path, follow_symlinks=False)
+        if (opened.st_dev, opened.st_ino) != (current.st_dev, current.st_ino):
+            raise legacy.HarnessError(
+                "v2 task lock inode changed during status inspection"
+            )
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            handle.seek(0)
+            try:
+                owner = json.loads(handle.read().decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError, OSError):
+                owner = None
+            return "LIVE", owner if isinstance(owner, dict) else None
+        finally:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
+        handle.seek(0)
+        try:
+            owner = json.loads(handle.read().decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError, OSError):
+            owner = None
+        return "STALE", owner if isinstance(owner, dict) else None
+    finally:
+        handle.close()
+
+
+def v2_status(contract: Mapping[str, Any], task_dir: Path) -> Dict[str, Any]:
+    state = load_v2_state(task_dir)
+    liveness, owner = lock_liveness(task_dir)
+    effective = state["status"]
+    if state["status"] == "VERIFYING" and liveness != "LIVE":
+        effective = "STALE"
+    return {
+        "generation": 2,
+        "contract": contract,
+        "state": state,
+        "effective_status": effective,
+        "lock": {"liveness": liveness, "owner": owner},
+        "task_dir": str(task_dir),
+    }
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    generation, contract, task_dir = resolve_generation(args.task_id, Path.cwd())
+    if generation == 1:
+        return legacy.main(["status", args.task_id, *(["--json"] if args.json else [])])
+    result = v2_status(contract, task_dir)
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(
+            f"{contract['task_id']}: {result['effective_status']} "
+            f"(stored {result['state']['status']}, lock {result['lock']['liveness']})"
+        )
+        print(f"worktree: {contract['worktree_path']}")
+        if result["state"].get("reason"):
+            print(f"reason: {result['state']['reason']}")
+        if result["lock"]["owner"]:
+            print("owner: " + json.dumps(result["lock"]["owner"], sort_keys=True))
+    return 0
+
+
+def _dual_lifecycle_audit(primary: Path, common: Path) -> Dict[str, Any]:
+    claimed_client: set = set()
+    claimed_server: set = set()
+    claimed_verification: set = set()
+    ghosts: List[str] = []
+    gc_debt: List[str] = []
+    roots = (
+        (1, common / "agent-harness" / "tasks"),
+        (2, v2_tasks(common)),
+    )
+    for generation, root in roots:
+        if not root.is_dir():
+            continue
+        for task_dir in sorted(path for path in root.iterdir() if path.is_dir()):
+            manifest = task_dir / "task.json"
+            if not manifest.is_file():
+                ghosts.append(f"v{generation}:{task_dir.name}:missing-task")
+                continue
+            try:
+                contract = legacy.load_json(manifest)
+                worktree = Path(str(contract["worktree_path"])).resolve()
+                claimed_client.add(worktree)
+                if generation == 1:
+                    claimed_server.add((worktree.parent / "murmur-server").resolve())
+                else:
+                    runtime_path = task_dir / "runtime.json"
+                    if runtime_path.is_file():
+                        runtime = legacy.load_json(runtime_path)
+                        server_worktree = runtime.get("server_worktree")
+                        if isinstance(server_worktree, str) and server_worktree:
+                            claimed_server.add(Path(server_worktree).resolve())
+                    attempts = task_dir / "attempts"
+                    if attempts.is_dir():
+                        for attempt in attempts.iterdir():
+                            snapshot_manifest = attempt / "snapshot.json"
+                            if not snapshot_manifest.is_file():
+                                continue
+                            snapshot_doc = legacy.load_json(snapshot_manifest)
+                            snapshot_path = Path(
+                                str(snapshot_doc.get("path", ""))
+                            ).resolve()
+                            if snapshot_path != _verification_snapshot_path(
+                                contract, attempt
+                            ):
+                                raise legacy.HarnessError(
+                                    "snapshot path differs from attempt"
+                                )
+                            claimed_verification.add(snapshot_path)
+            except Exception as exc:  # noqa: BLE001 - doctor reports malformed debt
+                ghosts.append(
+                    f"v{generation}:{task_dir.name}:malformed-task:{type(exc).__name__}"
+                )
+                continue
+            if generation == 1:
+                state_path = task_dir / "state.json"
+                if not state_path.is_file():
+                    ghosts.append(f"v1:{task_dir.name}:missing-state")
+                    status = "UNKNOWN"
+                else:
+                    try:
+                        status = str(legacy.load_json(state_path).get("status"))
+                    except Exception:
+                        ghosts.append(f"v1:{task_dir.name}:malformed-state")
+                        status = "UNKNOWN"
+                if status in {"RUNNING", "CHECKING", "REVIEWING", "REPAIRING"} and not legacy.task_run_lock_blocks_reap(task_dir):
+                    ghosts.append(f"v1:{task_dir.name}:stale-{status.lower()}")
+                if status in {"CLOSED", "REAPED"} and worktree.exists():
+                    gc_debt.append(f"v1:{task_dir.name}:terminal-worktree")
+            else:
+                try:
+                    event_state = _last_state_event(task_dir)
+                    if event_state is None:
+                        raise legacy.HarnessError("missing event state")
+                    status = str(event_state.get("status"))
+                    projection = (
+                        legacy.load_json(task_dir / "state.json")
+                        if (task_dir / "state.json").is_file()
+                        else None
+                    )
+                    if projection != event_state:
+                        ghosts.append(f"v2:{task_dir.name}:projection-gap")
+                except Exception:
+                    ghosts.append(f"v2:{task_dir.name}:malformed-state")
+                    status = "UNKNOWN"
+                liveness, _owner = lock_liveness(task_dir)
+                if status == "VERIFYING" and liveness != "LIVE":
+                    ghosts.append(f"v2:{task_dir.name}:stale-verifying")
+                if status in verifier.V2_TERMINAL_STATES and worktree.exists():
+                    gc_debt.append(f"v2:{task_dir.name}:terminal-worktree")
+                if status in verifier.V2_TERMINAL_STATES and any(
+                    path.exists()
+                    for path in claimed_verification
+                    if path.parent == worktree.parent
+                ):
+                    gc_debt.append(
+                        f"v2:{task_dir.name}:terminal-verification-snapshot"
+                    )
+
+    orphans: List[str] = []
+    repositories = [(primary, claimed_client)]
+    sibling_server = primary.parent / "murmur-server"
+    if (sibling_server / ".git").exists():
+        repositories.append((sibling_server, claimed_server))
+    for repository, claimed in repositories:
+        output = legacy.run_capture(
+            ["git", "worktree", "list", "--porcelain"], repository
+        ).stdout
+        for line in output.splitlines():
+            if not line.startswith("worktree "):
+                continue
+            path = Path(line.removeprefix("worktree ")).resolve()
+            if ".murmur-agent-tasks" in path.parts and path not in claimed:
+                orphans.append(str(path))
+    return {
+        "ghosts": sorted(set(ghosts)),
+        "gc_debt": sorted(set(gc_debt)),
+        "orphan_worktrees": sorted(set(orphans)),
+        "verification_snapshots": sorted(
+            str(path) for path in claimed_verification if path.exists()
+        ),
+    }
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    completed = subprocess.run(
+        [sys.executable, str(Path(legacy.__file__).resolve()), "doctor", "--json"],
+        cwd=str(Path.cwd()),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise legacy.HarnessError(
+            "legacy doctor did not return JSON: " + completed.stderr.strip()
+        ) from exc
+    primary, common = legacy.repo_context(Path.cwd())
+    lifecycle = _dual_lifecycle_audit(primary, common)
+    checks = list(payload.get("checks", []))
+    for name in (
+        "v2-task",
+        "v2-plan",
+        "v2-review",
+        "v2-evidence",
+        "v2-commit-intent",
+        "v2-commit",
+    ):
+        try:
+            legacy.load_schema(name)
+            checks.append(
+                {
+                    "name": f"schema:{name}",
+                    "ok": True,
+                    "required": True,
+                    "detail": str(legacy.SCHEMAS_DIR / f"{name}.schema.json"),
+                }
+            )
+        except legacy.HarnessError as exc:
+            checks.append(
+                {
+                    "name": f"schema:{name}",
+                    "ok": False,
+                    "required": True,
+                    "detail": str(exc),
+                }
+            )
+    ok = (
+        completed.returncode == 0
+        and all(item.get("ok") for item in checks if item.get("required", True))
+        and not lifecycle["ghosts"]
+        and not lifecycle["orphan_worktrees"]
+    )
+    result = {"ok": ok, "checks": checks, "lifecycle": lifecycle}
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        for item in checks:
+            marker = "OK" if item.get("ok") else (
+                "WARN" if not item.get("required", True) else "FAIL"
+            )
+            print(f"[{marker}] {item['name']}: {item['detail']}")
+        for name, values in lifecycle.items():
+            marker = "OK" if not values else ("WARN" if name == "gc_debt" else "FAIL")
+            print(f"[{marker}] lifecycle:{name}: {', '.join(values) if values else 'none'}")
+    return 0 if ok else 1
+
+
+def cmd_selftest(args: argparse.Namespace) -> int:
+    legacy_args = ["selftest", *(["--ci"] if args.ci else [])]
+    legacy_result = legacy.main(legacy_args)
+    if legacy_result != 0:
+        return legacy_result
+    for script in (
+        "v2_selftest.py",
+        "v2_fault_selftest.py",
+        "metrics_selftest.py",
+    ):
+        completed = subprocess.run(
+            [sys.executable, str(Path(__file__).with_name(script))],
+            cwd=str(Path.cwd()),
+            check=False,
+        )
+        if completed.returncode != 0:
+            return completed.returncode
+    return 0
+
+
+def cmd_metrics(args: argparse.Namespace) -> int:
+    # Metrics is deliberately a lazy, read-only extension: verification and
+    # commit commands do not import non-protocol telemetry code.
+    import metrics as harness_metrics
+
+    if args.limit < 1:
+        raise legacy.HarnessError("metrics --limit must be positive")
+    _, common = legacy.repo_context(Path.cwd())
+    report = harness_metrics.collect_metrics(common, limit=args.limit)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(harness_metrics.render_text(report))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="agent-harness", description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    open_parser = subparsers.add_parser(
+        "open", help="create a verifier-only v2 task and isolated client worktree"
+    )
+    open_parser.add_argument("task_id")
+    open_parser.add_argument(
+        "--kind",
+        choices=["bug", "feature", "refactor", "docs", "harness"],
+        default="feature",
+    )
+    prompt = open_parser.add_mutually_exclusive_group(required=True)
+    prompt.add_argument("--prompt")
+    prompt.add_argument("--prompt-file")
+    open_parser.add_argument("--owned", action="append", required=True)
+    open_parser.add_argument(
+        "--claim", action="append", choices=["runtime", "performance"], default=[]
+    )
+    open_parser.add_argument("--reviewer", choices=["codex", "claude"])
+    open_parser.add_argument("--base")
+    open_parser.add_argument("--branch")
+    open_parser.set_defaults(expected_change=True)
+    open_parser.set_defaults(handler=cmd_open)
+
+    plan_parser = subparsers.add_parser(
+        "plan", help="derive checks and reviews from the exact current diff"
+    )
+    plan_parser.add_argument("task_id")
+    plan_parser.set_defaults(handler=cmd_plan)
+
+    status_parser = subparsers.add_parser("status", help="show v1 or v2 state")
+    status_parser.add_argument("task_id")
+    status_parser.add_argument("--json", action="store_true")
+    status_parser.set_defaults(handler=cmd_status)
+
+    commit_parser = subparsers.add_parser(
+        "commit", help="commit the exact PASS receipt for v1 or v2"
+    )
+    commit_parser.add_argument("task_id")
+    commit_parser.add_argument("-m", "--message", required=True)
+    commit_parser.set_defaults(handler=cmd_v2_commit)
+    guard_parser = subparsers.add_parser(
+        "guard-commit", help="fail closed unless the exact current v2 diff has PASS"
+    )
+    guard_parser.add_argument("task_id", nargs="?")
+    guard_parser.set_defaults(handler=cmd_v2_guard)
+
+    verify_parser = subparsers.add_parser(
+        "verify", help="resume exact-diff checks/reviews and produce v2 evidence"
+    )
+    verify_parser.add_argument("task_id")
+    verify_parser.set_defaults(handler=cmd_verify)
+    resume_parser = subparsers.add_parser(
+        "resume", help="resume only missing evidence for the current exact diff"
+    )
+    resume_parser.add_argument("task_id")
+    resume_parser.set_defaults(handler=cmd_resume)
+    import_parser = subparsers.add_parser(
+        "import-v1", help="adopt a v1 diff/history without mutating v1 evidence"
+    )
+    import_parser.add_argument("task_id")
+    import_parser.add_argument(
+        "--invalidate-pass",
+        action="store_true",
+        help="explicitly invalidate a v1 PASS/COMMITTED lifecycle before adopting it",
+    )
+    import_parser.add_argument(
+        "--claim", action="append", choices=["runtime", "performance"], default=[]
+    )
+    import_parser.add_argument("--reviewer", choices=["codex", "claude"])
+    import_parser.set_defaults(handler=cmd_import_v1)
+    clean_parser = subparsers.add_parser(
+        "clean", help="archive every visible byte, then close or abandon a v2 task"
+    )
+    clean_parser.add_argument("task_id")
+    clean_parser.add_argument("--abandon", action="store_true")
+    clean_parser.set_defaults(handler=cmd_clean)
+    doctor_parser = subparsers.add_parser(
+        "doctor", help="audit dependencies plus v1/v2 ghost and GC debt"
+    )
+    doctor_parser.add_argument("--json", action="store_true")
+    doctor_parser.set_defaults(handler=cmd_doctor)
+    metrics_parser = subparsers.add_parser(
+        "metrics", help="roll up append-only v1/v2 operational telemetry"
+    )
+    metrics_parser.add_argument("--json", action="store_true")
+    metrics_parser.add_argument("--limit", type=int, default=20)
+    metrics_parser.set_defaults(handler=cmd_metrics)
+    selftest_parser = subparsers.add_parser(
+        "selftest", help="run legacy and v2 deterministic fault tests"
+    )
+    selftest_parser.add_argument("--ci", action="store_true")
+    selftest_parser.set_defaults(handler=cmd_selftest)
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    arguments = list(argv if argv is not None else sys.argv[1:])
+    if arguments and arguments[0] in V1_COMMANDS:
+        return legacy.main(arguments)
+    if arguments and arguments[0] in {"commit", "guard-commit"}:
+        task_id = next((item for item in arguments[1:] if not item.startswith("-")), "")
+        if task_id:
+            generation, _, _ = resolve_generation(task_id, Path.cwd())
+            if generation == 1:
+                return legacy.main(arguments)
+        elif arguments[0] == "guard-commit":
+            try:
+                _v2_task_for_worktree(Path.cwd())
+            except legacy.HarnessError as exc:
+                if "found 0" in str(exc):
+                    return legacy.main(arguments)
+                raise
+    parser = build_parser()
+    args = parser.parse_args(arguments)
+    return int(args.handler(args))
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except legacy.HarnessError as exc:
+        print(f"agent-harness: {exc}", file=sys.stderr)
+        raise SystemExit(exc.exit_code)

--- a/.agents/harness/config.json
+++ b/.agents/harness/config.json
@@ -7,6 +7,8 @@
   "agent_timeout_seconds": 3600,
   "writer_timeout_seconds": 5400,
   "reviewer_timeout_seconds": 2400,
+  "review_retry_max_delay_seconds": 60,
+  "v2_max_parallel_reviews": 3,
   "base_fetch_timeout_seconds": 30,
   "check_timeout_seconds": 1800,
   "max_diff_bytes_for_review": 500000,
@@ -47,7 +49,12 @@
     "ng-lint": "npx ng lint",
     "ng-build": "npx ng build",
     "playwright": "npm run test:e2e -- --workers=1",
-    "perf-contracts": "bash .agents/harness/checks/perf-contracts.sh"
+    "perf-contracts": "bash .agents/harness/checks/perf-contracts.sh",
+    "harness-python": "python3 -m py_compile .agents/harness/task_runner.py .agents/harness/cli.py .agents/harness/verifier.py .agents/harness/process_guardian.py .agents/harness/config_audit.py .agents/harness/hook_guard.py .agents/harness/resource_policy.py .agents/harness/v2_selftest.py",
+    "harness-v2-selftest": "python3 .agents/harness/v2_selftest.py",
+    "receipt-selftest": "scripts/verify-harness-attestation --selftest",
+    "hook-selftest": "bash .codex/hooks/selftest.sh",
+    "config-audit": "scripts/agent-config-audit --ci"
   },
   "shared_artifacts": {
     "sherpa_onnx": {

--- a/.agents/harness/hook_guard.py
+++ b/.agents/harness/hook_guard.py
@@ -20,6 +20,7 @@ import re
 import shlex
 import shutil
 import signal
+import stat
 import subprocess
 import sys
 import tempfile
@@ -115,6 +116,17 @@ def _task_runner_module() -> Any:
     except Exception as exc:  # pragma: no cover - exercised as a fail-closed path
         raise GuardFailure(f"cannot load the canonical task runner: {exc}") from exc
     return task_runner
+
+
+def _v2_verifier_module() -> Any:
+    harness_path = str(HARNESS_ROOT)
+    if harness_path not in sys.path:
+        sys.path.insert(0, harness_path)
+    try:
+        import verifier  # type: ignore
+    except Exception as exc:  # pragma: no cover - fail closed
+        raise GuardFailure(f"cannot load the canonical v2 verifier: {exc}") from exc
+    return verifier
 
 
 def _payload_command(payload: Any) -> str:
@@ -283,16 +295,51 @@ def _effective_tokens(tokens: Sequence[str]) -> Tuple[str, ...]:
     return tuple(values)
 
 
+_QUOTED_HEREDOC_RE = re.compile(
+    r"<<(?P<strip>-)?[ \t]*(?P<quote>['\"])(?P<name>[A-Za-z_][A-Za-z0-9_]*)"
+    r"(?P=quote)"
+)
+
+
+def _strip_quoted_heredoc_bodies(command: str) -> str:
+    """Hide literal heredoc payloads while preserving executable shell lines.
+
+    A quoted delimiter disables shell expansion in its body, so Rust doc
+    backticks and ``$()`` there are data. Unquoted heredocs remain visible and
+    fail closed because the shell would execute their substitutions.
+    """
+
+    visible: List[str] = []
+    pending: List[Tuple[str, bool]] = []
+    for line in command.splitlines(keepends=True):
+        body = line.rstrip("\r\n")
+        newline = line[len(body) :]
+        if pending:
+            delimiter, strip_tabs = pending[0]
+            candidate = body.lstrip("\t") if strip_tabs else body
+            if candidate == delimiter:
+                pending.pop(0)
+            visible.append(newline)
+            continue
+        visible.append(line)
+        pending.extend(
+            (match.group("name"), bool(match.group("strip")))
+            for match in _QUOTED_HEREDOC_RE.finditer(body)
+        )
+    return "".join(visible)
+
+
 def _unsupported_execution_indirection(command: str) -> Optional[str]:
     """Fail closed when the hook cannot see the executable command directly."""
 
+    visible_command = _strip_quoted_heredoc_bodies(command)
     single_quoted = False
     double_quoted = False
     escaped = False
     active_shell_indirection = False
     index = 0
-    while index < len(command):
-        character = command[index]
+    while index < len(visible_command):
+        character = visible_command[index]
         if escaped:
             escaped = False
             index += 1
@@ -311,16 +358,16 @@ def _unsupported_execution_indirection(command: str) -> Optional[str]:
             continue
         if not single_quoted and (
             character == "`"
-            or command.startswith("$(", index)
-            or command.startswith("<(", index)
-            or command.startswith(">(", index)
+            or visible_command.startswith("$(", index)
+            or visible_command.startswith("<(", index)
+            or visible_command.startswith(">(", index)
         ):
             active_shell_indirection = True
             break
         index += 1
     if active_shell_indirection:
         return "shell substitution/process indirection is unsupported by the command guard"
-    for simple in _simple_commands(command):
+    for simple in _simple_commands(visible_command):
         raw = list(simple.tokens)
         while raw and _ASSIGNMENT_RE.match(raw[0]):
             raw.pop(0)
@@ -455,6 +502,174 @@ def _push_targets_protected(invocation: GitInvocation) -> bool:
     return False
 
 
+def _v1_terminal_state_is_proven(task_dir: Path) -> bool:
+    """Require the v1 state projection and its latest state event to agree."""
+
+    try:
+        runner = _task_runner_module()
+        state = _load_json(task_dir / "state.json")
+        if not isinstance(state, dict):
+            return False
+        status = state.get("status")
+        updated_at = state.get("updated_at")
+        if (
+            state.get("task_id") != task_dir.name
+            or status not in runner.TERMINAL_STATES
+            or not isinstance(updated_at, str)
+        ):
+            return False
+        runner.parse_timestamp(updated_at, f"{task_dir.name}.updated_at")
+
+        last_state_event: Optional[Dict[str, Any]] = None
+        with (task_dir / "events.jsonl").open(
+            "r", encoding="utf-8", errors="strict"
+        ) as handle:
+            for line in handle:
+                event = json.loads(line)
+                if not isinstance(event, dict):
+                    raise ValueError("v1 event is not an object")
+                if event.get("event") == "state":
+                    last_state_event = event
+        if last_state_event is None:
+            return False
+        event_at = last_state_event.get("at")
+        if not isinstance(event_at, str):
+            return False
+        runner.parse_timestamp(event_at, f"{task_dir.name} state event at")
+        if (
+            last_state_event.get("status") != status
+            or event_at != updated_at
+            or last_state_event.get("round", 0) != state.get("round", 0)
+        ):
+            return False
+        for key in ("phase", "reason"):
+            if key in state and last_state_event.get(key) != state.get(key):
+                return False
+        return True
+    except Exception:
+        # An existing claimed worktree with incomplete lifecycle evidence is
+        # unknown-live. Branch surgery in the primary checkout must fail closed.
+        return False
+
+
+def _v2_terminal_state_is_proven(task_dir: Path) -> bool:
+    """Use the v2 append-only last-state event; state.json is a projection."""
+
+    try:
+        verifier = _v2_verifier_module()
+        last_wrapper: Optional[Dict[str, Any]] = None
+        with (task_dir / "events.jsonl").open(
+            "r", encoding="utf-8", errors="strict"
+        ) as handle:
+            for line in handle:
+                event = json.loads(line)
+                if not isinstance(event, dict):
+                    raise ValueError("v2 event is not an object")
+                if event.get("event") == "state":
+                    if not isinstance(event.get("state"), dict):
+                        raise ValueError("v2 state event payload is malformed")
+                    last_wrapper = event
+
+        state = verifier.last_state_event(task_dir)
+        if last_wrapper is None or state != last_wrapper["state"]:
+            return False
+        updated_at = state.get("updated_at")
+        if (
+            state.get("schema_version") != 2
+            or state.get("task_id") != task_dir.name
+            or state.get("status") not in verifier.V2_STATES
+            or not isinstance(updated_at, str)
+            or last_wrapper.get("at") != updated_at
+        ):
+            return False
+        _task_runner_module().parse_timestamp(
+            updated_at, f"{task_dir.name} v2 state event updated_at"
+        )
+        return state["status"] in verifier.V2_TERMINAL_STATES
+    except Exception:
+        # Missing/malformed authoritative state means unknown-live whenever the
+        # task still claims an existing worktree.
+        return False
+
+
+def _live_harness_task_ids(common: Path) -> List[str]:
+    """Return nonterminal or state-unknown tasks with an existing worktree.
+
+    V2's append-only event is authoritative, so a SIGKILL between its fsync and
+    the state.json projection cannot hide a live task. V1 predates that ordering
+    and is terminal only when state.json and its latest state event agree.
+    """
+
+    result: List[str] = []
+    for generation, root in (
+        ("v1", common / "agent-harness" / "tasks"),
+        ("v2", common / "agent-harness" / "v2" / "tasks"),
+    ):
+        if not root.is_dir():
+            continue
+        for task_dir in sorted(path for path in root.iterdir() if path.is_dir()):
+            try:
+                contract = json.loads((task_dir / "task.json").read_text(encoding="utf-8"))
+                worktree_raw = contract["worktree_path"]
+                if not isinstance(worktree_raw, str) or not worktree_raw:
+                    continue
+                worktree = Path(worktree_raw).resolve()
+            except (
+                OSError,
+                KeyError,
+                TypeError,
+                ValueError,
+                json.JSONDecodeError,
+            ):
+                continue
+            if not worktree.exists():
+                continue
+            terminal = (
+                _v1_terminal_state_is_proven(task_dir)
+                if generation == "v1"
+                else _v2_terminal_state_is_proven(task_dir)
+            )
+            if not terminal:
+                result.append(f"{generation}:{task_dir.name}")
+    return result
+
+
+def _primary_branch_surgery_reason(invocation: GitInvocation) -> Optional[str]:
+    if invocation.subcommand not in {
+        "checkout",
+        "switch",
+        "merge",
+        "rebase",
+        "reset",
+        "cherry-pick",
+        "pull",
+    }:
+        return None
+    top_raw = _git_text(
+        invocation.cwd, "rev-parse", "--show-toplevel", check=False
+    )
+    if not top_raw:
+        return None
+    top = Path(top_raw).resolve()
+    if top != _primary_worktree(top):
+        return None
+    common_raw = Path(_git_text(top, "rev-parse", "--git-common-dir"))
+    common = (
+        common_raw.resolve()
+        if common_raw.is_absolute()
+        else (top / common_raw).resolve()
+    )
+    live = _live_harness_task_ids(common)
+    if not live:
+        return None
+    preview = ", ".join(live[:3]) + ("…" if len(live) > 3 else "")
+    return (
+        f"primary-checkout branch surgery is blocked while Harness task(s) "
+        f"are live or state-unknown ({preview}); continue from the isolated task/driver worktree "
+        "and use server-side PR merge"
+    )
+
+
 def _has_option(tokens: Sequence[str], short: str, long: str) -> bool:
     for token in tokens:
         if token == long:
@@ -469,6 +684,9 @@ def _has_option(tokens: Sequence[str], short: str, long: str) -> bool:
 def _block_bash(command: str, process_cwd: Path) -> Optional[str]:
     simples = _simple_commands(command)
     for invocation in _git_invocations(command, process_cwd):
+        surgery_reason = _primary_branch_surgery_reason(invocation)
+        if surgery_reason is not None:
+            return surgery_reason
         if _push_targets_protected(invocation):
             return "direct push to protected trunk murmur/main/master; use a feature branch and PR merge"
 
@@ -592,29 +810,104 @@ def _manifest_worktree(document: Any) -> Optional[Path]:
     return Path(document["worktree_path"]).resolve()
 
 
-def _resolve_task(repo: Path, common: Path) -> Tuple[Dict[str, Any], Path]:
-    tasks_root = common / "agent-harness" / "tasks"
-    explicit = os.environ.get("MURMUR_AGENT_TASK_ID", "").strip()
-    if explicit:
-        if not TASK_ID_RE.fullmatch(explicit):
-            raise GuardFailure("MURMUR_AGENT_TASK_ID is invalid")
-        task_dir = tasks_root / explicit
-        document = _load_json(task_dir / "task.json")
-        if _manifest_worktree(document) != repo.resolve():
-            raise GuardFailure("explicit task manifest belongs to a different worktree")
-        return document, task_dir
+def _validate_task_manifest(
+    document: Any, generation: int, manifest: Path
+) -> Dict[str, Any]:
+    if not isinstance(document, dict):
+        raise GuardFailure(f"task manifest is not an object: {manifest}")
+    runner = _task_runner_module()
+    try:
+        if generation == 1:
+            runner.validate_schema(
+                document, runner.load_schema("task"), label="v1 task contract"
+            )
+            if runner.contract_hash(document) != document.get("contract_sha256"):
+                raise GuardFailure("v1 task contract hash is malformed or stale")
+        elif generation == 2:
+            v2 = _v2_verifier_module()
+            v2.validate_hashed_document(
+                document,
+                "v2-task",
+                "contract_sha256",
+                "v2 task contract",
+            )
+        else:
+            raise GuardFailure(f"unknown task generation: {generation}")
+    except GuardFailure:
+        raise
+    except Exception as exc:
+        raise GuardFailure(f"invalid task manifest {manifest}: {exc}") from exc
+    return document
 
-    matches: List[Tuple[Dict[str, Any], Path]] = []
-    if tasks_root.is_dir():
-        for manifest in sorted(tasks_root.glob("*/task.json")):
+
+def _resolve_task(repo: Path, common: Path) -> Tuple[Dict[str, Any], Path, int]:
+    v1_root = common / "agent-harness" / "tasks"
+    v2_root = common / "agent-harness" / "v2" / "tasks"
+    explicit_ref = os.environ.get("MURMUR_AGENT_TASK_REF", "").strip()
+    explicit_id = os.environ.get("MURMUR_AGENT_TASK_ID", "").strip()
+    if explicit_ref:
+        match = re.fullmatch(r"(v1|v2):(.+)", explicit_ref)
+        if not match or not TASK_ID_RE.fullmatch(match.group(2)):
+            raise GuardFailure("MURMUR_AGENT_TASK_REF must be v1:<id> or v2:<id>")
+        generation = 1 if match.group(1) == "v1" else 2
+        explicit_id = match.group(2)
+    else:
+        generation = 0
+    if explicit_id:
+        if not TASK_ID_RE.fullmatch(explicit_id):
+            raise GuardFailure("MURMUR_AGENT_TASK_ID is invalid")
+        roots = [(generation, v1_root if generation == 1 else v2_root)] if generation else [
+            (2, v2_root),
+            (1, v1_root),
+        ]
+        found: List[Tuple[Dict[str, Any], Path, int]] = []
+        for candidate_generation, root in roots:
+            manifest = root / explicit_id / "task.json"
+            if manifest.is_file():
+                document = _validate_task_manifest(
+                    _load_json(manifest), candidate_generation, manifest
+                )
+                if _manifest_worktree(document) != repo.resolve():
+                    raise GuardFailure("explicit task manifest belongs to a different worktree")
+                found.append((document, manifest.parent, candidate_generation))
+        if len(found) == 1:
+            return found[0]
+        if not found:
+            raise GuardFailure("explicit task reference does not exist")
+
+    matches: List[Tuple[Dict[str, Any], Path, int]] = []
+    for candidate_generation, root in ((1, v1_root), (2, v2_root)):
+        if not root.is_dir():
+            continue
+        for manifest in sorted(root.glob("*/task.json")):
             try:
-                document = _load_json(manifest)
+                raw = _load_json(manifest)
             except GuardFailure:
+                # A foreign unreadable record is lifecycle debt for `doctor`,
+                # not proof that it claims this worktree. Explicit task refs
+                # still validate and fail closed above.
                 continue
-            if _manifest_worktree(document) == repo.resolve():
-                matches.append((document, manifest.parent))
-    if len(matches) > 1:
+            if _manifest_worktree(raw) != repo.resolve():
+                continue
+            document = _validate_task_manifest(
+                raw, candidate_generation, manifest
+            )
+            matches.append((document, manifest.parent, candidate_generation))
+    if len(matches) > 2:
         raise GuardFailure("multiple task manifests claim this worktree")
+    if len(matches) == 2:
+        v1 = next((item for item in matches if item[2] == 1), None)
+        v2 = next((item for item in matches if item[2] == 2), None)
+        if v1 is None or v2 is None:
+            raise GuardFailure("multiple same-generation task manifests claim this worktree")
+        expected = {
+            "generation": 1,
+            "task_id": v1[0].get("task_id"),
+            "contract_sha256": v1[0].get("contract_sha256"),
+        }
+        if v2[0].get("supersedes") != expected:
+            raise GuardFailure("v1/v2 worktree claim is ambiguous")
+        return v2
     if len(matches) == 1:
         return matches[0]
 
@@ -630,10 +923,10 @@ def _resolve_task(repo: Path, common: Path) -> Tuple[Dict[str, Any], Path]:
         except (OSError, json.JSONDecodeError) as exc:
             raise GuardFailure(f"invalid legacy current-task pointer: {exc}") from exc
         if TASK_ID_RE.fullmatch(raw):
-            task_dir = tasks_root / raw
+            task_dir = v1_root / raw
             document = _load_json(task_dir / "task.json")
             if _manifest_worktree(document) == repo.resolve():
-                return document, task_dir
+                return document, task_dir, 1
             raise GuardFailure("legacy current-task pointer belongs to a different worktree")
     raise NoTaskForWorktree(
         "no task manifest matches this worktree; use scripts/agent-harness init/run"
@@ -971,14 +1264,20 @@ def _finish_guard(
         try:
             repo = _repo_for_invocation(commits[0])
             _, common, _, _ = _repo_context(repo)
-            task, task_dir = _resolve_task(repo, common)
-            _validate_attestation(
-                repo,
-                common,
-                task,
-                task_dir,
-                allow_test_adapter=allow_test_adapter,
-            )
+            task, task_dir, generation = _resolve_task(repo, common)
+            if generation == 2:
+                raise GuardFailure(
+                    "Harness v2 owns the durable commit intent and receipt; "
+                    f"use scripts/agent-harness commit {task['task_id']} -m <message>"
+                )
+            else:
+                _validate_attestation(
+                    repo,
+                    common,
+                    task,
+                    task_dir,
+                    allow_test_adapter=allow_test_adapter,
+                )
             return None
         except NoTaskForWorktree:
             return None  # normal mode: no active harness task → allow the commit
@@ -990,9 +1289,125 @@ def _finish_guard(
     return "Definition-of-Done receipt rejected: " + reason
 
 
-def _emit(vendor: str, reason: Optional[str], guard: str) -> int:
+def _guard_refusal_task_dirs(
+    process_cwd: Path, *, include_live_primary_tasks: bool
+) -> List[Path]:
+    """Find task ledgers that should receive a best-effort refusal event."""
+
+    top_raw = _git_text(
+        process_cwd, "rev-parse", "--show-toplevel", check=False
+    )
+    if not top_raw:
+        return []
+    top = Path(top_raw).resolve()
+    common_raw = Path(_git_text(top, "rev-parse", "--git-common-dir"))
+    common = (
+        common_raw.resolve()
+        if common_raw.is_absolute()
+        else (top / common_raw).resolve()
+    )
+    primary = _primary_worktree(top)
+    matches: List[Path] = []
+    for generation, root in (
+        ("v1", common / "agent-harness" / "tasks"),
+        ("v2", common / "agent-harness" / "v2" / "tasks"),
+    ):
+        if not root.is_dir():
+            continue
+        for task_dir in sorted(path for path in root.iterdir() if path.is_dir()):
+            try:
+                task = _load_json(task_dir / "task.json")
+                claimed = _manifest_worktree(task)
+            except Exception:
+                continue
+            if claimed == top:
+                matches.append(task_dir)
+                continue
+            if not include_live_primary_tasks or top != primary:
+                continue
+            if claimed is None or not claimed.exists():
+                continue
+            terminal = (
+                _v1_terminal_state_is_proven(task_dir)
+                if generation == "v1"
+                else _v2_terminal_state_is_proven(task_dir)
+            )
+            if not terminal:
+                matches.append(task_dir)
+    return sorted(set(matches))
+
+
+def _record_guard_refusal(
+    process_cwd: Path, command: str, guard: str, reason: str
+) -> None:
+    """Append diagnostics without ever changing the guard's allow/block result."""
+
+    try:
+        compact = " ".join(command.split())
+        preview = (
+            "<secret-bearing command redacted>"
+            if guard == "secret-scan"
+            else compact[:80]
+        )
+        payload = (
+            json.dumps(
+                {
+                    "at": dt.datetime.now(dt.timezone.utc)
+                    .isoformat()
+                    .replace("+00:00", "Z"),
+                    "event": "guard-refusal",
+                    "guard": guard,
+                    "reason": reason,
+                    "command_preview": preview,
+                    "command_sha256": hashlib.sha256(
+                        command.encode("utf-8", "surrogateescape")
+                    ).hexdigest(),
+                    "cwd": str(process_cwd.resolve()),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            + b"\n"
+        )
+        for task_dir in _guard_refusal_task_dirs(
+            process_cwd,
+            include_live_primary_tasks=reason.startswith(
+                "primary-checkout branch surgery"
+            ),
+        ):
+            path = task_dir / "events.jsonl"
+            flags = os.O_WRONLY | os.O_APPEND
+            if hasattr(os, "O_CLOEXEC"):
+                flags |= os.O_CLOEXEC
+            if hasattr(os, "O_NOFOLLOW"):
+                flags |= os.O_NOFOLLOW
+            descriptor = os.open(path, flags)
+            try:
+                metadata = os.fstat(descriptor)
+                if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+                    continue
+                if os.write(descriptor, payload) != len(payload):
+                    continue
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+    except Exception:
+        # Telemetry is never authority and may not weaken or strengthen a
+        # refusal. Doctor can report an unwritable/corrupt task ledger.
+        return
+
+
+def _emit(
+    vendor: str,
+    reason: Optional[str],
+    guard: str,
+    *,
+    command: str = "",
+    process_cwd: Optional[Path] = None,
+) -> int:
     if reason is None:
         return 0
+    _record_guard_refusal(process_cwd or Path.cwd(), command, guard, reason)
     message = f"{guard} refused this command: {reason}"
     if vendor == "codex":
         print(json.dumps({"decision": "block", "reason": message}, separators=(",", ":")))
@@ -1422,6 +1837,134 @@ def _resource_lane_runner_cases(test: _Selftest) -> None:
             "PASS",
         )
 
+        lane_env = {
+            **os.environ,
+            "MURMUR_HARNESS_TASK": "lane-owner",
+        }
+        owner = subprocess.Popen(
+            [
+                str(runner),
+                "--deadline-seconds",
+                "3",
+                "--",
+                "sh",
+                "-c",
+                "sleep 2",
+            ],
+            cwd=str(repo),
+            env=lane_env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            common = Path(
+                _run(
+                    [
+                        "git",
+                        "rev-parse",
+                        "--path-format=absolute",
+                        "--git-common-dir",
+                    ],
+                    repo,
+                    text=True,
+                ).stdout.strip()
+            )
+            lane_path = (
+                _task_runner_module().shared_resource_root_for_common(common)
+                / "cargo.lock"
+            )
+            owner_seen = False
+            for _attempt in range(50):
+                try:
+                    payload = json.loads(lane_path.read_text(encoding="utf-8"))
+                    owner_seen = payload.get("pid") == owner.pid
+                except (FileNotFoundError, OSError, json.JSONDecodeError):
+                    owner_seen = False
+                if owner_seen:
+                    break
+                time.sleep(0.02)
+            test.result(
+                "resource lane publishes owner before waiters",
+                "PASS" if owner_seen else "FAIL",
+                "PASS",
+            )
+
+            waiter = subprocess.run(
+                [
+                    str(runner),
+                    "--deadline-seconds",
+                    "0.25",
+                    "--heartbeat-seconds",
+                    "0.05",
+                    "--",
+                    "sh",
+                    "-c",
+                    "exit 0",
+                ],
+                cwd=str(repo),
+                env={**os.environ, "MURMUR_HARNESS_TASK": "lane-waiter"},
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+                timeout=3,
+            )
+            waiter_stderr = waiter.stderr
+            test.result(
+                "resource runner wait reports owner immediately and heartbeats",
+                "PASS"
+                if (
+                    waiter.returncode == 124
+                    and f"owner_pid={owner.pid}" in waiter_stderr
+                    and "task=lane-owner" in waiter_stderr
+                    and "command=sh -c sleep 2" in waiter_stderr
+                    and waiter_stderr.count("heartbeat=") >= 2
+                )
+                else f"FAIL({waiter.returncode}: {waiter_stderr[-300:]})",
+                "PASS",
+            )
+
+            direct_task = common / "agent-harness" / "v2" / "tasks" / "lane-direct"
+            direct_task.mkdir(parents=True)
+            direct_code = (
+                "import pathlib,sys;"
+                f"sys.path.insert(0,{str((SOURCE_ROOT / '.agents' / 'harness')).__repr__()});"
+                "import task_runner;"
+                "task_runner.acquire_cargo_lane("
+                "pathlib.Path(sys.argv[1]),0.25,"
+                "command='direct-selftest',heartbeat_seconds=0.05)"
+            )
+            direct = subprocess.run(
+                [sys.executable, "-c", direct_code, str(direct_task)],
+                cwd=str(repo),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+                timeout=3,
+            )
+            test.result(
+                "run_check Cargo lane path reports owner and heartbeats",
+                "PASS"
+                if (
+                    direct.returncode != 0
+                    and f"owner_pid={owner.pid}" in direct.stderr
+                    and "task=lane-owner" in direct.stderr
+                    and "command=sh -c sleep 2" in direct.stderr
+                    and direct.stderr.count("heartbeat=") >= 2
+                )
+                else f"FAIL({direct.returncode}: {direct.stderr[-300:]})",
+                "PASS",
+            )
+        finally:
+            if owner.poll() is None:
+                owner.terminate()
+            try:
+                owner.communicate(timeout=2)
+            except subprocess.TimeoutExpired:
+                owner.kill()
+                owner.communicate(timeout=2)
+
         fake_bin = Path(temp) / "fake-bin"
         fake_bin.mkdir()
         tool_log = Path(temp) / "tool.log"
@@ -1686,6 +2229,11 @@ def _run_selftest() -> int:
                 ("git global options", "git -c user.name=x -C . --no-pager push origin murmur", "BLOCK"),
                 ("multiline push", "git -c user.name=x \\" + "\n --no-pager push origin master", "BLOCK"),
                 ("feature push", "git push -u origin feature/x", "ALLOW"),
+                (
+                    "catch-up merge then feature push",
+                    "git checkout feature/x && git merge origin/murmur && git push origin feature/x",
+                    "ALLOW",
+                ),
                 ("absolute security", "/usr/bin/security find-identity -v", "BLOCK"),
                 ("sudo security", "sudo /usr/bin/security unlock-keychain login.keychain", "BLOCK"),
                 ("security management text", "pkill security", "ALLOW"),
@@ -1729,7 +2277,284 @@ def _run_selftest() -> int:
                     repo,
                     "ALLOW",
                 )
+                test.expect(
+                    f"{action} permits literal quoted heredoc body",
+                    vendor,
+                    action,
+                    "python3 - <<'PY'\n"
+                    "print(\"Rust `doc` and $(literal) with writer's apostrophe\")\n"
+                    "PY\n",
+                    repo,
+                    "ALLOW",
+                )
+                test.expect(
+                    f"{action} rejects expanding heredoc substitution",
+                    vendor,
+                    action,
+                    "python3 - <<PY\n$(printf git) push origin main\nPY\n",
+                    repo,
+                    "BLOCK",
+                )
 
+            live_worktree = Path(temp) / "live-v2-task"
+            live_worktree.mkdir()
+            live_task = (
+                repo
+                / ".git"
+                / "agent-harness"
+                / "v2"
+                / "tasks"
+                / "primary-isolation"
+            )
+            live_task.mkdir(parents=True)
+            (live_task / "task.json").write_text(
+                json.dumps({"worktree_path": str(live_worktree.resolve())})
+                + "\n",
+                encoding="utf-8",
+            )
+            live_updated_at = "2026-07-28T10:00:00Z"
+            live_state = {
+                "schema_version": 2,
+                "task_id": live_task.name,
+                "status": "OPEN",
+                "updated_at": live_updated_at,
+            }
+            (live_task / "events.jsonl").write_text(
+                json.dumps(
+                    {
+                        "at": live_updated_at,
+                        "event": "state",
+                        "state": live_state,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            test.expect(
+                "SIGKILL ledger-only v2 task blocks primary branch surgery",
+                vendor,
+                "block-bash",
+                "git checkout -b unsafe-primary-move",
+                repo,
+                "BLOCK",
+            )
+            refusal_events = [
+                json.loads(line)
+                for line in (live_task / "events.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+                if line.strip()
+            ]
+            refusal = next(
+                (
+                    event
+                    for event in reversed(refusal_events)
+                    if event.get("event") == "guard-refusal"
+                ),
+                {},
+            )
+            test.result(
+                f"{vendor}: guard refusal is recorded in active task ledger",
+                "RECORDED"
+                if (
+                    refusal.get("guard") == "block-bash"
+                    and refusal.get("command_preview")
+                    == "git checkout -b unsafe-primary-move"
+                    and SHA256_RE.fullmatch(
+                        str(refusal.get("command_sha256", ""))
+                    )
+                )
+                else "MISSING",
+                "RECORDED",
+            )
+            test.expect(
+                "git pull is primary branch surgery",
+                vendor,
+                "block-bash",
+                "git pull --ff-only",
+                repo,
+                "BLOCK",
+            )
+
+            terminal_updated_at = "2026-07-28T10:01:00Z"
+            terminal_state = {
+                **live_state,
+                "status": "CLOSED",
+                "updated_at": terminal_updated_at,
+            }
+            with (live_task / "events.jsonl").open("a", encoding="utf-8") as handle:
+                handle.write(
+                    json.dumps(
+                        {
+                            "at": terminal_updated_at,
+                            "event": "state",
+                            "state": terminal_state,
+                        }
+                    )
+                    + "\n"
+                )
+            (live_task / "state.json").write_text(
+                "{malformed projection\n", encoding="utf-8"
+            )
+            test.expect(
+                "authoritative v2 terminal event permits existing task worktree",
+                vendor,
+                "block-bash",
+                "git checkout --detach HEAD",
+                repo,
+                "ALLOW",
+            )
+            (live_task / "events.jsonl").write_text(
+                "{malformed authoritative state\n", encoding="utf-8"
+            )
+            test.expect(
+                "malformed v2 authoritative state is unknown-live",
+                vendor,
+                "block-bash",
+                "git checkout --detach HEAD",
+                repo,
+                "BLOCK",
+            )
+            (live_task / "events.jsonl").write_text(
+                json.dumps(
+                    {
+                        "at": terminal_updated_at,
+                        "event": "state",
+                        "state": terminal_state,
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            v1_worktree = Path(temp) / "live-v1-task"
+            v1_worktree.mkdir()
+            v1_task = (
+                repo / ".git" / "agent-harness" / "tasks" / "v1-primary-isolation"
+            )
+            v1_task.mkdir(parents=True)
+            (v1_task / "task.json").write_text(
+                json.dumps({"worktree_path": str(v1_worktree.resolve())}) + "\n",
+                encoding="utf-8",
+            )
+            v1_live_updated_at = "2026-07-28T10:02:00Z"
+            v1_live_state = {
+                "task_id": v1_task.name,
+                "status": "INITIALIZED",
+                "updated_at": v1_live_updated_at,
+                "round": 0,
+                "phase": "init",
+            }
+            (v1_task / "state.json").write_text(
+                json.dumps(v1_live_state) + "\n", encoding="utf-8"
+            )
+            (v1_task / "events.jsonl").write_text(
+                json.dumps(
+                    {
+                        "at": v1_live_updated_at,
+                        "event": "state",
+                        "status": "INITIALIZED",
+                        "round": 0,
+                        "phase": "init",
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            test.expect(
+                "live v1 task blocks primary branch surgery",
+                vendor,
+                "block-bash",
+                "git reset --hard HEAD",
+                repo,
+                "BLOCK",
+            )
+
+            v1_terminal_updated_at = "2026-07-28T10:03:00Z"
+            v1_terminal_state = {
+                **v1_live_state,
+                "status": "CLOSED",
+                "updated_at": v1_terminal_updated_at,
+                "phase": "close",
+            }
+            (v1_task / "state.json").write_text(
+                json.dumps(v1_terminal_state) + "\n", encoding="utf-8"
+            )
+            v1_terminal_event = {
+                "at": v1_terminal_updated_at,
+                "event": "state",
+                "status": "CLOSED",
+                "round": 0,
+                "phase": "close",
+            }
+            (v1_task / "events.jsonl").write_text(
+                json.dumps(v1_terminal_event) + "\n",
+                encoding="utf-8",
+            )
+            test.expect(
+                "matching v1 terminal state and event permit existing task worktree",
+                vendor,
+                "block-bash",
+                "git switch --detach HEAD",
+                repo,
+                "ALLOW",
+            )
+            (v1_task / "events.jsonl").write_text(
+                json.dumps({**v1_terminal_event, "status": "REAPED"}) + "\n",
+                encoding="utf-8",
+            )
+            test.expect(
+                "disagreeing v1 terminal state and event are unknown-live",
+                vendor,
+                "block-bash",
+                "git switch --detach HEAD",
+                repo,
+                "BLOCK",
+            )
+            (v1_task / "events.jsonl").write_text(
+                json.dumps(v1_terminal_event) + "\n",
+                encoding="utf-8",
+            )
+            (v1_task / "state.json").write_text(
+                "{malformed state\n", encoding="utf-8"
+            )
+            test.expect(
+                "malformed v1 state with existing claimed worktree is unknown-live",
+                vendor,
+                "block-bash",
+                "git merge feature/nope",
+                repo,
+                "BLOCK",
+            )
+            (v1_task / "state.json").unlink()
+            test.expect(
+                "missing v1 state with existing claimed worktree is unknown-live",
+                vendor,
+                "block-bash",
+                "git merge feature/nope",
+                repo,
+                "BLOCK",
+            )
+
+            driver = Path(temp) / "driver"
+            _run(
+                ["git", "worktree", "add", "--detach", str(driver), "HEAD"],
+                repo,
+            )
+            test.expect(
+                "dedicated driver worktree may move independently",
+                vendor,
+                "block-bash",
+                "git checkout --detach HEAD",
+                driver,
+                "ALLOW",
+            )
+
+        resource_fixture_root = Path(
+            tempfile.mkdtemp(prefix="murmur-hook-resource-command-")
+        )
+        resource_case_cwd = resource_fixture_root / "repo"
+        _init_repo(resource_case_cwd)
         resource_cases = [
             ("direct cargo metadata", "cargo metadata --no-deps", "ALLOW"),
             ("direct Rust test", "cd src-tauri && cargo test --lib", "ALLOW"),
@@ -1825,7 +2650,15 @@ def _run_selftest() -> int:
             ),
         ]
         for label, command, want in resource_cases:
-            test.expect(label, vendor, "block-bash", command, SOURCE_ROOT, want)
+            test.expect(
+                label,
+                vendor,
+                "block-bash",
+                command,
+                resource_case_cwd,
+                want,
+            )
+        shutil.rmtree(resource_fixture_root)
 
         for label, cmd, want in [
             ("gh live $() substitution is heavy", 'gh pr create --title x --body "$(cargo build --release)"', "HEAVY"),
@@ -1947,6 +2780,84 @@ def _run_selftest() -> int:
             extra_env={"MURMUR_AGENT_TASK_ID": "malformed"},
         )
         test.result(f"{vendor}: malformed task manifest", got, "BLOCK")
+        got, _ = test.invoke(
+            vendor,
+            "finish-guard",
+            "git commit -m x",
+            repo,
+        )
+        test.result(
+            f"{vendor}: unrelated unreadable historical manifest does not poison commits",
+            got,
+            "ALLOW",
+        )
+        shutil.rmtree(malformed_dir)
+
+        valid_json_bad_dir = common / "agent-harness" / "v2" / "tasks" / "bad-v2"
+        valid_json_bad_dir.mkdir(parents=True)
+        (valid_json_bad_dir / "task.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "task_id": "bad-v2",
+                    "worktree_path": str(repo.resolve()),
+                    "contract_sha256": "0" * 64,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        got, _ = test.invoke(
+            vendor,
+            "finish-guard",
+            "git commit -m x",
+            repo,
+        )
+        test.result(
+            f"{vendor}: malformed v2 manifest claiming current worktree",
+            got,
+            "BLOCK",
+        )
+        got, _ = test.invoke(
+            vendor,
+            "finish-guard",
+            "git commit -m x",
+            repo,
+            extra_env={"MURMUR_AGENT_TASK_REF": "v2:bad-v2"},
+        )
+        test.result(
+            f"{vendor}: valid JSON malformed v2 hash/schema claim",
+            got,
+            "BLOCK",
+        )
+        shutil.rmtree(valid_json_bad_dir.parent.parent)
+        valid_json_bad_v1 = common / "agent-harness" / "tasks" / "bad-v1"
+        valid_json_bad_v1.mkdir(parents=True)
+        (valid_json_bad_v1 / "task.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "task_id": "bad-v1",
+                    "worktree_path": str(repo.resolve()),
+                    "contract_sha256": "0" * 64,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        got, _ = test.invoke(
+            vendor,
+            "finish-guard",
+            "git commit -m x",
+            repo,
+            extra_env={"MURMUR_AGENT_TASK_REF": "v1:bad-v1"},
+        )
+        test.result(
+            f"{vendor}: valid JSON malformed v1 hash/schema claim",
+            got,
+            "BLOCK",
+        )
+        shutil.rmtree(valid_json_bad_v1)
 
         task_dir, task, attestation = _write_receipt(repo, "fresh")
         got, _ = test.invoke(vendor, "finish-guard", "git commit -m x", repo)
@@ -2088,6 +2999,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     args = parser.parse_args(argv)
     if args.action == "selftest":
         return _run_selftest()
+    command = ""
+    process_cwd = Path.cwd()
     try:
         command, process_cwd = _read_payload()
         reason = _unsupported_execution_indirection(command)
@@ -2101,7 +3014,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             reason = _finish_guard(command, process_cwd)
     except GuardFailure as exc:
         reason = str(exc)
-    return _emit(args.vendor, reason, args.action)
+    return _emit(
+        args.vendor,
+        reason,
+        args.action,
+        command=command,
+        process_cwd=process_cwd,
+    )
 
 
 if __name__ == "__main__":

--- a/.agents/harness/metrics.py
+++ b/.agents/harness/metrics.py
@@ -1,0 +1,555 @@
+#!/usr/bin/env python3
+"""Small read-only rollup over append-only Harness v1/v2 event ledgers."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import math
+import os
+from pathlib import Path
+import re
+import stat
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+
+
+Observation = Tuple[str, Any]
+RETRY_LABEL = re.compile(r"-try-(\d+)$")
+
+
+def _utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+
+def _is_real(path: Path, kind: int) -> bool:
+    try:
+        return stat.S_IFMT(os.lstat(path).st_mode) == kind
+    except OSError:
+        return False
+
+
+def _timestamp(value: Any) -> Optional[float]:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed.timestamp() if parsed.tzinfo is not None else None
+
+
+def _ledger_paths(task: Path, generation: int) -> Tuple[List[Path], int]:
+    candidates = [task / "events.jsonl"]
+    unsafe = 0
+    attempts = task / "attempts"
+    if generation == 2 and _is_real(attempts, stat.S_IFDIR):
+        try:
+            children = sorted(attempts.iterdir(), key=lambda item: item.name)
+        except OSError:
+            children = []
+            unsafe += 1
+        attempt_dirs = [
+            child for child in children if _is_real(child, stat.S_IFDIR)
+        ]
+        candidates.extend(child / "events.jsonl" for child in attempt_dirs)
+        unsafe += sum(1 for child in children if not _is_real(child, stat.S_IFDIR))
+        for attempt in attempt_dirs:
+            review_runs = attempt / "review-runs"
+            if _is_real(review_runs, stat.S_IFDIR):
+                try:
+                    review_children = sorted(
+                        review_runs.iterdir(), key=lambda item: item.name
+                    )
+                except OSError:
+                    review_children = []
+                    unsafe += 1
+                review_dirs = [
+                    child
+                    for child in review_children
+                    if _is_real(child, stat.S_IFDIR)
+                ]
+                candidates.extend(
+                    child / "events.jsonl" for child in review_dirs
+                )
+                unsafe += sum(
+                    1
+                    for child in review_children
+                    if not _is_real(child, stat.S_IFDIR)
+                )
+            elif review_runs.exists() or review_runs.is_symlink():
+                unsafe += 1
+    elif generation == 2 and (attempts.exists() or attempts.is_symlink()):
+        unsafe += 1
+    ledgers: List[Path] = []
+    for path in candidates:
+        if _is_real(path, stat.S_IFREG):
+            ledgers.append(path)
+        elif path.exists() or path.is_symlink():
+            unsafe += 1
+    return ledgers, unsafe
+
+
+def _read(path: Path) -> Dict[str, Any]:
+    result: Dict[str, Any] = {
+        "readable": False,
+        "lines": 0,
+        "valid": 0,
+        "malformed": 0,
+        "non_object": 0,
+        "events": [],
+    }
+    try:
+        with path.open("r", encoding="utf-8", errors="strict") as handle:
+            result["readable"] = True
+            for line_number, line in enumerate(handle, start=1):
+                result["lines"] += 1
+                if not line.strip():
+                    continue
+                try:
+                    document = json.loads(line)
+                except (json.JSONDecodeError, UnicodeDecodeError):
+                    result["malformed"] += 1
+                    continue
+                if not isinstance(document, dict):
+                    result["non_object"] += 1
+                    continue
+                result["valid"] += 1
+                result["events"].append(
+                    {**document, "_ledger": str(path), "_line": line_number}
+                )
+    except (OSError, UnicodeError):
+        result["readable"] = False
+    return result
+
+
+def _discover(common: Path) -> Tuple[List[Dict[str, Any]], int]:
+    records: List[Dict[str, Any]] = []
+    unsafe = 0
+    for generation, root in (
+        (1, common / "agent-harness" / "tasks"),
+        (2, common / "agent-harness" / "v2" / "tasks"),
+    ):
+        if not _is_real(root, stat.S_IFDIR):
+            if root.exists() or root.is_symlink():
+                unsafe += 1
+            continue
+        try:
+            entries = sorted(root.iterdir(), key=lambda item: item.name)
+        except OSError:
+            unsafe += 1
+            continue
+        for task in entries:
+            if not _is_real(task, stat.S_IFDIR):
+                unsafe += int(task.is_symlink())
+                continue
+            paths, skipped = _ledger_paths(task, generation)
+            unsafe += skipped
+            reads = [_read(path) for path in paths]
+            events = [event for read in reads for event in read["events"]]
+            status: Optional[str] = None
+            last_at: Optional[str] = None
+            last_epoch: Optional[float] = None
+            for event in events:
+                epoch = _timestamp(event.get("at"))
+                if epoch is not None and (last_epoch is None or epoch >= last_epoch):
+                    last_epoch, last_at = epoch, event["at"]
+                if event.get("event") == "state":
+                    nested = event.get("state")
+                    candidate = (
+                        nested.get("status")
+                        if isinstance(nested, Mapping)
+                        else event.get("status")
+                    )
+                    if isinstance(candidate, str) and candidate:
+                        status = candidate
+            records.append(
+                {
+                    "task_id": task.name,
+                    "generation": generation,
+                    "status": status,
+                    "last_event_at": last_at,
+                    "last_epoch": last_epoch,
+                    "reads": reads,
+                    "events": events,
+                }
+            )
+    return records, unsafe
+
+
+def _coverage(observations: Sequence[Observation]) -> Dict[str, Any]:
+    available = sum(state == "available" for state, _ in observations)
+    missing = sum(state == "missing" for state, _ in observations)
+    invalid = len(observations) - available - missing
+    return {
+        "available": available,
+        "missing": missing,
+        "invalid": invalid,
+        "total": len(observations),
+        "percent": round(100.0 * available / len(observations), 1)
+        if observations
+        else None,
+    }
+
+
+def _valid_number(value: Any) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+        and float(value) >= 0
+    )
+
+
+def _valid_integer(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _observe(
+    groups: Sequence[Sequence[Mapping[str, Any]]],
+    field: str,
+    valid: Callable[[Any], bool],
+) -> List[Observation]:
+    observations: List[Observation] = []
+    for group in groups:
+        values = [event[field] for event in group if event.get(field) is not None]
+        if not values:
+            observations.append(("missing", None))
+        elif any(not valid(value) for value in values):
+            observations.append(("invalid", None))
+        elif any(value != values[0] for value in values[1:]):
+            observations.append(("invalid", None))
+        else:
+            observations.append(("available", values[0]))
+    return observations
+
+
+def _number(value: float) -> Any:
+    return int(value) if float(value).is_integer() else round(float(value), 6)
+
+
+def _numeric(observations: Sequence[Observation]) -> Dict[str, Any]:
+    values = sorted(
+        float(value) for state, value in observations if state == "available"
+    )
+
+    def percentile(fraction: float) -> Optional[Any]:
+        if not values:
+            return None
+        return _number(values[max(0, math.ceil(fraction * len(values)) - 1)])
+
+    return {
+        "total": _number(math.fsum(values)) if values else None,
+        "p50": percentile(0.50),
+        "p90": percentile(0.90),
+        "coverage": _coverage(observations),
+    }
+
+
+def _model_key(task_key: str, event: Mapping[str, Any], ordinal: int) -> Tuple[str, ...]:
+    for field in ("result_path", "invocation_path", "execution_id"):
+        value = event.get(field)
+        if isinstance(value, str) and value:
+            return task_key, str(event["_ledger"]), field, value
+    label = event.get("label")
+    if isinstance(label, str) and label:
+        return task_key, str(event["_ledger"]), "label", label, str(
+            event.get("session_id") or ""
+        )
+    return task_key, str(event["_ledger"]), "line", str(ordinal)
+
+
+def _model_groups(records: Sequence[Mapping[str, Any]]) -> List[List[Mapping[str, Any]]]:
+    groups: Dict[Tuple[str, ...], List[Mapping[str, Any]]] = {}
+    for record in records:
+        task_key = f"v{record['generation']}:{record['task_id']}"
+        for ordinal, event in enumerate(record["events"]):
+            if event.get("event") not in {
+                "model-process-exit",
+                "model-invocation",
+            }:
+                continue
+            groups.setdefault(_model_key(task_key, event, ordinal), []).append(event)
+    return list(groups.values())
+
+
+def _true_count(observations: Sequence[Observation]) -> Dict[str, Any]:
+    return {
+        "count": sum(
+            state == "available" and value is True
+            for state, value in observations
+        ),
+        "coverage": _coverage(observations),
+    }
+
+
+def _retries(groups: Sequence[Sequence[Mapping[str, Any]]]) -> Dict[str, Any]:
+    labels = _observe(
+        groups, "label", lambda value: isinstance(value, str) and bool(value)
+    )
+    return {
+        "count": sum(
+            state == "available"
+            and (match := RETRY_LABEL.search(str(label))) is not None
+            and int(match.group(1)) >= 2
+            for state, label in labels
+        ),
+        "label_coverage": _coverage(labels),
+    }
+
+
+def _models(groups: Sequence[Sequence[Mapping[str, Any]]]) -> Dict[str, Any]:
+    roles = _observe(
+        groups, "role", lambda value: isinstance(value, str) and bool(value)
+    )
+    by_role: Dict[str, int] = {}
+    for state, role in roles:
+        if state == "available":
+            by_role[str(role)] = by_role.get(str(role), 0) + 1
+    costs = _observe(groups, "total_cost_usd", _valid_number)
+    turns = _observe(groups, "num_turns", _valid_integer)
+    http = _observe(
+        groups,
+        "http_status",
+        lambda value: isinstance(value, int)
+        and not isinstance(value, bool)
+        and 100 <= value <= 599,
+    )
+    return {
+        "invocations": len(groups),
+        "by_role": dict(sorted(by_role.items())),
+        "role_coverage": _coverage(roles),
+        "total_cost_usd": _numeric(costs)["total"],
+        "cost_usd_coverage": _coverage(costs),
+        "total_num_turns": _numeric(turns)["total"],
+        "num_turns_coverage": _coverage(turns),
+        "durations_ms": _numeric(_observe(groups, "duration_ms", _valid_number)),
+        "timeouts": _true_count(
+            _observe(groups, "timed_out", lambda value: isinstance(value, bool))
+        ),
+        "retry_invocations": _retries(groups),
+        "retryable_http_failures": {
+            "count": sum(
+                state == "available" and (value == 429 or value >= 500)
+                for state, value in http
+            ),
+            "coverage": _coverage(http),
+        },
+    }
+
+
+def _reviews(groups: Sequence[Sequence[Mapping[str, Any]]]) -> Dict[str, Any]:
+    selected = [
+        group
+        for group in groups
+        if _observe(
+            [group], "role", lambda value: isinstance(value, str) and bool(value)
+        )[0]
+        == ("available", "reviewer")
+    ]
+    return {
+        "attempts": len(selected),
+        "durations_ms": _numeric(
+            _observe(selected, "duration_ms", _valid_number)
+        ),
+        "timeouts": _true_count(
+            _observe(selected, "timed_out", lambda value: isinstance(value, bool))
+        ),
+        "retry_invocations": _retries(selected),
+    }
+
+
+def _checks(records: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
+    events = [
+        event
+        for record in records
+        for event in record["events"]
+        if event.get("event") == "check"
+    ]
+    groups = [[event] for event in events]
+    outcomes = _observe(
+        groups, "outcome", lambda value: isinstance(value, str) and bool(value)
+    )
+    by_outcome: Dict[str, int] = {}
+    for state, outcome in outcomes:
+        if state == "available":
+            by_outcome[str(outcome)] = by_outcome.get(str(outcome), 0) + 1
+    return {
+        "runs": len(events),
+        "by_outcome": dict(sorted(by_outcome.items())),
+        "outcome_coverage": _coverage(outcomes),
+        "durations_ms": _numeric(
+            _observe(groups, "duration_ms", _valid_number)
+        ),
+        "timeouts": _true_count(
+            _observe(groups, "timed_out", lambda value: isinstance(value, bool))
+        ),
+    }
+
+
+def collect_metrics(common_dir: Path, *, limit: int = 20) -> Dict[str, Any]:
+    if limit < 1:
+        raise ValueError("metrics limit must be positive")
+    common = common_dir.resolve()
+    records, unsafe = _discover(common)
+    records.sort(
+        key=lambda record: (
+            record["last_epoch"] is not None,
+            record["last_epoch"] or 0,
+            record["generation"],
+            record["task_id"],
+        ),
+        reverse=True,
+    )
+    selected = records[:limit]
+    status_counts: Dict[str, int] = {}
+    generation_counts = {"v1": 0, "v2": 0}
+    for record in selected:
+        status = record["status"] or "UNKNOWN"
+        status_counts[status] = status_counts.get(status, 0) + 1
+        generation_counts[f"v{record['generation']}"] += 1
+    status_observations = [
+        ("available", record["status"])
+        if record["status"] is not None
+        else ("missing", None)
+        for record in selected
+    ]
+    model_groups = _model_groups(selected)
+    reads = [read for record in selected for read in record["reads"]]
+    retryable_states = sum(
+        event.get("event") == "state"
+        and (
+            event.get("state", {}).get("status")
+            if isinstance(event.get("state"), Mapping)
+            else event.get("status")
+        )
+        == "PAUSED_RETRYABLE"
+        for record in selected
+        for event in record["events"]
+    )
+    return {
+        "schema_version": 1,
+        "generated_at": _utc_now(),
+        "git_common_dir": str(common),
+        "selection": {
+            "limit": limit,
+            "discovered_tasks": len(records),
+            "selected_tasks": len(selected),
+            "order": "latest valid event timestamp descending; task id tie-break",
+        },
+        "tasks": {
+            "count": len(selected),
+            "by_generation": generation_counts,
+            "by_status": dict(sorted(status_counts.items())),
+            "status_coverage": _coverage(status_observations),
+            "records": [
+                {
+                    "task_id": record["task_id"],
+                    "generation": record["generation"],
+                    "status": record["status"] or "UNKNOWN",
+                    "last_event_at": record["last_event_at"],
+                    "event_ledgers": len(record["reads"]),
+                }
+                for record in selected
+            ],
+        },
+        "models": _models(model_groups),
+        "checks": _checks(selected),
+        "reviews": _reviews(model_groups),
+        "events": {
+            "ledgers": {
+                "discovered": len(reads),
+                "readable": sum(read["readable"] for read in reads),
+                "unreadable": sum(not read["readable"] for read in reads),
+            },
+            "lines": {
+                "total": sum(read["lines"] for read in reads),
+                "valid_objects": sum(read["valid"] for read in reads),
+                "malformed": sum(read["malformed"] for read in reads),
+                "non_object": sum(read["non_object"] for read in reads),
+            },
+            "retryable_state_transitions": retryable_states,
+        },
+        "unsafe_entries_skipped": unsafe,
+    }
+
+
+def _coverage_text(value: Mapping[str, Any]) -> str:
+    percent = "n/a" if value["percent"] is None else f"{value['percent']:.1f}%"
+    return (
+        f"{value['available']}/{value['total']} ({percent}; "
+        f"missing {value['missing']}, invalid {value['invalid']})"
+    )
+
+
+def _duration_text(value: Mapping[str, Any]) -> str:
+    summary = (
+        "n/a"
+        if value["p50"] is None
+        else f"p50 {value['p50']} ms, p90 {value['p90']} ms, total {value['total']} ms"
+    )
+    return f"{summary}; coverage {_coverage_text(value['coverage'])}"
+
+
+def render_text(report: Mapping[str, Any]) -> str:
+    selection = report["selection"]
+    tasks = report["tasks"]
+    models = report["models"]
+    checks = report["checks"]
+    reviews = report["reviews"]
+    events = report["events"]
+    cost = (
+        "n/a"
+        if models["total_cost_usd"] is None
+        else f"${models['total_cost_usd']:.6f}"
+    )
+    turns = (
+        "n/a"
+        if models["total_num_turns"] is None
+        else str(models["total_num_turns"])
+    )
+    return "\n".join(
+        [
+            (
+                f"Harness metrics: {selection['selected_tasks']}/"
+                f"{selection['discovered_tasks']} most recent task generations "
+                f"(limit {selection['limit']})"
+            ),
+            (
+                f"tasks: status {json.dumps(tasks['by_status'], sort_keys=True)}; "
+                f"generation {json.dumps(tasks['by_generation'], sort_keys=True)}; "
+                f"coverage {_coverage_text(tasks['status_coverage'])}"
+            ),
+            (
+                f"models: {models['invocations']} invocations; observed cost {cost} "
+                f"(coverage {_coverage_text(models['cost_usd_coverage'])}); "
+                f"observed turns {turns} "
+                f"(coverage {_coverage_text(models['num_turns_coverage'])})"
+            ),
+            f"model durations: {_duration_text(models['durations_ms'])}",
+            (
+                f"reviews: {reviews['attempts']} attempts, "
+                f"{reviews['retry_invocations']['count']} retries, "
+                f"{reviews['timeouts']['count']} timeouts; "
+                f"durations {_duration_text(reviews['durations_ms'])}"
+            ),
+            (
+                f"checks: {checks['runs']} runs, {checks['timeouts']['count']} timeouts; "
+                f"outcomes {json.dumps(checks['by_outcome'], sort_keys=True)}; "
+                f"durations {_duration_text(checks['durations_ms'])}"
+            ),
+            (
+                f"retry signals: {models['retry_invocations']['count']} model retries, "
+                f"{models['retryable_http_failures']['count']} observed HTTP 429/5xx "
+                f"exits, {events['retryable_state_transitions']} PAUSED_RETRYABLE"
+            ),
+            (
+                f"ledgers: {events['ledgers']['readable']}/"
+                f"{events['ledgers']['discovered']} readable; "
+                f"{events['lines']['valid_objects']}/{events['lines']['total']} valid; "
+                f"{events['lines']['malformed']} malformed; "
+                f"{report['unsafe_entries_skipped']} unsafe entries skipped"
+            ),
+        ]
+    )

--- a/.agents/harness/metrics_selftest.py
+++ b/.agents/harness/metrics_selftest.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Deterministic selftest for Harness telemetry aggregation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+from typing import Any, Mapping
+
+import metrics
+
+
+class Tests:
+    def __init__(self) -> None:
+        self.assertions = 0
+        self.failures: list[str] = []
+
+    def equal(self, name: str, actual: Any, expected: Any) -> None:
+        self.assertions += 1
+        if actual != expected:
+            self.failures.append(f"{name}: expected {expected!r}, got {actual!r}")
+
+    def true(self, name: str, condition: bool) -> None:
+        self.assertions += 1
+        if not condition:
+            self.failures.append(name)
+
+
+def _append(path: Path, *documents: Any, raw: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        for document in documents:
+            handle.write(json.dumps(document, sort_keys=True) + "\n")
+        if raw:
+            handle.write(raw)
+
+
+def _state(at: str, status: str, *, generation: int) -> Mapping[str, Any]:
+    if generation == 1:
+        return {"at": at, "event": "state", "status": status}
+    return {
+        "at": at,
+        "event": "state",
+        "state": {
+            "schema_version": 2,
+            "task_id": "fixture",
+            "status": status,
+            "updated_at": at,
+        },
+    }
+
+
+def cases(test: Tests) -> None:
+    with tempfile.TemporaryDirectory(prefix="murmur-metrics-") as raw:
+        common = Path(raw) / ".git"
+        v1 = common / "agent-harness" / "tasks"
+        v2 = common / "agent-harness" / "v2" / "tasks"
+
+        task_a = v1 / "task-a" / "events.jsonl"
+        _append(
+            task_a,
+            _state("2026-07-01T10:00:00Z", "INITIALIZED", generation=1),
+            {
+                "at": "2026-07-01T10:01:00Z",
+                "event": "model-invocation",
+                "label": "round-01-writer",
+                "role": "writer",
+                "vendor": "claude",
+                "result_path": "/task-a/writer.json",
+                "duration_ms": 1000,
+                "timed_out": False,
+            },
+            {
+                "at": "2026-07-01T10:02:00Z",
+                "event": "check",
+                "id": "rust-lib",
+                "duration_ms": 300,
+                "timed_out": False,
+                "outcome": "PASS",
+            },
+            _state("2026-07-01T10:03:00Z", "CLOSED", generation=1),
+        )
+
+        task_b = v1 / "task-b" / "events.jsonl"
+        process = {
+            "at": "2026-07-02T10:01:00Z",
+            "event": "model-process-exit",
+            "label": "round-01-spec",
+            "role": "reviewer",
+            "vendor": "codex",
+            "result_path": "/task-b/spec.json",
+            "execution_id": "exec-b",
+            "duration_ms": 2000,
+            "total_cost_usd": 1.5,
+            "num_turns": 3,
+            "http_status": 429,
+            "timed_out": False,
+        }
+        invocation = {
+            **process,
+            "event": "model-invocation",
+            "session_id": "session-b",
+        }
+        _append(
+            task_b,
+            _state("2026-07-02T10:00:00Z", "RUNNING", generation=1),
+            process,
+            invocation,
+            {
+                "at": "2026-07-02T10:02:00Z",
+                "event": "check",
+                "id": "tauri-boot",
+                "duration_ms": 500,
+                "timed_out": True,
+                "outcome": "BLOCKED",
+            },
+            _state("2026-07-02T10:03:00Z", "BLOCKED", generation=1),
+            [1, 2, 3],
+            raw="{not-json}\n",
+        )
+
+        task_c_top = v2 / "task-c" / "events.jsonl"
+        _append(
+            task_c_top,
+            _state("2026-07-03T10:00:00Z", "OPEN", generation=2),
+            {
+                "at": "2026-07-03T10:01:00Z",
+                "event": "check",
+                "id": "ng-build",
+                "duration_ms": 700,
+                "timed_out": False,
+                "outcome": "PASS",
+            },
+            _state("2026-07-03T10:05:00Z", "PAUSED_RETRYABLE", generation=2),
+            _state("2026-07-03T10:06:00Z", "PASSED", generation=2),
+        )
+        task_c_review = (
+            v2
+            / "task-c"
+            / "attempts"
+            / "attempt-1"
+            / "review-runs"
+            / "combined"
+            / "events.jsonl"
+        )
+        for number, duration, cost, turns, timed_out in (
+            (1, 3000, 2.0, 4, True),
+            (2, 4000, 3.0, 5, False),
+        ):
+            model_exit = {
+                "at": f"2026-07-03T10:0{number + 1}:00Z",
+                "event": "model-process-exit",
+                "label": f"review-combined-try-{number}",
+                "role": "reviewer",
+                "vendor": "claude",
+                "result_path": f"/task-c/review-{number}.json",
+                "execution_id": f"exec-c-{number}",
+                "duration_ms": duration,
+                "total_cost_usd": cost,
+                "num_turns": turns,
+                "timed_out": timed_out,
+            }
+            _append(
+                task_c_review,
+                model_exit,
+                {**model_exit, "event": "model-invocation"},
+            )
+
+        report = metrics.collect_metrics(common, limit=20)
+        test.equal("TASK all generations counted", report["tasks"]["count"], 3)
+        test.equal(
+            "TASK statuses come only from authoritative state events",
+            report["tasks"]["by_status"],
+            {"BLOCKED": 1, "CLOSED": 1, "PASSED": 1},
+        )
+        test.equal(
+            "TASK generation split is explicit",
+            report["tasks"]["by_generation"],
+            {"v1": 2, "v2": 1},
+        )
+        test.equal(
+            "MODEL process-exit plus invocation is deduplicated",
+            report["models"]["invocations"],
+            4,
+        )
+        test.equal(
+            "MODEL absent legacy cost is not guessed",
+            report["models"]["cost_usd_coverage"],
+            {
+                "available": 3,
+                "missing": 1,
+                "invalid": 0,
+                "total": 4,
+                "percent": 75.0,
+            },
+        )
+        test.equal(
+            "MODEL observed costs sum only covered invocations",
+            report["models"]["total_cost_usd"],
+            6.5,
+        )
+        test.equal(
+            "MODEL observed turns sum only covered invocations",
+            report["models"]["total_num_turns"],
+            12,
+        )
+        test.equal(
+            "MODEL nearest-rank p50 is stable",
+            report["models"]["durations_ms"]["p50"],
+            2000,
+        )
+        test.equal(
+            "MODEL nearest-rank p90 is stable",
+            report["models"]["durations_ms"]["p90"],
+            4000,
+        )
+        test.equal(
+            "REVIEW attempts are role-derived",
+            report["reviews"]["attempts"],
+            3,
+        )
+        test.equal(
+            "REVIEW retry labels count only extra attempts",
+            report["reviews"]["retry_invocations"]["count"],
+            1,
+        )
+        test.equal(
+            "REVIEW timeouts retain typed evidence",
+            report["reviews"]["timeouts"]["count"],
+            1,
+        )
+        test.equal(
+            "LEDGER production review-runs depth is discovered",
+            report["events"]["ledgers"]["discovered"],
+            4,
+        )
+        test.equal(
+            "CHECK runs include both generations",
+            report["checks"]["runs"],
+            3,
+        )
+        test.equal(
+            "CHECK p50 is stable",
+            report["checks"]["durations_ms"]["p50"],
+            500,
+        )
+        test.equal(
+            "CHECK timeout is counted",
+            report["checks"]["timeouts"]["count"],
+            1,
+        )
+        test.equal(
+            "RETRY HTTP status is reported without inference",
+            report["models"]["retryable_http_failures"]["count"],
+            1,
+        )
+        test.equal(
+            "RETRYABLE state transition is counted",
+            report["events"]["retryable_state_transitions"],
+            1,
+        )
+        test.equal(
+            "LEDGER malformed JSON remains visible",
+            report["events"]["lines"]["malformed"],
+            1,
+        )
+        test.equal(
+            "LEDGER non-object JSON remains visible",
+            report["events"]["lines"]["non_object"],
+            1,
+        )
+        test.equal(
+            "LIMIT selects newest task generations",
+            [
+                item["task_id"]
+                for item in metrics.collect_metrics(common, limit=2)["tasks"]["records"]
+            ],
+            ["task-c", "task-b"],
+        )
+        text = metrics.render_text(report)
+        test.true(
+            "TEXT output makes coverage explicit",
+            "coverage 3/4 (75.0%; missing 1, invalid 0)" in text,
+        )
+
+        empty = metrics.collect_metrics(Path(raw) / "empty.git", limit=5)
+        test.equal("EMPTY totals stay unavailable", empty["models"]["total_cost_usd"], None)
+        test.equal(
+            "EMPTY coverage does not invent a percentage",
+            empty["models"]["cost_usd_coverage"]["percent"],
+            None,
+        )
+        try:
+            metrics.collect_metrics(common, limit=0)
+        except ValueError as exc:
+            test.true("LIMIT zero fails clearly", "positive" in str(exc))
+        else:
+            test.true("LIMIT zero fails clearly", False)
+
+
+def main() -> int:
+    test = Tests()
+    cases(test)
+    if test.failures:
+        for failure in test.failures:
+            print(f"metrics-selftest: FAIL: {failure}")
+        return 1
+    print(f"metrics-selftest: PASS ({test.assertions} assertions)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/harness/process_guardian.py
+++ b/.agents/harness/process_guardian.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Out-of-process parent-death and deadline guardian for harness children.
+
+The harness process can be SIGKILLed, so an in-process ``finally`` block is not
+enough to reap a Cargo/model child or release inherited flock descriptors. This
+small supervisor receives a liveness pipe from its parent, starts exactly one
+new-session child, and kills that owned process group if the pipe closes, a
+signal arrives, or the deadline expires.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+from pathlib import Path
+import select
+import signal
+import subprocess
+import sys
+import time
+from typing import Any, Dict, Optional, Sequence
+
+
+POLL_SECONDS = 0.1
+
+
+def utc_now() -> str:
+    return (
+        dt.datetime.now(dt.timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def atomic_json(path: Path, document: Dict[str, Any]) -> None:
+    """Publish one guardian result without ever replacing an older artifact."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    payload = (
+        json.dumps(document, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode("utf-8")
+    descriptor = os.open(
+        temporary,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+        0o600,
+    )
+    try:
+        written = os.write(descriptor, payload)
+        if written != len(payload):
+            raise OSError("short guardian result write")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    try:
+        # A hard-link publish is atomic and fails with EEXIST. ``os.replace``
+        # would silently destroy the prior crash evidence if an immediate
+        # resume accidentally reused a result path.
+        os.link(temporary, path)
+    finally:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+    directory = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory)
+    finally:
+        os.close(directory)
+
+
+def group_exists(pgid: int) -> bool:
+    try:
+        os.killpg(pgid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def terminate_group(process: subprocess.Popen[Any], grace: float) -> None:
+    pgid = process.pid
+    if not group_exists(pgid):
+        process.poll()
+        return
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    deadline = time.monotonic() + max(0.0, grace)
+    while time.monotonic() < deadline:
+        process.poll()  # reap a responsive group leader
+        if not group_exists(pgid):
+            return
+        time.sleep(POLL_SECONDS)
+    kill_deadline = time.monotonic() + 5.0
+    permission_error: Optional[PermissionError] = None
+    while time.monotonic() < kill_deadline:
+        process.poll()
+        if not group_exists(pgid):
+            return
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+        except PermissionError as exc:
+            # A just-exited, not-yet-reaped leader can transiently report EPERM.
+            # Reap/poll and retry, but never spin forever or silently release.
+            permission_error = exc
+        time.sleep(POLL_SECONDS)
+    process.poll()
+    if group_exists(pgid):
+        if permission_error is not None:
+            raise RuntimeError(
+                f"could not kill owned process group {pgid}: {permission_error}"
+            )
+        raise RuntimeError(f"owned process group {pgid} survived SIGKILL")
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--parent-fd", required=True, type=int)
+    parser.add_argument("--stdin-fd", type=int)
+    parser.add_argument("--result", required=True)
+    parser.add_argument("--cwd", required=True)
+    parser.add_argument("--timeout-seconds", required=True, type=float)
+    parser.add_argument("--term-grace-seconds", type=float, default=3.0)
+    parser.add_argument("--pass-fd", action="append", type=int, default=[])
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    if args.command[:1] == ["--"]:
+        args.command = args.command[1:]
+    if not args.command:
+        parser.error("missing child command")
+    if args.timeout_seconds <= 0:
+        parser.error("timeout must be positive")
+    return args
+
+
+def main(argv: Sequence[str]) -> int:
+    args = parse_args(argv)
+    result_path = Path(args.result)
+    parent_fd = args.parent_fd
+    stdin_fd: Optional[int] = args.stdin_fd
+    stop_signal: Optional[int] = None
+
+    def request_stop(signum: int, _frame: Any) -> None:
+        nonlocal stop_signal
+        stop_signal = signum
+
+    for signum in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+        signal.signal(signum, request_stop)
+
+    started = time.monotonic()
+    started_at = utc_now()
+    child: Optional[subprocess.Popen[Any]] = None
+    timed_out = False
+    parent_lost = False
+    leader_exited_with_live_group = False
+    termination_reason: Optional[str] = None
+    try:
+        child = subprocess.Popen(
+            list(args.command),
+            cwd=args.cwd,
+            env=os.environ.copy(),
+            stdin=stdin_fd if stdin_fd is not None else subprocess.DEVNULL,
+            stdout=None,
+            stderr=None,
+            start_new_session=True,
+            pass_fds=tuple(args.pass_fd),
+        )
+        if stdin_fd is not None:
+            os.close(stdin_fd)
+            stdin_fd = None
+        deadline = started + args.timeout_seconds
+        while True:
+            if child.poll() is not None:
+                leader_exited_with_live_group = group_exists(child.pid)
+                if leader_exited_with_live_group:
+                    termination_reason = "leader-exited-with-live-group"
+                break
+            if stop_signal is not None:
+                termination_reason = "guardian-signal"
+                break
+            now = time.monotonic()
+            if now >= deadline:
+                timed_out = True
+                termination_reason = "timeout"
+                break
+            readable, _, _ = select.select(
+                [parent_fd],
+                [],
+                [],
+                min(POLL_SECONDS, max(0.0, deadline - now)),
+            )
+            if readable:
+                marker = os.read(parent_fd, 1)
+                if marker == b"":
+                    parent_lost = True
+                    termination_reason = "parent-lost"
+                    break
+        # A successful group leader is not proof that the owned process group
+        # is gone: shell commands, Cargo wrappers, and model CLIs can leave
+        # same-PGID descendants alive. Always inspect and drain the group before
+        # publishing a result, including after the leader has already exited.
+        if group_exists(child.pid):
+            terminate_group(child, args.term_grace_seconds)
+        leader_exit_code = child.wait()
+        # A command which returned success while leaving owned background work
+        # behind did not terminate cleanly. Cleanup prevents an orphan, but it
+        # must not green-wash the check/model invocation that leaked it.
+        exit_code = (
+            125
+            if leader_exited_with_live_group and leader_exit_code == 0
+            else leader_exit_code
+        )
+        atomic_json(
+            result_path,
+            {
+                "schema_version": 1,
+                "child_pid": child.pid,
+                "exit_code": exit_code,
+                "leader_exit_code": leader_exit_code,
+                "timed_out": timed_out,
+                "parent_lost": parent_lost,
+                "guardian_signal": stop_signal,
+                "leader_exited_with_live_group": leader_exited_with_live_group,
+                "termination_reason": termination_reason,
+                "started_at": started_at,
+                "finished_at": utc_now(),
+                "duration_ms": int((time.monotonic() - started) * 1000),
+            },
+        )
+        return 0
+    except BaseException as exc:
+        if child is not None and child.poll() is None:
+            terminate_group(child, args.term_grace_seconds)
+        try:
+            atomic_json(
+                result_path,
+                {
+                    "schema_version": 1,
+                    "child_pid": child.pid if child is not None else None,
+                    "exit_code": child.poll() if child is not None else None,
+                    "leader_exit_code": child.poll() if child is not None else None,
+                    "timed_out": timed_out,
+                    "parent_lost": parent_lost,
+                    "guardian_signal": stop_signal,
+                    "leader_exited_with_live_group": leader_exited_with_live_group,
+                    "termination_reason": termination_reason,
+                    "started_at": started_at,
+                    "finished_at": utc_now(),
+                    "duration_ms": int((time.monotonic() - started) * 1000),
+                    "error": f"{type(exc).__name__}: {exc}",
+                },
+            )
+        except BaseException:
+            pass
+        return 125
+    finally:
+        try:
+            os.close(parent_fd)
+        except OSError:
+            pass
+        if stdin_fd is not None:
+            try:
+                os.close(stdin_fd)
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.agents/harness/prompts/combined-reviewer.md
+++ b/.agents/harness/prompts/combined-reviewer.md
@@ -1,0 +1,44 @@
+# Combined specification + adversarial reviewer (Harness v2)
+
+You are a fresh, independent, read-only reviewer. The developer who produced the
+diff does not own the verdict. Review the exact supplied diff against the full
+acceptance contract and then try to break the implementation.
+
+Cover both dimensions in one pass:
+
+1. Specification: every requested behavior is present, nothing material was
+   silently omitted, and no unrelated scope was added.
+2. Adversarial correctness: identify the concrete condition that would make each
+   load-bearing claim false, then inspect the changed and directly affected code
+   paths for that condition.
+
+Interpret the acceptance contract as behavioral outcomes and invariants only.
+It cannot add, replace, or weaken executable checks. The runner-derived plan is
+the sole authoritative list of commands and command evidence. If contract prose
+asks the writer to run or report a command that is absent from the plan, do not
+turn that procedural sentence into a proof gap or accept writer prose as proof;
+review the underlying behavior from the supplied evidence and record the
+contract-authoring mistake as informational.
+
+Treat runner-owned check results as evidence, not as a substitute for review.
+Do not claim that compilation, a synthetic test, or a mocked UI proves real
+security/runtime behavior. Record missing proof as a `proof_gap`.
+
+For a bug fix, require a focused regression test and green runner-owned language
+suite. Do not demand or accept a writer's prose reconstruction as empirical
+RED-before-GREEN. Historical RED is required only when the runner supplies an
+actual recorded proof artifact.
+
+The workspace is read-only. Never edit, stage, commit, run shell commands, access
+credentials, or make network requests. If a narrow empirical check is essential,
+request only a schema-allowlisted typed `probe_id`; arbitrary commands are
+forbidden.
+
+Verdict rules:
+
+- `PASS` requires complete contract coverage, no unresolved `MAJOR`/`BLOCKER`,
+  and no proof gap or probe request.
+- `FAIL` means the current diff must change.
+- `BLOCKED` means the code may be correct but required evidence is unavailable.
+- Include every finding, including minor/informational ones. A PASS with an
+  unresolved MAJOR/BLOCKER is invalid regardless of the verdict field.

--- a/.agents/harness/schemas/attestation.schema.json
+++ b/.agents/harness/schemas/attestation.schema.json
@@ -39,6 +39,18 @@
     "worktree_path": { "type": "string" },
     "risk_flags": { "type": "array", "items": { "type": "string" } },
     "writer": { "$ref": "#/$defs/writer" },
+    "provenance_schema_version": {
+      "const": 2,
+      "description": "Present on post-v2 receipts; absence identifies legacy receipts."
+    },
+    "writer_attempts": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "degraded_provenance": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true }
+    },
     "reviewer": { "$ref": "#/$defs/reviewerBase" },
     "rounds": { "type": "integer", "minimum": 1 },
     "checks": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/check" } },
@@ -152,6 +164,10 @@
         "log_path": { "type": "string", "minLength": 1 },
         "log_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
         "staged_diff_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "findings": {
+          "type": "array",
+          "items": { "type": "object", "additionalProperties": true }
+        },
         "created_at": { "type": "string", "format": "date-time" }
       }
     }

--- a/.agents/harness/schemas/task.schema.json
+++ b/.agents/harness/schemas/task.schema.json
@@ -57,6 +57,11 @@
     },
     "writer": { "enum": ["codex", "claude", "fake"] },
     "reviewer": { "enum": ["codex", "claude", "fake"] },
+    "verification_profile": {
+      "type": "string",
+      "enum": ["full"],
+      "description": "Legacy pre-v2 contract field retained for read/close compatibility."
+    },
     "max_repair_rounds": { "type": "integer", "minimum": 0, "maximum": 5 },
     "checks": { "$ref": "#/$defs/checks" },
     "final_checks": { "$ref": "#/$defs/checks" },

--- a/.agents/harness/schemas/v2-commit-intent.schema.json
+++ b/.agents/harness/schemas/v2-commit-intent.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://murmurnotes.io/schemas/harness-v2-commit-intent.json",
+  "title": "Murmur crash-recoverable v2 commit intent",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "task_id",
+    "contract_sha256",
+    "evidence_sha256",
+    "parent_sha",
+    "tree_sha",
+    "diff_sha256",
+    "message",
+    "message_sha256",
+    "created_at",
+    "intent_sha256"
+  ],
+  "properties": {
+    "schema_version": { "const": 2 },
+    "task_id": { "type": "string" },
+    "contract_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "evidence_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "parent_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "tree_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "diff_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "message": { "type": "string", "minLength": 1 },
+    "message_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "intent_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+  }
+}

--- a/.agents/harness/schemas/v2-commit.schema.json
+++ b/.agents/harness/schemas/v2-commit.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://murmurnotes.io/schemas/harness-v2-commit.json",
+  "title": "Murmur v2 exact commit receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "task_id",
+    "contract_sha256",
+    "evidence_sha256",
+    "commit_sha",
+    "parent_sha",
+    "tree_sha",
+    "diff_sha256",
+    "author",
+    "committer",
+    "message",
+    "authored_at",
+    "committed_at",
+    "recorded_at"
+  ],
+  "properties": {
+    "schema_version": { "const": 2 },
+    "task_id": { "type": "string" },
+    "contract_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "evidence_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "commit_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "parent_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "tree_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "diff_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "author": { "type": "object", "additionalProperties": true },
+    "committer": { "type": "object", "additionalProperties": true },
+    "message": { "type": "string" },
+    "authored_at": { "type": "string" },
+    "committed_at": { "type": "string" },
+    "recorded_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/.agents/harness/schemas/v2-evidence.schema.json
+++ b/.agents/harness/schemas/v2-evidence.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://murmurnotes.io/schemas/harness-v2-evidence.json",
+  "title": "Murmur exact-diff v2 evidence",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "task_id",
+    "contract_sha256",
+    "diff_sha256",
+    "plan_sha256",
+    "protocol_sha256",
+    "parent_sha",
+    "tree_sha",
+    "changed_paths",
+    "actual_risk_flags",
+    "claims",
+    "checks",
+    "probes",
+    "reviews",
+    "findings",
+    "proof_gaps",
+    "probe_requests",
+    "degraded_provenance",
+    "telemetry",
+    "verdict",
+    "reason",
+    "created_at",
+    "evidence_sha256"
+  ],
+  "properties": {
+    "schema_version": { "const": 2 },
+    "task_id": { "type": "string" },
+    "contract_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "diff_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "plan_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "protocol_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "parent_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "tree_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "changed_paths": { "type": "array", "items": { "type": "string" } },
+    "actual_risk_flags": { "type": "array", "items": { "type": "string" } },
+    "claims": { "type": "array", "items": { "type": "string" } },
+    "checks": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "probes": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "reviews": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "findings": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "proof_gaps": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "probe_requests": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "degraded_provenance": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "telemetry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "resource_wait_ms",
+        "review_attempts",
+        "review_transient_failures",
+        "review_terminal_reasons"
+      ],
+      "properties": {
+        "resource_wait_ms": { "type": "integer", "minimum": 0 },
+        "review_attempts": { "type": "integer", "minimum": 0 },
+        "review_transient_failures": { "type": "integer", "minimum": 0 },
+        "review_terminal_reasons": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "verdict": {
+      "enum": [
+        "PASSED",
+        "NEEDS_FIX",
+        "NEEDS_EVIDENCE",
+        "PAUSED_RETRYABLE"
+      ]
+    },
+    "reason": { "type": "string" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "evidence_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+  }
+}

--- a/.agents/harness/schemas/v2-plan.schema.json
+++ b/.agents/harness/schemas/v2-plan.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://murmurnotes.io/schemas/harness-v2-plan.json",
+  "title": "Murmur exact-diff verification plan",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "task_id",
+    "contract_sha256",
+    "base_sha",
+    "diff_sha256",
+    "tree_sha",
+    "protocol_sha256",
+    "changed_paths",
+    "claims",
+    "actual_risk_flags",
+    "checks",
+    "reviews",
+    "server_required",
+    "created_at",
+    "plan_sha256"
+  ],
+  "properties": {
+    "schema_version": { "const": 2 },
+    "task_id": { "type": "string" },
+    "contract_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "base_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "diff_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "tree_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "protocol_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "changed_paths": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "type": "string" }
+    },
+    "claims": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "enum": ["runtime", "performance"] }
+    },
+    "actual_risk_flags": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "enum": ["lock", "egress", "protocol"] }
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "command", "timeout_seconds"],
+        "properties": {
+          "id": { "type": "string" },
+          "command": { "type": "string" },
+          "timeout_seconds": { "type": "integer", "minimum": 1, "maximum": 7200 }
+        }
+      }
+    },
+    "reviews": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["kind", "vendor"],
+        "properties": {
+          "kind": {
+            "enum": [
+              "combined",
+              "lock-security",
+              "egress-security",
+              "protocol-security"
+            ]
+          },
+          "vendor": { "enum": ["codex", "claude", "fake"] }
+        }
+      }
+    },
+    "server_required": { "type": "boolean" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "plan_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+  }
+}

--- a/.agents/harness/schemas/v2-review.schema.json
+++ b/.agents/harness/schemas/v2-review.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://murmurnotes.io/schemas/harness-v2-review.json",
+  "title": "Murmur combined or specialist v2 review",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "verdict",
+    "summary",
+    "requirements_covered",
+    "findings",
+    "proof_gaps",
+    "probe_requests"
+  ],
+  "properties": {
+    "verdict": { "enum": ["PASS", "FAIL", "BLOCKED"] },
+    "summary": { "type": "string" },
+    "requirements_covered": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["severity", "file", "evidence", "required_fix"],
+        "properties": {
+          "severity": { "enum": ["BLOCKER", "MAJOR", "MINOR", "INFO"] },
+          "file": { "type": "string" },
+          "evidence": { "type": "string" },
+          "required_fix": { "type": "string" }
+        }
+      }
+    },
+    "proof_gaps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["claim", "evidence_missing", "how_to_prove"],
+        "properties": {
+          "claim": { "type": "string" },
+          "evidence_missing": { "type": "string" },
+          "how_to_prove": { "type": "string" }
+        }
+      }
+    },
+    "probe_requests": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["probe_id", "rationale"],
+        "properties": {
+          "probe_id": {
+            "enum": [
+              "rust-lib",
+              "protocol-server",
+              "tauri-boot",
+              "ng-lint",
+              "ng-build",
+              "playwright",
+              "perf-contracts",
+              "harness-python",
+              "harness-v2-selftest",
+              "receipt-selftest",
+              "hook-selftest",
+              "config-audit"
+            ]
+          },
+          "rationale": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/.agents/harness/schemas/v2-task.schema.json
+++ b/.agents/harness/schemas/v2-task.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://murmurnotes.io/schemas/harness-v2-task.json",
+  "title": "Murmur verifier-only task contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "task_id",
+    "description",
+    "kind",
+    "base_sha",
+    "contract_sha256",
+    "repo_realpath",
+    "git_common_dir",
+    "worktree_path",
+    "branch",
+    "owned_paths",
+    "claims",
+    "reviewer",
+    "expected_change",
+    "degraded_provenance",
+    "created_at"
+  ],
+  "properties": {
+    "schema_version": { "const": 2 },
+    "task_id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{1,63}$" },
+    "description": { "type": "string", "minLength": 1 },
+    "kind": { "enum": ["bug", "feature", "refactor", "docs", "harness", "import"] },
+    "base_sha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+    "contract_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "repo_realpath": { "type": "string", "minLength": 1 },
+    "git_common_dir": { "type": "string", "minLength": 1 },
+    "worktree_path": { "type": "string", "minLength": 1 },
+    "branch": { "type": "string", "minLength": 1 },
+    "owned_paths": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "claims": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "enum": ["runtime", "performance"] }
+    },
+    "reviewer": { "enum": ["codex", "claude", "fake"] },
+    "expected_change": { "const": true },
+    "degraded_provenance": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "supersedes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["generation", "task_id", "contract_sha256"],
+      "properties": {
+        "generation": { "const": 1 },
+        "task_id": { "type": "string" },
+        "contract_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      }
+    },
+    "created_at": { "type": "string", "format": "date-time" }
+  }
+}

--- a/.agents/harness/task_runner.py
+++ b/.agents/harness/task_runner.py
@@ -21,6 +21,7 @@ import os
 import platform
 import pwd
 import re
+import shlex
 import shutil
 import signal
 import socket
@@ -38,6 +39,19 @@ HARNESS_ROOT = Path(__file__).resolve().parent
 SCHEMAS_DIR = HARNESS_ROOT / "schemas"
 PROMPTS_DIR = HARNESS_ROOT / "prompts"
 CONFIG_PATH = HARNESS_ROOT / "config.json"
+PROCESS_GUARDIAN_PATH = HARNESS_ROOT / "process_guardian.py"
+REVIEWER_CWD = Path("/var/empty")
+REVIEWER_TOOL_DENIAL = {
+    "hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": (
+            "Harness reviewers have no local tools. Review the supplied "
+            "immutable diff and evidence, or return a schema-allowlisted "
+            "typed probe request."
+        ),
+    }
+}
 TASK_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{1,63}$")
 SHA1_RE = re.compile(r"^[0-9a-f]{40}$")
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
@@ -73,12 +87,157 @@ class HarnessError(RuntimeError):
         self.exit_code = exit_code
 
 
+class ManagedProcessTimeout(HarnessError):
+    """Typed model-process wall timeout with runner-owned guardian evidence."""
+
+    def __init__(
+        self,
+        label: str,
+        timeout_seconds: float,
+        process_result: Mapping[str, Any],
+    ) -> None:
+        self.label = label
+        self.timeout_seconds = float(timeout_seconds)
+        self.process_result = dict(process_result)
+        self.timed_out = True
+        log_path = str(process_result.get("log") or "unknown")
+        guardian_path = str(process_result.get("guardian_path") or "unknown")
+        super().__init__(
+            f"{label} wall timeout after {self.timeout_seconds:g}s "
+            f"(exit_code={process_result.get('exit_code')}, "
+            f"duration_ms={process_result.get('duration_ms')}, "
+            f"log={log_path}, guardian={guardian_path})",
+            exit_code=124,
+        )
+
+
 class HarnessCancellation(BaseException):
     """Catchable SIGTERM/SIGHUP so managed child groups are drained first."""
 
     def __init__(self, signum: int) -> None:
         super().__init__(signum)
         self.signum = signum
+
+
+def reviewer_tool_guard_command() -> str:
+    """Return a deny-all hook whose executable state is entirely in argv."""
+    denial_json = json.dumps(
+        REVIEWER_TOOL_DENIAL,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return "/usr/bin/printf '%s\\n' " + shlex.quote(denial_json)
+
+
+def reviewer_execution_cwd() -> Path:
+    """Resolve a root-owned, non-writable cwd with no project configuration."""
+    try:
+        resolved = REVIEWER_CWD.resolve(strict=True)
+    except (FileNotFoundError, OSError) as exc:
+        raise HarnessError(f"reviewer cwd is unavailable: {REVIEWER_CWD}") from exc
+    for component in (resolved, *resolved.parents):
+        info = component.stat()
+        if not stat.S_ISDIR(info.st_mode):
+            raise HarnessError(f"reviewer cwd ancestor is not a directory: {component}")
+        if info.st_uid != 0 or info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+            raise HarnessError(
+                f"reviewer cwd ancestor is mutable by the invoking user: {component}"
+            )
+    return resolved
+
+
+def reviewer_model_environment(
+    environment: Mapping[str, str],
+    *,
+    vendor: str,
+    cwd: Path,
+) -> Dict[str, str]:
+    """Remove mutable shell startup state from a verifier-only model process."""
+    isolated = dict(environment)
+    isolated["SHELL"] = "/bin/sh"
+    if vendor == "codex":
+        original_home = isolated.get("HOME")
+        if "CODEX_HOME" not in isolated:
+            if not original_home:
+                raise HarnessError("Codex reviewer has no HOME or CODEX_HOME for auth")
+            isolated["CODEX_HOME"] = str(Path(original_home) / ".codex")
+        isolated["HOME"] = str(cwd)
+    return isolated
+
+
+def reviewer_tool_activity(log_path: Path, vendor: str) -> List[str]:
+    """Return model tool events that make a verifier-only review inadmissible."""
+    activity: List[str] = []
+    claude_init_seen = False
+    with log_path.open("r", encoding="utf-8", errors="replace") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
+                continue
+            if vendor == "codex":
+                event_type = event.get("type")
+                if isinstance(event_type, str) and event_type.startswith("item."):
+                    item = event.get("item")
+                    item_type = item.get("type") if isinstance(item, dict) else None
+                    # A verifier-only Codex process may stream prose/reasoning, but
+                    # every executable, hosted, file-mutating, or future unknown item
+                    # is inadmissible. The closed allowlist makes new CLI tool shapes
+                    # fail closed instead of silently bypassing this audit.
+                    if item_type not in {"agent_message", "reasoning"}:
+                        activity.append(
+                            f"line {line_number}: {item_type or 'malformed-item'}"
+                        )
+                elif isinstance(event_type, str) and (
+                    "tool" in event_type
+                    or "command" in event_type
+                    or "file_change" in event_type
+                ):
+                    activity.append(f"line {line_number}: {event_type}")
+            elif vendor == "claude" and event.get("type") == "system":
+                if event.get("subtype") != "init":
+                    continue
+                claude_init_seen = True
+                tools = event.get("tools")
+                mcp_servers = event.get("mcp_servers")
+                if tools != ["StructuredOutput"]:
+                    activity.append(
+                        f"line {line_number}: unexpected-tools:{tools!r}"
+                    )
+                if mcp_servers != []:
+                    activity.append(
+                        f"line {line_number}: unexpected-mcp:{mcp_servers!r}"
+                    )
+            elif vendor == "claude" and event.get("type") == "assistant":
+                message = event.get("message")
+                content = message.get("content") if isinstance(message, dict) else None
+                if not isinstance(content, list):
+                    continue
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "tool_use":
+                        # Claude Code implements --json-schema by exposing one
+                        # non-executing response channel named StructuredOutput.
+                        # It is the only admissible tool-shaped block; Read, Bash,
+                        # WebSearch, MCP, Task, and every future name still fail.
+                        if block.get("name") == "StructuredOutput":
+                            continue
+                        activity.append(
+                            f"line {line_number}: tool_use:{block.get('name', 'unknown')}"
+                        )
+    if vendor == "claude" and not claude_init_seen:
+        activity.append("missing Claude init telemetry")
+    return activity
+
+
+def assert_reviewer_used_no_tools(log_path: Path, vendor: str) -> None:
+    activity = reviewer_tool_activity(log_path, vendor)
+    if activity:
+        raise HarnessError(
+            "reviewer-only model used a local or hosted tool; evidence is "
+            "inadmissible: " + ", ".join(activity[:8])
+        )
 
 
 class TaskRunLock:
@@ -111,6 +270,22 @@ def sha256_file(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def _new_execution_id() -> str:
+    return str(uuid.uuid4())
+
+
+def _execution_artifact_path(base_path: Path, execution_id: str) -> Path:
+    """Insert one canonical UUID before a base artifact's final suffix."""
+
+    try:
+        parsed = uuid.UUID(execution_id)
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise HarnessError(f"invalid managed-process execution id: {execution_id!r}") from exc
+    if str(parsed) != execution_id:
+        raise HarnessError(f"managed-process execution id is not canonical: {execution_id!r}")
+    return base_path.with_name(f"{base_path.stem}-{execution_id}{base_path.suffix}")
 
 
 def load_json(path: Path) -> Any:
@@ -154,6 +329,41 @@ def atomic_write_bytes(path: Path, value: bytes) -> None:
             os.unlink(tmp_name)
         except FileNotFoundError:
             pass
+
+
+def atomic_create_bytes(path: Path, value: bytes) -> None:
+    """Atomically create an immutable artifact, failing instead of replacing."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(value)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(tmp_name, path)
+        except FileExistsError as exc:
+            raise HarnessError(f"refusing to overwrite prior execution artifact: {path}") from exc
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        try:
+            os.unlink(tmp_name)
+        except FileNotFoundError:
+            pass
+
+
+def atomic_create_json(path: Path, value: Any) -> None:
+    atomic_create_bytes(
+        path,
+        (
+            json.dumps(value, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+        ).encode("utf-8"),
+    )
 
 
 def append_jsonl(path: Path, value: Mapping[str, Any]) -> None:
@@ -594,7 +804,9 @@ def validate_canonical_checks(
     for check_id, check in by_id.items():
         if check_id in canonical and check.get("command") != canonical[check_id]:
             raise HarnessError(
-                f"canonical check {check_id} command differs from the runner-owned profile"
+                f"canonical check {check_id} command differs from the runner-owned profile. "
+                f"Expected exactly: {canonical[check_id]!r}. If the check is selected by "
+                "an inferred risk, omit that --check entirely; the harness adds it."
             )
     for check_id in required_risk_evidence(risk_flags, config):
         expected = canonical.get(check_id)
@@ -658,7 +870,15 @@ def instruction_paths(repo_root: Path) -> List[Tuple[str, Path]]:
     # use, not a hypothetical copy from the base commit.
     source_repo = HARNESS_ROOT.parent.parent
     harness_files = [CONFIG_PATH, Path(__file__).resolve()]
-    for name in ("hook_guard.py", "config_audit.py", "eval_runner.py"):
+    for name in (
+        "cli.py",
+        "verifier.py",
+        "hook_guard.py",
+        "config_audit.py",
+        "eval_runner.py",
+        "resource_policy.py",
+        "remote-policy.json",
+    ):
         candidate = HARNESS_ROOT / name
         if candidate.is_file():
             harness_files.append(candidate)
@@ -667,7 +887,14 @@ def instruction_paths(repo_root: Path) -> List[Tuple[str, Path]]:
     checks_dir = HARNESS_ROOT / "checks"
     if checks_dir.is_dir():
         harness_files.extend(sorted(path for path in checks_dir.rglob("*") if path.is_file()))
-    for name in ("agent-harness", "agent-config-audit", "agent-remote-audit"):
+    for name in (
+        "agent-harness",
+        "agent-resource-run",
+        "agent-config-audit",
+        "agent-remote-audit",
+        "verify-harness-attestation",
+        "ci.sh",
+    ):
         wrapper = source_repo / "scripts" / name
         if wrapper.is_file():
             harness_files.append(wrapper)
@@ -1306,13 +1533,9 @@ def command_needs_sherpa_archive(command: str, worktree: Optional[Path] = None) 
             "scripts/e2e-core.sh",
             "scripts/e2e-mix.sh",
             "scripts/harness-runtime-smoke",
-            # A harness check SCRIPT compiles the tree from inside itself, so the marker never
-            # appears in the command string the runner matches on. `perf-contracts.sh` runs
-            # `cd src-tauri && cargo test --lib …`, but its command is only
-            # `bash .agents/harness/checks/perf-contracts.sh` — so without this marker the pinned
-            # archive stayed unexposed and the network-isolated build tried to DOWNLOAD
-            # sherpa-onnx, which can never succeed under `network_mode: none`. Match the checks
-            # directory so any future check script inherits the offline archive too.
+            # A runner-owned check script can compile Rust without exposing
+            # `src-tauri` in its command string. Match the checks directory so
+            # the pinned offline sherpa archive is available to those scripts.
             ".agents/harness/checks/",
             "npm run dev",
             "npm run tauri",
@@ -1695,7 +1918,132 @@ def _release_owned_directory_lock(lock: Optional[Path]) -> None:
         pass
 
 
-def acquire_cargo_lane(task_dir: Path, timeout_seconds: float) -> Any:
+def git_common_for_task_dir(task_dir: Path) -> Path:
+    """Resolve the Git common directory for v1 or nested v2 task evidence."""
+
+    resolved = task_dir.resolve()
+    for candidate in (resolved, *resolved.parents):
+        if candidate.name == "agent-harness":
+            return candidate.parent
+    raise HarnessError(f"task evidence is outside agent-harness: {task_dir}")
+
+
+def shared_resource_root_for_common(git_common_dir: Path) -> Path:
+    """Return the Murmur workspace-wide resource root.
+
+    A dedicated harness driver is intentionally a standalone clone, so its
+    Git common directory differs from the user's primary checkout.  A lock
+    stored in either ``.git`` would therefore serialize only half the machine.
+    Every Murmur checkout kept under the same workspace parent instead shares
+    the narrowly-scoped sibling ``.murmur-agent-tasks/.resources`` directory.
+    """
+
+    completed = subprocess.run(
+        [
+            "git",
+            "--git-dir",
+            str(git_common_dir),
+            "worktree",
+            "list",
+            "--porcelain",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise HarnessError(
+            "cannot resolve the repository primary for shared resources: "
+            + completed.stderr.strip()
+        )
+    first = next(
+        (
+            line.removeprefix("worktree ").strip()
+            for line in completed.stdout.splitlines()
+            if line.startswith("worktree ")
+        ),
+        "",
+    )
+    if not first:
+        raise HarnessError("cannot resolve a primary worktree for shared resources")
+    primary = Path(first).resolve()
+    return primary.parent / ".murmur-agent-tasks" / ".resources"
+
+
+def shared_resource_root_for_task(task_dir: Path) -> Path:
+    return shared_resource_root_for_common(git_common_for_task_dir(task_dir))
+
+
+def assert_v1_not_imported(task_dir: Path) -> None:
+    """Refuse v1 mutation after an exact v2 import adopted its worktree."""
+
+    common = git_common_for_task_dir(task_dir)
+    candidate = (
+        common
+        / "agent-harness"
+        / "v2"
+        / "tasks"
+        / task_dir.name
+        / "task.json"
+    )
+    if not candidate.exists():
+        return
+    imported = load_json(candidate)
+    if imported.get("schema_version") != 2:
+        raise HarnessError("a malformed v2 claim shadows this v1 task")
+    source = load_json(task_dir / "task.json")
+    expected = {
+        "generation": 1,
+        "task_id": source["task_id"],
+        "contract_sha256": source["contract_sha256"],
+    }
+    if imported.get("supersedes") != expected:
+        raise HarnessError("an ambiguous v2 claim collides with this v1 task")
+    raise HarnessError(
+        "v1 task was imported into Harness v2; use v2 plan/verify/resume/clean"
+    )
+
+
+def _cargo_lane_owner(lock_handle: Any) -> Dict[str, Any]:
+    try:
+        lock_handle.seek(0)
+        raw = lock_handle.read().strip()
+        document = json.loads(raw) if raw else {}
+    except (OSError, json.JSONDecodeError):
+        document = {}
+    if not isinstance(document, dict):
+        document = {}
+    return {
+        "owner_pid": document.get("pid", "unknown"),
+        "task": document.get("task", document.get("task_id", "unknown")),
+        "command": document.get("command", "unknown"),
+        "since": document.get(
+            "since", document.get("acquired_at", "unknown")
+        ),
+    }
+
+
+def _print_cargo_lane_wait(lock_handle: Any) -> None:
+    owner = _cargo_lane_owner(lock_handle)
+    print(
+        "agent-harness: waiting for Cargo lane "
+        "owner_pid={owner_pid} task={task} command={command} since={since} "
+        "heartbeat={heartbeat}".format(
+            **owner,
+            heartbeat=utc_now(),
+        ),
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def acquire_cargo_lane(
+    task_dir: Path,
+    timeout_seconds: float,
+    *,
+    command: str = "unknown",
+    heartbeat_seconds: float = 5.0,
+) -> Any:
     """Acquire the one cross-task Rust build lane.
 
     This is a kernel advisory lock, not a PID-file lock: normal exit, cancellation,
@@ -1703,30 +2051,49 @@ def acquire_cargo_lane(task_dir: Path, timeout_seconds: float) -> Any:
     small JSON payload is diagnostic only and never used to infer ownership.
     """
 
-    # Share the exact kernel lane used by scripts/agent-resource-run. The task
-    # store is <git-common>/agent-harness/tasks/<id>, so three parents resolve
-    # the linked-worktree common Git directory. Separate lock files here would
-    # let a harness Cargo check overlap an operator/agent build in another WT.
-    git_common_dir = task_dir.parent.parent.parent
-    lock_path = git_common_dir / "murmur-agent-resource-lane.lock"
+    # Share the exact kernel lane used by scripts/agent-resource-run across v1,
+    # v2, the operator checkout and the standalone driver clone.
+    resource_root = shared_resource_root_for_task(task_dir)
+    resource_root.mkdir(parents=True, exist_ok=True)
+    lock_path = resource_root / "cargo.lock"
     lock_handle = lock_path.open("a+", encoding="utf-8")
     deadline = time.monotonic() + timeout_seconds
+    next_heartbeat: Optional[float] = None
     try:
         while True:
             try:
                 fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
                 break
             except BlockingIOError:
-                if time.monotonic() >= deadline:
-                    raise HarnessError("timed out waiting for the shared Cargo build lane")
-                time.sleep(0.1)
+                now = time.monotonic()
+                if next_heartbeat is None or now >= next_heartbeat:
+                    _print_cargo_lane_wait(lock_handle)
+                    next_heartbeat = now + max(0.01, heartbeat_seconds)
+                if now >= deadline:
+                    owner = _cargo_lane_owner(lock_handle)
+                    raise HarnessError(
+                        "timed out waiting for the shared Cargo build lane "
+                        "owner_pid={owner_pid} task={task} command={command} "
+                        "since={since}".format(**owner)
+                    )
+                time.sleep(
+                    min(
+                        0.1,
+                        max(0.0, deadline - now),
+                        max(0.01, next_heartbeat - now),
+                    )
+                )
         lock_handle.seek(0)
         lock_handle.truncate()
         json.dump(
             {
                 "pid": os.getpid(),
+                "cwd": str(Path.cwd()),
                 "task_id": task_dir.name,
+                "task": task_dir.name,
+                "command": command,
                 "acquired_at": utc_now(),
+                "since": utc_now(),
             },
             lock_handle,
             sort_keys=True,
@@ -1752,7 +2119,7 @@ def release_cargo_lane(lock_handle: Optional[Any]) -> None:
 def acquire_playwright_port(task_dir: Path, timeout_seconds: float) -> Tuple[Path, int]:
     """Reserve a task-private loopback port across concurrent harness runs."""
 
-    locks_root = task_dir.parent.parent / "playwright-ports"
+    locks_root = shared_resource_root_for_task(task_dir) / "playwright-ports"
     locks_root.mkdir(parents=True, exist_ok=True)
     port_floor = 42000
     port_count = 20000
@@ -1802,6 +2169,145 @@ def acquire_playwright_port(task_dir: Path, timeout_seconds: float) -> Tuple[Pat
     raise HarnessError("timed out reserving a task-private Playwright port")
 
 
+def _write_all(descriptor: int, payload: bytes) -> None:
+    view = memoryview(payload)
+    while view:
+        written = os.write(descriptor, view)
+        if written <= 0:
+            raise OSError("short write to managed child stdin")
+        view = view[written:]
+
+
+def run_guarded_process(
+    argv: Sequence[str],
+    *,
+    cwd: Path,
+    timeout_seconds: float,
+    stdout_handle: Any,
+    stderr_handle: Any,
+    result_path: Path,
+    stdin_bytes: Optional[bytes] = None,
+    env: Optional[Mapping[str, str]] = None,
+    inherited_fds: Sequence[int] = (),
+    term_grace_seconds: float = 3.0,
+) -> Dict[str, Any]:
+    """Run through an out-of-process parent-death guardian.
+
+    If this runner is SIGKILLed, the liveness pipe closes in the guardian. The
+    guardian then terminates the exact new-session child group before releasing
+    inherited resource-lane descriptors.
+    """
+
+    if not PROCESS_GUARDIAN_PATH.is_file():
+        raise HarnessError(f"process guardian is missing: {PROCESS_GUARDIAN_PATH}")
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        result_path.lstat()
+    except FileNotFoundError:
+        pass
+    else:
+        raise HarnessError(
+            f"refusing to overwrite prior guardian artifact: {result_path}"
+        )
+    parent_read, parent_write = os.pipe()
+    stdin_read: Optional[int] = None
+    stdin_write: Optional[int] = None
+    if stdin_bytes is not None:
+        stdin_read, stdin_write = os.pipe()
+    pass_fds = [parent_read, *inherited_fds]
+    if stdin_read is not None:
+        pass_fds.append(stdin_read)
+    command = [
+        sys.executable,
+        str(PROCESS_GUARDIAN_PATH),
+        "--parent-fd",
+        str(parent_read),
+        "--result",
+        str(result_path),
+        "--cwd",
+        str(cwd),
+        "--timeout-seconds",
+        str(float(timeout_seconds)),
+        "--term-grace-seconds",
+        str(float(term_grace_seconds)),
+    ]
+    if stdin_read is not None:
+        command.extend(["--stdin-fd", str(stdin_read)])
+    for descriptor in inherited_fds:
+        command.extend(["--pass-fd", str(descriptor)])
+    command.extend(["--", *list(argv)])
+    guardian: Optional[subprocess.Popen[Any]] = None
+    try:
+        guardian = subprocess.Popen(
+            command,
+            cwd=str(cwd),
+            env=dict(env) if env else None,
+            stdin=subprocess.DEVNULL,
+            stdout=stdout_handle,
+            stderr=stderr_handle,
+            start_new_session=True,
+            pass_fds=tuple(pass_fds),
+        )
+        os.close(parent_read)
+        parent_read = -1
+        if stdin_read is not None:
+            os.close(stdin_read)
+            stdin_read = None
+        if stdin_write is not None:
+            try:
+                _write_all(stdin_write, stdin_bytes or b"")
+            finally:
+                os.close(stdin_write)
+                stdin_write = None
+        try:
+            guardian.wait(
+                timeout=float(timeout_seconds) + max(0.0, term_grace_seconds) + 10.0
+            )
+        except subprocess.TimeoutExpired:
+            _terminate_process(guardian)
+        if guardian.returncode is None:
+            guardian.wait()
+        if not result_path.is_file():
+            raise HarnessError(
+                "managed child guardian exited without a durable result"
+            )
+        result = load_json(result_path)
+        if result.get("parent_lost"):
+            raise HarnessError("managed child observed an unexpected parent death")
+        if result.get("error"):
+            raise HarnessError(f"managed child guardian failed: {result['error']}")
+        if guardian.returncode != 0:
+            raise HarnessError(
+                f"managed child guardian exited {guardian.returncode}"
+            )
+        if not isinstance(result.get("exit_code"), int):
+            raise HarnessError("managed child result has no exit code")
+        result["guardian_path"] = str(result_path)
+        result["guardian_sha256"] = sha256_file(result_path)
+        return result
+    except BaseException:
+        # Closing this descriptor is the parent-death signal. Give the guardian
+        # time to reap its owned group before escalating against the guardian.
+        try:
+            os.close(parent_write)
+        except OSError:
+            pass
+        parent_write = -1
+        if guardian is not None and guardian.poll() is None:
+            try:
+                guardian.wait(timeout=max(0.0, term_grace_seconds) + 5.0)
+            except subprocess.TimeoutExpired:
+                _terminate_process(guardian)
+        raise
+    finally:
+        for descriptor in (parent_read, parent_write, stdin_read, stdin_write):
+            if descriptor is not None and descriptor >= 0:
+                try:
+                    os.close(descriptor)
+                except OSError:
+                    pass
+
+
 def run_logged_process(
     argv: Sequence[str],
     *,
@@ -1810,39 +2316,40 @@ def run_logged_process(
     log_path: Path,
     stdin_bytes: Optional[bytes] = None,
     env: Optional[Mapping[str, str]] = None,
+    execution_id: Optional[str] = None,
+    term_grace_seconds: float = 3.0,
 ) -> Dict[str, Any]:
+    execution_id = execution_id or _new_execution_id()
+    log_path = _execution_artifact_path(log_path, execution_id)
     log_path.parent.mkdir(parents=True, exist_ok=True)
     started = time.monotonic()
-    timed_out = False
-    process: Optional[subprocess.Popen] = None
-    with log_path.open("wb") as log_handle:
-        try:
-            process = subprocess.Popen(
-                list(argv),
-                cwd=str(cwd),
-                env=dict(env) if env else None,
-                stdin=subprocess.PIPE if stdin_bytes is not None else subprocess.DEVNULL,
-                stdout=log_handle,
-                stderr=subprocess.STDOUT,
-                start_new_session=True,
-            )
-            timed_out = _wait_managed_process(
-                process,
-                timeout_seconds,
-                stdin_bytes=stdin_bytes,
-            )
-        finally:
-            if process is not None and _process_group_alive(_owned_process_group_id(process)):
-                _terminate_process(process)
-    if process is None:
-        raise HarnessError("managed process did not start")
+    with log_path.open("xb") as log_handle:
+        guarded = run_guarded_process(
+            argv,
+            cwd=cwd,
+            timeout_seconds=timeout_seconds,
+            stdout_handle=log_handle,
+            stderr_handle=subprocess.STDOUT,
+            result_path=log_path.with_suffix(log_path.suffix + ".guardian.json"),
+            stdin_bytes=stdin_bytes,
+            env=env,
+            term_grace_seconds=term_grace_seconds,
+        )
     duration_ms = int((time.monotonic() - started) * 1000)
     return {
-        "exit_code": process.returncode,
-        "timed_out": timed_out,
+        "exit_code": guarded["exit_code"],
+        "leader_exit_code": guarded.get("leader_exit_code"),
+        "leader_exited_with_live_group": bool(
+            guarded.get("leader_exited_with_live_group")
+        ),
+        "termination_reason": guarded.get("termination_reason"),
+        "timed_out": bool(guarded.get("timed_out")),
         "duration_ms": duration_ms,
+        "execution_id": execution_id,
         "log": str(log_path),
         "log_sha256": sha256_file(log_path),
+        "guardian_path": guarded["guardian_path"],
+        "guardian_sha256": guarded["guardian_sha256"],
     }
 
 
@@ -1898,9 +2405,20 @@ def _probe_blocked_reason(stdout_path: Path) -> Optional[str]:
 
 def run_check(worktree: Path, task_dir: Path, check: Mapping[str, Any], phase: str) -> Dict[str, Any]:
     safe_phase = re.sub(r"[^a-z0-9._-]+", "-", phase.lower())
-    log_path = task_dir / "logs" / f"{safe_phase}-{check['id']}.log"
-    stdout_path = task_dir / "logs" / f"{safe_phase}-{check['id']}.stdout.log"
-    stderr_path = task_dir / "logs" / f"{safe_phase}-{check['id']}.stderr.log"
+    execution_id = _new_execution_id()
+    log_path = _execution_artifact_path(
+        task_dir / "logs" / f"{safe_phase}-{check['id']}.log",
+        execution_id,
+    )
+    stdout_path = log_path.with_suffix(".stdout.log")
+    stderr_path = log_path.with_suffix(".stderr.log")
+    guardian_result_path = _execution_artifact_path(
+        task_dir
+        / "runtime"
+        / "guardians"
+        / f"{safe_phase}-{check['id']}.json",
+        execution_id,
+    )
     uses_playwright = command_uses_playwright(str(check["command"]))
     needs_loopback = command_needs_loopback(str(check["command"]))
     needs_sherpa = command_needs_sherpa_archive(str(check["command"]), worktree)
@@ -1908,17 +2426,28 @@ def run_check(worktree: Path, task_dir: Path, check: Mapping[str, Any], phase: s
     started_at = utc_now()
     deadline = started + float(check["timeout_seconds"])
     timed_out = False
+    exit_code: Optional[int] = None
+    guardian_path: Optional[str] = None
+    guardian_sha256: Optional[str] = None
+    resource_wait_ms = 0
     cargo_lane: Optional[Any] = None
     playwright_lock: Optional[Path] = None
     playwright_port: Optional[int] = None
-    process: Optional[subprocess.Popen] = None
     inherited_sandbox = inherited_outer_sandbox_is_active()
     try:
         if command_uses_cargo_lane(str(check["command"])):
             remaining_for_cargo = deadline - time.monotonic()
             if remaining_for_cargo <= 0:
                 raise HarnessError(f"check {check['id']} exhausted its deadline before the Cargo lane")
-            cargo_lane = acquire_cargo_lane(task_dir, remaining_for_cargo)
+            resource_wait_started = time.monotonic()
+            cargo_lane = acquire_cargo_lane(
+                task_dir,
+                remaining_for_cargo,
+                command=str(check["command"]),
+            )
+            resource_wait_ms = int(
+                (time.monotonic() - resource_wait_started) * 1000
+            )
         if uses_playwright:
             remaining_for_port = deadline - time.monotonic()
             if remaining_for_port <= 0:
@@ -1941,56 +2470,76 @@ def run_check(worktree: Path, task_dir: Path, check: Mapping[str, Any], phase: s
             network_mode=network_mode,
             expose_sherpa_archive=needs_sherpa,
         )
-        profile_path = runtime["profiles"] / f"{safe_phase}-{check['id']}.sb"
-        atomic_write_bytes(profile_path, profile.encode("utf-8"))
+        profile_path = _execution_artifact_path(
+            runtime["profiles"] / f"{safe_phase}-{check['id']}.sb",
+            execution_id,
+        )
+        atomic_create_bytes(profile_path, profile.encode("utf-8"))
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             raise HarnessError(f"check {check['id']} exhausted its deadline before process start")
         stdout_path.parent.mkdir(parents=True, exist_ok=True)
-        with stdout_path.open("wb") as stdout_handle, stderr_path.open("wb") as stderr_handle:
+        with stdout_path.open("xb") as stdout_handle, stderr_path.open("xb") as stderr_handle:
             check_argv = (
                 ["/bin/zsh", "-f", "-c", str(check["command"])]
                 if inherited_sandbox
                 else sandboxed_check_argv(profile, str(check["command"]))
             )
-            process = subprocess.Popen(
+            guarded = run_guarded_process(
                 check_argv,
-                cwd=str(worktree),
+                cwd=worktree,
+                timeout_seconds=remaining,
+                stdout_handle=stdout_handle,
+                stderr_handle=stderr_handle,
+                result_path=guardian_result_path,
                 env=environment,
-                stdin=subprocess.DEVNULL,
-                stdout=stdout_handle,
-                stderr=stderr_handle,
-                start_new_session=True,
-                pass_fds=(cargo_lane.fileno(),) if cargo_lane is not None else (),
+                inherited_fds=(
+                    (cargo_lane.fileno(),) if cargo_lane is not None else ()
+                ),
             )
-            timed_out = _wait_managed_process(process, remaining)
+            exit_code = int(guarded["exit_code"])
+            timed_out = bool(guarded.get("timed_out"))
+            guardian_path = str(guarded["guardian_path"])
+            guardian_sha256 = str(guarded["guardian_sha256"])
+            leader_exit_code = guarded.get("leader_exit_code")
+            leader_exited_with_live_group = bool(
+                guarded.get("leader_exited_with_live_group")
+            )
+            termination_reason = guarded.get("termination_reason")
     finally:
         try:
-            if process is not None and _process_group_alive(_owned_process_group_id(process)):
-                _terminate_process(process)
+            _release_owned_directory_lock(playwright_lock)
         finally:
-            try:
-                _release_owned_directory_lock(playwright_lock)
-            finally:
-                release_cargo_lane(cargo_lane)
-    if process is None:
+            release_cargo_lane(cargo_lane)
+    if exit_code is None or guardian_path is None or guardian_sha256 is None:
         raise HarnessError(f"check {check['id']} did not start")
     duration_ms = int((time.monotonic() - started) * 1000)
-    with log_path.open("wb") as combined:
-        combined.write(b"=== stdout ===\n")
-        combined.write(stdout_path.read_bytes())
-        combined.write(b"\n=== stderr ===\n")
-        combined.write(stderr_path.read_bytes())
+    combined = (
+        b"=== stdout ===\n"
+        + stdout_path.read_bytes()
+        + b"\n=== stderr ===\n"
+        + stderr_path.read_bytes()
+    )
+    atomic_create_bytes(log_path, combined)
     result = {
-        "exit_code": process.returncode,
+        "exit_code": exit_code,
+        "leader_exit_code": leader_exit_code,
+        "leader_exited_with_live_group": leader_exited_with_live_group,
+        "termination_reason": termination_reason,
         "timed_out": timed_out,
         "duration_ms": duration_ms,
+        "resource_wait_ms": resource_wait_ms,
+        "execution_id": execution_id,
         "log_path": str(log_path),
         "log_sha256": sha256_file(log_path),
+        "stdout_path": str(stdout_path),
         "stdout_sha256": sha256_file(stdout_path),
+        "stderr_path": str(stderr_path),
         "stderr_sha256": sha256_file(stderr_path),
         "sandbox_profile_path": str(profile_path),
         "sandbox_profile_sha256": sha256_file(profile_path),
+        "guardian_path": guardian_path,
+        "guardian_sha256": guardian_sha256,
         "sandbox_mode": "inherited" if inherited_sandbox else "direct",
         "environment_keys_sha256": sha256_bytes(canonical_json(sorted(environment))),
         "environment_sha256": sha256_bytes(canonical_json(environment)),
@@ -2022,12 +2571,23 @@ def run_check(worktree: Path, task_dir: Path, check: Mapping[str, Any], phase: s
             "id": evidence["id"],
             "phase": phase,
             "exit_code": evidence["exit_code"],
+            "leader_exit_code": evidence["leader_exit_code"],
+            "leader_exited_with_live_group": evidence[
+                "leader_exited_with_live_group"
+            ],
+            "termination_reason": evidence["termination_reason"],
             "timed_out": evidence["timed_out"],
             "duration_ms": evidence["duration_ms"],
+            "resource_wait_ms": evidence["resource_wait_ms"],
             "passed": evidence["passed"],
             "outcome": evidence["outcome"],
             "blocked_reason": evidence["blocked_reason"],
+            "execution_id": evidence["execution_id"],
             "log_path": evidence["log_path"],
+            "stdout_path": evidence["stdout_path"],
+            "stderr_path": evidence["stderr_path"],
+            "guardian_path": evidence["guardian_path"],
+            "sandbox_profile_path": evidence["sandbox_profile_path"],
             "network_mode": evidence["network_mode"],
             "sandbox_mode": evidence["sandbox_mode"],
             "created_at": evidence["created_at"],
@@ -2044,6 +2604,33 @@ def command_version(command: str) -> Optional[str]:
     text = f"{completed.stdout}\n{completed.stderr}"
     match = re.search(r"\d+(?:\.\d+){1,3}", text)
     return match.group(0) if match else text.strip().splitlines()[0]
+
+
+def runtime_preflight(repo: Path) -> Dict[str, Any]:
+    """Fail before worktree/model work when exclusive runtime ownership is blocked."""
+
+    script = HARNESS_ROOT.parent.parent / "scripts" / "harness-runtime-smoke"
+    completed = run_capture(
+        [str(script), "--preflight"],
+        repo,
+        check=False,
+    )
+    lines = [line for line in completed.stdout.splitlines() if line.strip()]
+    try:
+        payload = json.loads(lines[-1]) if lines else {}
+    except json.JSONDecodeError as exc:
+        raise HarnessError(
+            "runtime preflight returned malformed evidence: "
+            + (completed.stderr.strip() or completed.stdout.strip())
+        ) from exc
+    if completed.returncode != 0 or payload.get("verdict") != "PASS":
+        reason = payload.get("reason") if isinstance(payload, dict) else None
+        raise HarnessError(
+            "runtime preflight blocked before task setup: "
+            + str(reason or completed.stderr.strip() or f"exit {completed.returncode}"),
+            exit_code=3 if completed.returncode == 3 else 1,
+        )
+    return payload
 
 
 def sanitized_model_environment(instructions_sha256: str, vendor: str) -> Tuple[Dict[str, str], List[str]]:
@@ -2194,11 +2781,35 @@ def _degraded_writer_document(vendor: str, subtype: str) -> Dict[str, Any]:
     }
 
 
-def extract_model_metadata(log_path: Path, vendor: str, fallback_session: str) -> Dict[str, str]:
-    """Best-effort extraction from vendor JSONL, with explicit non-empty fallbacks."""
+def extract_model_metadata(
+    log_path: Path, vendor: str, fallback_session: str
+) -> Dict[str, Any]:
+    """Best-effort identity and usage extraction from vendor JSONL.
+
+    Model CLIs do not expose one stable cross-vendor envelope, so keep this
+    deliberately tolerant and retain the last typed value encountered.  The
+    runner records the result for successful *and failed* invocations; metrics
+    therefore do not need to re-parse multi-megabyte raw logs later.
+    """
 
     session_id = fallback_session
     model = "unspecified"
+    total_cost_usd: Optional[float] = None
+    num_turns: Optional[int] = None
+    usage: Optional[Mapping[str, Any]] = None
+    terminal_reason: Optional[str] = None
+    http_status: Optional[int] = None
+    retry_after_seconds: Optional[float] = None
+
+    def walk(value: Any) -> Iterable[Tuple[str, Any]]:
+        if isinstance(value, Mapping):
+            for key, child in value.items():
+                yield str(key), child
+                yield from walk(child)
+        elif isinstance(value, list):
+            for child in value:
+                yield from walk(child)
+
     try:
         with log_path.open("r", encoding="utf-8", errors="replace") as handle:
             for line in handle:
@@ -2222,9 +2833,106 @@ def extract_model_metadata(log_path: Path, vendor: str, fallback_session: str) -
                     message = event.get("message")
                     if isinstance(message, dict) and isinstance(message.get("model"), str):
                         model = message["model"]
+                for key, value in walk(event):
+                    lowered = key.lower()
+                    if lowered in {"total_cost_usd", "cost_usd"}:
+                        try:
+                            total_cost_usd = float(value)
+                        except (TypeError, ValueError):
+                            pass
+                    elif lowered in {"num_turns", "turns"}:
+                        try:
+                            num_turns = int(value)
+                        except (TypeError, ValueError):
+                            pass
+                    elif lowered == "usage" and isinstance(value, Mapping):
+                        usage = dict(value)
+                    elif lowered in {
+                        "terminal_reason",
+                        "stop_reason",
+                        "subtype",
+                    } and isinstance(value, str):
+                        terminal_reason = value
+                    elif lowered in {
+                        "api_error_status",
+                        "status_code",
+                        "http_status",
+                    }:
+                        try:
+                            http_status = int(value)
+                        except (TypeError, ValueError):
+                            pass
+                    elif lowered in {"retry_after", "retry_after_seconds"}:
+                        try:
+                            retry_after_seconds = max(0.0, float(value))
+                        except (TypeError, ValueError):
+                            pass
     except OSError:
         pass
-    return {"session_id": session_id, "model": model}
+    return {
+        "session_id": session_id,
+        "model": model,
+        "total_cost_usd": total_cost_usd,
+        "num_turns": num_turns,
+        "usage": usage,
+        "terminal_reason": terminal_reason,
+        "http_status": http_status,
+        "retry_after_seconds": retry_after_seconds,
+    }
+
+
+def _record_model_process_exit(
+    task_dir: Path,
+    *,
+    label: str,
+    role: str,
+    vendor: str,
+    timeout_seconds: int,
+    process_result: Mapping[str, Any],
+    result_path: Path,
+    invocation_path: Path,
+    terminal_subtype: Optional[str],
+) -> None:
+    """Persist the exact per-execution process artifacts before any error raises."""
+
+    log_path = Path(str(process_result.get("log", "")))
+    telemetry = extract_model_metadata(
+        log_path,
+        vendor,
+        str(process_result.get("execution_id") or label),
+    )
+    append_jsonl(
+        task_dir / "events.jsonl",
+        {
+            "at": utc_now(),
+            "event": "model-process-exit",
+            "label": label,
+            "role": role,
+            "vendor": vendor,
+            "exit_code": process_result.get("exit_code"),
+            "leader_exit_code": process_result.get("leader_exit_code"),
+            "leader_exited_with_live_group": bool(
+                process_result.get("leader_exited_with_live_group")
+            ),
+            "termination_reason": process_result.get("termination_reason"),
+            "timed_out": bool(process_result.get("timed_out")),
+            "duration_ms": process_result.get("duration_ms"),
+            "wall_timeout_seconds": timeout_seconds,
+            "terminal_subtype": terminal_subtype,
+            "execution_id": process_result.get("execution_id"),
+            "log_path": process_result.get("log"),
+            "log_sha256": process_result.get("log_sha256"),
+            "guardian_path": process_result.get("guardian_path"),
+            "guardian_sha256": process_result.get("guardian_sha256"),
+            "result_path": str(result_path),
+            "invocation_path": str(invocation_path),
+            "total_cost_usd": telemetry.get("total_cost_usd"),
+            "num_turns": telemetry.get("num_turns"),
+            "usage": telemetry.get("usage"),
+            "http_status": telemetry.get("http_status"),
+            "retry_after_seconds": telemetry.get("retry_after_seconds"),
+        },
+    )
 
 
 def invoke_model(
@@ -2243,14 +2951,22 @@ def invoke_model(
 
     schema_path = SCHEMAS_DIR / f"{schema_name}.schema.json"
     schema = load_schema(schema_name)
-    log_path = task_dir / "logs" / f"{label}-{vendor}.jsonl"
-    result_path = task_dir / "results" / f"{label}-{vendor}.json"
-    invocation_path = task_dir / "results" / f"{label}-{vendor}-invocation.json"
+    invocation_id = _new_execution_id()
+    log_base_path = task_dir / "logs" / f"{label}-{vendor}.jsonl"
+    log_path = _execution_artifact_path(log_base_path, invocation_id)
+    result_path = _execution_artifact_path(
+        task_dir / "results" / f"{label}-{vendor}.json",
+        invocation_id,
+    )
+    invocation_path = _execution_artifact_path(
+        task_dir / "results" / f"{label}-{vendor}-invocation.json",
+        invocation_id,
+    )
     result_path.parent.mkdir(parents=True, exist_ok=True)
-    invocation_id = str(uuid.uuid4())
     recorded_argv: List[str] = [vendor, "fake"]
     budget: Optional[str] = None
     removed_env_names: List[str] = []
+    model_cwd = reviewer_execution_cwd() if role == "reviewer" else worktree
     # RUNNER-OWNED record of an abnormal round. It must not come from the model's own
     # self-report: a killed writer cannot be trusted to describe its own death, and a
     # self-report is not delivered to reviewers anyway. `None` = a clean round.
@@ -2268,7 +2984,14 @@ def invoke_model(
         else:
             verdict = verdict_override or os.environ.get("MURMUR_HARNESS_FAKE_REVIEW_VERDICT", "PASS")
             findings: List[Dict[str, str]] = []
-            if verdict != "PASS":
+            # A v2 BLOCKED verdict represents a proof/evidence gap.  Giving it
+            # a synthetic BLOCKER finding would classify the same result as a
+            # code defect (NEEDS_FIX) before the verdict can classify it as
+            # resumable NEEDS_EVIDENCE.  Keep legacy fake reviews unchanged,
+            # but make the v2 adapter model the real state distinction.
+            if verdict != "PASS" and not (
+                schema_name == "v2-review" and verdict == "BLOCKED"
+            ):
                 findings.append(
                     {
                         "severity": "MAJOR" if verdict == "FAIL" else "BLOCKER",
@@ -2283,13 +3006,30 @@ def invoke_model(
                 "requirements_covered": ["selftest"],
                 "findings": findings,
             }
-        atomic_write_json(result_path, document)
+            if schema_name == "v2-review":
+                document["proof_gaps"] = (
+                    [
+                        {
+                            "claim": "synthetic selftest evidence",
+                            "evidence_missing": "synthetic proof",
+                            "how_to_prove": "resume with a fresh reviewer result",
+                        }
+                    ]
+                    if verdict == "BLOCKED"
+                    else []
+                )
+                document["probe_requests"] = []
+        atomic_create_json(result_path, document)
         log_path.parent.mkdir(parents=True, exist_ok=True)
-        log_path.write_text(json.dumps({"type": "fake", "result": document}) + "\n", encoding="utf-8")
+        with log_path.open("x", encoding="utf-8") as handle:
+            handle.write(json.dumps({"type": "fake", "result": document}) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
         process_result = {
             "exit_code": 0,
             "timed_out": False,
             "duration_ms": 0,
+            "execution_id": invocation_id,
             "log": str(log_path),
             "log_sha256": sha256_file(log_path),
         }
@@ -2331,6 +3071,21 @@ def invoke_model(
             *(json.dumps(path) + '="deny"' for path in denied_host_paths),
         ]
         filesystem_profile = "{" + ",".join(filesystem_entries) + "}"
+        reviewer_guard_config: Optional[str] = None
+        if role == "reviewer":
+            # Keep the deny decision inside this already-running runner's
+            # immutable argv. Pointing Codex at a script in the live worktree
+            # creates an A->B->A replacement race: another process can swap
+            # the hook during review, allow a tool, then restore the original
+            # bytes before any final integrity comparison. /usr/bin/printf is
+            # SIP-protected on macOS and the static JSON never reads hook
+            # input, so there is no mutable runtime hook surface.
+            guard_command = reviewer_tool_guard_command()
+            reviewer_guard_config = (
+                '[{matcher="*",hooks=[{type="command",command='
+                + json.dumps(guard_command)
+                + ',timeout=5,statusMessage="Blocking reviewer tool access"}]}]'
+            )
         argv = [
             executable,
             "exec",
@@ -2344,28 +3099,79 @@ def invoke_model(
             "--config",
             f'default_permissions="{permission_profile}"',
             "--cd",
-            str(worktree),
+            str(model_cwd),
             "--output-schema",
             str(schema_path),
             "--output-last-message",
             str(result_path),
             "--json",
         ]
+        if reviewer_guard_config is not None:
+            # Codex has no Claude-style --tools allowlist. A read-only sandbox
+            # still permits read commands such as /bin/pwd, so the
+            # protocol-bound wildcard PreToolUse hook is the actual reviewer
+            # capability boundary.
+            argv.extend(
+                [
+                    "--skip-git-repo-check",
+                    "--ignore-rules",
+                    "--dangerously-bypass-hook-trust",
+                    "--enable",
+                    "hooks",
+                    "--config",
+                    f"hooks.PreToolUse={reviewer_guard_config}",
+                    "--config",
+                    'approval_policy="never"',
+                    "--config",
+                    'web_search="disabled"',
+                    "--config",
+                    "features.apps=false",
+                    "--config",
+                    "features.plugins=false",
+                    "--config",
+                    "features.multi_agent=false",
+                ]
+            )
         model_override = os.environ.get("MURMUR_HARNESS_CODEX_MODEL")
         if model_override:
             argv.extend(["--model", model_override])
         argv.append("-")
         environment, removed_env_names = sanitized_model_environment(instructions_sha256, vendor)
+        if role == "reviewer":
+            environment = reviewer_model_environment(
+                environment,
+                vendor=vendor,
+                cwd=model_cwd,
+            )
         recorded_argv = list(argv)
         process_result = run_logged_process(
             argv,
-            cwd=worktree,
+            cwd=model_cwd,
             timeout_seconds=timeout_seconds,
-            log_path=log_path,
+            log_path=log_base_path,
             stdin_bytes=prompt.encode("utf-8"),
             env=environment,
+            execution_id=invocation_id,
         )
-        if process_result["exit_code"] != 0 or process_result["timed_out"]:
+        log_path = Path(str(process_result["log"]))
+        _record_model_process_exit(
+            task_dir,
+            label=label,
+            role=role,
+            vendor=vendor,
+            timeout_seconds=timeout_seconds,
+            process_result=process_result,
+            result_path=result_path,
+            invocation_path=invocation_path,
+            terminal_subtype=None,
+        )
+        if process_result["timed_out"]:
+            raise ManagedProcessTimeout(
+                f"Codex {label}",
+                timeout_seconds,
+                process_result,
+            )
+        if process_result["exit_code"] != 0:
             raise HarnessError(f"Codex {label} failed; inspect {log_path}")
         document = load_json(result_path)
     elif vendor == "claude":
@@ -2376,7 +3182,7 @@ def invoke_model(
         if role == "writer":
             tools = "Read,Grep,Glob,Edit,Write,Bash"
         else:
-            tools = "Read,Grep,Glob"
+            tools = ""
         permission_mode = "dontAsk"
         denied_read_paths = [
             "~/.ssh/**",
@@ -2399,6 +3205,13 @@ def invoke_model(
                 "sandbox": {
                     "enabled": True,
                     "failIfUnavailable": True,
+                    # Project settings enable sandboxed Bash for ordinary
+                    # development sessions. A reviewer must not inherit that
+                    # scalar: --allowedTools controls approval, not tool
+                    # availability. The explicit --tools list below is the
+                    # capability boundary; this setting closes the project
+                    # auto-approval path as defense in depth.
+                    "autoAllowBashIfSandboxed": False,
                     "allowUnsandboxedCommands": False,
                     "network": {"deniedDomains": ["*"]},
                     "filesystem": {"denyRead": denied_read_paths},
@@ -2420,6 +3233,8 @@ def invoke_model(
             sandbox_settings,
             "--mcp-config",
             '{"mcpServers":{}}',
+            "--tools",
+            tools,
             "--allowedTools",
             tools,
             "--permission-mode",
@@ -2427,9 +3242,6 @@ def invoke_model(
             "--json-schema",
             schema_text,
         ]
-        sibling_server = worktree.parent / "murmur-server"
-        if role == "reviewer" and sibling_server.is_dir():
-            argv.extend(["--add-dir", str(sibling_server)])
         model_override = os.environ.get("MURMUR_HARNESS_CLAUDE_MODEL")
         if model_override:
             argv.extend(["--model", model_override])
@@ -2438,15 +3250,23 @@ def invoke_model(
             argv.extend(["--max-budget-usd", budget])
         argv.append("-")
         environment, removed_env_names = sanitized_model_environment(instructions_sha256, vendor)
+        if role == "reviewer":
+            environment = reviewer_model_environment(
+                environment,
+                vendor=vendor,
+                cwd=model_cwd,
+            )
         recorded_argv = list(argv)
         process_result = run_logged_process(
             argv,
-            cwd=worktree,
+            cwd=model_cwd,
             timeout_seconds=timeout_seconds,
-            log_path=log_path,
+            log_path=log_base_path,
             stdin_bytes=prompt.encode("utf-8"),
             env=environment,
+            execution_id=invocation_id,
         )
+        log_path = Path(str(process_result["log"]))
         # RECORD THE PROCESS OUTCOME BEFORE ANY BRANCH CAN RAISE.
         #
         # The `model-invocation` event below is appended only on the SUCCESS path, so every
@@ -2455,24 +3275,20 @@ def invoke_model(
         # misdiagnosed as a permission rejection: with no recorded exit reason, the only
         # evidence left was the position of the last tool call in the log. Emitting here
         # makes every future failure self-diagnosing.
-        append_jsonl(
-            task_dir / "events.jsonl",
-            {
-                "at": utc_now(),
-                "event": "model-process-exit",
-                "label": label,
-                "role": role,
-                "vendor": vendor,
-                "exit_code": process_result["exit_code"],
-                "timed_out": process_result["timed_out"],
-                "duration_ms": process_result["duration_ms"],
-                "wall_timeout_seconds": timeout_seconds,
-                "terminal_subtype": _claude_terminal_subtype(log_path),
-                "log_path": str(log_path),
-            },
+        terminal_subtype = _claude_terminal_subtype(log_path)
+        _record_model_process_exit(
+            task_dir,
+            label=label,
+            role=role,
+            vendor=vendor,
+            timeout_seconds=timeout_seconds,
+            process_result=process_result,
+            result_path=result_path,
+            invocation_path=invocation_path,
+            terminal_subtype=terminal_subtype,
         )
         if process_result["exit_code"] != 0 or process_result["timed_out"]:
-            subtype = None if process_result["timed_out"] else _claude_terminal_subtype(log_path)
+            subtype = None if process_result["timed_out"] else terminal_subtype
             if role == "writer" and process_result["timed_out"]:
                 # A TIMED-OUT WRITER IS RECOVERED, NOT DISCARDED.
                 #
@@ -2515,21 +3331,38 @@ def invoke_model(
                         "reason": "writer structured-output retries exhausted; proceeding on the staged tree",
                     },
                 )
+            elif process_result["timed_out"]:
+                raise ManagedProcessTimeout(
+                    f"Claude {label}",
+                    timeout_seconds,
+                    process_result,
+                )
             else:
                 raise HarnessError(f"Claude {label} failed; inspect {log_path}")
         else:
             document = _extract_claude_result(log_path)
-        atomic_write_json(result_path, document)
+        atomic_create_json(result_path, document)
     else:
         raise HarnessError(f"unsupported model adapter: {vendor}")
 
+    if role == "reviewer" and vendor != "fake":
+        assert_reviewer_used_no_tools(log_path, vendor)
     validate_schema(document, schema, label=f"{label} result")
     metadata = extract_model_metadata(log_path, vendor, invocation_id)
     resolved_session = f"fake-{invocation_id}" if vendor == "fake" else metadata["session_id"]
     resolved_model = "fake" if vendor == "fake" else metadata["model"]
     resolved_cli_version = "fake" if vendor == "fake" else (command_version(vendor) or "unknown")
     invocation_created_at = utc_now()
-    atomic_write_json(
+    prompt_sha256 = sha256_bytes(prompt.encode("utf-8"))
+    telemetry = {
+        "total_cost_usd": metadata.get("total_cost_usd"),
+        "num_turns": metadata.get("num_turns"),
+        "usage": metadata.get("usage"),
+        "terminal_reason": metadata.get("terminal_reason"),
+        "http_status": metadata.get("http_status"),
+        "retry_after_seconds": metadata.get("retry_after_seconds"),
+    }
+    atomic_create_json(
         invocation_path,
         {
             "invocation_id": invocation_id,
@@ -2537,13 +3370,16 @@ def invoke_model(
             "role": role,
             "label": label,
             "argv": recorded_argv,
+            "cwd": str(model_cwd),
             "wall_timeout_seconds": timeout_seconds,
             "budget_usd": budget,
             "removed_env_names": removed_env_names,
             "instructions_sha256": instructions_sha256,
+            "prompt_sha256": prompt_sha256,
             "session_id": resolved_session,
             "model": resolved_model,
             "cli_version": resolved_cli_version,
+            "telemetry": telemetry,
             "created_at": invocation_created_at,
         },
     )
@@ -2559,6 +3395,9 @@ def invoke_model(
             "exit_code": process_result["exit_code"],
             "timed_out": process_result["timed_out"],
             "duration_ms": process_result["duration_ms"],
+            "total_cost_usd": telemetry["total_cost_usd"],
+            "num_turns": telemetry["num_turns"],
+            "usage": telemetry["usage"],
             "result_path": str(result_path),
         },
     )
@@ -2575,6 +3414,8 @@ def invoke_model(
         "artifact_sha256": sha256_file(result_path),
         "invocation_path": str(invocation_path),
         "invocation_sha256": sha256_file(invocation_path),
+        "prompt_sha256": prompt_sha256,
+        "telemetry": telemetry,
         "created_at": invocation_created_at,
         **process_result,
     }
@@ -2702,6 +3543,77 @@ def protected_owned_paths(
         for path in contract.get("owned_paths", [])
         if any(path_overlaps(path, guard) for guard in protected)
     )
+
+
+def assert_external_v1_control_plane(
+    contract: Mapping[str, Any], *, allow_test_adapter: bool = False
+) -> None:
+    """Protected v1 bootstraps must be judged by base-pinned external bytes.
+
+    A task worktree changing the harness cannot execute its own verifier.  The
+    caller must use the canonical primary checkout, and every executable v1
+    control-plane byte there must still equal the task's committed base.
+    """
+
+    if not protected_owned_paths(contract) or allow_test_adapter:
+        return
+    source_repo = HARNESS_ROOT.parent.parent.resolve()
+    canonical_repo = Path(str(contract.get("repo_realpath", ""))).resolve()
+    if source_repo != canonical_repo:
+        raise HarnessError(
+            "protected v1 task must be run by the external primary-checkout "
+            "agent-harness, never by candidate worktree code"
+        )
+    base_sha = str(contract.get("base_sha", ""))
+    if not SHA1_RE.fullmatch(base_sha):
+        raise HarnessError("protected v1 task base SHA is malformed")
+    if (
+        run_capture(
+            ["git", "cat-file", "-e", f"{base_sha}^{{commit}}"],
+            source_repo,
+            check=False,
+        ).returncode
+        != 0
+    ):
+        raise HarnessError("protected v1 task base commit is unavailable")
+    trusted_paths = (
+        ".agents/harness",
+        "scripts/agent-harness",
+        "scripts/agent-resource-run",
+        "scripts/harness-runtime-smoke.py",
+        "scripts/verify-harness-attestation",
+    )
+    if (
+        run_capture(
+            ["git", "diff", "--quiet", base_sha, "--", *trusted_paths],
+            source_repo,
+            check=False,
+        ).returncode
+        != 0
+    ):
+        raise HarnessError(
+            "external v1 control-plane bytes differ from the task base"
+        )
+    untracked = git_bytes(
+        source_repo,
+        "ls-files",
+        "--others",
+        "--exclude-standard",
+        "-z",
+        "--",
+        *trusted_paths,
+    )
+    if untracked:
+        raise HarnessError(
+            "external v1 control plane contains untracked executable bytes"
+        )
+    runner = Path(__file__).resolve()
+    try:
+        runner.relative_to(source_repo)
+    except ValueError as exc:
+        raise HarnessError(
+            "executing v1 runner is outside the canonical repository"
+        ) from exc
 
 
 def verify_prepared_control_plane(
@@ -2977,6 +3889,7 @@ def create_attestation(
             "log_path": review["log"],
             "log_sha256": review["log_sha256"],
             "staged_diff_sha256": review["staged_diff_sha256"],
+            "findings": list(review["result"].get("findings", [])),
             "created_at": review["created_at"],
         }
         for review in reviews
@@ -2994,6 +3907,7 @@ def create_attestation(
         "repo_realpath": contract["repo_realpath"],
         "worktree_path": str(worktree.resolve()),
         "risk_flags": contract["risk_flags"],
+        "provenance_schema_version": 2,
         "writer": {
             "vendor": contract["writer"],
             "cli_version": latest_writer["cli_version"],
@@ -3016,6 +3930,30 @@ def create_attestation(
             "timed_out": bool(latest_writer.get("timed_out")),
             "duration_ms": latest_writer.get("duration_ms"),
         },
+        "writer_attempts": [
+            {
+                "round": index + 1,
+                "label": run["label"],
+                "vendor": run["vendor"],
+                "session_id": run["session_id"],
+                "degraded": run.get("degraded"),
+                "timed_out": bool(run.get("timed_out")),
+                "duration_ms": run.get("duration_ms"),
+                "artifact_sha256": run["artifact_sha256"],
+                "log_sha256": run["log_sha256"],
+            }
+            for index, run in enumerate(writer_runs)
+        ],
+        "degraded_provenance": [
+            {
+                "round": index + 1,
+                "label": run["label"],
+                "degraded": run.get("degraded"),
+                "timed_out": bool(run.get("timed_out")),
+            }
+            for index, run in enumerate(writer_runs)
+            if run.get("degraded") or run.get("timed_out")
+        ],
         "reviewer": {
             "vendor": contract["reviewer"],
             "cli_version": reviews[-1]["cli_version"],
@@ -3150,6 +4088,10 @@ def prune_task_runtime(task_dir: Path) -> List[str]:
 def run_task(
     contract: Dict[str, Any], task_dir: Path, *, allow_test_adapter: bool = False
 ) -> str:
+    assert_v1_not_imported(task_dir)
+    assert_external_v1_control_plane(
+        contract, allow_test_adapter=allow_test_adapter
+    )
     config = load_config()
     validate_model_vendors(contract, allow_test_adapter=allow_test_adapter)
     validate_canonical_checks(
@@ -3438,10 +4380,15 @@ def run_task(
                 ):
                     raise HarnessError(f"{review_name} review changed the worktree; read-only review violated")
                 verdict = model_review["result"]["verdict"]
+                severe_findings = [
+                    finding
+                    for finding in model_review["result"].get("findings", [])
+                    if finding.get("severity") in {"MAJOR", "BLOCKER"}
+                ]
                 if verdict == "BLOCKED":
                     review_blocked = True
                     break
-                if verdict == "FAIL":
+                if verdict == "FAIL" or severe_findings:
                     review_failed = True
                     break
 
@@ -3457,7 +4404,14 @@ def run_task(
                     [
                         {
                             "id": review["kind"],
-                            "verdict": review["result"]["verdict"],
+                            "verdict": (
+                                "FAIL"
+                                if any(
+                                    finding.get("severity") in {"MAJOR", "BLOCKER"}
+                                    for finding in review["result"].get("findings", [])
+                                )
+                                else review["result"]["verdict"]
+                            ),
                         }
                         for review in reviews_this_round
                         if review["result"]["verdict"] != "PASS"
@@ -3466,11 +4420,22 @@ def run_task(
                 feedback = [
                     {
                         "source": review["name"],
-                        "verdict": review["result"]["verdict"],
+                        "verdict": (
+                            "FAIL"
+                            if any(
+                                finding.get("severity") in {"MAJOR", "BLOCKER"}
+                                for finding in review["result"].get("findings", [])
+                            )
+                            else review["result"]["verdict"]
+                        ),
                         "findings": review["result"]["findings"],
                     }
                     for review in reviews_this_round
                     if review["result"]["verdict"] != "PASS"
+                    or any(
+                        finding.get("severity") in {"MAJOR", "BLOCKER"}
+                        for finding in review["result"].get("findings", [])
+                    )
                 ]
                 if latest_failure_signature == previous_failure_signature:
                     set_state(
@@ -3568,11 +4533,41 @@ def parse_timestamp(raw: Any, label: str) -> dt.datetime:
     return parsed.astimezone(dt.timezone.utc)
 
 
+def _artifact_execution_id(path: Path, expected: Path) -> Optional[str]:
+    """Return a UUID suffix for a dynamic artifact, or ``None`` for legacy exact paths."""
+
+    if path == expected:
+        return None
+    if path.parent != expected.parent or path.suffix != expected.suffix:
+        return None
+    prefix = expected.stem + "-"
+    if not path.stem.startswith(prefix):
+        return None
+    candidate = path.stem[len(prefix) :]
+    try:
+        parsed = uuid.UUID(candidate)
+    except (AttributeError, TypeError, ValueError):
+        return None
+    if str(parsed) != candidate:
+        return None
+    return candidate
+
+
 def evidence_file(task_dir: Path, raw: Any, expected: Path, label: str) -> Path:
     if not isinstance(raw, str) or not raw or "\x00" in raw:
         raise HarnessError(f"{label} path is malformed")
     path = Path(raw)
-    if not path.is_absolute() or path != expected:
+    execution_id = _artifact_execution_id(path, expected)
+    canonical_expected = (
+        _execution_artifact_path(expected, execution_id)
+        if execution_id is not None
+        else expected
+    )
+    if (
+        not path.is_absolute()
+        or (path != expected and execution_id is None)
+        or path != canonical_expected
+    ):
         raise HarnessError(f"{label} path is not the exact runner-owned artifact")
     try:
         resolved = path.resolve(strict=True)
@@ -3580,7 +4575,11 @@ def evidence_file(task_dir: Path, raw: Any, expected: Path, label: str) -> Path:
         metadata = path.lstat()
     except (FileNotFoundError, OSError, ValueError) as exc:
         raise HarnessError(f"{label} is missing or outside the task evidence store") from exc
-    if resolved != expected.resolve() or not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+    if (
+        resolved != canonical_expected.resolve()
+        or not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_nlink != 1
+    ):
         raise HarnessError(f"{label} must be a single-link regular file inside the task evidence store")
     return path
 
@@ -3598,6 +4597,7 @@ def verify_model_invocation(
     invocation_sha256: Any,
     expected_path: Path,
     instructions_sha256: str,
+    prompt_sha256: Optional[str] = None,
 ) -> dt.datetime:
     invocation_path = evidence_file(task_dir, invocation_path_raw, expected_path, f"{label} invocation")
     if sha256_file(invocation_path) != invocation_sha256:
@@ -3614,9 +4614,18 @@ def verify_model_invocation(
     ):
         if invocation.get(key) != expected:
             raise HarnessError(f"{label} invocation {key} is not bound to the attested run")
+    if prompt_sha256 is not None and invocation.get("prompt_sha256") != prompt_sha256:
+        raise HarnessError(
+            f"{label} invocation prompt_sha256 is not bound to the attested run"
+        )
     invocation_id = invocation.get("invocation_id")
     if not isinstance(invocation_id, str) or not invocation_id:
         raise HarnessError(f"{label} invocation id is missing")
+    path_execution_id = _artifact_execution_id(invocation_path, expected_path)
+    if path_execution_id is not None and invocation_id != path_execution_id:
+        raise HarnessError(
+            f"{label} invocation id does not match its execution artifact path"
+        )
     if vendor == "fake" and session_id != f"fake-{invocation_id}":
         raise HarnessError(f"{label} fake session is not bound to its invocation id")
     argv = invocation.get("argv")
@@ -3624,6 +4633,11 @@ def verify_model_invocation(
         raise HarnessError(f"{label} invocation argv is missing")
     if Path(argv[0]).name != vendor:
         raise HarnessError(f"{label} invocation executable does not match vendor {vendor}")
+    invocation_cwd = invocation.get("cwd")
+    if not isinstance(invocation_cwd, str) or not Path(invocation_cwd).is_absolute():
+        raise HarnessError(f"{label} invocation cwd is missing or not absolute")
+    if role == "reviewer" and Path(invocation_cwd) != reviewer_execution_cwd():
+        raise HarnessError(f"{label} reviewer did not run from the isolated cwd")
     timeout = invocation.get("wall_timeout_seconds")
     if not isinstance(timeout, int) or isinstance(timeout, bool) or timeout < 1:
         raise HarnessError(f"{label} invocation timeout is invalid")
@@ -3639,6 +4653,9 @@ def verify_attestation(
     """Canonical fail-closed verifier used by verify, guard, and commit."""
 
     validate_schema(dict(contract), load_schema("task"), label="task contract")
+    assert_external_v1_control_plane(
+        contract, allow_test_adapter=allow_test_adapter
+    )
     validate_model_vendors(contract, allow_test_adapter=allow_test_adapter)
     attestation_path = task_dir / "attestation.json"
     attestation = load_json(attestation_path)
@@ -3758,6 +4775,57 @@ def verify_attestation(
     require(isinstance(writer_session, str) and bool(writer_session), "writer session provenance is empty")
     for field in ("cli_version", "model"):
         require(isinstance(writer.get(field), str) and bool(writer.get(field)), f"writer {field} provenance is empty")
+    provenance_version = attestation.get("provenance_schema_version")
+    writer_attempts = attestation.get("writer_attempts", [])
+    if provenance_version is None:
+        # Compatibility path for already-earned v1 receipts. They predate the
+        # aggregate writer-attempt fields and are surfaced conservatively by
+        # attestation_degraded_labels() when more than one round contributed.
+        require(
+            "writer_attempts" not in attestation
+            and "degraded_provenance" not in attestation,
+            "legacy attestation mixes old and new provenance fields",
+        )
+        writer_attempts = []
+    else:
+        require(
+            provenance_version == 2,
+            "unsupported attestation provenance schema version",
+        )
+        require(
+            isinstance(writer_attempts, list) and len(writer_attempts) == rounds,
+            "writer_attempts must contain every bounded writer round",
+        )
+        for index, attempt in enumerate(writer_attempts):
+            require(
+                isinstance(attempt, dict)
+                and attempt.get("round") == index + 1
+                and attempt.get("label") == f"round-{index + 1:02d}-writer",
+                f"writer_attempts round {index + 1} provenance is malformed",
+            )
+        if writer_attempts:
+            latest_attempt = writer_attempts[-1]
+            require(
+                latest_attempt.get("session_id") == writer.get("session_id")
+                and latest_attempt.get("artifact_sha256") == writer.get("artifact_sha256")
+                and latest_attempt.get("log_sha256") == writer.get("log_sha256"),
+                "final writer summary differs from writer_attempts",
+            )
+        expected_degraded = [
+            {
+                "round": attempt.get("round"),
+                "label": attempt.get("label"),
+                "degraded": attempt.get("degraded"),
+                "timed_out": bool(attempt.get("timed_out")),
+            }
+            for attempt in writer_attempts
+            if isinstance(attempt, dict)
+            and (attempt.get("degraded") or attempt.get("timed_out"))
+        ]
+        require(
+            attestation.get("degraded_provenance") == expected_degraded,
+            "degraded_provenance does not aggregate every degraded writer round",
+        )
     if isinstance(writer_session, str) and isinstance(writer_vendor, str):
         writer_result_expected = task_dir / "results" / f"{writer_label}-{writer_vendor}.json"
         writer_invocation_expected = task_dir / "results" / f"{writer_label}-{writer_vendor}-invocation.json"
@@ -3784,6 +4852,18 @@ def verify_attestation(
             writer_time = parse_timestamp(writer.get("created_at"), "writer.created_at")
             require(writer_time == invocation_time, "writer timestamp differs from invocation metadata")
             writer_log = evidence_file(task_dir, writer.get("log_path"), writer_log_expected, "writer log")
+            execution_ids = {
+                _artifact_execution_id(writer_result_path, writer_result_expected),
+                _artifact_execution_id(
+                    Path(str(writer.get("invocation_path"))),
+                    writer_invocation_expected,
+                ),
+                _artifact_execution_id(writer_log, writer_log_expected),
+            }
+            require(
+                len(execution_ids) == 1,
+                "writer artifacts come from different executions",
+            )
             require(sha256_file(writer_log) == writer.get("log_sha256"), "writer log changed")
             if writer_vendor != "fake":
                 log_metadata = extract_model_metadata(writer_log, writer_vendor, writer_session)
@@ -3824,14 +4904,28 @@ def verify_attestation(
             log_path = evidence_file(task_dir, check.get("log_path"), expected_log, f"check {check_id} log")
             stdout_path = evidence_file(
                 task_dir,
-                str(expected_log.with_suffix(".stdout.log")),
-                expected_log.with_suffix(".stdout.log"),
+                str(log_path.with_suffix(".stdout.log")),
+                (
+                    _execution_artifact_path(
+                        expected_log,
+                        _artifact_execution_id(log_path, expected_log),
+                    ).with_suffix(".stdout.log")
+                    if _artifact_execution_id(log_path, expected_log) is not None
+                    else expected_log.with_suffix(".stdout.log")
+                ),
                 f"check {check_id} stdout",
             )
             stderr_path = evidence_file(
                 task_dir,
-                str(expected_log.with_suffix(".stderr.log")),
-                expected_log.with_suffix(".stderr.log"),
+                str(log_path.with_suffix(".stderr.log")),
+                (
+                    _execution_artifact_path(
+                        expected_log,
+                        _artifact_execution_id(log_path, expected_log),
+                    ).with_suffix(".stderr.log")
+                    if _artifact_execution_id(log_path, expected_log) is not None
+                    else expected_log.with_suffix(".stderr.log")
+                ),
                 f"check {check_id} stderr",
             )
             profile_path = evidence_file(
@@ -3839,6 +4933,14 @@ def verify_attestation(
                 check.get("sandbox_profile_path"),
                 expected_profile,
                 f"check {check_id} sandbox profile",
+            )
+            log_execution_id = _artifact_execution_id(log_path, expected_log)
+            profile_execution_id = _artifact_execution_id(
+                profile_path, expected_profile
+            )
+            require(
+                log_execution_id == profile_execution_id,
+                f"check {check_id} artifacts come from different executions",
             )
             require(sha256_file(log_path) == check.get("log_sha256"), f"check {check_id} combined log changed")
             require(sha256_file(stdout_path) == check.get("stdout_sha256"), f"check {check_id} stdout changed")
@@ -3931,6 +5033,19 @@ def verify_attestation(
                 result = load_json(result_path)
                 validate_schema(result, load_schema("review"), label=f"review {kind} result")
                 require(result.get("verdict") == "PASS", f"review {kind} result artifact is not PASS")
+                artifact_findings = result.get("findings", [])
+                require(
+                    review.get("findings") == artifact_findings,
+                    f"review {kind} findings summary differs from its result artifact",
+                )
+                require(
+                    not any(
+                        isinstance(finding, Mapping)
+                        and finding.get("severity") in {"MAJOR", "BLOCKER"}
+                        for finding in artifact_findings
+                    ),
+                    f"review {kind} PASS contains unresolved MAJOR/BLOCKER findings",
+                )
                 invocation_time = verify_model_invocation(
                     task_dir,
                     vendor=vendor,
@@ -3945,6 +5060,18 @@ def verify_attestation(
                     instructions_sha256=contract["instructions_sha256"],
                 )
                 log_path = evidence_file(task_dir, review.get("log_path"), log_expected, f"review {kind} log")
+                execution_ids = {
+                    _artifact_execution_id(result_path, result_expected),
+                    _artifact_execution_id(
+                        Path(str(review.get("invocation_path"))),
+                        invocation_expected,
+                    ),
+                    _artifact_execution_id(log_path, log_expected),
+                }
+                require(
+                    len(execution_ids) == 1,
+                    f"review {kind} artifacts come from different executions",
+                )
                 require(sha256_file(log_path) == review.get("log_sha256"), f"review {kind} log changed")
                 if vendor != "fake":
                     log_metadata = extract_model_metadata(log_path, vendor, session)
@@ -3982,8 +5109,20 @@ def cmd_init(args: argparse.Namespace) -> int:
     if not TASK_ID_RE.fullmatch(args.task_id):
         raise HarnessError("task id must match [a-z0-9][a-z0-9._-]{1,63}")
     config = load_config()
+    prompt = getattr(args, "prompt", None)
+    prompt_file = getattr(args, "prompt_file", None)
+    if prompt_file:
+        try:
+            prompt = Path(prompt_file).read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            raise HarnessError(f"cannot read prompt file {prompt_file}: {exc}") from exc
+    if not isinstance(prompt, str) or not prompt.strip():
+        raise HarnessError("init requires a non-empty --prompt or --prompt-file")
+    prompt = prompt.strip()
     task_dir = task_dir_for(common, args.task_id)
-    if task_dir.exists():
+    if task_dir.exists() or (
+        common / "agent-harness" / "v2" / "tasks" / args.task_id
+    ).exists():
         raise HarnessError(f"task already exists: {args.task_id}")
 
     owned = sorted(set(normalize_owned_path(path) for path in args.owned))
@@ -4073,6 +5212,8 @@ def cmd_init(args: argparse.Namespace) -> int:
     checks = [parse_check(raw, timeout) for raw in args.check]
     final_checks = [parse_check(raw, timeout) for raw in args.final_check]
     risks = classify_risks(owned, args.risk, config)
+    if "runtime" in risks:
+        runtime_preflight(primary)
     reviewer, reviewer_escalated = escalate_reviewer_for_risk(
         writer,
         reviewer,
@@ -4095,6 +5236,23 @@ def cmd_init(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
     add_missing_canonical_risk_checks(checks, risks, timeout, config)
+    if any(path_overlaps(path, "src-tauri/src") for path in owned):
+        rust_command = canonical_check_commands(config).get("rust-lib")
+        if not rust_command:
+            raise HarnessError("canonical rust-lib command is missing")
+        existing_rust = next(
+            (check for check in checks if check.get("id") == "rust-lib"), None
+        )
+        if existing_rust is None:
+            checks.append(
+                {
+                    "id": "rust-lib",
+                    "command": rust_command,
+                    "timeout_seconds": timeout,
+                }
+            )
+        elif existing_rust.get("command") != rust_command:
+            raise HarnessError("rust-lib is runner-owned and must use its canonical command")
     if not checks:
         raise HarnessError(
             "every task requires at least one deterministic pre-review check; "
@@ -4109,7 +5267,7 @@ def cmd_init(args: argparse.Namespace) -> int:
     contract: Dict[str, Any] = {
         "schema_version": 1,
         "task_id": args.task_id,
-        "description": args.prompt,
+        "description": prompt,
         "kind": args.kind,
         "base_sha": base_sha,
         "contract_sha256": "",
@@ -4226,8 +5384,13 @@ def cmd_seal_prepared(args: argparse.Namespace) -> int:
     """Seal a prepared control-plane bootstrap before any model dispatch."""
 
     contract, task_dir, _ = load_task_from_current_repo(args.task_id, Path.cwd())
+    assert_v1_not_imported(task_dir)
     if contract.get("kind") != "harness":
         raise HarnessError("seal-prepared is restricted to kind=harness tasks")
+    assert_external_v1_control_plane(
+        contract,
+        allow_test_adapter=bool(getattr(args, "_allow_test_adapter", False)),
+    )
     state = load_json(task_dir / "state.json")
     if state.get("status") != "INITIALIZED" or state.get("phase") != "init":
         raise HarnessError("seal-prepared requires a fresh INITIALIZED task")
@@ -4330,13 +5493,29 @@ def cmd_run(args: argparse.Namespace) -> int:
 def cmd_status(args: argparse.Namespace) -> int:
     contract, task_dir, _ = load_task_from_current_repo(args.task_id, Path.cwd())
     state = load_json(task_dir / "state.json")
-    result = {"contract": contract, "state": state}
+    lock_path = task_dir / "run.lock"
+    lock_live = task_run_lock_blocks_reap(task_dir)
+    lock_liveness = "LIVE" if lock_live else ("STALE" if lock_path.exists() else "ABSENT")
+    effective_status = state["status"]
+    if state["status"] in {"RUNNING", "CHECKING", "REVIEWING", "REPAIRING"} and not lock_live:
+        effective_status = "STALE"
+    result = {
+        "generation": 1,
+        "contract": contract,
+        "state": state,
+        "effective_status": effective_status,
+        "lock": {"liveness": lock_liveness},
+    }
     if (task_dir / "attestation.json").exists():
         result["attestation"] = load_json(task_dir / "attestation.json")
     if args.json:
         print(json.dumps(result, indent=2, sort_keys=True))
     else:
-        print(f"{contract['task_id']}: {state['status']} (round {state.get('round', 0)})")
+        print(
+            f"{contract['task_id']}: {effective_status} "
+            f"(stored {state['status']}, round {state.get('round', 0)}, "
+            f"lock {lock_liveness})"
+        )
         print(f"worktree: {contract['worktree_path']}")
         if state.get("reason"):
             print(f"reason: {state['reason']}")
@@ -4393,6 +5572,7 @@ def cmd_guard_commit(args: argparse.Namespace) -> int:
         validate_schema(contract, load_schema("task"), label="task contract")
         if contract_hash(contract) != contract.get("contract_sha256"):
             raise HarnessError("task contract hash mismatch")
+    assert_v1_not_imported(task_dir)
     verify_attestation(
         contract,
         task_dir,
@@ -4480,6 +5660,7 @@ def verify_committed_task(contract: Mapping[str, Any], task_dir: Path) -> Dict[s
 
 def cmd_commit(args: argparse.Namespace) -> int:
     contract, task_dir, _ = load_task_from_current_repo(args.task_id, Path.cwd())
+    assert_v1_not_imported(task_dir)
     state = load_json(task_dir / "state.json")
     if state.get("status") != "PASSED":
         raise HarnessError(f"only a PASSED task can be committed; current status is {state.get('status')}")
@@ -4539,9 +5720,11 @@ def cmd_commit(args: argparse.Namespace) -> int:
     # the independent reviews — but the receipt must SAY SO. Publishing a degraded round
     # under a trailer identical to a clean one is exactly the false confidence this receipt
     # exists to prevent.
-    writer_degraded = (attestation.get("writer") or {}).get("degraded")
-    if writer_degraded:
-        trailer_lines.insert(2, f"Harness-Writer-Degraded: {writer_degraded}")
+    degraded_labels = attestation_degraded_labels(attestation)
+    if degraded_labels:
+        trailer_lines.insert(
+            2, "Harness-Writer-Degraded: " + ",".join(degraded_labels)
+        )
     trailers = "\n".join(trailer_lines)
     message = f"{message}\n\n{trailers}"
     commit_argv = ["git", "commit"]
@@ -4599,6 +5782,31 @@ def cmd_commit(args: argparse.Namespace) -> int:
     if not getattr(args, "quiet", False):
         print(json.dumps({"task_id": contract["task_id"], "status": "COMMITTED", "commit_sha": commit_sha}, indent=2))
     return 0
+
+
+def attestation_degraded_labels(attestation: Mapping[str, Any]) -> List[str]:
+    labels = {
+        str(item.get("degraded") or ("timeout" if item.get("timed_out") else "degraded"))
+        for item in attestation.get("degraded_provenance", [])
+        if isinstance(item, Mapping)
+        and (item.get("degraded") or item.get("timed_out"))
+    }
+    writer = attestation.get("writer", {})
+    if isinstance(writer, Mapping) and (
+        writer.get("degraded") or writer.get("timed_out")
+    ):
+        labels.add(
+            str(
+                writer.get("degraded")
+                or ("timeout" if writer.get("timed_out") else "degraded")
+            )
+        )
+    if (
+        attestation.get("provenance_schema_version") is None
+        and int(attestation.get("rounds", 0) or 0) > 1
+    ):
+        labels.add("legacy-provenance-unknown")
+    return sorted(labels)
 
 
 def task_archive_ref(contract: Mapping[str, Any]) -> str:
@@ -4772,6 +5980,7 @@ def task_worktree_is_untouched(contract: Mapping[str, Any]) -> bool:
 
 def cmd_reap(args: argparse.Namespace) -> int:
     contract, task_dir, _ = load_task_from_current_repo(args.task_id, Path.cwd())
+    assert_v1_not_imported(task_dir)
     lock = acquire_run_lock(
         task_dir, stale_before=getattr(args, "stale_before", None)
     )
@@ -4902,6 +6111,10 @@ def gc_candidates(
     if not tasks_root.is_dir():
         return candidates, prune_only
     for task_dir in sorted(path for path in tasks_root.iterdir() if path.is_dir()):
+        if (tasks_root.parent / "v2" / "tasks" / task_dir.name / "task.json").exists():
+            # import-v1 transfers lifecycle ownership without mutating v1
+            # evidence; legacy GC must leave both its worktree and artifacts.
+            continue
         state_path = task_dir / "state.json"
         contract_path = task_dir / "task.json"
         if not state_path.is_file() or not contract_path.is_file():
@@ -4972,6 +6185,7 @@ def cmd_gc(args: argparse.Namespace) -> int:
 
 def cmd_close(args: argparse.Namespace) -> int:
     contract, task_dir, _ = load_task_from_current_repo(args.task_id, Path.cwd())
+    assert_v1_not_imported(task_dir)
     state = load_json(task_dir / "state.json")
     verify_committed_task(contract, task_dir)
     worktree = Path(contract["worktree_path"])
@@ -5197,6 +6411,158 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
         finally:
             os.environ.pop(OUTER_SANDBOX_ENV, None)
     config = load_config()
+    try:
+        isolated_cwd = reviewer_execution_cwd()
+        codex_environment = reviewer_model_environment(
+            {"HOME": "/Users/selftest", "PATH": "/usr/bin:/bin"},
+            vendor="codex",
+            cwd=isolated_cwd,
+        )
+        if codex_environment.get("SHELL") != "/bin/sh":
+            failures.append("Codex reviewer shell was not pinned to /bin/sh")
+        if codex_environment.get("HOME") != str(isolated_cwd):
+            failures.append("Codex reviewer HOME was not isolated")
+        if codex_environment.get("CODEX_HOME") != "/Users/selftest/.codex":
+            failures.append("Codex reviewer auth home was not preserved explicitly")
+        if "reviewer_tool_guard.py" in reviewer_tool_guard_command():
+            failures.append("reviewer deny hook still depends on a mutable helper file")
+    except HarnessError as exc:
+        failures.append(f"reviewer execution isolation failed: {exc}")
+    with tempfile.TemporaryDirectory(prefix="murmur-reviewer-tools-") as raw:
+        fixture_dir = Path(raw)
+
+        def tool_fixture(name: str, events: Sequence[Mapping[str, Any]]) -> Path:
+            path = fixture_dir / name
+            path.write_text(
+                "".join(json.dumps(event, sort_keys=True) + "\n" for event in events),
+                encoding="utf-8",
+            )
+            return path
+
+        claude_schema_only = tool_fixture(
+            "claude-schema-only.jsonl",
+            [
+                {
+                    "type": "system",
+                    "subtype": "init",
+                    "tools": ["StructuredOutput"],
+                    "mcp_servers": [],
+                },
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "name": "StructuredOutput",
+                                "input": {"verdict": "PASS"},
+                            }
+                        ]
+                    },
+                },
+            ],
+        )
+        if reviewer_tool_activity(claude_schema_only, "claude"):
+            failures.append("Claude StructuredOutput response was treated as tool execution")
+
+        claude_bash = tool_fixture(
+            "claude-bash.jsonl",
+            [
+                {
+                    "type": "system",
+                    "subtype": "init",
+                    "tools": ["StructuredOutput"],
+                    "mcp_servers": [],
+                },
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [
+                            {"type": "tool_use", "name": "Bash", "input": {"command": "pwd"}}
+                        ]
+                    },
+                },
+            ],
+        )
+        if not reviewer_tool_activity(claude_bash, "claude"):
+            failures.append("Claude Bash tool use was not rejected")
+
+        claude_extra_surface = tool_fixture(
+            "claude-extra-surface.jsonl",
+            [
+                {
+                    "type": "system",
+                    "subtype": "init",
+                    "tools": ["StructuredOutput", "Read"],
+                    "mcp_servers": [{"name": "unexpected"}],
+                }
+            ],
+        )
+        if len(reviewer_tool_activity(claude_extra_surface, "claude")) != 2:
+            failures.append("Claude init tool and MCP surfaces did not fail closed")
+
+        codex_prose = tool_fixture(
+            "codex-prose.jsonl",
+            [
+                {
+                    "type": "item.completed",
+                    "item": {"type": "agent_message", "text": "PASS"},
+                }
+            ],
+        )
+        if reviewer_tool_activity(codex_prose, "codex"):
+            failures.append("Codex prose response was treated as tool execution")
+
+        for label, item_type in (
+            ("command", "command_execution"),
+            ("unknown", "dynamic_tool_call"),
+        ):
+            codex_tool = tool_fixture(
+                f"codex-{label}.jsonl",
+                [
+                    {
+                        "type": "item.started",
+                        "item": {"type": item_type},
+                    }
+                ],
+            )
+            if not reviewer_tool_activity(codex_tool, "codex"):
+                failures.append(f"Codex {item_type} event did not fail closed")
+    with tempfile.TemporaryDirectory(prefix="murmur-model-telemetry-") as raw:
+        telemetry_log = Path(raw) / "claude.jsonl"
+        telemetry_log.write_text(
+            json.dumps(
+                {
+                    "type": "result",
+                    "session_id": "telemetry-session",
+                    "model": "telemetry-model",
+                    "total_cost_usd": 1.25,
+                    "num_turns": 7,
+                    "usage": {"input_tokens": 11, "output_tokens": 13},
+                    "api_error_status": 429,
+                    "retry_after_seconds": 2,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        telemetry = extract_model_metadata(
+            telemetry_log, "claude", "telemetry-fallback"
+        )
+        expected_telemetry = {
+            "session_id": "telemetry-session",
+            "model": "telemetry-model",
+            "total_cost_usd": 1.25,
+            "num_turns": 7,
+            "usage": {"input_tokens": 11, "output_tokens": 13},
+            "terminal_reason": None,
+            "http_status": 429,
+            "retry_after_seconds": 2.0,
+        }
+        if telemetry != expected_telemetry:
+            failures.append(
+                "model terminal cost/turn/usage metadata was not retained"
+            )
     instruction_labels = {label for label, _path in instruction_paths(Path.cwd())}
     if "scripts/agent-remote-audit.py" not in instruction_labels:
         failures.append("remote-audit implementation is absent from the instruction hash")
@@ -5534,6 +6900,7 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
                 argparse.Namespace(
                     task_id="selftest-prepared-harness",
                     quiet=True,
+                    _allow_test_adapter=True,
                 )
             )
             sealed_contract, prepared_dir, _ = load_task_from_current_repo(
@@ -5686,6 +7053,74 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
                 pass
             finally:
                 atomic_write_json(task_dir / "attestation.json", original_attestation)
+
+            severe_attestation = copy.deepcopy(original_attestation)
+            severe_review = severe_attestation["reviews"][0]
+            severe_result_path = Path(severe_review["result_path"])
+            original_review_result = load_json(severe_result_path)
+            severe_result = copy.deepcopy(original_review_result)
+            severe_result["verdict"] = "PASS"
+            severe_result["findings"] = [
+                {
+                    "severity": "MAJOR",
+                    "file": "owned.txt",
+                    "evidence": "forged PASS still contains a major defect",
+                    "required_fix": "repair it",
+                }
+            ]
+            atomic_write_json(severe_result_path, severe_result)
+            severe_review["artifact_sha256"] = sha256_file(severe_result_path)
+            severe_review["findings"] = severe_result["findings"]
+            atomic_write_json(task_dir / "attestation.json", severe_attestation)
+            try:
+                verify_attestation(contract, task_dir, allow_test_adapter=True)
+                failures.append(
+                    "canonical verifier accepted forged PASS plus MAJOR finding"
+                )
+            except HarnessError as exc:
+                if "MAJOR/BLOCKER" not in str(exc):
+                    failures.append(
+                        "forged PASS plus MAJOR failed for an unrelated reason"
+                    )
+            finally:
+                atomic_write_json(severe_result_path, original_review_result)
+                atomic_write_json(task_dir / "attestation.json", original_attestation)
+
+            synthetic_rounds = copy.deepcopy(original_attestation)
+            clean_attempt = copy.deepcopy(synthetic_rounds["writer_attempts"][-1])
+            clean_attempt.update(
+                {
+                    "round": 2,
+                    "label": "round-02-writer",
+                    "degraded": None,
+                    "timed_out": False,
+                }
+            )
+            degraded_attempt = copy.deepcopy(clean_attempt)
+            degraded_attempt.update(
+                {
+                    "round": 1,
+                    "label": "round-01-writer",
+                    "degraded": "timeout",
+                    "timed_out": True,
+                }
+            )
+            synthetic_rounds["writer_attempts"] = [
+                degraded_attempt,
+                clean_attempt,
+            ]
+            synthetic_rounds["degraded_provenance"] = [
+                {
+                    "round": 1,
+                    "label": "round-01-writer",
+                    "degraded": "timeout",
+                    "timed_out": True,
+                }
+            ]
+            if attestation_degraded_labels(synthetic_rounds) != ["timeout"]:
+                failures.append(
+                    "round-1 degraded plus round-2 clean lost published provenance"
+                )
 
             # Deterministic TCB mutation campaign: every security-relevant
             # single-field change must turn an accepted receipt into DENY.
@@ -6343,7 +7778,8 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
             lane_ready = lane_runtime["tmp"] / "lane-inheritance-ready"
             lane_ready.unlink(missing_ok=True)
             lane_probe = (
-                "import os,pathlib,time; "
+                "import os,pathlib,signal,time; "
+                "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
                 f"pathlib.Path({str(lane_ready)!r}).write_text(str(os.getpgrp())); "
                 "time.sleep(30)"
             )
@@ -6905,7 +8341,9 @@ def build_parser() -> argparse.ArgumentParser:
         help="keep a same-vendor reviewer even on lock/egress/protocol risk "
         "(default: auto-escalate the reviewer to the opposite vendor)",
     )
-    init_parser.add_argument("--prompt", required=True)
+    prompt_group = init_parser.add_mutually_exclusive_group(required=True)
+    prompt_group.add_argument("--prompt")
+    prompt_group.add_argument("--prompt-file")
     init_parser.add_argument("--owned", action="append", required=True, metavar="PATH")
     init_parser.add_argument(
         "--risk",
@@ -6916,7 +8354,13 @@ def build_parser() -> argparse.ArgumentParser:
     init_parser.add_argument("--check", action="append", default=[], metavar="ID::COMMAND")
     init_parser.add_argument("--final-check", action="append", default=[], metavar="ID::COMMAND")
     init_parser.add_argument("--max-repair-rounds", type=int, default=2, choices=range(0, 6))
-    init_parser.add_argument("--base", help="committed base ref (default: HEAD)")
+    init_parser.add_argument(
+        "--base",
+        help=(
+            "committed base ref (default: fetched origin/murmur; loud fallback "
+            "to local HEAD only when the remote base is unavailable)"
+        ),
+    )
     init_parser.add_argument("--branch", help="task branch (default: agent/<task-id>)")
     expected = init_parser.add_mutually_exclusive_group()
     expected.add_argument("--expected-change", dest="expected_change", action="store_true", default=True)

--- a/.agents/harness/verifier.py
+++ b/.agents/harness/verifier.py
@@ -1,0 +1,1816 @@
+#!/usr/bin/env python3
+"""Trust kernel for the thin, resumable Murmur Harness v2.
+
+This module deliberately has no writer or repair primitive.  It derives a
+verification plan from the exact staged diff, runs only runner-owned checks and
+fresh read-only reviews, and verifies the resulting exact-diff evidence bundle.
+The lifecycle/worktree commands live in :mod:`cli`.
+"""
+
+from __future__ import annotations
+
+import copy
+import fnmatch
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import time
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+import task_runner as legacy
+
+
+V2_STATES = {
+    "OPEN",
+    "VERIFYING",
+    "NEEDS_FIX",
+    "NEEDS_EVIDENCE",
+    "PAUSED_RETRYABLE",
+    "INTERRUPTED",
+    "PASSED",
+    "COMMITTED",
+    "CLOSED",
+    "ABANDONED",
+}
+V2_TERMINAL_STATES = {"CLOSED", "ABANDONED"}
+V2_RESUMABLE_STATES = V2_STATES - V2_TERMINAL_STATES - {"COMMITTED"}
+SEVERE_FINDINGS = {"MAJOR", "BLOCKER"}
+ALLOWED_PROBES = {
+    "rust-lib",
+    "protocol-server",
+    "tauri-boot",
+    "ng-lint",
+    "ng-build",
+    "playwright",
+    "perf-contracts",
+    "harness-python",
+    "harness-v2-selftest",
+    "receipt-selftest",
+    "hook-selftest",
+    "config-audit",
+}
+TRANSIENT_HTTP_STATUSES = {408, 409, 425, 429, 500, 502, 503, 504}
+PROTOCOL_FILES = (
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".claude/settings.json",
+    ".codex/config.toml",
+    ".codex/hooks.json",
+    ".codex/rules/agentic-workflow.md",
+    ".claude/rules/agentic-workflow.md",
+    ".agents/harness/cli.py",
+    ".agents/harness/verifier.py",
+    ".agents/harness/task_runner.py",
+    ".agents/harness/process_guardian.py",
+    ".agents/harness/hook_guard.py",
+    ".agents/harness/config_audit.py",
+    ".agents/harness/resource_policy.py",
+    ".agents/harness/v2_selftest.py",
+    ".agents/harness/config.json",
+    ".agents/harness/prompts/combined-reviewer.md",
+    ".agents/harness/prompts/lock-security-reviewer.md",
+    ".agents/harness/prompts/egress-security-reviewer.md",
+    ".agents/harness/prompts/protocol-security-reviewer.md",
+    ".agents/harness/schemas/v2-task.schema.json",
+    ".agents/harness/schemas/v2-plan.schema.json",
+    ".agents/harness/schemas/v2-review.schema.json",
+    ".agents/harness/schemas/v2-evidence.schema.json",
+    ".agents/harness/schemas/v2-commit-intent.schema.json",
+    ".agents/harness/schemas/v2-commit.schema.json",
+    "scripts/agent-harness",
+    "scripts/agent-resource-run",
+    "scripts/agent-config-audit",
+    "scripts/harness-runtime-smoke",
+    "scripts/harness-runtime-smoke.py",
+    "scripts/verify-harness-attestation",
+    "scripts/ci.sh",
+    ".github/workflows/ci.yml",
+    ".codex/hooks/finish-guard.sh",
+    ".codex/hooks/selftest.sh",
+    ".claude/hooks/finish-guard.sh",
+    ".claude/hooks/selftest.sh",
+)
+SOURCE_ROOT = Path(__file__).resolve().parents[2]
+
+
+class ReviewPaused(legacy.HarnessError):
+    """A reviewer infrastructure failure exhausted the one bounded retry."""
+
+    def __init__(self, message: str, attempts: Sequence[Mapping[str, Any]]) -> None:
+        super().__init__(message)
+        self.attempts = [dict(item) for item in attempts]
+
+
+def last_state_event(task_dir: Path) -> Optional[Dict[str, Any]]:
+    path = task_dir / "events.jsonl"
+    if not path.is_file():
+        return None
+    result: Optional[Dict[str, Any]] = None
+    try:
+        with path.open("r", encoding="utf-8", errors="strict") as handle:
+            for line in handle:
+                document = json.loads(line)
+                if (
+                    isinstance(document, dict)
+                    and document.get("event") == "state"
+                    and isinstance(document.get("state"), dict)
+                ):
+                    result = document["state"]
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise legacy.HarnessError(
+            f"v2 event ledger is malformed: {path}: {exc}"
+        ) from exc
+    return result
+
+
+def load_v2_state(task_dir: Path) -> Dict[str, Any]:
+    """Resolve the append-only ledger and repair only a missing/stale projection."""
+
+    event_state = last_state_event(task_dir)
+    if event_state is None:
+        raise legacy.HarnessError("v2 state has no authoritative event")
+    if (
+        event_state.get("schema_version") != 2
+        or event_state.get("task_id") != task_dir.name
+        or event_state.get("status") not in V2_STATES
+        or not isinstance(event_state.get("updated_at"), str)
+    ):
+        raise legacy.HarnessError("v2 authoritative state event is malformed")
+    event_time = legacy.parse_timestamp(
+        event_state["updated_at"], "v2 state event updated_at"
+    )
+    state_path = task_dir / "state.json"
+    if not state_path.is_file():
+        legacy.atomic_write_json(state_path, event_state)
+        return event_state
+    projected = legacy.load_json(state_path)
+    if (
+        projected.get("schema_version") != 2
+        or projected.get("task_id") != task_dir.name
+        or projected.get("status") not in V2_STATES
+        or not isinstance(projected.get("updated_at"), str)
+    ):
+        raise legacy.HarnessError("v2 state projection is malformed")
+    projected_time = legacy.parse_timestamp(
+        projected["updated_at"], "v2 state projection updated_at"
+    )
+    if projected_time > event_time:
+        raise legacy.HarnessError("v2 state projection is newer than its event ledger")
+    if projected != event_state:
+        legacy.atomic_write_json(state_path, event_state)
+    return event_state
+
+
+def canonical_hash(value: Any) -> str:
+    return legacy.sha256_bytes(legacy.canonical_json(value))
+
+
+def document_hash(document: Mapping[str, Any], hash_field: str) -> str:
+    payload = copy.deepcopy(dict(document))
+    payload[hash_field] = ""
+    return canonical_hash(payload)
+
+
+def validate_hashed_document(
+    document: Mapping[str, Any],
+    schema_name: str,
+    hash_field: str,
+    label: str,
+    *,
+    schema: Optional[Mapping[str, Any]] = None,
+) -> None:
+    selected_schema = (
+        dict(schema) if schema is not None else legacy.load_schema(schema_name)
+    )
+    legacy.validate_schema(dict(document), selected_schema, label=label)
+    expected = document_hash(document, hash_field)
+    if document.get(hash_field) != expected:
+        raise legacy.HarnessError(
+            f"{label} {hash_field} mismatch: expected {expected}, found {document.get(hash_field)}"
+        )
+
+
+def protocol_relative_paths(worktree: Path) -> List[str]:
+    values = set(PROTOCOL_FILES)
+    harness_root = worktree / ".agents" / "harness"
+    if not harness_root.is_dir() or harness_root.is_symlink():
+        raise legacy.HarnessError(
+            "v2 protocol directory is missing or unsafe: .agents/harness"
+        )
+    # New runner modules must enter the protocol automatically.  A hand-kept
+    # list silently omitted exactly the sort of executable helper that can
+    # change a verdict (metrics, migrations, or fault-test entrypoints).
+    python_modules = sorted(harness_root.glob("*.py"))
+    unsafe_python = [
+        path.relative_to(worktree).as_posix()
+        for path in python_modules
+        if not path.is_file() or path.is_symlink()
+    ]
+    if unsafe_python:
+        raise legacy.HarnessError(
+            "v2 protocol Python module is missing or unsafe: "
+            + ", ".join(unsafe_python)
+        )
+    values.update(
+        path.relative_to(worktree).as_posix() for path in python_modules
+    )
+    for directory in (
+        ".agents/harness/checks",
+        ".agents/harness/prompts",
+        ".agents/harness/schemas",
+    ):
+        root = worktree / directory
+        if not root.is_dir() or root.is_symlink():
+            raise legacy.HarnessError(
+                f"v2 protocol directory is missing or unsafe: {directory}"
+            )
+        values.update(
+            path.relative_to(worktree).as_posix()
+            for path in root.rglob("*")
+            if path.is_file() and not path.is_symlink()
+        )
+    return sorted(values)
+
+
+def protocol_bundle(worktree: Path) -> Dict[str, Any]:
+    files: List[Dict[str, str]] = []
+    for relative in protocol_relative_paths(worktree):
+        path = worktree / relative
+        if not path.is_file() or path.is_symlink():
+            raise legacy.HarnessError(f"v2 protocol file is missing or unsafe: {relative}")
+        files.append(
+            {
+                "path": relative,
+                "sha256": legacy.sha256_file(path),
+            }
+        )
+    bundle: Dict[str, Any] = {
+        "schema_version": 2,
+        "files": files,
+    }
+    bundle["protocol_sha256"] = canonical_hash(bundle)
+    return bundle
+
+
+def executable_protocol_bundle(worktree: Path) -> Dict[str, Any]:
+    """Require the running verifier to equal the task-pinned protocol bytes."""
+
+    executing = protocol_bundle(SOURCE_ROOT)
+    pinned = protocol_bundle(worktree)
+    if executing != pinned:
+        raise legacy.HarnessError(
+            "the executing Harness v2 protocol differs from the task worktree; "
+            f"run {worktree / 'scripts' / 'agent-harness'} for this task"
+        )
+    return pinned
+
+
+def git_file_at_commit(repo: Path, commit_sha: str, relative: str) -> bytes:
+    completed = subprocess.run(
+        ["git", "show", f"{commit_sha}:{relative}"],
+        cwd=str(repo),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise legacy.HarnessError(
+            f"v2 attested commit is missing required file: {relative}"
+        )
+    return completed.stdout
+
+
+def attested_json_object(
+    repo: Path, commit_sha: str, relative: str, label: str
+) -> Dict[str, Any]:
+    try:
+        document = json.loads(
+            git_file_at_commit(repo, commit_sha, relative).decode("utf-8")
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise legacy.HarnessError(
+            f"v2 attested {label} is malformed"
+        ) from exc
+    if not isinstance(document, dict):
+        raise legacy.HarnessError(f"v2 attested {label} is not an object")
+    return document
+
+
+def attested_schema(
+    repo: Path, commit_sha: str, schema_name: str
+) -> Dict[str, Any]:
+    return attested_json_object(
+        repo,
+        commit_sha,
+        f".agents/harness/schemas/{schema_name}.schema.json",
+        f"{schema_name} schema",
+    )
+
+
+def _matches(path: str, patterns: Iterable[str]) -> bool:
+    return any(
+        re.fullmatch(legacy._glob_pattern_to_regex(pattern), path)
+        for pattern in patterns
+    )
+
+
+def actual_risks(paths: Sequence[str], config: Mapping[str, Any]) -> List[str]:
+    result: List[str] = []
+    classification = config.get("risk_classification", {})
+    if not isinstance(classification, Mapping):
+        raise legacy.HarnessError("risk_classification is malformed")
+    for risk in ("lock", "egress", "protocol"):
+        patterns = classification.get(risk, [])
+        if not isinstance(patterns, list):
+            raise legacy.HarnessError(f"risk_classification.{risk} is malformed")
+        if any(
+            isinstance(pattern, str)
+            and re.fullmatch(legacy._glob_pattern_to_regex(pattern), path)
+            for path in paths
+            for pattern in patterns
+        ):
+            result.append(risk)
+    if _protocol_surface(paths) and "protocol" not in result:
+        result.append("protocol")
+    return result
+
+
+def _rust_surface(paths: Sequence[str]) -> bool:
+    patterns = (
+        "src-tauri/src/**",
+        "src-tauri/crates/**",
+        "crates/**/*.rs",
+        "crates/**/Cargo.toml",
+        "src-tauri/Cargo.toml",
+        "src-tauri/Cargo.lock",
+        "Cargo.toml",
+        "Cargo.lock",
+        ".cargo/**",
+        ".murmur-server-revision",
+    )
+    return any(_matches(path, patterns) for path in paths)
+
+
+def _angular_surface(paths: Sequence[str]) -> bool:
+    patterns = (
+        "src/app/**",
+        "src/design-tokens/**",
+        "src/main.ts",
+        "src/styles.*",
+        "angular.json",
+        "package.json",
+        "package-lock.json",
+        "tsconfig*.json",
+        "eslint.config.*",
+    )
+    return any(_matches(path, patterns) for path in paths)
+
+
+def _ui_behavior_surface(paths: Sequence[str]) -> bool:
+    for path in paths:
+        if path.startswith("e2e/") or path == "playwright.config.ts":
+            return True
+        if path.startswith(("src/app/features/", "src/app/core/", "src/app/services/")):
+            return Path(path).suffix in {".ts", ".html"}
+    return False
+
+
+def _protocol_surface(paths: Sequence[str]) -> bool:
+    return any(
+        path.startswith("src-tauri/src/share/")
+        or path == ".murmur-server-revision"
+        or path.startswith("crates/murmur-protocol/")
+        for path in paths
+    )
+
+
+def _harness_surface(paths: Sequence[str]) -> bool:
+    patterns = (
+        ".agents/harness/**",
+        ".agents/skills/harness/**",
+        ".agents/skills/ship-feature/**",
+        ".claude/skills/harness/**",
+        ".claude/skills/ship-feature/**",
+        ".codex/rules/agentic-workflow.md",
+        ".claude/rules/agentic-workflow.md",
+        ".codex/hooks/**",
+        ".claude/hooks/**",
+        "scripts/agent-harness",
+        "scripts/agent-resource-run",
+        "scripts/harness-runtime-smoke*",
+        "scripts/verify-harness-attestation",
+        "scripts/ci.sh",
+        ".github/workflows/ci.yml",
+    )
+    return any(_matches(path, patterns) for path in paths)
+
+
+def derive_profile(
+    paths: Sequence[str],
+    claims: Sequence[str],
+    config: Mapping[str, Any],
+    *,
+    reviewer: str,
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, str]], List[str]]:
+    """Return checks, reviews and actual sensitive risks for an exact path set.
+
+    Language/build checks are selected independently from semantic sensitivity.
+    Runtime and performance are selected only from explicit claims.
+    """
+
+    claim_set = set(claims)
+    unknown_claims = claim_set - {"runtime", "performance"}
+    if unknown_claims:
+        raise legacy.HarnessError("unknown v2 claims: " + ", ".join(sorted(unknown_claims)))
+    canonical = config.get("canonical_checks", {})
+    if not isinstance(canonical, Mapping):
+        raise legacy.HarnessError("canonical_checks is malformed")
+    timeout = int(config.get("check_timeout_seconds", 1800))
+    check_ids: List[str] = []
+
+    def require(check_id: str) -> None:
+        if check_id not in check_ids:
+            check_ids.append(check_id)
+
+    if _rust_surface(paths):
+        require("rust-lib")
+    if _angular_surface(paths):
+        require("ng-lint")
+        require("ng-build")
+    if _ui_behavior_surface(paths):
+        require("playwright")
+    if _protocol_surface(paths):
+        require("rust-lib")
+        require("protocol-server")
+    if "runtime" in claim_set:
+        require("tauri-boot")
+    if "performance" in claim_set:
+        require("perf-contracts")
+    if _harness_surface(paths):
+        for check_id in (
+            "harness-python",
+            "harness-v2-selftest",
+            "receipt-selftest",
+            "hook-selftest",
+            "config-audit",
+        ):
+            require(check_id)
+
+    checks = [canonical_check(check_id, config) for check_id in check_ids]
+
+    risks = actual_risks(paths, config)
+    reviews = [{"kind": "combined", "vendor": reviewer}]
+    opposite = {"claude": "codex", "codex": "claude", "fake": "fake"}.get(reviewer)
+    if opposite is None:
+        raise legacy.HarnessError(f"unsupported v2 reviewer: {reviewer}")
+    mapping = config.get("risk_reviews", {})
+    for risk in risks:
+        kind = mapping.get(risk) if isinstance(mapping, Mapping) else None
+        if not isinstance(kind, str):
+            raise legacy.HarnessError(f"no specialist review configured for {risk}")
+        reviews.append({"kind": kind, "vendor": opposite})
+    return checks, reviews, risks
+
+
+def canonical_check(
+    check_id: str, config: Mapping[str, Any]
+) -> Dict[str, Any]:
+    if check_id not in ALLOWED_PROBES:
+        raise legacy.HarnessError(f"probe/check id is not allowlisted: {check_id}")
+    canonical = config.get("canonical_checks", {})
+    command = canonical.get(check_id) if isinstance(canonical, Mapping) else None
+    if not isinstance(command, str) or not command.strip():
+        raise legacy.HarnessError(f"no canonical command for v2 check {check_id}")
+    return {
+        "id": check_id,
+        "command": command,
+        "timeout_seconds": int(config.get("check_timeout_seconds", 1800)),
+    }
+
+
+def probe_evidence_hash(records: Sequence[Mapping[str, Any]]) -> str:
+    ordered = sorted(
+        (dict(record) for record in records),
+        key=lambda item: str(item.get("id", "")),
+    )
+    return canonical_hash(ordered)
+
+
+def build_plan(
+    contract: Mapping[str, Any],
+    worktree: Path,
+    paths: Sequence[str],
+    diff: bytes,
+    tree_sha: str,
+    config: Mapping[str, Any],
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    bundle = executable_protocol_bundle(worktree)
+    checks, reviews, risks = derive_profile(
+        paths,
+        list(contract.get("claims", [])),
+        config,
+        reviewer=str(contract["reviewer"]),
+    )
+    head_sha = legacy.git(worktree, "rev-parse", "HEAD")
+    plan: Dict[str, Any] = {
+        "schema_version": 2,
+        "task_id": contract["task_id"],
+        "contract_sha256": contract["contract_sha256"],
+        "base_sha": head_sha,
+        "diff_sha256": legacy.sha256_bytes(diff),
+        "tree_sha": tree_sha,
+        "protocol_sha256": bundle["protocol_sha256"],
+        "changed_paths": list(paths),
+        "claims": list(contract.get("claims", [])),
+        "actual_risk_flags": risks,
+        "checks": checks,
+        "reviews": reviews,
+        "server_required": any(
+            check["id"] in {"rust-lib", "protocol-server"} for check in checks
+        ),
+        # The plan is a content binding, not an execution event.  Replanning the
+        # exact same contract and diff must reproduce the same plan/attempt IDs.
+        "created_at": contract["created_at"],
+        "plan_sha256": "",
+    }
+    plan["plan_sha256"] = document_hash(plan, "plan_sha256")
+    legacy.validate_schema(plan, legacy.load_schema("v2-plan"), label="v2 plan")
+    return plan, bundle
+
+
+def snapshot_scoped_diff(
+    worktree: Path,
+    contract: Mapping[str, Any],
+    task_dir: Path,
+) -> Tuple[List[str], bytes, str]:
+    """Snapshot all Git-visible task bytes through a private temporary index.
+
+    Unlike the v1 staging primitive this never resets or writes the developer's
+    real index.  Untracked files and deletions are represented exactly, and the
+    resulting tree SHA is the one a later v2 commit must reproduce.
+    """
+
+    if legacy.git(worktree, "rev-parse", "HEAD") != contract["base_sha"]:
+        raise legacy.HarnessError(
+            "v2 task HEAD changed; import/re-open against the actual parent before verification"
+        )
+    paths = legacy.changed_paths(worktree)
+    violations = [
+        path
+        for path in paths
+        if not legacy.path_is_owned(path, contract["owned_paths"])
+    ]
+    if violations:
+        raise legacy.HarnessError(
+            "out-of-scope v2 changes: " + ", ".join(violations)
+        )
+    unsafe = legacy.unsafe_changed_nodes(worktree, paths)
+    if unsafe:
+        raise legacy.HarnessError(
+            "unsafe changed nodes in v2 task: " + ", ".join(unsafe)
+        )
+    contaminated = legacy.tool_output_contaminated_paths(worktree, paths)
+    if contaminated:
+        raise legacy.HarnessError(
+            "renderer-truncated output exists in changed files: "
+            + ", ".join(contaminated)
+        )
+    runtime = task_dir / "runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    descriptor, raw_index = tempfile.mkstemp(prefix="v2-index-", dir=str(runtime))
+    os.close(descriptor)
+    index_path = Path(raw_index)
+    environment = {**os.environ, "GIT_INDEX_FILE": str(index_path)}
+    try:
+        index_path.unlink(missing_ok=True)
+        subprocess.run(
+            ["git", "read-tree", "HEAD"],
+            cwd=str(worktree),
+            env=environment,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if paths:
+            subprocess.run(
+                ["git", "add", "-A", "--", *contract["owned_paths"]],
+                cwd=str(worktree),
+                env=environment,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        diff = subprocess.run(
+            [
+                "git",
+                "diff",
+                "--cached",
+                "--binary",
+                "--full-index",
+                "--no-ext-diff",
+                "--no-renames",
+                "--",
+            ],
+            cwd=str(worktree),
+            env=environment,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        ).stdout
+        tree_sha = subprocess.run(
+            ["git", "write-tree"],
+            cwd=str(worktree),
+            env=environment,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        ).stdout.strip()
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.decode("utf-8", "replace") if isinstance(exc.stderr, bytes) else str(exc.stderr)
+        raise legacy.HarnessError(f"could not snapshot v2 diff: {stderr.strip()}") from exc
+    finally:
+        index_path.unlink(missing_ok=True)
+    if bool(diff) != bool(contract["expected_change"]):
+        expectation = "requires a change" if contract["expected_change"] else "is no-change"
+        raise legacy.HarnessError(f"v2 task {expectation}, but exact diff presence disagrees")
+    return paths, diff, tree_sha
+
+
+def attempt_id(plan: Mapping[str, Any]) -> str:
+    return canonical_hash(
+        {
+            "diff_sha256": plan["diff_sha256"],
+            "plan_sha256": plan["plan_sha256"],
+            "protocol_sha256": plan["protocol_sha256"],
+        }
+    )
+
+
+def evidence_binding(plan: Mapping[str, Any]) -> Dict[str, str]:
+    return {
+        "diff_sha256": str(plan["diff_sha256"]),
+        "plan_sha256": str(plan["plan_sha256"]),
+        "protocol_sha256": str(plan["protocol_sha256"]),
+    }
+
+
+def binding_matches(document: Mapping[str, Any], plan: Mapping[str, Any]) -> bool:
+    return all(document.get(key) == value for key, value in evidence_binding(plan).items())
+
+
+def _walk_json(value: Any) -> Iterable[Tuple[str, Any]]:
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            yield str(key), child
+            yield from _walk_json(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk_json(child)
+
+
+def model_telemetry(log_path: Path, *, timed_out: bool = False) -> Dict[str, Any]:
+    terminal_reason: Optional[str] = "timeout" if timed_out else None
+    http_status: Optional[int] = None
+    retry_after_seconds: Optional[float] = None
+    cost_usd: Optional[float] = None
+    turns: Optional[int] = None
+    usage: Any = None
+    if log_path.is_file():
+        try:
+            lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            lines = []
+        for line in lines:
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            for key, value in _walk_json(event):
+                lowered = key.lower()
+                if lowered in {"api_error_status", "status_code", "http_status"}:
+                    try:
+                        http_status = int(value)
+                    except (TypeError, ValueError):
+                        pass
+                elif lowered in {"retry_after", "retry_after_seconds"}:
+                    try:
+                        retry_after_seconds = max(0.0, float(value))
+                    except (TypeError, ValueError):
+                        pass
+                elif lowered in {"total_cost_usd", "cost_usd"}:
+                    try:
+                        cost_usd = float(value)
+                    except (TypeError, ValueError):
+                        pass
+                elif lowered in {"num_turns", "turns"}:
+                    try:
+                        turns = int(value)
+                    except (TypeError, ValueError):
+                        pass
+                elif lowered == "usage" and isinstance(value, Mapping):
+                    usage = value
+                elif lowered in {"terminal_reason", "stop_reason", "subtype"} and isinstance(value, str):
+                    terminal_reason = value
+    return {
+        "terminal_reason": terminal_reason,
+        "http_status": http_status,
+        "retry_after_seconds": retry_after_seconds,
+        "cost_usd": cost_usd,
+        "turns": turns,
+        "usage": usage,
+    }
+
+
+def transient_failure(message: str, telemetry: Mapping[str, Any], *, timed_out: bool) -> bool:
+    if timed_out:
+        return True
+    status = telemetry.get("http_status")
+    if isinstance(status, int) and status in TRANSIENT_HTTP_STATUSES:
+        return True
+    text = " ".join(
+        str(item)
+        for item in (message, telemetry.get("terminal_reason"))
+        if item is not None
+    ).lower()
+    markers = (
+        "rate limit",
+        "429",
+        "timed out",
+        "timeout",
+        "temporar",
+        "connection reset",
+        "connection refused",
+        "network",
+        "service unavailable",
+        "overloaded",
+        "502",
+        "503",
+        "504",
+    )
+    return any(marker in text for marker in markers)
+
+
+def retry_call(
+    invoke: Callable[[int], Mapping[str, Any]],
+    *,
+    sleep: Callable[[float], None] = time.sleep,
+    max_retry_delay_seconds: float = 60.0,
+) -> Tuple[Mapping[str, Any], List[Dict[str, Any]]]:
+    """Invoke at most twice, retaining a typed record for both attempts.
+
+    The callable may return ``{"ok": False, "transient": ...}`` or raise.  This
+    small injectable seam is also used by deterministic fault tests; production
+    review invocation remains the read-only model adapter below.
+    """
+
+    attempts: List[Dict[str, Any]] = []
+    for number in (1, 2):
+        try:
+            outcome = dict(invoke(number))
+        except Exception as exc:  # noqa: BLE001 - converted to typed retry evidence
+            outcome = {
+                "ok": False,
+                "transient": False,
+                "error": f"{type(exc).__name__}: {exc}",
+                "retry_after_seconds": None,
+            }
+        outcome["attempt"] = number
+        attempts.append(outcome)
+        if outcome.get("ok"):
+            return outcome, attempts
+        if not outcome.get("transient"):
+            raise legacy.HarnessError(
+                f"review invocation failed permanently: {outcome.get('error', 'unknown error')}"
+            )
+        if number == 2:
+            raise ReviewPaused(
+                "review infrastructure failed twice; resume will retry only the missing review",
+                attempts,
+            )
+        delay = outcome.get("retry_after_seconds")
+        if not isinstance(delay, (int, float)):
+            delay = 1.0
+        sleep(min(max(0.0, float(delay)), max_retry_delay_seconds))
+    raise AssertionError("unreachable")
+
+
+def review_result_state(result: Mapping[str, Any]) -> str:
+    findings = result.get("findings", [])
+    if any(
+        isinstance(finding, Mapping) and finding.get("severity") in SEVERE_FINDINGS
+        for finding in findings
+    ):
+        return "NEEDS_FIX"
+    if result.get("verdict") == "FAIL":
+        return "NEEDS_FIX"
+    if result.get("verdict") == "BLOCKED":
+        return "NEEDS_EVIDENCE"
+    proof_gaps = result.get("proof_gaps", [])
+    probes = result.get("probe_requests", [])
+    if proof_gaps or probes:
+        return "NEEDS_EVIDENCE"
+    if result.get("verdict") != "PASS":
+        return "NEEDS_EVIDENCE"
+    return "PASSED"
+
+
+def combined_review_prompt(
+    contract: Mapping[str, Any],
+    plan: Mapping[str, Any],
+    diff: bytes,
+    checks: Sequence[Mapping[str, Any]],
+    kind: str,
+    worktree: Path,
+    *,
+    policy_text: Optional[str] = None,
+) -> str:
+    if policy_text is not None:
+        policy = policy_text
+    elif kind == "combined":
+        policy = legacy.read_prompt("combined-reviewer")
+    else:
+        policy = legacy.read_prompt(kind + "-reviewer")
+    check_summary = []
+    for item in checks:
+        evidence = item.get("evidence", item)
+        check_summary.append(
+            {
+                "id": item.get("id"),
+                "passed": evidence.get("passed"),
+                "outcome": evidence.get("outcome"),
+                "exit_code": evidence.get("exit_code"),
+                "duration_ms": evidence.get("duration_ms"),
+                "resource_wait_ms": evidence.get("resource_wait_ms", 0),
+                "log_sha256": evidence.get("log_sha256"),
+            }
+        )
+    return (
+        f"{policy}\n\n"
+        "## Exact v2 task\n"
+        f"Task: {contract['task_id']}\n"
+        f"Acceptance contract:\n{contract['description']}\n\n"
+        f"Changed paths: {json.dumps(plan['changed_paths'])}\n"
+        f"Claims: {json.dumps(plan['claims'])}\n"
+        f"Actual sensitive risks: {json.dumps(plan['actual_risk_flags'])}\n"
+        f"Diff SHA-256: {plan['diff_sha256']}\n"
+        f"Plan SHA-256: {plan['plan_sha256']}\n"
+        f"Protocol SHA-256: {plan['protocol_sha256']}\n"
+        f"Check evidence: {json.dumps(check_summary, sort_keys=True)}\n"
+        "Pinned server checkout required: "
+        f"{'yes' if plan.get('server_required') else 'no'}\n\n"
+        "## Exact diff\n"
+        f"{diff.decode('utf-8', 'replace')}\n\n"
+        "Return every finding and every missing proof. PASS is forbidden when a "
+        "MAJOR/BLOCKER remains. If an empirical proof is missing, use proof_gaps "
+        "and optionally a typed probe_requests entry from the schema allowlist; "
+        "never ask for or attempt arbitrary shell access."
+    )
+
+
+def invoke_readonly_review(
+    *,
+    contract: Mapping[str, Any],
+    plan: Mapping[str, Any],
+    worktree: Path,
+    attempt_dir: Path,
+    diff: bytes,
+    checks: Sequence[Mapping[str, Any]],
+    review: Mapping[str, str],
+    probe_evidence_sha256: str,
+    allow_test_adapter: bool = False,
+    sleep: Callable[[float], None] = time.sleep,
+) -> Dict[str, Any]:
+    vendor = review["vendor"]
+    if vendor == "fake" and not allow_test_adapter:
+        raise legacy.HarnessError("fake v2 reviewer is restricted to selftests")
+    kind = review["kind"]
+    safe_kind = re.sub(r"[^a-z0-9._-]+", "-", kind.lower())
+    config = legacy.load_config()
+    timeout = int(config.get("reviewer_timeout_seconds", config["agent_timeout_seconds"]))
+    retry_records = attempt_dir / "review-attempts"
+    retry_records.mkdir(parents=True, exist_ok=True)
+    before = legacy.workspace_fingerprint(worktree)
+    prompt = combined_review_prompt(
+        contract, plan, diff, checks, kind, worktree
+    )
+    prompt_sha256 = legacy.sha256_bytes(prompt.encode("utf-8"))
+
+    def one(number: int) -> Mapping[str, Any]:
+        label = f"review-{safe_kind}-try-{number}"
+        log_path = attempt_dir / "logs" / f"{label}-{vendor}.jsonl"
+        started = time.monotonic()
+        try:
+            run = legacy.invoke_model(
+                vendor,
+                role="reviewer",
+                prompt=prompt,
+                schema_name="v2-review",
+                worktree=worktree,
+                task_dir=attempt_dir,
+                label=label,
+                timeout_seconds=timeout,
+                instructions_sha256=plan["protocol_sha256"],
+            )
+            telemetry = model_telemetry(
+                Path(run["log"]), timed_out=bool(run.get("timed_out"))
+            )
+            record: Dict[str, Any] = {
+                "ok": True,
+                "transient": False,
+                "label": label,
+                "vendor": vendor,
+                "duration_ms": run.get("duration_ms"),
+                "telemetry": telemetry,
+                "run": run,
+                "created_at": legacy.utc_now(),
+            }
+        except Exception as exc:  # noqa: BLE001 - classify from runner-owned process evidence
+            telemetry = model_telemetry(log_path, timed_out="timeout" in str(exc).lower())
+            is_transient = transient_failure(
+                str(exc), telemetry, timed_out=telemetry.get("terminal_reason") == "timeout"
+            )
+            record = {
+                "ok": False,
+                "transient": is_transient,
+                "label": label,
+                "vendor": vendor,
+                "duration_ms": int((time.monotonic() - started) * 1000),
+                "telemetry": telemetry,
+                "retry_after_seconds": telemetry.get("retry_after_seconds"),
+                "error": f"{type(exc).__name__}: {exc}",
+                "created_at": legacy.utc_now(),
+            }
+        legacy.atomic_write_json(retry_records / f"{label}.json", record)
+        return record
+
+    try:
+        successful, attempts = retry_call(
+            one,
+            sleep=sleep,
+            max_retry_delay_seconds=float(
+                config.get("review_retry_max_delay_seconds", 60)
+            ),
+        )
+    except ReviewPaused as exc:
+        exc.attempts = [
+            {
+                key: value
+                for key, value in item.items()
+                if key != "run"
+            }
+            for item in exc.attempts
+        ]
+        raise
+    if legacy.workspace_fingerprint(worktree) != before:
+        raise legacy.HarnessError(
+            f"{kind} review changed the worktree; reviewer sandbox must remain read-only"
+        )
+    run = dict(successful["run"])
+    if run.get("prompt_sha256") != prompt_sha256:
+        raise legacy.HarnessError(
+            f"{kind} review invocation prompt hash differs from runner input"
+        )
+    result = run["result"]
+    legacy.validate_schema(
+        result, legacy.load_schema("v2-review"), label=f"{kind} v2 review"
+    )
+    for request in result.get("probe_requests", []):
+        if request.get("probe_id") not in ALLOWED_PROBES:
+            raise legacy.HarnessError(
+                f"review requested non-allowlisted probe: {request.get('probe_id')}"
+            )
+    record = {
+        "schema_version": 2,
+        **evidence_binding(plan),
+        "kind": kind,
+        "vendor": vendor,
+        "label": successful["label"],
+        "result": result,
+        "result_path": run["result_path"],
+        "result_sha256": run["artifact_sha256"],
+        "invocation_path": run["invocation_path"],
+        "invocation_sha256": run["invocation_sha256"],
+        "log_path": run["log"],
+        "log_sha256": run["log_sha256"],
+        "session_id": run["session_id"],
+        "model": run["model"],
+        "cli_version": run["cli_version"],
+        "duration_ms": run.get("duration_ms"),
+        "execution_id": run.get("execution_id"),
+        "guardian_path": run.get("guardian_path"),
+        "guardian_sha256": run.get("guardian_sha256"),
+        "leader_exited_with_live_group": bool(
+            run.get("leader_exited_with_live_group")
+        ),
+        "termination_reason": run.get("termination_reason"),
+        "telemetry": successful.get("telemetry", {}),
+        "probe_evidence_sha256": probe_evidence_sha256,
+        "prompt_sha256": run["prompt_sha256"],
+        "attempts": [
+            {
+                key: value
+                for key, value in item.items()
+                if key != "run"
+            }
+            for item in attempts
+        ],
+        "created_at": legacy.utc_now(),
+    }
+    return record
+
+
+def check_record(
+    check: Mapping[str, Any], plan: Mapping[str, Any], evidence: Mapping[str, Any]
+) -> Dict[str, Any]:
+    return {
+        "schema_version": 2,
+        **evidence_binding(plan),
+        "id": check["id"],
+        "command": check["command"],
+        "evidence": dict(evidence),
+        "created_at": legacy.utc_now(),
+    }
+
+
+def aggregate_verdict(
+    checks: Sequence[Mapping[str, Any]], reviews: Sequence[Mapping[str, Any]]
+) -> Tuple[str, str]:
+    if len(checks) == 0 and len(reviews) == 0:
+        return "NEEDS_EVIDENCE", "no check or review evidence exists"
+    for check in checks:
+        evidence = check.get("evidence", {})
+        if evidence.get("outcome") == "BLOCKED" or evidence.get("timed_out"):
+            return "PAUSED_RETRYABLE", f"check {check.get('id')} is retryable"
+        if not evidence.get("passed"):
+            return "NEEDS_FIX", f"check {check.get('id')} failed"
+    review_states = [review_result_state(review.get("result", {})) for review in reviews]
+    if "NEEDS_FIX" in review_states:
+        return "NEEDS_FIX", "a review has unresolved FAIL/MAJOR/BLOCKER findings"
+    if "NEEDS_EVIDENCE" in review_states:
+        return "NEEDS_EVIDENCE", "a review has unresolved proof gaps or missing evidence"
+    return "PASSED", "all planned checks and reviews passed"
+
+
+def build_evidence(
+    contract: Mapping[str, Any],
+    plan: Mapping[str, Any],
+    worktree: Path,
+    checks: Sequence[Mapping[str, Any]],
+    probes: Sequence[Mapping[str, Any]],
+    reviews: Sequence[Mapping[str, Any]],
+) -> Dict[str, Any]:
+    findings = [
+        {"review": review["kind"], **finding}
+        for review in reviews
+        for finding in review.get("result", {}).get("findings", [])
+    ]
+    proof_gaps = [
+        {"review": review["kind"], **gap}
+        for review in reviews
+        for gap in review.get("result", {}).get("proof_gaps", [])
+    ]
+    probe_requests = [
+        {"review": review["kind"], **probe}
+        for review in reviews
+        for probe in review.get("result", {}).get("probe_requests", [])
+    ]
+    verdict, reason = aggregate_verdict(checks, reviews)
+    evidence: Dict[str, Any] = {
+        "schema_version": 2,
+        "task_id": contract["task_id"],
+        "contract_sha256": contract["contract_sha256"],
+        **evidence_binding(plan),
+        "parent_sha": legacy.git(worktree, "rev-parse", "HEAD"),
+        "tree_sha": plan["tree_sha"],
+        "changed_paths": list(plan["changed_paths"]),
+        "actual_risk_flags": list(plan["actual_risk_flags"]),
+        "claims": list(plan["claims"]),
+        "checks": [dict(item) for item in checks],
+        "probes": [dict(item) for item in probes],
+        "reviews": [dict(item) for item in reviews],
+        "findings": findings,
+        "proof_gaps": proof_gaps,
+        "probe_requests": probe_requests,
+        "degraded_provenance": list(contract.get("degraded_provenance", [])),
+        "telemetry": {
+            "resource_wait_ms": sum(
+                int(record.get("evidence", {}).get("resource_wait_ms", 0) or 0)
+                for record in [*checks, *probes]
+            ),
+            "review_attempts": sum(
+                len(review.get("attempts", [])) for review in reviews
+            ),
+            "review_transient_failures": sum(
+                1
+                for review in reviews
+                for attempt in review.get("attempts", [])
+                if attempt.get("transient")
+            ),
+            "review_terminal_reasons": sorted(
+                {
+                    str(attempt.get("telemetry", {}).get("terminal_reason"))
+                    for review in reviews
+                    for attempt in review.get("attempts", [])
+                    if attempt.get("telemetry", {}).get("terminal_reason")
+                }
+            ),
+        },
+        "verdict": verdict,
+        "reason": reason,
+        "created_at": legacy.utc_now(),
+        "evidence_sha256": "",
+    }
+    evidence["evidence_sha256"] = document_hash(evidence, "evidence_sha256")
+    legacy.validate_schema(
+        evidence, legacy.load_schema("v2-evidence"), label="v2 evidence"
+    )
+    return evidence
+
+
+def _artifact_inside(task_dir: Path, raw: Any, expected_hash: Any, label: str) -> Path:
+    if not isinstance(raw, str) or not raw:
+        raise legacy.HarnessError(f"{label} path is missing")
+    path = Path(raw)
+    try:
+        resolved = path.resolve(strict=True)
+        resolved.relative_to(task_dir.resolve())
+    except (FileNotFoundError, OSError, ValueError) as exc:
+        raise legacy.HarnessError(f"{label} is missing or outside the v2 task store") from exc
+    metadata = path.lstat()
+    if not path.is_file() or path.is_symlink() or metadata.st_nlink != 1:
+        raise legacy.HarnessError(f"{label} is not a single-link regular evidence file")
+    if legacy.sha256_file(path) != expected_hash:
+        raise legacy.HarnessError(f"{label} hash changed")
+    return path
+
+
+def validate_check_checkpoint(
+    record: Mapping[str, Any],
+    declared: Mapping[str, Any],
+    plan: Mapping[str, Any],
+    task_dir: Path,
+) -> None:
+    if not binding_matches(record, plan):
+        raise legacy.HarnessError("v2 check checkpoint binding is stale")
+    if record.get("id") != declared.get("id"):
+        raise legacy.HarnessError("v2 check checkpoint id changed")
+    if record.get("command") != declared.get("command"):
+        raise legacy.HarnessError("v2 check checkpoint command changed")
+    result = record.get("evidence")
+    if not isinstance(result, Mapping):
+        raise legacy.HarnessError("v2 check checkpoint evidence is malformed")
+    if result.get("id") != declared.get("id"):
+        raise legacy.HarnessError("v2 check result id changed")
+    if result.get("command") != declared.get("command"):
+        raise legacy.HarnessError("v2 check result command changed")
+    log_path = _artifact_inside(
+        task_dir,
+        result.get("log_path"),
+        result.get("log_sha256"),
+        f"check {declared.get('id')} log",
+    )
+    expected_stdout = log_path.with_suffix(".stdout.log")
+    expected_stderr = log_path.with_suffix(".stderr.log")
+    if result.get("stdout_path") != str(expected_stdout):
+        raise legacy.HarnessError("v2 check stdout path is not bound to its log")
+    if result.get("stderr_path") != str(expected_stderr):
+        raise legacy.HarnessError("v2 check stderr path is not bound to its log")
+    _artifact_inside(
+        task_dir,
+        str(expected_stdout),
+        result.get("stdout_sha256"),
+        f"check {declared.get('id')} stdout",
+    )
+    _artifact_inside(
+        task_dir,
+        str(expected_stderr),
+        result.get("stderr_sha256"),
+        f"check {declared.get('id')} stderr",
+    )
+    _artifact_inside(
+        task_dir,
+        result.get("sandbox_profile_path"),
+        result.get("sandbox_profile_sha256"),
+        f"check {declared.get('id')} sandbox",
+    )
+    _artifact_inside(
+        task_dir,
+        result.get("guardian_path"),
+        result.get("guardian_sha256"),
+        f"check {declared.get('id')} guardian",
+    )
+    if result.get("leader_exited_with_live_group"):
+        raise legacy.HarnessError(
+            f"v2 check {declared.get('id')} left a live process group"
+        )
+
+
+def validate_review_checkpoint(
+    record: Mapping[str, Any],
+    declared: Mapping[str, Any],
+    plan: Mapping[str, Any],
+    task_dir: Path,
+    *,
+    expected_prompt_sha256: str,
+    allow_test_adapter: bool,
+    review_schema: Optional[Mapping[str, Any]] = None,
+) -> None:
+    if not binding_matches(record, plan):
+        raise legacy.HarnessError("v2 review checkpoint binding is stale")
+    if record.get("kind") != declared.get("kind"):
+        raise legacy.HarnessError("v2 review checkpoint kind changed")
+    if record.get("vendor") != declared.get("vendor"):
+        raise legacy.HarnessError("v2 review checkpoint vendor changed")
+    if record.get("prompt_sha256") != expected_prompt_sha256:
+        raise legacy.HarnessError("v2 review checkpoint prompt hash changed")
+    if record.get("vendor") == "fake" and not allow_test_adapter:
+        raise legacy.HarnessError("fake v2 review checkpoint is forbidden")
+    label = record.get("label")
+    vendor = record.get("vendor")
+    if not isinstance(label, str) or not isinstance(vendor, str):
+        raise legacy.HarnessError("v2 review checkpoint label/vendor is malformed")
+    raw_invocation_path = Path(str(record.get("invocation_path", "")))
+    run_dir = raw_invocation_path.parent.parent
+    expected_result = run_dir / "results" / f"{label}-{vendor}.json"
+    expected_invocation = (
+        run_dir / "results" / f"{label}-{vendor}-invocation.json"
+    )
+    expected_log = run_dir / "logs" / f"{label}-{vendor}.jsonl"
+
+    result_path = legacy.evidence_file(
+        task_dir,
+        record.get("result_path"),
+        expected_result,
+        f"review {declared.get('kind')} result",
+    )
+    if legacy.sha256_file(result_path) != record.get("result_sha256"):
+        raise legacy.HarnessError("v2 review checkpoint result hash changed")
+    result = legacy.load_json(result_path)
+    legacy.validate_schema(
+        result,
+        (
+            dict(review_schema)
+            if review_schema is not None
+            else legacy.load_schema("v2-review")
+        ),
+        label=f"review {declared.get('kind')}",
+    )
+    if result != record.get("result"):
+        raise legacy.HarnessError("v2 review checkpoint result summary changed")
+    invocation_path = legacy.evidence_file(
+        task_dir,
+        record.get("invocation_path"),
+        expected_invocation,
+        f"review {declared.get('kind')} invocation",
+    )
+    if legacy.sha256_file(invocation_path) != record.get("invocation_sha256"):
+        raise legacy.HarnessError("v2 review checkpoint invocation hash changed")
+    invocation = legacy.load_json(invocation_path)
+    if invocation.get("prompt_sha256") != expected_prompt_sha256:
+        raise legacy.HarnessError(
+            "v2 review invocation prompt hash changed"
+        )
+    log_path = legacy.evidence_file(
+        task_dir,
+        record.get("log_path"),
+        expected_log,
+        f"review {declared.get('kind')} log",
+    )
+    if legacy.sha256_file(log_path) != record.get("log_sha256"):
+        raise legacy.HarnessError("v2 review checkpoint log hash changed")
+    execution_ids = {
+        legacy._artifact_execution_id(result_path, expected_result),
+        legacy._artifact_execution_id(invocation_path, expected_invocation),
+        legacy._artifact_execution_id(log_path, expected_log),
+    }
+    if (
+        len(execution_ids) != 1
+        or None in execution_ids
+        or record.get("execution_id") not in execution_ids
+    ):
+        raise legacy.HarnessError(
+            "v2 review artifacts do not share one execution id"
+        )
+    if record.get("vendor") != "fake":
+        _artifact_inside(
+            task_dir,
+            record.get("guardian_path"),
+            record.get("guardian_sha256"),
+            f"review {declared.get('kind')} guardian",
+        )
+        if record.get("leader_exited_with_live_group"):
+            raise legacy.HarnessError(
+                f"v2 review {declared.get('kind')} left a live process group"
+            )
+
+
+def verify_v2_evidence(
+    contract: Mapping[str, Any],
+    task_dir: Path,
+    *,
+    allow_test_adapter: bool = False,
+    allow_committed_head: bool = False,
+    attested_commit_sha: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Fail closed unless current bytes exactly match a complete v2 PASS."""
+
+    worktree = Path(str(contract["worktree_path"]))
+    attested_schemas: Dict[str, Dict[str, Any]] = {}
+    if attested_commit_sha is not None:
+        if not legacy.SHA1_RE.fullmatch(attested_commit_sha):
+            raise legacy.HarnessError("v2 attested commit is malformed")
+        attested_schemas = {
+            name: attested_schema(worktree, attested_commit_sha, name)
+            for name in ("v2-task", "v2-plan", "v2-review", "v2-evidence")
+        }
+    validate_hashed_document(
+        contract,
+        "v2-task",
+        "contract_sha256",
+        "v2 task",
+        schema=attested_schemas.get("v2-task"),
+    )
+    state = load_v2_state(task_dir)
+    if state.get("status") not in {"PASSED", "COMMITTED"}:
+        raise legacy.HarnessError(
+            f"v2 receipt requires PASSED/COMMITTED state; found {state.get('status')}"
+        )
+    if not worktree.is_dir() or worktree.is_symlink():
+        raise legacy.HarnessError("v2 task worktree is missing or unsafe")
+    if Path(legacy.git(worktree, "rev-parse", "--show-toplevel")).resolve() != worktree.resolve():
+        raise legacy.HarnessError("v2 worktree path is not its Git root")
+    if legacy.git(worktree, "branch", "--show-current") != contract["branch"]:
+        raise legacy.HarnessError("v2 task branch changed")
+    current_head = legacy.git(worktree, "rev-parse", "HEAD")
+    if attested_commit_sha is not None:
+        parents = legacy.git(
+            worktree, "show", "-s", "--format=%P", attested_commit_sha
+        ).split()
+        if parents != [contract["base_sha"]]:
+            raise legacy.HarnessError(
+                "v2 attested commit is not the exact child of task base"
+            )
+        if legacy.git_bytes(worktree, "status", "--porcelain").strip():
+            raise legacy.HarnessError(
+                "v2 committed evidence requires a clean worktree/index"
+            )
+        evidence_parent = contract["base_sha"]
+        encoded_paths = legacy.git_bytes(
+            worktree,
+            "diff",
+            "--name-only",
+            "-z",
+            "--no-renames",
+            evidence_parent,
+            attested_commit_sha,
+            "--",
+        )
+        paths = sorted(
+            item.decode("utf-8", "surrogateescape")
+            for item in encoded_paths.split(b"\x00")
+            if item
+        )
+        diff = legacy.git_bytes(
+            worktree,
+            "diff",
+            "--binary",
+            "--full-index",
+            "--no-ext-diff",
+            "--no-renames",
+            evidence_parent,
+            attested_commit_sha,
+            "--",
+        )
+        tree_sha = legacy.git(
+            worktree, "rev-parse", f"{attested_commit_sha}^{{tree}}"
+        )
+        violations = [
+            path
+            for path in paths
+            if not legacy.path_is_owned(path, contract["owned_paths"])
+        ]
+        if violations:
+            raise legacy.HarnessError(
+                "out-of-scope paths in v2 attested commit: "
+                + ", ".join(violations)
+            )
+    elif current_head == contract["base_sha"]:
+        paths, diff, tree_sha = snapshot_scoped_diff(worktree, contract, task_dir)
+        evidence_parent = current_head
+    elif allow_committed_head:
+        evidence_parent = legacy.git(worktree, "rev-parse", "HEAD^")
+        if evidence_parent != contract["base_sha"]:
+            raise legacy.HarnessError(
+                "v2 recovery commit is not the single exact child of task base"
+            )
+        if legacy.git_bytes(worktree, "status", "--porcelain").strip():
+            raise legacy.HarnessError(
+                "v2 recovery commit worktree/index is not clean"
+            )
+        encoded_paths = legacy.git_bytes(
+            worktree,
+            "diff",
+            "--name-only",
+            "-z",
+            "--no-renames",
+            evidence_parent,
+            current_head,
+            "--",
+        )
+        paths = sorted(
+            item.decode("utf-8", "surrogateescape")
+            for item in encoded_paths.split(b"\x00")
+            if item
+        )
+        diff = legacy.git_bytes(
+            worktree,
+            "diff",
+            "--binary",
+            "--full-index",
+            "--no-ext-diff",
+            "--no-renames",
+            evidence_parent,
+            current_head,
+            "--",
+        )
+        tree_sha = legacy.git(worktree, "rev-parse", "HEAD^{tree}")
+        violations = [
+            path
+            for path in paths
+            if not legacy.path_is_owned(path, contract["owned_paths"])
+        ]
+        if violations:
+            raise legacy.HarnessError(
+                "out-of-scope paths in v2 recovery commit: "
+                + ", ".join(violations)
+            )
+    else:
+        raise legacy.HarnessError(
+            "v2 task HEAD changed after PASS without an active commit recovery"
+        )
+
+    plan_path = Path(str(state.get("plan_path", "")))
+    try:
+        plan_path.resolve(strict=True).relative_to(task_dir.resolve())
+    except (FileNotFoundError, OSError, ValueError) as exc:
+        raise legacy.HarnessError("v2 plan path escapes the task store") from exc
+    plan = legacy.load_json(plan_path)
+    validate_hashed_document(
+        plan,
+        "v2-plan",
+        "plan_sha256",
+        "v2 plan",
+        schema=attested_schemas.get("v2-plan"),
+    )
+    if plan.get("changed_paths") != paths:
+        raise legacy.HarnessError("v2 plan changed paths are stale")
+    if plan.get("diff_sha256") != legacy.sha256_bytes(diff):
+        raise legacy.HarnessError("v2 plan diff is stale")
+    if plan.get("tree_sha") != tree_sha:
+        raise legacy.HarnessError("v2 plan tree is stale")
+    protocol_path = plan_path.parent / "protocol.json"
+    try:
+        protocol_path.resolve(strict=True).relative_to(task_dir.resolve())
+    except (FileNotFoundError, OSError, ValueError) as exc:
+        raise legacy.HarnessError(
+            "v2 protocol bundle path escapes the task store"
+        ) from exc
+    bundle = legacy.load_json(protocol_path)
+    if (
+        bundle.get("schema_version") != 2
+        or bundle.get("protocol_sha256")
+        != canonical_hash(
+            {
+                key: value
+                for key, value in bundle.items()
+                if key != "protocol_sha256"
+            }
+        )
+        or not isinstance(bundle.get("files"), list)
+    ):
+        raise legacy.HarnessError("v2 recorded protocol bundle is malformed")
+    if attested_commit_sha is None:
+        if bundle != executable_protocol_bundle(worktree):
+            raise legacy.HarnessError(
+                "v2 recorded protocol bundle differs from executable bytes"
+            )
+    else:
+        seen_protocol_paths: set[str] = set()
+        for item in bundle["files"]:
+            if (
+                not isinstance(item, Mapping)
+                or not isinstance(item.get("path"), str)
+                or not isinstance(item.get("sha256"), str)
+                or item["path"] in seen_protocol_paths
+            ):
+                raise legacy.HarnessError(
+                    "v2 recorded protocol file entry is malformed"
+                )
+            seen_protocol_paths.add(item["path"])
+            committed_bytes = git_file_at_commit(
+                worktree, attested_commit_sha, item["path"]
+            )
+            if legacy.sha256_bytes(committed_bytes) != item["sha256"]:
+                raise legacy.HarnessError(
+                    f"v2 attested protocol byte changed: {item['path']}"
+                )
+    for key, value in (
+        ("task_id", contract["task_id"]),
+        ("contract_sha256", contract["contract_sha256"]),
+        ("base_sha", contract["base_sha"]),
+        ("claims", list(contract.get("claims", []))),
+        (
+            "server_required",
+            any(
+                check["id"] in {"rust-lib", "protocol-server"}
+                for check in plan.get("checks", [])
+            ),
+        ),
+        ("created_at", contract["created_at"]),
+    ):
+        if plan.get(key) != value:
+            raise legacy.HarnessError(f"v2 plan {key} differs from its contract")
+    if plan.get("protocol_sha256") != bundle["protocol_sha256"]:
+        raise legacy.HarnessError("v2 plan protocol bundle is stale")
+    if attested_commit_sha is None:
+        profile_config = legacy.load_config()
+    else:
+        profile_config = attested_json_object(
+            worktree,
+            attested_commit_sha,
+            ".agents/harness/config.json",
+            "harness config",
+        )
+    expected_checks, expected_reviews, expected_risks = derive_profile(
+        paths,
+        list(contract.get("claims", [])),
+        profile_config,
+        reviewer=str(contract["reviewer"]),
+    )
+    if plan.get("checks") != expected_checks:
+        raise legacy.HarnessError("v2 plan check profile is stale")
+    if plan.get("reviews") != expected_reviews:
+        raise legacy.HarnessError("v2 plan review profile is stale")
+    if plan.get("actual_risk_flags") != expected_risks:
+        raise legacy.HarnessError("v2 plan sensitive-risk profile is stale")
+
+    evidence_path = Path(str(state.get("evidence_path", "")))
+    try:
+        evidence_path.resolve(strict=True).relative_to(task_dir.resolve())
+    except (FileNotFoundError, OSError, ValueError) as exc:
+        raise legacy.HarnessError("v2 evidence path escapes the task store") from exc
+    evidence = legacy.load_json(evidence_path)
+    validate_hashed_document(
+        evidence,
+        "v2-evidence",
+        "evidence_sha256",
+        "v2 evidence",
+        schema=attested_schemas.get("v2-evidence"),
+    )
+    for key, value in (
+        ("task_id", contract["task_id"]),
+        ("contract_sha256", contract["contract_sha256"]),
+        ("diff_sha256", plan["diff_sha256"]),
+        ("plan_sha256", plan["plan_sha256"]),
+        ("protocol_sha256", plan["protocol_sha256"]),
+        ("parent_sha", evidence_parent),
+        ("tree_sha", tree_sha),
+        ("changed_paths", paths),
+        ("actual_risk_flags", expected_risks),
+        ("claims", list(plan["claims"])),
+        (
+            "degraded_provenance",
+            list(contract.get("degraded_provenance", [])),
+        ),
+    ):
+        if evidence.get(key) != value:
+            raise legacy.HarnessError(f"v2 evidence {key} is stale")
+    if evidence.get("verdict") != "PASSED":
+        raise legacy.HarnessError("v2 evidence verdict is not PASSED")
+    if evidence.get("findings") and any(
+        item.get("severity") in SEVERE_FINDINGS for item in evidence["findings"]
+    ):
+        raise legacy.HarnessError("v2 PASS contains unresolved MAJOR/BLOCKER findings")
+    if evidence.get("proof_gaps") or evidence.get("probe_requests"):
+        raise legacy.HarnessError("v2 PASS contains unresolved proof gaps")
+
+    check_records = evidence.get("checks", [])
+    if [item.get("id") for item in check_records] != [
+        item["id"] for item in expected_checks
+    ]:
+        raise legacy.HarnessError("v2 evidence check set/order differs from plan")
+    for record, declared in zip(check_records, expected_checks):
+        validate_check_checkpoint(record, declared, plan, task_dir)
+        result = record.get("evidence", {})
+        if not result.get("passed") or result.get("exit_code") != 0:
+            raise legacy.HarnessError(f"v2 check {declared['id']} is not green")
+        _artifact_inside(
+            task_dir, result.get("log_path"), result.get("log_sha256"), f"check {declared['id']} log"
+        )
+        log_path = Path(str(result.get("log_path")))
+        _artifact_inside(
+            task_dir,
+            str(log_path.with_suffix(".stdout.log")),
+            result.get("stdout_sha256"),
+            f"check {declared['id']} stdout",
+        )
+        _artifact_inside(
+            task_dir,
+            str(log_path.with_suffix(".stderr.log")),
+            result.get("stderr_sha256"),
+            f"check {declared['id']} stderr",
+        )
+        _artifact_inside(
+            task_dir,
+            result.get("sandbox_profile_path"),
+            result.get("sandbox_profile_sha256"),
+            f"check {declared['id']} sandbox",
+        )
+
+    probe_records = evidence.get("probes", [])
+    probe_ids: set = set()
+    for record in probe_records:
+        probe_id = record.get("id")
+        if probe_id not in ALLOWED_PROBES or probe_id in probe_ids:
+            raise legacy.HarnessError("v2 probe evidence has a duplicate/non-allowlisted id")
+        probe_ids.add(probe_id)
+        if not binding_matches(record, plan):
+            raise legacy.HarnessError(f"v2 probe {probe_id} binding is stale")
+        declared = canonical_check(str(probe_id), profile_config)
+        validate_check_checkpoint(record, declared, plan, task_dir)
+        result = record.get("evidence", {})
+        if not result.get("passed") or result.get("exit_code") != 0:
+            raise legacy.HarnessError(f"v2 probe {probe_id} is not green")
+        log_path = _artifact_inside(
+            task_dir,
+            result.get("log_path"),
+            result.get("log_sha256"),
+            f"probe {probe_id} log",
+        )
+        _artifact_inside(
+            task_dir,
+            str(log_path.with_suffix(".stdout.log")),
+            result.get("stdout_sha256"),
+            f"probe {probe_id} stdout",
+        )
+        _artifact_inside(
+            task_dir,
+            str(log_path.with_suffix(".stderr.log")),
+            result.get("stderr_sha256"),
+            f"probe {probe_id} stderr",
+        )
+        _artifact_inside(
+            task_dir,
+            result.get("sandbox_profile_path"),
+            result.get("sandbox_profile_sha256"),
+            f"probe {probe_id} sandbox",
+        )
+    expected_probe_hash = probe_evidence_hash(probe_records)
+
+    review_records = evidence.get("reviews", [])
+    if [(item.get("kind"), item.get("vendor")) for item in review_records] != [
+        (item["kind"], item["vendor"]) for item in expected_reviews
+    ]:
+        raise legacy.HarnessError("v2 evidence review set/order differs from plan")
+    sessions: set = set()
+    for record, declared in zip(review_records, expected_reviews):
+        if not binding_matches(record, plan):
+            raise legacy.HarnessError(f"v2 review {declared['kind']} binding is stale")
+        if record.get("vendor") != declared["vendor"]:
+            raise legacy.HarnessError(f"v2 review {declared['kind']} vendor changed")
+        if record.get("probe_evidence_sha256") != expected_probe_hash:
+            raise legacy.HarnessError(
+                f"v2 review {declared['kind']} did not see the recorded probe evidence"
+            )
+        if attested_commit_sha is None:
+            policy_text = None
+        else:
+            policy_name = (
+                "combined-reviewer"
+                if declared["kind"] == "combined"
+                else str(declared["kind"]) + "-reviewer"
+            )
+            try:
+                policy_text = git_file_at_commit(
+                    worktree,
+                    attested_commit_sha,
+                    f".agents/harness/prompts/{policy_name}.md",
+                ).decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise legacy.HarnessError(
+                    f"v2 attested review policy is not UTF-8: {policy_name}"
+                ) from exc
+        expected_prompt = combined_review_prompt(
+            contract,
+            plan,
+            diff,
+            [*check_records, *probe_records],
+            str(declared["kind"]),
+            worktree,
+            policy_text=policy_text,
+        )
+        validate_review_checkpoint(
+            record,
+            declared,
+            plan,
+            task_dir,
+            expected_prompt_sha256=legacy.sha256_bytes(
+                expected_prompt.encode("utf-8")
+            ),
+            allow_test_adapter=allow_test_adapter,
+            review_schema=attested_schemas.get("v2-review"),
+        )
+        if record.get("vendor") == "fake" and not allow_test_adapter:
+            raise legacy.HarnessError("fake v2 evidence is forbidden outside selftests")
+        session = record.get("session_id")
+        if not isinstance(session, str) or not session or session in sessions:
+            raise legacy.HarnessError(
+                f"v2 review {declared['kind']} has missing/reused session provenance"
+            )
+        sessions.add(session)
+        result_path = _artifact_inside(
+            task_dir,
+            record.get("result_path"),
+            record.get("result_sha256"),
+            f"review {declared['kind']} result",
+        )
+        result = legacy.load_json(result_path)
+        legacy.validate_schema(
+            result,
+            (
+                attested_schemas["v2-review"]
+                if attested_commit_sha is not None
+                else legacy.load_schema("v2-review")
+            ),
+            label=f"review {declared['kind']}",
+        )
+        if result != record.get("result"):
+            raise legacy.HarnessError(
+                f"v2 review {declared['kind']} result summary changed"
+            )
+        if review_result_state(result) != "PASSED":
+            raise legacy.HarnessError(
+                f"v2 review {declared['kind']} is not an admissible PASS"
+            )
+        invocation_path = _artifact_inside(
+            task_dir,
+            record.get("invocation_path"),
+            record.get("invocation_sha256"),
+            f"review {declared['kind']} invocation",
+        )
+        log_path = _artifact_inside(
+            task_dir,
+            record.get("log_path"),
+            record.get("log_sha256"),
+            f"review {declared['kind']} log",
+        )
+        label = record.get("label")
+        safe_kind = re.sub(r"[^a-z0-9._-]+", "-", declared["kind"].lower())
+        if not isinstance(label, str) or re.fullmatch(
+            rf"review-{re.escape(safe_kind)}-try-[12]", label
+        ) is None:
+            raise legacy.HarnessError(
+                f"v2 review {declared['kind']} invocation label is malformed"
+            )
+        invocation_time = legacy.verify_model_invocation(
+            task_dir,
+            vendor=str(record["vendor"]),
+            role="reviewer",
+            label=label,
+            session_id=str(session),
+            model=str(record.get("model", "")),
+            cli_version=str(record.get("cli_version", "")),
+            invocation_path_raw=str(invocation_path),
+            invocation_sha256=record.get("invocation_sha256"),
+            expected_path=(
+                invocation_path.parent
+                / f"{label}-{record['vendor']}-invocation.json"
+            ),
+            instructions_sha256=plan["protocol_sha256"],
+            prompt_sha256=str(record["prompt_sha256"]),
+        )
+        review_time = legacy.parse_timestamp(
+            record.get("created_at"), f"v2 review {declared['kind']}.created_at"
+        )
+        if invocation_time > review_time:
+            raise legacy.HarnessError(
+                f"v2 review {declared['kind']} predates its invocation"
+            )
+        if record["vendor"] != "fake":
+            metadata = legacy.extract_model_metadata(
+                log_path, str(record["vendor"]), str(session)
+            )
+            if metadata["session_id"] != session:
+                raise legacy.HarnessError(
+                    f"v2 review {declared['kind']} session differs from real model log"
+                )
+            if metadata["model"] != record.get("model"):
+                raise legacy.HarnessError(
+                    f"v2 review {declared['kind']} model differs from real model log"
+                )
+    return evidence

--- a/scripts/agent-resource-run
+++ b/scripts/agent-resource-run
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Run one agent-owned command inside Murmur's repo-global resource lane.
+"""Run one agent-owned command inside Murmur's workspace-global resource lane.
 
-The lane is a kernel flock stored in git's common directory, so linked worktrees
-serialize with one another and a killed supervisor cannot leave a stale lock.
-The command runs in a fresh process group that this supervisor alone owns.
+The lane is a kernel flock under the shared Murmur task root. Linked worktrees,
+the user's primary checkout, and the standalone harness driver clone therefore
+serialize with one another. A killed supervisor cannot leave a stale lock. The
+command runs in a fresh process group that this supervisor alone owns.
 """
 
 import argparse
@@ -60,6 +61,12 @@ def parse_args(argv):
         metavar="PATH",
         help="run the child in PATH after resolving the repo-global lane",
     )
+    parser.add_argument(
+        "--heartbeat-seconds",
+        type=positive_seconds,
+        default=os.environ.get("MURMUR_AGENT_LANE_HEARTBEAT_SECONDS", "30"),
+        help=argparse.SUPPRESS,
+    )
     parser.add_argument("command", nargs=argparse.REMAINDER)
     args = parser.parse_args(argv)
     if args.command[:1] == ["--"]:
@@ -86,8 +93,47 @@ def git_common_dir(start_dir):
     return common.resolve()
 
 
+def primary_worktree(start_dir):
+    common = git_common_dir(start_dir)
+    result = subprocess.run(
+        [
+            "git",
+            "--git-dir",
+            str(common),
+            "worktree",
+            "list",
+            "--porcelain",
+        ],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "cannot resolve repository primary for shared resources: "
+            + result.stderr.strip()
+        )
+    first = next(
+        (
+            line[len("worktree ") :].strip()
+            for line in result.stdout.splitlines()
+            if line.startswith("worktree ")
+        ),
+        "",
+    )
+    if not first:
+        raise RuntimeError("cannot resolve a primary worktree for shared resources")
+    return Path(first).resolve()
+
+
 def lane_file_path(start_dir):
-    return git_common_dir(start_dir) / "murmur-agent-resource-lane.lock"
+    return (
+        primary_worktree(start_dir).parent
+        / ".murmur-agent-tasks"
+        / ".resources"
+        / "cargo.lock"
+    )
 
 
 def exit_code(returncode):
@@ -220,7 +266,51 @@ class ProcessGroupSupervisor:
             time.sleep(min(POLL_SECONDS, remaining))
 
 
-def acquire_lane(lane_handle, lane_path, supervisor, absolute_deadline):
+def lane_owner(lane_handle):
+    try:
+        lane_handle.seek(0)
+        raw = lane_handle.read().strip()
+        document = json.loads(raw) if raw else {}
+    except (OSError, json.JSONDecodeError):
+        document = {}
+    if not isinstance(document, dict):
+        document = {}
+    return {
+        "owner_pid": document.get("pid", document.get("guardian_pid", "unknown")),
+        "task": document.get("task", document.get("task_id", "unknown")),
+        "command": document.get("command", "unknown"),
+        "since": document.get(
+            "since",
+            document.get("acquired_at", document.get("acquired_epoch", "unknown")),
+        ),
+    }
+
+
+def print_lane_wait(lane_handle):
+    owner = lane_owner(lane_handle)
+    print(
+        "agent-resource-run: waiting for lane "
+        "owner_pid={owner_pid} task={task} command={command} since={since} "
+        "heartbeat={heartbeat}".format(
+            **owner,
+            heartbeat=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        ),
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def acquire_lane(
+    lane_handle,
+    lane_path,
+    supervisor,
+    absolute_deadline,
+    *,
+    task,
+    command,
+    heartbeat_seconds,
+):
+    next_heartbeat = None
     while True:
         if supervisor.signal_received is not None:
             return False
@@ -233,6 +323,9 @@ def acquire_lane(lane_handle, lane_path, supervisor, absolute_deadline):
                     "pid": os.getpid(),
                     "cwd": str(Path.cwd()),
                     "acquired_epoch": int(time.time()),
+                    "task": task,
+                    "command": command,
+                    "since": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
                 },
                 lane_handle,
                 sort_keys=True,
@@ -245,7 +338,12 @@ def acquire_lane(lane_handle, lane_path, supervisor, absolute_deadline):
             if error.errno not in (errno.EACCES, errno.EAGAIN):
                 raise
 
-        remaining = absolute_deadline - time.monotonic()
+        now = time.monotonic()
+        if next_heartbeat is None or now >= next_heartbeat:
+            print_lane_wait(lane_handle)
+            next_heartbeat = now + heartbeat_seconds
+
+        remaining = absolute_deadline - now
         if remaining <= 0:
             owner = ""
             try:
@@ -261,7 +359,8 @@ def acquire_lane(lane_handle, lane_path, supervisor, absolute_deadline):
                 file=sys.stderr,
             )
             return False
-        time.sleep(min(POLL_SECONDS, remaining))
+        until_heartbeat = max(0.0, next_heartbeat - time.monotonic())
+        time.sleep(min(POLL_SECONDS, remaining, until_heartbeat or POLL_SECONDS))
 
 
 def survivor_lock_guard(supervisor, lane_fd):
@@ -355,7 +454,22 @@ def main(argv):
 
     try:
         with lane_path.open("a+", encoding="utf-8") as lane_handle:
-            if not acquire_lane(lane_handle, lane_path, supervisor, absolute_deadline):
+            task = os.environ.get(
+                "MURMUR_HARNESS_TASK",
+                os.environ.get("MURMUR_AGENT_TASK_ID", "operator"),
+            )
+            command = " ".join(args.command)
+            if len(command) > 240:
+                command = command[:237] + "..."
+            if not acquire_lane(
+                lane_handle,
+                lane_path,
+                supervisor,
+                absolute_deadline,
+                task=task,
+                command=command,
+                heartbeat_seconds=args.heartbeat_seconds,
+            ):
                 if supervisor.signal_received is not None:
                     return 128 + supervisor.signal_received
                 return TIMEOUT_EXIT

--- a/scripts/harness-runtime-smoke.py
+++ b/scripts/harness-runtime-smoke.py
@@ -94,6 +94,30 @@ def angular_ready() -> bool:
     return False
 
 
+def runtime_mode(root: Path) -> str:
+    candidates = (
+        root / "src-tauri" / "target" / "debug" / "Murmur",
+        root / "target" / "debug" / "Murmur",
+    )
+    return "warm" if any(path.is_file() for path in candidates) else "cold"
+
+
+def selected_timeout(
+    root: Path,
+    *,
+    explicit: int | None,
+    warm_timeout: int,
+    cold_timeout: int,
+) -> tuple[str, int]:
+    mode = runtime_mode(root)
+    timeout = explicit if explicit is not None else (
+        warm_timeout if mode == "warm" else cold_timeout
+    )
+    if timeout < 1:
+        raise ValueError("runtime timeout must be positive")
+    return mode, timeout
+
+
 def emit(verdict: str, reason: str, log_path: Path | None, started_at: str) -> int:
     payload = {
         "schema_version": 1,
@@ -116,13 +140,29 @@ def emit(verdict: str, reason: str, log_path: Path | None, started_at: str) -> i
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Safely prove that the real Tauri dev app boots")
-    parser.add_argument("--timeout", type=int, default=240)
+    parser.add_argument("--timeout", type=int)
+    parser.add_argument("--warm-timeout", type=int, default=240)
+    parser.add_argument("--cold-timeout", type=int, default=900)
+    parser.add_argument(
+        "--preflight",
+        action="store_true",
+        help="check ownership/prerequisites and report the cold/warm budget without launching",
+    )
     parser.add_argument("--settle-seconds", type=int, default=10)
     parser.add_argument("--runtime-write-probe", action="store_true", help=argparse.SUPPRESS)
     args = parser.parse_args()
     started_at = utc_now()
 
     root = repo_root()
+    try:
+        mode, timeout = selected_timeout(
+            root,
+            explicit=args.timeout,
+            warm_timeout=args.warm_timeout,
+            cold_timeout=args.cold_timeout,
+        )
+    except ValueError as exc:
+        return emit("FAIL", str(exc), None, started_at)
     runtime_root = runtime_dir(root)
     runtime_root.mkdir(parents=True, exist_ok=True)
     run_id = f"boot-{int(time.time())}-{os.getpid()}"
@@ -140,6 +180,17 @@ def main() -> int:
                 None,
                 started_at,
             )
+    if shutil.which("npm") is None:
+        return emit("BLOCKED", "npm is unavailable; runtime probe cannot start", None, started_at)
+    if not (root / "package.json").is_file():
+        return emit("FAIL", "package.json is missing from the Git root", None, started_at)
+    if args.preflight:
+        return emit(
+            "PASS",
+            f"runtime preflight clear; {mode} start budget is {timeout}s",
+            None,
+            started_at,
+        )
 
     original_home = Path.home()
     temp_root = Path(tempfile.mkdtemp(prefix=f"murmur-{run_id}-"))
@@ -170,7 +221,7 @@ def main() -> int:
                 stderr=subprocess.STDOUT,
                 start_new_session=True,
             )
-            deadline = time.monotonic() + args.timeout
+            deadline = time.monotonic() + timeout
             while time.monotonic() < deadline:
                 if proc.poll() is not None:
                     return emit("FAIL", f"dev process exited early with {proc.returncode}", log_path, started_at)
@@ -178,7 +229,12 @@ def main() -> int:
                     break
                 time.sleep(1)
             else:
-                return emit("FAIL", "timed out waiting for Angular and the real Rust MCP listener", log_path, started_at)
+                return emit(
+                    "FAIL",
+                    f"timed out after {timeout}s waiting for Angular and the real Rust MCP listener ({mode} start)",
+                    log_path,
+                    started_at,
+                )
 
             time.sleep(max(0, args.settle_seconds))
             if proc.poll() is not None:


### PR DESCRIPTION
## Summary

- add the dormant Harness v2 verifier, CLI engine, schemas, metrics, process guardian, and combined-reviewer protocol
- harden reviewer isolation: root-owned cwd, sanitized shell and HOME, static Codex deny hook, no Claude local tools, and fail-closed tool-event auditing
- preserve the existing v1 dispatcher; v2 activation and CI integration land in the lineage-bound follow-up
- preserve the merged offline sherpa archive marker from #478

## Verification

- Harness v1 attestation PASS on the exact staged tree
- Python AST and import checks PASS
- metrics selftest PASS (25 assertions)
- hook guard selftest PASS (281 assertions)
- legacy harness selftest PASS
- live Claude 2.1.220 reviewer transport: cwd /private/var/empty, tools exactly StructuredOutput, MCP empty, no local execution
- independent spec review PASS
- independent adversarial review PASS

## Recorded rollout findings

The adversarial review found one operational MAJOR: stale nonterminal task worktrees will trigger the new primary-checkout branch-surgery guard. Cleanup is an explicit rollout step before the primary checkout is used. Legacy receipt compatibility and the full v2 fault suites are intentionally carried into the integration PR.