### PR TITLE
refactor(harness): activate resumable verifier-only v2

### DIFF
--- a/.agents/harness/README.md
+++ b/.agents/harness/README.md
@@ -1,217 +1,313 @@
-# Murmur development agent harness
+# Murmur development harness
 
-This is the vendor-neutral control plane around Claude Code and Codex. It is separate from Murmur's in-product AI evals.
+The harness is Murmur's vendor-neutral verification control plane. It is
+separate from the application's AI features and model evaluations.
 
-The runner owns the lifecycle:
+Harness v2 is a Phase-1 shadow candidate. It is deliberately thin and
+verifier-only, but it does not become the repository default until historical
+defect replay and real-task shadow budgets pass:
 
 ```text
-contract -> isolated worktree -> writer -> deterministic checks -> final checks
-         -> fresh spec review -> fresh adversarial review
-         -> risk review(s) -> bounded repair (re-runs checks + final checks first)
-         -> hash-bound PASS attestation
+open -> edit isolated worktree -> plan exact diff -> verify/resume
+     -> exact PASS evidence -> commit -> push/PR/CI/merge -> clean
 ```
 
-The model never decides that the task is complete. `PASS` belongs to the runner and is valid only for the exact contract, base commit, worktree, staged binary diff, checks, and independent reviews recorded in the attestation. Any later edit invalidates it.
+There is no harness-owned writer and no automatic repair loop in v2. The
+developer or delegated implementation agent edits the isolated worktree. The
+runner owns only isolation, deterministic evidence, fresh tool-free reviews,
+receipt verification, the exact commit, and cleanup. The implementer never
+owns the verdict.
 
-`instructions_sha256` is deterministic: sort the active instruction paths (`AGENTS.md`, `CLAUDE.md`, both clients' rules/agent adapters, canonical `.codex/learnings`, and the harness config/prompts/schemas), then hash each UTF-8 path, a NUL byte, its raw contents, and another NUL byte. Changing instructions creates a new harness variant and invalidates an older task receipt. Each dispatch receives a bounded, role-relevant extract of canonical `## Recurring patterns`; journal history is not injected.
+Legacy v1 remains executable for existing tasks and is the only supported
+bootstrap for protected harness/control-plane changes. Its `init`, `run`,
+`seal-prepared`, `verify-attestation`, `close`, `reap`, `gc`, and `eval`
+commands dispatch unchanged to `task_runner.py`.
 
-## Daily use
+## Shadow-candidate v2 workflow
 
-Create an isolated task:
+Run multi-task orchestration from a dedicated, long-lived **standalone driver
+clone**, not the user's primary checkout and not a linked worktree. The
+standalone `.git` is the driver's isolation boundary: Claude may create task
+worktrees without receiving write access to the user's primary `.git`. Create
+it once with ordinary Git:
 
 ```bash
-scripts/agent-harness init attachment-loss \
+git fetch origin murmur
+git clone --local --no-hardlinks --no-checkout . ../.murmur-agent-driver
+git -C ../.murmur-agent-driver remote set-url origin https://github.com/murmur-io/murmur.git
+git -C ../.murmur-agent-driver fetch origin murmur
+git -C ../.murmur-agent-driver switch --detach origin/murmur
+cd ../.murmur-agent-driver
+```
+
+Do not replace this with `git worktree add`: a linked driver stores its Git
+metadata in the user's primary checkout, outside Claude's project sandbox.
+The checked-in Claude policy grants only the sibling
+`../.murmur-agent-tasks` root needed for task worktrees. Cargo/full-CI and
+runtime-port reservations live under that same narrow root, so the standalone
+driver and the user's primary checkout still share one visible resource lane.
+
+Open a candidate task from that driver:
+
+```bash
+scripts/agent-harness open attachment-loss \
   --kind bug \
   --prompt "Fix attachment loss after closing a note" \
   --owned src-tauri/src/storage/attachment_store.rs \
   --owned src-tauri/src/commands/attachments.rs \
-  --owned src-tauri/src/commands/tests/attachment_tests.rs \
-  --risk lock \
-  --final-check 'ci::MURMUR_CI_SKIP_E2E=1 bash scripts/ci.sh'
+  --owned src-tauri/src/commands/tests/attachment_tests.rs
+```
 
-scripts/agent-harness run attachment-loss
+`open` starts from a committed base, creates
+`../.murmur-agent-tasks/v2/<task-id>/meetnotes`, and prints the exact worktree.
+The primary checkout's dirty bytes are never copied. Edit only the printed
+worktree and stay inside the declared `--owned` paths. After opening, invoke the
+task worktree's own `scripts/agent-harness`; the runner refuses a caller whose
+executable protocol differs from the task-pinned protocol.
+
+Plan and verify from the isolated task worktree:
+
+```bash
+scripts/agent-harness plan attachment-loss
+scripts/agent-harness verify attachment-loss
 scripts/agent-harness status attachment-loss
 ```
 
-The writer/reviewer pair is configurable per task via `--agent` (writer) and `--reviewer`
-(reviewer); both default to `config.json` `default_writer` / `default_reviewer` (shipped:
-`claude` / `claude`). Any pair of real vendors is allowed, including same-vendor
-(`claude/claude`, `codex/codex`) — the reviewer is always a fresh, independent session with no
-writer context, so same-vendor is a procedurally independent adversarial review (though not
-model-family-diverse). High-risk paths (`lock`/`egress`/`protocol`) auto-escalate a same-vendor
-reviewer to the opposite vendor unless you pass `--allow-same-vendor-high-risk`. The `fake`
-adapter is not accepted by public `init`, verification, hooks, or commit; it exists only behind the
-in-process deterministic selftest interface.
-
-`init` always starts from a committed `base_sha`; it never copies dirty changes from the primary checkout.
-
-In normal conversation you do not have to type that contract yourself. A request such as
-"fix attachment loss and ship it" activates the `ship-feature` workflow; the agent translates
-the request into `init`, reports the owned paths and checks, and runs the same state machine. The
-CLI remains available when you want an explicit/reproducible experiment or want to choose which
-vendor writes and which vendor reviews.
-
-Each task mirrors the real sibling-repository layout under one isolated root:
-
-```text
-../.murmur-agent-tasks/<task-id>/
-├── meetnotes/       # branch agent/<task-id>; this is where the writer may edit
-└── murmur-server/   # detached, clean, read-only-by-contract revision from .murmur-server-revision
-```
-
-The primary checkout and the operator's dirty `../murmur-server` checkout are never copied into
-the trial. Manifests, logs, model streams, diffs, results, and attestations live under the shared
-Git common directory at `.git/agent-harness/`.
-
-UI checks receive a runner-owned `MURMUR_E2E_PORT` reservation for their full lifetime. The
-Playwright config propagates that one value to its worker processes and refuses server reuse, so a
-test cannot silently attach to another task's Angular server.
-
-Every deterministic check also runs under a fail-closed macOS Seatbelt profile. It receives a
-fixed allowlist environment (no ambient tokens/DEKs), can write only the isolated worktree and
-explicit task-private runtime/cache leaves, and has no Internet access. The profile starts from
-macOS's `allow default` capability baseline and then imposes explicit file/network/process/secret
-denials; it is strong file/network containment, not a pure capability allowlist. Contracts, logs,
-reviews, and attestations remain parent-**writable** only; checks may read runner inputs needed for
-reproducibility but cannot create or alter evidence.
-The machine's Cargo registry, advisory database, tool binaries, Rustup toolchains, and the
-checksum-verified sherpa-onnx prebuilt archive are exposed read-only; offline Cargo writes and
-build artifacts stay inside that one task. Native resolvers may enumerate only the literal ancestor
-directories needed to reach an allowed leaf such as shared `node_modules`; those ancestors do not
-gain subtree read access.
-Playwright, native runtime probes, and Rust test commands get loopback TCP only because the
-existing Rust suite owns ephemeral local HTTP listeners; ordinary build/lint checks remain
-network-denied. The profile, complete sanitized
-environment (keys and values), stdout/stderr and combined log are hash-bound into the attestation.
-If `sandbox-exec` is absent,
-the task is `BLOCKED`; checks never fall back to an unsandboxed shell.
-
-The default loop permits two repair rounds and has a two-hour task-wide deadline in addition to
-per-process timeouts. Two consecutive repair rounds with the same staged diff and the same
-failing-check/review signature stop as `BLOCKED/no progress`. Any terminal task stays terminal;
-an abandoned nonterminal run lands `BLOCKED/interrupted` instead of silently receiving a fresh
-repair budget. Retrying requires a new contract. A failed or
-blocked run emits a content-free `learning-candidate.json` for explicit human curation; it never
-edits binding learnings automatically. Disposable task caches are pruned immediately after
-`FAILED`/`BLOCKED`, while small sandbox profiles and all logs/evidence remain.
-
-Risk evidence is runner-owned. Path classification automatically injects byte-exact canonical
-commands from `config.json`; a caller cannot satisfy a lock or egress requirement with a label such
-as `rust-lib::true`. Performance-sensitive paths add `perf-contracts`, which checks bounded audio,
-spill, inference-lane and thermal lifecycle invariants. Noisy wall-clock/RSS/Metal measurements are
-deliberately not PR gates; use the signed-Mac `scripts/measure-recording-ram.sh` protocol for them.
-
-After `PASSED`, commit the exact attested index from the isolated worktree, then close it:
+`plan` is optional but useful for inspection. `verify` always rebuilds the plan
+from the current exact binary diff before using evidence. If infrastructure
+pauses or a typed probe is collected, continue with:
 
 ```bash
-scripts/agent-harness status attachment-loss   # prints the exact worktree path
-scripts/agent-harness verify-attestation attachment-loss
+scripts/agent-harness resume attachment-loss
+```
+
+Completed green checks for the same attempt are reused byte-for-byte.
+Timed-out or environmentally blocked checks rerun. Any diff, tree, plan, or
+protocol change creates a different attempt and invalidates stale evidence.
+
+The task description is a behavioral acceptance contract. It names outcomes
+and invariants, not commands for the writer to run or report. The plan derived
+from the actual changed paths is the sole executable check profile.
+
+After `PASSED`, commit, push, and create the PR. Keep the task worktree until
+the PR has merged or the operator explicitly accepts an archived handoff:
+
+```bash
 scripts/agent-harness commit attachment-loss \
   -m "fix(attachments): preserve files when closing a note"
-git -C ../.murmur-agent-tasks/attachment-loss/meetnotes \
-  push -u origin agent/attachment-loss
-scripts/agent-harness close attachment-loss
+git -C ../.murmur-agent-tasks/v2/attachment-loss/meetnotes \
+  push -u origin agent/v2/attachment-loss
+gh pr create -R murmur-io/murmur --base murmur \
+  --head agent/v2/attachment-loss \
+  --title "fix(attachments): preserve files when closing a note" \
+  --body "What changed and how the exact diff was verified"
+# After the PR merges:
+scripts/agent-harness clean attachment-loss
 ```
 
-`commit` re-verifies the receipt, requires the QueaT identity, rejects AI co-author trailers, and
-creates one commit from exactly the attested index (an explicit empty commit for a valid
-`--no-expected-change` task). `verify-attestation` and the defense-in-depth
-commit hook fail after any post-review edit. If a manual commit is ever needed, use
-`git -C <printed-worktree> commit ...` so the hook can resolve the task explicitly. `close` is
-deliberately strict: only the runner's `COMMITTED` state is accepted; the commit receipt must match
-the exact HEAD, sole parent, tree, message, timestamps, and QueaT author/committer. It then removes
-only the two task worktrees, stores the exact task tip under `refs/agent-harness/archive/`, removes
-the local task branch, prunes disposable caches, and preserves the evidence.
+`commit` stages only the declared scope, re-verifies the exact PASS evidence,
+requires `QueaT <kgm004a@gmail.com>`, rejects receipt/co-author injection, and
+writes one commit with v2 receipt trailers. A durable intent makes the command
+resumable if the process dies after `git commit` but before the receipt/state
+write: rerunning the exact message finalizes the existing commit and never
+creates another one.
 
-Changing the executable control-plane itself has one explicit bootstrap because `init` normally
-freezes the auto-loaded instruction fingerprint before the writer runs. For a `--kind harness`
-task only, an operator may copy a prepared patch into the new isolated worktree and run
-`scripts/agent-harness seal-prepared <task-id>` **before any model or check**. The command requires
-an actually changed protected path, stages the exact owned bytes, refuses dependency-pin changes,
-rebinds the instruction fingerprint once, and writes `prepared.json`. From that point the new
-instructions are immutable again and the ordinary writer, checks, fresh independent reviews,
-attestation, commit, and close lifecycle is mandatory. Feature/product tasks cannot use this path.
+`clean` verifies a clean committed task, archives the exact tip, then removes
+only its isolated worktree and branch. An uncommitted task requires
+`clean --abandon`; before removal it archives every Git-visible tracked and
+untracked byte through a private index.
 
-Failed or blocked tasks can be cleaned without losing their work:
+## Plans are derived, not claimed
+
+The changed path set selects canonical commands from `config.json`; callers
+cannot replace them with weaker commands:
+
+- Rust source or manifests: `cargo test --lib`.
+- Angular source: lint and production build; behavior `.ts`/`.html` also gets
+  Playwright.
+- Sharing protocol or `.murmur-server-revision`: client Rust plus the pinned
+  sibling `murmur-protocol` test.
+- Harness/control-plane changes are refused by v2. During shadow they use the
+  externally anchored v1 `--kind harness` plus `seal-prepared` workflow.
+- Runtime and performance checks: only explicit `--claim runtime` or
+  `--claim performance`.
+- Actual lock, egress, and protocol paths: the combined review plus the
+  corresponding cross-vendor security specialist.
+
+The protocol hash includes the runner, canonical checks, prompts, schemas,
+wrappers, receipt verifier, hooks, config audit, runtime smoke implementation,
+and CI wiring. Changing any of those invalidates prior plan evidence.
+
+V2 refuses every path protected by `config.json`, including its own runner,
+hooks, schemas, CI, rules, and skills. A task may not weaken the code that
+judges it.
+
+Reviews run in fresh tool-free model sessions, at most three in parallel. Each
+receives only the runner-built immutable diff/evidence bundle and has no
+filesystem or shell tools. A transient reviewer failure gets one bounded retry
+with both attempts recorded. A review may request only a typed, allowlisted
+probe; the runner executes the canonical command, records it, and requires a
+fresh review bound to that probe evidence. `PASS` is rejected when any
+MAJOR/BLOCKER, proof gap, or unresolved probe remains.
+
+## Crash and contention behavior
+
+The append-only state event is authoritative; `state.json` is a repairable
+projection. Runner checkpoints are written atomically before progress advances.
+`resume` therefore recovers from SIGKILL without repeating green evidence.
+
+Plan, verify/resume, commit/guard, and clean mutations are serialized by one
+task lock. Cargo and full-CI work share one workspace resource lane under
+`../.murmur-agent-tasks/.resources`, across the primary checkout, linked task
+worktrees, and the standalone driver clone:
 
 ```bash
-scripts/agent-harness reap attachment-loss
-scripts/agent-harness gc --older-than-hours 168 --dry-run
-scripts/agent-harness gc --older-than-hours 168
+scripts/agent-resource-run --chdir src-tauri -- cargo test --lib
+scripts/agent-resource-run -- bash scripts/ci.sh
+scripts/agent-dev-run -- npm run dev
 ```
 
-`reap` first writes every Git-visible tracked and untracked task byte to a hidden Git archive ref
-(ignored dependency caches remain disposable), then removes
-only the contract-bound client/server worktrees and local task branch. It refuses dirty sibling
-server worktrees. `gc` applies the same operation to old `FAILED`/`BLOCKED`/legacy `CLOSED`
-tasks and to stale abandoned `INITIALIZED`/`RUNNING`/`CHECKING`/`REVIEWING`/`REPAIRING`
-tasks only after the age cutoff and only when no live task-run lock exists. The locked reaper
-revalidates both conditions before converting an abandoned task to `BLOCKED/interrupted`.
-When an older runner already lost/removed a task worktree, `gc` cannot invent a code
-snapshot; it preserves the existing evidence/state and prunes only disposable runtime caches.
-`--dry-run` lists reap and runtime-only targets separately.
+The lane publishes owner PID, task, command, start time, and heartbeat
+immediately. Waiters report that owner immediately and then heartbeat; there is
+no silent 30-second wait. Long-lived dev supervision stays outside the lane and
+wraps only its child Cargo/rustc processes.
 
-For a change that claims native boot behavior, add the exclusive runtime evidence before review:
+Runtime claims run `scripts/harness-runtime-smoke` as a preflight before an
+expensive reviewer dispatch. It uses isolated ports/home/process groups and
+separate warm/cold budgets. A headless smoke still does not prove Touch ID,
+ScreenCaptureKit/TCC, real capture, notarization, or signed-build behavior.
+
+## Evidence and receipts
+
+V2 task artifacts live under:
+
+```text
+.git/agent-harness/v2/tasks/<task-id>/
+├── task.json
+├── events.jsonl
+├── state.json
+├── attempts/<attempt-id>/
+│   ├── plan.json
+│   ├── protocol.json
+│   ├── diff.patch
+│   ├── checks/
+│   ├── probes/
+│   ├── reviews/
+│   └── evidence.json
+├── commit-intent.json
+└── commit.json
+```
+
+The local evidence verifier binds the contract, base, exact binary diff, tree, plan, protocol,
+checks, probes, fresh reviewer invocation metadata/logs, findings, telemetry,
+and degradation provenance. The remote
+`scripts/verify-harness-attestation` cannot reconstruct private local evidence;
+it recomputes the commit parent and exact diff and checks strict v1/v2 trailer
+consistency rather than accepting trailer presence alone.
+
+Remote receipt policy is monotonic. `agent/v2/*` is reserved: every
+branch-authored non-merge commit there requires a v2 receipt. A receipted
+history may upgrade v1 -> v2, but it may never downgrade v2 -> v1 or return to
+`Harness-Lane: B`. Lane B is only a deliberate pre-receipt opt-out on an
+ordinary non-v2 `agent/*` branch. Renaming a branch does not escape receipt
+coverage once its history contains one.
+
+The receipt verifier's deterministic selftest builds real temporary Git
+histories for v1, v2, mixed ancestry, merge topology, duplicates, aliases,
+unknown versions, amendments, cherry-picks, renamed files, unattested commits,
+catch-up smuggling, reserved v2 branches, Lane-B conflicts, and downgrade
+attempts. CI runs this suite before expensive builds, on both `pull_request`
+and `merge_group`.
+
+Remote policy auditing has two deliberately separate scopes. Pull-request
+runs lend GitHub's ordinary read-only token only to
+`scripts/agent-remote-audit --public` and may report `PASS_MERGE_SCOPE`: every
+merge-blocking rule visible to that token passed, while admin-only controls
+remain explicitly `MONITOR_ONLY`. A `merge_group` run executes the
+deterministic evaluator selftest and receipt gate, but no live GitHub audit.
+Privileged monitoring runs only on `schedule` or `workflow_dispatch` at
+`refs/heads/murmur`, using `MURMUR_REMOTE_AUDIT_TOKEN`. The audit script is
+repository code and necessarily receives the selected token; `scripts/ci.sh`
+clears every token variable immediately afterward, before later repository
+checks. The expected split is declared in
+`.agents/harness/remote-policy.json`.
+
+## V1 compatibility and import
+
+Finish a valid v1 `PASSED`/`COMMITTED` task in v1. To adopt a nonterminal v1
+task without rerunning its writer:
 
 ```bash
---check 'tauri-boot::scripts/harness-runtime-smoke'
+scripts/agent-harness import-v1 <task-id>
 ```
 
-The smoke uses an isolated temporary home and terminates only the process group it created. If the installed app or another dev task owns `:1420`/`:8765`, it returns `BLOCKED`; it never kills or reuses that process. Touch ID, ScreenCaptureKit/TCC, notarization and real capture still require recorded signed-Mac evidence.
+Import is byte-preserving and idempotent. It records the source contract and
+degraded provenance, reconstructs a missing worktree only from exact archived
+Git evidence, and never fabricates PASS. If exact bytes cannot be recovered,
+the imported task becomes history-only `NEEDS_EVIDENCE`. Adopting a prior v1
+PASS requires explicit `--invalidate-pass`.
 
-## Agent evaluations
+While v1 remains the bootstrap for protected control-plane paths, its checks
+still run in fail-closed macOS Seatbelt profiles; Playwright receives a
+runner-reserved `MURMUR_E2E_PORT`. Writer/reviewer vendors remain selectable
+with `--agent`/`--reviewer`, and lock/egress/protocol work escalates a
+same-vendor reviewer unless explicitly overridden. `reap` archives the exact
+bytes of terminal failed/blocked/closed work before removing its worktree;
+`gc` applies that lifecycle to stale tasks.
+
+Historical markerless v1 receipts retain their original, narrower provenance
+field set so honestly earned archives remain verifiable. New v1 contracts are
+policy-2 and cannot run through that path. This is a consistency receipt, not
+a signature: deliberately rewriting both runner-owned contract and receipt
+artifacts is outside its stated threat model.
+
+## Operational telemetry
+
+The append-only ledgers for both generations can be rolled up without parsing
+multi-megabyte raw model logs:
 
 ```bash
-scripts/agent-harness eval list
-scripts/agent-harness eval run --suite smoke --agent codex --trials 1
-scripts/agent-harness eval run --suite smoke --agent claude --trials 1
-scripts/agent-harness eval report <run-id>
+scripts/agent-harness metrics
+scripts/agent-harness metrics --limit 50 --json
 ```
 
-Eval trials use disposable history-free snapshots. Hidden graders remain outside the writer's workspace. A normal trial is single-shot; repair rounds are an explicit, separately reported mode. The report includes pass-at-1, any-pass-at-k, all-pass-at-k, duration, failures, scope violations, and harness/infra errors.
+`--limit` selects the most recently active task generations by their latest
+valid event timestamp. The report includes task/status counts, model
+invocations, observed cost and turns, model/check/review durations with
+nearest-rank p50/p90, retries, timeouts, and malformed-ledger counts. Every
+optional total is paired with coverage (`available`, `missing`, `invalid`);
+missing historical telemetry is never imputed as zero. A successful
+`model-process-exit` plus its matching `model-invocation` is counted once, while
+each bounded retry remains a separate invocation.
 
-Only deterministic harness/eval selftests belong in blocking PR CI. Live Codex/Claude capability
-trials are manual or scheduled until a pinned task/configuration has a reviewed reference solution
-and repeated near-100% reliability; one stochastic trial must never red-bar a product PR.
-
-## Enforcement
-
-- Claude/Codex hooks are fast defense-in-depth and call one canonical implementation.
-- The canonical commit hook verifies the exact staged diff against the task attestation.
-- `scripts/agent-config-audit` and `scripts/agent-harness selftest` run at the start of `scripts/ci.sh`.
-- GitHub required checks remain the authoritative remote merge boundary; local hooks are bypassable by design.
-
-Audit that boundary without mutating GitHub:
+## Control-plane verification
 
 ```bash
-scripts/agent-remote-audit
+python3 .agents/harness/v2_selftest.py
+python3 .agents/harness/metrics_selftest.py
+scripts/verify-harness-attestation --selftest
+bash .codex/hooks/selftest.sh
+scripts/agent-config-audit --ci
+scripts/agent-harness selftest --ci
 ```
 
-The repository policy is versioned in `remote-policy.json`. Its merge scope requires an active
-ruleset that actually applies to `murmur`, requires the exact GitHub Actions check
-`gate (full ci.sh — release parity)` with strict-up-to-date checks, resolves every review thread,
-and blocks deletion/non-fast-forward updates. The privileged monitoring scope separately requires
-no bypass actors plus secret scanning and push protection.
-The approval count is deliberately **zero** while Murmur has one operator: requiring the PR author
-to obtain an independent approval would deadlock, not add separation. The no-bypass ruleset plus
-the exact CI status is the honest enforceable boundary.
+`selftest` runs both generations. `doctor` audits dependencies, both schema
+families, stale state/lock projections, ghost tasks, orphan worktrees, and
+cleanup debt. Local selftests prove the control plane's deterministic behavior;
+they do not certify application behavior or remote branch enforcement.
 
-CI runs a live read-only audit first. Pull requests lend only their ordinary, least-privilege
-GitHub Actions token and may return `PASS_MERGE_SCOPE` only when every merge-scope control passes.
-The three admin-only controls are labeled `MONITOR_ONLY`;
-that verdict explicitly does not attest them for the PR. Trusted schedule/dispatch runs require
-the privileged audit with the repository-scoped `MURMUR_REMOTE_AUDIT_TOKEN`; a missing or
-under-scoped secret fails closed and never falls back to the narrower PR scope. The secret is never
-exposed to pull-request code. A token exists only in the `ci.sh` step and is unset immediately
-after the audit, before any other repository command. Local runs execute the deterministic
-evaluator selftest unless `MURMUR_CI_PUBLIC_REMOTE_AUDIT=1` or privileged
-`MURMUR_CI_LIVE_REMOTE_AUDIT=1` is set. A remote FAIL means the development loop is locally
-functional but the audited enforcement scope is incomplete; this audit never mutates GitHub.
+Hooks are fast defense-in-depth. GitHub's required `gate (full ci.sh — release
+parity)` remains the remote merge boundary. Push, PR creation, merge, signing,
+notarization, and publication remain operator-owned actions.
 
-Control-plane tasks declare the harness and hook meta-selftests as hash-bound checks. Their nested
-fake checks inherit the already-applied outer no-network Seatbelt because macOS refuses a second
-`sandbox_apply`. Inherited mode is accepted only for fake/selftest receipts and only after
-`sandbox_check` proves the current process is kernel-sandboxed; a forged host environment marker
-fails closed. Production task checks always record `sandbox_mode: direct`.
+## Program continuity and cutover
 
-No production vault, MeetingNotes database, Keychain item, live microphone, ScreenCaptureKit session, or real cloud provider belongs in an automated trial. Signed-build-only behavior stays an explicit human/runtime gate.
+The verifier schedules one task only. For a Claude multi-PR session, set a
+session-scoped `/goal` that requires the next manifest action within 60 seconds
+after the prior task reaches a stable state. Do not add a repository-wide Stop
+hook or put a program queue inside the receipt state machine.
+
+V2 remains a candidate until shadow evidence includes the historical MAJOR
+corpus, at least ten representative real tasks, the declared kill/429/timeout/
+occupied-port/lane/trunk faults, and measured p50/p90 budgets. Only a later
+cutover change may call it the default or retire v1's writer/repair topology.

--- a/.agents/harness/config.json
+++ b/.agents/harness/config.json
@@ -50,7 +50,7 @@
     "ng-build": "npx ng build",
     "playwright": "npm run test:e2e -- --workers=1",
     "perf-contracts": "bash .agents/harness/checks/perf-contracts.sh",
-    "harness-python": "python3 -m py_compile .agents/harness/task_runner.py .agents/harness/cli.py .agents/harness/verifier.py .agents/harness/process_guardian.py .agents/harness/config_audit.py .agents/harness/hook_guard.py .agents/harness/resource_policy.py .agents/harness/v2_selftest.py",
+    "harness-python": "python3 -B -c 'import ast, importlib, pathlib, sys; names=(\"task_runner\",\"cli\",\"verifier\",\"process_guardian\",\"config_audit\",\"hook_guard\",\"resource_policy\",\"v2_selftest\",\"v2_fault_selftest\",\"metrics\",\"metrics_selftest\"); root=pathlib.Path(\".agents/harness\"); [ast.parse((root / (name + \".py\")).read_text(encoding=\"utf-8\"), filename=str(root / (name + \".py\"))) for name in names]; sys.path.insert(0, str(root)); [importlib.import_module(name) for name in names]'",
     "harness-v2-selftest": "python3 .agents/harness/v2_selftest.py",
     "receipt-selftest": "scripts/verify-harness-attestation --selftest",
     "hook-selftest": "bash .codex/hooks/selftest.sh",

--- a/.agents/harness/config_audit.py
+++ b/.agents/harness/config_audit.py
@@ -77,6 +77,127 @@ def _canonical_json(value: Any) -> bytes:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
 
 
+_HEREDOC_START = re.compile(
+    r"<<(?P<tabs>-)?\s*(?:'(?P<single>[^']+)'|\"(?P<double>[^\"]+)\"|(?P<bare>[A-Za-z_][A-Za-z0-9_]*))"
+)
+
+
+def _blank_shell_arithmetic(source: str) -> str:
+    """Blank arithmetic expansions/commands before looking for heredocs."""
+
+    chars = list(source)
+    single = False
+    double = False
+    escaped = False
+    index = 0
+    while index < len(source):
+        char = source[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if char == "\\" and not single:
+            escaped = True
+            index += 1
+            continue
+        if char == "'" and not double:
+            single = not single
+            index += 1
+            continue
+        if char == '"' and not single:
+            double = not double
+            index += 1
+            continue
+
+        expansion = not single and source.startswith("$((", index)
+        command = not single and not double and source.startswith("((", index)
+        if not expansion and not command:
+            index += 1
+            continue
+
+        start = index
+        cursor = index + (3 if expansion else 2)
+        depth = 2
+        arithmetic_escaped = False
+        while cursor < len(source) and depth:
+            arithmetic_char = source[cursor]
+            if arithmetic_escaped:
+                arithmetic_escaped = False
+            elif arithmetic_char == "\\":
+                arithmetic_escaped = True
+            elif arithmetic_char == "(":
+                depth += 1
+            elif arithmetic_char == ")":
+                depth -= 1
+            cursor += 1
+        if depth:
+            index += 1
+            continue
+        chars[start:cursor] = " " * (cursor - start)
+        index = cursor
+    return "".join(chars)
+
+
+def _strip_shell_comment(line: str) -> str:
+    """Remove a real shell comment while preserving quoted hash characters."""
+
+    single = False
+    double = False
+    escaped = False
+    for index, char in enumerate(line):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\" and not single:
+            escaped = True
+            continue
+        if char == "'" and not double:
+            single = not single
+            continue
+        if char == '"' and not single:
+            double = not double
+            continue
+        if (
+            char == "#"
+            and not single
+            and not double
+            and (index == 0 or line[index - 1].isspace())
+        ):
+            return line[:index]
+    return line
+
+
+def _shell_executable_statements(source: str) -> List[Tuple[int, str]]:
+    """Return executable shell lines, excluding comments and heredoc bodies."""
+
+    statements: List[Tuple[int, str]] = []
+    heredocs: List[Tuple[str, bool]] = []
+    offset = 0
+    for line in source.splitlines(keepends=True):
+        if heredocs:
+            delimiter, strip_tabs = heredocs[0]
+            candidate = line.rstrip("\r\n")
+            if strip_tabs:
+                candidate = candidate.lstrip("\t")
+            if candidate == delimiter:
+                heredocs.pop(0)
+            offset += len(line)
+            continue
+
+        code = _strip_shell_comment(line).strip()
+        if code:
+            statements.append((offset, code))
+            for match in _HEREDOC_START.finditer(_blank_shell_arithmetic(code)):
+                delimiter = (
+                    match.group("single")
+                    or match.group("double")
+                    or match.group("bare")
+                )
+                heredocs.append((delimiter, bool(match.group("tabs"))))
+        offset += len(line)
+    return statements
+
+
 @dataclass
 class Audit:
     errors: List[str] = field(default_factory=list)
@@ -433,6 +554,39 @@ def _codex_permission_profiles(audit: Audit) -> None:
         "task runner selects and inlines Codex writer/reviewer permission profiles",
         "task runner must select and inline the Codex permission profile per role",
     )
+    audit.require(
+        re.search(
+            r'"--tools",\s*tools,\s*"--allowedTools",\s*tools,',
+            runner_text,
+        )
+        is not None
+        and '"autoAllowBashIfSandboxed": False' in runner_text
+        and re.search(
+            r'if role == "writer":\s*'
+            r'tools = "Read,Grep,Glob,Edit,Write,Bash"\s*'
+            r'else:\s*tools = ""',
+            runner_text,
+        )
+        is not None
+        and "reviewer_execution_cwd() if role == \"reviewer\" else worktree"
+        in runner_text,
+        "Claude reviewer has an empty tool surface and isolated non-project cwd",
+        "Claude reviewer must pass empty --tools/--allowedTools values, override "
+        "project sandbox Bash auto-approval, and run outside the project tree",
+    )
+    audit.require(
+        "REVIEWER_TOOL_DENIAL" in runner_text
+        and '"/usr/bin/printf \'%s\\\\n\' "' in runner_text
+        and 'f"hooks.PreToolUse={reviewer_guard_config}"' in runner_text
+        and '"--dangerously-bypass-hook-trust"' in runner_text
+        and "'web_search=\"disabled\"'" in runner_text
+        and '"features.apps=false"' in runner_text
+        and '"features.plugins=false"' in runner_text
+        and '"features.multi_agent=false"' in runner_text,
+        "Codex reviewer has a runner-owned deny-all tool boundary",
+        "Codex reviewer must deny every local tool with the protocol-bound "
+        "PreToolUse guard and disable hosted/networked tool surfaces",
+    )
 
 
 def _eval_adapter_security(audit: Audit) -> None:
@@ -622,10 +776,15 @@ def _remote_workflow_contract(audit: Audit) -> None:
         audit.error(f"cannot read remote-audit workflow contract: {exc}")
         return
 
-    dedicated_mapping = re.findall(
-        r"(?m)^\s+MURMUR_REMOTE_AUDIT_TOKEN:\s*"
-        r"\$\{\{\s*secrets\.MURMUR_REMOTE_AUDIT_TOKEN\s*\}\}\s*$",
-        workflow_text,
+    dedicated_mapping = [
+        line.strip()
+        for line in workflow_text.splitlines()
+        if line.lstrip().startswith("MURMUR_REMOTE_AUDIT_TOKEN:")
+    ]
+    expected_privileged_mapping = (
+        "MURMUR_REMOTE_AUDIT_TOKEN: ${{ ((github.event_name == 'schedule' || "
+        "github.event_name == 'workflow_dispatch') && github.ref == "
+        "'refs/heads/murmur') && secrets.MURMUR_REMOTE_AUDIT_TOKEN || '' }}"
     )
     public_mapping = re.findall(
         r"(?m)^\s+MURMUR_PUBLIC_REMOTE_AUDIT_TOKEN:\s*"
@@ -633,9 +792,11 @@ def _remote_workflow_contract(audit: Audit) -> None:
         workflow_text,
     )
     audit.require(
-        len(dedicated_mapping) == 1,
-        "privileged remote audit receives exactly the dedicated secret",
-        "ci.yml must pass MURMUR_REMOTE_AUDIT_TOKEN directly from its same-named secret",
+        dedicated_mapping == [expected_privileged_mapping]
+        and workflow_text.count("secrets.MURMUR_REMOTE_AUDIT_TOKEN") == 1,
+        "privileged remote audit secret is scoped to trusted default-branch monitoring",
+        "ci.yml must expose MURMUR_REMOTE_AUDIT_TOKEN exactly once and only to "
+        "schedule/workflow_dispatch runs on refs/heads/murmur",
     )
     audit.require(
         len(public_mapping) == 1,
@@ -709,6 +870,275 @@ def _headless_e2e_no_egress_contract(audit: Audit) -> None:
     )
 
 
+def _harness_v2_contract(audit: Audit) -> None:
+    required = (
+        ".agents/harness/cli.py",
+        ".agents/harness/verifier.py",
+        ".agents/harness/v2_selftest.py",
+        ".agents/harness/v2_fault_selftest.py",
+        ".agents/harness/metrics_selftest.py",
+        ".agents/harness/prompts/combined-reviewer.md",
+        ".agents/harness/schemas/v2-task.schema.json",
+        ".agents/harness/schemas/v2-plan.schema.json",
+        ".agents/harness/schemas/v2-review.schema.json",
+        ".agents/harness/schemas/v2-evidence.schema.json",
+        ".agents/harness/schemas/v2-commit-intent.schema.json",
+        ".agents/harness/schemas/v2-commit.schema.json",
+    )
+    audit.require(
+        all((ROOT / path).is_file() for path in required),
+        "Harness v2 dispatcher, verifier, prompt, selftest, and schemas exist",
+        "Harness v2 executable/schema surface is incomplete",
+    )
+    config = _load_json(ROOT / ".agents" / "harness" / "config.json", audit)
+    canonical = config.get("canonical_checks", {}) if isinstance(config, dict) else {}
+    required_checks = {
+        "harness-python",
+        "harness-v2-selftest",
+        "receipt-selftest",
+        "hook-selftest",
+        "config-audit",
+    }
+    audit.require(
+        isinstance(canonical, dict)
+        and required_checks.issubset(canonical)
+        and config.get("v2_max_parallel_reviews") == 3
+        and isinstance(config.get("review_retry_max_delay_seconds"), int),
+        "Harness v2 concurrency, retry, and control-plane checks are pinned",
+        "Harness v2 config must pin max 3 reviews, retry delay, and all self-check ids",
+    )
+    try:
+        wrapper = (ROOT / "scripts" / "agent-harness").read_text(encoding="utf-8")
+        dispatcher = (ROOT / ".agents" / "harness" / "cli.py").read_text(
+            encoding="utf-8"
+        )
+        ci = (ROOT / "scripts" / "ci.sh").read_text(encoding="utf-8")
+        workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
+            encoding="utf-8"
+        )
+        receipt_gate = (
+            ROOT / "scripts" / "verify-harness-attestation"
+        ).read_text(encoding="utf-8")
+        finish_guard = (ROOT / ".agents" / "harness" / "hook_guard.py").read_text(
+            encoding="utf-8"
+        )
+    except OSError as exc:
+        audit.error(f"cannot read Harness v2 wrapper/CI contract: {exc}")
+        return
+    audit.require(
+        ".agents/harness/cli.py" in wrapper,
+        "agent-harness wrapper dispatches through the generation-aware v2 CLI",
+        "scripts/agent-harness must execute .agents/harness/cli.py",
+    )
+    audit.require(
+        all(
+            f'"{script}"' in dispatcher
+            for script in (
+                "v2_selftest.py",
+                "v2_fault_selftest.py",
+                "metrics_selftest.py",
+            )
+        ),
+        "generation-aware selftest aggregates legacy, v2, fault, and metrics suites",
+        "Harness v2 CLI selftest must retain all deterministic sub-suites",
+    )
+    audit.require(
+        "scripts/verify-harness-attestation --selftest" in ci
+        and ci.index("scripts/verify-harness-attestation --selftest")
+        < ci.index("scripts/agent-config-audit --ci"),
+        "strict temp-git receipt selftest runs before expensive CI work",
+        "scripts/ci.sh must run receipt --selftest before config/product gates",
+    )
+    token_capture = 'remote_audit_token="${MURMUR_REMOTE_AUDIT_TOKEN:-}"'
+    public_token_capture = (
+        'public_audit_token="${MURMUR_PUBLIC_REMOTE_AUDIT_TOKEN:-}"'
+    )
+    token_scrub = (
+        "unset MURMUR_REMOTE_AUDIT_TOKEN MURMUR_PUBLIC_REMOTE_AUDIT_TOKEN "
+        "GH_TOKEN GITHUB_TOKEN"
+    )
+    receipt_selftest = "scripts/verify-harness-attestation --selftest"
+
+    def token_quarantine_contract(candidate: str) -> bool:
+        positions: Dict[str, List[int]] = {
+            statement: []
+            for statement in (
+                token_capture,
+                public_token_capture,
+                token_scrub,
+                receipt_selftest,
+            )
+        }
+        for offset, statement in _shell_executable_statements(candidate):
+            if statement in positions:
+                positions[statement].append(offset)
+        return (
+            all(len(found) == 1 for found in positions.values())
+            and positions[token_capture][0] < positions[token_scrub][0]
+            and positions[public_token_capture][0] < positions[token_scrub][0]
+            and positions[token_scrub][0] < positions[receipt_selftest][0]
+        )
+
+    comment_spoof = ci.replace(
+        f"  {token_scrub}",
+        f"  # {token_scrub}",
+        1,
+    ).replace(
+        f"  {receipt_selftest}",
+        f"  {receipt_selftest}\n"
+        "  unset MURMUR_REMOTE_AUDIT_TOKEN MURMUR_PUBLIC_REMOTE_AUDIT_TOKEN\n"
+        "  unset GH_TOKEN GITHUB_TOKEN",
+        1,
+    )
+    heredoc_spoof = ci.replace(
+        f"  {token_scrub}",
+        "  cat <<'TOKEN_SCRUB'\n"
+        f"{token_scrub}\n"
+        "TOKEN_SCRUB",
+        1,
+    ).replace(
+        f"  {receipt_selftest}",
+        f"  {receipt_selftest}\n"
+        "  unset MURMUR_REMOTE_AUDIT_TOKEN MURMUR_PUBLIC_REMOTE_AUDIT_TOKEN\n"
+        "  unset GH_TOKEN GITHUB_TOKEN",
+        1,
+    )
+    arithmetic_shift = ci.replace(
+        f"  {token_scrub}",
+        "  shifted=$((offset << shift))\n"
+        f"  {token_scrub}",
+        1,
+    )
+    audit.require(
+        token_quarantine_contract(arithmetic_shift),
+        "CI quarantine parser distinguishes arithmetic shifts from heredocs",
+        "scripts/ci.sh token quarantine parser must not treat shell arithmetic "
+        "left shift as a heredoc opener",
+    )
+    audit.require(
+        token_quarantine_contract(ci)
+        and not token_quarantine_contract(comment_spoof)
+        and not token_quarantine_contract(heredoc_spoof),
+        "CI quarantines audit tokens before any repository command",
+        "scripts/ci.sh must copy audit credentials into unexported locals, unset "
+        "all exported token names with executable shell statements, and only "
+        "then run the receipt selftest; comments and heredocs are not evidence",
+    )
+    monotonic_receipt_markers = (
+        "Lane B cannot downgrade an agent/v2 branch",
+        "agent/v2 branches require v2 receipts on every authored commit",
+        "downgrades a v2 receipt history",
+        "v2 receipt downgrade rejected",
+        "agent/v2 rejects legacy v1 receipt",
+        "ordinary agent branch accepts explicit Lane B",
+        "agent/v2 rejects Lane B downgrade",
+        "receipted history rejects Lane B downgrade",
+    )
+    audit.require(
+        all(marker in receipt_gate for marker in monotonic_receipt_markers),
+        "receipt policy is monotonic from Lane B/v1 into v2 and selftests the downgrade boundary",
+        "verify-harness-attestation must reserve agent/v2, reject Lane B after receipts, "
+        "reject v2-to-v1 downgrade, and retain RED selftests for each boundary",
+    )
+    rust_lane = re.compile(
+        r"(?m)^\s+run:\s+bash scripts/ci\.sh rust\s*$"
+    )
+    web_lane = re.compile(
+        r"(?m)^\s+run:\s+bash scripts/ci\.sh web\s*$"
+    )
+
+    def thin_lane_contract(candidate: str) -> bool:
+        return (
+            re.search(r"(?m)^\s+merge_group:\s*$", candidate) is not None
+            and len(rust_lane.findall(candidate)) == 1
+            and len(web_lane.findall(candidate)) == 1
+        )
+
+    duplicate_rust_lane = workflow + "\n        run: bash scripts/ci.sh rust\n"
+    duplicate_web_lane = workflow + "\n        run: bash scripts/ci.sh web\n"
+    audit.require(
+        thin_lane_contract(workflow)
+        and not thin_lane_contract(duplicate_rust_lane)
+        and not thin_lane_contract(duplicate_web_lane),
+        "GitHub merge queue remains a thin ci.sh wrapper",
+        "ci.yml must trigger merge_group and contain exactly one real run step "
+        "for each scripts/ci.sh lane; duplicate-step mutations must fail",
+    )
+    base_checkout = re.compile(
+        r"(?m)^\s+ref:\s*\$\{\{\s*github\.event\.pull_request\.base\.sha\s*\}\}\s*$"
+    )
+    trusted_extract = re.compile(
+        r'(?m)^\s+git show "\$BASE_SHA:scripts/verify-harness-attestation" '
+        r'> "\$TRUSTED_VERIFIER"\s*$'
+    )
+    trusted_exec = re.compile(
+        r'(?m)^\s+python3 "\$TRUSTED_VERIFIER"\s+\\\s*$'
+    )
+    candidate_exec = re.compile(
+        r"(?m)^\s+python3\s+(?:\./)?scripts/verify-harness-attestation(?:\s+\\)?\s*$"
+    )
+    pr_only_receipt = re.compile(
+        r"(?m)^\s+if:\s*github\.event_name\s*==\s*'pull_request'\s*$"
+    )
+
+    def trusted_receipt_anchor(text: str) -> bool:
+        return (
+            len(base_checkout.findall(text)) == 1
+            and len(trusted_extract.findall(text)) == 1
+            and len(trusted_exec.findall(text)) == 1
+            and candidate_exec.search(text) is None
+            and 'git cat-file -e "${BASE_SHA}^{commit}"' in text
+            and 'git cat-file -e "${HEAD_SHA}^{commit}"' in text
+            and 'test -s "$TRUSTED_VERIFIER"' in text
+        )
+
+    candidate_execution_mutation = workflow.replace(
+        'python3 "$TRUSTED_VERIFIER"',
+        "python3 scripts/verify-harness-attestation",
+        1,
+    )
+    head_extraction_mutation = workflow.replace(
+        "$BASE_SHA:scripts/verify-harness-attestation",
+        "$HEAD_SHA:scripts/verify-harness-attestation",
+        1,
+    )
+    audit.require(
+        trusted_receipt_anchor(workflow)
+        and not trusted_receipt_anchor(candidate_execution_mutation)
+        and not trusted_receipt_anchor(head_extraction_mutation),
+        "GitHub receipt gate executes only the verifier extracted from the exact PR base SHA",
+        "ci.yml must checkout pull_request.base.sha, extract the receipt verifier from "
+        "that commit, fail closed on missing blobs, and never execute the candidate copy",
+    )
+    audit.require(
+        len(pr_only_receipt.findall(workflow)) == 1
+        and re.search(r"(?m)^\s+merge_group:\s*$", workflow) is not None
+        and re.search(
+            r"(?m)^\s+types:\s*\[\s*checks_requested\s*\]\s*$",
+            workflow,
+        )
+        is not None
+        and "needs: [attestation, rust, web]" in workflow
+        and "if: always()" in workflow
+        and '[ "${{ github.event_name }}" = "pull_request" ]' in workflow
+        and '${{ needs.attestation.result }}" != "success"' in workflow
+        and '${{ needs.attestation.result }}" != "skipped"' in workflow,
+        "PR receipts stay PR-payload-bound while merge queue runs aggregate safely",
+        "the receipt job must remain pull_request-only; the aggregate must require "
+        "receipt success on PRs, allow only the expected skip elsewhere, and include "
+        "both full CI lanes on checks_requested merge groups",
+    )
+    audit.require(
+        "_v2_verifier_module" in finish_guard
+        and "validate_hashed_document" in finish_guard
+        and "supersedes" in finish_guard
+        and "Harness v2 owns the durable commit intent and receipt" in finish_guard,
+        "finish guard resolves v1/v2 manifests, exact import collisions, and delegates v2 commits",
+        "finish guard must validate v2 manifests, fail closed on ambiguous supersedes "
+        "bindings, and delegate durable v2 commits to agent-harness",
+    )
+
+
 def run_audit() -> Audit:
     audit = Audit()
     documents = _json_audit(audit)
@@ -721,6 +1151,7 @@ def run_audit() -> Audit:
     _semantic_lint(audit)
     _remote_workflow_contract(audit)
     _headless_e2e_no_egress_contract(audit)
+    _harness_v2_contract(audit)
     return audit
 
 

--- a/.agents/harness/schemas/task.schema.json
+++ b/.agents/harness/schemas/task.schema.json
@@ -29,6 +29,10 @@
   ],
   "properties": {
     "schema_version": { "const": 1 },
+    "receipt_policy_version": {
+      "const": 2,
+      "description": "Optional only so historical markerless v1 contracts remain verifiable; every new contract is bound to policy 2."
+    },
     "task_id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._-]{1,63}$" },
     "description": { "type": "string", "minLength": 1 },
     "kind": { "enum": ["bug", "feature", "refactor", "docs", "harness"] },

--- a/.agents/harness/task_runner.py
+++ b/.agents/harness/task_runner.py
@@ -55,6 +55,7 @@ REVIEWER_TOOL_DENIAL = {
 TASK_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{1,63}$")
 SHA1_RE = re.compile(r"^[0-9a-f]{40}$")
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+RECEIPT_POLICY_VERSION = 2
 TERMINAL_STATES = {"PASSED", "FAILED", "BLOCKED", "COMMITTED", "CLOSED", "REAPED"}
 REAPABLE_STATES = {"FAILED", "BLOCKED", "CLOSED"}
 ABANDONABLE_STATES = {"INITIALIZED", "RUNNING", "CHECKING", "REVIEWING", "REPAIRING"}
@@ -3372,6 +3373,8 @@ def invoke_model(
             "argv": recorded_argv,
             "cwd": str(model_cwd),
             "wall_timeout_seconds": timeout_seconds,
+            "process_duration_ms": process_result["duration_ms"],
+            "process_timed_out": bool(process_result["timed_out"]),
             "budget_usd": budget,
             "removed_env_names": removed_env_names,
             "instructions_sha256": instructions_sha256,
@@ -3427,6 +3430,16 @@ def writer_prompt(contract: Mapping[str, Any], feedback: Sequence[Mapping[str, A
         learning_prompt(contract, role="writer"),
         "\n## Task contract\n```json\n" + json.dumps(contract, indent=2, sort_keys=True) + "\n```",
     ]
+    if contract.get("prepared_input_sha256"):
+        sections.append(
+            "\n## PREPARED_CONTROL_PLANE_READ_ONLY\n"
+            "This protected control-plane candidate was hash-sealed before model "
+            "dispatch. Its staged bytes are immutable. Inspect them read-only and "
+            "do not call editing or write tools. Return status=completed when the "
+            "sealed candidate already satisfies the contract. Return status=blocked "
+            "only for a concrete missing behavior, with its exact location. The "
+            "external runner owns all authoritative checks."
+        )
     if feedback:
         sections.append("\n## Authoritative feedback from the previous round\n```json\n" + json.dumps(feedback, indent=2) + "\n```")
     return "\n".join(sections)
@@ -3935,12 +3948,20 @@ def create_attestation(
                 "round": index + 1,
                 "label": run["label"],
                 "vendor": run["vendor"],
+                "cli_version": run["cli_version"],
+                "model": run["model"],
                 "session_id": run["session_id"],
                 "degraded": run.get("degraded"),
                 "timed_out": bool(run.get("timed_out")),
                 "duration_ms": run.get("duration_ms"),
+                "result_path": run["result_path"],
                 "artifact_sha256": run["artifact_sha256"],
+                "invocation_path": run["invocation_path"],
+                "invocation_sha256": run["invocation_sha256"],
+                "prompt_sha256": run["prompt_sha256"],
+                "log_path": run["log"],
                 "log_sha256": run["log_sha256"],
+                "created_at": run["created_at"],
             }
             for index, run in enumerate(writer_runs)
         ],
@@ -4089,6 +4110,11 @@ def run_task(
     contract: Dict[str, Any], task_dir: Path, *, allow_test_adapter: bool = False
 ) -> str:
     assert_v1_not_imported(task_dir)
+    if contract.get("receipt_policy_version") != RECEIPT_POLICY_VERSION:
+        raise HarnessError(
+            "legacy task contracts are read-only; import the diff or create a "
+            "new lineage-bound task before running"
+        )
     assert_external_v1_control_plane(
         contract, allow_test_adapter=allow_test_adapter
     )
@@ -4598,6 +4624,10 @@ def verify_model_invocation(
     expected_path: Path,
     instructions_sha256: str,
     prompt_sha256: Optional[str] = None,
+    require_cwd_binding: bool,
+    expected_writer_cwd: Optional[Path] = None,
+    expected_process_duration_ms: Optional[int] = None,
+    expected_process_timed_out: Optional[bool] = None,
 ) -> dt.datetime:
     invocation_path = evidence_file(task_dir, invocation_path_raw, expected_path, f"{label} invocation")
     if sha256_file(invocation_path) != invocation_sha256:
@@ -4633,17 +4663,40 @@ def verify_model_invocation(
         raise HarnessError(f"{label} invocation argv is missing")
     if Path(argv[0]).name != vendor:
         raise HarnessError(f"{label} invocation executable does not match vendor {vendor}")
-    invocation_cwd = invocation.get("cwd")
-    if not isinstance(invocation_cwd, str) or not Path(invocation_cwd).is_absolute():
-        raise HarnessError(f"{label} invocation cwd is missing or not absolute")
-    if role == "reviewer" and Path(invocation_cwd) != reviewer_execution_cwd():
-        raise HarnessError(f"{label} reviewer did not run from the isolated cwd")
+    if "cwd" not in invocation:
+        if require_cwd_binding:
+            raise HarnessError(f"{label} invocation cwd is missing")
+    else:
+        invocation_cwd = invocation.get("cwd")
+        if not isinstance(invocation_cwd, str) or not Path(invocation_cwd).is_absolute():
+            raise HarnessError(f"{label} invocation cwd is not absolute")
+        if role == "reviewer" and Path(invocation_cwd) != reviewer_execution_cwd():
+            raise HarnessError(f"{label} reviewer did not run from the isolated cwd")
+        if (
+            role == "writer"
+            and require_cwd_binding
+            and expected_writer_cwd is not None
+            and Path(invocation_cwd) != expected_writer_cwd.resolve()
+        ):
+            raise HarnessError(f"{label} writer did not run from the task worktree")
     timeout = invocation.get("wall_timeout_seconds")
     if not isinstance(timeout, int) or isinstance(timeout, bool) or timeout < 1:
         raise HarnessError(f"{label} invocation timeout is invalid")
     removed = invocation.get("removed_env_names")
     if not isinstance(removed, list) or any(not isinstance(name, str) for name in removed):
         raise HarnessError(f"{label} invocation environment audit is malformed")
+    if (
+        expected_process_duration_ms is not None
+        and invocation.get("process_duration_ms")
+        != expected_process_duration_ms
+    ):
+        raise HarnessError(f"{label} invocation duration differs from process evidence")
+    if (
+        expected_process_timed_out is not None
+        and invocation.get("process_timed_out")
+        is not expected_process_timed_out
+    ):
+        raise HarnessError(f"{label} invocation timeout differs from process evidence")
     return parse_timestamp(invocation.get("created_at"), f"{label}.invocation.created_at")
 
 
@@ -4673,6 +4726,12 @@ def verify_attestation(
         if not condition:
             failures.append(message)
 
+    receipt_policy_version = contract.get("receipt_policy_version")
+    modern_receipt = receipt_policy_version == RECEIPT_POLICY_VERSION
+    require(
+        receipt_policy_version in (None, RECEIPT_POLICY_VERSION),
+        "unsupported task receipt policy version",
+    )
     if contract_hash(contract) != contract.get("contract_sha256"):
         failures.append("task contract hash is stale")
     disk_contract = load_json(task_dir / "task.json")
@@ -4777,6 +4836,11 @@ def verify_attestation(
         require(isinstance(writer.get(field), str) and bool(writer.get(field)), f"writer {field} provenance is empty")
     provenance_version = attestation.get("provenance_schema_version")
     writer_attempts = attestation.get("writer_attempts", [])
+    if modern_receipt:
+        require(
+            provenance_version == RECEIPT_POLICY_VERSION,
+            "modern attestation is missing provenance schema version 2",
+        )
     if provenance_version is None:
         # Compatibility path for already-earned v1 receipts. They predate the
         # aggregate writer-attempt fields and are surfaced conservatively by
@@ -4803,14 +4867,239 @@ def verify_attestation(
                 and attempt.get("label") == f"round-{index + 1:02d}-writer",
                 f"writer_attempts round {index + 1} provenance is malformed",
             )
+            if not isinstance(attempt, dict):
+                continue
+            require(
+                attempt.get("vendor") == contract["writer"],
+                f"writer_attempts round {index + 1} vendor differs from the task contract",
+            )
+            require(
+                isinstance(attempt.get("session_id"), str)
+                and bool(attempt.get("session_id")),
+                f"writer_attempts round {index + 1} session provenance is empty",
+            )
+            if modern_receipt:
+                for text_field in ("cli_version", "model"):
+                    require(
+                        isinstance(attempt.get(text_field), str)
+                        and bool(attempt.get(text_field)),
+                        f"writer_attempts round {index + 1} {text_field} provenance is empty",
+                    )
+            require(
+                attempt.get("degraded")
+                in {None, "timeout", "unparseable-report"},
+                f"writer_attempts round {index + 1} degraded provenance is invalid",
+            )
+            require(
+                isinstance(attempt.get("timed_out"), bool),
+                f"writer_attempts round {index + 1} timeout provenance is invalid",
+            )
+            duration_ms = attempt.get("duration_ms")
+            require(
+                duration_ms is None
+                or (
+                    isinstance(duration_ms, int)
+                    and not isinstance(duration_ms, bool)
+                    and duration_ms >= 0
+                ),
+                f"writer_attempts round {index + 1} duration provenance is invalid",
+            )
+            if modern_receipt:
+                require(
+                    isinstance(duration_ms, int)
+                    and not isinstance(duration_ms, bool)
+                    and duration_ms >= 0,
+                    f"writer_attempts round {index + 1} duration provenance is missing",
+                )
+            hash_fields = ["artifact_sha256", "log_sha256"]
+            if modern_receipt:
+                hash_fields.extend(
+                    ("invocation_sha256", "prompt_sha256")
+                )
+            for hash_field in hash_fields:
+                hash_value = attempt.get(hash_field)
+                require(
+                    isinstance(hash_value, str)
+                    and SHA256_RE.fullmatch(hash_value) is not None,
+                    f"writer_attempts round {index + 1} {hash_field} is invalid",
+                )
+            if attempt.get("timed_out"):
+                require(
+                    attempt.get("degraded") == "timeout",
+                    f"writer_attempts round {index + 1} timeout is not marked degraded",
+                )
+            if attempt.get("degraded") == "timeout":
+                require(
+                    attempt.get("timed_out") is True,
+                    f"writer_attempts round {index + 1} timeout degradation is inconsistent",
+                )
+            if modern_receipt:
+                attempt_label = f"round-{index + 1:02d}-writer"
+                attempt_vendor = attempt.get("vendor")
+                attempt_session = attempt.get("session_id")
+                attempt_model = attempt.get("model")
+                attempt_cli_version = attempt.get("cli_version")
+                if not all(
+                    isinstance(value, str) and bool(value)
+                    for value in (
+                        attempt_vendor,
+                        attempt_session,
+                        attempt_model,
+                        attempt_cli_version,
+                    )
+                ):
+                    continue
+                result_expected = (
+                    task_dir
+                    / "results"
+                    / f"{attempt_label}-{attempt_vendor}.json"
+                )
+                invocation_expected = (
+                    task_dir
+                    / "results"
+                    / f"{attempt_label}-{attempt_vendor}-invocation.json"
+                )
+                log_expected = (
+                    task_dir
+                    / "logs"
+                    / f"{attempt_label}-{attempt_vendor}.jsonl"
+                )
+                try:
+                    result_path = evidence_file(
+                        task_dir,
+                        attempt.get("result_path"),
+                        result_expected,
+                        f"{attempt_label} result",
+                    )
+                    require(
+                        sha256_file(result_path)
+                        == attempt.get("artifact_sha256"),
+                        f"writer_attempts round {index + 1} result artifact changed",
+                    )
+                    attempt_result = load_json(result_path)
+                    validate_schema(
+                        attempt_result,
+                        load_schema("model-result"),
+                        label=f"{attempt_label} result",
+                    )
+                    require(
+                        attempt_result.get("status") == "completed",
+                        f"writer_attempts round {index + 1} did not complete",
+                    )
+                    invocation_time = verify_model_invocation(
+                        task_dir,
+                        vendor=attempt_vendor,
+                        role="writer",
+                        label=attempt_label,
+                        session_id=attempt_session,
+                        model=attempt_model,
+                        cli_version=attempt_cli_version,
+                        invocation_path_raw=attempt.get("invocation_path"),
+                        invocation_sha256=attempt.get(
+                            "invocation_sha256"
+                        ),
+                        expected_path=invocation_expected,
+                        instructions_sha256=contract[
+                            "instructions_sha256"
+                        ],
+                        prompt_sha256=attempt.get("prompt_sha256"),
+                        require_cwd_binding=True,
+                        expected_writer_cwd=worktree,
+                        expected_process_duration_ms=duration_ms,
+                        expected_process_timed_out=attempt.get(
+                            "timed_out"
+                        ),
+                    )
+                    attempt_time = parse_timestamp(
+                        attempt.get("created_at"),
+                        f"writer_attempts[{index}].created_at",
+                    )
+                    require(
+                        attempt_time == invocation_time,
+                        f"writer_attempts round {index + 1} timestamp differs from invocation metadata",
+                    )
+                    log_path = evidence_file(
+                        task_dir,
+                        attempt.get("log_path"),
+                        log_expected,
+                        f"{attempt_label} log",
+                    )
+                    execution_ids = {
+                        _artifact_execution_id(
+                            result_path,
+                            result_expected,
+                        ),
+                        _artifact_execution_id(
+                            Path(str(attempt.get("invocation_path"))),
+                            invocation_expected,
+                        ),
+                        _artifact_execution_id(
+                            log_path,
+                            log_expected,
+                        ),
+                    }
+                    require(
+                        len(execution_ids) == 1,
+                        f"writer_attempts round {index + 1} artifacts come from different executions",
+                    )
+                    require(
+                        sha256_file(log_path)
+                        == attempt.get("log_sha256"),
+                        f"writer_attempts round {index + 1} log changed",
+                    )
+                    if attempt_vendor != "fake":
+                        log_metadata = extract_model_metadata(
+                            log_path,
+                            attempt_vendor,
+                            attempt_session,
+                        )
+                        require(
+                            log_metadata["session_id"]
+                            == attempt_session,
+                            f"writer_attempts round {index + 1} session differs from the model log",
+                        )
+                        require(
+                            log_metadata["model"] == attempt_model,
+                            f"writer_attempts round {index + 1} model differs from the model log",
+                        )
+                    require(
+                        task_created
+                        <= attempt_time
+                        <= receipt_created,
+                        f"writer_attempts round {index + 1} timestamp is outside the task lifetime",
+                    )
+                except HarnessError as exc:
+                    failures.append(str(exc))
         if writer_attempts:
             latest_attempt = writer_attempts[-1]
             require(
-                latest_attempt.get("session_id") == writer.get("session_id")
+                latest_attempt.get("vendor") == writer.get("vendor")
+                and latest_attempt.get("session_id") == writer.get("session_id")
                 and latest_attempt.get("artifact_sha256") == writer.get("artifact_sha256")
                 and latest_attempt.get("log_sha256") == writer.get("log_sha256"),
                 "final writer summary differs from writer_attempts",
             )
+            if modern_receipt:
+                require(
+                    latest_attempt.get("cli_version")
+                    == writer.get("cli_version")
+                    and latest_attempt.get("model") == writer.get("model")
+                    and latest_attempt.get("degraded")
+                    == writer.get("degraded")
+                    and bool(latest_attempt.get("timed_out"))
+                    == bool(writer.get("timed_out"))
+                    and latest_attempt.get("duration_ms")
+                    == writer.get("duration_ms")
+                    and latest_attempt.get("result_path")
+                    == writer.get("result_path")
+                    and latest_attempt.get("invocation_path")
+                    == writer.get("invocation_path")
+                    and latest_attempt.get("invocation_sha256")
+                    == writer.get("invocation_sha256")
+                    and latest_attempt.get("log_path")
+                    == writer.get("log_path"),
+                    "final writer summary differs from writer_attempts",
+                )
         expected_degraded = [
             {
                 "round": attempt.get("round"),
@@ -4848,6 +5137,8 @@ def verify_attestation(
                 invocation_sha256=writer.get("invocation_sha256"),
                 expected_path=writer_invocation_expected,
                 instructions_sha256=contract["instructions_sha256"],
+                require_cwd_binding=modern_receipt,
+                expected_writer_cwd=worktree,
             )
             writer_time = parse_timestamp(writer.get("created_at"), "writer.created_at")
             require(writer_time == invocation_time, "writer timestamp differs from invocation metadata")
@@ -5034,10 +5325,11 @@ def verify_attestation(
                 validate_schema(result, load_schema("review"), label=f"review {kind} result")
                 require(result.get("verdict") == "PASS", f"review {kind} result artifact is not PASS")
                 artifact_findings = result.get("findings", [])
-                require(
-                    review.get("findings") == artifact_findings,
-                    f"review {kind} findings summary differs from its result artifact",
-                )
+                if modern_receipt or "findings" in review:
+                    require(
+                        review.get("findings") == artifact_findings,
+                        f"review {kind} findings summary differs from its result artifact",
+                    )
                 require(
                     not any(
                         isinstance(finding, Mapping)
@@ -5058,6 +5350,7 @@ def verify_attestation(
                     invocation_sha256=review.get("invocation_sha256"),
                     expected_path=invocation_expected,
                     instructions_sha256=contract["instructions_sha256"],
+                    require_cwd_binding=modern_receipt,
                 )
                 log_path = evidence_file(task_dir, review.get("log_path"), log_expected, f"review {kind} log")
                 execution_ids = {
@@ -5266,6 +5559,7 @@ def cmd_init(args: argparse.Namespace) -> int:
     created_at = utc_now()
     contract: Dict[str, Any] = {
         "schema_version": 1,
+        "receipt_policy_version": RECEIPT_POLICY_VERSION,
         "task_id": args.task_id,
         "description": prompt,
         "kind": args.kind,
@@ -6831,6 +7125,37 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
             cmd_init(args)
             contract, task_dir, _ = load_task_from_current_repo("selftest-pass", repo)
             worktree = Path(contract["worktree_path"])
+            if contract.get("receipt_policy_version") != RECEIPT_POLICY_VERSION:
+                failures.append("new v1 task was not bound to receipt policy 2")
+            unfinished_legacy_contract = copy.deepcopy(contract)
+            unfinished_legacy_contract.pop("receipt_policy_version", None)
+            unfinished_legacy_contract["contract_sha256"] = contract_hash(
+                unfinished_legacy_contract
+            )
+            unfinished_events_before = (
+                task_dir / "events.jsonl"
+            ).read_bytes()
+            try:
+                run_task(
+                    unfinished_legacy_contract,
+                    task_dir,
+                    allow_test_adapter=True,
+                )
+                failures.append("unfinished markerless legacy task was allowed to run")
+            except HarnessError as exc:
+                if "legacy task contracts are read-only" not in str(exc):
+                    failures.append(
+                        "unfinished markerless legacy task returned an unclear error"
+                    )
+            if (
+                load_json(task_dir / "state.json").get("status")
+                != "INITIALIZED"
+                or (task_dir / "events.jsonl").read_bytes()
+                != unfinished_events_before
+            ):
+                failures.append(
+                    "markerless legacy run refusal mutated lifecycle evidence"
+                )
             shared_modules = worktree / "node_modules"
             if not shared_modules.is_symlink() or shared_modules.resolve() != (repo / "node_modules").resolve():
                 failures.append("isolated worktree did not safely share ignored node_modules")
@@ -6918,6 +7243,13 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
             ):
                 failures.append(
                     "prepared harness seal did not rebind and receipt the instruction migration"
+                )
+            if (
+                "PREPARED_CONTROL_PLANE_READ_ONLY"
+                not in writer_prompt(sealed_contract, [])
+            ):
+                failures.append(
+                    "prepared harness writer prompt did not forbid edits to sealed bytes"
                 )
             sealed_skill = (
                 prepared_worktree
@@ -7042,6 +7374,157 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
                 )
             verify_attestation(contract, task_dir, allow_test_adapter=True)
             original_attestation = load_json(task_dir / "attestation.json")
+            if (
+                original_attestation.get("provenance_schema_version")
+                != RECEIPT_POLICY_VERSION
+            ):
+                failures.append("new v1 attestation omitted provenance schema 2")
+
+            def expect_receipt_rejection(
+                candidate: Mapping[str, Any],
+                *,
+                label: str,
+                message_fragment: str,
+            ) -> None:
+                atomic_write_json(task_dir / "attestation.json", candidate)
+                try:
+                    verify_attestation(
+                        contract,
+                        task_dir,
+                        allow_test_adapter=True,
+                    )
+                    failures.append(f"canonical verifier accepted {label}")
+                except HarnessError as exc:
+                    if message_fragment not in str(exc):
+                        failures.append(
+                            f"{label} failed for an unrelated reason"
+                        )
+                finally:
+                    atomic_write_json(
+                        task_dir / "attestation.json",
+                        original_attestation,
+                    )
+
+            stripped_modern_attestation = copy.deepcopy(original_attestation)
+            for field in (
+                "provenance_schema_version",
+                "writer_attempts",
+                "degraded_provenance",
+            ):
+                stripped_modern_attestation.pop(field, None)
+            expect_receipt_rejection(
+                stripped_modern_attestation,
+                label="modern receipt with stripped provenance fields",
+                message_fragment="modern attestation is missing provenance schema version 2",
+            )
+
+            rewritten_attempt_attestation = copy.deepcopy(
+                original_attestation
+            )
+            rewritten_attempt_attestation["writer_attempts"][0][
+                "vendor"
+            ] = "claude"
+            expect_receipt_rejection(
+                rewritten_attempt_attestation,
+                label="modern receipt with rewritten per-round writer vendor",
+                message_fragment="vendor differs from the task contract",
+            )
+
+            missing_findings_attestation = copy.deepcopy(original_attestation)
+            missing_findings_attestation["reviews"][0].pop("findings", None)
+            expect_receipt_rejection(
+                missing_findings_attestation,
+                label="modern receipt with a missing review findings summary",
+                message_fragment="findings summary differs",
+            )
+
+            mismatched_findings_attestation = copy.deepcopy(original_attestation)
+            mismatched_findings_attestation["reviews"][0]["findings"] = [
+                {
+                    "severity": "INFO",
+                    "file": "owned.txt",
+                    "evidence": "forged receipt-only finding",
+                    "required_fix": "",
+                }
+            ]
+            expect_receipt_rejection(
+                mismatched_findings_attestation,
+                label="modern receipt with a mismatched review findings summary",
+                message_fragment="findings summary differs",
+            )
+
+            writer_invocation_path = Path(
+                original_attestation["writer"]["invocation_path"]
+            )
+            original_writer_invocation = load_json(writer_invocation_path)
+            missing_cwd_invocation = copy.deepcopy(original_writer_invocation)
+            missing_cwd_invocation.pop("cwd", None)
+            atomic_write_json(writer_invocation_path, missing_cwd_invocation)
+            missing_cwd_attestation = copy.deepcopy(original_attestation)
+            missing_cwd_attestation["writer"]["invocation_sha256"] = sha256_file(
+                writer_invocation_path
+            )
+            try:
+                expect_receipt_rejection(
+                    missing_cwd_attestation,
+                    label="modern receipt with a missing writer cwd binding",
+                    message_fragment="invocation cwd is missing",
+                )
+            finally:
+                atomic_write_json(
+                    writer_invocation_path,
+                    original_writer_invocation,
+                )
+
+            wrong_writer_cwd_invocation = copy.deepcopy(
+                original_writer_invocation
+            )
+            wrong_writer_cwd_invocation["cwd"] = "/"
+            atomic_write_json(
+                writer_invocation_path,
+                wrong_writer_cwd_invocation,
+            )
+            wrong_writer_cwd_attestation = copy.deepcopy(
+                original_attestation
+            )
+            wrong_writer_cwd_attestation["writer"][
+                "invocation_sha256"
+            ] = sha256_file(writer_invocation_path)
+            try:
+                expect_receipt_rejection(
+                    wrong_writer_cwd_attestation,
+                    label="writer invocation rebound outside the task worktree",
+                    message_fragment="writer did not run from the task worktree",
+                )
+            finally:
+                atomic_write_json(
+                    writer_invocation_path,
+                    original_writer_invocation,
+                )
+
+            reviewer_invocation_path = Path(
+                original_attestation["reviews"][0]["invocation_path"]
+            )
+            original_reviewer_invocation = load_json(reviewer_invocation_path)
+            mutable_cwd_invocation = copy.deepcopy(original_reviewer_invocation)
+            mutable_cwd_invocation["cwd"] = str(worktree)
+            atomic_write_json(reviewer_invocation_path, mutable_cwd_invocation)
+            mutable_cwd_attestation = copy.deepcopy(original_attestation)
+            mutable_cwd_attestation["reviews"][0][
+                "invocation_sha256"
+            ] = sha256_file(reviewer_invocation_path)
+            try:
+                expect_receipt_rejection(
+                    mutable_cwd_attestation,
+                    label="reviewer invocation rebound to a mutable task cwd",
+                    message_fragment="reviewer did not run from the isolated cwd",
+                )
+            finally:
+                atomic_write_json(
+                    reviewer_invocation_path,
+                    original_reviewer_invocation,
+                )
+
             reused_session_attestation = copy.deepcopy(original_attestation)
             for review in reused_session_attestation["reviews"]:
                 review["reviewer"]["session_id"] = reused_session_attestation["writer"]["session_id"]
@@ -7054,37 +7537,273 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
             finally:
                 atomic_write_json(task_dir / "attestation.json", original_attestation)
 
-            severe_attestation = copy.deepcopy(original_attestation)
-            severe_review = severe_attestation["reviews"][0]
-            severe_result_path = Path(severe_review["result_path"])
+            severe_result_path = Path(
+                original_attestation["reviews"][0]["result_path"]
+            )
             original_review_result = load_json(severe_result_path)
-            severe_result = copy.deepcopy(original_review_result)
-            severe_result["verdict"] = "PASS"
-            severe_result["findings"] = [
-                {
-                    "severity": "MAJOR",
-                    "file": "owned.txt",
-                    "evidence": "forged PASS still contains a major defect",
-                    "required_fix": "repair it",
-                }
-            ]
-            atomic_write_json(severe_result_path, severe_result)
-            severe_review["artifact_sha256"] = sha256_file(severe_result_path)
-            severe_review["findings"] = severe_result["findings"]
-            atomic_write_json(task_dir / "attestation.json", severe_attestation)
-            try:
-                verify_attestation(contract, task_dir, allow_test_adapter=True)
-                failures.append(
-                    "canonical verifier accepted forged PASS plus MAJOR finding"
+            for severity in ("MAJOR", "BLOCKER"):
+                severe_attestation = copy.deepcopy(original_attestation)
+                severe_review = severe_attestation["reviews"][0]
+                severe_result = copy.deepcopy(original_review_result)
+                severe_result["verdict"] = "PASS"
+                severe_result["findings"] = [
+                    {
+                        "severity": severity,
+                        "file": "owned.txt",
+                        "evidence": (
+                            "forged PASS still contains an unresolved "
+                            f"{severity.lower()} defect"
+                        ),
+                        "required_fix": "repair it",
+                    }
+                ]
+                atomic_write_json(severe_result_path, severe_result)
+                severe_review["artifact_sha256"] = sha256_file(
+                    severe_result_path
                 )
-            except HarnessError as exc:
-                if "MAJOR/BLOCKER" not in str(exc):
-                    failures.append(
-                        "forged PASS plus MAJOR failed for an unrelated reason"
+                severe_review["findings"] = severe_result["findings"]
+                atomic_write_json(
+                    task_dir / "attestation.json",
+                    severe_attestation,
+                )
+                try:
+                    verify_attestation(
+                        contract,
+                        task_dir,
+                        allow_test_adapter=True,
                     )
+                    failures.append(
+                        "canonical verifier accepted forged PASS plus "
+                        f"{severity} finding"
+                    )
+                except HarnessError as exc:
+                    if "MAJOR/BLOCKER" not in str(exc):
+                        failures.append(
+                            f"forged PASS plus {severity} failed for an "
+                            "unrelated reason"
+                        )
+                finally:
+                    atomic_write_json(
+                        severe_result_path,
+                        original_review_result,
+                    )
+                    atomic_write_json(
+                        task_dir / "attestation.json",
+                        original_attestation,
+                    )
+
+            # Historical v1 receipts were honestly earned before policy 2 and
+            # therefore have no contract marker, provenance aggregate, review
+            # findings summary, or invocation cwd. This fixture declares that
+            # old field set directly (including the created_at of the archived
+            # harness-v2-engine2 receipt); it is not made by deleting a marker
+            # from the on-disk modern contract. A deliberate rewrite of every
+            # runner-owned contract/receipt byte is outside this consistency
+            # receipt's threat model and would require signing, which the
+            # harness intentionally does not claim.
+            original_contract_artifact = load_json(task_dir / "task.json")
+            original_invocations: Dict[Path, Dict[str, Any]] = {}
+            legacy_contract = {
+                key: copy.deepcopy(contract[key])
+                for key in (
+                    "schema_version",
+                    "task_id",
+                    "description",
+                    "kind",
+                    "base_sha",
+                    "contract_sha256",
+                    "instructions_sha256",
+                    "dependency_revisions",
+                    "repo_realpath",
+                    "git_common_dir",
+                    "worktree_path",
+                    "branch",
+                    "owned_paths",
+                    "risk_flags",
+                    "writer",
+                    "reviewer",
+                    "max_repair_rounds",
+                    "checks",
+                    "final_checks",
+                    "expected_change",
+                    "created_at",
+                )
+            }
+            legacy_contract["created_at"] = "2026-07-28T02:26:48Z"
+            legacy_contract["contract_sha256"] = contract_hash(legacy_contract)
+            legacy_attestation = {
+                key: copy.deepcopy(original_attestation[key])
+                for key in (
+                    "schema_version",
+                    "task_id",
+                    "contract_sha256",
+                    "instructions_sha256",
+                    "dependency_revisions",
+                    "base_sha",
+                    "head_sha",
+                    "tree_sha",
+                    "staged_diff_sha256",
+                    "repo_realpath",
+                    "worktree_path",
+                    "risk_flags",
+                    "writer",
+                    "reviewer",
+                    "rounds",
+                    "checks",
+                    "reviews",
+                    "verdict",
+                    "created_at",
+                )
+            }
+            legacy_attestation["contract_sha256"] = legacy_contract[
+                "contract_sha256"
+            ]
+            invocation_summaries = [
+                legacy_attestation["writer"],
+                *legacy_attestation["reviews"],
+            ]
+            try:
+                for summary in invocation_summaries:
+                    invocation_path = Path(summary["invocation_path"])
+                    invocation_document = load_json(invocation_path)
+                    original_invocations[invocation_path] = invocation_document
+                    legacy_invocation = copy.deepcopy(invocation_document)
+                    legacy_invocation.pop("cwd", None)
+                    atomic_write_json(invocation_path, legacy_invocation)
+                    summary["invocation_sha256"] = sha256_file(invocation_path)
+                historical_review_result = copy.deepcopy(
+                    original_review_result
+                )
+                historical_review_result["verdict"] = "PASS"
+                historical_review_result["findings"] = []
+                atomic_write_json(
+                    severe_result_path,
+                    historical_review_result,
+                )
+                legacy_attestation["reviews"][0][
+                    "artifact_sha256"
+                ] = sha256_file(severe_result_path)
+                for review in legacy_attestation["reviews"]:
+                    review.pop("findings", None)
+                atomic_write_json(task_dir / "task.json", legacy_contract)
+                atomic_write_json(
+                    task_dir / "attestation.json",
+                    legacy_attestation,
+                )
+                try:
+                    verify_attestation(
+                        legacy_contract,
+                        task_dir,
+                        allow_test_adapter=True,
+                    )
+                except HarnessError as exc:
+                    failures.append(
+                        "genuine historical-shape markerless receipt was "
+                        f"rejected: {exc}"
+                    )
+                severe_legacy_result = copy.deepcopy(
+                    historical_review_result
+                )
+                severe_legacy_result["findings"] = [
+                    {
+                        "severity": "MAJOR",
+                        "file": "owned.txt",
+                        "evidence": (
+                            "legacy PASS must not launder a severe finding"
+                        ),
+                        "required_fix": "reject the receipt",
+                    }
+                ]
+                atomic_write_json(
+                    severe_result_path,
+                    severe_legacy_result,
+                )
+                severe_legacy_attestation = copy.deepcopy(
+                    legacy_attestation
+                )
+                severe_legacy_attestation["reviews"][0][
+                    "artifact_sha256"
+                ] = sha256_file(severe_result_path)
+                atomic_write_json(
+                    task_dir / "attestation.json",
+                    severe_legacy_attestation,
+                )
+                try:
+                    verify_attestation(
+                        legacy_contract,
+                        task_dir,
+                        allow_test_adapter=True,
+                    )
+                    failures.append(
+                        "legacy receipt accepted unresolved MAJOR finding"
+                    )
+                except HarnessError as exc:
+                    if "unresolved MAJOR/BLOCKER" not in str(exc):
+                        failures.append(
+                            "legacy severe finding failed for an unrelated "
+                            "reason"
+                        )
+                atomic_write_json(
+                    severe_result_path,
+                    historical_review_result,
+                )
+                atomic_write_json(
+                    task_dir / "attestation.json",
+                    legacy_attestation,
+                )
+                invalid_legacy_invocation = load_json(
+                    writer_invocation_path
+                )
+                invalid_legacy_invocation["cwd"] = None
+                atomic_write_json(
+                    writer_invocation_path,
+                    invalid_legacy_invocation,
+                )
+                invalid_legacy_attestation = copy.deepcopy(
+                    legacy_attestation
+                )
+                invalid_legacy_attestation["writer"][
+                    "invocation_sha256"
+                ] = sha256_file(writer_invocation_path)
+                atomic_write_json(
+                    task_dir / "attestation.json",
+                    invalid_legacy_attestation,
+                )
+                try:
+                    verify_attestation(
+                        legacy_contract,
+                        task_dir,
+                        allow_test_adapter=True,
+                    )
+                    failures.append(
+                        "legacy receipt accepted an explicitly null cwd"
+                    )
+                except HarnessError as exc:
+                    if "invocation cwd is not absolute" not in str(exc):
+                        failures.append(
+                            "legacy explicit-null cwd failed for an unrelated "
+                            "reason"
+                        )
             finally:
-                atomic_write_json(severe_result_path, original_review_result)
-                atomic_write_json(task_dir / "attestation.json", original_attestation)
+                for invocation_path, invocation_document in (
+                    original_invocations.items()
+                ):
+                    atomic_write_json(
+                        invocation_path,
+                        invocation_document,
+                    )
+                atomic_write_json(
+                    severe_result_path,
+                    original_review_result,
+                )
+                atomic_write_json(
+                    task_dir / "task.json",
+                    original_contract_artifact,
+                )
+                atomic_write_json(
+                    task_dir / "attestation.json",
+                    original_attestation,
+                )
 
             synthetic_rounds = copy.deepcopy(original_attestation)
             clean_attempt = copy.deepcopy(synthetic_rounds["writer_attempts"][-1])
@@ -7476,6 +8195,42 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
             if repair_state.get("round") != 2:
                 failures.append("repair task did not record exactly two writer rounds")
             verify_attestation(repair_contract, repair_dir, allow_test_adapter=True)
+            repair_attestation = load_json(
+                repair_dir / "attestation.json"
+            )
+            for field, forged_value in (
+                ("session_id", "fake-forged-earlier-round"),
+                ("artifact_sha256", "0" * 64),
+                ("log_sha256", "1" * 64),
+                ("duration_ms", 999_999),
+            ):
+                rewritten_earlier_attempt = copy.deepcopy(
+                    repair_attestation
+                )
+                rewritten_earlier_attempt["writer_attempts"][0][
+                    field
+                ] = forged_value
+                atomic_write_json(
+                    repair_dir / "attestation.json",
+                    rewritten_earlier_attempt,
+                )
+                try:
+                    verify_attestation(
+                        repair_contract,
+                        repair_dir,
+                        allow_test_adapter=True,
+                    )
+                    failures.append(
+                        "canonical verifier accepted rewritten earlier "
+                        f"writer {field}"
+                    )
+                except HarnessError:
+                    pass
+                finally:
+                    atomic_write_json(
+                        repair_dir / "attestation.json",
+                        repair_attestation,
+                    )
             cmd_commit(
                 argparse.Namespace(
                     task_id="selftest-repair",
@@ -7776,12 +8531,18 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
             # invokes Cargo, but inherits the exact lock descriptor through the sandbox process.
             lane_runtime = _check_runtime_paths(scope_dir)
             lane_ready = lane_runtime["tmp"] / "lane-inheritance-ready"
+            lane_release = lane_runtime["tmp"] / "lane-inheritance-release"
             lane_ready.unlink(missing_ok=True)
+            lane_release.unlink(missing_ok=True)
             lane_probe = (
-                "import os,pathlib,signal,time; "
+                "import itertools,os,pathlib,signal,time; "
                 "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
                 f"pathlib.Path({str(lane_ready)!r}).write_text(str(os.getpgrp())); "
-                "time.sleep(30)"
+                "deadline=time.monotonic()+30; "
+                "next(index for index in itertools.count() "
+                f"if pathlib.Path({str(lane_release)!r}).exists() "
+                "or time.monotonic()>=deadline "
+                "or (time.sleep(0.05) and False))"
             )
             lane_driver_code = (
                 "import pathlib; from task_runner import run_check; "
@@ -7824,14 +8585,14 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
                     finally:
                         release_cargo_lane(acquired_while_child_alive)
             finally:
+                lane_release.touch()
                 if lane_driver.poll() is None:
-                    os.kill(lane_driver.pid, signal.SIGKILL)
-                    lane_driver.wait(timeout=3)
-                if lane_check_pgid > 1 and lane_check_pgid != os.getpgrp():
                     try:
-                        os.killpg(lane_check_pgid, signal.SIGKILL)
-                    except ProcessLookupError:
-                        pass
+                        lane_driver.wait(timeout=2)
+                    except subprocess.TimeoutExpired:
+                        lane_driver.kill()
+                        lane_driver.wait(timeout=3)
+                if lane_check_pgid > 1:
                     lane_exit_deadline = time.monotonic() + 2.0
                     while _process_group_alive(lane_check_pgid) and time.monotonic() < lane_exit_deadline:
                         time.sleep(0.05)
@@ -7977,8 +8738,20 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
             if not loopback_check["passed"]:
                 failures.append("loopback-only sandbox blocked a local runtime check")
 
+            outside_release_path = Path(temp_name) / "outside-signal.release"
             outside_process = subprocess.Popen(
-                [sys.executable, "-c", "import time; time.sleep(30)"],
+                [
+                    sys.executable,
+                    "-c",
+                    (
+                        "import itertools,pathlib,time; "
+                        "deadline=time.monotonic()+30; "
+                        "next(index for index in itertools.count() "
+                        f"if pathlib.Path({str(outside_release_path)!r}).exists() "
+                        "or time.monotonic()>=deadline "
+                        "or (time.sleep(0.05) and False))"
+                    ),
+                ],
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
@@ -8000,8 +8773,13 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
                 ):
                     failures.append("check sandbox signalled a process outside its own sandbox")
             finally:
+                outside_release_path.touch()
                 if outside_process.poll() is None:
-                    _terminate_process(outside_process)
+                    try:
+                        outside_process.wait(timeout=2)
+                    except subprocess.TimeoutExpired:
+                        outside_process.kill()
+                        outside_process.wait(timeout=3)
 
             timeout_result = run_logged_process(
                 [sys.executable, "-c", "import time; time.sleep(5)"],
@@ -8016,10 +8794,13 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
             # old cleanup returned as soon as the leader was reaped and orphaned the child under
             # pid 1 — exactly how an interrupted Cargo check left rustc consuming GBs of RAM.
             stubborn_pid_path = Path(temp_name) / "stubborn-grandchild.pid"
+            stubborn_release_path = Path(temp_name) / "stubborn-grandchild.release"
             stubborn_child = (
-                "import signal,time; "
+                "import pathlib,signal,time; "
                 "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
-                "time.sleep(30)"
+                "deadline=time.monotonic()+30; "
+                f"\nwhile not pathlib.Path({str(stubborn_release_path)!r}).exists() "
+                "and time.monotonic()<deadline:\n time.sleep(0.05)"
             )
             stubborn_parent = (
                 "import pathlib,subprocess,sys,time; "
@@ -8039,26 +8820,34 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
                 time.sleep(0.05)
             if not stubborn_result["timed_out"] or _pid_is_alive(stubborn_pid):
                 failures.append("managed timeout orphaned a TERM-ignoring grandchild")
-                try:
-                    os.kill(stubborn_pid, signal.SIGKILL)
-                except ProcessLookupError:
-                    pass
+            stubborn_release_path.touch()
+            stubborn_release_deadline = time.monotonic() + 1.0
+            while (
+                _pid_is_alive(stubborn_pid)
+                and time.monotonic() < stubborn_release_deadline
+            ):
+                time.sleep(0.05)
 
             # Ctrl-C reaches the harness driver, not its start_new_session child. Prove that the
             # resulting KeyboardInterrupt still drains the complete managed group.
             cancel_leader_path = Path(temp_name) / "cancel-leader.pid"
             cancel_grandchild_path = Path(temp_name) / "cancel-grandchild.pid"
+            cancel_release_path = Path(temp_name) / "cancel.release"
             cancel_grandchild = (
                 "import os,pathlib,signal,time; "
                 "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
                 f"pathlib.Path({str(cancel_grandchild_path)!r}).write_text(str(os.getpid())); "
-                "time.sleep(30)"
+                "deadline=time.monotonic()+30; "
+                f"\nwhile not pathlib.Path({str(cancel_release_path)!r}).exists() "
+                "and time.monotonic()<deadline:\n time.sleep(0.05)"
             )
             cancel_managed = (
                 "import os,pathlib,subprocess,sys,time; "
                 f"pathlib.Path({str(cancel_leader_path)!r}).write_text(str(os.getpid())); "
                 f"subprocess.Popen([sys.executable,'-c',{cancel_grandchild!r}]); "
-                "time.sleep(30)"
+                "deadline=time.monotonic()+30; "
+                f"\nwhile not pathlib.Path({str(cancel_release_path)!r}).exists() "
+                "and time.monotonic()<deadline:\n time.sleep(0.05)"
             )
             cancel_driver = (
                 "import pathlib,sys; "
@@ -8105,13 +8894,13 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
                     if _pid_is_alive(cancel_leader_pid) or _pid_is_alive(cancel_grandchild_pid):
                         failures.append("managed SIGINT orphaned its child process group")
             finally:
+                cancel_release_path.touch()
                 if cancel_process.poll() is None:
-                    _terminate_process(cancel_process)
-                if cancel_leader_pid > 1 and cancel_leader_pid != os.getpgrp():
                     try:
-                        os.killpg(cancel_leader_pid, signal.SIGKILL)
-                    except ProcessLookupError:
-                        pass
+                        cancel_process.wait(timeout=2)
+                    except subprocess.TimeoutExpired:
+                        cancel_process.kill()
+                        cancel_process.wait(timeout=3)
 
             # A cancellation can also arrive AFTER the managed leader exits, while the driver is
             # already escalating a TERM-ignoring descendant. That cleanup window must be
@@ -8123,11 +8912,14 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
                 signal_label = signal.Signals(cleanup_signum).name.lower()
                 cleanup_leader_path = Path(temp_name) / f"cleanup-{signal_label}-leader.pid"
                 cleanup_grandchild_path = Path(temp_name) / f"cleanup-{signal_label}-grandchild.pid"
+                cleanup_release_path = Path(temp_name) / f"cleanup-{signal_label}.release"
                 cleanup_grandchild = (
                     "import os,pathlib,signal,time; "
                     "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
                     f"pathlib.Path({str(cleanup_grandchild_path)!r}).write_text(str(os.getpid())); "
-                    "time.sleep(30)"
+                    "deadline=time.monotonic()+30; "
+                    f"\nwhile not pathlib.Path({str(cleanup_release_path)!r}).exists() "
+                    "and time.monotonic()<deadline:\n time.sleep(0.05)"
                 )
                 cleanup_leader = (
                     "import os,pathlib,subprocess,sys,time; "
@@ -8200,13 +8992,13 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
                                 f"managed {signal_label} interrupted cleanup orphaned a grandchild"
                             )
                 finally:
+                    cleanup_release_path.touch()
                     if cleanup_driver_process.poll() is None:
-                        _terminate_process(cleanup_driver_process)
-                    if cleanup_leader_pid > 1 and cleanup_leader_pid != os.getpgrp():
                         try:
-                            os.killpg(cleanup_leader_pid, signal.SIGKILL)
-                        except ProcessLookupError:
-                            pass
+                            cleanup_driver_process.wait(timeout=2)
+                        except subprocess.TimeoutExpired:
+                            cleanup_driver_process.kill()
+                            cleanup_driver_process.wait(timeout=3)
             os.environ["MURMUR_SELFTEST_SECRET_TOKEN"] = "must-not-cross-model-boundary"
             try:
                 clean_env, removed_names = sanitized_model_environment("0" * 64, "codex")

--- a/.agents/harness/v2_fault_selftest.py
+++ b/.agents/harness/v2_fault_selftest.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+"""Deterministic fault injection for Harness v2's immutable evidence boundary.
+
+The suite uses real temporary Git repositories, but no network or external
+model.  It intentionally exercises private trust-kernel seams because these
+are crash/ABA/tamper regressions, not product behavior tests.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any, Callable, Dict, Mapping, Sequence
+
+import cli as harness_cli
+import task_runner as legacy
+import verifier
+
+
+ROOT = Path(__file__).resolve().parents[2]
+A_BYTES = b"state-A\n\x00\xffexact bytes\n"
+B_BYTES = b"state-B\n\x00\x7fdifferent bytes\n"
+UNTRACKED_BYTES = bytes(range(256)) + b"\x00\xffuntracked\n"
+
+
+class Tests:
+    def __init__(self) -> None:
+        self.count = 0
+        self.failures: list[str] = []
+
+    def equal(self, label: str, actual: Any, expected: Any) -> None:
+        self.count += 1
+        if actual == expected:
+            print(f"  [PASS] {label}")
+            return
+        self.failures.append(
+            f"{label}: expected {expected!r}, found {actual!r}"
+        )
+        print(f"  [FAIL] {label}: {actual!r}")
+
+    def true(self, label: str, value: Any) -> None:
+        self.equal(label, bool(value), True)
+
+    def raises(
+        self,
+        label: str,
+        invoke: Callable[[], Any],
+        contains: str,
+    ) -> None:
+        self.count += 1
+        try:
+            invoke()
+        except Exception as exc:  # noqa: BLE001 - intentional tamper injection
+            if contains in str(exc):
+                print(f"  [PASS] {label}")
+                return
+            self.failures.append(
+                f"{label}: error did not contain {contains!r}: {exc}"
+            )
+            print(f"  [FAIL] {label}: {exc}")
+            return
+        self.failures.append(f"{label}: expected an exception")
+        print(f"  [FAIL] {label}: no exception")
+
+
+def _git(repo: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"git {' '.join(args)} failed: {completed.stderr.strip()}"
+        )
+    return completed.stdout.strip()
+
+
+def _fixture(root: Path) -> Dict[str, Any]:
+    primary = root / "primary"
+    primary.mkdir()
+    _git(primary, "init", "-q", "-b", "murmur")
+    _git(primary, "config", "user.name", "QueaT")
+    _git(primary, "config", "user.email", "kgm004a@gmail.com")
+    (primary / "owned.bin").write_bytes(b"base\n")
+    _git(primary, "add", "owned.bin")
+    _git(primary, "commit", "-q", "-m", "base")
+    base = _git(primary, "rev-parse", "HEAD")
+
+    worktree = root / "task" / "meetnotes"
+    worktree.parent.mkdir()
+    branch = "agent/v2/fault-selftest"
+    _git(
+        primary,
+        "worktree",
+        "add",
+        "-q",
+        "-b",
+        branch,
+        str(worktree),
+        base,
+    )
+    (worktree / "owned.bin").write_bytes(A_BYTES)
+    (worktree / "untracked.bin").write_bytes(UNTRACKED_BYTES)
+    executable = worktree / "exact.sh"
+    executable.write_bytes(b"#!/bin/sh\nprintf exact\n")
+    executable.chmod(0o755)
+
+    common = Path(
+        _git(
+            primary,
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-common-dir",
+        )
+    ).resolve()
+    task_dir = common / "agent-harness" / "v2" / "tasks" / "fault-selftest"
+    attempt_dir = task_dir / "attempts" / ("a" * 64)
+    (attempt_dir / "checks").mkdir(parents=True)
+    contract: Dict[str, Any] = {
+        "schema_version": 2,
+        "task_id": "fault-selftest",
+        "description": "exercise immutable snapshot fault boundaries",
+        "kind": "harness",
+        "base_sha": base,
+        "contract_sha256": "",
+        "repo_realpath": str(primary.resolve()),
+        "git_common_dir": str(common),
+        "worktree_path": str(worktree.resolve()),
+        "branch": branch,
+        "owned_paths": ["owned.bin", "untracked.bin", "exact.sh"],
+        "claims": [],
+        "reviewer": "fake",
+        "expected_change": True,
+        "degraded_provenance": [],
+        "created_at": legacy.utc_now(),
+    }
+    contract["contract_sha256"] = verifier.document_hash(
+        contract, "contract_sha256"
+    )
+    legacy.atomic_write_json(task_dir / "task.json", contract)
+    paths, diff, tree_sha = verifier.snapshot_scoped_diff(
+        worktree, contract, task_dir
+    )
+    plan = {
+        "schema_version": 2,
+        "task_id": contract["task_id"],
+        "contract_sha256": contract["contract_sha256"],
+        "base_sha": base,
+        "diff_sha256": legacy.sha256_bytes(diff),
+        "tree_sha": tree_sha,
+        "protocol_sha256": "2" * 64,
+        "changed_paths": paths,
+        "claims": [],
+        "actual_risk_flags": [],
+        "checks": [],
+        "reviews": [{"kind": "combined", "vendor": "fake"}],
+        "server_required": False,
+        "created_at": contract["created_at"],
+        "plan_sha256": "1" * 64,
+    }
+    snapshot = harness_cli._ensure_verification_snapshot(
+        contract, task_dir, plan, attempt_dir
+    )
+    return {
+        "primary": primary,
+        "worktree": worktree,
+        "task_dir": task_dir,
+        "attempt_dir": attempt_dir,
+        "contract": contract,
+        "plan": plan,
+        "diff": diff,
+        "snapshot": snapshot,
+    }
+
+
+def _wait_for(path: Path, process: subprocess.Popen[str]) -> None:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if path.is_file():
+            return
+        if process.poll() is not None:
+            raise RuntimeError(
+                "slow snapshot reader exited before its synchronization point"
+            )
+        time.sleep(0.01)
+    raise RuntimeError("slow snapshot reader did not reach its synchronization point")
+
+
+def snapshot_aba_and_reconstruction_cases(test: Tests) -> None:
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-fault-snapshot-") as raw:
+        values = _fixture(Path(raw))
+        worktree: Path = values["worktree"]
+        snapshot: Path = values["snapshot"]
+        task_dir: Path = values["task_dir"]
+        attempt_dir: Path = values["attempt_dir"]
+        contract: Mapping[str, Any] = values["contract"]
+        plan: Mapping[str, Any] = values["plan"]
+
+        ready = Path(raw) / "slow-check.ready"
+        release = Path(raw) / "slow-check.release"
+        child_code = (
+            "import hashlib,json,pathlib,sys,time;"
+            "target=pathlib.Path('owned.bin');"
+            "first=target.read_bytes();"
+            "pathlib.Path(sys.argv[1]).write_text('ready');"
+            "release=pathlib.Path(sys.argv[2]);"
+            "deadline=time.monotonic()+5;"
+            "\nwhile not release.exists() and time.monotonic()<deadline:"
+            "\n time.sleep(0.01)"
+            "\nsecond=target.read_bytes();"
+            "\nprint(json.dumps({'first':hashlib.sha256(first).hexdigest(),"
+            "'second':hashlib.sha256(second).hexdigest()}))"
+        )
+        process = subprocess.Popen(
+            [sys.executable, "-c", child_code, str(ready), str(release)],
+            cwd=str(snapshot),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            _wait_for(ready, process)
+            (worktree / "owned.bin").write_bytes(B_BYTES)
+            _, b_diff, b_tree = verifier.snapshot_scoped_diff(
+                worktree, contract, task_dir
+            )
+            test.true(
+                "SNAPSHOT source B really differs while the slow check is running",
+                legacy.sha256_bytes(b_diff) != plan["diff_sha256"]
+                and b_tree != plan["tree_sha"],
+            )
+            test.equal(
+                "SNAPSHOT slow check still reads immutable A during source B",
+                (snapshot / "owned.bin").read_bytes(),
+                A_BYTES,
+            )
+            (worktree / "owned.bin").write_bytes(A_BYTES)
+            _, restored_diff, restored_tree = verifier.snapshot_scoped_diff(
+                worktree, contract, task_dir
+            )
+            test.true(
+                "SNAPSHOT source A-B-A returns to the exact planned identity",
+                legacy.sha256_bytes(restored_diff) == plan["diff_sha256"]
+                and restored_tree == plan["tree_sha"],
+            )
+            release.write_text("continue", encoding="utf-8")
+            stdout, stderr = process.communicate(timeout=5)
+        finally:
+            if process.poll() is None:
+                process.kill()
+                process.wait(timeout=2)
+        test.equal(
+            "SNAPSHOT slow check survives source A-B-A without byte drift",
+            json.loads(stdout),
+            {
+                "first": hashlib.sha256(A_BYTES).hexdigest(),
+                "second": hashlib.sha256(A_BYTES).hexdigest(),
+            },
+        )
+        test.equal("SNAPSHOT slow check has no hidden error", stderr, "")
+        snapshot_paths, snapshot_diff, snapshot_tree = (
+            verifier.snapshot_scoped_diff(snapshot, contract, task_dir)
+        )
+        test.true(
+            "SNAPSHOT evidence identity remains bound to A",
+            snapshot_paths == plan["changed_paths"]
+            and legacy.sha256_bytes(snapshot_diff) == plan["diff_sha256"]
+            and snapshot_tree == plan["tree_sha"],
+        )
+
+        original_bytes = {
+            relative: (snapshot / relative).read_bytes()
+            for relative in ("owned.bin", "untracked.bin", "exact.sh")
+        }
+        reference = harness_cli._verification_snapshot_ref(
+            contract["task_id"], attempt_dir.name
+        )
+        anchored_commit = _git(
+            values["primary"], "rev-parse", "--verify", reference
+        )
+        harness_cli._discard_claimed_verification_snapshot(
+            contract, attempt_dir, snapshot
+        )
+        test.true(
+            "SNAPSHOT cleanup removes only the materialized clone",
+            not snapshot.exists(),
+        )
+        test.equal(
+            "SNAPSHOT cleanup preserves the immutable reconstruction anchor",
+            _git(values["primary"], "rev-parse", "--verify", reference),
+            anchored_commit,
+        )
+        snapshot.mkdir()
+        (snapshot / "partial-after-crash").write_bytes(b"partial")
+        rebuilt = harness_cli._ensure_verification_snapshot(
+            contract, task_dir, plan, attempt_dir
+        )
+        test.true(
+            "SNAPSHOT resume replaces a partial clone from the durable anchor",
+            not (rebuilt / "partial-after-crash").exists(),
+        )
+        test.equal(
+            "SNAPSHOT reconstruction preserves every tracked/untracked byte",
+            {
+                relative: (rebuilt / relative).read_bytes()
+                for relative in ("owned.bin", "untracked.bin", "exact.sh")
+            },
+            original_bytes,
+        )
+        test.true(
+            "SNAPSHOT reconstruction preserves executable mode",
+            bool((rebuilt / "exact.sh").stat().st_mode & 0o111),
+        )
+        rebuilt_paths, rebuilt_diff, rebuilt_tree = verifier.snapshot_scoped_diff(
+            rebuilt, contract, task_dir
+        )
+        test.true(
+            "SNAPSHOT reconstruction preserves exact diff and tree evidence",
+            rebuilt_paths == plan["changed_paths"]
+            and rebuilt_diff == values["diff"]
+            and rebuilt_tree == plan["tree_sha"],
+        )
+
+
+def cached_artifact_tamper_case(test: Tests) -> None:
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-fault-cache-") as raw:
+        values = _fixture(Path(raw))
+        contract: Mapping[str, Any] = values["contract"]
+        plan: Mapping[str, Any] = values["plan"]
+        task_dir: Path = values["task_dir"]
+        attempt_dir: Path = values["attempt_dir"]
+        snapshot: Path = values["snapshot"]
+        declared = {
+            "id": "synthetic-cache",
+            "command": "runner-owned synthetic check",
+            "timeout_seconds": 5,
+        }
+        counter = 0
+        original_run_check = legacy.run_check
+
+        def synthetic_run_check(
+            _worktree: Path,
+            task: Path,
+            check: Mapping[str, Any],
+            phase: str,
+        ) -> Dict[str, Any]:
+            nonlocal counter
+            counter += 1
+            log_path = task / "logs" / f"fault-cache-{counter}.log"
+            stdout_path = log_path.with_suffix(".stdout.log")
+            stderr_path = log_path.with_suffix(".stderr.log")
+            sandbox_path = task / "runtime" / f"fault-cache-{counter}.sb"
+            guardian_path = task / "runtime" / f"fault-cache-{counter}.json"
+            for path, content in (
+                (log_path, f"run {counter}\n".encode()),
+                (stdout_path, b"green\n"),
+                (stderr_path, b""),
+                (sandbox_path, b"(version 1)\n"),
+                (guardian_path, b'{"clean":true}\n'),
+            ):
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_bytes(content)
+            return {
+                "id": check["id"],
+                "command": check["command"],
+                "phase": phase,
+                "exit_code": 0,
+                "timed_out": False,
+                "duration_ms": 1,
+                "resource_wait_ms": 0,
+                "execution_id": f"synthetic-{counter}",
+                "log_path": str(log_path),
+                "log_sha256": legacy.sha256_file(log_path),
+                "stdout_path": str(stdout_path),
+                "stdout_sha256": legacy.sha256_file(stdout_path),
+                "stderr_path": str(stderr_path),
+                "stderr_sha256": legacy.sha256_file(stderr_path),
+                "sandbox_profile_path": str(sandbox_path),
+                "sandbox_profile_sha256": legacy.sha256_file(sandbox_path),
+                "guardian_path": str(guardian_path),
+                "guardian_sha256": legacy.sha256_file(guardian_path),
+                "leader_exited_with_live_group": False,
+                "passed": True,
+                "outcome": "PASS",
+            }
+
+        legacy.run_check = synthetic_run_check
+        try:
+            first, first_did_run = harness_cli._run_or_resume_check(
+                contract,
+                task_dir,
+                plan,
+                attempt_dir,
+                declared,
+                snapshot,
+                checkpoint_number=1,
+            )
+            first_log = Path(first["evidence"]["log_path"])
+            first_log.write_bytes(first_log.read_bytes() + b"tampered\n")
+            second, second_did_run = harness_cli._run_or_resume_check(
+                contract,
+                task_dir,
+                plan,
+                attempt_dir,
+                declared,
+                snapshot,
+                checkpoint_number=2,
+            )
+        finally:
+            legacy.run_check = original_run_check
+        test.true(
+            "CACHE initial exact-diff checkpoint executes once",
+            first_did_run and counter == 2,
+        )
+        test.true(
+            "CACHE corrupt artifact is rejected and rerun, never reused",
+            second_did_run
+            and second["evidence"]["passed"]
+            and second["evidence"]["log_path"] != str(first_log),
+        )
+        test.equal(
+            "CACHE rerun publishes evidence for the second execution",
+            Path(second["evidence"]["log_path"]).read_bytes(),
+            b"run 2\n",
+        )
+
+
+def prompt_policy_tamper_cases(test: Tests) -> None:
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-fault-prompt-") as raw:
+        values = _fixture(Path(raw))
+        contract: Mapping[str, Any] = values["contract"]
+        plan: Mapping[str, Any] = values["plan"]
+        snapshot: Path = values["snapshot"]
+        task_dir: Path = values["task_dir"]
+        run_dir = values["attempt_dir"] / "review-runs" / "combined"
+        review = {"kind": "combined", "vendor": "fake"}
+        record = verifier.invoke_readonly_review(
+            contract=contract,
+            plan=plan,
+            worktree=snapshot,
+            attempt_dir=run_dir,
+            diff=values["diff"],
+            checks=[],
+            review=review,
+            probe_evidence_sha256=verifier.probe_evidence_hash([]),
+            allow_test_adapter=True,
+            sleep=lambda _delay: None,
+        )
+        prompt = verifier.combined_review_prompt(
+            contract,
+            plan,
+            values["diff"],
+            [],
+            "combined",
+            snapshot,
+        )
+        expected_prompt_sha = legacy.sha256_bytes(prompt.encode("utf-8"))
+        verifier.validate_review_checkpoint(
+            record,
+            review,
+            plan,
+            task_dir,
+            expected_prompt_sha256=expected_prompt_sha,
+            allow_test_adapter=True,
+        )
+        test.true(
+            "PROMPT untouched runner/model artifacts validate",
+            record["prompt_sha256"] == expected_prompt_sha,
+        )
+
+        forged = copy.deepcopy(record)
+        forged["prompt_sha256"] = "f" * 64
+        test.raises(
+            "PROMPT substituted checkpoint hash is rejected",
+            lambda: verifier.validate_review_checkpoint(
+                forged,
+                review,
+                plan,
+                task_dir,
+                expected_prompt_sha256=expected_prompt_sha,
+                allow_test_adapter=True,
+            ),
+            "prompt hash changed",
+        )
+
+        policy = legacy.read_prompt("combined-reviewer")
+        drifted_prompt = verifier.combined_review_prompt(
+            contract,
+            plan,
+            values["diff"],
+            [],
+            "combined",
+            snapshot,
+            policy_text=policy + "\nFAULT POLICY DRIFT\n",
+        )
+        drifted_prompt_sha = legacy.sha256_bytes(
+            drifted_prompt.encode("utf-8")
+        )
+        test.true(
+            "POLICY drift produces a distinct review input binding",
+            drifted_prompt_sha != expected_prompt_sha,
+        )
+        test.raises(
+            "POLICY drift rejects the cached review rather than laundering it",
+            lambda: verifier.validate_review_checkpoint(
+                record,
+                review,
+                plan,
+                task_dir,
+                expected_prompt_sha256=drifted_prompt_sha,
+                allow_test_adapter=True,
+            ),
+            "prompt hash changed",
+        )
+
+
+def protocol_manifest_cases(test: Tests) -> None:
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-fault-protocol-") as raw:
+        fixture = Path(raw) / "fixture"
+        manifest = verifier.protocol_relative_paths(ROOT)
+        for relative in manifest:
+            source = ROOT / relative
+            target = fixture / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+        baseline = verifier.protocol_bundle(fixture)["protocol_sha256"]
+
+        expected_python = {
+            path.relative_to(ROOT).as_posix()
+            for path in (ROOT / ".agents" / "harness").glob("*.py")
+            if path.is_file() and not path.is_symlink()
+        }
+        test.true(
+            "PROTOCOL manifest automatically binds every harness Python module",
+            expected_python.issubset(set(manifest))
+            and ".agents/harness/v2_fault_selftest.py" in manifest,
+        )
+        checked_inputs = {
+            "AGENTS.md",
+            "CLAUDE.md",
+            ".claude/settings.json",
+            ".codex/config.toml",
+            ".codex/hooks.json",
+            ".codex/rules/agentic-workflow.md",
+            ".claude/rules/agentic-workflow.md",
+        }
+        test.true(
+            "PROTOCOL manifest binds checked vendor settings and instructions",
+            checked_inputs.issubset(set(manifest)),
+        )
+
+        representatives = (
+            (".agents/harness/verifier.py", "runner code"),
+            (
+                ".agents/harness/prompts/combined-reviewer.md",
+                "review policy",
+            ),
+            (".claude/settings.json", "Claude sandbox settings"),
+            (".codex/config.toml", "Codex configuration"),
+            (".codex/rules/agentic-workflow.md", "workflow instruction"),
+            ("AGENTS.md", "root project instruction"),
+        )
+        for relative, label in representatives:
+            path = fixture / relative
+            original = path.read_bytes()
+            path.write_bytes(original + b"\n# fault drift\n")
+            drifted = verifier.protocol_bundle(fixture)["protocol_sha256"]
+            test.true(
+                f"PROTOCOL {label} drift changes the protocol hash",
+                drifted != baseline,
+            )
+            path.write_bytes(original)
+            test.equal(
+                f"PROTOCOL restoring {label} restores the protocol hash",
+                verifier.protocol_bundle(fixture)["protocol_sha256"],
+                baseline,
+            )
+
+        future_module = fixture / ".agents" / "harness" / "future_module.py"
+        future_module.write_text("VALUE = 'new executable module'\n", encoding="utf-8")
+        test.true(
+            "PROTOCOL an unlisted future Python module cannot escape the hash",
+            verifier.protocol_bundle(fixture)["protocol_sha256"] != baseline
+            and ".agents/harness/future_module.py"
+            in verifier.protocol_relative_paths(fixture),
+        )
+        future_module.unlink()
+        future_module.symlink_to(fixture / ".agents" / "harness" / "verifier.py")
+        test.raises(
+            "PROTOCOL a symlinked future Python module fails closed",
+            lambda: verifier.protocol_relative_paths(fixture),
+            "Python module is missing or unsafe",
+        )
+
+
+def main() -> int:
+    test = Tests()
+    snapshot_aba_and_reconstruction_cases(test)
+    cached_artifact_tamper_case(test)
+    prompt_policy_tamper_cases(test)
+    protocol_manifest_cases(test)
+    if test.failures:
+        print("v2 fault selftest: FAIL")
+        for failure in test.failures:
+            print(f"  - {failure}")
+        return 1
+    print(f"v2 fault selftest: PASS ({test.count} assertions)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/harness/v2_selftest.py
+++ b/.agents/harness/v2_selftest.py
@@ -1,0 +1,3130 @@
+#!/usr/bin/env python3
+"""Dependency-free deterministic fault tests for Harness v2."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import contextlib
+import hashlib
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any, Dict, List, Mapping, Sequence
+
+import cli as harness_cli
+import task_runner as legacy
+import verifier
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CANONICAL_MURMUR_ORIGIN = "https://github.com/murmur-io/murmur.git"
+
+
+class Tests:
+    def __init__(self) -> None:
+        self.count = 0
+        self.failures: List[str] = []
+
+    def equal(self, label: str, actual: Any, expected: Any) -> None:
+        self.count += 1
+        if actual == expected:
+            print(f"  [PASS] {label}")
+        else:
+            self.failures.append(
+                f"{label}: expected {expected!r}, found {actual!r}"
+            )
+            print(f"  [FAIL] {label}: {actual!r}")
+
+    def true(self, label: str, value: bool) -> None:
+        self.equal(label, bool(value), True)
+
+    def raises(self, label: str, function: Any, contains: str = "") -> None:
+        self.count += 1
+        try:
+            function()
+        except Exception as exc:  # noqa: BLE001 - fault-injection assertion
+            if not contains or contains in str(exc):
+                print(f"  [PASS] {label}")
+                return
+            self.failures.append(
+                f"{label}: error did not contain {contains!r}: {exc}"
+            )
+            print(f"  [FAIL] {label}: {exc}")
+            return
+        self.failures.append(f"{label}: expected an exception")
+        print(f"  [FAIL] {label}: no exception")
+
+
+def _git(repo: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=str(repo),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"git {' '.join(args)} failed: {completed.stderr.strip()}"
+        )
+    return completed.stdout.strip()
+
+
+def _init_repo(repo: Path) -> str:
+    repo.mkdir(parents=True)
+    _git(repo, "init", "-q", "-b", "murmur")
+    _git(repo, "config", "user.name", "QueaT")
+    _git(repo, "config", "user.email", "kgm004a@gmail.com")
+    (repo / "owned.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", "owned.txt")
+    _git(repo, "commit", "-q", "-m", "base")
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _standalone_driver(
+    root: Path,
+    *,
+    name: str = ".murmur-agent-driver",
+    canonical_origin: bool = True,
+    detached: bool = True,
+) -> tuple[Path, Path, str]:
+    primary = root / "meetnotes"
+    base = _init_repo(primary)
+    driver = root / name
+    _git(
+        primary,
+        "clone",
+        "-q",
+        "--local",
+        "--no-hardlinks",
+        "--no-checkout",
+        str(primary),
+        str(driver),
+    )
+    _git(driver, "config", "user.name", "QueaT")
+    _git(driver, "config", "user.email", "kgm004a@gmail.com")
+    if canonical_origin:
+        _git(driver, "remote", "set-url", "origin", CANONICAL_MURMUR_ORIGIN)
+    if detached:
+        _git(driver, "checkout", "-q", "--detach", base)
+    else:
+        _git(driver, "checkout", "-q", "murmur")
+    return primary, driver, base
+
+
+def _invoke_open(driver: Path, args: argparse.Namespace) -> int:
+    previous = Path.cwd()
+    try:
+        os.chdir(driver)
+        with contextlib.redirect_stdout(io.StringIO()):
+            return harness_cli.cmd_open(args)
+    finally:
+        os.chdir(previous)
+
+
+def _git_tree_digest(git_dir: Path) -> str:
+    digest = hashlib.sha256()
+    for current, directories, files in os.walk(git_dir, followlinks=False):
+        directories.sort()
+        files.sort()
+        current_path = Path(current)
+        for name in [*directories, *files]:
+            path = current_path / name
+            relative = path.relative_to(git_dir).as_posix()
+            metadata = path.lstat()
+            digest.update(relative.encode("utf-8"))
+            digest.update(b"\0")
+            digest.update(str(metadata.st_mode).encode("ascii"))
+            digest.update(b"\0")
+            if path.is_symlink():
+                digest.update(os.readlink(path).encode("utf-8"))
+            elif path.is_file():
+                digest.update(path.read_bytes())
+            digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _open_args(task_id: str, base: str, branch: str) -> argparse.Namespace:
+    return argparse.Namespace(
+        task_id=task_id,
+        prompt="open branch ownership selftest",
+        prompt_file=None,
+        owned=["owned.txt"],
+        claim=[],
+        reviewer="codex",
+        base=base,
+        branch=branch,
+        kind="harness",
+        expected_change=True,
+    )
+
+
+def open_branch_ownership_cases(test: Tests) -> None:
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-open-") as raw:
+        root = Path(raw)
+        _primary, driver, base = _standalone_driver(root)
+        common = Path(
+            _git(
+                driver,
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-common-dir",
+            )
+        )
+        branch = "agent/v2/existing-valuable"
+        _git(driver, "checkout", "-q", "-b", branch)
+        (driver / "owned.txt").write_text(
+            "base\nvaluable branch content\n", encoding="utf-8"
+        )
+        _git(driver, "add", "owned.txt")
+        _git(driver, "commit", "-q", "-m", "valuable branch")
+        valuable_oid = _git(driver, "rev-parse", "HEAD")
+        _git(driver, "checkout", "-q", "--detach", base)
+
+        test.raises(
+            "OPEN rejects a pre-existing exact local branch",
+            lambda: _invoke_open(
+                driver,
+                _open_args("existing-valuable", base, branch),
+            ),
+            "branch already exists",
+        )
+        test.equal(
+            "OPEN preserves a pre-existing valuable branch",
+            harness_cli._local_branch_oid(driver, branch),
+            valuable_oid,
+        )
+        test.true(
+            "OPEN preflight leaves no task record",
+            not harness_cli.v2_task_dir(common, "existing-valuable").exists(),
+        )
+
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-open-failure-") as raw:
+        root = Path(raw)
+        _primary, driver, base = _standalone_driver(root)
+        branch = "agent/v2/forced-add-failure"
+        original_run_capture = legacy.run_capture
+
+        def fail_worktree_add(
+            argv: Sequence[str],
+            cwd: Path | None = None,
+            *,
+            check: bool = True,
+            env: Mapping[str, str] | None = None,
+        ) -> subprocess.CompletedProcess:
+            if list(argv[:3]) == ["git", "worktree", "add"]:
+                raise legacy.HarnessError("forced worktree-add failure")
+            return original_run_capture(
+                argv,
+                cwd,
+                check=check,
+                env=env,
+            )
+
+        legacy.run_capture = fail_worktree_add
+        try:
+            test.raises(
+                "OPEN reports a forced worktree-add failure",
+                lambda: _invoke_open(
+                    driver,
+                    _open_args("forced-add-failure", base, branch),
+                ),
+                "forced worktree-add failure",
+            )
+        finally:
+            legacy.run_capture = original_run_capture
+        test.equal(
+            "OPEN deletes its unchanged branch after worktree-add failure",
+            harness_cli._local_branch_oid(driver, branch),
+            None,
+        )
+
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-open-moved-") as raw:
+        root = Path(raw)
+        _primary, driver, base = _standalone_driver(root)
+        (driver / "owned.txt").write_text(
+            "base\nvaluable moved content\n", encoding="utf-8"
+        )
+        _git(driver, "add", "owned.txt")
+        _git(driver, "commit", "-q", "-m", "valuable moved tip")
+        valuable_oid = _git(driver, "rev-parse", "HEAD")
+        _git(driver, "checkout", "-q", "--detach", base)
+        branch = "agent/v2/moved-during-failure"
+        original_run_capture = legacy.run_capture
+
+        def move_then_fail_worktree_add(
+            argv: Sequence[str],
+            cwd: Path | None = None,
+            *,
+            check: bool = True,
+            env: Mapping[str, str] | None = None,
+        ) -> subprocess.CompletedProcess:
+            if list(argv[:3]) == ["git", "worktree", "add"]:
+                _git(
+                    driver,
+                    "update-ref",
+                    f"refs/heads/{branch}",
+                    valuable_oid,
+                )
+                raise legacy.HarnessError("forced moved-branch failure")
+            return original_run_capture(
+                argv,
+                cwd,
+                check=check,
+                env=env,
+            )
+
+        legacy.run_capture = move_then_fail_worktree_add
+        try:
+            test.raises(
+                "OPEN reports failure after its branch moves",
+                lambda: _invoke_open(
+                    driver,
+                    _open_args("moved-during-failure", base, branch),
+                ),
+                "forced moved-branch failure",
+            )
+        finally:
+            legacy.run_capture = original_run_capture
+        test.equal(
+            "OPEN preserves a created branch that no longer has the expected OID",
+            harness_cli._local_branch_oid(driver, branch),
+            valuable_oid,
+        )
+
+
+def standalone_driver_open_cases(test: Tests) -> None:
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-driver-open-") as raw:
+        root = Path(raw)
+        primary, driver, base = _standalone_driver(root)
+        empty_alternates = driver / ".git" / "objects" / "info" / "alternates"
+        empty_alternates.parent.mkdir(parents=True, exist_ok=True)
+        empty_alternates.write_bytes(b"")
+        primary_git = primary / ".git"
+        primary_refs_before = _git(
+            primary,
+            "for-each-ref",
+            "--format=%(refname) %(objectname)",
+        )
+        primary_worktrees_before = _git(
+            primary, "worktree", "list", "--porcelain"
+        )
+        primary_digest_before = _git_tree_digest(primary_git)
+
+        task_id = "standalone-isolation"
+        branch = f"agent/v2/{task_id}"
+        opened = _invoke_open(
+            driver,
+            _open_args(task_id, base, branch),
+        )
+        primary_refs_after = _git(
+            primary,
+            "for-each-ref",
+            "--format=%(refname) %(objectname)",
+        )
+        primary_worktrees_after = _git(
+            primary, "worktree", "list", "--porcelain"
+        )
+        primary_digest_after = _git_tree_digest(primary_git)
+
+        common = (driver / ".git").resolve()
+        task_dir = harness_cli.v2_task_dir(common, task_id)
+        task_root = root / ".murmur-agent-tasks" / "v2" / task_id
+        worktree = task_root / "meetnotes"
+        contract = legacy.load_json(task_dir / "task.json")
+        runtime = legacy.load_json(task_dir / "runtime.json")
+        metadata_valid = True
+        try:
+            loaded, loaded_dir, loaded_common = harness_cli.load_v2_task(
+                task_id, driver
+            )
+            state = harness_cli.load_v2_state(task_dir)
+            metadata_valid = (
+                loaded == contract
+                and loaded_dir == task_dir
+                and loaded_common == common
+                and state.get("status") == "OPEN"
+            )
+        except Exception:  # noqa: BLE001 - aggregate metadata assertion
+            metadata_valid = False
+
+        test.equal("OPEN standalone driver succeeds offline", opened, 0)
+        test.equal(
+            "OPEN creates task branch only in driver common",
+            harness_cli._local_branch_oid(driver, branch),
+            base,
+        )
+        test.equal(
+            "OPEN creates no task branch in user primary",
+            harness_cli._local_branch_oid(primary, branch),
+            None,
+        )
+        test.equal(
+            "OPEN leaves user primary refs byte-for-byte equivalent",
+            primary_refs_after,
+            primary_refs_before,
+        )
+        test.equal(
+            "OPEN leaves user primary worktree registry unchanged",
+            primary_worktrees_after,
+            primary_worktrees_before,
+        )
+        test.equal(
+            "OPEN leaves user primary .git digest unchanged",
+            primary_digest_after,
+            primary_digest_before,
+        )
+        test.equal(
+            "OPEN task worktree uses fixed meetnotes leaf",
+            worktree.name,
+            "meetnotes",
+        )
+        test.true(
+            "OPEN task worktree exists at the dedicated task root",
+            worktree.is_dir() and not worktree.is_symlink(),
+        )
+        test.equal(
+            "OPEN task worktree is registered only in driver common",
+            Path(
+                _git(
+                    worktree,
+                    "rev-parse",
+                    "--path-format=absolute",
+                    "--git-common-dir",
+                )
+            ).resolve(),
+            common,
+        )
+        test.equal(
+            "OPEN contract records standalone driver common",
+            contract["git_common_dir"],
+            str(common),
+        )
+        test.equal(
+            "OPEN contract records fixed task worktree",
+            contract["worktree_path"],
+            str(worktree.resolve()),
+        )
+        test.equal(
+            "OPEN runtime records exact safe task root",
+            runtime["task_root"],
+            str(task_root.resolve()),
+        )
+        test.true("OPEN writes valid task metadata and state", metadata_valid)
+        test.equal(
+            "OPEN leaves standalone driver HEAD detached",
+            _git(driver, "branch", "--show-current"),
+            "",
+        )
+
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-driver-linked-") as raw:
+        root = Path(raw)
+        primary = root / "meetnotes"
+        base = _init_repo(primary)
+        _git(primary, "remote", "add", "origin", CANONICAL_MURMUR_ORIGIN)
+        driver = root / ".murmur-agent-driver"
+        _git(
+            primary,
+            "worktree",
+            "add",
+            "-q",
+            "--detach",
+            str(driver),
+            base,
+        )
+        test.raises(
+            "OPEN rejects a linked driver worktree",
+            lambda: _invoke_open(
+                driver,
+                _open_args(
+                    "reject-linked",
+                    base,
+                    "agent/v2/reject-linked",
+                ),
+            ),
+            "linked driver worktrees are forbidden",
+        )
+
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-driver-origin-") as raw:
+        root = Path(raw)
+        _primary, driver, base = _standalone_driver(
+            root, canonical_origin=False
+        )
+        test.raises(
+            "OPEN rejects a local origin",
+            lambda: _invoke_open(
+                driver,
+                _open_args(
+                    "reject-local-origin",
+                    base,
+                    "agent/v2/reject-local-origin",
+                ),
+            ),
+            "local/file origins are forbidden",
+        )
+
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-driver-symlink-") as raw:
+        root = Path(raw)
+        _primary, driver, base = _standalone_driver(root)
+        redirected = root / "redirected-tasks"
+        redirected.mkdir()
+        (root / ".murmur-agent-tasks").symlink_to(
+            redirected, target_is_directory=True
+        )
+        branch = "agent/v2/reject-symlink-root"
+        test.raises(
+            "OPEN rejects a symlinked task-root component",
+            lambda: _invoke_open(
+                driver,
+                _open_args("reject-symlink-root", base, branch),
+            ),
+            "unsafe or symlinked",
+        )
+        test.equal(
+            "OPEN rejects symlink root before branch mutation",
+            harness_cli._local_branch_oid(driver, branch),
+            None,
+        )
+
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-driver-dirty-") as raw:
+        root = Path(raw)
+        _primary, driver, base = _standalone_driver(root)
+        (driver / "owned.txt").write_text(
+            "base\ndirty driver\n", encoding="utf-8"
+        )
+        test.raises(
+            "OPEN rejects a dirty standalone driver",
+            lambda: _invoke_open(
+                driver,
+                _open_args(
+                    "reject-dirty",
+                    base,
+                    "agent/v2/reject-dirty",
+                ),
+            ),
+            "must be clean",
+        )
+
+    with tempfile.TemporaryDirectory(
+        prefix="murmur-v2-driver-alternates-"
+    ) as raw:
+        root = Path(raw)
+        primary, driver, base = _standalone_driver(root)
+        alternates = driver / ".git" / "objects" / "info" / "alternates"
+        alternates.parent.mkdir(parents=True, exist_ok=True)
+        alternates.write_text(
+            str(primary / ".git" / "objects") + "\n",
+            encoding="utf-8",
+        )
+        test.raises(
+            "OPEN rejects nonempty object alternates",
+            lambda: _invoke_open(
+                driver,
+                _open_args(
+                    "reject-alternates",
+                    base,
+                    "agent/v2/reject-alternates",
+                ),
+            ),
+            "alternates must be absent or empty",
+        )
+
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-driver-attached-") as raw:
+        root = Path(raw)
+        _primary, driver, base = _standalone_driver(root, detached=False)
+        test.raises(
+            "OPEN rejects an attached standalone driver HEAD",
+            lambda: _invoke_open(
+                driver,
+                _open_args(
+                    "reject-attached",
+                    base,
+                    "agent/v2/reject-attached",
+                ),
+            ),
+            "HEAD must be detached",
+        )
+
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-driver-name-") as raw:
+        root = Path(raw)
+        _primary, driver, base = _standalone_driver(root, name="driver")
+        test.raises(
+            "OPEN rejects a standalone clone with the wrong directory name",
+            lambda: _invoke_open(
+                driver,
+                _open_args(
+                    "reject-name",
+                    base,
+                    "agent/v2/reject-name",
+                ),
+            ),
+            ".murmur-agent-driver",
+        )
+
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-driver-existing-") as raw:
+        root = Path(raw)
+        _primary, driver, base = _standalone_driver(root)
+        task_id = "reject-existing-root"
+        branch = f"agent/v2/{task_id}"
+        task_root = root / ".murmur-agent-tasks" / "v2" / task_id
+        task_root.mkdir(parents=True)
+        test.raises(
+            "OPEN rejects a pre-existing task root",
+            lambda: _invoke_open(
+                driver,
+                _open_args(task_id, base, branch),
+            ),
+            "task root already exists",
+        )
+        test.equal(
+            "OPEN rejects pre-existing root before branch mutation",
+            harness_cli._local_branch_oid(driver, branch),
+            None,
+        )
+
+
+def _profile(
+    paths: Sequence[str], claims: Sequence[str] = ()
+) -> tuple[List[str], List[str], List[str]]:
+    checks, reviews, risks = verifier.derive_profile(
+        list(paths),
+        list(claims),
+        legacy.load_config(),
+        reviewer="claude",
+    )
+    return (
+        [item["id"] for item in checks],
+        [item["kind"] for item in reviews],
+        risks,
+    )
+
+
+def profile_cases(test: Tests) -> None:
+    checks, reviews, risks = _profile(["docs/guide.md"])
+    test.equal("PROFILE docs has no build check", checks, [])
+    test.equal("PROFILE docs still has combined review", reviews, ["combined"])
+    test.equal("PROFILE docs has no sensitive review", risks, [])
+
+    checks, reviews, _ = _profile(["src-tauri/src/transcribe/render.rs"])
+    test.equal("PROFILE Rust source always runs rust-lib", checks, ["rust-lib"])
+    test.true("PROFILE Rust source has combined review", reviews == ["combined"])
+    test.true("PROFILE Rust path does not infer runtime", "tauri-boot" not in checks)
+    test.true("PROFILE Rust path does not infer performance", "perf-contracts" not in checks)
+
+    checks, _, _ = _profile(["src-tauri/Cargo.toml"])
+    test.equal("PROFILE Rust manifest runs rust-lib", checks, ["rust-lib"])
+
+    checks, reviews, _ = _profile(["src/app/features/detail/detail.ts"])
+    test.equal(
+        "PROFILE Angular behavior runs lint build Playwright",
+        checks,
+        ["ng-lint", "ng-build", "playwright"],
+    )
+    test.equal("PROFILE Angular behavior has one reviewer", reviews, ["combined"])
+
+    checks, _, _ = _profile(["src/app/features/detail/detail.scss"])
+    test.equal(
+        "PROFILE Angular style runs lint and build only",
+        checks,
+        ["ng-lint", "ng-build"],
+    )
+
+    checks, _, _ = _profile(
+        ["src-tauri/src/lib.rs", "src/app/core/ipc.service.ts"]
+    )
+    test.equal(
+        "PROFILE mixed surface is stable union",
+        checks,
+        ["rust-lib", "ng-lint", "ng-build", "playwright"],
+    )
+
+    checks, _, _ = _profile(
+        ["src-tauri/src/transcribe/live.rs"], ["runtime", "performance"]
+    )
+    test.equal(
+        "PROFILE explicit runtime and performance claims add checks",
+        checks,
+        ["rust-lib", "tauri-boot", "perf-contracts"],
+    )
+
+    checks, reviews, risks = _profile(["src-tauri/src/share/envelope.rs"])
+    test.equal(
+        "PROFILE protocol runs client and server checks",
+        checks,
+        ["rust-lib", "protocol-server"],
+    )
+    test.equal("PROFILE protocol actual risks", risks, ["egress", "protocol"])
+    test.equal(
+        "PROFILE protocol adds one cross-vendor specialist",
+        reviews,
+        ["combined", "egress-security", "protocol-security"],
+    )
+    checks, reviews, risks = _profile([".murmur-server-revision"])
+    test.equal(
+        "PROFILE server revision runs client and protocol checks",
+        checks,
+        ["rust-lib", "protocol-server"],
+    )
+    test.equal(
+        "PROFILE server revision is protocol-sensitive",
+        risks,
+        ["protocol"],
+    )
+    test.equal(
+        "PROFILE server revision adds protocol specialist",
+        reviews,
+        ["combined", "protocol-security"],
+    )
+
+    checks, reviews, risks = _profile(
+        ["crates/murmur-protocol/src/envelope.rs"]
+    )
+    test.equal(
+        "PROFILE protocol crate has protocol checks",
+        checks,
+        ["rust-lib", "protocol-server"],
+    )
+    test.equal("PROFILE protocol crate has protocol risk", risks, ["protocol"])
+    test.equal(
+        "PROFILE protocol crate adds specialist",
+        reviews,
+        ["combined", "protocol-security"],
+    )
+
+    checks, reviews, risks = _profile(["src-tauri/src/storage/meeting_store.rs"])
+    test.equal("PROFILE lock surface retains rust baseline", checks, ["rust-lib"])
+    test.equal("PROFILE shallow lock path matches", risks, ["lock"])
+    test.equal(
+        "PROFILE lock adds specialist",
+        reviews,
+        ["combined", "lock-security"],
+    )
+
+    checks, _, _ = _profile([".agents/harness/cli.py"])
+    test.equal(
+        "PROFILE harness control plane runs deterministic control-plane gates",
+        checks,
+        [
+            "harness-python",
+            "harness-v2-selftest",
+            "receipt-selftest",
+            "hook-selftest",
+            "config-audit",
+        ],
+    )
+    test.equal(
+        "PROFILE v2 refuses protected self-certification scope",
+        harness_cli._protected_v2_paths([".agents/harness"]),
+        [".agents/harness"],
+    )
+    harness_python = legacy.load_config()["canonical_checks"][
+        "harness-python"
+    ]
+    harness_python_result = subprocess.run(
+        shlex.split(harness_python),
+        cwd=str(ROOT),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    test.equal(
+        "PROFILE canonical harness-python command executes",
+        harness_python_result.returncode,
+        0,
+    )
+
+
+def reviewer_tool_guard_cases(test: Tests) -> None:
+    isolated_cwd = legacy.reviewer_execution_cwd()
+    test.true(
+        "REVIEWER isolated cwd and every ancestor are immutable root-owned directories",
+        all(
+            component.stat().st_uid == 0
+            and stat.S_ISDIR(component.stat().st_mode)
+            and not component.stat().st_mode & (stat.S_IWGRP | stat.S_IWOTH)
+            for component in (isolated_cwd, *isolated_cwd.parents)
+        ),
+    )
+    with tempfile.TemporaryDirectory(prefix="murmur-reviewer-cwd-") as raw:
+        mutable_cwd = Path(raw)
+        mutable_cwd.chmod(0o777)
+        original_reviewer_cwd = legacy.REVIEWER_CWD
+        legacy.REVIEWER_CWD = mutable_cwd
+        try:
+            test.raises(
+                "REVIEWER mutable temporary cwd is rejected",
+                legacy.reviewer_execution_cwd,
+                "mutable by the invoking user",
+            )
+        finally:
+            legacy.REVIEWER_CWD = original_reviewer_cwd
+
+    codex_environment = legacy.reviewer_model_environment(
+        {"HOME": "/Users/selftest", "PATH": "/usr/bin:/bin", "SHELL": "/bin/zsh"},
+        vendor="codex",
+        cwd=isolated_cwd,
+    )
+    test.equal(
+        "REVIEWER shell is pinned independently of ambient startup state",
+        codex_environment["SHELL"],
+        "/bin/sh",
+    )
+    test.equal(
+        "REVIEWER Codex HOME is pinned to the isolated cwd",
+        codex_environment["HOME"],
+        str(isolated_cwd),
+    )
+    test.equal(
+        "REVIEWER Codex auth home remains explicit after HOME isolation",
+        codex_environment["CODEX_HOME"],
+        "/Users/selftest/.codex",
+    )
+
+    decision = legacy.REVIEWER_TOOL_DENIAL
+    output = decision["hookSpecificOutput"]
+    test.equal(
+        "REVIEWER guard denies every intercepted local tool",
+        output["permissionDecision"],
+        "deny",
+    )
+    test.true(
+        "REVIEWER guard never reflects model-controlled tool input",
+        "tool_input" not in json.dumps(decision, sort_keys=True),
+    )
+    command = legacy.reviewer_tool_guard_command()
+    test.true(
+        "REVIEWER inline guard has no mutable worktree dependency",
+        command.startswith("/usr/bin/printf ")
+        and "reviewer_tool_guard" not in command
+        and str(legacy.HARNESS_ROOT) not in command,
+    )
+    completed = subprocess.run(
+        command,
+        shell=True,
+        text=True,
+        input=json.dumps(
+            {"tool_name": "Bash", "tool_input": {"command": "/bin/pwd"}}
+        ),
+        capture_output=True,
+        check=False,
+    )
+    test.equal(
+        "REVIEWER inline guard exits successfully",
+        completed.returncode,
+        0,
+    )
+    test.equal(
+        "REVIEWER inline guard emits the static deny decision",
+        json.loads(completed.stdout),
+        decision,
+    )
+
+    with tempfile.TemporaryDirectory(prefix="murmur-reviewer-tools-") as raw:
+        fixture_dir = Path(raw)
+
+        def tool_fixture(
+            name: str, events: Sequence[Mapping[str, Any]]
+        ) -> Path:
+            path = fixture_dir / name
+            path.write_text(
+                "".join(
+                    json.dumps(event, sort_keys=True) + "\n"
+                    for event in events
+                ),
+                encoding="utf-8",
+            )
+            return path
+
+        claude_21220_projection = tool_fixture(
+            "claude-2.1.220-sanitized.jsonl",
+            [
+                {
+                    "type": "system",
+                    "subtype": "init",
+                    "claude_code_version": "2.1.220",
+                    "tools": ["StructuredOutput"],
+                    "mcp_servers": [],
+                },
+                {"type": "system", "subtype": "thinking_tokens"},
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "thinking"}]},
+                },
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text"}]},
+                },
+                {
+                    "type": "assistant",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "name": "StructuredOutput",
+                            }
+                        ]
+                    },
+                },
+                {"type": "user"},
+                {"type": "rate_limit_event"},
+                {"type": "result", "subtype": "success"},
+            ],
+        )
+        test.equal(
+            "REVIEWER sanitized Claude 2.1.220 StructuredOutput projection is admissible",
+            legacy.reviewer_tool_activity(
+                claude_21220_projection, "claude"
+            ),
+            [],
+        )
+
+        missing_init = tool_fixture(
+            "claude-missing-init.jsonl",
+            [
+                {
+                    "type": "assistant",
+                    "message": {"content": [{"type": "text"}]},
+                }
+            ],
+        )
+        test.true(
+            "REVIEWER Claude log without init telemetry is rejected",
+            "missing Claude init telemetry"
+            in legacy.reviewer_tool_activity(missing_init, "claude"),
+        )
+
+        valid_claude_init = {
+            "type": "system",
+            "subtype": "init",
+            "tools": ["StructuredOutput"],
+            "mcp_servers": [],
+        }
+        for label, tool_name in (("bash", "Bash"), ("read", "Read")):
+            tool_log = tool_fixture(
+                f"claude-{label}.jsonl",
+                [
+                    valid_claude_init,
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "content": [
+                                {
+                                    "type": "tool_use",
+                                    "name": tool_name,
+                                }
+                            ]
+                        },
+                    },
+                ],
+            )
+            test.true(
+                f"REVIEWER Claude {tool_name} tool use is rejected",
+                bool(legacy.reviewer_tool_activity(tool_log, "claude")),
+            )
+
+        extra_tools = tool_fixture(
+            "claude-extra-tools.jsonl",
+            [
+                {
+                    **valid_claude_init,
+                    "tools": ["StructuredOutput", "Read"],
+                }
+            ],
+        )
+        test.true(
+            "REVIEWER unexpected Claude init tool surface is rejected",
+            any(
+                "unexpected-tools" in item
+                for item in legacy.reviewer_tool_activity(
+                    extra_tools, "claude"
+                )
+            ),
+        )
+        unexpected_mcp = tool_fixture(
+            "claude-unexpected-mcp.jsonl",
+            [
+                {
+                    **valid_claude_init,
+                    "mcp_servers": [{"name": "local-filesystem"}],
+                }
+            ],
+        )
+        test.true(
+            "REVIEWER unexpected Claude MCP surface is rejected",
+            any(
+                "unexpected-mcp" in item
+                for item in legacy.reviewer_tool_activity(
+                    unexpected_mcp, "claude"
+                )
+            ),
+        )
+
+        codex_prose = tool_fixture(
+            "codex-prose.jsonl",
+            [
+                {
+                    "type": "item.started",
+                    "item": {"type": "reasoning"},
+                },
+                {
+                    "type": "item.completed",
+                    "item": {"type": "agent_message", "text": "PASS"},
+                },
+            ],
+        )
+        test.equal(
+            "REVIEWER Codex reasoning and prose remain admissible",
+            legacy.reviewer_tool_activity(codex_prose, "codex"),
+            [],
+        )
+        for label, item_type in (
+            ("command", "command_execution"),
+            ("unknown", "dynamic_tool_call"),
+        ):
+            codex_tool = tool_fixture(
+                f"codex-{label}.jsonl",
+                [
+                    {
+                        "type": "item.started",
+                        "item": {"type": item_type},
+                    }
+                ],
+            )
+            test.true(
+                f"REVIEWER Codex {item_type} event fails closed",
+                bool(legacy.reviewer_tool_activity(codex_tool, "codex")),
+            )
+
+
+def verdict_cases(test: Tests) -> None:
+    base: Dict[str, Any] = {
+        "verdict": "PASS",
+        "findings": [],
+        "proof_gaps": [],
+        "probe_requests": [],
+    }
+    test.equal("VERDICT clean PASS", verifier.review_result_state(base), "PASSED")
+    major = {
+        **base,
+        "findings": [
+            {
+                "severity": "MAJOR",
+                "file": "x",
+                "evidence": "broken",
+                "required_fix": "fix",
+            }
+        ],
+    }
+    test.equal(
+        "VERDICT PASS plus MAJOR is rejected",
+        verifier.review_result_state(major),
+        "NEEDS_FIX",
+    )
+    blocker = copy.deepcopy(major)
+    blocker["findings"][0]["severity"] = "BLOCKER"
+    test.equal(
+        "VERDICT PASS plus BLOCKER is rejected",
+        verifier.review_result_state(blocker),
+        "NEEDS_FIX",
+    )
+    gap = {
+        **base,
+        "proof_gaps": [
+            {
+                "claim": "boot",
+                "evidence_missing": "real launch",
+                "how_to_prove": "runtime smoke",
+            }
+        ],
+    }
+    test.equal(
+        "VERDICT PASS plus proof gap is rejected",
+        verifier.review_result_state(gap),
+        "NEEDS_EVIDENCE",
+    )
+
+
+def retry_cases(test: Tests) -> None:
+    calls: List[int] = []
+
+    def rate_limited(number: int) -> Mapping[str, Any]:
+        calls.append(number)
+        if number == 1:
+            return {
+                "ok": False,
+                "transient": True,
+                "error": "api_error_status=429",
+                "retry_after_seconds": 0,
+            }
+        return {"ok": True, "result": "PASS"}
+
+    result, attempts = verifier.retry_call(rate_limited, sleep=lambda _delay: None)
+    test.equal("RETRY 429 then PASS attempts twice", calls, [1, 2])
+    test.equal("RETRY 429 then PASS succeeds", result["result"], "PASS")
+    test.equal("RETRY retains both labels", len(attempts), 2)
+
+    timeout_calls: List[int] = []
+
+    def timed_out_once(number: int) -> Mapping[str, Any]:
+        timeout_calls.append(number)
+        if number == 1:
+            return {
+                "ok": False,
+                "transient": True,
+                "error": "review timeout",
+                "retry_after_seconds": 0,
+            }
+        return {"ok": True, "result": "PASS"}
+
+    timeout_result, timeout_attempts = verifier.retry_call(
+        timed_out_once, sleep=lambda _delay: None
+    )
+    test.equal("RETRY timeout then PASS attempts twice", timeout_calls, [1, 2])
+    test.equal("RETRY timeout then PASS succeeds", timeout_result["result"], "PASS")
+    test.equal("RETRY timeout telemetry keeps both attempts", len(timeout_attempts), 2)
+
+    def always_transient(number: int) -> Mapping[str, Any]:
+        return {
+            "ok": False,
+            "transient": True,
+            "error": f"api_error_status=503 try={number}",
+            "retry_after_seconds": 0,
+        }
+
+    paused_attempts: List[Mapping[str, Any]] = []
+    try:
+        verifier.retry_call(always_transient, sleep=lambda _delay: None)
+    except verifier.ReviewPaused as exc:
+        paused_attempts = exc.attempts
+    test.equal(
+        "RETRY second transient becomes explicit pause",
+        len(paused_attempts),
+        2,
+    )
+
+
+def _wait_until_missing(pid: int, timeout_seconds: float = 3.0) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while legacy._pid_is_alive(pid) and time.monotonic() < deadline:
+        time.sleep(0.05)
+    return not legacy._pid_is_alive(pid)
+
+
+def guardian_and_artifact_cases(test: Tests) -> None:
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-guardian-") as raw:
+        root = Path(raw)
+
+        # The leader returns 0 while a same-PGID descendant ignores TERM. The
+        # guardian must escalate to KILL and the process result must remain red:
+        # cleanup is not permission to green-wash leaked background work.
+        descendant_pid_path = root / "leader-exit-descendant.pid"
+        descendant = (
+            "import os,pathlib,signal,time;"
+            "signal.signal(signal.SIGTERM,signal.SIG_IGN);"
+            f"pathlib.Path({str(descendant_pid_path)!r}).write_text(str(os.getpid()));"
+            "time.sleep(30)"
+        )
+        leader = (
+            "import pathlib,subprocess,sys,time;"
+            f"pid_path=pathlib.Path({str(descendant_pid_path)!r});"
+            f"subprocess.Popen([sys.executable,'-c',{descendant!r}]);"
+            "deadline=time.monotonic()+3;"
+            "exec('while not pid_path.exists() and "
+            "time.monotonic()<deadline:\\n time.sleep(0.01)')"
+        )
+        leaked = legacy.run_logged_process(
+            [sys.executable, "-c", leader],
+            cwd=root,
+            timeout_seconds=5,
+            log_path=root / "leader-exit.log",
+            term_grace_seconds=0.1,
+        )
+        descendant_pid = int(descendant_pid_path.read_text(encoding="utf-8"))
+        test.true(
+            "GUARDIAN leader exit drains surviving same-PGID descendant",
+            _wait_until_missing(descendant_pid),
+        )
+        test.true(
+            "GUARDIAN records live group after leader exit",
+            leaked["leader_exited_with_live_group"],
+        )
+        test.equal(
+            "GUARDIAN background descendant cannot green-wash exit zero",
+            leaked["exit_code"],
+            125,
+        )
+        test.equal(
+            "GUARDIAN records background cleanup reason",
+            leaked["termination_reason"],
+            "leader-exited-with-live-group",
+        )
+
+        # A SIGKILLed runner cannot execute finally blocks. The detached
+        # guardian must observe EOF on its liveness pipe and finish supervising
+        # the complete managed group by itself.
+        parent_kill_leader_pid = root / "parent-kill-leader.pid"
+        parent_kill_descendant_pid = root / "parent-kill-descendant.pid"
+        parent_kill_release = root / "parent-kill.release"
+        parent_kill_descendant = (
+            "import os,pathlib,signal,time;"
+            "signal.signal(signal.SIGTERM,signal.SIG_IGN);"
+            f"pathlib.Path({str(parent_kill_descendant_pid)!r}).write_text(str(os.getpid()));"
+            "deadline=time.monotonic()+30;"
+            f"\nwhile not pathlib.Path({str(parent_kill_release)!r}).exists() "
+            "and time.monotonic()<deadline:\n time.sleep(0.05)"
+        )
+        parent_kill_managed = (
+            "import os,pathlib,subprocess,sys,time;"
+            f"pathlib.Path({str(parent_kill_leader_pid)!r}).write_text(str(os.getpid()));"
+            f"subprocess.Popen([sys.executable,'-c',{parent_kill_descendant!r}]);"
+            "deadline=time.monotonic()+30;"
+            f"\nwhile not pathlib.Path({str(parent_kill_release)!r}).exists() "
+            "and time.monotonic()<deadline:\n time.sleep(0.05)"
+        )
+        driver = (
+            "import pathlib,sys;"
+            "import task_runner;"
+            f"task_runner.run_logged_process([sys.executable,'-c',{parent_kill_managed!r}],"
+            f"cwd=pathlib.Path({str(root)!r}),timeout_seconds=30,"
+            f"log_path=pathlib.Path({str(root / 'parent-kill.log')!r}),"
+            "term_grace_seconds=0.1)"
+        )
+        driver_env = {
+            **os.environ,
+            "PYTHONPATH": str(Path(__file__).resolve().parent),
+        }
+        driver_process = subprocess.Popen(
+            [sys.executable, "-c", driver],
+            cwd=str(root),
+            env=driver_env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        managed_pid = 0
+        managed_descendant_pid = 0
+        try:
+            armed_deadline = time.monotonic() + 4.0
+            while (
+                not parent_kill_leader_pid.is_file()
+                or not parent_kill_descendant_pid.is_file()
+            ) and time.monotonic() < armed_deadline:
+                time.sleep(0.05)
+            test.true(
+                "GUARDIAN parent-SIGKILL fixture arms complete group",
+                parent_kill_leader_pid.is_file()
+                and parent_kill_descendant_pid.is_file(),
+            )
+            if parent_kill_leader_pid.is_file() and parent_kill_descendant_pid.is_file():
+                managed_pid = int(parent_kill_leader_pid.read_text(encoding="utf-8"))
+                managed_descendant_pid = int(
+                    parent_kill_descendant_pid.read_text(encoding="utf-8")
+                )
+                os.kill(driver_process.pid, signal.SIGKILL)
+                driver_process.wait(timeout=3)
+                result_deadline = time.monotonic() + 5.0
+                guardian_results: List[Path] = []
+                while time.monotonic() < result_deadline:
+                    guardian_results = list(
+                        root.glob("parent-kill-*.log.guardian.json")
+                    )
+                    if guardian_results:
+                        break
+                    time.sleep(0.05)
+                test.true(
+                    "GUARDIAN survives parent SIGKILL long enough to publish result",
+                    len(guardian_results) == 1,
+                )
+                guardian_result = (
+                    legacy.load_json(guardian_results[0])
+                    if len(guardian_results) == 1
+                    else {}
+                )
+                test.true(
+                    "GUARDIAN records parent liveness loss",
+                    bool(guardian_result.get("parent_lost")),
+                )
+                test.true(
+                    "GUARDIAN parent SIGKILL drains managed leader",
+                    _wait_until_missing(managed_pid),
+                )
+                test.true(
+                    "GUARDIAN parent SIGKILL drains TERM-ignoring descendant",
+                    _wait_until_missing(managed_descendant_pid),
+                )
+        finally:
+            parent_kill_release.touch()
+            if driver_process.poll() is None:
+                try:
+                    driver_process.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    driver_process.kill()
+                    driver_process.wait(timeout=3)
+
+        # Reusing the same semantic label must allocate a fresh UUID namespace
+        # and leave every byte of the prior execution untouched.
+        log_base = root / "resume.log"
+        first_logged = legacy.run_logged_process(
+            [sys.executable, "-c", "print('first')"],
+            cwd=root,
+            timeout_seconds=5,
+            log_path=log_base,
+        )
+        first_logged_bytes = {
+            key: Path(str(first_logged[key])).read_bytes()
+            for key in ("log", "guardian_path")
+        }
+        second_logged = legacy.run_logged_process(
+            [sys.executable, "-c", "print('second')"],
+            cwd=root,
+            timeout_seconds=5,
+            log_path=log_base,
+        )
+        test.true(
+            "ARTIFACT repeated guarded log label gets a fresh UUID path",
+            first_logged["log"] != second_logged["log"]
+            and first_logged["guardian_path"] != second_logged["guardian_path"],
+        )
+        test.true(
+            "ARTIFACT repeated guarded run preserves prior crash namespace",
+            all(
+                Path(str(first_logged[key])).read_bytes() == value
+                for key, value in first_logged_bytes.items()
+            ),
+        )
+
+        repo = root / "repo"
+        _init_repo(repo)
+        common = Path(
+            _git(repo, "rev-parse", "--path-format=absolute", "--git-common-dir")
+        )
+        task_dir = common / "agent-harness" / "v2" / "tasks" / "artifacts"
+        task_dir.mkdir(parents=True)
+        legacy.atomic_write_json(
+            task_dir / "task.json",
+            {"worktree_path": str(repo.resolve())},
+        )
+        declared = {
+            "id": "uuid-artifacts",
+            "command": "printf same",
+            "timeout_seconds": 5,
+        }
+        background_child = "import time;time.sleep(30)"
+        background_leader = (
+            "import subprocess,sys;"
+            f"subprocess.Popen([sys.executable,'-c',{background_child!r}])"
+        )
+        background_check = legacy.run_check(
+            repo,
+            task_dir,
+            {
+                "id": "background-leak",
+                "command": (
+                    f"{json.dumps(sys.executable)} -c "
+                    f"{json.dumps(background_leader)}"
+                ),
+                "timeout_seconds": 5,
+            },
+            "v2-resume",
+        )
+        test.true(
+            "GUARDIAN check records background descendant lifecycle violation",
+            background_check["leader_exited_with_live_group"],
+        )
+        test.true(
+            "GUARDIAN check cannot PASS after background cleanup",
+            background_check["exit_code"] != 0
+            and not background_check["passed"]
+            and background_check["outcome"] == "FAIL",
+        )
+        first_check = legacy.run_check(repo, task_dir, declared, "v2-resume")
+        first_check_paths = [
+            Path(str(first_check[key]))
+            for key in (
+                "log_path",
+                "stdout_path",
+                "stderr_path",
+                "guardian_path",
+                "sandbox_profile_path",
+            )
+        ]
+        first_check_bytes = {path: path.read_bytes() for path in first_check_paths}
+        second_check = legacy.run_check(repo, task_dir, declared, "v2-resume")
+        second_check_paths = [
+            Path(str(second_check[key]))
+            for key in (
+                "log_path",
+                "stdout_path",
+                "stderr_path",
+                "guardian_path",
+                "sandbox_profile_path",
+            )
+        ]
+        test.true(
+            "ARTIFACT immediate check resume gets disjoint UUID paths",
+            set(first_check_paths).isdisjoint(second_check_paths),
+        )
+        test.true(
+            "ARTIFACT immediate check resume preserves all prior bytes",
+            all(path.read_bytes() == value for path, value in first_check_bytes.items()),
+        )
+        test.true(
+            "ARTIFACT check evidence records exact stream and guardian paths",
+            all(
+                Path(str(first_check[key])).is_file()
+                for key in ("stdout_path", "stderr_path", "guardian_path")
+            ),
+        )
+
+        model_worktree = root / "model-worktree"
+        model_worktree.mkdir()
+        model_dir = root / "model-evidence"
+        first_model = legacy.invoke_model(
+            "fake",
+            role="reviewer",
+            prompt="selftest",
+            schema_name="v2-review",
+            worktree=model_worktree,
+            task_dir=model_dir,
+            label="review-combined-try-1",
+            timeout_seconds=5,
+            instructions_sha256="a" * 64,
+        )
+        first_model_paths = [
+            Path(str(first_model[key]))
+            for key in ("result_path", "invocation_path", "log")
+        ]
+        first_model_bytes = {path: path.read_bytes() for path in first_model_paths}
+        second_model = legacy.invoke_model(
+            "fake",
+            role="reviewer",
+            prompt="selftest",
+            schema_name="v2-review",
+            worktree=model_worktree,
+            task_dir=model_dir,
+            label="review-combined-try-1",
+            timeout_seconds=5,
+            instructions_sha256="a" * 64,
+        )
+        second_model_paths = [
+            Path(str(second_model[key]))
+            for key in ("result_path", "invocation_path", "log")
+        ]
+        test.true(
+            "ARTIFACT repeated model label gets disjoint UUID paths",
+            set(first_model_paths).isdisjoint(second_model_paths),
+        )
+        test.true(
+            "ARTIFACT repeated model label preserves prior result/log/invocation",
+            all(path.read_bytes() == value for path, value in first_model_bytes.items()),
+        )
+
+
+def readonly_review_wall_timeout_cases(test: Tests) -> None:
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-review-timeout-") as raw:
+        root = Path(raw)
+        repo = root / "repo"
+        _init_repo(repo)
+        attempt_dir = root / "attempt"
+        fake_bin = root / "bin"
+        fake_bin.mkdir()
+        counter_path = root / "claude-invocations"
+        fake_claude = fake_bin / "claude"
+        fake_claude.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json,os,pathlib,sys,time\n"
+            "if '--version' in sys.argv:\n"
+            " print('claude 2.1.999')\n"
+            " raise SystemExit(0)\n"
+            "sys.stdin.read()\n"
+            f"counter=pathlib.Path({str(counter_path)!r})\n"
+            "number=int(counter.read_text() or '0')+1 if counter.exists() else 1\n"
+            "counter.write_text(str(number))\n"
+            "print(json.dumps({'type':'system','subtype':'init',"
+            "'tools':['StructuredOutput'],'mcp_servers':[]}),flush=True)\n"
+            "if number == 1:\n"
+            " time.sleep(10)\n"
+            "result={'verdict':'PASS','summary':'second real process completed',"
+            "'requirements_covered':['timeout retry'],'findings':[],"
+            "'proof_gaps':[],'probe_requests':[]}\n"
+            "print(json.dumps({'type':'result','session_id':f'session-{number}',"
+            "'model':'claude-selftest','structured_output':result}),flush=True)\n",
+            encoding="utf-8",
+        )
+        fake_claude.chmod(0o755)
+        contract = {
+            "task_id": "review-timeout",
+            "description": "retry a real reviewer wall timeout",
+        }
+        plan = {
+            "changed_paths": ["owned.txt"],
+            "claims": [],
+            "actual_risk_flags": [],
+            "diff_sha256": "1" * 64,
+            "plan_sha256": "2" * 64,
+            "protocol_sha256": "3" * 64,
+        }
+        original_path = os.environ.get("PATH")
+        original_load_config = legacy.load_config
+        base_config = original_load_config()
+
+        def timeout_config() -> Dict[str, Any]:
+            return {
+                **base_config,
+                "reviewer_timeout_seconds": 1,
+                "review_retry_max_delay_seconds": 0,
+            }
+
+        legacy.load_config = timeout_config
+        os.environ["PATH"] = str(fake_bin) + os.pathsep + (original_path or "")
+        try:
+            record = verifier.invoke_readonly_review(
+                contract=contract,
+                plan=plan,
+                worktree=repo,
+                attempt_dir=attempt_dir,
+                diff=b"diff --git a/owned.txt b/owned.txt\n",
+                checks=[],
+                review={"kind": "combined", "vendor": "claude"},
+                probe_evidence_sha256=verifier.probe_evidence_hash([]),
+                sleep=lambda _delay: None,
+            )
+        finally:
+            legacy.load_config = original_load_config
+            if original_path is None:
+                os.environ.pop("PATH", None)
+            else:
+                os.environ["PATH"] = original_path
+        attempts = record["attempts"]
+        test.equal(
+            "TIMEOUT real sleeping reviewer is retried exactly once",
+            counter_path.read_text(encoding="utf-8"),
+            "2",
+        )
+        test.equal("TIMEOUT retry record keeps both real attempts", len(attempts), 2)
+        test.true(
+            "TIMEOUT first real process is typed transient evidence",
+            not attempts[0]["ok"]
+            and attempts[0]["transient"]
+            and attempts[0]["telemetry"]["terminal_reason"] == "timeout"
+            and "ManagedProcessTimeout" in attempts[0]["error"],
+        )
+        test.true(
+            "TIMEOUT second real process supplies the accepted review",
+            attempts[1]["ok"] and record["result"]["verdict"] == "PASS",
+        )
+        background_child = "import time;time.sleep(30)"
+        background_leader = (
+            "import subprocess,sys;"
+            f"subprocess.Popen([sys.executable,'-c',{background_child!r}])"
+        )
+        background_process_result = legacy.run_logged_process(
+            [sys.executable, "-c", background_leader],
+            cwd=root,
+            timeout_seconds=5,
+            log_path=root / "model-background.log",
+            term_grace_seconds=0.1,
+        )
+        original_run_logged_process = legacy.run_logged_process
+        legacy.run_logged_process = (
+            lambda *_args, **_kwargs: dict(background_process_result)
+        )
+        os.environ["PATH"] = str(fake_bin) + os.pathsep + (original_path or "")
+        try:
+            test.raises(
+                "GUARDIAN model cannot accept structured PASS with background descendant",
+                lambda: legacy.invoke_model(
+                    "claude",
+                    role="reviewer",
+                    prompt="background lifecycle violation",
+                    schema_name="v2-review",
+                    worktree=repo,
+                    task_dir=attempt_dir,
+                    label="review-background",
+                    timeout_seconds=5,
+                    instructions_sha256=plan["protocol_sha256"],
+                ),
+                "failed",
+            )
+        finally:
+            legacy.run_logged_process = original_run_logged_process
+            if original_path is None:
+                os.environ.pop("PATH", None)
+            else:
+                os.environ["PATH"] = original_path
+        events = [
+            json.loads(line)
+            for line in (attempt_dir / "events.jsonl").read_text(
+                encoding="utf-8"
+            ).splitlines()
+            if line.strip()
+        ]
+        timeout_events = [
+            event
+            for event in events
+            if event.get("event") == "model-process-exit"
+            and event.get("label") == "review-combined-try-1"
+        ]
+        background_events = [
+            event
+            for event in events
+            if event.get("event") == "model-process-exit"
+            and event.get("label") == "review-background"
+        ]
+        test.true(
+            "GUARDIAN model event preserves non-admissible background cleanup evidence",
+            len(background_events) == 1
+            and background_events[0].get("leader_exited_with_live_group") is True
+            and background_events[0].get("exit_code") == 125,
+        )
+        test.equal(
+            "TIMEOUT runner records the real timed-out process event",
+            len(timeout_events),
+            1,
+        )
+        if timeout_events:
+            timeout_event = timeout_events[0]
+            test.true(
+                "TIMEOUT event records exact UUID log and guardian artifacts",
+                bool(timeout_event.get("timed_out"))
+                and Path(str(timeout_event.get("log_path"))).is_file()
+                and Path(str(timeout_event.get("guardian_path"))).is_file(),
+            )
+            test.true(
+                "TIMEOUT retry uses a disjoint model artifact namespace",
+                timeout_event.get("log_path") != record["log_path"]
+                and timeout_event.get("result_path") != record["result_path"]
+                and timeout_event.get("invocation_path") != record["invocation_path"],
+            )
+
+
+def state_and_lock_cases(test: Tests) -> None:
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-state-") as raw:
+        root = Path(raw)
+        task_dir = root / "open-gap"
+        task_dir.mkdir()
+        code = (
+            "import pathlib,sys;"
+            f"sys.path.insert(0,{str(Path(__file__).resolve().parent)!r});"
+            "import cli;"
+            "cli.set_v2_state(pathlib.Path(sys.argv[1]),'OPEN',phase='open')"
+        )
+        environment = {
+            **os.environ,
+            "MURMUR_HARNESS_SELFTEST": "1",
+            "MURMUR_HARNESS_SELFTEST_KILL_AFTER_STATE_EVENT": "OPEN",
+        }
+        killed = subprocess.run(
+            [sys.executable, "-c", code, str(task_dir)],
+            env=environment,
+            capture_output=True,
+            check=False,
+        )
+        test.equal(
+            "STATE real SIGKILL occurs after authoritative OPEN event",
+            killed.returncode,
+            -signal.SIGKILL,
+        )
+        test.true(
+            "STATE projection is absent at injected crash",
+            not (task_dir / "state.json").exists(),
+        )
+        recovered = harness_cli.load_v2_state(task_dir)
+        test.equal("STATE loader recovers OPEN from ledger", recovered["status"], "OPEN")
+        test.equal(
+            "STATE loader safely rebuilds projection",
+            legacy.load_json(task_dir / "state.json"),
+            recovered,
+        )
+        stale_projection = {
+            **recovered,
+            "status": "VERIFYING",
+            "updated_at": "2000-01-01T00:00:00Z",
+        }
+        legacy.atomic_write_json(task_dir / "state.json", stale_projection)
+        test.equal(
+            "STATE stale divergent projection is repaired from ledger",
+            harness_cli.load_v2_state(task_dir),
+            recovered,
+        )
+        future_projection = {
+            **recovered,
+            "updated_at": "2999-01-01T00:00:00Z",
+        }
+        legacy.atomic_write_json(task_dir / "state.json", future_projection)
+        test.raises(
+            "STATE projection newer than ledger fails closed",
+            lambda: harness_cli.load_v2_state(task_dir),
+            "newer than",
+        )
+        legacy.atomic_write_json(task_dir / "state.json", recovered)
+
+        lock_dir = root / "lock-task"
+        lock_dir.mkdir()
+        lock_code = (
+            "import pathlib,sys,time;"
+            f"sys.path.insert(0,{str(Path(__file__).resolve().parent)!r});"
+            "import cli;"
+            "lock=cli.acquire_v2_run_lock(pathlib.Path(sys.argv[1]),'selftest');"
+            "print('ready',flush=True);time.sleep(5)"
+        )
+        owner = subprocess.Popen(
+            [sys.executable, "-c", lock_code, str(lock_dir)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            ready = owner.stdout.readline().strip() if owner.stdout else ""
+            liveness, metadata = harness_cli.lock_liveness(lock_dir)
+            test.equal("LOCK child acquired real flock", ready, "ready")
+            test.equal("LOCK live owner is reported LIVE", liveness, "LIVE")
+            test.equal(
+                "LOCK live metadata carries owner PID",
+                int((metadata or {}).get("pid", -1)),
+                owner.pid,
+            )
+        finally:
+            owner.terminate()
+            owner.wait(timeout=3)
+        liveness, _metadata = harness_cli.lock_liveness(lock_dir)
+        test.equal("LOCK dead owner is reported STALE", liveness, "STALE")
+
+
+def standalone_driver_lane_cases(test: Tests) -> None:
+    """Independent driver/primary clones must still share one heavy-build lane."""
+
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-driver-lane-") as raw:
+        root = Path(raw)
+        primary = root / "meetnotes"
+        driver = root / ".murmur-agent-driver"
+        _init_repo(primary)
+        _init_repo(driver)
+        task_dirs = []
+        for repository, task_id in (
+            (primary, "primary-lane"),
+            (driver, "driver-lane"),
+        ):
+            common = Path(
+                _git(
+                    repository,
+                    "rev-parse",
+                    "--path-format=absolute",
+                    "--git-common-dir",
+                )
+            )
+            task_dir = common / "agent-harness" / "v2" / "tasks" / task_id
+            task_dir.mkdir(parents=True)
+            task_dirs.append(task_dir)
+        primary_task, driver_task = task_dirs
+        primary_root = legacy.shared_resource_root_for_task(primary_task)
+        driver_root = legacy.shared_resource_root_for_task(driver_task)
+        test.equal(
+            "LANE standalone driver and primary resolve one resource root",
+            driver_root,
+            primary_root,
+        )
+        test.equal(
+            "LANE shared root stays inside narrow task sibling",
+            driver_root,
+            root.resolve() / ".murmur-agent-tasks" / ".resources",
+        )
+
+        release_marker = root / "release-standalone-holder"
+        holder_code = (
+            "import pathlib,sys,time;"
+            f"sys.path.insert(0,{str(Path(__file__).resolve().parent)!r});"
+            "import task_runner;"
+            "lease=task_runner.acquire_cargo_lane("
+            "pathlib.Path(sys.argv[1]),2,command='standalone-driver-holder');"
+            "print('ready',flush=True);"
+            "marker=pathlib.Path(sys.argv[2]);deadline=time.monotonic()+10;"
+            "\nwhile not marker.exists() and time.monotonic()<deadline:"
+            "\n time.sleep(0.01)"
+            "\n"
+            "task_runner.release_cargo_lane(lease)"
+        )
+        holder = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                holder_code,
+                str(primary_task),
+                str(release_marker),
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        runner = ROOT / "scripts" / "agent-resource-run"
+        try:
+            ready = holder.stdout.readline().strip() if holder.stdout else ""
+            blocked = subprocess.run(
+                [
+                    str(runner),
+                    "--deadline-seconds",
+                    "0.2",
+                    "--",
+                    "/usr/bin/true",
+                ],
+                cwd=str(driver),
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            test.equal("LANE standalone holder acquired", ready, "ready")
+            test.equal(
+                "LANE operator wrapper cannot overlap independent clone",
+                blocked.returncode,
+                124,
+            )
+            test.true(
+                "LANE independent-clone wait is visible",
+                "waiting for lane" in blocked.stderr,
+            )
+        finally:
+            release_marker.write_text("release\n", encoding="utf-8")
+            if holder.poll() is None:
+                try:
+                    holder.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    holder.terminate()
+                    holder.wait(timeout=3)
+        released = subprocess.run(
+            [str(runner), "--deadline-seconds", "1", "--", "/usr/bin/true"],
+            cwd=str(driver),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        test.equal(
+            "LANE independent clone proceeds after release",
+            released.returncode,
+            0,
+        )
+
+
+def checkpoint_cases(test: Tests) -> None:
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-checkpoint-") as raw:
+        repo = Path(raw) / "repo"
+        base = _init_repo(repo)
+        (repo / "owned.txt").write_text("base\nchanged\n", encoding="utf-8")
+        common = Path(
+            _git(repo, "rev-parse", "--path-format=absolute", "--git-common-dir")
+        )
+        task_dir = common / "agent-harness" / "v2" / "tasks" / "checkpoint"
+        attempt_dir = task_dir / "attempts" / ("a" * 64)
+        (attempt_dir / "checks").mkdir(parents=True)
+        contract = {
+            "task_id": "checkpoint",
+            "base_sha": base,
+            "worktree_path": str(repo),
+            "owned_paths": ["owned.txt"],
+            "expected_change": True,
+        }
+        legacy.atomic_write_json(task_dir / "task.json", contract)
+        paths, diff, tree = verifier.snapshot_scoped_diff(repo, contract, task_dir)
+        plan = {
+            "changed_paths": paths,
+            "diff_sha256": legacy.sha256_bytes(diff),
+            "tree_sha": tree,
+            "plan_sha256": "1" * 64,
+            "protocol_sha256": "2" * 64,
+        }
+        declared = {
+            "id": "checkpoint",
+            "command": "test -f owned.txt",
+            "timeout_seconds": 10,
+        }
+        legacy.atomic_write_json(task_dir / "selftest-contract.json", contract)
+        legacy.atomic_write_json(task_dir / "selftest-plan.json", plan)
+        legacy.atomic_write_json(task_dir / "selftest-check.json", declared)
+        code = (
+            "import json,pathlib,sys;"
+            f"sys.path.insert(0,{str(Path(__file__).resolve().parent)!r});"
+            "import cli;"
+            "td=pathlib.Path(sys.argv[1]);ad=pathlib.Path(sys.argv[2]);"
+            "contract=json.loads((td/'selftest-contract.json').read_text());"
+            "plan=json.loads((td/'selftest-plan.json').read_text());"
+            "declared=json.loads((td/'selftest-check.json').read_text());"
+            "cli._run_or_resume_check(contract,td,plan,ad,declared,"
+            "pathlib.Path(contract['worktree_path']),"
+            "checkpoint_number=1)"
+        )
+        killed = subprocess.run(
+            [sys.executable, "-c", code, str(task_dir), str(attempt_dir)],
+            env={
+                **os.environ,
+                "MURMUR_HARNESS_SELFTEST": "1",
+                "MURMUR_HARNESS_SELFTEST_KILL_AFTER_CHECK": "1",
+            },
+            capture_output=True,
+            check=False,
+        )
+        record_path = attempt_dir / "checks" / "checkpoint.json"
+        test.equal(
+            "CHECKPOINT process is SIGKILLed after artifact fsync",
+            killed.returncode,
+            -signal.SIGKILL,
+        )
+        test.true("CHECKPOINT record exists after SIGKILL", record_path.is_file())
+        if not record_path.is_file():
+            test.failures.append(
+                "CHECKPOINT child stderr: "
+                + killed.stderr.decode("utf-8", "replace")[-2000:]
+            )
+            return
+        before_bytes = record_path.read_bytes()
+        before_mtime = record_path.stat().st_mtime_ns
+        record, did_run = harness_cli._run_or_resume_check(
+            contract,
+            task_dir,
+            plan,
+            attempt_dir,
+            declared,
+            repo,
+            checkpoint_number=1,
+        )
+        test.equal("CHECKPOINT resume reuses green artifact", did_run, False)
+        test.true("CHECKPOINT reused record remains green", record["evidence"]["passed"])
+        test.equal("CHECKPOINT reused bytes are unchanged", record_path.read_bytes(), before_bytes)
+        test.equal(
+            "CHECKPOINT reused mtime is unchanged",
+            record_path.stat().st_mtime_ns,
+            before_mtime,
+        )
+
+        retryable = legacy.load_json(record_path)
+        retryable["evidence"]["passed"] = False
+        retryable["evidence"]["outcome"] = "BLOCKED"
+        retryable["evidence"]["timed_out"] = True
+        legacy.atomic_write_json(record_path, retryable)
+        record, did_run = harness_cli._run_or_resume_check(
+            contract,
+            task_dir,
+            plan,
+            attempt_dir,
+            declared,
+            repo,
+            checkpoint_number=2,
+        )
+        test.equal("CHECKPOINT retryable pause is rerun on resume", did_run, True)
+        test.true("CHECKPOINT retry can become green", record["evidence"]["passed"])
+        test.true(
+            "CHECKPOINT resource wait telemetry is present",
+            isinstance(record["evidence"].get("resource_wait_ms"), int),
+        )
+        release_marker = Path(raw) / "release-checkpoint-holder"
+        lane_code = (
+            "import pathlib,sys,time;"
+            f"sys.path.insert(0,{str(Path(__file__).resolve().parent)!r});"
+            "import task_runner;"
+            "lock=task_runner.acquire_cargo_lane("
+            "pathlib.Path(sys.argv[1]),2,command='lane-holder');"
+            "print('ready',flush=True);"
+            "marker=pathlib.Path(sys.argv[2]);deadline=time.monotonic()+10;"
+            "\nwhile not marker.exists() and time.monotonic()<deadline:"
+            "\n time.sleep(0.01)"
+            "\nif marker.exists():"
+            "\n time.sleep(0.05)"
+            "\n"
+            "task_runner.release_cargo_lane(lock)"
+        )
+        holder = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                lane_code,
+                str(task_dir),
+                str(release_marker),
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            ready = holder.stdout.readline().strip() if holder.stdout else ""
+
+            class ReleaseOnVisibleWait(io.StringIO):
+                def write(self, value: str) -> int:
+                    written = super().write(value)
+                    if "waiting for Cargo lane" in self.getvalue():
+                        release_marker.write_text(
+                            "release\n", encoding="utf-8"
+                        )
+                    return written
+
+            wait_stderr = ReleaseOnVisibleWait()
+            with contextlib.redirect_stderr(wait_stderr):
+                waited = legacy.run_check(
+                    repo,
+                    task_dir,
+                    {
+                        "id": "resource-wait",
+                        "command": "cargo --version",
+                        "timeout_seconds": 5,
+                    },
+                    "resource-wait",
+                )
+            test.equal("CHECKPOINT controlled Cargo owner is ready", ready, "ready")
+            test.true("CHECKPOINT contended Cargo probe passes", waited["passed"])
+            test.true(
+                "CHECKPOINT contended wait is visibly reported",
+                "waiting for Cargo lane" in wait_stderr.getvalue(),
+            )
+            test.true(
+                "CHECKPOINT evidence measures observed resource wait separately",
+                waited["resource_wait_ms"] >= 20,
+            )
+        finally:
+            release_marker.write_text("release\n", encoding="utf-8")
+            if holder.poll() is None:
+                try:
+                    holder.wait(timeout=3)
+                except subprocess.TimeoutExpired:
+                    holder.terminate()
+                    holder.wait(timeout=3)
+
+
+def protocol_and_runtime_cases(test: Tests) -> None:
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-protocol-") as raw:
+        fixture = Path(raw) / "fixture"
+        for relative in verifier.protocol_relative_paths(ROOT):
+            source = ROOT / relative
+            target = fixture / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+        before = verifier.protocol_bundle(fixture)["protocol_sha256"]
+        runtime_impl = fixture / "scripts" / "harness-runtime-smoke.py"
+        runtime_impl.write_text(
+            runtime_impl.read_text(encoding="utf-8") + "\n# drift\n",
+            encoding="utf-8",
+        )
+        after = verifier.protocol_bundle(fixture)["protocol_sha256"]
+        test.true(
+            "PROTOCOL runner-owned check implementation drift changes protocol hash",
+            before != after,
+        )
+        test.raises(
+            "PROTOCOL changed caller cannot plan under task-side protocol hash",
+            lambda: verifier.executable_protocol_bundle(fixture),
+            "executing Harness v2 protocol differs",
+        )
+        manifest = verifier.protocol_relative_paths(ROOT)
+        test.true(
+            "PROTOCOL manifest includes runtime smoke implementation",
+            "scripts/harness-runtime-smoke.py" in manifest,
+        )
+        test.true(
+            "PROTOCOL manifest includes its v2 fault suite",
+            ".agents/harness/v2_selftest.py" in manifest,
+        )
+        test.true(
+            "PROTOCOL manifest includes all canonical check scripts",
+            all(
+                path.relative_to(ROOT).as_posix() in manifest
+                for path in (ROOT / ".agents" / "harness" / "checks").rglob("*")
+                if path.is_file()
+            ),
+        )
+
+        evidence_root = Path(raw) / "evidence"
+        invocation_path = evidence_root / "results" / "review-invocation.json"
+        invocation_path.parent.mkdir(parents=True)
+        invocation = {
+            "vendor": "claude",
+            "role": "reviewer",
+            "label": "review-combined-try-1",
+            "instructions_sha256": "a" * 64,
+            "session_id": "session-real",
+            "model": "claude-test",
+            "cli_version": "2.1.214",
+            "invocation_id": "invocation-real",
+            "argv": ["/usr/local/bin/claude", "--print"],
+            "cwd": str(legacy.reviewer_execution_cwd()),
+            "wall_timeout_seconds": 30,
+            "removed_env_names": [],
+            "created_at": legacy.utc_now(),
+        }
+        legacy.atomic_write_json(invocation_path, invocation)
+        legacy.verify_model_invocation(
+            evidence_root,
+            vendor="claude",
+            role="reviewer",
+            label="review-combined-try-1",
+            session_id="session-real",
+            model="claude-test",
+            cli_version="2.1.214",
+            invocation_path_raw=str(invocation_path),
+            invocation_sha256=legacy.sha256_file(invocation_path),
+            expected_path=invocation_path,
+            instructions_sha256="a" * 64,
+            require_cwd_binding=True,
+        )
+        tampered = {**invocation, "role": "writer"}
+        legacy.atomic_write_json(invocation_path, tampered)
+        test.raises(
+            "PROVENANCE forged reviewer invocation role is rejected",
+            lambda: legacy.verify_model_invocation(
+                evidence_root,
+                vendor="claude",
+                role="reviewer",
+                label="review-combined-try-1",
+                session_id="session-real",
+                model="claude-test",
+                cli_version="2.1.214",
+                invocation_path_raw=str(invocation_path),
+                invocation_sha256=legacy.sha256_file(invocation_path),
+                expected_path=invocation_path,
+                instructions_sha256="a" * 64,
+                require_cwd_binding=True,
+            ),
+            "role",
+        )
+        tampered_cwd = {**invocation, "cwd": str(evidence_root.resolve())}
+        legacy.atomic_write_json(invocation_path, tampered_cwd)
+        test.raises(
+            "PROVENANCE reviewer invocation outside isolated cwd is rejected",
+            lambda: legacy.verify_model_invocation(
+                evidence_root,
+                vendor="claude",
+                role="reviewer",
+                label="review-combined-try-1",
+                session_id="session-real",
+                model="claude-test",
+                cli_version="2.1.214",
+                invocation_path_raw=str(invocation_path),
+                invocation_sha256=legacy.sha256_file(invocation_path),
+                expected_path=invocation_path,
+                instructions_sha256="a" * 64,
+                require_cwd_binding=True,
+            ),
+            "isolated cwd",
+        )
+        log_path = evidence_root / "logs" / "review.jsonl"
+        log_path.parent.mkdir()
+        log_path.write_text(
+            json.dumps(
+                {
+                    "session_id": "session-from-another-run",
+                    "model": "claude-test",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        test.equal(
+            "PROVENANCE real log exposes session mismatch",
+            legacy.extract_model_metadata(
+                log_path, "claude", "session-real"
+            )["session_id"],
+            "session-from-another-run",
+        )
+
+    runtime_path = ROOT / "scripts" / "harness-runtime-smoke.py"
+    specification = importlib.util.spec_from_file_location(
+        "harness_runtime_smoke_selftest", runtime_path
+    )
+    if specification is None or specification.loader is None:
+        test.true("RUNTIME smoke module can be loaded", False)
+        return
+    runtime_module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(runtime_module)
+    with tempfile.TemporaryDirectory(prefix="murmur-runtime-budget-") as raw:
+        root = Path(raw)
+        mode, timeout = runtime_module.selected_timeout(
+            root,
+            explicit=None,
+            warm_timeout=240,
+            cold_timeout=900,
+        )
+        test.equal("RUNTIME cold checkout gets cold budget", (mode, timeout), ("cold", 900))
+        binary = root / "src-tauri" / "target" / "debug" / "Murmur"
+        binary.parent.mkdir(parents=True)
+        binary.write_bytes(b"fixture")
+        mode, timeout = runtime_module.selected_timeout(
+            root,
+            explicit=None,
+            warm_timeout=240,
+            cold_timeout=900,
+        )
+        test.equal("RUNTIME built checkout gets warm budget", (mode, timeout), ("warm", 240))
+        mode, timeout = runtime_module.selected_timeout(
+            root,
+            explicit=17,
+            warm_timeout=240,
+            cold_timeout=900,
+        )
+        test.equal("RUNTIME explicit budget wins", (mode, timeout), ("warm", 17))
+
+
+def commit_recovery_cases(test: Tests) -> None:
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-commit-") as raw:
+        root = Path(raw)
+        primary = root / "primary"
+        primary.mkdir(parents=True)
+        _git(primary, "init", "-q", "-b", "murmur")
+        _git(primary, "config", "user.name", "QueaT")
+        _git(primary, "config", "user.email", "kgm004a@gmail.com")
+        for relative in verifier.protocol_relative_paths(ROOT):
+            source = ROOT / relative
+            target = primary / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+        primary_owned = primary / "docs" / "commit-recovery.md"
+        primary_owned.parent.mkdir(parents=True, exist_ok=True)
+        primary_owned.write_text("base\n", encoding="utf-8")
+        _git(primary, "add", ".")
+        _git(primary, "commit", "-q", "-m", "base")
+        base = _git(primary, "rev-parse", "HEAD")
+        repo = root / "task" / "meetnotes"
+        repo.parent.mkdir()
+        task_branch = "agent/v2/commit-crash"
+        _git(
+            primary,
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            task_branch,
+            str(repo),
+            base,
+        )
+        owned = repo / "docs" / "commit-recovery.md"
+        common = Path(
+            _git(
+                primary,
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-common-dir",
+            )
+        )
+        task_id = "commit-crash"
+        task_dir = harness_cli.v2_task_dir(common, task_id)
+        task_dir.mkdir(parents=True)
+        contract: Dict[str, Any] = {
+            "schema_version": 2,
+            "task_id": task_id,
+            "description": "real post-commit crash recovery",
+            "kind": "docs",
+            "base_sha": base,
+            "contract_sha256": "",
+            "repo_realpath": str(primary.resolve()),
+            "git_common_dir": str(common.resolve()),
+            "worktree_path": str(repo.resolve()),
+            "branch": task_branch,
+            "owned_paths": ["docs/commit-recovery.md"],
+            "claims": [],
+            "reviewer": "fake",
+            "expected_change": True,
+            "degraded_provenance": [{"event": "timeout"}],
+            "created_at": legacy.utc_now(),
+        }
+        contract["contract_sha256"] = verifier.document_hash(
+            contract, "contract_sha256"
+        )
+        legacy.validate_schema(
+            contract,
+            legacy.load_schema("v2-task"),
+            label="v2 commit crash contract",
+        )
+        legacy.atomic_write_json(task_dir / "task.json", contract)
+        legacy.atomic_write_json(
+            task_dir / "runtime.json",
+            {
+                "schema_version": 2,
+                "task_root": str(root),
+                "shared_node_modules": None,
+                "server_worktree": None,
+                "server_source": str(root / "murmur-server"),
+                "server_revision": None,
+            },
+        )
+        harness_cli.set_v2_state(task_dir, "OPEN", phase="open")
+        owned.write_text("base\ncommitted\n", encoding="utf-8")
+        previous_review_verdict = os.environ.get(
+            "MURMUR_HARNESS_FAKE_REVIEW_VERDICT"
+        )
+        os.environ["MURMUR_HARNESS_FAKE_REVIEW_VERDICT"] = "BLOCKED"
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                incomplete = harness_cli.verify_task(
+                    contract,
+                    task_dir,
+                    allow_test_adapter=True,
+                )
+        finally:
+            if previous_review_verdict is None:
+                os.environ.pop("MURMUR_HARNESS_FAKE_REVIEW_VERDICT", None)
+            else:
+                os.environ[
+                    "MURMUR_HARNESS_FAKE_REVIEW_VERDICT"
+                ] = previous_review_verdict
+        test.equal(
+            "REVIEW incomplete result pauses as NEEDS_EVIDENCE",
+            incomplete,
+            "NEEDS_EVIDENCE",
+        )
+        # An artifact-valid BLOCKED review is a deterministic checkpoint for
+        # its exact diff/probe binding. Change the diff before expecting a new
+        # reviewer invocation; unchanged evidence must not be sampled again.
+        owned.write_text(
+            "base\ncommitted after exact-diff change\n",
+            encoding="utf-8",
+        )
+        with contextlib.redirect_stdout(io.StringIO()):
+            verified = harness_cli.verify_task(
+                contract,
+                task_dir,
+                allow_test_adapter=True,
+            )
+        test.equal("COMMIT fixture obtains exact v2 PASS", verified, "PASSED")
+        passed_state = harness_cli.load_v2_state(task_dir)
+        if verified != "PASSED":
+            test.failures.append(
+                "COMMIT fixture state detail: "
+                + json.dumps(passed_state, sort_keys=True)
+            )
+            return
+        evidence_path = Path(str(passed_state["evidence_path"]))
+        original_evidence = legacy.load_json(evidence_path)
+        laundered = copy.deepcopy(original_evidence)
+        laundered["degraded_provenance"] = []
+        laundered["evidence_sha256"] = verifier.document_hash(
+            laundered, "evidence_sha256"
+        )
+        legacy.atomic_write_json(evidence_path, laundered)
+        test.raises(
+            "EVIDENCE degraded provenance cannot be laundered",
+            lambda: verifier.verify_v2_evidence(
+                contract, task_dir, allow_test_adapter=True
+            ),
+            "degraded_provenance is stale",
+        )
+        legacy.atomic_write_json(evidence_path, original_evidence)
+
+        forged_summary = copy.deepcopy(original_evidence)
+        forged_summary["findings"].append(
+            {
+                "review": "combined",
+                "severity": "INFO",
+                "file": "owned.txt",
+                "evidence": "forged receipt-only finding",
+                "required_fix": "none",
+            }
+        )
+        forged_summary["evidence_sha256"] = verifier.document_hash(
+            forged_summary, "evidence_sha256"
+        )
+        legacy.atomic_write_json(evidence_path, forged_summary)
+        test.raises(
+            "EVIDENCE rehashed top-level findings cannot diverge from review records",
+            lambda: verifier.verify_v2_evidence(
+                contract, task_dir, allow_test_adapter=True
+            ),
+            "findings differs from its bound review records",
+        )
+        legacy.atomic_write_json(evidence_path, original_evidence)
+
+        forged_probe_summary = copy.deepcopy(original_evidence)
+        forged_probe_summary["probe_requests"].append(
+            {
+                "review": "combined",
+                "probe_id": "rust-lib",
+                "rationale": "forged receipt-only probe request",
+            }
+        )
+        forged_probe_summary["evidence_sha256"] = verifier.document_hash(
+            forged_probe_summary, "evidence_sha256"
+        )
+        legacy.atomic_write_json(evidence_path, forged_probe_summary)
+        test.raises(
+            "EVIDENCE rehashed top-level probe requests cannot diverge from review records",
+            lambda: verifier.verify_v2_evidence(
+                contract, task_dir, allow_test_adapter=True
+            ),
+            "probe_requests differs from its bound review records",
+        )
+        legacy.atomic_write_json(evidence_path, original_evidence)
+
+        original_review = original_evidence["reviews"][0]
+        original_result_path = Path(str(original_review["result_path"]))
+        original_review_result = legacy.load_json(original_result_path)
+        for severity in ("MAJOR", "BLOCKER"):
+            severe_result = copy.deepcopy(original_review_result)
+            severe_result["findings"] = [
+                {
+                    "severity": severity,
+                    "file": "docs/commit-recovery.md",
+                    "evidence": "bound severe selftest finding",
+                    "required_fix": "reject the v2 PASS",
+                }
+            ]
+            legacy.atomic_write_json(original_result_path, severe_result)
+            severe_evidence = copy.deepcopy(original_evidence)
+            severe_evidence["reviews"][0]["result"] = severe_result
+            severe_evidence["reviews"][0][
+                "result_sha256"
+            ] = legacy.sha256_file(original_result_path)
+            outcomes = verifier.aggregate_review_outcomes(
+                severe_evidence["reviews"]
+            )
+            severe_evidence.update(outcomes)
+            severe_evidence["evidence_sha256"] = verifier.document_hash(
+                severe_evidence, "evidence_sha256"
+            )
+            legacy.atomic_write_json(evidence_path, severe_evidence)
+            test.raises(
+                f"EVIDENCE bound {severity} review cannot verify PASS",
+                lambda: verifier.verify_v2_evidence(
+                    contract, task_dir, allow_test_adapter=True
+                ),
+                "unresolved MAJOR/BLOCKER",
+            )
+
+        gap_result = copy.deepcopy(original_review_result)
+        gap_result["proof_gaps"] = [
+            {
+                "claim": "exact runtime proof",
+                "evidence_missing": "runner artifact",
+                "how_to_prove": "run an allowlisted probe",
+            }
+        ]
+        legacy.atomic_write_json(original_result_path, gap_result)
+        gap_evidence = copy.deepcopy(original_evidence)
+        gap_evidence["reviews"][0]["result"] = gap_result
+        gap_evidence["reviews"][0][
+            "result_sha256"
+        ] = legacy.sha256_file(original_result_path)
+        gap_evidence.update(
+            verifier.aggregate_review_outcomes(gap_evidence["reviews"])
+        )
+        gap_evidence["evidence_sha256"] = verifier.document_hash(
+            gap_evidence, "evidence_sha256"
+        )
+        legacy.atomic_write_json(evidence_path, gap_evidence)
+        test.raises(
+            "EVIDENCE bound proof gap cannot verify PASS",
+            lambda: verifier.verify_v2_evidence(
+                contract, task_dir, allow_test_adapter=True
+            ),
+            "unresolved proof gaps",
+        )
+
+        probe_result = copy.deepcopy(original_review_result)
+        probe_result["probe_requests"] = [
+            {
+                "probe_id": "rust-lib",
+                "rationale": "bound empirical proof is still required",
+            }
+        ]
+        legacy.atomic_write_json(original_result_path, probe_result)
+        probe_evidence = copy.deepcopy(original_evidence)
+        probe_evidence["reviews"][0]["result"] = probe_result
+        probe_evidence["reviews"][0][
+            "result_sha256"
+        ] = legacy.sha256_file(original_result_path)
+        probe_evidence.update(
+            verifier.aggregate_review_outcomes(probe_evidence["reviews"])
+        )
+        probe_evidence["evidence_sha256"] = verifier.document_hash(
+            probe_evidence, "evidence_sha256"
+        )
+        legacy.atomic_write_json(evidence_path, probe_evidence)
+        test.raises(
+            "EVIDENCE bound probe request cannot verify PASS",
+            lambda: verifier.verify_v2_evidence(
+                contract, task_dir, allow_test_adapter=True
+            ),
+            "unresolved proof gaps",
+        )
+        legacy.atomic_write_json(
+            original_result_path, original_review_result
+        )
+        legacy.atomic_write_json(evidence_path, original_evidence)
+
+        message = "selftest crash-resumable commit"
+        child_code = (
+            "import argparse,os,pathlib,sys;"
+            f"sys.path.insert(0,{str(Path(__file__).resolve().parent)!r});"
+            "import cli;"
+            "os.chdir(sys.argv[1]);"
+            "cli.cmd_v2_commit(argparse.Namespace("
+            "task_id='commit-crash',message='selftest crash-resumable commit',"
+            "_allow_test_adapter=True))"
+        )
+        killed = subprocess.run(
+            [sys.executable, "-c", child_code, str(repo)],
+            env={
+                **os.environ,
+                "MURMUR_HARNESS_SELFTEST": "1",
+                "MURMUR_HARNESS_SELFTEST_KILL_AFTER_GIT_COMMIT": "1",
+            },
+            capture_output=True,
+            check=False,
+        )
+        test.equal(
+            "COMMIT child receives real SIGKILL after git commit",
+            killed.returncode,
+            -signal.SIGKILL,
+        )
+        test.equal(
+            "COMMIT crash leaves exactly one child commit",
+            _git(repo, "rev-list", "--count", f"{base}..HEAD"),
+            "1",
+        )
+        committed_head = _git(repo, "rev-parse", "HEAD")
+        test.equal(
+            "COMMIT crash preserves PASSED state until receipt finalization",
+            harness_cli.load_v2_state(task_dir)["status"],
+            "PASSED",
+        )
+        test.true(
+            "COMMIT durable intent precedes crash",
+            (task_dir / "commit-intent.json").is_file(),
+        )
+        test.true(
+            "COMMIT receipt is absent at injected crash",
+            not (task_dir / "commit.json").exists(),
+        )
+        previous = Path.cwd()
+        try:
+            os.chdir(repo)
+            with contextlib.redirect_stdout(io.StringIO()):
+                resumed = harness_cli.cmd_v2_commit(
+                    argparse.Namespace(
+                        task_id=task_id,
+                        message=message,
+                        _allow_test_adapter=True,
+                    )
+                )
+        finally:
+            os.chdir(previous)
+        test.equal("COMMIT resume command succeeds", resumed, 0)
+        test.equal(
+            "COMMIT resume finalizes COMMITTED state",
+            harness_cli.load_v2_state(task_dir)["status"],
+            "COMMITTED",
+        )
+        test.equal(
+            "COMMIT resume does not create a second commit",
+            _git(repo, "rev-list", "--count", f"{base}..HEAD"),
+            "1",
+        )
+        test.equal(
+            "COMMIT resume preserves the exact committed HEAD",
+            _git(repo, "rev-parse", "HEAD"),
+            committed_head,
+        )
+        receipt = harness_cli.verify_v2_committed(
+            contract, task_dir, allow_test_adapter=True
+        )
+        test.equal(
+            "COMMIT finalized receipt binds exact post-commit HEAD",
+            receipt["commit_sha"],
+            committed_head,
+        )
+        test.raises(
+            "COMMIT idempotent resume rejects a forged receipt",
+            lambda: harness_cli._validate_v2_commit_head(
+                repo,
+                {
+                    "parent_sha": receipt["parent_sha"],
+                    "tree_sha": receipt["tree_sha"],
+                    "diff_sha256": receipt["diff_sha256"],
+                },
+                {
+                    "parent_sha": receipt["parent_sha"],
+                    "tree_sha": receipt["tree_sha"],
+                    "diff_sha256": receipt["diff_sha256"],
+                    "message": "different",
+                    "message_sha256": hashlib.sha256(b"different").hexdigest(),
+                },
+                {"name": "QueaT", "email": "kgm004a@gmail.com"},
+            ),
+            "message differs",
+        )
+
+        # A trunk update may be merged after the immutable task commit without
+        # invalidating its receipt.  Only Git's exact automatic merge tree is
+        # admissible; any later branch-authored commit must be re-verified.
+        (primary / "trunk.txt").write_text("trunk moved\n", encoding="utf-8")
+        config_path = primary / ".agents" / "harness" / "config.json"
+        drifted_config = json.loads(config_path.read_text(encoding="utf-8"))
+        drifted_config["default_base"] = "origin/future-trunk"
+        config_path.write_text(
+            json.dumps(drifted_config, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        for schema_name in (
+            "v2-task",
+            "v2-plan",
+            "v2-review",
+            "v2-evidence",
+            "v2-commit",
+        ):
+            schema_path = (
+                primary
+                / ".agents"
+                / "harness"
+                / "schemas"
+                / f"{schema_name}.schema.json"
+            )
+            drifted_schema = json.loads(
+                schema_path.read_text(encoding="utf-8")
+            )
+            required = list(drifted_schema.get("required", []))
+            required.append("future_required")
+            drifted_schema["required"] = required
+            schema_path.write_text(
+                json.dumps(drifted_schema, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+        policy_path = (
+            primary
+            / ".agents"
+            / "harness"
+            / "prompts"
+            / "combined-reviewer.md"
+        )
+        policy_path.write_text(
+            policy_path.read_text(encoding="utf-8")
+            + "\nCURRENT POLICY DRIFT MUST NOT REVALIDATE OLD EVIDENCE.\n",
+            encoding="utf-8",
+        )
+        _git(primary, "add", ".")
+        _git(primary, "commit", "-q", "-m", "move trunk and verifier policy")
+        trunk_tip = _git(primary, "rev-parse", "HEAD")
+        _git(primary, "update-ref", "refs/remotes/origin/murmur", trunk_tip)
+        _git(
+            repo,
+            "-c",
+            "user.name=QueaT",
+            "-c",
+            "user.email=kgm004a@gmail.com",
+            "merge",
+            "--no-ff",
+            "-q",
+            "-m",
+            "merge origin/murmur",
+            "origin/murmur",
+        )
+        catchup_head = _git(repo, "rev-parse", "HEAD")
+        catchup_receipt = harness_cli.verify_v2_committed(
+            contract, task_dir, allow_test_adapter=True
+        )
+        test.equal(
+            "COMMIT clean trunk catch-up preserves immutable receipt",
+            catchup_receipt["commit_sha"],
+            committed_head,
+        )
+
+        fixture_python = str(repo / ".agents" / "harness")
+        fresh_schema_check = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import pathlib,sys;"
+                    f"sys.path.insert(0,{fixture_python!r});"
+                    "import task_runner as legacy,verifier;"
+                    f"doc=legacy.load_json(pathlib.Path({str(task_dir / 'task.json')!r}));"
+                    "verifier.validate_hashed_document("
+                    "doc,'v2-task','contract_sha256','fresh task')"
+                ),
+            ],
+            cwd=str(repo),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        test.true(
+            "COMMIT fresh task validation still enforces the current stricter schema",
+            fresh_schema_check.returncode != 0
+            and "future_required" in fresh_schema_check.stderr,
+        )
+        pinned_verify = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import pathlib,sys;"
+                    f"sys.path.insert(0,{fixture_python!r});"
+                    "import cli,task_runner as legacy;"
+                    f"task=pathlib.Path({str(task_dir)!r});"
+                    "contract=legacy.load_json(task/'task.json');"
+                    "receipt=cli.verify_v2_committed("
+                    "contract,task,allow_test_adapter=True);"
+                    "print(receipt['commit_sha'])"
+                ),
+            ],
+            cwd=str(repo),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        test.equal(
+            "COMMIT catch-up verifies with attested schema config and policy",
+            (pinned_verify.returncode, pinned_verify.stdout.strip()),
+            (0, committed_head),
+        )
+        (repo / "unverified.txt").write_text("branch content\n", encoding="utf-8")
+        _git(repo, "add", "unverified.txt")
+        _git(repo, "commit", "-q", "-m", "unverified branch content")
+        test.raises(
+            "COMMIT branch-authored descendant requires fresh verification",
+            lambda: harness_cli.verify_v2_committed(
+                contract, task_dir, allow_test_adapter=True
+            ),
+            "non-merge commit",
+        )
+        _git(repo, "reset", "--hard", "-q", catchup_head)
+        clean_result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import argparse,sys;"
+                    f"sys.path.insert(0,{fixture_python!r});"
+                    "import cli;"
+                    f"sys.path.insert(0,{str(repo)!r});"
+                    f"__import__('os').chdir({str(repo)!r});"
+                    "cli.cmd_clean(argparse.Namespace("
+                    "task_id='commit-crash',abandon=False,"
+                    "_allow_test_adapter=True))"
+                ),
+            ],
+            cwd=str(repo),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        test.equal(
+            "CLEAN closes old committed evidence after verifier-policy catch-up",
+            clean_result.returncode,
+            0,
+        )
+        test.equal(
+            "CLEAN records the old committed task as CLOSED",
+            harness_cli.load_v2_state(task_dir)["status"],
+            "CLOSED",
+        )
+        test.true(
+            "CLEAN removes the linked committed worktree",
+            not repo.exists(),
+        )
+
+
+def _v1_contract(
+    *,
+    task_id: str,
+    repo: Path,
+    common: Path,
+    worktree: Path,
+    base: str,
+    branch: str,
+) -> Dict[str, Any]:
+    contract: Dict[str, Any] = {
+        "schema_version": 1,
+        "task_id": task_id,
+        "description": "v1 import selftest",
+        "kind": "harness",
+        "base_sha": base,
+        "contract_sha256": "",
+        "instructions_sha256": "0" * 64,
+        "dependency_revisions": {},
+        "repo_realpath": str(repo.resolve()),
+        "git_common_dir": str(common.resolve()),
+        "worktree_path": str(worktree.resolve()),
+        "branch": branch,
+        "owned_paths": ["owned.txt"],
+        "risk_flags": [],
+        "writer": "fake",
+        "reviewer": "fake",
+        "max_repair_rounds": 2,
+        "checks": [],
+        "final_checks": [],
+        "expected_change": True,
+        "created_at": legacy.utc_now(),
+    }
+    contract["contract_sha256"] = legacy.contract_hash(contract)
+    legacy.validate_schema(
+        contract, legacy.load_schema("task"), label="v1 import selftest task"
+    )
+    return contract
+
+
+def import_cases(test: Tests) -> None:
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-import-") as raw:
+        root = Path(raw)
+        repo = root / "repo"
+        base = _init_repo(repo)
+        common = Path(
+            _git(repo, "rev-parse", "--path-format=absolute", "--git-common-dir")
+        )
+        task_id = "legacy-ghost"
+        branch = f"agent/{task_id}"
+        worktree = root / "task" / "meetnotes"
+        worktree.parent.mkdir()
+        _git(repo, "worktree", "add", "-q", "-b", branch, str(worktree), base)
+        (worktree / "owned.txt").write_text("base\nlegacy bytes\n", encoding="utf-8")
+        _git(worktree, "add", "owned.txt")
+        tree = _git(worktree, "write-tree")
+        snapshot = _git(
+            repo,
+            "-c",
+            "user.name=QueaT",
+            "-c",
+            "user.email=kgm004a@gmail.com",
+            "commit-tree",
+            tree,
+            "-p",
+            base,
+            "-m",
+            "legacy archive",
+        )
+        _git(worktree, "reset", "--quiet", "HEAD", "--", ".")
+        source_dir = common / "agent-harness" / "tasks" / task_id
+        source_dir.mkdir(parents=True)
+        contract = _v1_contract(
+            task_id=task_id,
+            repo=repo,
+            common=common,
+            worktree=worktree,
+            base=base,
+            branch=branch,
+        )
+        legacy.atomic_write_json(source_dir / "task.json", contract)
+        legacy.append_jsonl(
+            source_dir / "events.jsonl",
+            {
+                "at": legacy.utc_now(),
+                "event": "state",
+                "status": "INITIALIZED",
+                "round": 0,
+                "phase": "init",
+            },
+        )
+        archive_ref = legacy.task_archive_ref(contract)
+        _git(repo, "update-ref", archive_ref, snapshot)
+        legacy.atomic_write_json(
+            source_dir / "archive.json",
+            {
+                "schema_version": 1,
+                "task_id": task_id,
+                "archive_ref": archive_ref,
+                "snapshot_sha": snapshot,
+                "original_head_sha": base,
+                "tree_sha": tree,
+                "created_at": legacy.utc_now(),
+            },
+        )
+        _git(repo, "worktree", "remove", "--force", str(worktree))
+        source_before = harness_cli._directory_digest(source_dir)
+        args = argparse.Namespace(
+            task_id=task_id,
+            invalidate_pass=False,
+            claim=[],
+            reviewer="fake",
+        )
+        previous_cwd = Path.cwd()
+        previous_selftest = os.environ.get("MURMUR_HARNESS_SELFTEST")
+        os.environ["MURMUR_HARNESS_SELFTEST"] = "1"
+        try:
+            os.chdir(repo)
+            with contextlib.redirect_stdout(io.StringIO()):
+                harness_cli.cmd_import_v1(args)
+            target_dir = harness_cli.v2_task_dir(common, task_id)
+            imported = legacy.load_json(target_dir / "imports" / "v1.json")
+            test.equal(
+                "IMPORT ghost state has no fabricated state hash",
+                imported["source_state_sha256"],
+                None,
+            )
+            test.equal(
+                "IMPORT reconstructs archived missing worktree",
+                harness_cli.load_v2_state(target_dir)["status"],
+                "OPEN",
+            )
+            test.equal(
+                "IMPORT reconstructed exact archived bytes",
+                (worktree / "owned.txt").read_text(encoding="utf-8"),
+                "base\nlegacy bytes\n",
+            )
+            test.equal(
+                "IMPORT v1 task directory is byte-identical",
+                harness_cli._directory_digest(source_dir),
+                source_before,
+            )
+            with contextlib.redirect_stdout(io.StringIO()):
+                harness_cli.cmd_import_v1(args)
+            test.equal(
+                "IMPORT repeat is idempotent and source remains byte-identical",
+                harness_cli._directory_digest(source_dir),
+                source_before,
+            )
+
+            missing_id = "legacy-missing"
+            missing_worktree = root / "missing" / "meetnotes"
+            missing_branch = f"agent/{missing_id}"
+            missing_dir = common / "agent-harness" / "tasks" / missing_id
+            missing_dir.mkdir(parents=True)
+            missing_contract = _v1_contract(
+                task_id=missing_id,
+                repo=repo,
+                common=common,
+                worktree=missing_worktree,
+                base=base,
+                branch=missing_branch,
+            )
+            legacy.atomic_write_json(missing_dir / "task.json", missing_contract)
+            legacy.append_jsonl(
+                missing_dir / "events.jsonl",
+                {
+                    "at": legacy.utc_now(),
+                    "event": "state",
+                    "status": "BLOCKED",
+                    "round": 1,
+                    "phase": "writer",
+                },
+            )
+            missing_before = harness_cli._directory_digest(missing_dir)
+            with contextlib.redirect_stdout(io.StringIO()):
+                harness_cli.cmd_import_v1(
+                    argparse.Namespace(
+                        task_id=missing_id,
+                        invalidate_pass=False,
+                        claim=[],
+                        reviewer="fake",
+                    )
+                )
+            missing_target = harness_cli.v2_task_dir(common, missing_id)
+            test.equal(
+                "IMPORT irrecoverable missing worktree is history-only",
+                harness_cli.load_v2_state(missing_target)["status"],
+                "NEEDS_EVIDENCE",
+            )
+            test.equal(
+                "IMPORT history-only path preserves all v1 bytes",
+                harness_cli._directory_digest(missing_dir),
+                missing_before,
+            )
+        finally:
+            os.chdir(previous_cwd)
+            if previous_selftest is None:
+                os.environ.pop("MURMUR_HARNESS_SELFTEST", None)
+            else:
+                os.environ["MURMUR_HARNESS_SELFTEST"] = previous_selftest
+
+
+def plan_and_probe_cases(test: Tests) -> None:
+    base = legacy.git(ROOT, "rev-parse", "HEAD")
+    tree = legacy.git(ROOT, "rev-parse", "HEAD^{tree}")
+    contract = {
+        "task_id": "plan-selftest",
+        "contract_sha256": "a" * 64,
+        "claims": [],
+        "reviewer": "claude",
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+    angular, _bundle = verifier.build_plan(
+        contract,
+        ROOT,
+        ["src/app/features/detail/detail.ts"],
+        b"angular diff",
+        tree,
+        legacy.load_config(),
+    )
+    angular_again, _bundle = verifier.build_plan(
+        contract,
+        ROOT,
+        ["src/app/features/detail/detail.ts"],
+        b"angular diff",
+        tree,
+        legacy.load_config(),
+    )
+    test.equal(
+        "PLAN identical diff has stable plan hash",
+        angular_again["plan_sha256"],
+        angular["plan_sha256"],
+    )
+    test.equal(
+        "PLAN frontend-only diff creates no sibling server",
+        angular["server_required"],
+        False,
+    )
+    rust, _bundle = verifier.build_plan(
+        contract,
+        ROOT,
+        ["src-tauri/src/lib.rs"],
+        b"rust diff",
+        tree,
+        legacy.load_config(),
+    )
+    test.equal(
+        "PLAN Rust diff lazily requires sibling server",
+        rust["server_required"],
+        True,
+    )
+    changed, _bundle = verifier.build_plan(
+        contract,
+        ROOT,
+        ["src/app/features/detail/detail.ts"],
+        b"changed angular diff",
+        tree,
+        legacy.load_config(),
+    )
+    test.true(
+        "PLAN changed diff invalidates attempt binding",
+        verifier.attempt_id(changed) != verifier.attempt_id(angular),
+    )
+    test.equal("PLAN parent remains current immutable base", angular["base_sha"], base)
+
+    test.raises(
+        "PROBE broker rejects arbitrary shell ids",
+        lambda: verifier.canonical_check("sh -c arbitrary", legacy.load_config()),
+        "not allowlisted",
+    )
+    request = {
+        "verdict": "PASS",
+        "findings": [],
+        "proof_gaps": [],
+        "probe_requests": [
+            {"probe_id": "rust-lib", "rationale": "need runner proof"}
+        ],
+    }
+    test.equal(
+        "PROBE typed request prevents immediate PASS",
+        verifier.review_result_state(request),
+        "NEEDS_EVIDENCE",
+    )
+    empty_hash = verifier.probe_evidence_hash([])
+    probe_record = {
+        "id": "rust-lib",
+        "diff_sha256": angular["diff_sha256"],
+        "plan_sha256": angular["plan_sha256"],
+        "protocol_sha256": angular["protocol_sha256"],
+        "evidence": {"passed": True},
+    }
+    test.true(
+        "PROBE evidence changes the reviewer round binding",
+        verifier.probe_evidence_hash([probe_record]) != empty_hash,
+    )
+
+
+def clean_cases(test: Tests) -> None:
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-clean-") as raw:
+        root = Path(raw)
+        repo = root / "repo"
+        base = _init_repo(repo)
+        common = Path(
+            _git(repo, "rev-parse", "--path-format=absolute", "--git-common-dir")
+        )
+        worktree = root / "task" / "meetnotes"
+        worktree.parent.mkdir()
+        branch = "agent/v2/clean-selftest"
+        _git(repo, "worktree", "add", "-q", "-b", branch, str(worktree), base)
+        (worktree / "owned.txt").write_text("base\ndirty tracked\n", encoding="utf-8")
+        (worktree / "untracked.txt").write_text("dirty untracked\n", encoding="utf-8")
+        task_dir = harness_cli.v2_task_dir(common, "clean-selftest")
+        task_dir.mkdir(parents=True)
+        contract: Dict[str, Any] = {
+            "schema_version": 2,
+            "task_id": "clean-selftest",
+            "description": "archive every dirty byte",
+            "kind": "harness",
+            "base_sha": base,
+            "contract_sha256": "",
+            "repo_realpath": str(repo.resolve()),
+            "git_common_dir": str(common.resolve()),
+            "worktree_path": str(worktree.resolve()),
+            "branch": branch,
+            "owned_paths": ["owned.txt", "untracked.txt"],
+            "claims": [],
+            "reviewer": "fake",
+            "expected_change": True,
+            "degraded_provenance": [],
+            "created_at": legacy.utc_now(),
+        }
+        contract["contract_sha256"] = verifier.document_hash(
+            contract, "contract_sha256"
+        )
+        legacy.atomic_write_json(task_dir / "task.json", contract)
+        legacy.atomic_write_json(
+            task_dir / "runtime.json",
+            {
+                "schema_version": 2,
+                "task_root": str(worktree.parent),
+                "shared_node_modules": None,
+                "server_worktree": None,
+                "server_source": str(root / "murmur-server"),
+                "server_revision": None,
+            },
+        )
+        harness_cli.set_v2_state(task_dir, "OPEN", phase="open")
+        previous = Path.cwd()
+        try:
+            os.chdir(repo)
+            with contextlib.redirect_stdout(io.StringIO()):
+                harness_cli.cmd_clean(
+                    argparse.Namespace(task_id="clean-selftest", abandon=True)
+                )
+        finally:
+            os.chdir(previous)
+        state = harness_cli.load_v2_state(task_dir)
+        archive_ref = state["archive_ref"]
+        test.equal("CLEAN dirty task becomes ABANDONED", state["status"], "ABANDONED")
+        test.true("CLEAN removes only task worktree", not worktree.exists())
+        test.equal(
+            "CLEAN archive preserves tracked dirty bytes",
+            _git(repo, "show", f"{archive_ref}:owned.txt"),
+            "base\ndirty tracked",
+        )
+        test.equal(
+            "CLEAN archive preserves untracked dirty bytes",
+            _git(repo, "show", f"{archive_ref}:untracked.txt"),
+            "dirty untracked",
+        )
+
+
+def main() -> int:
+    test = Tests()
+    open_branch_ownership_cases(test)
+    standalone_driver_open_cases(test)
+    profile_cases(test)
+    reviewer_tool_guard_cases(test)
+    verdict_cases(test)
+    retry_cases(test)
+    guardian_and_artifact_cases(test)
+    readonly_review_wall_timeout_cases(test)
+    state_and_lock_cases(test)
+    standalone_driver_lane_cases(test)
+    checkpoint_cases(test)
+    protocol_and_runtime_cases(test)
+    commit_recovery_cases(test)
+    import_cases(test)
+    plan_and_probe_cases(test)
+    clean_cases(test)
+    if test.failures:
+        print("v2 selftest: FAIL")
+        for failure in test.failures:
+            print(f"  - {failure}")
+        return 1
+    print(f"v2 selftest: PASS ({test.count} assertions)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/harness/verifier.py
+++ b/.agents/harness/verifier.py
@@ -1056,6 +1056,30 @@ def aggregate_verdict(
     return "PASSED", "all planned checks and reviews passed"
 
 
+def aggregate_review_outcomes(
+    reviews: Sequence[Mapping[str, Any]],
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Derive the receipt-level review summary from the bound review records."""
+
+    return {
+        "findings": [
+            {"review": review["kind"], **finding}
+            for review in reviews
+            for finding in review.get("result", {}).get("findings", [])
+        ],
+        "proof_gaps": [
+            {"review": review["kind"], **gap}
+            for review in reviews
+            for gap in review.get("result", {}).get("proof_gaps", [])
+        ],
+        "probe_requests": [
+            {"review": review["kind"], **probe}
+            for review in reviews
+            for probe in review.get("result", {}).get("probe_requests", [])
+        ],
+    }
+
+
 def build_evidence(
     contract: Mapping[str, Any],
     plan: Mapping[str, Any],
@@ -1064,21 +1088,7 @@ def build_evidence(
     probes: Sequence[Mapping[str, Any]],
     reviews: Sequence[Mapping[str, Any]],
 ) -> Dict[str, Any]:
-    findings = [
-        {"review": review["kind"], **finding}
-        for review in reviews
-        for finding in review.get("result", {}).get("findings", [])
-    ]
-    proof_gaps = [
-        {"review": review["kind"], **gap}
-        for review in reviews
-        for gap in review.get("result", {}).get("proof_gaps", [])
-    ]
-    probe_requests = [
-        {"review": review["kind"], **probe}
-        for review in reviews
-        for probe in review.get("result", {}).get("probe_requests", [])
-    ]
+    review_outcomes = aggregate_review_outcomes(reviews)
     verdict, reason = aggregate_verdict(checks, reviews)
     evidence: Dict[str, Any] = {
         "schema_version": 2,
@@ -1093,9 +1103,7 @@ def build_evidence(
         "checks": [dict(item) for item in checks],
         "probes": [dict(item) for item in probes],
         "reviews": [dict(item) for item in reviews],
-        "findings": findings,
-        "proof_gaps": proof_gaps,
-        "probe_requests": probe_requests,
+        **review_outcomes,
         "degraded_provenance": list(contract.get("degraded_provenance", [])),
         "telemetry": {
             "resource_wait_ms": sum(
@@ -1592,12 +1600,6 @@ def verify_v2_evidence(
             raise legacy.HarnessError(f"v2 evidence {key} is stale")
     if evidence.get("verdict") != "PASSED":
         raise legacy.HarnessError("v2 evidence verdict is not PASSED")
-    if evidence.get("findings") and any(
-        item.get("severity") in SEVERE_FINDINGS for item in evidence["findings"]
-    ):
-        raise legacy.HarnessError("v2 PASS contains unresolved MAJOR/BLOCKER findings")
-    if evidence.get("proof_gaps") or evidence.get("probe_requests"):
-        raise legacy.HarnessError("v2 PASS contains unresolved proof gaps")
 
     check_records = evidence.get("checks", [])
     if [item.get("id") for item in check_records] != [
@@ -1753,7 +1755,19 @@ def verify_v2_evidence(
             raise legacy.HarnessError(
                 f"v2 review {declared['kind']} result summary changed"
             )
-        if review_result_state(result) != "PASSED":
+        result_state = review_result_state(result)
+        if result_state != "PASSED":
+            if any(
+                finding.get("severity") in SEVERE_FINDINGS
+                for finding in result.get("findings", [])
+            ):
+                raise legacy.HarnessError(
+                    "v2 PASS contains unresolved MAJOR/BLOCKER findings"
+                )
+            if result.get("proof_gaps") or result.get("probe_requests"):
+                raise legacy.HarnessError(
+                    "v2 PASS contains unresolved proof gaps"
+                )
             raise legacy.HarnessError(
                 f"v2 review {declared['kind']} is not an admissible PASS"
             )
@@ -1793,6 +1807,7 @@ def verify_v2_evidence(
             ),
             instructions_sha256=plan["protocol_sha256"],
             prompt_sha256=str(record["prompt_sha256"]),
+            require_cwd_binding=True,
         )
         review_time = legacy.parse_timestamp(
             record.get("created_at"), f"v2 review {declared['kind']}.created_at"
@@ -1813,4 +1828,16 @@ def verify_v2_evidence(
                 raise legacy.HarnessError(
                     f"v2 review {declared['kind']} model differs from real model log"
                 )
+    expected_review_outcomes = aggregate_review_outcomes(review_records)
+    for field, expected in expected_review_outcomes.items():
+        if evidence.get(field) != expected:
+            raise legacy.HarnessError(
+                f"v2 evidence {field} differs from its bound review records"
+            )
+    if evidence.get("findings") and any(
+        item.get("severity") in SEVERE_FINDINGS for item in evidence["findings"]
+    ):
+        raise legacy.HarnessError("v2 PASS contains unresolved MAJOR/BLOCKER findings")
+    if evidence.get("proof_gaps") or evidence.get("probe_requests"):
+        raise legacy.HarnessError("v2 PASS contains unresolved proof gaps")
     return evidence

--- a/.agents/skills/harness/SKILL.md
+++ b/.agents/skills/harness/SKILL.md
@@ -1,76 +1,118 @@
 ---
 name: harness
-description: Run a change through the full Murmur harness — isolated worktree, writer, deterministic checks, independent adversarial + risk reviews, hash-bound PASS attestation, guarded commit. Use PROACTIVELY when a change is risky, multi-step, or you want the earned safety net (lock/crypto/egress/protocol, or anything you want independently verified). Skip it for docs, chores, and low-risk edits — those commit normally.
+description: Shadow-test a risky or multi-step Murmur change through the verifier-only Harness v2 candidate — isolated worktree, exact-diff plan, deterministic checks, fresh adversarial and risk reviews, crash-resumable PASS receipt, guarded commit, and lossless cleanup. Use proactively for lock, crypto, egress, protocol, or any change needing independent verification. Skip it for docs, chores, and low-risk edits.
 ---
 
-# `/harness` — opt-in rigor
+# `/harness` — opt-in verifier-only rigor
 
-Murmur's harness is **opt-in**. Normal commits run freely (only secret-scan and
-trunk-push protection are always on). Invoke the harness deliberately, via this
-skill, when a change deserves independent verification.
+Murmur's harness is opt-in. Use it when a change deserves an independently
+earned, hash-bound verdict. Ordinary low-risk commits remain outside it. V2 is
+still a shadow candidate, not the repository default.
 
-## When to reach for it
+Harness v2 does not dispatch a writer or repair code. You or the assigned
+implementer edits one isolated worktree; the runner derives and verifies the
+exact diff. The implementer never owns PASS.
 
-- Anything touching the lock model / crypto / secrets / storage / MCP / egress /
-  the sharing protocol (the `risk_classification` paths in
-  `.agents/harness/config.json`).
-- A multi-step feature or refactor where you want a fresh adversarial reviewer to
-  try to break the change before it lands.
-- Any time you want the hash-bound Definition-of-Done receipt on the commit.
+## Use it for
 
-For a docs fix, a chore, a version bump, or a small low-risk edit: **do not use
-this** — just commit normally.
+- Lock, crypto, secrets, gated content reads, storage, MCP, egress, or sharing
+  protocol changes.
+- Multi-step features/refactors where a fresh reviewer should try to break the
+  result.
+- Any change that needs an exact-diff receipt before commit.
 
-## How it works
+Skip it for a small docs edit, chore, metadata bump, or clearly low-risk
+mechanical change unless the operator explicitly wants the receipt.
 
-The switch is physical: the harness runs in an **isolated sibling worktree** that
-carries a task manifest. While that task is active, `finish-guard` enforces the
-full attestation and the resource lane is required for heavy commands. Your main
-`murmur` checkout never has a task, so work there is unconstrained.
+## Required lifecycle
 
-## Run it
+Run orchestration from a dedicated standalone driver clone, never the user's
+primary checkout or a linked driver worktree. After `open`, change into the
+printed task worktree and use that
+worktree's runner so the executable protocol equals the pinned protocol.
 
 ```bash
-# 1. Create the contract + isolated worktree (task_id is positional;
-#    --prompt and --owned are required, --owned may repeat for multiple paths)
-scripts/agent-harness init <task-id> --kind <bug|feature|refactor|docs|harness> \
-  --prompt "<what>" --owned <path> [--owned <path> ...] \
-  [--risk <lock|egress|protocol|runtime|ui|performance|release>] \
-  [--agent <codex|claude>] [--reviewer <codex|claude>]
+# 1. Open the contract and isolated worktree.
+scripts/agent-harness open <task-id> \
+  --kind <bug|feature|refactor|docs|harness> \
+  --prompt "<what must be true>" \
+  --owned <path> [--owned <path> ...] \
+  [--claim <runtime|performance>] \
+  [--reviewer <codex|claude>]
 
-# 2. Drive writer → checks → independent reviews → PASS attestation
-scripts/agent-harness run <task-id>
+# 2. Implement only in the printed worktree and declared scope.
 
-# 3. Commit from the attested index (QueaT identity, no AI trailers) and open a PR
-scripts/agent-harness commit <task-id> -m "<type>(<scope>): <subject>"
-gh pr create -R murmur-io/murmur --base murmur
-gh pr merge --merge
+# The prompt is behavioral acceptance only. It must not demand that the writer
+# run or report commands; the derived plan is the sole executable evidence.
 
-# 4. Close the task
-scripts/agent-harness close <task-id>
+# 3. Inspect the exact derived plan, then verify.
+scripts/agent-harness plan <task-id>
+scripts/agent-harness verify <task-id>
+scripts/agent-harness status <task-id>
+
+# 4. Continue only missing/retryable evidence when needed.
+scripts/agent-harness resume <task-id>
+
+# 5. Commit the exact PASS. Push and create/merge the PR before cleanup.
+scripts/agent-harness commit <task-id> \
+  -m "<type>(<scope>): <subject>"
+
+# 6. After merge or an explicit archived handoff, clean the isolated task.
+scripts/agent-harness clean <task-id>
 ```
 
-## Choosing the writer/reviewer pair
+The plan, not the caller, chooses canonical checks from changed paths. Rust,
+Angular behavior, and protocol surfaces get their required deterministic
+gates. Runtime/performance require explicit claims. Actual
+lock/egress/protocol paths add the required cross-vendor specialist. V2
+refuses protected harness/control-plane paths; use the externally anchored v1
+`--kind harness` and `seal-prepared` flow for those during the shadow.
 
-- `--agent` sets the writer vendor (default: `config.json` `default_writer`).
-- `--reviewer` sets the reviewer vendor (default: `config.json` `default_reviewer`).
-- All four pairs are allowed: `claude→codex`, `codex→claude`, `claude→claude`,
-  `codex→codex`. **The shipped default is `claude→claude`** — the harness runs
-  entirely on Claude, no Codex dependency.
-- Whatever the pair, the reviewer is ALWAYS a fresh, independent session with no
-  writer context — so same-vendor is still a real adversarial review, not
-  self-grading, and the implementer never owns the verdict.
-- **Trade-off:** same-vendor loses cross-model-family diversity (Codex and Claude
-  catch different failure modes) — a fresh same-family session recovers the
-  writer's self-attribution blind spot but not its family-level blind spots.
-  So **`lock`/`egress`/`protocol` tasks auto-escalate a same-vendor reviewer to
-  the opposite vendor** (pass `--allow-same-vendor-high-risk` to keep same-vendor
-  there, printed with a loud warning). Other paths stay same-vendor by default.
+Reviewers are fresh, tool-free sessions. They receive only the runner-built
+immutable diff/evidence bundle and have no filesystem or shell tools. A
+transient review gets one bounded retry. Reviewers may request only typed
+allowlisted probes, which the runner executes canonically before a fresh
+review. No PASS is valid with a MAJOR/BLOCKER, proof gap, unresolved probe,
+stale diff, or changed protocol hash.
 
-## Verify the harness itself
+If verification returns:
+
+- `NEEDS_FIX`: repair the worktree yourself, then rerun `verify`.
+- `NEEDS_EVIDENCE`: use `resume`; it runs only the missing evidence.
+- `PAUSED_RETRYABLE` or `INTERRUPTED`: use `resume`; green checkpoints survive.
+- `PASSED`: use only `commit`; keep the task through push, PR, CI, and merge,
+  then `clean`.
+
+For abandonment, run `clean <task-id> --abandon`. It archives every visible
+tracked/untracked byte before removing only that task's worktree.
+
+## Compatibility
+
+Legacy-only `init`, `run`, `seal-prepared`, `verify-attestation`, `close`,
+`reap`, `gc`, and `eval` still dispatch to v1; generation-aware `status` and
+`commit` preserve existing v1 tasks. Finish a valid v1 PASS in v1. Adopt a
+nonterminal v1 diff with `import-v1`; import preserves source artifacts and
+never fabricates PASS.
+
+Receipt policy is monotonic. `agent/v2/*` is reserved for v2 receipts. A
+legacy receipted history may upgrade v1 -> v2, but cannot downgrade v2 -> v1
+or return to `Harness-Lane: B`. Lane B is valid only as a pre-receipt opt-out
+on an ordinary non-v2 `agent/*` branch.
+
+For a Claude multi-task program, establish a session `/goal` requiring the next
+manifest action within 60 seconds of the previous stable outcome. Scheduling
+does not belong to the verifier.
+
+## Verify the harness
 
 ```bash
-bash .claude/hooks/selftest.sh
-scripts/agent-harness selftest --ci
+python3 .agents/harness/v2_selftest.py
+scripts/verify-harness-attestation --selftest
+bash .codex/hooks/selftest.sh
 scripts/agent-config-audit --ci
+scripts/agent-harness selftest --ci
 ```
+
+These certify deterministic control-plane behavior, not Murmur product
+behavior. Push, PR, merge, signing, notarization, and publication remain
+operator-owned.

--- a/.agents/skills/ship-feature/SKILL.md
+++ b/.agents/skills/ship-feature/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship-feature
-description: The agentic feature-shipping discipline for Murmur (Tauri 2.11 Rust core + Angular 22 zoneless). Scope → (Workflow) plan → build backend and/or FE under the project conventions → ADVERSARIAL verify (an adversarial-verifier pass, plus a lock-security review when the change touches the lock/crypto/visibility path) → gates green (cargo test --lib, ng lint, ng build, scripts/ci.sh) → QueaT commit → PR to the `murmur` trunk. Use whenever the user wants to build, implement, add, or ship a feature/fix in Murmur end-to-end. Encodes the verify-before-trust discipline that caught 7 bugs.
+description: Ship a Murmur feature through scope, isolated implementation, fresh adversarial and required security review, project gates, a QueaT commit, and a PR to `murmur`. Use the Harness v2 shadow candidate only for risky, multi-step, or explicitly requested work; ordinary low-risk fixes keep the normal isolated-worktree route.
 ---
 
 # /ship-feature — ship a Murmur feature end-to-end
@@ -29,29 +29,49 @@ builder and whether the lock-security review is mandatory:
   `screenshare.rs`, `storage/migration.rs`, the unlock/seal/visibility path,
   or content-read gating ⇒ the **lock-security review is MANDATORY** in stage 4.
 
-### 2. Create the executable task contract
+### 2. Choose the smallest honest route
+
+The harness is opt-in. A small docs/chore/mechanical/low-risk fix uses a normal
+isolated feature worktree, fresh independent review, the relevant project gates,
+and a normal QueaT commit. Do not add a Harness receipt merely because this
+skill was invoked.
+
+Use the Harness v2 shadow candidate for lock/crypto/egress/protocol work,
+multi-step changes, or when the operator explicitly requests the receipt. V2
+must not own protected control-plane paths; those still require the v1
+`--kind harness` plus `seal-prepared` bootstrap.
+
+### 2a. Create the v2 executable task contract when that route applies
 For a multi-part change, write a short plan: the exact files/symbols, the IPC seam (new Tauri
 command name + the `ipc.service.ts` call), data shape (`core/models.ts` ↔ Rust DTO), and the
-verification you'll demand. Every mutation task is initialized through `scripts/agent-harness init`:
-give it explicit owned paths, risk flags and deterministic checks. The harness creates the worktree;
-never point a writer at the shared primary checkout. Then run `scripts/agent-harness run <task-id>`.
-Unless the user explicitly chooses otherwise, the checked-in harness policy selects **Claude as
-writer and Codex as reviewer**; do not silently reverse that pair in the orchestration prompt.
-It owns the writer → checks → fresh spec review → fresh adversarial/risk review → bounded repair
-state machine. Keep the contract honest about what a dev run *can't* prove (Touch ID / lock-at-rest /
-screen-share need a signed build — see `/tauri-dev`).
+behavioral outcomes and invariants the implementation must satisfy. Do not put
+imperative check commands or requests to report command output in the contract:
+the derived plan is the sole executable evidence profile. Open Harness v2 with
+explicit owned paths and only real runtime or performance claims:
+
+```bash
+scripts/agent-harness open <task-id> --kind <bug|feature|refactor> \
+  --prompt "<scope and acceptance criteria>" \
+  --owned <path> [--owned <path> ...] \
+  [--claim <runtime|performance>] [--reviewer <codex|claude>]
+```
+
+Run this from a dedicated standalone driver clone, not the shared primary
+checkout or a linked driver worktree. The harness creates and prints the
+isolated worktree. Assign exactly one implementer to that worktree, then use
+that worktree's own runner. V2 does not dispatch a writer or repair code.
+The current exact diff derives canonical checks and actual lock/egress/protocol reviews, so do not
+substitute caller-selected risk labels or weaker commands. Keep the contract honest about what a
+dev run cannot prove (Touch ID / lock-at-rest / screen-share need a signed build).
 
 ### 3. Build — to the project conventions (non-negotiable)
-Dispatch the work to the matching builder role (today only `murmur-researcher` exists as a
-standing agent; the builder/verifier roles below are dispatched as task subagents — give each
-the conventions explicitly). Iterate with `/tauri-dev` (`MURMUR_DEV_DEK` recipe,
-`cargo test --lib` loop).
+Dispatch implementation to the matching custom role (`rust-tauri-dev` and/or
+`angular-zoneless-dev`) and keep the verifier in a fresh, separate session.
+Iterate with `/tauri-dev` (`MURMUR_DEV_DEK` recipe, `cargo test --lib` loop).
 
-**Prior lessons are executable input.** The harness deterministically selects and prepends the
-role-relevant curated `## Recurring patterns` from canonical `.codex/learnings/`, bounds the
-injected bytes, and includes the full canonical learnings tree in `instructions_sha256`. Do not
-manually duplicate that block in a harness task. For a read-only subagent dispatched outside the
-harness, prepend the relevant curated section explicitly.
+**Prior lessons are executable input.** Read the binding `.codex/rules/` file for each surface
+before editing and apply relevant curated `## Recurring patterns` from `.codex/learnings/`.
+Harness v2 verifies the resulting diff; it does not inject implementation context or repair it.
 
 **Rust / Tauri rules:**
 - `AppError` + `Result` everywhere (`error.rs`); new commands registered in the
@@ -87,18 +107,24 @@ explicit user approval.** Banned:
 constructor injection.
 
 ### 4. ADVERSARIAL verify (the part that caught 7 bugs)
-The author does **not** self-certify. Verify in **two sequential passes** (a spec review before a
-code review catches "built the wrong thing" before code-quality noise buries it):
+The author does **not** self-certify. On the v2 route, inspect the plan and run
+the verifier:
 
-**4a — Spec review (fast):** does the diff implement what stage-1 scope / stage-2 plan actually
-asked for? Nothing missing, nothing extra, the IPC seam and data shape as agreed. Only after this
-signs off does the code/adversarial pass begin.
+```bash
+scripts/agent-harness plan <task-id>
+scripts/agent-harness verify <task-id>
+scripts/agent-harness resume <task-id> # when paused/interrupted/evidence was added
+```
 
-**4b — Adversarial-verifier pass** over the diff whose job is to make it FAIL:
+The fresh combined reviewer checks both scope/spec fidelity and adversarial correctness. Its job is
+to make the exact diff FAIL:
 - For each load-bearing claim ("it locks", "it's gated", "the migration is safe", "the signal
   updates"), ask **"what would make this false?"** and try it.
-- Exercise the real seam, not mocks: run it under `/tauri-dev`, drive the IPC command, read
-  `/tmp/murmur-dev.log` for panics/aborts, confirm the FE signal actually re-renders.
+- Demand evidence from the real seam, not merely mocks. The v2 reviewer itself
+  is tool-free: it receives the immutable runner-built bundle and has no
+  filesystem or shell access. It may request only a typed runner-owned probe.
+  Live `/tauri-dev`, IPC, log, or browser evidence is produced outside that
+  reviewer session and named honestly.
 - Check the **negative**: a locked/sealed meeting leaks nothing through detail, segments,
   timeline, audio, OR MCP; an additive migration leaves existing rows intact.
 - **If the change touches lock/crypto/visibility (stage 1), run the lock-security review TOO**
@@ -106,24 +132,41 @@ signs off does the code/adversarial pass begin.
   every read path is visibility-gated, keychain ACL / `com.meetnotes.app` continuity
   untouched, no DEK/KEK/plaintext in logs, biometric gate not bypassed outside the dev hatch.
 
-A verifier finding sends it BACK to stage 3. Do not advance on the author's say-so.
+A verifier finding sends it BACK to stage 3; rerun `verify` on the new exact diff. Do not advance
+on the author's say-so. Actual lock/egress/protocol paths add the corresponding cross-vendor
+specialist automatically.
 
-**The runner records the verdict; reviewers do not write their own PASS files.** The canonical
-attestation lives under the shared Git common directory at
-`.git/agent-harness/tasks/<task>/attestation.json`. It binds the contract/instruction/base/tree/staged
-diff hashes, CLI/model identity, every command exit/log hash and each fresh review. The commit hook
-recomputes the staged diff and automatic risk classification; any edit, missing review or failed
-check invalidates PASS.
+For a bug fix, require a focused regression test and the green language suite.
+Do not demand a prose reconstruction of historical RED from the writer. Empirical
+RED is required only when a runner-owned artifact actually performed and
+recorded that proof.
 
-### 5. Gates green
-```bash
-scripts/agent-resource-run --chdir src-tauri -- cargo test --lib
-npx ng lint
-scripts/agent-resource-run -- npx ng build
-scripts/agent-resource-run -- bash scripts/ci.sh
-```
-`scripts/ci.sh` must end `✅ CI: all gates green`. (Reminder: `clippy --all-targets` belongs
-in `ci.sh`, NOT the inner loop — see `/tauri-dev`.)
+On the normal low-risk route, dispatch a fresh read-only adversarial verifier
+outside the author session and retain its concrete verdict in the PR handoff.
+
+**The runner records the verdict; reviewers do not write their own PASS files.** V2 evidence lives
+under `.git/agent-harness/v2/tasks/<task>/attempts/<attempt>/evidence.json`. It binds contract,
+base, exact binary diff/tree, plan, protocol, check/probe artifacts, reviewer invocation metadata,
+findings and telemetry. Any edit or protocol drift invalidates PASS. A reviewer may request only a
+typed allowlisted probe; arbitrary shell access is forbidden.
+
+### 5. Selected gates green; integration stays remote
+
+On the v2 route, do not manually rerun checks that the exact-diff plan already
+recorded. A changed diff gets a new plan and `verify`; an unchanged PASS proceeds
+to commit and PR.
+
+On the normal low-risk route, run each relevant local gate once:
+
+- Rust source: `scripts/agent-resource-run --chdir src-tauri -- cargo test --lib`.
+- Angular source: `npx ng lint` and
+  `scripts/agent-resource-run -- npx ng build`.
+- Behavioral UI work: the relevant Playwright smoke.
+
+The full `scripts/ci.sh` is the GitHub PR/release-parity integration gate, not a
+second local repair-loop pass. Run it locally only when the operator explicitly
+asks or as release preflight. (`clippy --all-targets` belongs inside `ci.sh`,
+never the inner loop.)
 
 ### 5b. Extract the lesson (close the loop)
 If verification caught anything real — or the run confirmed a non-obvious approach that worked —
@@ -134,24 +177,40 @@ lesson" instead of a re-paid one.
 
 ### 6. Commit as QueaT
 ```bash
-# Commit through the runner — never from the shared checkout.
+# V2 route: commit through the runner; its durable intent survives a crash.
 scripts/agent-harness status <task-id>
-scripts/agent-harness verify-attestation <task-id>
 scripts/agent-harness commit <task-id> -m "<type>(<scope>): <subject>"
-git -C ../.murmur-agent-tasks/<task-id>/meetnotes log -1 --format='%an <%ae>'
+git -C ../.murmur-agent-tasks/v2/<task-id>/meetnotes log -1 --format='%an <%ae>'
 # MUST be QueaT <kgm004a@gmail.com>
 ```
-Never use `git add -A` in a shared repository. **No `Co-Authored-By: Codex` / no Codex trailers.** Conventional-commit style
+Never use `git add -A` in a shared repository. **No AI co-author trailers.** Conventional-commit style
 (`feat`/`fix`/`chore(scope)`), matching the existing log.
+
+For the normal low-risk route, stage only the explicit owned files and create a
+normal QueaT commit without Harness trailers. Use a conventional `fix/<slug>`,
+`feat/<slug>`, or `chore/<slug>` branch so the remote `agent/*` receipt gate does
+not mistake it for a harness task. If an operator deliberately keeps a
+non-harness commit on an `agent/*` branch, the PR description must declare the
+explicit Lane-B handoff on its own line:
+
+```text
+Harness-Lane: B
+```
+
+Lane B is valid only before any receipt exists on an ordinary non-v2
+`agent/*` branch. Never use it on `agent/v2/*`, after a v1/v2 receipt, or to
+paper over a failed receipt check; repair or re-verify the receipted lifecycle
+instead.
 
 ### 7. PR to the `murmur` trunk (never direct push)
 ```bash
-git -C ../.murmur-agent-tasks/<task-id>/meetnotes push -u origin agent/<task-id>
-gh pr create -R murmur-io/murmur --base murmur --head agent/<task-id> \
+git -C ../.murmur-agent-tasks/v2/<task-id>/meetnotes push -u origin agent/v2/<task-id>
+gh pr create -R murmur-io/murmur --base murmur --head agent/v2/<task-id> \
   --title "<type>(<scope>): <subject>" --body "<what + how verified>"
 
-# From the primary checkout after the exact task commit exists (before or after PR merge):
-scripts/agent-harness close <task-id>
+# Keep the task/worktree through push, PR creation, and CI. After the PR merges
+# (or the operator explicitly accepts an archived handoff), clean it:
+scripts/agent-harness clean <task-id>
 ```
 `gh` active account MUST be `JakubGawr`. Base is `murmur` (the trunk) via PR — direct
 `git push origin murmur` is blocked by the environment guard. If this feature is a release,
@@ -165,7 +224,7 @@ hand off to **`/release-murmur`**.
 - **Conventions are binding** — the Rust (AppError/Result, additive migrations,
   verify-before-destroy, gated reads, crash-safe FFI) and Angular-zoneless (signals/`@if`/
   `toSignal`/no-`setTimeout`/no-new-deps) rules above are non-negotiable.
-- **Identity interlocks:** commit author=QueaT (no Codex trailers), gh=JakubGawr, PR base
+- **Identity interlocks:** commit author=QueaT (no AI trailers), gh=JakubGawr, PR base
   =`murmur`, `com.meetnotes.app` immutable.
 - **Honest about the signed-build boundary.** A dev run cannot prove Touch ID / lock-at-rest /
   screen-share — say so; only a Developer-ID build verifies them (`/release-murmur`).

--- a/.claude/rules/agentic-workflow.md
+++ b/.claude/rules/agentic-workflow.md
@@ -1,22 +1,84 @@
 # Agentic workflow — Murmur (binding)
 
-How to get maximum leverage out of the agent fleet on this project. The throughline: **the implementer never owns the verdict.** Every real bug here was caught by an *independent, adversarial* check — not by the agent that wrote the code.
+The implementer never owns the verdict. Use independent, adversarial evidence
+for every risky or multi-step change.
 
-## The executable workflow
+## Verifier-only Harness v2 shadow candidate
 
-Use `scripts/agent-harness` for every write task that is multi-step or benefits from independent verification. The runner, not chat state, owns the contract, isolated worktree, checks, reviews, bounded repairs, trace and final attestation:
+Harness v2 is an opt-in Phase-1 candidate for risky, multi-step, or
+operator-requested work. It is not the default until the historical replay and
+real-task shadow budgets pass:
 
-- **Ship a feature** → `plan → build (backend and/or FE) → adversarial verify`. See `.agents/skills/ship-feature`.
-- **Refactor / migrate** → `map the seams → change → re-verify the same behavior`.
-- **Research / design** → fan out independent angles (`murmur-researcher`) → synthesize a decision-ready brief.
-- **Release** → the `release-murmur` runbook stages can be driven as a `build → sign → notarize → publish` pipeline, or with fanned-out pre-release gates. See `.agents/skills/release-murmur`.
+```text
+open -> implement in isolated worktree -> plan -> verify/resume
+     -> exact PASS -> commit -> push/PR/CI/merge -> clean
+```
 
-Default shape: `init → writer → checks → spec review → adversarial/risk review → max two repairs → final checks → hash-bound PASS → exact commit → PR → close`. The writer/reviewer pair is configurable per task (`--agent`/`--reviewer`): any of Claude→Codex, Codex→Claude, Claude→Claude, Codex→Codex. The default is **Claude writer → Claude reviewer**. Whatever the pair, the reviewer is ALWAYS a fresh, independent session with no writer context — the implementer never owns the verdict; `lock`/`egress`/`protocol` tasks auto-escalate a same-vendor reviewer to the opposite vendor (opt out with `--allow-same-vendor-high-risk`). The selftest-only `fake` adapter stays forbidden in production. Use `scripts/agent-harness commit` so the committed tree and QueaT identity are derived from the receipt. One writer owns one worktree. Parallelize read-only research; serialize writers, Cargo and anything sharing a file.
+It has no writer dispatch and no automatic repair loop. One assigned writer
+owns the isolated worktree and declared paths. The runner owns the exact-diff
+snapshot, deterministic checks, fresh tool-free reviews, typed probes, receipt,
+commit, and cleanup.
 
-## One resource lane for every Rust/full-CI process
+Run orchestration from a dedicated standalone driver clone, never a linked
+worktree backed by the user's primary `.git`. After `open`, run the task's own
+`scripts/agent-harness`; executable protocol drift is a hard refusal.
+V2 cannot own protected control-plane paths. Those continue through v1
+`--kind harness` plus `seal-prepared` during the shadow.
 
-Parallel reasoning is useful; overlapping the always-compiled ML tree is not. Every agent-issued
-Cargo/rustc/full-CI command must run through the repo-global supervisor:
+```bash
+scripts/agent-harness open <task-id> --prompt "<scope>" \
+  --owned <path> [--owned <path> ...]
+scripts/agent-harness plan <task-id>
+scripts/agent-harness verify <task-id>
+scripts/agent-harness resume <task-id>  # only when evidence is incomplete
+scripts/agent-harness commit <task-id> -m "<message>"
+# After push, PR checks, and merge (or explicit archived handoff):
+scripts/agent-harness clean <task-id>
+```
+
+The behavioral contract cannot prescribe executable proof commands; the
+actual-diff plan is the sole command/evidence profile. Keep a committed task
+through push, PR creation, and CI. Run `clean` only after merge or an explicit
+operator-approved archived handoff.
+
+The current exact changed paths, not caller-provided risk labels, select the
+canonical profile. Rust, Angular, UI behavior, and protocol surfaces get their
+required checks. Protected harness/control-plane surfaces are refused by v2
+and stay on the externally anchored v1 bootstrap. Runtime/performance are
+explicit `--claim` values. Actual lock/egress/protocol paths add the mandatory
+security specialist.
+
+Reviewers are fresh and tool-free, with at most three independent reviews in
+parallel. They receive only the runner-built immutable diff/evidence bundle;
+they have no filesystem or shell tools. One bounded retry is allowed only for
+transient reviewer failure. They may request a typed allowlisted probe; the
+runner executes the canonical command and reruns a fresh review bound to that
+probe evidence. A MAJOR/BLOCKER, proof gap, unresolved probe, stale diff, or
+protocol drift forbids PASS.
+
+Completed exact-attempt green checkpoints survive interruption. State events
+are authoritative, projections repair only from those events, and a durable
+commit intent recovers a process death after `git commit` without creating a
+second commit. `clean --abandon` archives every visible tracked/untracked task
+byte before removing the isolated worktree.
+
+Legacy v1 `init/run/seal-prepared/verify-attestation/commit/close/reap/gc/eval`
+remains available for existing task lifecycle compatibility. Finish valid v1
+PASS/COMMITTED tasks in v1. Use `import-v1` to adopt a nonterminal v1 diff
+without rerunning its writer; import must preserve v1 artifacts and never
+fabricate PASS.
+
+Receipt policy is monotonic. `agent/v2/*` is reserved for v2 and every
+branch-authored non-merge commit there needs a v2 receipt. A legacy receipted
+history may upgrade v1 -> v2, but no history may downgrade v2 -> v1 or from
+any receipt back to `Harness-Lane: B`. Lane B remains only an explicit
+pre-receipt opt-out on an ordinary non-v2 `agent/*` branch.
+
+## One shared resource lane
+
+Every agent-issued Cargo/rustc/full-CI process must use the workspace lane
+under `../.murmur-agent-tasks/.resources`; it is shared by the primary checkout,
+linked task worktrees, and the standalone driver clone:
 
 ```bash
 scripts/agent-resource-run --chdir src-tauri -- cargo test --lib
@@ -24,52 +86,57 @@ scripts/agent-resource-run -- bash scripts/ci.sh
 scripts/agent-dev-run -- npm run dev
 ```
 
-The supervisor locks Git's common directory, so linked worktrees serialize; it caps build/test
-parallelism, owns a fresh process group, and reaps descendants on timeout, signal, or normal exit.
-The executable harness uses that exact same kernel lock for its deterministic checks. A long-lived
-dev server is the one special case: `agent-dev-run` supervises it outside the flock and injects
-private `cargo`/`rustc` PATH proxies whose individual processes acquire `agent-resource-run`.
-Wrapping `npm run dev` in `agent-resource-run` is forbidden because it starves every other
-worktree. Direct Cargo (including metadata), bare Tauri dev/build, and Angular production builds
-are blocked by the shared hook guard; text searches and lightweight lint remain available.
+The lane publishes owner PID/task/command/start time and heartbeat immediately.
+Waiters report the owner immediately and heartbeat; there is no silent wait.
+Long-lived dev stays outside the flock and proxies only child Cargo/rustc
+processes through it.
 
-## The adversarial-verify discipline (the core)
+## Adversarial verification
 
-A change is not done because it compiles. It is done when an independent agent **tried to break it and failed**:
+A compiling change is not done. A fresh verifier must try to make its claims
+false:
 
-- Run the **real gates**: `scripts/agent-resource-run --chdir src-tauri -- cargo test --lib` (never bare `clippy --all-targets` — it thrashes the openssl/sqlcipher profile and times out), `npx ng lint`, `scripts/agent-resource-run -- npx ng build`.
-- **Live-reproduce**, don't trust unit tests at the FE↔BE seam: drive the running app at `http://localhost:1420` via Playwright MCP with a mocked `window.__TAURI_INTERNALS__.invoke`; or launch the dev app and watch `/tmp/murmur-dev.log` for a clean boot (no abort).
-- **RED before GREEN.** A bug fix needs a regression that fails on the old code and passes on the new. A test that passes against unpatched code didn't capture the bug.
-- **Hunt the failure modes this project actually ships** (every one slipped past a green build+lint):
-  1. **Seal content-loss** — keyed dedup destroying non-first rows on encrypt.
-  2. **Sealed-content leak** — a read/asset path returning sealed data un-gated (incl. `audio_path` reaching `convertFileSrc`/the `asset:` protocol, which bypasses every backend command).
-  3. **macOS FFI abort** — an unrecognized-selector `NSException` crossing FFI ("Rust cannot catch foreign exceptions") and aborting at launch.
-  4. **Unguarded IPC effect** — an effect-orchestrated fetch without a stale-result guard
-     (late response overwrites newer state; NG0600/`allowSignalWrites` itself is gone since v19).
-  5. **Import-cycle `ɵcmp`** — mutually-recursive standalone components each in the other's `imports` (needs `forwardRef`).
-  6. **Opacity bleed** — a popover/modal using the frosted `.card` instead of an opaque `--surface-overlay`.
-  7. **Prod-only CSP style break** — Angular component styles disappear in packaged WebKit when
-     a nonce is injected into `style-src`; a styled shell screenshot is not route-content proof.
-- The **adversarial-verifier** agent owns PASS/FAIL. For anything touching the lock model or crypto, the **lock-security-reviewer** is a required second gate. The implementing agent self-checks but **must not self-certify**.
+- Run the real selected gates. For Rust inner loops use `cargo test --lib`,
+  never bare `clippy --all-targets`.
+- Live-reproduce FE/IPC behavior when the change requires it. Drive
+  `http://localhost:1420` with a mocked
+  `window.__TAURI_INTERNALS__.invoke`, or boot the dev app and inspect
+  `/tmp/murmur-dev.log` for an abort-free launch; a synthetic or unit-only gate
+  is not runtime proof.
+- A bug regression must fail on the unpatched code and pass on the new code. A
+  test that also passes before the fix did not capture the bug. Empirical RED
+  counts only when a runner-owned artifact performed and recorded it; writer
+  prose or a reconstruction is never proof.
+- Hunt known shipped failures: seal content loss, sealed-content/asset leaks,
+  macOS FFI aborts, stale IPC effects, standalone import cycles, overlay opacity
+  bleed, and packaged WebKit CSP style loss.
+- Any lock/crypto/content-read change requires the lock security specialist.
+
+The verifier records findings; it never edits the implementation. Repair
+belongs to the assigned writer, followed by a new exact-diff verify.
 
 ## Trust code, not docs
 
-The hard-won lesson on this repo: **the docs were repeatedly wrong.** `docs/STATUS.md` and friends drift. When a claim is load-bearing, open the file (`file:line`) and confirm it against the current tree. Distrust your own first read, too.
+Repository prose drifts. Confirm every load-bearing claim against the current
+file and symbol, and distrust the first read.
 
-**Cite by SYMBOL, not line number.** Commands and storage are split across growing domain modules
-under `commands/` and `storage/`; `grep` the symbol name (`fn meeting_is_unlocked`,
-`visibility_clause`) before trusting any prose anchor. A line citation is a hint, never a promise
-about the current row. (The audit that surfaced this:
-`docs/research/2026-07-02-claude-setup-audit.md`.)
+**Cite by symbol, not line number.** Commands and storage move among growing
+domain modules under `commands/` and `storage/`; search symbols such as
+`meeting_is_unlocked` or `visibility_clause` before trusting a prose anchor. A
+line citation is only a hint. The sourcing audit is
+`docs/research/2026-07-02-claude-setup-audit.md`.
 
-## Honesty bar
+For Claude multi-task programs, use a session-scoped `/goal` that requires the
+next manifest action within 60 seconds after the prior stable outcome. Task
+scheduling stays outside the verifier.
 
-Some things genuinely cannot be verified headless: real mic capture, live ScreenCaptureKit, the **Touch ID** prompt, lock-at-rest behavior, and whether screen-share auto-relock fires on a real Zoom/Meet share — these need a **signed build on a real Mac**. Say so plainly; don't claim a green unit test proves them. "Needs a signed build / a real Mac / recorded evidence" is the honest bar.
+## Honesty and ownership
 
-## Constraints the fleet must respect
+Headless checks cannot prove real mic capture, ScreenCaptureKit/TCC, Touch ID,
+lock-at-rest, signed-build behavior, notarization, or a real meeting workflow.
+Name that boundary explicitly.
 
-- Commits/PRs authored **only** by `QueaT <kgm004a@gmail.com>`; **no AI co-author trailers**. `gh` active account = `JakubGawr`.
-- **Never push to the `murmur` trunk directly** (the canonical `block-bash` guard, exposed through
-  both vendor hook adapters, refuses it with exit 2) — merge via a PR (`gh pr create` → `gh pr merge`).
-- `com.meetnotes.app` is immutable (TCC/Keychain continuity).
-- No new npm packages or crates without explicit user approval.
+Commits are only `QueaT <kgm004a@gmail.com>` with no AI co-author trailers.
+Push, PR creation, merge, signing, notarization, and publication are
+operator-owned. Never direct-push `murmur`; use a PR. `com.meetnotes.app` is
+immutable. No new npm package or crate without explicit approval.

--- a/.claude/skills/harness/SKILL.md
+++ b/.claude/skills/harness/SKILL.md
@@ -1,76 +1,118 @@
 ---
 name: harness
-description: Run a change through the full Murmur harness — isolated worktree, writer, deterministic checks, independent adversarial + risk reviews, hash-bound PASS attestation, guarded commit. Use PROACTIVELY when a change is risky, multi-step, or you want the earned safety net (lock/crypto/egress/protocol, or anything you want independently verified). Skip it for docs, chores, and low-risk edits — those commit normally.
+description: Shadow-test a risky or multi-step Murmur change through the verifier-only Harness v2 candidate — isolated worktree, exact-diff plan, deterministic checks, fresh adversarial and risk reviews, crash-resumable PASS receipt, guarded commit, and lossless cleanup. Use proactively for lock, crypto, egress, protocol, or any change needing independent verification. Skip it for docs, chores, and low-risk edits.
 ---
 
-# `/harness` — opt-in rigor
+# `/harness` — opt-in verifier-only rigor
 
-Murmur's harness is **opt-in**. Normal commits run freely (only secret-scan and
-trunk-push protection are always on). Invoke the harness deliberately, via this
-skill, when a change deserves independent verification.
+Murmur's harness is opt-in. Use it when a change deserves an independently
+earned, hash-bound verdict. Ordinary low-risk commits remain outside it. V2 is
+still a shadow candidate, not the repository default.
 
-## When to reach for it
+Harness v2 does not dispatch a writer or repair code. You or the assigned
+implementer edits one isolated worktree; the runner derives and verifies the
+exact diff. The implementer never owns PASS.
 
-- Anything touching the lock model / crypto / secrets / storage / MCP / egress /
-  the sharing protocol (the `risk_classification` paths in
-  `.agents/harness/config.json`).
-- A multi-step feature or refactor where you want a fresh adversarial reviewer to
-  try to break the change before it lands.
-- Any time you want the hash-bound Definition-of-Done receipt on the commit.
+## Use it for
 
-For a docs fix, a chore, a version bump, or a small low-risk edit: **do not use
-this** — just commit normally.
+- Lock, crypto, secrets, gated content reads, storage, MCP, egress, or sharing
+  protocol changes.
+- Multi-step features/refactors where a fresh reviewer should try to break the
+  result.
+- Any change that needs an exact-diff receipt before commit.
 
-## How it works
+Skip it for a small docs edit, chore, metadata bump, or clearly low-risk
+mechanical change unless the operator explicitly wants the receipt.
 
-The switch is physical: the harness runs in an **isolated sibling worktree** that
-carries a task manifest. While that task is active, `finish-guard` enforces the
-full attestation and the resource lane is required for heavy commands. Your main
-`murmur` checkout never has a task, so work there is unconstrained.
+## Required lifecycle
 
-## Run it
+Run orchestration from a dedicated standalone driver clone, never the user's
+primary checkout or a linked driver worktree. After `open`, change into the
+printed task worktree and use that
+worktree's runner so the executable protocol equals the pinned protocol.
 
 ```bash
-# 1. Create the contract + isolated worktree (task_id is positional;
-#    --prompt and --owned are required, --owned may repeat for multiple paths)
-scripts/agent-harness init <task-id> --kind <bug|feature|refactor|docs|harness> \
-  --prompt "<what>" --owned <path> [--owned <path> ...] \
-  [--risk <lock|egress|protocol|runtime|ui|performance|release>] \
-  [--agent <codex|claude>] [--reviewer <codex|claude>]
+# 1. Open the contract and isolated worktree.
+scripts/agent-harness open <task-id> \
+  --kind <bug|feature|refactor|docs|harness> \
+  --prompt "<what must be true>" \
+  --owned <path> [--owned <path> ...] \
+  [--claim <runtime|performance>] \
+  [--reviewer <codex|claude>]
 
-# 2. Drive writer → checks → independent reviews → PASS attestation
-scripts/agent-harness run <task-id>
+# 2. Implement only in the printed worktree and declared scope.
 
-# 3. Commit from the attested index (QueaT identity, no AI trailers) and open a PR
-scripts/agent-harness commit <task-id> -m "<type>(<scope>): <subject>"
-gh pr create -R murmur-io/murmur --base murmur
-gh pr merge --merge
+# The prompt is behavioral acceptance only. It must not demand that the writer
+# run or report commands; the derived plan is the sole executable evidence.
 
-# 4. Close the task
-scripts/agent-harness close <task-id>
+# 3. Inspect the exact derived plan, then verify.
+scripts/agent-harness plan <task-id>
+scripts/agent-harness verify <task-id>
+scripts/agent-harness status <task-id>
+
+# 4. Continue only missing/retryable evidence when needed.
+scripts/agent-harness resume <task-id>
+
+# 5. Commit the exact PASS. Push and create/merge the PR before cleanup.
+scripts/agent-harness commit <task-id> \
+  -m "<type>(<scope>): <subject>"
+
+# 6. After merge or an explicit archived handoff, clean the isolated task.
+scripts/agent-harness clean <task-id>
 ```
 
-## Choosing the writer/reviewer pair
+The plan, not the caller, chooses canonical checks from changed paths. Rust,
+Angular behavior, and protocol surfaces get their required deterministic
+gates. Runtime/performance require explicit claims. Actual
+lock/egress/protocol paths add the required cross-vendor specialist. V2
+refuses protected harness/control-plane paths; use the externally anchored v1
+`--kind harness` and `seal-prepared` flow for those during the shadow.
 
-- `--agent` sets the writer vendor (default: `config.json` `default_writer`).
-- `--reviewer` sets the reviewer vendor (default: `config.json` `default_reviewer`).
-- All four pairs are allowed: `claude→codex`, `codex→claude`, `claude→claude`,
-  `codex→codex`. **The shipped default is `claude→claude`** — the harness runs
-  entirely on Claude, no Codex dependency.
-- Whatever the pair, the reviewer is ALWAYS a fresh, independent session with no
-  writer context — so same-vendor is still a real adversarial review, not
-  self-grading, and the implementer never owns the verdict.
-- **Trade-off:** same-vendor loses cross-model-family diversity (Codex and Claude
-  catch different failure modes) — a fresh same-family session recovers the
-  writer's self-attribution blind spot but not its family-level blind spots.
-  So **`lock`/`egress`/`protocol` tasks auto-escalate a same-vendor reviewer to
-  the opposite vendor** (pass `--allow-same-vendor-high-risk` to keep same-vendor
-  there, printed with a loud warning). Other paths stay same-vendor by default.
+Reviewers are fresh, tool-free sessions. They receive only the runner-built
+immutable diff/evidence bundle and have no filesystem or shell tools. A
+transient review gets one bounded retry. Reviewers may request only typed
+allowlisted probes, which the runner executes canonically before a fresh
+review. No PASS is valid with a MAJOR/BLOCKER, proof gap, unresolved probe,
+stale diff, or changed protocol hash.
 
-## Verify the harness itself
+If verification returns:
+
+- `NEEDS_FIX`: repair the worktree yourself, then rerun `verify`.
+- `NEEDS_EVIDENCE`: use `resume`; it runs only the missing evidence.
+- `PAUSED_RETRYABLE` or `INTERRUPTED`: use `resume`; green checkpoints survive.
+- `PASSED`: use only `commit`; keep the task through push, PR, CI, and merge,
+  then `clean`.
+
+For abandonment, run `clean <task-id> --abandon`. It archives every visible
+tracked/untracked byte before removing only that task's worktree.
+
+## Compatibility
+
+Legacy-only `init`, `run`, `seal-prepared`, `verify-attestation`, `close`,
+`reap`, `gc`, and `eval` still dispatch to v1; generation-aware `status` and
+`commit` preserve existing v1 tasks. Finish a valid v1 PASS in v1. Adopt a
+nonterminal v1 diff with `import-v1`; import preserves source artifacts and
+never fabricates PASS.
+
+Receipt policy is monotonic. `agent/v2/*` is reserved for v2 receipts. A
+legacy receipted history may upgrade v1 -> v2, but cannot downgrade v2 -> v1
+or return to `Harness-Lane: B`. Lane B is valid only as a pre-receipt opt-out
+on an ordinary non-v2 `agent/*` branch.
+
+For a Claude multi-task program, establish a session `/goal` requiring the next
+manifest action within 60 seconds of the previous stable outcome. Scheduling
+does not belong to the verifier.
+
+## Verify the harness
 
 ```bash
-bash .claude/hooks/selftest.sh
-scripts/agent-harness selftest --ci
+python3 .agents/harness/v2_selftest.py
+scripts/verify-harness-attestation --selftest
+bash .codex/hooks/selftest.sh
 scripts/agent-config-audit --ci
+scripts/agent-harness selftest --ci
 ```
+
+These certify deterministic control-plane behavior, not Murmur product
+behavior. Push, PR, merge, signing, notarization, and publication remain
+operator-owned.

--- a/.claude/skills/ship-feature/SKILL.md
+++ b/.claude/skills/ship-feature/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship-feature
-description: The agentic feature-shipping discipline for Murmur (Tauri 2.11 Rust core + Angular 22 zoneless). Scope → (Workflow) plan → build backend and/or FE under the project conventions → ADVERSARIAL verify (an adversarial-verifier pass, plus a lock-security review when the change touches the lock/crypto/visibility path) → gates green (cargo test --lib, ng lint, ng build, scripts/ci.sh) → QueaT commit → PR to the `murmur` trunk. Use whenever the user wants to build, implement, add, or ship a feature/fix in Murmur end-to-end. Encodes the verify-before-trust discipline that caught 7 bugs.
+description: Ship a Murmur feature through scope, isolated implementation, fresh adversarial and required security review, project gates, a QueaT commit, and a PR to `murmur`. Use the Harness v2 shadow candidate only for risky, multi-step, or explicitly requested work; ordinary low-risk fixes keep the normal isolated-worktree route.
 ---
 
 # /ship-feature — ship a Murmur feature end-to-end
@@ -29,29 +29,49 @@ builder and whether the lock-security review is mandatory:
   `screenshare.rs`, `storage/migration.rs`, the unlock/seal/visibility path,
   or content-read gating ⇒ the **lock-security review is MANDATORY** in stage 4.
 
-### 2. Create the executable task contract
+### 2. Choose the smallest honest route
+
+The harness is opt-in. A small docs/chore/mechanical/low-risk fix uses a normal
+isolated feature worktree, fresh independent review, the relevant project gates,
+and a normal QueaT commit. Do not add a Harness receipt merely because this
+skill was invoked.
+
+Use the Harness v2 shadow candidate for lock/crypto/egress/protocol work,
+multi-step changes, or when the operator explicitly requests the receipt. V2
+must not own protected control-plane paths; those still require the v1
+`--kind harness` plus `seal-prepared` bootstrap.
+
+### 2a. Create the v2 executable task contract when that route applies
 For a multi-part change, write a short plan: the exact files/symbols, the IPC seam (new Tauri
 command name + the `ipc.service.ts` call), data shape (`core/models.ts` ↔ Rust DTO), and the
-verification you'll demand. Every mutation task is initialized through `scripts/agent-harness init`:
-give it explicit owned paths, risk flags and deterministic checks. The harness creates the worktree;
-never point a writer at the shared primary checkout. Then run `scripts/agent-harness run <task-id>`.
-Unless the user explicitly chooses otherwise, the checked-in harness policy selects **Claude as
-writer and Codex as reviewer**; do not silently reverse that pair in the orchestration prompt.
-It owns the writer → checks → fresh spec review → fresh adversarial/risk review → bounded repair
-state machine. Keep the contract honest about what a dev run *can't* prove (Touch ID / lock-at-rest /
-screen-share need a signed build — see `/tauri-dev`).
+behavioral outcomes and invariants the implementation must satisfy. Do not put
+imperative check commands or requests to report command output in the contract:
+the derived plan is the sole executable evidence profile. Open Harness v2 with
+explicit owned paths and only real runtime or performance claims:
+
+```bash
+scripts/agent-harness open <task-id> --kind <bug|feature|refactor> \
+  --prompt "<scope and acceptance criteria>" \
+  --owned <path> [--owned <path> ...] \
+  [--claim <runtime|performance>] [--reviewer <codex|claude>]
+```
+
+Run this from a dedicated standalone driver clone, not the shared primary
+checkout or a linked driver worktree. The harness creates and prints the
+isolated worktree. Assign exactly one implementer to that worktree, then use
+that worktree's own runner. V2 does not dispatch a writer or repair code.
+The current exact diff derives canonical checks and actual lock/egress/protocol reviews, so do not
+substitute caller-selected risk labels or weaker commands. Keep the contract honest about what a
+dev run cannot prove (Touch ID / lock-at-rest / screen-share need a signed build).
 
 ### 3. Build — to the project conventions (non-negotiable)
-Dispatch the work to the matching builder role (today only `murmur-researcher` exists as a
-standing agent; the builder/verifier roles below are dispatched as task subagents — give each
-the conventions explicitly). Iterate with `/tauri-dev` (`MURMUR_DEV_DEK` recipe,
-`cargo test --lib` loop).
+Dispatch implementation to the matching custom role (`rust-tauri-dev` and/or
+`angular-zoneless-dev`) and keep the verifier in a fresh, separate session.
+Iterate with `/tauri-dev` (`MURMUR_DEV_DEK` recipe, `cargo test --lib` loop).
 
-**Prior lessons are executable input.** The harness deterministically selects and prepends the
-role-relevant curated `## Recurring patterns` from canonical `.codex/learnings/`, bounds the
-injected bytes, and includes the full canonical learnings tree in `instructions_sha256`. Do not
-manually duplicate that block in a harness task. For a read-only subagent dispatched outside the
-harness, prepend the relevant curated section explicitly.
+**Prior lessons are executable input.** Read the binding `.codex/rules/` file for each surface
+before editing and apply relevant curated `## Recurring patterns` from `.codex/learnings/`.
+Harness v2 verifies the resulting diff; it does not inject implementation context or repair it.
 
 **Rust / Tauri rules:**
 - `AppError` + `Result` everywhere (`error.rs`); new commands registered in the
@@ -87,18 +107,24 @@ explicit user approval.** Banned:
 constructor injection.
 
 ### 4. ADVERSARIAL verify (the part that caught 7 bugs)
-The author does **not** self-certify. Verify in **two sequential passes** (a spec review before a
-code review catches "built the wrong thing" before code-quality noise buries it):
+The author does **not** self-certify. On the v2 route, inspect the plan and run
+the verifier:
 
-**4a — Spec review (fast):** does the diff implement what stage-1 scope / stage-2 plan actually
-asked for? Nothing missing, nothing extra, the IPC seam and data shape as agreed. Only after this
-signs off does the code/adversarial pass begin.
+```bash
+scripts/agent-harness plan <task-id>
+scripts/agent-harness verify <task-id>
+scripts/agent-harness resume <task-id> # when paused/interrupted/evidence was added
+```
 
-**4b — Adversarial-verifier pass** over the diff whose job is to make it FAIL:
+The fresh combined reviewer checks both scope/spec fidelity and adversarial correctness. Its job is
+to make the exact diff FAIL:
 - For each load-bearing claim ("it locks", "it's gated", "the migration is safe", "the signal
   updates"), ask **"what would make this false?"** and try it.
-- Exercise the real seam, not mocks: run it under `/tauri-dev`, drive the IPC command, read
-  `/tmp/murmur-dev.log` for panics/aborts, confirm the FE signal actually re-renders.
+- Demand evidence from the real seam, not merely mocks. The v2 reviewer itself
+  is tool-free: it receives the immutable runner-built bundle and has no
+  filesystem or shell access. It may request only a typed runner-owned probe.
+  Live `/tauri-dev`, IPC, log, or browser evidence is produced outside that
+  reviewer session and named honestly.
 - Check the **negative**: a locked/sealed meeting leaks nothing through detail, segments,
   timeline, audio, OR MCP; an additive migration leaves existing rows intact.
 - **If the change touches lock/crypto/visibility (stage 1), run the lock-security review TOO**
@@ -106,52 +132,85 @@ signs off does the code/adversarial pass begin.
   every read path is visibility-gated, keychain ACL / `com.meetnotes.app` continuity
   untouched, no DEK/KEK/plaintext in logs, biometric gate not bypassed outside the dev hatch.
 
-A verifier finding sends it BACK to stage 3. Do not advance on the author's say-so.
+A verifier finding sends it BACK to stage 3; rerun `verify` on the new exact diff. Do not advance
+on the author's say-so. Actual lock/egress/protocol paths add the corresponding cross-vendor
+specialist automatically.
 
-**The runner records the verdict; reviewers do not write their own PASS files.** The canonical
-attestation lives under the shared Git common directory at
-`.git/agent-harness/tasks/<task>/attestation.json`. It binds the contract/instruction/base/tree/staged
-diff hashes, CLI/model identity, every command exit/log hash and each fresh review. The commit hook
-recomputes the staged diff and automatic risk classification; any edit, missing review or failed
-check invalidates PASS.
+For a bug fix, require a focused regression test and the green language suite.
+Do not demand a prose reconstruction of historical RED from the writer. Empirical
+RED is required only when a runner-owned artifact actually performed and
+recorded that proof.
 
-### 5. Gates green
-```bash
-scripts/agent-resource-run --chdir src-tauri -- cargo test --lib
-npx ng lint
-scripts/agent-resource-run -- npx ng build
-scripts/agent-resource-run -- bash scripts/ci.sh
-```
-`scripts/ci.sh` must end `✅ CI: all gates green`. (Reminder: `clippy --all-targets` belongs
-in `ci.sh`, NOT the inner loop — see `/tauri-dev`.)
+On the normal low-risk route, dispatch a fresh read-only adversarial verifier
+outside the author session and retain its concrete verdict in the PR handoff.
+
+**The runner records the verdict; reviewers do not write their own PASS files.** V2 evidence lives
+under `.git/agent-harness/v2/tasks/<task>/attempts/<attempt>/evidence.json`. It binds contract,
+base, exact binary diff/tree, plan, protocol, check/probe artifacts, reviewer invocation metadata,
+findings and telemetry. Any edit or protocol drift invalidates PASS. A reviewer may request only a
+typed allowlisted probe; arbitrary shell access is forbidden.
+
+### 5. Selected gates green; integration stays remote
+
+On the v2 route, do not manually rerun checks that the exact-diff plan already
+recorded. A changed diff gets a new plan and `verify`; an unchanged PASS proceeds
+to commit and PR.
+
+On the normal low-risk route, run each relevant local gate once:
+
+- Rust source: `scripts/agent-resource-run --chdir src-tauri -- cargo test --lib`.
+- Angular source: `npx ng lint` and
+  `scripts/agent-resource-run -- npx ng build`.
+- Behavioral UI work: the relevant Playwright smoke.
+
+The full `scripts/ci.sh` is the GitHub PR/release-parity integration gate, not a
+second local repair-loop pass. Run it locally only when the operator explicitly
+asks or as release preflight. (`clippy --all-targets` belongs inside `ci.sh`,
+never the inner loop.)
 
 ### 5b. Extract the lesson (close the loop)
 If verification caught anything real — or the run confirmed a non-obvious approach that worked —
-append ONE `## Run journal` entry to the relevant `.claude/learnings/<agent>.md` (or run
+append ONE `## Run journal` entry to the relevant `.codex/learnings/<agent>.md` (or run
 `/learn <agent>: <lesson>`), citing the artifact that revealed it. Periodically `/curate-learnings`
 promotes repeat offenders into `## Recurring patterns`. This is what makes "every bug a permanent
 lesson" instead of a re-paid one.
 
 ### 6. Commit as QueaT
 ```bash
-# Commit through the runner — never from the shared checkout.
+# V2 route: commit through the runner; its durable intent survives a crash.
 scripts/agent-harness status <task-id>
-scripts/agent-harness verify-attestation <task-id>
 scripts/agent-harness commit <task-id> -m "<type>(<scope>): <subject>"
-git -C ../.murmur-agent-tasks/<task-id>/meetnotes log -1 --format='%an <%ae>'
+git -C ../.murmur-agent-tasks/v2/<task-id>/meetnotes log -1 --format='%an <%ae>'
 # MUST be QueaT <kgm004a@gmail.com>
 ```
-Never use `git add -A` in a shared repository. **No `Co-Authored-By: Claude` / no Claude trailers.** Conventional-commit style
+Never use `git add -A` in a shared repository. **No AI co-author trailers.** Conventional-commit style
 (`feat`/`fix`/`chore(scope)`), matching the existing log.
+
+For the normal low-risk route, stage only the explicit owned files and create a
+normal QueaT commit without Harness trailers. Use a conventional `fix/<slug>`,
+`feat/<slug>`, or `chore/<slug>` branch so the remote `agent/*` receipt gate does
+not mistake it for a harness task. If an operator deliberately keeps a
+non-harness commit on an `agent/*` branch, the PR description must declare the
+explicit Lane-B handoff on its own line:
+
+```text
+Harness-Lane: B
+```
+
+Lane B is valid only before any receipt exists on an ordinary non-v2
+`agent/*` branch. Never use it on `agent/v2/*`, after a v1/v2 receipt, or to
+paper over a failed receipt check; repair or re-verify the receipted lifecycle
+instead.
 
 ### 7. PR to the `murmur` trunk (never direct push)
 ```bash
-git -C ../.murmur-agent-tasks/<task-id>/meetnotes push -u origin agent/<task-id>
-gh pr create -R murmur-io/murmur --base murmur --head agent/<task-id> \
+git -C ../.murmur-agent-tasks/v2/<task-id>/meetnotes push -u origin agent/v2/<task-id>
+gh pr create -R murmur-io/murmur --base murmur --head agent/v2/<task-id> \
   --title "<type>(<scope>): <subject>" --body "<what + how verified>"
 
-# From the primary checkout after the exact task commit exists (before or after PR merge):
-scripts/agent-harness close <task-id>
+# Keep the task/worktree through push, PR creation, and CI. After the PR merges
+# (or the operator explicitly accepts an archived handoff), clean it:
+scripts/agent-harness clean <task-id>
 ```
 `gh` active account MUST be `JakubGawr`. Base is `murmur` (the trunk) via PR — direct
 `git push origin murmur` is blocked by the environment guard. If this feature is a release,
@@ -165,7 +224,7 @@ hand off to **`/release-murmur`**.
 - **Conventions are binding** — the Rust (AppError/Result, additive migrations,
   verify-before-destroy, gated reads, crash-safe FFI) and Angular-zoneless (signals/`@if`/
   `toSignal`/no-`setTimeout`/no-new-deps) rules above are non-negotiable.
-- **Identity interlocks:** commit author=QueaT (no Claude trailers), gh=JakubGawr, PR base
+- **Identity interlocks:** commit author=QueaT (no AI trailers), gh=JakubGawr, PR base
   =`murmur`, `com.meetnotes.app` immutable.
 - **Honest about the signed-build boundary.** A dev run cannot prove Touch ID / lock-at-rest /
   screen-share — say so; only a Developer-ID build verifies them (`/release-murmur`).

--- a/.codex/rules/agentic-workflow.md
+++ b/.codex/rules/agentic-workflow.md
@@ -1,22 +1,84 @@
 # Agentic workflow — Murmur (binding)
 
-How to get maximum leverage out of the agent fleet on this project. The throughline: **the implementer never owns the verdict.** Every real bug here was caught by an *independent, adversarial* check — not by the agent that wrote the code.
+The implementer never owns the verdict. Use independent, adversarial evidence
+for every risky or multi-step change.
 
-## The executable workflow
+## Verifier-only Harness v2 shadow candidate
 
-Use `scripts/agent-harness` for every write task that is multi-step or benefits from independent verification. The runner, not chat state, owns the contract, isolated worktree, checks, reviews, bounded repairs, trace and final attestation:
+Harness v2 is an opt-in Phase-1 candidate for risky, multi-step, or
+operator-requested work. It is not the default until the historical replay and
+real-task shadow budgets pass:
 
-- **Ship a feature** → `plan → build (backend and/or FE) → adversarial verify`. See `.agents/skills/ship-feature`.
-- **Refactor / migrate** → `map the seams → change → re-verify the same behavior`.
-- **Research / design** → fan out independent angles (`murmur-researcher`) → synthesize a decision-ready brief.
-- **Release** → the `release-murmur` runbook stages can be driven as a `build → sign → notarize → publish` pipeline, or with fanned-out pre-release gates. See `.agents/skills/release-murmur`.
+```text
+open -> implement in isolated worktree -> plan -> verify/resume
+     -> exact PASS -> commit -> push/PR/CI/merge -> clean
+```
 
-Default shape: `init → writer → checks → spec review → adversarial/risk review → max two repairs → final checks → hash-bound PASS → exact commit → PR → close`. The writer/reviewer pair is configurable per task (`--agent`/`--reviewer`): any of Claude→Codex, Codex→Claude, Claude→Claude, Codex→Codex. The default is **Claude writer → Claude reviewer**. Whatever the pair, the reviewer is ALWAYS a fresh, independent session with no writer context — the implementer never owns the verdict; `lock`/`egress`/`protocol` tasks auto-escalate a same-vendor reviewer to the opposite vendor (opt out with `--allow-same-vendor-high-risk`). The selftest-only `fake` adapter stays forbidden in production. Use `scripts/agent-harness commit` so the committed tree and QueaT identity are derived from the receipt. One writer owns one worktree. Parallelize read-only research; serialize writers, Cargo and anything sharing a file.
+It has no writer dispatch and no automatic repair loop. One assigned writer
+owns the isolated worktree and declared paths. The runner owns the exact-diff
+snapshot, deterministic checks, fresh tool-free reviews, typed probes, receipt,
+commit, and cleanup.
 
-## One resource lane for every Rust/full-CI process
+Run orchestration from a dedicated standalone driver clone, never a linked
+worktree backed by the user's primary `.git`. After `open`, run the task's own
+`scripts/agent-harness`; executable protocol drift is a hard refusal.
+V2 cannot own protected control-plane paths. Those continue through v1
+`--kind harness` plus `seal-prepared` during the shadow.
 
-Parallel reasoning is useful; overlapping the always-compiled ML tree is not. Every agent-issued
-Cargo/rustc/full-CI command must run through the repo-global supervisor:
+```bash
+scripts/agent-harness open <task-id> --prompt "<scope>" \
+  --owned <path> [--owned <path> ...]
+scripts/agent-harness plan <task-id>
+scripts/agent-harness verify <task-id>
+scripts/agent-harness resume <task-id>  # only when evidence is incomplete
+scripts/agent-harness commit <task-id> -m "<message>"
+# After push, PR checks, and merge (or explicit archived handoff):
+scripts/agent-harness clean <task-id>
+```
+
+The behavioral contract cannot prescribe executable proof commands; the
+actual-diff plan is the sole command/evidence profile. Keep a committed task
+through push, PR creation, and CI. Run `clean` only after merge or an explicit
+operator-approved archived handoff.
+
+The current exact changed paths, not caller-provided risk labels, select the
+canonical profile. Rust, Angular, UI behavior, and protocol surfaces get their
+required checks. Protected harness/control-plane surfaces are refused by v2
+and stay on the externally anchored v1 bootstrap. Runtime/performance are
+explicit `--claim` values. Actual lock/egress/protocol paths add the mandatory
+security specialist.
+
+Reviewers are fresh and tool-free, with at most three independent reviews in
+parallel. They receive only the runner-built immutable diff/evidence bundle;
+they have no filesystem or shell tools. One bounded retry is allowed only for
+transient reviewer failure. They may request a typed allowlisted probe; the
+runner executes the canonical command and reruns a fresh review bound to that
+probe evidence. A MAJOR/BLOCKER, proof gap, unresolved probe, stale diff, or
+protocol drift forbids PASS.
+
+Completed exact-attempt green checkpoints survive interruption. State events
+are authoritative, projections repair only from those events, and a durable
+commit intent recovers a process death after `git commit` without creating a
+second commit. `clean --abandon` archives every visible tracked/untracked task
+byte before removing the isolated worktree.
+
+Legacy v1 `init/run/seal-prepared/verify-attestation/commit/close/reap/gc/eval`
+remains available for existing task lifecycle compatibility. Finish valid v1
+PASS/COMMITTED tasks in v1. Use `import-v1` to adopt a nonterminal v1 diff
+without rerunning its writer; import must preserve v1 artifacts and never
+fabricate PASS.
+
+Receipt policy is monotonic. `agent/v2/*` is reserved for v2 and every
+branch-authored non-merge commit there needs a v2 receipt. A legacy receipted
+history may upgrade v1 -> v2, but no history may downgrade v2 -> v1 or from
+any receipt back to `Harness-Lane: B`. Lane B remains only an explicit
+pre-receipt opt-out on an ordinary non-v2 `agent/*` branch.
+
+## One shared resource lane
+
+Every agent-issued Cargo/rustc/full-CI process must use the workspace lane
+under `../.murmur-agent-tasks/.resources`; it is shared by the primary checkout,
+linked task worktrees, and the standalone driver clone:
 
 ```bash
 scripts/agent-resource-run --chdir src-tauri -- cargo test --lib
@@ -24,52 +86,57 @@ scripts/agent-resource-run -- bash scripts/ci.sh
 scripts/agent-dev-run -- npm run dev
 ```
 
-The supervisor locks Git's common directory, so linked worktrees serialize; it caps build/test
-parallelism, owns a fresh process group, and reaps descendants on timeout, signal, or normal exit.
-The executable harness uses that exact same kernel lock for its deterministic checks. A long-lived
-dev server is the one special case: `agent-dev-run` supervises it outside the flock and injects
-private `cargo`/`rustc` PATH proxies whose individual processes acquire `agent-resource-run`.
-Wrapping `npm run dev` in `agent-resource-run` is forbidden because it starves every other
-worktree. Direct Cargo (including metadata), bare Tauri dev/build, and Angular production builds
-are blocked by the shared hook guard; text searches and lightweight lint remain available.
+The lane publishes owner PID/task/command/start time and heartbeat immediately.
+Waiters report the owner immediately and heartbeat; there is no silent wait.
+Long-lived dev stays outside the flock and proxies only child Cargo/rustc
+processes through it.
 
-## The adversarial-verify discipline (the core)
+## Adversarial verification
 
-A change is not done because it compiles. It is done when an independent agent **tried to break it and failed**:
+A compiling change is not done. A fresh verifier must try to make its claims
+false:
 
-- Run the **real gates**: `scripts/agent-resource-run --chdir src-tauri -- cargo test --lib` (never bare `clippy --all-targets` — it thrashes the openssl/sqlcipher profile and times out), `npx ng lint`, `scripts/agent-resource-run -- npx ng build`.
-- **Live-reproduce**, don't trust unit tests at the FE↔BE seam: drive the running app at `http://localhost:1420` via Playwright MCP with a mocked `window.__TAURI_INTERNALS__.invoke`; or launch the dev app and watch `/tmp/murmur-dev.log` for a clean boot (no abort).
-- **RED before GREEN.** A bug fix needs a regression that fails on the old code and passes on the new. A test that passes against unpatched code didn't capture the bug.
-- **Hunt the failure modes this project actually ships** (every one slipped past a green build+lint):
-  1. **Seal content-loss** — keyed dedup destroying non-first rows on encrypt.
-  2. **Sealed-content leak** — a read/asset path returning sealed data un-gated (incl. `audio_path` reaching `convertFileSrc`/the `asset:` protocol, which bypasses every backend command).
-  3. **macOS FFI abort** — an unrecognized-selector `NSException` crossing FFI ("Rust cannot catch foreign exceptions") and aborting at launch.
-  4. **Unguarded IPC effect** — an effect-orchestrated fetch without a stale-result guard
-     (late response overwrites newer state; NG0600/`allowSignalWrites` itself is gone since v19).
-  5. **Import-cycle `ɵcmp`** — mutually-recursive standalone components each in the other's `imports` (needs `forwardRef`).
-  6. **Opacity bleed** — a popover/modal using the frosted `.card` instead of an opaque `--surface-overlay`.
-  7. **Prod-only CSP style break** — Angular component styles disappear in packaged WebKit when
-     a nonce is injected into `style-src`; a styled shell screenshot is not route-content proof.
-- The **adversarial-verifier** agent owns PASS/FAIL. For anything touching the lock model or crypto, the **lock-security-reviewer** is a required second gate. The implementing agent self-checks but **must not self-certify**.
+- Run the real selected gates. For Rust inner loops use `cargo test --lib`,
+  never bare `clippy --all-targets`.
+- Live-reproduce FE/IPC behavior when the change requires it. Drive
+  `http://localhost:1420` with a mocked
+  `window.__TAURI_INTERNALS__.invoke`, or boot the dev app and inspect
+  `/tmp/murmur-dev.log` for an abort-free launch; a synthetic or unit-only gate
+  is not runtime proof.
+- A bug regression must fail on the unpatched code and pass on the new code. A
+  test that also passes before the fix did not capture the bug. Empirical RED
+  counts only when a runner-owned artifact performed and recorded it; writer
+  prose or a reconstruction is never proof.
+- Hunt known shipped failures: seal content loss, sealed-content/asset leaks,
+  macOS FFI aborts, stale IPC effects, standalone import cycles, overlay opacity
+  bleed, and packaged WebKit CSP style loss.
+- Any lock/crypto/content-read change requires the lock security specialist.
+
+The verifier records findings; it never edits the implementation. Repair
+belongs to the assigned writer, followed by a new exact-diff verify.
 
 ## Trust code, not docs
 
-The hard-won lesson on this repo: **the docs were repeatedly wrong.** `docs/STATUS.md` and friends drift. When a claim is load-bearing, open the file (`file:line`) and confirm it against the current tree. Distrust your own first read, too.
+Repository prose drifts. Confirm every load-bearing claim against the current
+file and symbol, and distrust the first read.
 
-**Cite by SYMBOL, not line number.** Commands and storage are split across growing domain modules
-under `commands/` and `storage/`; `grep` the symbol name (`fn meeting_is_unlocked`,
-`visibility_clause`) before trusting any prose anchor. A line citation is a hint, never a promise
-about the current row. (The audit that surfaced this:
-`docs/research/2026-07-02-claude-setup-audit.md`.)
+**Cite by symbol, not line number.** Commands and storage move among growing
+domain modules under `commands/` and `storage/`; search symbols such as
+`meeting_is_unlocked` or `visibility_clause` before trusting a prose anchor. A
+line citation is only a hint. The sourcing audit is
+`docs/research/2026-07-02-claude-setup-audit.md`.
 
-## Honesty bar
+For Claude multi-task programs, use a session-scoped `/goal` that requires the
+next manifest action within 60 seconds after the prior stable outcome. Task
+scheduling stays outside the verifier.
 
-Some things genuinely cannot be verified headless: real mic capture, live ScreenCaptureKit, the **Touch ID** prompt, lock-at-rest behavior, and whether screen-share auto-relock fires on a real Zoom/Meet share — these need a **signed build on a real Mac**. Say so plainly; don't claim a green unit test proves them. "Needs a signed build / a real Mac / recorded evidence" is the honest bar.
+## Honesty and ownership
 
-## Constraints the fleet must respect
+Headless checks cannot prove real mic capture, ScreenCaptureKit/TCC, Touch ID,
+lock-at-rest, signed-build behavior, notarization, or a real meeting workflow.
+Name that boundary explicitly.
 
-- Commits/PRs authored **only** by `QueaT <kgm004a@gmail.com>`; **no AI co-author trailers**. `gh` active account = `JakubGawr`.
-- **Never push to the `murmur` trunk directly** (the canonical `block-bash` guard, exposed through
-  both vendor hook adapters, refuses it with exit 2) — merge via a PR (`gh pr create` → `gh pr merge`).
-- `com.meetnotes.app` is immutable (TCC/Keychain continuity).
-- No new npm packages or crates without explicit user approval.
+Commits are only `QueaT <kgm004a@gmail.com>` with no AI co-author trailers.
+Push, PR creation, merge, signing, notarization, and publication are
+operator-owned. Never direct-push `murmur`; use a PR. `com.meetnotes.app` is
+immutable. No new npm package or crate without explicit approval.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ name: CI
 on:
   pull_request:
     branches: [murmur]
+  # Merge queue synthetic commits run the same thin ci.sh wrapper. The
+  # PR-specific receipt job is intentionally skipped there because the receipt
+  # was already required on the pull_request event, and merge_group has no PR
+  # description from which to read the deliberate Lane B declaration.
+  merge_group:
+    types: [checks_requested]
   # Populate the DEFAULT-BRANCH cache scope after every merge.
   #
   # Without this the gate had no `push:` trigger at all, so nothing ever wrote a cache
@@ -70,40 +76,89 @@ env:
   MURMUR_E2E_NO_EGRESS: "1"
 
 jobs:
-  # ── Attestation gate: harness-written code cannot merge unverified. ───────────
-  # Cheap (ubuntu, seconds) and deliberately FIRST: it answers "was this branch's
-  # work ever verified at all", which the expensive lanes below cannot. A harness
+  # ── Receipt gate: opted-in agent branches need consistent PASS receipts. ──────
+  # Cheap (ubuntu, seconds) and deliberately FIRST: it answers "does this branch
+  # carry a self-consistent PASS receipt", which the expensive lanes below cannot.
+  # A harness
   # task that dies (timeout, 429, a killed session) leaves its branch mergeable and
   # its attestation stranded in local .git — on 2026-07-26 that put 2,566 unattested
-  # lines on trunk with nobody the wiser. Only `agent/*` branches are in scope; a
-  # deliberate non-harness PR declares `Harness-Lane: B` in its description.
+  # lines on trunk with nobody the wiser. `agent/*` branches are always in scope,
+  # and a renamed branch stays in scope once its history contains a receipt. A
+  # deliberate pre-receipt non-v2 `agent/*` PR may declare `Harness-Lane: B`.
+  #
+  # Threat boundary: this is a presence-and-consistency receipt, not a signed
+  # proof against a malicious author who can rewrite this pull_request workflow.
+  # Selecting the verifier from BASE_SHA prevents an ordinary gate change from
+  # silently reinterpreting older receipts. An organization-level required
+  # workflow or a separate GitHub App would be needed for adversarial workflow
+  # immutability; do not describe this repository status check as that.
   attestation:
     name: attestation gate (harness receipt)
     # PR-only: every input it reads (head ref, base sha, description) lives on the
-    # pull_request payload and is empty on a push. On the post-merge cache-warming run
-    # the work has already been gated, so there is nothing left to attest.
+    # pull_request payload. The merge-group head is synthetic and has no PR body;
+    # its constituent PRs were already receipt-gated before entering the queue.
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Checkout (full history — the receipt's base must be provably an ancestor)
+      - name: Checkout the PR base revision (full history)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          # Never execute the receipt verifier from candidate PR bytes. The
+          # candidate is fetched below only as inert Git objects to be judged.
+          ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
 
-      - name: Verify the harness receipt
+      - name: Verify the harness receipt with the base-revision verifier
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          if ! [[ "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::pull_request.base.sha is not exactly 40 lowercase hex characters"
+            exit 1
+          fi
+          if ! [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::pull_request.head.sha is not exactly 40 lowercase hex characters"
+            exit 1
+          fi
+          case "$PR_NUMBER" in
+            '' | *[!0-9]*)
+              echo "::error::pull request number is malformed"
+              exit 1
+              ;;
+          esac
+          git check-ref-format "refs/heads/$BASE_REF"
+          git check-ref-format "refs/heads/$HEAD_REF"
+          test "$(git rev-parse HEAD)" = "$BASE_SHA"
+
+          # A base checkout does not reliably contain a fork PR's head. Fetch
+          # GitHub's immutable pull ref, then prove that it is the event SHA.
+          git fetch --no-tags --no-recurse-submodules origin \
+            "+refs/pull/${PR_NUMBER}/head:refs/remotes/pull/${PR_NUMBER}/head"
+          test "$(git rev-parse "refs/remotes/pull/${PR_NUMBER}/head^{commit}")" = "$HEAD_SHA"
+          git fetch --no-tags --no-recurse-submodules origin \
+            "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+
+          # Fail closed if the base revision does not carry the gate. `git
+          # show` reads the blob from the cryptographically named base commit;
+          # no candidate checkout or candidate script is ever executed.
+          TRUSTED_VERIFIER="$RUNNER_TEMP/verify-harness-attestation"
+          git cat-file -e "${BASE_SHA}^{commit}"
+          git cat-file -e "${HEAD_SHA}^{commit}"
+          git show "$BASE_SHA:scripts/verify-harness-attestation" > "$TRUSTED_VERIFIER"
+          test -s "$TRUSTED_VERIFIER"
+          chmod 500 "$TRUSTED_VERIFIER"
+
           printf '%s' "$PR_BODY" > "$RUNNER_TEMP/pr-body.md"
           # --base-branch is the TIP of the branch being merged into. A catch-up merge
           # legitimately brings in commits newer than the PR's base commit, so judging
           # merges against BASE_SHA alone rejects the repo's required flow.
-          python3 scripts/verify-harness-attestation \
+          python3 "$TRUSTED_VERIFIER" \
             --base "$BASE_SHA" \
             --head "$HEAD_SHA" \
             --branch "$HEAD_REF" \
@@ -213,7 +268,9 @@ jobs:
         env:
           MURMUR_CI_LIVE_REMOTE_AUDIT: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/murmur' && '1' || '0' }}
           MURMUR_CI_PUBLIC_REMOTE_AUDIT: ${{ github.event_name == 'pull_request' && '1' || '0' }}
-          MURMUR_REMOTE_AUDIT_TOKEN: ${{ secrets.MURMUR_REMOTE_AUDIT_TOKEN }}
+          # Candidate PR and merge-group scripts never receive the privileged
+          # monitor token. Only trusted default-branch schedule/manual runs do.
+          MURMUR_REMOTE_AUDIT_TOKEN: ${{ ((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/murmur') && secrets.MURMUR_REMOTE_AUDIT_TOKEN || '' }}
           MURMUR_PUBLIC_REMOTE_AUDIT_TOKEN: ${{ github.event_name == 'pull_request' && github.token || '' }}
         run: bash scripts/ci.sh rust
 
@@ -267,10 +324,10 @@ jobs:
           echo "attestation: ${{ needs.attestation.result }}"
           echo "rust lane  : ${{ needs.rust.result }}"
           echo "web  lane  : ${{ needs.web.result }}"
-          # `skipped` is legitimate ONLY on the post-merge cache-warming push, where the
-          # attestation job does not run because there is no pull_request payload to read.
-          # On a pull_request event anything but `success` is a hard failure — a skipped
-          # gate must never read as a satisfied one.
+          # `skipped` is legitimate on merge_group, push, schedule and manual runs:
+          # none carries the PR body required by the receipt policy. On pull_request,
+          # anything but `success` is a hard failure — a skipped gate must never read
+          # as a satisfied one.
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             if [ "${{ needs.attestation.result }}" != "success" ]; then
               echo "::error::harness-written code without a PASS receipt — see the attestation gate"

--- a/scripts/agent-harness
+++ b/scripts/agent-harness
@@ -2,4 +2,4 @@
 set -eu
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-exec python3 "$SCRIPT_DIR/../.agents/harness/task_runner.py" "$@"
+exec python3 "$SCRIPT_DIR/../.agents/harness/cli.py" "$@"

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -44,16 +44,24 @@ cleanup_swift_src_tests() {
 }
 
 rust_gate() {
-  # ── Remote merge enforcement is the first, cheapest gate. Local runs exercise the evaluator
-  #    deterministically. GitHub Actions lends either the ordinary PR token or the dedicated
-  #    privileged monitoring credential only to the matching audit command. Copy then immediately
-  #    drop all exported token names before executing repo code. Privileged mode has no fallback:
-  #    a missing dedicated credential is an explicit gate failure. PRs attest only merge scope;
-  #    admin-only controls are MONITOR_ONLY and checked by trusted schedule/manual runs. ──
-  echo "── development agent remote enforcement audit ──"
+  # Quarantine workflow credentials before executing any repository command.
+  # These shell locals are not exported; only the selected audit subprocess
+  # receives GH_TOKEN below.
   remote_audit_token="${MURMUR_REMOTE_AUDIT_TOKEN:-}"
   public_audit_token="${MURMUR_PUBLIC_REMOTE_AUDIT_TOKEN:-}"
   unset MURMUR_REMOTE_AUDIT_TOKEN MURMUR_PUBLIC_REMOTE_AUDIT_TOKEN GH_TOKEN GITHUB_TOKEN
+
+  # The merge receipt parser is security-sensitive and cheap. Exercise real
+  # temporary Git histories before any network audit or product build.
+  echo "── harness receipt gate: temp-git self-test ──"
+  scripts/verify-harness-attestation --selftest
+
+  # ── Remote merge enforcement is the first network-aware gate. Local runs exercise the evaluator
+  #    deterministically. GitHub Actions lends either the ordinary PR token or the dedicated
+  #    privileged monitoring credential only to the matching audit command. Privileged mode has no fallback:
+  #    a missing dedicated credential is an explicit gate failure. PRs attest only merge scope;
+  #    admin-only controls are MONITOR_ONLY and checked by trusted schedule/manual runs. ──
+  echo "── development agent remote enforcement audit ──"
   if [ "${MURMUR_CI_LIVE_REMOTE_AUDIT:-0}" = "1" ]; then
     if [ -z "$remote_audit_token" ]; then
       echo "remote audit: MURMUR_REMOTE_AUDIT_TOKEN is required for privileged monitoring" >&2

--- a/scripts/verify-harness-attestation
+++ b/scripts/verify-harness-attestation
@@ -1,108 +1,240 @@
 #!/usr/bin/env python3
-"""Refuse to merge harness-written code that was never verified.
+"""Verify exact per-commit Harness v1/v2 receipts on a pull-request branch.
 
-WHY THIS EXISTS. On 2026-07-26 a harness task timed out, went `BLOCKED` with an empty
-`results/` directory and no attestation — and its branch was merged to trunk anyway,
-carrying 2,566 lines across 14 files. Nothing noticed, because the attestation lives in
-`.git/agent-harness/`, which never leaves the machine that produced it. Every enforcement
-up to that point depended on the operator remembering.
-
-WHAT IT CHECKS. For a pull request whose head branch is `agent/*` — i.e. a branch the
-harness itself created — at least one commit must carry the receipt trailers that
-`agent-harness commit` writes:
-
-    Harness-Task: <task-id>
-    Harness-Verdict: PASS
-    Harness-Base: <sha>
-    Harness-Diff-Sha256: <sha256>
-    Harness-Attestation-Sha256: <sha256>
-
-An explicitly declared light-lane PR is allowed through: put `Harness-Lane: B` on a line
-of its own in the PR body (or set HARNESS_LANE=B). That makes "no attestation" a RECORDED
-CHOICE rather than an oversight, which is the whole point — the failure being prevented is
-silence, not deliberate bypass.
-
-WHAT IT DOES NOT CHECK. This is presence and consistency, not a cryptographic proof. A
-trailer can be typed by hand. It defends against forgetting; it does not defend against
-forging, and it is not offered as though it did.
-
-Usage:
-    verify-harness-attestation --base <ref> --head <ref> [--branch <name>] [--pr-body-file <path>]
-Exit codes: 0 = satisfied or not applicable, 1 = refused, 2 = usage error.
+Unversioned receipts are legacy v1.  Version 2 requires an exact evidence hash
+and an equal transitional Attestation alias.  Every branch-authored non-merge
+commit is covered; clean catch-up merges from the base branch remain supported
+only when their tree equals Git's deterministic merge result.  Receipt policy
+is monotonic: v1 may upgrade to v2, but v2 may not downgrade to v1 or Lane B;
+the ``agent/v2/*`` namespace requires v2 throughout.
 """
+
 from __future__ import annotations
 
 import argparse
 import hashlib
+import html
 import os
+from pathlib import Path
 import re
 import subprocess
 import sys
-from typing import List, Optional, Tuple
+import tempfile
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple
 
-TRAILER_RE = {
-    "task": re.compile(r"^\s*Harness-Task:\s*(\S+)\s*$", re.MULTILINE),
-    "verdict": re.compile(r"^\s*Harness-Verdict:\s*(\S+)\s*$", re.MULTILINE),
-    "base": re.compile(r"^\s*Harness-Base:\s*([0-9a-f]{40})\s*$", re.MULTILINE),
-    "diff": re.compile(r"^\s*Harness-Diff-Sha256:\s*([0-9a-f]{64})\s*$", re.MULTILINE),
-    "attestation": re.compile(
-        r"^\s*Harness-Attestation-Sha256:\s*([0-9a-f]{64})\s*$", re.MULTILINE
-    ),
+
+HEX40 = re.compile(r"^[0-9a-f]{40}$")
+HEX64 = re.compile(r"^[0-9a-f]{64}$")
+TASK_ID = re.compile(r"^[a-z0-9][a-z0-9._-]{1,63}$")
+RECOGNIZED = {
+    "Harness-Version",
+    "Harness-Task",
+    "Harness-Verdict",
+    "Harness-Base",
+    "Harness-Diff-Sha256",
+    "Harness-Evidence-Sha256",
+    "Harness-Attestation-Sha256",
+    "Harness-Writer-Degraded",
+    "Harness-Lane",
 }
-# Anchored at column 0, case-sensitive, and matched only against a body with fenced code
-# blocks and quoted lines stripped. The looser earlier form let the gate NEUTER ITSELF: its
-# own refusal message contained the token on an indented line, so pasting the CI error into
-# the PR description to ask what it meant silently turned a REFUSE into a PASS.
-LANE_B_RE = re.compile(r"^Harness-Lane: B[ \t]*$", re.MULTILINE)
-# Surfaced, not refused: a degraded round still earns PASS from real checks and real
-# independent reviews. The point is that the reviewer of the PR can SEE it.
-DEGRADED_RE = re.compile(r"^\s*Harness-Writer-Degraded:\s*(\S+)\s*$", re.MULTILINE)
+RECEIPT_KEYS = RECOGNIZED - {"Harness-Lane", "Harness-Writer-Degraded"}
+TRAILER_LINE = re.compile(r"^(Harness-[A-Za-z0-9-]+):[ \t]*(.*?)[ \t]*$")
+HARNESS_LIKE_LINE = re.compile(
+    r"^\s*(Harness-[A-Za-z0-9-]+)\s*:", re.IGNORECASE
+)
+LANE_B_LINE = re.compile(r"^Harness-Lane:[ \t]+B[ \t]*$", re.MULTILINE)
 
 
-def git(*args: str) -> str:
-    return subprocess.run(
-        ["git", *args], capture_output=True, text=True, check=True
-    ).stdout.strip()
+class ReceiptError(RuntimeError):
+    pass
 
 
-def is_ancestor(candidate: str, of: str) -> bool:
+def git(*args: str, cwd: Optional[Path] = None, check: bool = True) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if check and completed.returncode != 0:
+        raise ReceiptError(
+            f"git {' '.join(args)} failed: {completed.stderr.strip()}"
+        )
+    return completed.stdout.strip()
+
+
+def git_bytes(*args: str, cwd: Optional[Path] = None) -> bytes:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd) if cwd else None,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise ReceiptError(
+            f"git {' '.join(args)} failed: "
+            + completed.stderr.decode("utf-8", "replace").strip()
+        )
+    return completed.stdout
+
+
+def is_ancestor(candidate: str, target: str, *, cwd: Optional[Path] = None) -> bool:
     return (
         subprocess.run(
-            ["git", "merge-base", "--is-ancestor", candidate, of],
+            ["git", "merge-base", "--is-ancestor", candidate, target],
+            cwd=str(cwd) if cwd else None,
             capture_output=True,
         ).returncode
         == 0
     )
 
 
-def branch_commits(base: str, head: str, base_branch: str) -> Tuple[List[dict], List[dict]]:
-    """Return (commits authored on this branch, illegitimate merges).
+def strip_discussion(body: str) -> str:
+    """Remove quoted/fenced/HTML-comment discussion before parsing declarations."""
 
-    `--first-parent` alone is NOT enough, and an earlier version of this script wrongly
-    claimed it "selects exactly the branch's own work". It selects the first-parent CHAIN,
-    which makes anything reachable only through a merge's SECOND parent invisible: a
-    `git merge --no-ff` of a side branch smuggles unreviewed files into the merged diff
-    while every commit on the chain still carries a valid receipt.
+    out: List[str] = []
+    fenced = False
+    in_comment = False
+    for raw in body.splitlines():
+        line = html.unescape(raw)
+        if "<!--" in line:
+            before, _, rest = line.partition("<!--")
+            line = before
+            in_comment = True
+            if "-->" in rest:
+                _, _, after = rest.partition("-->")
+                line += after
+                in_comment = False
+        elif in_comment:
+            if "-->" in line:
+                _, _, line = line.partition("-->")
+                in_comment = False
+            else:
+                continue
+        stripped = line.lstrip()
+        if stripped.startswith(("```", "~~~")):
+            fenced = not fenced
+            continue
+        if fenced or stripped.startswith(">"):
+            continue
+        out.append(line)
+    return "\n".join(out)
 
-    So merges are inspected rather than skipped. A merge is legitimate only when every
-    non-first parent is contained in the BASE BRANCH — i.e. it is a genuine "bring the
-    branch up to date with trunk" merge, which this repo requires. Any other merge pulls in
-    work this gate never saw, and is reported.
 
-    The comparison must be against the base BRANCH TIP, not the PR's base COMMIT. A
-    catch-up merge brings in commits that are by definition NEWER than the base commit, so
-    testing ancestry against the base commit rejects the very flow this repo depends on —
-    a false positive, which is worse than no gate because it trains the operator to bypass.
-    """
+def trailer_values(message: str) -> Dict[str, str]:
+    values: Dict[str, str] = {}
+    counts: Dict[str, int] = {}
+    unknown: List[str] = []
+    malformed: List[str] = []
+    for line in message.splitlines():
+        match = TRAILER_LINE.fullmatch(line)
+        if not match:
+            harness_like = HARNESS_LIKE_LINE.match(line)
+            if harness_like is not None:
+                malformed.append(harness_like.group(1))
+            continue
+        key, value = match.groups()
+        if key not in RECOGNIZED:
+            unknown.append(key)
+            continue
+        counts[key] = counts.get(key, 0) + 1
+        values[key] = value
+    duplicates = sorted(key for key, count in counts.items() if count != 1)
+    if duplicates:
+        raise ReceiptError(
+            "duplicate recognized receipt trailers: " + ", ".join(duplicates)
+        )
+    if malformed:
+        raise ReceiptError(
+            "malformed Harness receipt trailers: "
+            + ", ".join(sorted(set(malformed), key=str.lower))
+        )
+    if unknown and any(key in values for key in RECEIPT_KEYS):
+        raise ReceiptError(
+            "unknown Harness receipt trailers: " + ", ".join(sorted(set(unknown)))
+        )
+    return values
 
-    raw = subprocess.run(
-        ["git", "log", "--first-parent", "--format=%H%x1f%P%x1f%B%x00", f"{base}..{head}"],
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout
-    commits: List[dict] = []
-    bad_merges: List[dict] = []
+
+def parse_receipt(message: str) -> Optional[Dict[str, str]]:
+    values = trailer_values(message)
+    present = RECEIPT_KEYS & set(values)
+    if not present:
+        return None
+    if "Harness-Lane" in values:
+        raise ReceiptError(
+            "Harness-Lane cannot coexist with a Harness receipt"
+        )
+    version = values.get("Harness-Version")
+    if version is None:
+        if "Harness-Evidence-Sha256" in values:
+            raise ReceiptError("unversioned v1 receipt contains v2 Evidence trailer")
+        required = {
+            "Harness-Task",
+            "Harness-Verdict",
+            "Harness-Base",
+            "Harness-Diff-Sha256",
+            "Harness-Attestation-Sha256",
+        }
+        generation = "1"
+    elif version == "2":
+        required = {
+            "Harness-Version",
+            "Harness-Task",
+            "Harness-Verdict",
+            "Harness-Base",
+            "Harness-Diff-Sha256",
+            "Harness-Evidence-Sha256",
+            "Harness-Attestation-Sha256",
+        }
+        generation = "2"
+    else:
+        raise ReceiptError(f"unknown Harness-Version: {version!r}")
+    missing = sorted(required - set(values))
+    if missing:
+        raise ReceiptError("partial receipt; missing: " + ", ".join(missing))
+    if values["Harness-Verdict"] != "PASS":
+        raise ReceiptError("Harness-Verdict is not PASS")
+    if not TASK_ID.fullmatch(values["Harness-Task"]):
+        raise ReceiptError("Harness-Task is malformed")
+    if not HEX40.fullmatch(values["Harness-Base"]):
+        raise ReceiptError("Harness-Base is malformed")
+    if not HEX64.fullmatch(values["Harness-Diff-Sha256"]):
+        raise ReceiptError("Harness-Diff-Sha256 is malformed")
+    if not HEX64.fullmatch(values["Harness-Attestation-Sha256"]):
+        raise ReceiptError("Harness-Attestation-Sha256 is malformed")
+    if generation == "2":
+        evidence = values["Harness-Evidence-Sha256"]
+        if not HEX64.fullmatch(evidence):
+            raise ReceiptError("Harness-Evidence-Sha256 is malformed")
+        if values["Harness-Attestation-Sha256"] != evidence:
+            raise ReceiptError("v2 Attestation alias must equal Evidence hash")
+    return {
+        "generation": generation,
+        "task": values["Harness-Task"],
+        "verdict": values["Harness-Verdict"],
+        "base": values["Harness-Base"],
+        "diff": values["Harness-Diff-Sha256"],
+        "evidence": values.get(
+            "Harness-Evidence-Sha256",
+            values["Harness-Attestation-Sha256"],
+        ),
+        "degraded": values.get("Harness-Writer-Degraded", ""),
+    }
+
+
+def branch_entries(
+    base: str, head: str, base_branch: str
+) -> Tuple[List[Dict[str, str]], List[Dict[str, str]]]:
+    raw = git(
+        "log",
+        "--first-parent",
+        "--format=%H%x1f%P%x1f%B%x00",
+        f"{base}..{head}",
+    )
+    commits: List[Dict[str, str]] = []
+    merges: List[Dict[str, str]] = []
     for chunk in raw.split("\x00"):
         if not chunk.strip():
             continue
@@ -114,232 +246,661 @@ def branch_commits(base: str, head: str, base_branch: str) -> Tuple[List[dict], 
             "message": message,
         }
         if len(parent_list) > 1:
-            # A merge. Legitimate only if everything it brings in is already on the base
-            # branch. `base_branch or base` keeps it working when the branch tip is not
-            # resolvable (a shallow clone, a local run) — degrading to the stricter check
-            # rather than to no check.
+            if len(parent_list) != 2:
+                raise ReceiptError(f"octopus merge {sha[:12]} is unsupported")
+            side = parent_list[1]
             containment = base_branch or base
-            side = [p for p in parent_list[1:] if not is_ancestor(p, containment)]
-            if side:
-                entry["side_parents"] = side
-                bad_merges.append(entry)
-            continue
-        commits.append(entry)
-    return commits, bad_merges
+            if not is_ancestor(side, containment):
+                raise ReceiptError(
+                    f"merge {sha[:12]} brings a side parent not on the base branch"
+                )
+            entry["side_parent"] = side
+            merges.append(entry)
+        else:
+            commits.append(entry)
+    return commits, merges
 
 
-def strip_quoted(body: str) -> str:
-    """Drop fenced code blocks and quoted lines before looking for the opt-out token.
-
-    Someone pasting this gate's output, or quoting it to ask a question, must not thereby
-    grant the exemption. Anything inside ``` fences or after a leading '>' is discussion,
-    not a declaration.
-    """
-
-    out: List[str] = []
-    fenced = False
-    for line in body.splitlines():
-        stripped = line.lstrip()
-        if stripped.startswith("```") or stripped.startswith("~~~"):
-            fenced = not fenced
-            continue
-        if fenced or stripped.startswith(">"):
-            continue
-        out.append(line)
-    return "\n".join(out)
+def verify_clean_catchup_merges(merges: Sequence[Mapping[str, str]]) -> None:
+    for merge in merges:
+        completed = subprocess.run(
+            [
+                "git",
+                "merge-tree",
+                "--write-tree",
+                "--no-messages",
+                merge["first_parent"],
+                merge["side_parent"],
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise ReceiptError(
+                f"catch-up merge {merge['sha'][:12]} had conflicts/manual resolution; "
+                "re-verify the resulting diff"
+            )
+        expected_tree = completed.stdout.strip().splitlines()[0]
+        actual_tree = git("rev-parse", f"{merge['sha']}^{{tree}}")
+        if expected_tree != actual_tree:
+            raise ReceiptError(
+                f"catch-up merge {merge['sha'][:12]} contains unreceipted resolution content"
+            )
 
 
 def fail(message: str) -> int:
     print(f"REFUSED: {message}", file=sys.stderr)
-    # Deliberately NOT printing a directly pasteable token: this text ends up in CI output
-    # that gets copied into PR descriptions, and the token was previously its own bypass.
     print(
-        "\nIf this PR was written WITHOUT the harness on purpose, declare it by adding a\n"
-        "line to the PR DESCRIPTION consisting of the header 'Harness-Lane' followed by a\n"
-        "colon, a space and the letter B — at the start of its own line, outside any code\n"
-        "fence or quote — OR, more reliably, put that same line as a TRAILER on any commit\n"
-        "in the branch. The commit route always works; the description route cannot be\n"
-        "applied to an already-failed run, because the event payload froze the body at\n"
-        "trigger time and a re-run replays it.",
+        "For a deliberate pre-receipt light lane, add a new commit trailer "
+        "using the Harness-Lane key with value B. Editing the PR body and "
+        "re-running an existing workflow may replay the frozen event payload; "
+        "push a new commit instead.",
         file=sys.stderr,
     )
     return 1
 
 
-def main(argv: Optional[List[str]] = None) -> int:
-    parser = argparse.ArgumentParser(add_help=True)
-    parser.add_argument("--base", required=True)
-    parser.add_argument("--head", default="HEAD")
-    parser.add_argument("--branch", default=os.environ.get("GITHUB_HEAD_REF", ""))
-    parser.add_argument("--pr-body-file", default="")
-    parser.add_argument(
-        "--base-branch",
-        default="",
-        help="Tip of the branch being merged INTO (e.g. origin/murmur). Catch-up merges are "
-        "judged against this, not against --base, because they legitimately bring in commits "
-        "newer than the PR's base commit.",
+def surface_degraded(commit: str, task: str, degraded: str) -> None:
+    message = (
+        f"Harness task {task} commit {commit[:12]} carries degraded writer "
+        f"provenance: {degraded}"
     )
-    args = parser.parse_args(argv)
+    print(f"::warning::{message}")
+    summary = os.environ.get("GITHUB_STEP_SUMMARY", "")
+    if summary:
+        try:
+            with Path(summary).open("a", encoding="utf-8") as handle:
+                handle.write(f"- WARNING: {message}\n")
+        except OSError as exc:
+            print(
+                f"could not append degraded provenance to step summary: {exc}",
+                file=sys.stderr,
+            )
 
-    base_branch = args.base_branch.strip()
-    if not base_branch:
-        env_base = os.environ.get("GITHUB_BASE_REF", "").strip()
-        for candidate in ([f"origin/{env_base}", env_base] if env_base else []):
-            if (
-                subprocess.run(
-                    ["git", "rev-parse", "--verify", "--quiet", f"{candidate}^{{commit}}"],
-                    capture_output=True,
-                ).returncode
-                == 0
-            ):
-                base_branch = candidate
-                break
 
+def resolve_base_branch(raw: str) -> str:
+    if raw:
+        return raw
+    env_base = os.environ.get("GITHUB_BASE_REF", "").strip()
+    for candidate in ([f"origin/{env_base}", env_base] if env_base else []):
+        if git("rev-parse", "--verify", "--quiet", f"{candidate}^{{commit}}", check=False):
+            return candidate
+    return ""
+
+
+def verify_range(args: argparse.Namespace) -> int:
     branch = (args.branch or "").strip()
-    if not branch.startswith("agent/"):
+    body = ""
+    if args.pr_body_file and Path(args.pr_body_file).is_file():
+        body = Path(args.pr_body_file).read_text(encoding="utf-8", errors="replace")
+    # Scope and Lane-B policy must be derived only from branch-authored
+    # non-merge commits. A full base..head walk also visits base-branch commits
+    # introduced by a clean catch-up merge; a receipt on trunk must never turn
+    # an ordinary fix/* branch into a receipted lifecycle.
+    messages = git(
+        "log",
+        "--first-parent",
+        "--no-merges",
+        "--format=%B%x00",
+        f"{args.base}..{args.head}",
+    )
+    chunks = [item for item in messages.split("\x00") if item.strip()]
+    # A branch that has entered a receipted lifecycle may move from legacy v1
+    # to v2, but it must never downgrade back to Lane B.  In particular,
+    # agent/v2/* is a reserved branch namespace: accepting an opt-out there
+    # would let an unattested follow-up commit erase the meaning of the v2
+    # branch and its earlier exact-diff receipt.
+    has_receipt = any(
+        any(
+            match is not None
+            and match.group(1).lower()
+            not in {"harness-lane", "harness-writer-degraded"}
+            for match in (
+                HARNESS_LIKE_LINE.match(line)
+                for line in chunk.splitlines()
+            )
+        )
+        for chunk in chunks
+    )
+    trailer_lane = any(
+        LANE_B_LINE.search(strip_discussion(chunk)) for chunk in chunks
+    )
+    lane_declared = (
+        trailer_lane
+        or LANE_B_LINE.search(strip_discussion(body))
+        or os.environ.get("HARNESS_LANE", "").strip().upper() == "B"
+    )
+    reserved_v2_branch = branch.startswith("agent/v2/")
+    if lane_declared and (reserved_v2_branch or has_receipt):
+        return fail(
+            "Lane B cannot downgrade an agent/v2 branch or a history that "
+            "already contains Harness receipts"
+        )
+    if lane_declared:
+        print("light lane explicitly declared — attestation not required")
+        return 0
+
+    # A renamed/copied agent branch still contains harness receipts.  Once a
+    # receipt appears, enforce coverage regardless of the current branch name.
+    if not branch.startswith("agent/") and not has_receipt:
         print(f"not a harness branch ({branch or 'unknown'}) — attestation not required")
         return 0
-
-    body = ""
-    if args.pr_body_file and os.path.exists(args.pr_body_file):
-        with open(args.pr_body_file, "r", encoding="utf-8", errors="replace") as handle:
-            body = handle.read()
-    # A COMMIT TRAILER is the reliable declaration route; the PR description is a
-    # convenience that cannot be applied retroactively.
-    #
-    # `github.event.pull_request.body` is frozen at trigger time and a re-run replays the
-    # same payload, so the description route is unusable in exactly the situation it exists
-    # for: the gate refuses, you add the line, you press re-run, and the gate re-reads the
-    # old body. A trailer lives in the pushed history, is visible in the diff, survives
-    # re-runs, and needs no privileged token to read (the repo's config audit forbids a
-    # `GH_TOKEN` expression in `ci.yml`, and rightly so).
-    trailer_declared = False
     try:
-        raw = subprocess.run(
-            ["git", "log", "--format=%B%x00", f"{args.base}..{args.head}"],
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stdout
-        trailer_declared = any(
-            LANE_B_RE.search(chunk) for chunk in raw.split("\x00") if chunk.strip()
+        commits, merges = branch_entries(
+            args.base, args.head, resolve_base_branch(args.base_branch)
         )
-    except subprocess.CalledProcessError:
-        pass
-
-    if (
-        trailer_declared
-        or LANE_B_RE.search(strip_quoted(body))
-        or os.environ.get("HARNESS_LANE", "").strip().upper() == "B"
-    ):
-        where = "commit trailer" if trailer_declared else "PR description"
-        print(f"light lane declared via the {where} — attestation not required")
-        return 0
-
-    try:
-        commits, bad_merges = branch_commits(args.base, args.head, base_branch)
-    except subprocess.CalledProcessError as exc:
-        print(f"could not read commits {args.base}..{args.head}: {exc}", file=sys.stderr)
-        return 2
-
-    if bad_merges:
-        listing = "\n".join(
-            f"    {m['sha'][:12]}  merges {', '.join(p[:12] for p in m['side_parents'])}"
-            f"  — {m['message'].strip().splitlines()[0][:56]}"
-            for m in bad_merges
-        )
-        return fail(
-            f"branch '{branch}' merges work that is not on the base ref, so the merged diff "
-            "contains commits this gate never saw:\n"
-            f"{listing}\n"
-            "  Only a catch-up merge FROM the base branch is allowed here."
-        )
-
+        verify_clean_catchup_merges(merges)
+    except ReceiptError as exc:
+        return fail(str(exc))
     if not commits:
+        if merges:
+            print("clean catch-up merge only — no branch-authored content")
+            return 0
         print("no branch-authored commits to attest")
         return 0
-
-    # COVERAGE, NOT PRESENCE. Checking that SOME commit carries a receipt was provably
-    # insufficient: an unattested hand commit rides along beside an attested one, and a
-    # cherry-pick copies a receipt verbatim onto work it never covered. Every commit the
-    # branch authored must carry its OWN receipt, and that receipt's recorded base must be
-    # that commit's own first parent — which is exactly what `agent-harness commit`
-    # produces and what a copied receipt cannot fake.
-    unattested = []
-    receipts = []
+    parsed: List[Tuple[Mapping[str, str], Dict[str, str]]] = []
     for commit in commits:
-        found = {name: rx.search(commit["message"]) for name, rx in TRAILER_RE.items()}
-        if not all(found.values()):
-            unattested.append(commit)
-            continue
-        receipt = {name: m.group(1) for name, m in found.items()}
-        receipt["commit"] = commit
-        receipts.append(receipt)
-
-    if unattested:
-        listing = "\n".join(
-            f"    {c['sha'][:12]}  {c['message'].strip().splitlines()[0][:72]}"
-            for c in unattested
-        )
-        return fail(
-            f"branch '{branch}' was created by the harness, but {len(unattested)} of "
-            f"{len(commits)} branch-authored commits carry no Harness-Verdict receipt:\n"
-            f"{listing}\n"
-            "  Each was written outside a PASSED harness task, or committed by hand."
-        )
-
-    for receipt in receipts:
-        commit = receipt["commit"]
-        if receipt["verdict"] != "PASS":
+        try:
+            receipt = parse_receipt(commit["message"])
+        except ReceiptError as exc:
+            return fail(f"commit {commit['sha'][:12]}: {exc}")
+        if receipt is None:
             return fail(
-                f"commit {commit['sha'][:12]} records verdict "
-                f"{receipt['verdict']}, not PASS"
+                f"commit {commit['sha'][:12]} has no complete Harness receipt"
             )
         if receipt["base"] != commit["first_parent"]:
             return fail(
-                f"commit {commit['sha'][:12]} carries a receipt for base "
-                f"{receipt['base'][:12]}, but its actual parent is "
-                f"{commit['first_parent'][:12]} — the receipt was copied onto work it "
-                "does not cover (cherry-pick, rebase, or a hand-edited trailer)."
+                f"commit {commit['sha'][:12]} receipt Base is not its actual parent"
             )
-        # CONTENT, not just lineage. Matching only the parent left `git commit --amend`
-        # wide open: amend after `agent-harness commit` keeps the parent, so arbitrary
-        # unreviewed content rode in under a valid receipt. The recorded hash is over the
-        # attested staged diff, which is recomputable here with the same normalisation
-        # (task_runner.staged_diff: --binary --full-index --no-ext-diff --no-renames).
-        actual = subprocess.run(
-            [
-                "git",
-                "diff",
-                "--binary",
-                "--full-index",
-                "--no-ext-diff",
-                "--no-renames",
-                commit["first_parent"],
-                commit["sha"],
-                "--",
-            ],
-            capture_output=True,
-            check=True,
-        ).stdout
+        actual = git_bytes(
+            "diff",
+            "--binary",
+            "--full-index",
+            "--no-ext-diff",
+            "--no-renames",
+            commit["first_parent"],
+            commit["sha"],
+            "--",
+        )
         actual_sha = hashlib.sha256(actual).hexdigest()
-        if actual_sha != receipt["diff"]:
+        if receipt["diff"] != actual_sha:
             return fail(
-                f"commit {commit['sha'][:12]} does not match its own receipt: the attested "
-                f"diff is {receipt['diff'][:12]}… but the commit's actual diff hashes to "
-                f"{actual_sha[:12]}…. The commit was amended or rewritten after it was "
-                "attested, so the receipt covers different content than what is merging."
+                f"commit {commit['sha'][:12]} actual diff {actual_sha[:12]}… "
+                f"does not match receipt {receipt['diff'][:12]}…"
+            )
+        parsed.append((commit, receipt))
+
+    if reserved_v2_branch:
+        legacy = [
+            commit["sha"][:12]
+            for commit, receipt in parsed
+            if receipt["generation"] != "2"
+        ]
+        if legacy:
+            return fail(
+                "agent/v2 branches require v2 receipts on every authored commit; "
+                "legacy v1 receipt found on " + ", ".join(legacy)
             )
 
-    for receipt in receipts:
-        degraded = DEGRADED_RE.search(receipt["commit"]["message"])
-        note = f"  [WRITER DEGRADED: {degraded.group(1)}]" if degraded else ""
+    seen_v2 = False
+    for commit, receipt in reversed(parsed):
+        if receipt["generation"] == "2":
+            seen_v2 = True
+        elif seen_v2:
+            return fail(
+                f"commit {commit['sha'][:12]} downgrades a v2 receipt history "
+                "back to legacy v1"
+            )
+
+    for commit, receipt in parsed:
+        note = (
+            f" [WRITER DEGRADED: {receipt['degraded']}]"
+            if receipt["degraded"]
+            else ""
+        )
+        if receipt["degraded"]:
+            surface_degraded(
+                commit["sha"], receipt["task"], receipt["degraded"]
+            )
         print(
-            f"OK: {receipt['commit']['sha'][:12]} task '{receipt['task']}' PASS "
-            f"(diff {receipt['diff'][:12]}…){note}"
+            f"OK: {commit['sha'][:12]} v{receipt['generation']} task "
+            f"'{receipt['task']}' PASS (diff {receipt['diff'][:12]}…){note}"
         )
     return 0
 
 
+def _run_verify(
+    script: Path,
+    repo: Path,
+    base: str,
+    head: str,
+    *,
+    branch: str = "agent/selftest",
+    base_branch: str = "",
+) -> int:
+    return subprocess.run(
+        [
+            str(script),
+            "--base",
+            base,
+            "--head",
+            head,
+            "--branch",
+            branch,
+            *(["--base-branch", base_branch] if base_branch else []),
+        ],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        check=False,
+    ).returncode
+
+
+def _commit(
+    repo: Path,
+    subject: str,
+    task: str,
+    *,
+    version: Optional[str],
+    extra: Sequence[str] = (),
+) -> str:
+    serial = len(git("rev-list", "--all", cwd=repo).splitlines())
+    (repo / "payload.txt").write_text(f"{subject}-{serial}\n", encoding="utf-8")
+    git("add", "payload.txt", cwd=repo)
+    parent = git("rev-parse", "HEAD", cwd=repo)
+    diff = git_bytes(
+        "diff",
+        "--cached",
+        "--binary",
+        "--full-index",
+        "--no-ext-diff",
+        "--no-renames",
+        "--",
+        cwd=repo,
+    )
+    digest = hashlib.sha256(diff).hexdigest()
+    evidence = hashlib.sha256(f"{task}-{serial}".encode()).hexdigest()
+    trailers: List[str] = []
+    if version is not None:
+        trailers.append(f"Harness-Version: {version}")
+    trailers.extend(
+        [
+            f"Harness-Task: {task}",
+            "Harness-Verdict: PASS",
+            f"Harness-Base: {parent}",
+            f"Harness-Diff-Sha256: {digest}",
+        ]
+    )
+    if version == "2":
+        trailers.append(f"Harness-Evidence-Sha256: {evidence}")
+    trailers.append(f"Harness-Attestation-Sha256: {evidence}")
+    trailers.extend(extra)
+    git("commit", "-m", subject, "-m", "\n".join(trailers), cwd=repo)
+    return git("rev-parse", "HEAD", cwd=repo)
+
+
+def selftest() -> int:
+    script = Path(__file__).resolve()
+    failures: List[str] = []
+    count = 0
+
+    def expect(label: str, actual: int, wanted: int) -> None:
+        nonlocal count
+        count += 1
+        marker = "PASS" if actual == wanted else "FAIL"
+        print(f"  [{marker}] {label}: exit {actual}")
+        if actual != wanted:
+            failures.append(f"{label}: expected {wanted}, found {actual}")
+
+    with tempfile.TemporaryDirectory(prefix="murmur-receipt-selftest-") as raw:
+        root = Path(raw)
+
+        def fresh(name: str) -> Tuple[Path, str]:
+            repo = root / name
+            repo.mkdir()
+            git("init", "-q", "-b", "murmur", cwd=repo)
+            git("config", "user.name", "QueaT", cwd=repo)
+            git("config", "user.email", "kgm004a@gmail.com", cwd=repo)
+            (repo / "payload.txt").write_text("base\n", encoding="utf-8")
+            git("add", "payload.txt", cwd=repo)
+            git("commit", "-q", "-m", "base", cwd=repo)
+            return repo, git("rev-parse", "HEAD", cwd=repo)
+
+        repo, base = fresh("v1")
+        head = _commit(repo, "v1", "receipt-v1", version=None)
+        expect("legacy unversioned v1", _run_verify(script, repo, base, head), 0)
+
+        repo, base = fresh("v2")
+        head = _commit(repo, "v2", "receipt-v2", version="2")
+        expect("strict v2", _run_verify(script, repo, base, head), 0)
+
+        repo, base = fresh("mixed")
+        _commit(repo, "v1", "mixed-v1", version=None)
+        head = _commit(repo, "v2", "mixed-v2", version="2")
+        expect("mixed v1 then v2 branch", _run_verify(script, repo, base, head), 0)
+
+        repo, base = fresh("downgrade")
+        _commit(repo, "v2", "downgrade-v2", version="2")
+        head = _commit(repo, "v1", "downgrade-v1", version=None)
+        expect(
+            "v2 receipt downgrade rejected",
+            _run_verify(script, repo, base, head),
+            1,
+        )
+
+        repo, base = fresh("reserved-v1")
+        head = _commit(repo, "v1", "reserved-v1", version=None)
+        expect(
+            "agent/v2 rejects legacy v1 receipt",
+            _run_verify(
+                script,
+                repo,
+                base,
+                head,
+                branch="agent/v2/reserved-v1",
+            ),
+            1,
+        )
+
+        repo, base = fresh("lane-b")
+        (repo / "payload.txt").write_text("light lane\n", encoding="utf-8")
+        git("add", "payload.txt", cwd=repo)
+        git("commit", "-m", "light lane", "-m", "Harness-Lane: B", cwd=repo)
+        head = git("rev-parse", "HEAD", cwd=repo)
+        expect(
+            "ordinary agent branch accepts explicit Lane B",
+            _run_verify(script, repo, base, head, branch="agent/light"),
+            0,
+        )
+
+        repo, base = fresh("reserved-lane-b")
+        (repo / "payload.txt").write_text("reserved lane\n", encoding="utf-8")
+        git("add", "payload.txt", cwd=repo)
+        git("commit", "-m", "reserved lane", "-m", "Harness-Lane: B", cwd=repo)
+        head = git("rev-parse", "HEAD", cwd=repo)
+        expect(
+            "agent/v2 rejects Lane B downgrade",
+            _run_verify(
+                script,
+                repo,
+                base,
+                head,
+                branch="agent/v2/reserved-lane",
+            ),
+            1,
+        )
+
+        repo, base = fresh("receipted-lane-b")
+        head = _commit(
+            repo,
+            "v2 plus lane",
+            "receipted-lane",
+            version="2",
+            extra=["Harness-Lane: B"],
+        )
+        expect(
+            "receipted history rejects Lane B downgrade",
+            _run_verify(script, repo, base, head),
+            1,
+        )
+
+        repo, base = fresh("hybrid")
+        head = _commit(
+            repo,
+            "hybrid",
+            "hybrid",
+            version=None,
+            extra=["Harness-Evidence-Sha256: " + "a" * 64],
+        )
+        expect("hybrid receipt rejected", _run_verify(script, repo, base, head), 1)
+
+        repo, base = fresh("duplicate")
+        head = _commit(
+            repo,
+            "duplicate",
+            "duplicate",
+            version="2",
+            extra=["Harness-Task: duplicate-again"],
+        )
+        expect("duplicate recognized trailer rejected", _run_verify(script, repo, base, head), 1)
+
+        repo, base = fresh("unknown")
+        head = _commit(repo, "unknown", "unknown", version="9")
+        expect("unknown version rejected", _run_verify(script, repo, base, head), 1)
+
+        repo, base = fresh("malformed")
+        head = _commit(
+            repo,
+            "malformed",
+            "malformed",
+            version="2",
+            extra=[" harness-task: shadow"],
+        )
+        expect(
+            "malformed Harness-like trailer rejected",
+            _run_verify(script, repo, base, head),
+            1,
+        )
+
+        repo, base = fresh("alias")
+        head = _commit(
+            repo,
+            "alias",
+            "alias",
+            version="2",
+            extra=["Harness-Attestation-Sha256: " + "b" * 64],
+        )
+        expect("duplicate/bad alias rejected", _run_verify(script, repo, base, head), 1)
+
+        repo, base = fresh("manual")
+        _commit(repo, "good", "manual-good", version="2")
+        (repo / "extra.txt").write_text("manual\n", encoding="utf-8")
+        git("add", "extra.txt", cwd=repo)
+        git("commit", "-m", "manual unattested", cwd=repo)
+        head = git("rev-parse", "HEAD", cwd=repo)
+        expect("extra unattested commit rejected", _run_verify(script, repo, base, head), 1)
+
+        repo, base = fresh("amended")
+        _commit(repo, "before amend", "amended", version="2")
+        (repo / "payload.txt").write_text("changed after receipt\n", encoding="utf-8")
+        git("add", "payload.txt", cwd=repo)
+        git("commit", "--amend", "--no-edit", cwd=repo)
+        head = git("rev-parse", "HEAD", cwd=repo)
+        expect(
+            "amended bytes with stale receipt rejected",
+            _run_verify(script, repo, base, head),
+            1,
+        )
+
+        repo, base = fresh("cherry-pick")
+        git("checkout", "-q", "-b", "agent/source", cwd=repo)
+        source_commit = _commit(repo, "source", "cherry", version="2")
+        git("checkout", "-q", "murmur", cwd=repo)
+        (repo / "base.txt").write_text("advance\n", encoding="utf-8")
+        git("add", "base.txt", cwd=repo)
+        git("commit", "-q", "-m", "advance", cwd=repo)
+        advanced = git("rev-parse", "HEAD", cwd=repo)
+        git("checkout", "-q", "-b", "agent/cherry", cwd=repo)
+        git("cherry-pick", source_commit, cwd=repo)
+        head = git("rev-parse", "HEAD", cwd=repo)
+        expect(
+            "cherry-picked receipt with another parent rejected",
+            _run_verify(script, repo, advanced, head),
+            1,
+        )
+
+        repo, base = fresh("fenced-lane")
+        (repo / "payload.txt").write_text("unattested\n", encoding="utf-8")
+        git("add", "payload.txt", cwd=repo)
+        git(
+            "commit",
+            "-m",
+            "unattested",
+            "-m",
+            "```\nHarness-Lane: B\n```\n> Harness-Lane: B",
+            cwd=repo,
+        )
+        head = git("rev-parse", "HEAD", cwd=repo)
+        expect(
+            "fenced and quoted Lane B paste is ignored",
+            _run_verify(script, repo, base, head),
+            1,
+        )
+
+        repo, base = fresh("rename")
+        head = _commit(repo, "renamed", "rename", version="2")
+        expect(
+            "renamed harness branch still enforced",
+            _run_verify(script, repo, base, head, branch="fix/renamed"),
+            0,
+        )
+
+        repo, base = fresh("ordinary-catchup-over-receipt")
+        git("checkout", "-q", "-b", "fix/catchup-over-receipt", cwd=repo)
+        (repo / "feature.txt").write_text("ordinary feature\n", encoding="utf-8")
+        git("add", "feature.txt", cwd=repo)
+        git("commit", "-q", "-m", "ordinary feature", cwd=repo)
+        git("checkout", "-q", "murmur", cwd=repo)
+        _commit(repo, "receipted base advance", "base-receipt", version="2")
+        base_tip = git("rev-parse", "HEAD", cwd=repo)
+        git("checkout", "-q", "fix/catchup-over-receipt", cwd=repo)
+        git("merge", "--no-ff", "-m", "catch up receipted base", "murmur", cwd=repo)
+        head = git("rev-parse", "HEAD", cwd=repo)
+        expect(
+            "ordinary branch ignores receipts introduced only by catch-up",
+            _run_verify(
+                script,
+                repo,
+                base,
+                head,
+                branch="fix/catchup-over-receipt",
+                base_branch=base_tip,
+            ),
+            0,
+        )
+
+        repo, base = fresh("lane-b-catchup-over-receipt")
+        git("checkout", "-q", "-b", "agent/light-catchup", cwd=repo)
+        (repo / "light.txt").write_text("light lane\n", encoding="utf-8")
+        git("add", "light.txt", cwd=repo)
+        git("commit", "-q", "-m", "light lane", "-m", "Harness-Lane: B", cwd=repo)
+        git("checkout", "-q", "murmur", cwd=repo)
+        _commit(repo, "receipted base advance", "lane-base-receipt", version="2")
+        base_tip = git("rev-parse", "HEAD", cwd=repo)
+        git("checkout", "-q", "agent/light-catchup", cwd=repo)
+        git("merge", "--no-ff", "-m", "catch up receipted base", "murmur", cwd=repo)
+        head = git("rev-parse", "HEAD", cwd=repo)
+        expect(
+            "Lane B ignores receipts introduced only by catch-up",
+            _run_verify(
+                script,
+                repo,
+                base,
+                head,
+                branch="agent/light-catchup",
+                base_branch=base_tip,
+            ),
+            0,
+        )
+
+        repo, base = fresh("catchup")
+        git("checkout", "-q", "-b", "agent/catchup", cwd=repo)
+        _commit(repo, "feature", "catchup", version="2")
+        git("checkout", "-q", "murmur", cwd=repo)
+        (repo / "base.txt").write_text("new base\n", encoding="utf-8")
+        git("add", "base.txt", cwd=repo)
+        git("commit", "-q", "-m", "base advance", cwd=repo)
+        base_tip = git("rev-parse", "HEAD", cwd=repo)
+        git("checkout", "-q", "agent/catchup", cwd=repo)
+        git("merge", "--no-ff", "-m", "catch up", "murmur", cwd=repo)
+        head = git("rev-parse", "HEAD", cwd=repo)
+        expect(
+            "clean catch-up merge preserved",
+            _run_verify(
+                script, repo, base, head, branch="agent/catchup", base_branch=base_tip
+            ),
+            0,
+        )
+
+        repo, base = fresh("merge-smuggle")
+        git("checkout", "-q", "-b", "agent/smuggle", cwd=repo)
+        _commit(repo, "feature", "smuggle", version="2")
+        git("checkout", "-q", "murmur", cwd=repo)
+        (repo / "base.txt").write_text("new base\n", encoding="utf-8")
+        git("add", "base.txt", cwd=repo)
+        git("commit", "-q", "-m", "base advance", cwd=repo)
+        base_tip = git("rev-parse", "HEAD", cwd=repo)
+        git("checkout", "-q", "agent/smuggle", cwd=repo)
+        git("merge", "--no-ff", "--no-commit", "murmur", cwd=repo)
+        (repo / "smuggled.txt").write_text("unreceipted\n", encoding="utf-8")
+        git("add", "smuggled.txt", cwd=repo)
+        git("commit", "-q", "-m", "catch up with smuggle", cwd=repo)
+        head = git("rev-parse", "HEAD", cwd=repo)
+        expect(
+            "catch-up merge resolution smuggle rejected",
+            _run_verify(
+                script, repo, base, head, branch="agent/smuggle", base_branch=base_tip
+            ),
+            1,
+        )
+
+        repo, base = fresh("side-merge")
+        git("checkout", "-q", "-b", "agent/side-merge", cwd=repo)
+        _commit(repo, "feature", "side-merge", version="2")
+        git("checkout", "-q", "-b", "untrusted-side", base, cwd=repo)
+        (repo / "side.txt").write_text("side\n", encoding="utf-8")
+        git("add", "side.txt", cwd=repo)
+        git("commit", "-q", "-m", "untrusted side", cwd=repo)
+        git("checkout", "-q", "agent/side-merge", cwd=repo)
+        git("merge", "--no-ff", "-m", "side merge", "untrusted-side", cwd=repo)
+        head = git("rev-parse", "HEAD", cwd=repo)
+        expect(
+            "side-parent merge outside base branch rejected",
+            _run_verify(
+                script,
+                repo,
+                base,
+                head,
+                branch="agent/side-merge",
+                base_branch="murmur",
+            ),
+            1,
+        )
+
+    if failures:
+        print("receipt selftest: FAIL")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+    print(f"receipt selftest: PASS ({count} cases)")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--selftest", action="store_true")
+    parser.add_argument("--base")
+    parser.add_argument("--head", default="HEAD")
+    parser.add_argument("--branch", default=os.environ.get("GITHUB_HEAD_REF", ""))
+    parser.add_argument("--pr-body-file", default="")
+    parser.add_argument("--base-branch", default="")
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.selftest:
+        return selftest()
+    if not args.base:
+        print("--base is required outside --selftest", file=sys.stderr)
+        return 2
+    try:
+        return verify_range(args)
+    except (ReceiptError, OSError) as exc:
+        print(f"receipt verifier error: {exc}", file=sys.stderr)
+        return 2
+
+
 if __name__ == "__main__":
-    sys.exit(main())
+    raise SystemExit(main())


### PR DESCRIPTION
Supersedes #497 with one fresh, base-anchored attested commit after remote CI exposed a selftest portability defect.

This activates the verifier-only Harness v2 lifecycle, durable resume/checkpoint handling, typed probes, tool-free independent reviews, monotonic receipts, visible resource-lane waits, lossless import/cleanup, and base-SHA remote verification. It also makes selftests deterministic without a real Claude executable, bounds cooperative sentinels, and distinguishes shell arithmetic left-shift from heredocs.

Local exact-tree evidence:
- harness suite PASS: 202 v2 assertions, 35 fault assertions, 25 metrics assertions
- receipt selftest PASS
- hook guard PASS
- config audit PASS: 164 checks
- remote audit selftest PASS
- independent spec review PASS
- independent adversarial review PASS
- receipt verifier PASS for commit f8cf611829c45f20d26d4ab20a42b38b301e6891