### PR TITLE
chore(ci): pin actions checkout v7

### DIFF
--- a/.agents/skills/github-actions/SKILL.md
+++ b/.agents/skills/github-actions/SKILL.md
@@ -21,16 +21,20 @@ Murmur's cloud CI is one file: `.github/workflows/ci.yml`, a **thin wrapper arou
 
 ```bash
 # lightweight tag → the ref sha IS the commit:
-gh api repos/actions/checkout/git/refs/tags/v4.2.2 --jq '.object.sha'
+gh api repos/actions/checkout/git/refs/tags/v7.0.1 --jq '.object.sha'
 # annotated tag (.object.type == "tag") → deref to the COMMIT sha:
 gh api repos/Swatinem/rust-cache/git/refs/tags/v2.7.5 --jq '.object.sha'      # -> tag object sha
 gh api repos/Swatinem/rust-cache/git/tags/<that-sha> --jq '.object.sha'       # -> commit sha (pin THIS)
 ```
 
 Pin the **commit** sha, comment the version. Currently pinned in `ci.yml`:
-`actions/checkout@…11bd719 # v4.2.2`, `actions/setup-node@…39370e3 # v4.1.0`,
+`actions/checkout@…3d3c42e # v7.0.1`, `actions/setup-node@…39370e3 # v4.1.0`,
 `Swatinem/rust-cache@…c193711 # v2.9.1`, `taiki-e/install-action@…678b06b # v2.44.60`,
 `actions/cache@…55cc834 # v6.1.0`.
+
+`actions/checkout` v7 runs on Node 24 and requires runner v2.327.1 or later.
+GitHub-hosted runners satisfy this; self-hosted runners must be upgraded before
+adopting the pin.
 
 **Cache-service deprecation (bitten 2026-07-05):** GitHub killed the legacy cache
 backend — `actions/cache` < v4.2 and `Swatinem/rust-cache` < v2.7.8 are AUTO-FAILED

--- a/.claude/skills/github-actions/SKILL.md
+++ b/.claude/skills/github-actions/SKILL.md
@@ -21,16 +21,20 @@ Murmur's cloud CI is one file: `.github/workflows/ci.yml`, a **thin wrapper arou
 
 ```bash
 # lightweight tag → the ref sha IS the commit:
-gh api repos/actions/checkout/git/refs/tags/v4.2.2 --jq '.object.sha'
+gh api repos/actions/checkout/git/refs/tags/v7.0.1 --jq '.object.sha'
 # annotated tag (.object.type == "tag") → deref to the COMMIT sha:
 gh api repos/Swatinem/rust-cache/git/refs/tags/v2.7.5 --jq '.object.sha'      # -> tag object sha
 gh api repos/Swatinem/rust-cache/git/tags/<that-sha> --jq '.object.sha'       # -> commit sha (pin THIS)
 ```
 
 Pin the **commit** sha, comment the version. Currently pinned in `ci.yml`:
-`actions/checkout@…11bd719 # v4.2.2`, `actions/setup-node@…39370e3 # v4.1.0`,
+`actions/checkout@…3d3c42e # v7.0.1`, `actions/setup-node@…39370e3 # v4.1.0`,
 `Swatinem/rust-cache@…c193711 # v2.9.1`, `taiki-e/install-action@…678b06b # v2.44.60`,
 `actions/cache@…55cc834 # v6.1.0`.
+
+`actions/checkout` v7 runs on Node 24 and requires runner v2.327.1 or later.
+GitHub-hosted runners satisfy this; self-hosted runners must be upgraded before
+adopting the pin.
 
 **Cache-service deprecation (bitten 2026-07-05):** GitHub killed the legacy cache
 backend — `actions/cache` < v4.2 and `Swatinem/rust-cache` < v2.7.8 are AUTO-FAILED

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout the PR base revision (full history)
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Never execute the receipt verifier from candidate PR bytes. The
           # candidate is fetched below only as inert Git objects to be judged.
@@ -174,7 +174,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # src-tauri/Cargo.toml has a PATH dependency on the murmur-protocol crate in
       # the (private) sibling repo: ../../murmur-server/crates/murmur-protocol.
@@ -282,7 +282,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node (version from .nvmrc — Angular 22 needs >= 24.15)
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0


### PR DESCRIPTION
Replaces #432 with a repository-owned branch so the private server deploy key remains available to the Rust lane.\n\n- pins all four executable checkout uses to verified v7.0.1 commit 3d3c42e5aac5ba805825da76410c181273ba90b1\n- keeps triggers, permissions, secrets, and job behavior unchanged\n- updates both mirrored GitHub Actions skills with Node 24 / runner 2.327.1 guidance\n\nHarness PASS. Local evidence: YAML parse, exact pin count, mirror equality, agent config audit (164), receipt selftest (23).