### PR TITLE
fix(harness): isolate verification snapshots

### DIFF
--- a/.agents/harness/cli.py
+++ b/.agents/harness/cli.py
@@ -876,6 +876,35 @@ def _validate_verification_snapshot(
         raise legacy.HarnessError(
             "v2 verification snapshot unexpectedly shares mutable Git metadata"
         )
+    alternates = common / "objects" / "info" / "alternates"
+    try:
+        alternates_metadata = alternates.lstat()
+    except FileNotFoundError:
+        alternates_metadata = None
+    except OSError as exc:
+        raise legacy.HarnessError(
+            "cannot inspect v2 verification snapshot object alternates"
+        ) from exc
+    if alternates_metadata is not None:
+        if (
+            stat.S_ISLNK(alternates_metadata.st_mode)
+            or not stat.S_ISREG(alternates_metadata.st_mode)
+        ):
+            raise legacy.HarnessError(
+                "v2 verification snapshot object alternates must be absent "
+                "or empty"
+            )
+        try:
+            nonempty_alternates = bool(alternates.read_bytes())
+        except OSError as exc:
+            raise legacy.HarnessError(
+                "cannot inspect v2 verification snapshot object alternates"
+            ) from exc
+        if nonempty_alternates:
+            raise legacy.HarnessError(
+                "v2 verification snapshot object alternates must be absent "
+                "or empty"
+            )
     if (
         Path(legacy.git(snapshot, "rev-parse", "--show-toplevel")).resolve()
         != snapshot.resolve()
@@ -916,11 +945,11 @@ def _ensure_verification_snapshot(
     plan: Mapping[str, Any],
     attempt_dir: Path,
 ) -> Path:
-    """Materialize the exact planned tree in a runner-owned standalone clone.
+    """Materialize the exact planned tree in a runner-owned standalone repo.
 
     Checks and reviewers never read the concurrently editable developer
-    worktree.  The standalone clone keeps its own index/HEAD while borrowing
-    immutable objects from the primary repository.
+    worktree.  The snapshot keeps its own index, HEAD, and object database so
+    deterministic Seatbelt checks need no read access to the primary repo.
     """
 
     snapshot = _verification_snapshot_path(contract, attempt_dir)
@@ -963,18 +992,58 @@ def _ensure_verification_snapshot(
     if not primary.is_dir() or primary.is_symlink():
         raise legacy.HarnessError("v2 primary repository is missing or unsafe")
     try:
+        local_snapshot_ref = "refs/agent-harness/v2/source"
         legacy.run_capture(
             [
                 "git",
-                "clone",
+                "init",
                 "--quiet",
-                "--shared",
-                "--no-checkout",
-                str(primary),
+                "--no-template",
+                "--object-format=sha1",
                 str(snapshot),
             ],
             snapshot.parent,
         )
+        legacy.run_capture(
+            [
+                "git",
+                "fetch",
+                "--quiet",
+                "--no-tags",
+                "--depth=2",
+                "--no-write-fetch-head",
+                str(primary),
+                f"{snapshot_ref}:{local_snapshot_ref}",
+            ],
+            snapshot,
+        )
+        fetched_commit = legacy.git(
+            snapshot,
+            "rev-parse",
+            "--verify",
+            "--end-of-options",
+            f"{local_snapshot_ref}^{{commit}}",
+        )
+        if fetched_commit != snapshot_commit:
+            raise legacy.HarnessError(
+                "v2 verification snapshot fetched a stale anchor"
+            )
+        if (
+            legacy.git(
+                snapshot, "rev-parse", f"{fetched_commit}^{{tree}}"
+            )
+            != plan["tree_sha"]
+        ):
+            raise legacy.HarnessError(
+                "v2 verification snapshot fetched a stale tree"
+            )
+        fetched_parents = legacy.git(
+            snapshot, "show", "-s", "--format=%P", fetched_commit
+        ).split()
+        if fetched_parents != [plan["base_sha"]]:
+            raise legacy.HarnessError(
+                "v2 verification snapshot fetched a stale parent"
+            )
         legacy.run_capture(
             ["git", "checkout", "--quiet", "--detach", plan["base_sha"]],
             snapshot,

--- a/.agents/harness/task_runner.py
+++ b/.agents/harness/task_runner.py
@@ -75,6 +75,7 @@ OUTER_SANDBOX_ENV = "MURMUR_HARNESS_OUTER_SANDBOX"
 INHERITED_SANDBOX_META_CHECKS = frozenset(
     (
         "scripts/agent-harness selftest --ci",
+        "python3 .agents/harness/v2_selftest.py",
         "bash .codex/hooks/selftest.sh",
     )
 )

--- a/.agents/harness/v2_selftest.py
+++ b/.agents/harness/v2_selftest.py
@@ -743,6 +743,15 @@ def profile_cases(test: Tests) -> None:
         harness_python_result.returncode,
         0,
     )
+    canonical_v2_selftest = legacy.load_config()["canonical_checks"][
+        "harness-v2-selftest"
+    ]
+    test.true(
+        "PROFILE canonical v2 selftest inherits the outer sandbox",
+        legacy.command_is_inherited_sandbox_meta_check(
+            canonical_v2_selftest
+        ),
+    )
 
 
 def reviewer_tool_guard_cases(test: Tests) -> None:
@@ -1813,6 +1822,149 @@ def standalone_driver_lane_cases(test: Tests) -> None:
             "LANE independent clone proceeds after release",
             released.returncode,
             0,
+        )
+
+
+def verification_snapshot_cases(test: Tests) -> None:
+    """A check snapshot must resolve Git objects inside its own Seatbelt scope."""
+
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-snapshot-") as raw:
+        root = Path(raw)
+        primary = root / "primary"
+        base = _init_repo(primary)
+        worktree = root / "task" / "meetnotes"
+        worktree.parent.mkdir()
+        _git(
+            primary,
+            "worktree",
+            "add",
+            "-q",
+            "--detach",
+            str(worktree),
+            base,
+        )
+        (worktree / "owned.txt").write_text(
+            "base\nsnapshot change\n", encoding="utf-8"
+        )
+        common = Path(
+            _git(
+                primary,
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-common-dir",
+            )
+        )
+        task_id = "snapshot-self-contained"
+        task_dir = harness_cli.v2_task_dir(common, task_id)
+        attempt_dir = task_dir / "attempts" / ("b" * 64)
+        attempt_dir.mkdir(parents=True)
+        contract: Dict[str, Any] = {
+            "task_id": task_id,
+            "contract_sha256": "c" * 64,
+            "base_sha": base,
+            "repo_realpath": str(primary.resolve()),
+            "worktree_path": str(worktree.resolve()),
+            "owned_paths": ["owned.txt"],
+            "expected_change": True,
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+        legacy.atomic_write_json(task_dir / "task.json", contract)
+        paths, diff, tree = verifier.snapshot_scoped_diff(
+            worktree, contract, task_dir
+        )
+        plan = {
+            "base_sha": base,
+            "changed_paths": paths,
+            "diff_sha256": legacy.sha256_bytes(diff),
+            "tree_sha": tree,
+            "plan_sha256": "d" * 64,
+        }
+
+        def has_no_object_alternates(repository: Path) -> bool:
+            alternates = (
+                repository / ".git" / "objects" / "info" / "alternates"
+            )
+            try:
+                metadata = alternates.lstat()
+            except FileNotFoundError:
+                return True
+            return (
+                stat.S_ISREG(metadata.st_mode)
+                and not stat.S_ISLNK(metadata.st_mode)
+                and alternates.read_bytes() == b""
+            )
+
+        snapshot = harness_cli._ensure_verification_snapshot(
+            contract, task_dir, plan, attempt_dir
+        )
+        alternates = snapshot / ".git" / "objects" / "info" / "alternates"
+        test.true(
+            "SNAPSHOT has no nonempty object alternates dependency",
+            has_no_object_alternates(snapshot),
+        )
+        alternates.parent.mkdir(parents=True, exist_ok=True)
+        alternates.write_text(
+            str(primary / ".git" / "objects") + "\n", encoding="utf-8"
+        )
+        resumed_snapshot = harness_cli._ensure_verification_snapshot(
+            contract, task_dir, plan, attempt_dir
+        )
+        test.true(
+            "SNAPSHOT resume reconstructs a claimed repo with object alternates",
+            resumed_snapshot == snapshot
+            and has_no_object_alternates(resumed_snapshot),
+        )
+        resumed_paths, resumed_diff, resumed_tree = verifier.snapshot_scoped_diff(
+            resumed_snapshot, contract, task_dir
+        )
+        test.equal(
+            "SNAPSHOT resume preserves the exact base, diff, and tree",
+            (
+                _git(resumed_snapshot, "rev-parse", "HEAD"),
+                resumed_paths,
+                legacy.sha256_bytes(resumed_diff),
+                resumed_tree,
+            ),
+            (
+                plan["base_sha"],
+                plan["changed_paths"],
+                plan["diff_sha256"],
+                plan["tree_sha"],
+            ),
+        )
+
+        base_tree = _git(primary, "rev-parse", f"{base}^{{tree}}")
+        evidence = legacy.run_check(
+            resumed_snapshot,
+            task_dir,
+            {
+                "id": "snapshot-head-tree",
+                "command": (
+                    "test \"$(git rev-parse 'HEAD^{tree}')\" = "
+                    f"'{base_tree}'"
+                ),
+                "timeout_seconds": 10,
+            },
+            "snapshot-self-contained",
+        )
+        expected_sandbox_mode = (
+            "inherited"
+            if legacy.inherited_outer_sandbox_is_active()
+            else "direct"
+        )
+        test.equal(
+            "SNAPSHOT runner-owned Seatbelt check resolves HEAD^{tree}",
+            (evidence["sandbox_mode"], evidence["passed"]),
+            (expected_sandbox_mode, True),
+        )
+        harness_cli._discard_claimed_verification_snapshot(
+            contract, attempt_dir, resumed_snapshot
+        )
+        test.true(
+            "SNAPSHOT cleanup removes only the claimed verification repo",
+            not resumed_snapshot.exists()
+            and worktree.is_dir()
+            and primary.is_dir(),
         )
 
 
@@ -3114,6 +3266,7 @@ def main() -> int:
     readonly_review_wall_timeout_cases(test)
     state_and_lock_cases(test)
     standalone_driver_lane_cases(test)
+    verification_snapshot_cases(test)
     checkpoint_cases(test)
     protocol_and_runtime_cases(test)
     commit_recovery_cases(test)


### PR DESCRIPTION
Fixes the real Harness v2 probe failure found during an interrupted/resumed docs task.\n\n- replaces shared verification clones with shallow, self-contained repos anchored to the exact planned tree\n- rejects non-empty or unsafe Git object alternates\n- allows the canonical v2 fault suite to inherit an already kernel-verified outer Seatbelt\n- covers reconstruction, exact base/diff/tree preservation, direct/inherited sandbox modes, and scoped cleanup\n\nFormal v1 Harness PASS. Composite harness selftest passed under the real check sandbox; v2 fault suite has 208 assertions. Seatbelt access was not widened.