### PR TITLE
fix: admit exact Codex hook warning

### DIFF
--- a/.agents/harness/task_runner.py
+++ b/.agents/harness/task_runner.py
@@ -52,6 +52,10 @@ REVIEWER_TOOL_DENIAL = {
         ),
     }
 }
+CODEX_HOOK_TRUST_WARNING = (
+    "`--dangerously-bypass-hook-trust` is enabled. Enabled hooks may run "
+    "without review for this invocation."
+)
 TASK_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{1,63}$")
 SHA1_RE = re.compile(r"^[0-9a-f]{40}$")
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
@@ -184,6 +188,12 @@ def reviewer_tool_activity(log_path: Path, vendor: str) -> List[str]:
                 if isinstance(event_type, str) and event_type.startswith("item."):
                     item = event.get("item")
                     item_type = item.get("type") if isinstance(item, dict) else None
+                    if (
+                        event_type == "item.completed"
+                        and item_type == "error"
+                        and item.get("message") == CODEX_HOOK_TRUST_WARNING
+                    ):
+                        continue
                     # A verifier-only Codex process may stream prose/reasoning, but
                     # every executable, hosted, file-mutating, or future unknown item
                     # is inadmissible. The closed allowlist makes new CLI tool shapes
@@ -6843,6 +6853,42 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
         )
         if reviewer_tool_activity(codex_prose, "codex"):
             failures.append("Codex prose response was treated as tool execution")
+
+        codex_hook_warning = tool_fixture(
+            "codex-hook-warning.jsonl",
+            [
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "type": "error",
+                        "message": CODEX_HOOK_TRUST_WARNING,
+                    },
+                },
+                {
+                    "type": "item.completed",
+                    "item": {"type": "agent_message", "text": "PASS"},
+                },
+            ],
+        )
+        if reviewer_tool_activity(codex_hook_warning, "codex"):
+            failures.append(
+                "Codex exact hook-trust warning was treated as tool execution"
+            )
+
+        codex_unknown_error = tool_fixture(
+            "codex-unknown-error.jsonl",
+            [
+                {
+                    "type": "item.completed",
+                    "item": {
+                        "type": "error",
+                        "message": "different reviewer error",
+                    },
+                }
+            ],
+        )
+        if not reviewer_tool_activity(codex_unknown_error, "codex"):
+            failures.append("Codex arbitrary error did not fail closed")
 
         for label, item_type in (
             ("command", "command_execution"),


### PR DESCRIPTION
Bootstrap Lane B: Codex CLI now emits a fixed hook-trust warning as an item.completed/error event before every isolated reviewer result. The harness incorrectly classifies that CLI warning as model tool activity, so valid Codex-only reviews are terminally blocked even when their logs contain no tool event and their structured verdict is PASS.

This change allows only the exact fixed warning string. Every other error item and every command, dynamic tool, hosted tool, MCP, file-change, or unknown executable item remains fail-closed. Deterministic regressions cover exact-warning acceptance and arbitrary-error refusal; the complete harness selftest is green.

Lane B is necessary only for this 46-line self-hosting bootstrap: the base-pinned external v1 runner contains the defect, while protected harness tasks correctly refuse to execute candidate runner bytes. After this lands, the full hash-bound Codex-only policy task will run through the normal protected harness lifecycle.