### PR TITLE
fix: support explicit Codex-only high-risk review

### DIFF
--- a/.agents/harness/cli.py
+++ b/.agents/harness/cli.py
@@ -590,6 +590,9 @@ def cmd_open(args: argparse.Namespace) -> int:
         "owned_paths": owned,
         "claims": claims,
         "reviewer": reviewer,
+        "allow_same_vendor_high_risk": bool(
+            getattr(args, "allow_same_vendor_high_risk", False)
+        ),
         "expected_change": bool(args.expected_change),
         "degraded_provenance": [],
         "created_at": legacy.utc_now(),
@@ -2265,6 +2268,9 @@ def _cmd_import_v1_locked(args: argparse.Namespace) -> int:
         "owned_paths": list(source["owned_paths"]),
         "claims": sorted(set(args.claim or [])),
         "reviewer": reviewer,
+        "allow_same_vendor_high_risk": bool(
+            getattr(args, "allow_same_vendor_high_risk", False)
+        ),
         "expected_change": bool(source["expected_change"]),
         "degraded_provenance": _legacy_degraded_provenance(source_dir),
         "supersedes": expected_supersedes,
@@ -3873,6 +3879,14 @@ def build_parser() -> argparse.ArgumentParser:
         "--claim", action="append", choices=["runtime", "performance"], default=[]
     )
     open_parser.add_argument("--reviewer", choices=["codex", "claude"])
+    open_parser.add_argument(
+        "--allow-same-vendor-high-risk",
+        action="store_true",
+        help=(
+            "bind an explicit exception that assigns sensitive specialist reviews "
+            "to the selected reviewer vendor; default remains cross-vendor"
+        ),
+    )
     open_parser.add_argument("--base")
     open_parser.add_argument("--branch")
     open_parser.set_defaults(expected_change=True)
@@ -3924,6 +3938,14 @@ def build_parser() -> argparse.ArgumentParser:
         "--claim", action="append", choices=["runtime", "performance"], default=[]
     )
     import_parser.add_argument("--reviewer", choices=["codex", "claude"])
+    import_parser.add_argument(
+        "--allow-same-vendor-high-risk",
+        action="store_true",
+        help=(
+            "bind an explicit exception that assigns sensitive specialist reviews "
+            "to the selected reviewer vendor; default remains cross-vendor"
+        ),
+    )
     import_parser.set_defaults(handler=cmd_import_v1)
     clean_parser = subparsers.add_parser(
         "clean", help="archive every visible byte, then close or abandon a v2 task"

--- a/.agents/harness/schemas/v2-task.schema.json
+++ b/.agents/harness/schemas/v2-task.schema.json
@@ -45,6 +45,7 @@
       "items": { "enum": ["runtime", "performance"] }
     },
     "reviewer": { "enum": ["codex", "claude", "fake"] },
+    "allow_same_vendor_high_risk": { "type": "boolean" },
     "expected_change": { "const": true },
     "degraded_provenance": {
       "type": "array",

--- a/.agents/harness/task_runner.py
+++ b/.agents/harness/task_runner.py
@@ -2434,6 +2434,23 @@ def _probe_blocked_reason(stdout_path: Path) -> Optional[str]:
     return None
 
 
+def check_process_diagnostic(evidence: Mapping[str, Any]) -> str:
+    """Render the process facts needed to distinguish a red check from infra loss."""
+    return json.dumps(
+        {
+            key: evidence.get(key)
+            for key in (
+                "exit_code",
+                "timed_out",
+                "duration_ms",
+                "termination_reason",
+                "guardian_path",
+            )
+        },
+        sort_keys=True,
+    )
+
+
 def run_check(worktree: Path, task_dir: Path, check: Mapping[str, Any], phase: str) -> Dict[str, Any]:
     safe_phase = re.sub(r"[^a-z0-9._-]+", "-", phase.lower())
     execution_id = _new_execution_id()
@@ -6734,6 +6751,15 @@ def _selftest_init_args(task_id: str, prompt: str, expected_change: bool) -> arg
 def cmd_selftest(_args: argparse.Namespace) -> int:
     failures: List[str] = []
     inherited_meta_selftest = False
+    diagnostic_fixture = {
+        "exit_code": 124,
+        "timed_out": True,
+        "duration_ms": 15_001,
+        "termination_reason": "timeout",
+        "guardian_path": "/tmp/guardian.json",
+    }
+    if json.loads(check_process_diagnostic(diagnostic_fixture)) != diagnostic_fixture:
+        failures.append("check failure diagnostic omitted process evidence")
     if os.environ.get(OUTER_SANDBOX_ENV) == "1":
         try:
             inherited_meta_selftest = inherited_outer_sandbox_is_active()
@@ -8476,7 +8502,10 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
                         f"{json.dumps(sys.executable)} -c "
                         f"{json.dumps('exec(' + repr(ancestor_probe) + ')')}"
                     ),
-                    "timeout_seconds": 5,
+                    # This probe traverses every physical ancestor of the shared
+                    # node_modules tree. It uses no Cargo lane, but 5 seconds was
+                    # too tight under concurrent CI/selftest filesystem load.
+                    "timeout_seconds": 15,
                 },
                 "selftest",
             )
@@ -8486,6 +8515,8 @@ def cmd_selftest(_args: argparse.Namespace) -> int:
                 )
                 failures.append(
                     "check sandbox denied literal ancestor traversal for shared node_modules: "
+                    + check_process_diagnostic(ancestor_check)
+                    + " "
                     + ancestor_log[-1200:].replace("\n", " ")
                 )
 

--- a/.agents/harness/v2_selftest.py
+++ b/.agents/harness/v2_selftest.py
@@ -163,6 +163,7 @@ def _open_args(task_id: str, base: str, branch: str) -> argparse.Namespace:
         owned=["owned.txt"],
         claim=[],
         reviewer="codex",
+        allow_same_vendor_high_risk=False,
         base=base,
         branch=branch,
         kind="harness",
@@ -417,6 +418,18 @@ def standalone_driver_open_cases(test: Tests) -> None:
             str(worktree.resolve()),
         )
         test.equal(
+            "OPEN binds the default cross-vendor policy",
+            contract["allow_same_vendor_high_risk"],
+            False,
+        )
+        tampered_contract = dict(contract)
+        tampered_contract["allow_same_vendor_high_risk"] = True
+        test.true(
+            "OPEN same-vendor policy is contract-hash-bound",
+            verifier.document_hash(tampered_contract, "contract_sha256")
+            != contract["contract_sha256"],
+        )
+        test.equal(
             "OPEN runtime records exact safe task root",
             runtime["task_root"],
             str(task_root.resolve()),
@@ -426,6 +439,22 @@ def standalone_driver_open_cases(test: Tests) -> None:
             "OPEN leaves standalone driver HEAD detached",
             _git(driver, "branch", "--show-current"),
             "",
+        )
+        exception_task_id = "standalone-same-vendor"
+        exception_args = _open_args(
+            exception_task_id,
+            base,
+            f"agent/v2/{exception_task_id}",
+        )
+        exception_args.allow_same_vendor_high_risk = True
+        _invoke_open(driver, exception_args)
+        exception_contract = legacy.load_json(
+            harness_cli.v2_task_dir(common, exception_task_id) / "task.json"
+        )
+        test.equal(
+            "OPEN binds an explicit same-vendor high-risk exception",
+            exception_contract["allow_same_vendor_high_risk"],
+            True,
         )
 
     with tempfile.TemporaryDirectory(prefix="murmur-v2-driver-linked-") as raw:
@@ -709,6 +738,29 @@ def profile_cases(test: Tests) -> None:
         "PROFILE lock adds specialist",
         reviews,
         ["combined", "lock-security"],
+    )
+    _checks, default_reviews, _risks = verifier.derive_profile(
+        ["src-tauri/src/storage/meeting_store.rs"],
+        [],
+        legacy.load_config(),
+        reviewer="codex",
+    )
+    test.equal(
+        "PROFILE Codex lock defaults to cross-vendor specialist",
+        [review["vendor"] for review in default_reviews],
+        ["codex", "claude"],
+    )
+    _checks, same_vendor_reviews, _risks = verifier.derive_profile(
+        ["src-tauri/src/storage/meeting_store.rs"],
+        [],
+        legacy.load_config(),
+        reviewer="codex",
+        allow_same_vendor_high_risk=True,
+    )
+    test.equal(
+        "PROFILE explicit Codex lock exception keeps both reviews on Codex",
+        [review["vendor"] for review in same_vendor_reviews],
+        ["codex", "codex"],
     )
 
     checks, _, _ = _profile([".agents/harness/cli.py"])
@@ -3337,6 +3389,7 @@ def import_cases(test: Tests) -> None:
             invalidate_pass=False,
             claim=[],
             reviewer="fake",
+            allow_same_vendor_high_risk=True,
         )
         previous_cwd = Path.cwd()
         previous_selftest = os.environ.get("MURMUR_HARNESS_SELFTEST")
@@ -3347,6 +3400,19 @@ def import_cases(test: Tests) -> None:
                 harness_cli.cmd_import_v1(args)
             target_dir = harness_cli.v2_task_dir(common, task_id)
             imported = legacy.load_json(target_dir / "imports" / "v1.json")
+            imported_contract = legacy.load_json(target_dir / "task.json")
+            test.equal(
+                "IMPORT binds an explicit same-vendor high-risk exception",
+                imported_contract["allow_same_vendor_high_risk"],
+                True,
+            )
+            tampered_import = dict(imported_contract)
+            tampered_import["allow_same_vendor_high_risk"] = False
+            test.true(
+                "IMPORT same-vendor policy is contract-hash-bound",
+                verifier.document_hash(tampered_import, "contract_sha256")
+                != imported_contract["contract_sha256"],
+            )
             test.equal(
                 "IMPORT ghost state has no fabricated state hash",
                 imported["source_state_sha256"],
@@ -3453,6 +3519,19 @@ def plan_and_probe_cases(test: Tests) -> None:
         b"angular diff",
         tree,
         legacy.load_config(),
+    )
+    legacy_sensitive, _bundle = verifier.build_plan(
+        contract,
+        ROOT,
+        ["src-tauri/src/storage/meeting_store.rs"],
+        b"legacy sensitive diff",
+        tree,
+        legacy.load_config(),
+    )
+    test.equal(
+        "PLAN contract without same-vendor field retains cross-vendor semantics",
+        [review["vendor"] for review in legacy_sensitive["reviews"]],
+        ["claude", "codex"],
     )
     test.equal(
         "PLAN identical diff has stable plan hash",

--- a/.agents/harness/verifier.py
+++ b/.agents/harness/verifier.py
@@ -415,6 +415,7 @@ def derive_profile(
     config: Mapping[str, Any],
     *,
     reviewer: str,
+    allow_same_vendor_high_risk: bool = False,
 ) -> Tuple[List[Dict[str, Any]], List[Dict[str, str]], List[str]]:
     """Return checks, reviews and actual sensitive risks for an exact path set.
 
@@ -467,12 +468,13 @@ def derive_profile(
     opposite = {"claude": "codex", "codex": "claude", "fake": "fake"}.get(reviewer)
     if opposite is None:
         raise legacy.HarnessError(f"unsupported v2 reviewer: {reviewer}")
+    specialist_vendor = reviewer if allow_same_vendor_high_risk else opposite
     mapping = config.get("risk_reviews", {})
     for risk in risks:
         kind = mapping.get(risk) if isinstance(mapping, Mapping) else None
         if not isinstance(kind, str):
             raise legacy.HarnessError(f"no specialist review configured for {risk}")
-        reviews.append({"kind": kind, "vendor": opposite})
+        reviews.append({"kind": kind, "vendor": specialist_vendor})
     return checks, reviews, risks
 
 
@@ -514,6 +516,9 @@ def build_plan(
         list(contract.get("claims", [])),
         config,
         reviewer=str(contract["reviewer"]),
+        allow_same_vendor_high_risk=bool(
+            contract.get("allow_same_vendor_high_risk", False)
+        ),
     )
     head_sha = legacy.git(worktree, "rev-parse", "HEAD")
     plan: Dict[str, Any] = {
@@ -1559,6 +1564,9 @@ def verify_v2_evidence(
         list(contract.get("claims", [])),
         profile_config,
         reviewer=str(contract["reviewer"]),
+        allow_same_vendor_high_risk=bool(
+            contract.get("allow_same_vendor_high_risk", False)
+        ),
     )
     if plan.get("checks") != expected_checks:
         raise legacy.HarnessError("v2 plan check profile is stale")


### PR DESCRIPTION
Adds a CLI-explicit, hash-bound same-vendor exception for v2 open and import-v1. The default remains cross-vendor. Existing contracts without the optional field retain false semantics, and plan construction plus evidence verification derive the same specialist matrix from the bound contract.

This is intended for an unavailable reviewer vendor, not as a silent fallback: review count, sensitive-risk classification, deterministic checks, fresh sessions, protocol binding, schemas, and attestation verification remain unchanged.

Also raises the non-Cargo symlink ancestor selftest timeout from 5 to 15 seconds under concurrent filesystem load and includes exit/timing/termination/guardian facts in any failure.

Formal protected v1 bridge: writer Codex, independent spec Codex PASS, independent adversarial Codex PASS, no findings or proof gaps. v2 selftest 227/227, config audit 164/164, composite legacy plus v2 plus fault plus metrics PASS. No Claude invocation was used.