### PR TITLE
fix(harness): bind reviewer probe evidence

### DIFF
--- a/.agents/harness/checks/npm-lock-evidence.py
+++ b/.agents/harness/checks/npm-lock-evidence.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Emit compact, reviewable evidence for a package.json/package-lock.json diff.
+
+The command is deliberately read-only and offline.  npm owns interpretation of
+its logical lock tree; this wrapper only reduces that complete tree to the
+direct and changed package names a reviewer must inspect.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Any, Dict, Iterable, Mapping, Sequence
+
+
+MAX_CHANGED_LOCK_ENTRIES = 512
+MAX_OUTPUT_BYTES = 65_536
+BASE_SHA_ENV = "MURMUR_HARNESS_BASE_SHA"
+SHA1_RE = re.compile(r"^[0-9a-f]{40}$")
+DIRECT_DEPENDENCY_KEYS = (
+    "dependencies",
+    "devDependencies",
+    "optionalDependencies",
+    "peerDependencies",
+)
+
+
+class EvidenceError(RuntimeError):
+    pass
+
+
+def _reject_duplicate_keys(pairs: Sequence[tuple[str, Any]]) -> Dict[str, Any]:
+    result: Dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise EvidenceError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _json_bytes(raw: bytes, label: str) -> Dict[str, Any]:
+    try:
+        value = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, EvidenceError) as exc:
+        raise EvidenceError(f"{label} is not strict JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise EvidenceError(f"{label} root must be an object")
+    return value
+
+
+def _read(path: Path) -> tuple[bytes, Dict[str, Any]]:
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise EvidenceError(f"cannot read {path}: {exc}") from exc
+    return raw, _json_bytes(raw, str(path))
+
+
+def _bound_base_sha() -> str:
+    requested = os.environ.get(BASE_SHA_ENV, "")
+    if not SHA1_RE.fullmatch(requested):
+        raise EvidenceError(
+            f"{BASE_SHA_ENV} must be the runner-bound 40-hex task base"
+        )
+    completed = subprocess.run(
+        [
+            "git",
+            "rev-parse",
+            "--verify",
+            "--end-of-options",
+            f"{requested}^{{commit}}",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    resolved = completed.stdout.decode("ascii", "replace").strip()
+    if completed.returncode != 0 or resolved != requested:
+        message = completed.stderr.decode("utf-8", "replace").strip()
+        raise EvidenceError(
+            f"runner-bound task base is unavailable: {message or requested}"
+        )
+    return requested
+
+
+def _base(relative: str, base_sha: str) -> tuple[bytes, Dict[str, Any]]:
+    completed = subprocess.run(
+        [
+            "git",
+            "show",
+            "--no-ext-diff",
+            "--no-textconv",
+            f"{base_sha}:{relative}",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        message = completed.stderr.decode("utf-8", "replace").strip()
+        raise EvidenceError(f"cannot read base {relative}: {message}")
+    return completed.stdout, _json_bytes(
+        completed.stdout, f"{base_sha}:{relative}"
+    )
+
+
+def _mapping(document: Mapping[str, Any], key: str, label: str) -> Dict[str, str]:
+    value = document.get(key, {})
+    if not isinstance(value, dict) or not all(
+        isinstance(name, str) and isinstance(spec, str)
+        for name, spec in value.items()
+    ):
+        raise EvidenceError(f"{label}.{key} must be a string map")
+    return dict(sorted(value.items()))
+
+
+def _peer_meta(
+    document: Mapping[str, Any], label: str
+) -> Dict[str, Dict[str, Any]]:
+    value = document.get("peerDependenciesMeta", {})
+    if not isinstance(value, dict):
+        raise EvidenceError(f"{label}.peerDependenciesMeta must be an object map")
+    result: Dict[str, Dict[str, Any]] = {}
+    for name, metadata in value.items():
+        if not isinstance(name, str) or not isinstance(metadata, dict):
+            raise EvidenceError(
+                f"{label}.peerDependenciesMeta entries must be objects"
+            )
+        optional = metadata.get("optional")
+        if optional is not None and not isinstance(optional, bool):
+            raise EvidenceError(
+                f"{label}.peerDependenciesMeta.{name}.optional must be boolean"
+            )
+        result[name] = dict(sorted(metadata.items()))
+    return dict(sorted(result.items()))
+
+
+def _packages(lock: Mapping[str, Any], label: str) -> Dict[str, Mapping[str, Any]]:
+    value = lock.get("packages")
+    if not isinstance(value, dict) or not all(
+        isinstance(path, str) and isinstance(item, dict)
+        for path, item in value.items()
+    ):
+        raise EvidenceError(f"{label}.packages must be an object map")
+    return {path: item for path, item in value.items()}
+
+
+def _package_name(path: str, item: Mapping[str, Any]) -> str | None:
+    declared = item.get("name")
+    if isinstance(declared, str) and declared:
+        return declared
+    marker = "node_modules/"
+    if marker not in path:
+        return None
+    candidate = path.rsplit(marker, 1)[-1]
+    return candidate or None
+
+
+def _changed_lock_entries(
+    before: Mapping[str, Mapping[str, Any]],
+    after: Mapping[str, Mapping[str, Any]],
+) -> list[Dict[str, Any]]:
+    rows: list[Dict[str, Any]] = []
+    for path in sorted(set(before) | set(after)):
+        old = before.get(path)
+        new = after.get(path)
+        if old == new:
+            continue
+        source = new if new is not None else old
+        assert source is not None
+        rows.append(
+            {
+                "path": path,
+                "name": _package_name(path, source),
+                "before_version": old.get("version") if old else None,
+                "after_version": new.get("version") if new else None,
+            }
+        )
+    if len(rows) > MAX_CHANGED_LOCK_ENTRIES:
+        raise EvidenceError(
+            "lock drift is too large for bounded review evidence: "
+            f"{len(rows)} entries > {MAX_CHANGED_LOCK_ENTRIES}"
+        )
+    return rows
+
+
+def _changed_mapping_names(
+    before: Mapping[str, Any], after: Mapping[str, Any]
+) -> set[str]:
+    return {
+        name
+        for name in set(before) | set(after)
+        if before.get(name) != after.get(name)
+    }
+
+
+def _logical_tree() -> Dict[str, Any]:
+    environment = {
+        **os.environ,
+        "NPM_CONFIG_AUDIT": "false",
+        "NPM_CONFIG_FUND": "false",
+        "NPM_CONFIG_IGNORE_SCRIPTS": "true",
+        "NPM_CONFIG_OFFLINE": "true",
+        "NPM_CONFIG_UPDATE_NOTIFIER": "false",
+    }
+    completed = subprocess.run(
+        ["npm", "ls", "--package-lock-only", "--all", "--json"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=environment,
+        check=False,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", "replace").strip()
+        if not detail:
+            detail = completed.stdout.decode("utf-8", "replace")[-2000:]
+        raise EvidenceError(
+            f"npm lock-only logical tree failed with {completed.returncode}: {detail}"
+        )
+    return _json_bytes(completed.stdout, "npm ls lock-only output")
+
+
+def _versions_by_name(
+    logical: Mapping[str, Any], relevant: Iterable[str]
+) -> tuple[Dict[str, list[str]], int]:
+    wanted = set(relevant)
+    found: Dict[str, set[str]] = {name: set() for name in wanted}
+    count = 0
+    root_dependencies = logical.get("dependencies", {})
+    if not isinstance(root_dependencies, dict):
+        raise EvidenceError("npm logical tree dependencies must be an object")
+    stack: list[tuple[str, Mapping[str, Any]]] = [
+        (str(name), item)
+        for name, item in root_dependencies.items()
+        if isinstance(item, dict)
+    ]
+    while stack:
+        name, item = stack.pop()
+        count += 1
+        version = item.get("version")
+        if name in wanted and isinstance(version, str) and version:
+            found[name].add(version)
+        children = item.get("dependencies", {})
+        if children is None:
+            continue
+        if not isinstance(children, dict):
+            raise EvidenceError(f"npm logical tree dependencies for {name} are malformed")
+        stack.extend(
+            (str(child_name), child)
+            for child_name, child in children.items()
+            if isinstance(child, dict)
+        )
+    result = {name: sorted(versions) for name, versions in sorted(found.items())}
+    return result, count
+
+
+def build_evidence(root: Path, base_sha: str) -> Dict[str, Any]:
+    manifest_raw, manifest = _read(root / "package.json")
+    lock_raw, lock = _read(root / "package-lock.json")
+    base_manifest_raw, base_manifest = _base("package.json", base_sha)
+    base_lock_raw, base_lock = _base("package-lock.json", base_sha)
+
+    if lock.get("lockfileVersion") != 3:
+        raise EvidenceError("package-lock.json lockfileVersion must be 3")
+    current_packages = _packages(lock, "package-lock.json")
+    base_packages = _packages(base_lock, f"{base_sha}:package-lock.json")
+    lock_root = current_packages.get("")
+    if not isinstance(lock_root, dict):
+        raise EvidenceError("package-lock.json packages[''] is missing")
+
+    current_direct = {
+        key: _mapping(manifest, key, "package.json")
+        for key in DIRECT_DEPENDENCY_KEYS
+    }
+    base_direct = {
+        key: _mapping(
+            base_manifest, key, f"{base_sha}:package.json"
+        )
+        for key in DIRECT_DEPENDENCY_KEYS
+    }
+    for key in DIRECT_DEPENDENCY_KEYS:
+        lock_mapping = _mapping(
+            lock_root, key, "package-lock.json packages['']"
+        )
+        if lock_mapping != current_direct[key]:
+            raise EvidenceError(
+                f"lock root {key} differ from package.json"
+            )
+    current_peer_meta = _peer_meta(manifest, "package.json")
+    lock_peer_meta = _peer_meta(
+        lock_root, "package-lock.json packages['']"
+    )
+    if lock_peer_meta != current_peer_meta:
+        raise EvidenceError(
+            "lock root peerDependenciesMeta differ from package.json"
+        )
+    base_peer_meta = _peer_meta(
+        base_manifest, f"{base_sha}:package.json"
+    )
+    for key in ("name", "version"):
+        expected = manifest.get(key)
+        if lock.get(key) != expected or lock_root.get(key) != expected:
+            raise EvidenceError(f"manifest/lock root {key} values differ")
+
+    changed_entries = _changed_lock_entries(base_packages, current_packages)
+    direct_names = {
+        name
+        for key in DIRECT_DEPENDENCY_KEYS
+        for name in current_direct[key]
+    }
+    optional_names = set(current_direct["optionalDependencies"]) | {
+        name
+        for name, metadata in current_peer_meta.items()
+        if metadata.get("optional") is True
+    }
+    changed_names = {
+        str(row["name"]) for row in changed_entries if row.get("name")
+    }
+    changed_manifest_names = set().union(
+        *(
+            _changed_mapping_names(base_direct[key], current_direct[key])
+            for key in DIRECT_DEPENDENCY_KEYS
+        ),
+        _changed_mapping_names(base_peer_meta, current_peer_meta),
+    )
+    relevant_names = sorted(
+        direct_names | changed_names | changed_manifest_names
+    )
+    logical = _logical_tree()
+    versions, logical_nodes = _versions_by_name(logical, relevant_names)
+    missing_required_direct = sorted(
+        name
+        for name in direct_names - optional_names
+        if not versions.get(name)
+    )
+    if missing_required_direct:
+        raise EvidenceError(
+            "direct packages missing from npm logical tree: "
+            + ", ".join(missing_required_direct)
+        )
+
+    peer_metadata: list[Dict[str, Any]] = []
+    for path, item in sorted(current_packages.items()):
+        name = _package_name(path, item)
+        peers = item.get("peerDependencies")
+        if name in relevant_names and isinstance(peers, dict) and peers:
+            peer_metadata.append(
+                {
+                    "path": path,
+                    "name": name,
+                    "peerDependencies": dict(sorted(peers.items())),
+                }
+            )
+
+    return {
+        "schema_version": 1,
+        "mode": "offline-package-lock-only",
+        "base_sha": base_sha,
+        "package_json_sha256": hashlib.sha256(manifest_raw).hexdigest(),
+        "package_lock_sha256": hashlib.sha256(lock_raw).hexdigest(),
+        "base_package_json_sha256": hashlib.sha256(base_manifest_raw).hexdigest(),
+        "base_package_lock_sha256": hashlib.sha256(base_lock_raw).hexdigest(),
+        "project": {
+            "name": manifest.get("name"),
+            "version": manifest.get("version"),
+            "lockfileVersion": lock.get("lockfileVersion"),
+        },
+        "direct": {
+            **current_direct,
+            "peerDependenciesMeta": current_peer_meta,
+            "dependency_keys_unchanged": (
+                sorted(current_direct["dependencies"])
+                == sorted(base_direct["dependencies"])
+            ),
+            "dev_dependency_keys_unchanged": (
+                sorted(current_direct["devDependencies"])
+                == sorted(base_direct["devDependencies"])
+            ),
+            "optional_dependency_keys_unchanged": (
+                sorted(current_direct["optionalDependencies"])
+                == sorted(base_direct["optionalDependencies"])
+            ),
+            "peer_dependency_keys_unchanged": (
+                sorted(current_direct["peerDependencies"])
+                == sorted(base_direct["peerDependencies"])
+            ),
+            "peer_dependencies_meta_unchanged": (
+                current_peer_meta == base_peer_meta
+            ),
+        },
+        "missing_optional_versions": sorted(
+            name for name in optional_names if not versions.get(name)
+        ),
+        "manifest_scripts_unchanged": (
+            manifest.get("scripts") == base_manifest.get("scripts")
+        ),
+        "changed_manifest_dependency_names": sorted(
+            changed_manifest_names
+        ),
+        "changed_lock_entries": changed_entries,
+        "changed_lock_entry_count": len(changed_entries),
+        "logical_tree_node_count": logical_nodes,
+        "versions_by_name": versions,
+        "peer_metadata": peer_metadata,
+    }
+
+
+def main() -> int:
+    try:
+        evidence = build_evidence(Path.cwd(), _bound_base_sha())
+        encoded = (
+            json.dumps(evidence, sort_keys=True, separators=(",", ":"))
+            + "\n"
+        ).encode("utf-8")
+        if len(encoded) > MAX_OUTPUT_BYTES:
+            raise EvidenceError(
+                "structured lock evidence exceeds the bounded output limit: "
+                f"{len(encoded)} > {MAX_OUTPUT_BYTES}"
+            )
+        sys.stdout.buffer.write(encoded)
+        return 0
+    except EvidenceError as exc:
+        print(f"npm-lock-evidence: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/harness/cli.py
+++ b/.agents/harness/cli.py
@@ -98,6 +98,13 @@ def set_v2_state(task_dir: Path, status: str, **details: Any) -> Dict[str, Any]:
             raise legacy.HarnessError(
                 f"v2 task is terminal ({prior.get('status')}); state cannot change"
             )
+    prior_revision = prior.get("state_revision", 0)
+    if (
+        isinstance(prior_revision, bool)
+        or not isinstance(prior_revision, int)
+        or prior_revision < 0
+    ):
+        raise legacy.HarnessError("v2 state revision is malformed")
     state = {
         "schema_version": 2,
         "task_id": task_dir.name,
@@ -109,6 +116,7 @@ def set_v2_state(task_dir: Path, status: str, **details: Any) -> Dict[str, Any]:
             if key not in {"schema_version", "task_id", "status", "updated_at"}
         },
         **details,
+        "state_revision": prior_revision + 1,
     }
     # The append-only event is authoritative.  The projection follows it, so a
     # crash between writes is repaired by load_v2_state instead of losing the
@@ -1243,6 +1251,441 @@ def _load_bound_record(
     return record
 
 
+def _probe_record_sha256(record: Mapping[str, Any]) -> str:
+    return legacy.sha256_bytes(legacy.canonical_json(record))
+
+
+def _probe_witness_key(probes_dir: Path, probe_id: str) -> str:
+    return f"{probes_dir.parent.name}/{probe_id}"
+
+
+def _witness_probe_high_water(
+    task_dir: Path,
+    probes_dir: Path,
+    probe_id: str,
+    execution_number: int,
+) -> None:
+    state = load_v2_state(task_dir)
+    raw = state.get("probe_high_water", {})
+    if not isinstance(raw, Mapping) or any(
+        not isinstance(key, str)
+        or isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 1
+        or value > verifier.MAX_PROBE_EXECUTIONS_PER_ID
+        for key, value in raw.items()
+    ):
+        raise legacy.HarnessError("v2 probe high-water witness is malformed")
+    witnesses = dict(raw)
+    key = _probe_witness_key(probes_dir, probe_id)
+    prior = int(witnesses.get(key, 0))
+    if prior > execution_number:
+        raise legacy.HarnessError(
+            f"v2 probe event ledger was rewound: {probe_id}"
+        )
+    if prior == execution_number:
+        return
+    witnesses[key] = execution_number
+    set_v2_state(
+        task_dir,
+        str(state["status"]),
+        phase="probes",
+        attempt_id=probes_dir.parent.name,
+        probe_high_water=witnesses,
+    )
+
+
+def _probe_execution_state(
+    task_dir: Path,
+    probes_dir: Path,
+    probe_id: str,
+    declared: Mapping[str, Any],
+    plan: Mapping[str, Any],
+    *,
+    allow_test_adapter: bool,
+) -> Tuple[
+    List[Dict[str, Any]],
+    int,
+    List[bool],
+    List[Dict[str, Any]],
+]:
+    """Load completed records, reserved high-water, and legacy presence."""
+
+    events_path = task_dir / "events.jsonl"
+    records: Dict[int, Dict[str, Any]] = {}
+    reservations: set[int] = set()
+    reservation_contexts: Dict[int, List[Dict[str, Any]]] = {}
+    legacy_event_outcomes: List[bool] = []
+    expected_command_sha256 = legacy.sha256_bytes(
+        str(declared["command"]).encode("utf-8")
+    )
+    try:
+        with events_path.open(
+            "r", encoding="utf-8", errors="strict"
+        ) as handle:
+            for line in handle:
+                document = json.loads(line)
+                if (
+                    not isinstance(document, dict)
+                    or document.get("attempt_id") != probes_dir.parent.name
+                    or document.get("probe_id") != probe_id
+                ):
+                    continue
+                event_kind = document.get("event")
+                if event_kind not in {
+                    "probe-execution-reserved",
+                    "probe-checkpoint",
+                }:
+                    continue
+                execution_number = document.get("execution_number")
+                # Pre-high-water events remain compatible. A validated legacy
+                # projection is migrated to a numbered event below.
+                if execution_number is None:
+                    if event_kind == "probe-checkpoint":
+                        if not isinstance(document.get("passed"), bool):
+                            raise legacy.HarnessError(
+                                "legacy probe event outcome is malformed"
+                            )
+                        legacy_event_outcomes.append(
+                            bool(document["passed"])
+                        )
+                    continue
+                if (
+                    isinstance(execution_number, bool)
+                    or not isinstance(execution_number, int)
+                    or execution_number < 1
+                    or execution_number
+                    > verifier.MAX_PROBE_EXECUTIONS_PER_ID
+                ):
+                    raise legacy.HarnessError(
+                        f"v2 probe event number is malformed: {probe_id}"
+                    )
+                if (
+                    document.get("plan_sha256")
+                    != plan.get("plan_sha256")
+                    or document.get("diff_sha256")
+                    != plan.get("diff_sha256")
+                ):
+                    raise legacy.HarnessError(
+                        f"v2 probe event binding changed: {probe_id}"
+                    )
+                if event_kind == "probe-execution-reserved":
+                    contexts = document.get("request_contexts")
+                    if (
+                        document.get("check_id") != probe_id
+                        or document.get("command_sha256")
+                        != expected_command_sha256
+                        or not isinstance(contexts, list)
+                        or not contexts
+                        or document.get("request_contexts_sha256")
+                        != legacy.sha256_bytes(
+                            legacy.canonical_json(contexts)
+                        )
+                        or any(
+                            not isinstance(context, Mapping)
+                            or context.get("probe_id") != probe_id
+                            or context.get("context_sha256")
+                            != verifier.document_hash(
+                                context, "context_sha256"
+                            )
+                            for context in contexts
+                        )
+                        or execution_number in reservations
+                    ):
+                        raise legacy.HarnessError(
+                            f"v2 probe reservation changed: {probe_id}"
+                        )
+                    reservations.add(execution_number)
+                    reservation_contexts[execution_number] = [
+                        dict(context) for context in contexts
+                    ]
+                    continue
+                expected_path = probes_dir / f"{probe_id}.json"
+                record = document.get("record")
+                if (
+                    not isinstance(record, Mapping)
+                    or not isinstance(document.get("projection_path"), str)
+                    or Path(
+                        str(document.get("projection_path"))
+                    ).absolute()
+                    != expected_path.absolute()
+                    or not isinstance(document.get("record_sha256"), str)
+                    or legacy.SHA256_RE.fullmatch(
+                        str(document.get("record_sha256"))
+                    )
+                    is None
+                ):
+                    raise legacy.HarnessError(
+                        f"v2 probe event binding changed: {probe_id}"
+                    )
+                bound_record = dict(record)
+                if (
+                    bound_record.get("execution_number")
+                    != execution_number
+                    or _probe_record_sha256(bound_record)
+                    != document["record_sha256"]
+                    or not verifier.binding_matches(bound_record, plan)
+                ):
+                    raise legacy.HarnessError(
+                        f"v2 probe event record changed: {probe_id}"
+                    )
+                verifier.validate_probe_checkpoint(
+                    bound_record,
+                    declared,
+                    plan,
+                    task_dir,
+                    allow_test_adapter=allow_test_adapter,
+                )
+                if execution_number in records:
+                    raise legacy.HarnessError(
+                        f"v2 probe event number was reused: {probe_id}"
+                    )
+                records[execution_number] = bound_record
+                if (
+                    execution_number in reservation_contexts
+                    and legacy.canonical_json(
+                        bound_record.get("request_contexts")
+                    )
+                    != legacy.canonical_json(
+                        reservation_contexts[execution_number]
+                    )
+                ):
+                    raise legacy.HarnessError(
+                        f"v2 probe completion context changed: {probe_id}"
+                    )
+                reservations.add(execution_number)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise legacy.HarnessError(
+            f"v2 probe event ledger is malformed: {events_path}: {exc}"
+        ) from exc
+    numbers = sorted(reservations)
+    if numbers and numbers != list(range(1, max(numbers) + 1)):
+        raise legacy.HarnessError(
+            f"v2 probe event high-water is not contiguous: {probe_id}"
+        )
+    high_water = max(numbers, default=0)
+    state = load_v2_state(task_dir)
+    witnesses = state.get("probe_high_water", {})
+    if not isinstance(witnesses, Mapping):
+        raise legacy.HarnessError("v2 probe high-water witness is malformed")
+    witnessed = witnesses.get(
+        _probe_witness_key(probes_dir, probe_id), 0
+    )
+    if (
+        isinstance(witnessed, bool)
+        or not isinstance(witnessed, int)
+        or witnessed < 0
+        or witnessed > verifier.MAX_PROBE_EXECUTIONS_PER_ID
+    ):
+        raise legacy.HarnessError("v2 probe high-water witness is malformed")
+    if witnessed > high_water:
+        raise legacy.HarnessError(
+            f"v2 probe event ledger was rewound: {probe_id}"
+        )
+    return (
+        [records[number] for number in sorted(records)],
+        high_water,
+        legacy_event_outcomes,
+        (
+            reservation_contexts.get(high_water, [])
+            if high_water not in records
+            else []
+        ),
+    )
+
+
+def _reserve_probe_execution(
+    task_dir: Path,
+    probes_dir: Path,
+    probe_id: str,
+    declared: Mapping[str, Any],
+    plan: Mapping[str, Any],
+    execution_number: int,
+    request_contexts: Sequence[Mapping[str, Any]],
+) -> None:
+    contexts = [copy.deepcopy(dict(item)) for item in request_contexts]
+    if not contexts:
+        raise legacy.HarnessError("v2 probe reservation context is missing")
+    _checkpoint_event(
+        task_dir,
+        "probe-execution-reserved",
+        attempt_id=probes_dir.parent.name,
+        probe_id=probe_id,
+        execution_number=execution_number,
+        check_id=probe_id,
+        command_sha256=legacy.sha256_bytes(
+            str(declared["command"]).encode("utf-8")
+        ),
+        request_contexts=contexts,
+        request_contexts_sha256=legacy.sha256_bytes(
+            legacy.canonical_json(contexts)
+        ),
+        plan_sha256=plan["plan_sha256"],
+        diff_sha256=plan["diff_sha256"],
+    )
+    _witness_probe_high_water(
+        task_dir, probes_dir, probe_id, execution_number
+    )
+
+
+def _append_probe_checkpoint(
+    task_dir: Path,
+    probes_dir: Path,
+    probe_id: str,
+    plan: Mapping[str, Any],
+    record: Mapping[str, Any],
+) -> None:
+    evidence = record.get("evidence", {})
+    _checkpoint_event(
+        task_dir,
+        "probe-checkpoint",
+        attempt_id=probes_dir.parent.name,
+        probe_id=probe_id,
+        execution_number=record["execution_number"],
+        projection_path=str(probes_dir / f"{probe_id}.json"),
+        record=record,
+        record_sha256=_probe_record_sha256(record),
+        plan_sha256=plan["plan_sha256"],
+        diff_sha256=plan["diff_sha256"],
+        passed=bool(evidence.get("passed")),
+    )
+
+
+def _load_probe_checkpoint(
+    probes_dir: Path,
+    probe_id: str,
+    declared: Mapping[str, Any],
+    plan: Mapping[str, Any],
+    task_dir: Path,
+    *,
+    allow_test_adapter: bool,
+) -> Tuple[Optional[Dict[str, Any]], int, bool, List[Dict[str, Any]]]:
+    """Load the append-only high-water and repair only its latest view."""
+
+    projection_path = probes_dir / f"{probe_id}.json"
+    projection = _load_bound_record(projection_path, plan)
+    if projection is not None:
+        verifier.validate_probe_checkpoint(
+            projection,
+            declared,
+            plan,
+            task_dir,
+            allow_test_adapter=allow_test_adapter,
+        )
+    (
+        records,
+        high_water,
+        legacy_event_outcomes,
+        outstanding_contexts,
+    ) = _probe_execution_state(
+        task_dir,
+        probes_dir,
+        probe_id,
+        declared,
+        plan,
+        allow_test_adapter=allow_test_adapter,
+    )
+    if high_water > 0:
+        _witness_probe_high_water(
+            task_dir, probes_dir, probe_id, high_water
+        )
+    if len(legacy_event_outcomes) > 1:
+        raise legacy.HarnessError(
+            "multiple legacy probe events cannot be migrated safely"
+        )
+    if legacy_event_outcomes and records:
+        migrated_numbered = records[0]
+        if (
+            int(migrated_numbered["execution_number"]) != 1
+            or bool(
+                migrated_numbered.get("evidence", {}).get("passed")
+            )
+            != legacy_event_outcomes[0]
+        ):
+            raise legacy.HarnessError(
+                "legacy probe outcome conflicts with numbered history"
+            )
+    if not records and (
+        high_water == 0 or bool(legacy_event_outcomes)
+    ):
+        if projection is None:
+            if legacy_event_outcomes:
+                raise legacy.HarnessError(
+                    "legacy probe event has no recoverable projection"
+                )
+            if projection_path.exists() or projection_path.is_symlink():
+                raise legacy.HarnessError(
+                    f"v2 probe projection is malformed: {probe_id}"
+                )
+            return None, 0, False, []
+        migration_count = 1
+        if high_water > migration_count:
+            raise legacy.HarnessError(
+                "legacy probe migration exceeds its execution history"
+            )
+        projection_number = projection.get("execution_number", 1)
+        if projection_number != migration_count:
+            raise legacy.HarnessError(
+                "v2 probe projection has no append-only execution history"
+            )
+        migrated = {
+            **projection,
+            "execution_number": migration_count,
+        }
+        if (
+            legacy_event_outcomes
+            and bool(migrated.get("evidence", {}).get("passed"))
+            != legacy_event_outcomes[0]
+        ):
+            raise legacy.HarnessError(
+                "legacy probe outcome conflicts with its projection"
+            )
+        if (
+            high_water == migration_count
+            and legacy.canonical_json(outstanding_contexts)
+            != legacy.canonical_json(migrated["request_contexts"])
+        ):
+            raise legacy.HarnessError(
+                "legacy probe migration context changed"
+            )
+        for number in range(high_water + 1, migration_count + 1):
+            _reserve_probe_execution(
+                task_dir,
+                probes_dir,
+                probe_id,
+                declared,
+                plan,
+                number,
+                migrated["request_contexts"],
+            )
+        _append_probe_checkpoint(
+            task_dir, probes_dir, probe_id, plan, migrated
+        )
+        records = [migrated]
+        high_water = migration_count
+        outstanding_contexts = []
+
+    # The per-ID JSON is only a convenience projection. The append-only event
+    # owns both the full record and its high-water, so rollback or deletion can
+    # never lower the execution count.
+    latest = records[-1] if records else None
+    if latest is not None and (
+        projection is None
+        or legacy.canonical_json(projection)
+        != legacy.canonical_json(latest)
+    ):
+        legacy.atomic_write_json(projection_path, latest)
+    completed_numbers = {
+        int(record["execution_number"]) for record in records
+    }
+    return (
+        latest,
+        high_water,
+        high_water not in completed_numbers,
+        outstanding_contexts,
+    )
+
+
 def _snapshot_still_matches(
     contract: Mapping[str, Any],
     task_dir: Path,
@@ -1291,6 +1734,11 @@ def _run_or_resume_check(
         task_dir,
         declared,
         f"v2-{attempt_dir.name[:12]}",
+        bound_environment=(
+            {"MURMUR_HARNESS_BASE_SHA": str(plan["base_sha"])}
+            if declared.get("id") == "npm-lock"
+            else None
+        ),
     )
     if not _snapshot_still_matches(
         {**contract, "worktree_path": str(verification_worktree)},
@@ -1439,23 +1887,82 @@ def verify_task(
         probes_dir = attempt_dir / "probes"
         probes_dir.mkdir(parents=True, exist_ok=True)
         probe_records: List[Dict[str, Any]] = []
-        for path in sorted(probes_dir.glob("*.json")):
-            record = _load_bound_record(path, plan)
+        probe_checkpoints: Dict[str, Dict[str, Any]] = {}
+        outstanding_probe_contexts: Dict[str, List[Dict[str, Any]]] = {}
+        deterministic_probe_failures: List[str] = []
+        config = legacy.load_config()
+        for probe_id in sorted(verifier.allowed_probe_ids(plan)):
+            declared_probe = verifier.canonical_check(probe_id, config)
+            (
+                record,
+                high_water,
+                incomplete,
+                reserved_contexts,
+            ) = _load_probe_checkpoint(
+                probes_dir,
+                probe_id,
+                declared_probe,
+                plan,
+                task_dir,
+                allow_test_adapter=allow_test_adapter,
+            )
+            if record is not None:
+                prior = record.get("evidence", {})
+                if (
+                    not prior.get("passed")
+                    and prior.get("outcome") != "BLOCKED"
+                    and not prior.get("timed_out")
+                ):
+                    deterministic_probe_failures.append(probe_id)
+                    probe_checkpoints[probe_id] = record
+                    continue
+            if incomplete:
+                if not reserved_contexts:
+                    raise legacy.HarnessError(
+                        f"v2 incomplete probe lost its request context: {probe_id}"
+                    )
+                outstanding_probe_contexts[probe_id] = reserved_contexts
+                probe_checkpoints[probe_id] = {
+                    "id": probe_id,
+                    "execution_number": high_water,
+                    "evidence": {
+                        "passed": False,
+                        "outcome": "BLOCKED",
+                        "timed_out": True,
+                        "blocked_reason": (
+                            "probe execution was reserved but interrupted "
+                            "before its checkpoint"
+                        ),
+                    },
+                }
+                continue
             if record is None:
                 continue
-            try:
-                declared_probe = verifier.canonical_check(
-                    str(record.get("id")), legacy.load_config()
-                )
-                verifier.validate_check_checkpoint(
-                    record, declared_probe, plan, task_dir
-                )
-            except legacy.HarnessError:
-                continue
+            probe_checkpoints[probe_id] = record
             prior = record.get("evidence", {})
             if prior.get("outcome") == "BLOCKED" or prior.get("timed_out"):
+                contexts = record.get("request_contexts")
+                if not isinstance(contexts, list) or not contexts:
+                    raise legacy.HarnessError(
+                        f"v2 retryable probe lost its request context: {probe_id}"
+                    )
+                outstanding_probe_contexts[probe_id] = [
+                    copy.deepcopy(dict(context)) for context in contexts
+                ]
                 continue
             probe_records.append(record)
+        if deterministic_probe_failures:
+            set_v2_state(
+                task_dir,
+                "NEEDS_FIX",
+                phase="probes",
+                reason=(
+                    "deterministic reviewer probe failed: "
+                    + ", ".join(deterministic_probe_failures)
+                ),
+                attempt_id=attempt_dir.name,
+            )
+            return "NEEDS_FIX"
         probe_records.sort(key=lambda item: str(item.get("id", "")))
         probe_hash = verifier.probe_evidence_hash(probe_records)
         records_by_kind: Dict[str, Dict[str, Any]] = {}
@@ -1468,9 +1975,11 @@ def verify_task(
                     contract,
                     plan,
                     diff,
-                    [*check_records, *probe_records],
+                    check_records,
                     str(declared["kind"]),
                     worktree,
+                    task_dir,
+                    probes=probe_records,
                 )
                 try:
                     verifier.validate_review_checkpoint(
@@ -1512,9 +2021,11 @@ def verify_task(
                     contract=contract,
                     plan=plan,
                     worktree=worktree,
+                    task_dir=task_dir,
                     attempt_dir=run_dir,
                     diff=diff,
-                    checks=[*check_records, *probe_records],
+                    checks=check_records,
+                    probes=probe_records,
                     review=declared,
                     probe_evidence_sha256=probe_hash,
                     allow_test_adapter=allow_test_adapter,
@@ -1602,7 +2113,52 @@ def verify_task(
                 for review in review_records
                 for request in review.get("result", {}).get("probe_requests", [])
             }
+            | set(outstanding_probe_contexts)
         )
+        eligible_probe_ids = set(verifier.allowed_probe_ids(plan))
+        invalid_probe_ids = sorted(
+            set(requested_probe_ids) - eligible_probe_ids
+        )
+        if invalid_probe_ids:
+            set_v2_state(
+                task_dir,
+                "NEEDS_EVIDENCE",
+                phase="reviews",
+                reason=(
+                    "review requested probes outside the exact plan; no command "
+                    f"was executed: {', '.join(invalid_probe_ids)}"
+                ),
+                attempt_id=attempt_dir.name,
+            )
+            return "NEEDS_EVIDENCE"
+        request_contexts: Dict[str, List[Dict[str, Any]]] = {}
+        for probe_id in requested_probe_ids:
+            contexts = [
+                *outstanding_probe_contexts.get(probe_id, []),
+                *verifier.probe_request_contexts(
+                    review_records, probe_id
+                ),
+            ]
+            request_contexts[probe_id] = (
+                verifier.canonical_probe_request_contexts(contexts)
+            )
+        missing_contexts = [
+            probe_id
+            for probe_id, contexts in request_contexts.items()
+            if not contexts
+        ]
+        if missing_contexts:
+            set_v2_state(
+                task_dir,
+                "NEEDS_EVIDENCE",
+                phase="reviews",
+                reason=(
+                    "reviewer probe request provenance is missing; no command "
+                    f"was executed: {', '.join(missing_contexts)}"
+                ),
+                attempt_id=attempt_dir.name,
+            )
+            return "NEEDS_EVIDENCE"
         # A typed probe can close an empirical proof gap, but it cannot repair a
         # reviewer-confirmed code or specification defect.  Resolve that
         # precedence before probe handling only when a probe was actually
@@ -1617,41 +2173,27 @@ def verify_task(
                 attempt_id=attempt_dir.name,
             )
             return "NEEDS_FIX"
-        existing_probe_ids = {
-            str(record.get("id")) for record in probe_records
-        }
-        passed_checks = {
-            str(record.get("id")): record
-            for record in check_records
-            if record.get("evidence", {}).get("passed")
-        }
-        aliased_probe_ids = [
-            probe_id
-            for probe_id in requested_probe_ids
-            if probe_id not in existing_probe_ids and probe_id in passed_checks
-        ]
-        for probe_id in aliased_probe_ids:
-            record_path = probes_dir / f"{probe_id}.json"
-            alias = {
-                **passed_checks[probe_id],
-                "source": "planned-check",
-                "created_at": legacy.utc_now(),
-            }
-            legacy.atomic_write_json(record_path, alias)
-            _checkpoint_event(
-                task_dir,
-                "probe-alias-checkpoint",
-                attempt_id=attempt_dir.name,
-                probe_id=probe_id,
-                record_path=str(record_path),
-                source="planned-check",
-            )
-        missing_probe_ids = [
-            probe_id
-            for probe_id in requested_probe_ids
-            if probe_id not in existing_probe_ids
-            and probe_id not in passed_checks
-        ]
+        missing_probe_ids: List[str] = []
+        for probe_id in requested_probe_ids:
+            existing = probe_checkpoints.get(probe_id)
+            if existing is None:
+                missing_probe_ids.append(probe_id)
+                continue
+            execution_number = int(existing.get("execution_number", 1))
+            prior_evidence = existing.get("evidence", {})
+            if (
+                prior_evidence.get("outcome") == "BLOCKED"
+                or prior_evidence.get("timed_out")
+            ):
+                if (
+                    execution_number
+                    < verifier.MAX_PROBE_EXECUTIONS_PER_ID
+                ):
+                    missing_probe_ids.append(probe_id)
+            # One green deterministic execution is sufficient for this exact
+            # plan/diff. Fresh reviewers receive it; rephrased rationales never
+            # create another process. Only retryable infrastructure outcomes
+            # consume the one bounded retry above.
         if missing_probe_ids:
             if any(
                 probe_id in {"rust-lib", "protocol-server"}
@@ -1663,17 +2205,46 @@ def verify_task(
                     {**plan, "server_required": True},
                     verification_worktree=verification_worktree,
                 )
-            config = legacy.load_config()
             probe_pause = False
             probe_failure = False
             for probe_id in missing_probe_ids:
                 declared = verifier.canonical_check(probe_id, config)
                 record_path = probes_dir / f"{probe_id}.json"
+                execution_number = (
+                    int(
+                        probe_checkpoints[probe_id].get(
+                            "execution_number", 1
+                        )
+                    )
+                    if probe_id in probe_checkpoints
+                    else 0
+                ) + 1
+                if (
+                    execution_number
+                    > verifier.MAX_PROBE_EXECUTIONS_PER_ID
+                ):
+                    raise legacy.HarnessError(
+                        f"v2 probe execution budget exhausted: {probe_id}"
+                    )
+                _reserve_probe_execution(
+                    task_dir,
+                    probes_dir,
+                    probe_id,
+                    declared,
+                    plan,
+                    execution_number,
+                    request_contexts[probe_id],
+                )
                 evidence = legacy.run_check(
                     worktree,
                     task_dir,
                     declared,
                     f"v2-{attempt_dir.name[:12]}-probe",
+                    bound_environment=(
+                        {"MURMUR_HARNESS_BASE_SHA": str(plan["base_sha"])}
+                        if probe_id == "npm-lock"
+                        else None
+                    ),
                 )
                 if not _snapshot_still_matches(
                     {
@@ -1690,16 +2261,16 @@ def verify_task(
                         "tree_mutated": True,
                         "blocked_reason": "runner-owned probe changed the exact task diff",
                     }
-                record = verifier.check_record(declared, plan, evidence)
-                legacy.atomic_write_json(record_path, record)
-                _checkpoint_event(
-                    task_dir,
-                    "probe-checkpoint",
-                    attempt_id=attempt_dir.name,
-                    probe_id=probe_id,
-                    record_path=str(record_path),
-                    passed=bool(evidence.get("passed")),
+                record = {
+                    **verifier.check_record(declared, plan, evidence),
+                    "source": "reviewer-probe",
+                    "request_contexts": request_contexts[probe_id],
+                    "execution_number": execution_number,
+                }
+                _append_probe_checkpoint(
+                    task_dir, probes_dir, probe_id, plan, record
                 )
+                legacy.atomic_write_json(record_path, record)
                 if not _snapshot_still_matches(contract, task_dir, plan):
                     set_v2_state(
                         task_dir,
@@ -1739,21 +2310,9 @@ def verify_task(
                 "NEEDS_EVIDENCE",
                 phase="probes",
                 reason=(
-                    "allowlisted probe evidence collected; resume will run fresh "
-                    "reviews against it"
-                ),
-                attempt_id=attempt_dir.name,
-            )
-            return "NEEDS_EVIDENCE"
-        if aliased_probe_ids:
-            set_v2_state(
-                task_dir,
-                "NEEDS_EVIDENCE",
-                phase="probes",
-                reason=(
-                    "reviewer-requested proof was already a planned green "
-                    "check; a bound alias was recorded and resume will run a "
-                    "fresh review without repeating the command"
+                    "context-bound probe evidence collected; resume will run "
+                    "fresh reviews against its command, output, rationale, and "
+                    "prior proof gaps"
                 ),
                 attempt_id=attempt_dir.name,
             )

--- a/.agents/harness/config.json
+++ b/.agents/harness/config.json
@@ -45,6 +45,7 @@
   "canonical_checks": {
     "rust-lib": "(cd src-tauri && CARGO_BUILD_JOBS=2 cargo test --lib -- --test-threads=1)",
     "protocol-server": "(cd ../murmur-server && CARGO_BUILD_JOBS=2 cargo test -p murmur-protocol -- --test-threads=1)",
+    "npm-lock": "python3 -B .agents/harness/checks/npm-lock-evidence.py",
     "tauri-boot": "scripts/harness-runtime-smoke",
     "ng-lint": "npx ng lint",
     "ng-build": "npx ng build",

--- a/.agents/harness/schemas/v2-review.schema.json
+++ b/.agents/harness/schemas/v2-review.schema.json
@@ -57,6 +57,7 @@
             "enum": [
               "rust-lib",
               "protocol-server",
+              "npm-lock",
               "tauri-boot",
               "ng-lint",
               "ng-build",

--- a/.agents/harness/task_runner.py
+++ b/.agents/harness/task_runner.py
@@ -2451,7 +2451,14 @@ def check_process_diagnostic(evidence: Mapping[str, Any]) -> str:
     )
 
 
-def run_check(worktree: Path, task_dir: Path, check: Mapping[str, Any], phase: str) -> Dict[str, Any]:
+def run_check(
+    worktree: Path,
+    task_dir: Path,
+    check: Mapping[str, Any],
+    phase: str,
+    *,
+    bound_environment: Optional[Mapping[str, str]] = None,
+) -> Dict[str, Any]:
     safe_phase = re.sub(r"[^a-z0-9._-]+", "-", phase.lower())
     execution_id = _new_execution_id()
     log_path = _execution_artifact_path(
@@ -2510,6 +2517,20 @@ def run_check(worktree: Path, task_dir: Path, check: Mapping[str, Any], phase: s
                 str(check["command"])
             ),
         )
+        bound_environment_record = dict(
+            sorted((bound_environment or {}).items())
+        )
+        if set(bound_environment_record) - {"MURMUR_HARNESS_BASE_SHA"}:
+            raise HarnessError("check requested an unsupported bound environment key")
+        base_sha = bound_environment_record.get("MURMUR_HARNESS_BASE_SHA")
+        if base_sha is not None and not SHA1_RE.fullmatch(base_sha):
+            raise HarnessError("check bound base SHA is malformed")
+        for name, value in bound_environment_record.items():
+            if name in environment:
+                raise HarnessError(
+                    f"check bound environment would replace runner key {name}"
+                )
+            environment[name] = value
         network_mode = "loopback" if needs_loopback else "none"
         profile = build_check_seatbelt_profile(
             worktree,
@@ -2591,6 +2612,7 @@ def run_check(worktree: Path, task_dir: Path, check: Mapping[str, Any], phase: s
         "sandbox_mode": "inherited" if inherited_sandbox else "direct",
         "environment_keys_sha256": sha256_bytes(canonical_json(sorted(environment))),
         "environment_sha256": sha256_bytes(canonical_json(environment)),
+        "bound_environment": bound_environment_record,
         "playwright_port": playwright_port,
         "network_mode": network_mode,
         "started_at": started_at,
@@ -3055,16 +3077,23 @@ def invoke_model(
                 "findings": findings,
             }
             if schema_name == "v2-review":
+                fake_proof_gaps = os.environ.get(
+                    "MURMUR_HARNESS_FAKE_REVIEW_PROOF_GAPS_JSON"
+                )
                 document["proof_gaps"] = (
-                    [
-                        {
-                            "claim": "synthetic selftest evidence",
-                            "evidence_missing": "synthetic proof",
-                            "how_to_prove": "resume with a fresh reviewer result",
-                        }
-                    ]
-                    if verdict == "BLOCKED"
-                    else []
+                    json.loads(fake_proof_gaps)
+                    if fake_proof_gaps is not None
+                    else (
+                        [
+                            {
+                                "claim": "synthetic selftest evidence",
+                                "evidence_missing": "synthetic proof",
+                                "how_to_prove": "resume with a fresh reviewer result",
+                            }
+                        ]
+                        if verdict == "BLOCKED"
+                        else []
+                    )
                 )
                 # `fake` is reachable only through the explicit selftest
                 # adapter gate. This knob exercises the real typed-probe state
@@ -3076,8 +3105,9 @@ def invoke_model(
                     [
                         {
                             "probe_id": fake_probe_id,
-                            "rationale": (
-                                "selftest-only typed probe state transition"
+                            "rationale": os.environ.get(
+                                "MURMUR_HARNESS_FAKE_REVIEW_PROBE_RATIONALE",
+                                "selftest-only typed probe state transition",
                             ),
                         }
                     ]

--- a/.agents/harness/v2_fault_selftest.py
+++ b/.agents/harness/v2_fault_selftest.py
@@ -18,7 +18,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from typing import Any, Callable, Dict, Mapping, Sequence
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence
 
 import cli as harness_cli
 import task_runner as legacy
@@ -355,6 +355,8 @@ def cached_artifact_tamper_case(test: Tests) -> None:
             task: Path,
             check: Mapping[str, Any],
             phase: str,
+            *,
+            bound_environment: Optional[Mapping[str, str]] = None,
         ) -> Dict[str, Any]:
             nonlocal counter
             counter += 1
@@ -407,6 +409,16 @@ def cached_artifact_tamper_case(test: Tests) -> None:
                 snapshot,
                 checkpoint_number=1,
             )
+            verifier.validate_check_checkpoint(
+                first,
+                declared,
+                plan,
+                task_dir,
+            )
+            test.true(
+                "CACHE pre-change non-npm checkpoint resumes without bound environment",
+                "bound_environment" not in first["evidence"],
+            )
             first_log = Path(first["evidence"]["log_path"])
             first_log.write_bytes(first_log.read_bytes() + b"tampered\n")
             second, second_did_run = harness_cli._run_or_resume_check(
@@ -450,6 +462,7 @@ def prompt_policy_tamper_cases(test: Tests) -> None:
             contract=contract,
             plan=plan,
             worktree=snapshot,
+            task_dir=task_dir,
             attempt_dir=run_dir,
             diff=values["diff"],
             checks=[],
@@ -465,6 +478,7 @@ def prompt_policy_tamper_cases(test: Tests) -> None:
             [],
             "combined",
             snapshot,
+            task_dir,
         )
         expected_prompt_sha = legacy.sha256_bytes(prompt.encode("utf-8"))
         verifier.validate_review_checkpoint(
@@ -478,6 +492,21 @@ def prompt_policy_tamper_cases(test: Tests) -> None:
         test.true(
             "PROMPT untouched runner/model artifacts validate",
             record["prompt_sha256"] == expected_prompt_sha,
+        )
+
+        relabelled = copy.deepcopy(record)
+        relabelled["kind"] = "lock-security"
+        test.raises(
+            "PROMPT review kind cannot be relabelled across planned roles",
+            lambda: verifier.validate_review_checkpoint(
+                relabelled,
+                {"kind": "lock-security", "vendor": "fake"},
+                plan,
+                task_dir,
+                expected_prompt_sha256=expected_prompt_sha,
+                allow_test_adapter=True,
+            ),
+            "label does not match review kind",
         )
 
         forged = copy.deepcopy(record)
@@ -503,6 +532,7 @@ def prompt_policy_tamper_cases(test: Tests) -> None:
             [],
             "combined",
             snapshot,
+            task_dir,
             policy_text=policy + "\nFAULT POLICY DRIFT\n",
         )
         drifted_prompt_sha = legacy.sha256_bytes(
@@ -523,6 +553,41 @@ def prompt_policy_tamper_cases(test: Tests) -> None:
                 allow_test_adapter=True,
             ),
             "prompt hash changed",
+        )
+
+
+def review_stream_binding_cases(test: Tests) -> None:
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-fault-stream-") as raw:
+        task_dir = Path(raw)
+        stream = task_dir / "stdout.log"
+        payload = b"HEAD:" + (b"x" * 5_000) + b":TAIL"
+        stream.write_bytes(payload)
+        digest = legacy.sha256_file(stream)
+        summary = verifier._bounded_stream_summary(  # noqa: SLF001
+            task_dir,
+            str(stream),
+            digest,
+            "fault stream",
+            128,
+        )
+        test.true(
+            "PROMPT stream excerpt is bounded with deterministic head and tail",
+            summary["truncated"]
+            and summary["bytes"] == len(payload)
+            and summary["excerpt"].startswith("HEAD:")
+            and summary["excerpt"].endswith(":TAIL")
+            and "evidence bytes omitted" in summary["excerpt"],
+        )
+        test.raises(
+            "PROMPT stream hash drift fails before review dispatch",
+            lambda: verifier._bounded_stream_summary(  # noqa: SLF001
+                task_dir,
+                str(stream),
+                "f" * 64,
+                "fault stream",
+                128,
+            ),
+            "hash changed",
         )
 
 
@@ -610,6 +675,7 @@ def main() -> int:
     snapshot_aba_and_reconstruction_cases(test)
     cached_artifact_tamper_case(test)
     prompt_policy_tamper_cases(test)
+    review_stream_binding_cases(test)
     protocol_manifest_cases(test)
     if test.failures:
         print("v2 fault selftest: FAIL")

--- a/.agents/harness/v2_selftest.py
+++ b/.agents/harness/v2_selftest.py
@@ -20,7 +20,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from typing import Any, Dict, List, Mapping, Sequence
+from typing import Any, Dict, List, Mapping, Optional, Sequence
 
 import cli as harness_cli
 import task_runner as legacy
@@ -669,6 +669,13 @@ def profile_cases(test: Tests) -> None:
         ["ng-lint", "ng-build"],
     )
 
+    checks, _, _ = _profile(["package.json", "package-lock.json"])
+    test.equal(
+        "PROFILE package manifests run lock evidence before Angular gates",
+        checks,
+        ["npm-lock", "ng-lint", "ng-build"],
+    )
+
     checks, _, _ = _profile(
         ["src-tauri/src/lib.rs", "src/app/core/ipc.service.ts"]
     )
@@ -804,6 +811,327 @@ def profile_cases(test: Tests) -> None:
             canonical_v2_selftest
         ),
     )
+    review_schema = legacy.load_schema("v2-review")
+    schema_probe_ids = set(
+        review_schema["properties"]["probe_requests"]["items"]["properties"][
+            "probe_id"
+        ]["enum"]
+    )
+    test.equal(
+        "PROFILE static probe vocabulary matches executable canonical ids",
+        schema_probe_ids,
+        verifier.ALLOWED_PROBES,
+    )
+    test.equal(
+        "PROFILE every static probe id has exactly one canonical command",
+        set(legacy.load_config()["canonical_checks"]),
+        verifier.ALLOWED_PROBES,
+    )
+
+
+def npm_lock_evidence_cases(test: Tests) -> None:
+    script = ROOT / ".agents" / "harness" / "checks" / "npm-lock-evidence.py"
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-npm-lock-valid-") as raw:
+        repo = Path(raw) / "repo"
+        _init_repo(repo)
+        manifest = legacy.load_json(ROOT / "package.json")
+        lock = legacy.load_json(ROOT / "package-lock.json")
+        lock["version"] = manifest["version"]
+        lock["packages"][""]["version"] = manifest["version"]
+        manifest["optionalDependencies"] = {"nanoid": "^3.3.15"}
+        manifest["peerDependencies"] = {"postcss": "^8.5.13"}
+        manifest["peerDependenciesMeta"] = {
+            "postcss": {"optional": False}
+        }
+        lock["packages"][""]["optionalDependencies"] = dict(
+            manifest["optionalDependencies"]
+        )
+        lock["packages"][""]["peerDependencies"] = dict(
+            manifest["peerDependencies"]
+        )
+        lock["packages"][""]["peerDependenciesMeta"] = copy.deepcopy(
+            manifest["peerDependenciesMeta"]
+        )
+        legacy.atomic_write_json(repo / "package.json", manifest)
+        legacy.atomic_write_json(repo / "package-lock.json", lock)
+        _git(repo, "add", "package.json", "package-lock.json")
+        _git(repo, "commit", "-q", "-m", "add coherent package fixture")
+        base_sha = _git(repo, "rev-parse", "HEAD")
+        before = legacy.git_bytes(repo, "status", "--porcelain", "-z")
+        completed = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=str(repo),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env={
+                **os.environ,
+                "MURMUR_HARNESS_BASE_SHA": base_sha,
+            },
+            check=False,
+        )
+        after = legacy.git_bytes(repo, "status", "--porcelain", "-z")
+        try:
+            evidence = json.loads(completed.stdout)
+        except json.JSONDecodeError:
+            evidence = {}
+        test.equal(
+            "NPM-LOCK coherent repository evidence is read-only and green",
+            (completed.returncode, after == before),
+            (0, True),
+        )
+        direct_names = {
+            name
+            for key in (
+                "dependencies",
+                "devDependencies",
+                "optionalDependencies",
+                "peerDependencies",
+            )
+            for name in evidence.get("direct", {}).get(key, {})
+        }
+        versions = evidence.get("versions_by_name", {})
+        test.true(
+            "NPM-LOCK evidence covers every direct logical version",
+            bool(direct_names)
+            and direct_names.issubset(set(versions))
+            and all(versions.get(name) for name in direct_names),
+        )
+        test.true(
+            "NPM-LOCK evidence covers optional and peer dependency classes",
+            {
+                "nanoid",
+                "postcss",
+            }.issubset(direct_names)
+            and evidence.get("direct", {}).get("peerDependenciesMeta")
+            == {"postcss": {"optional": False}},
+        )
+        test.true(
+            "NPM-LOCK evidence remains compact and names its offline mode",
+            len(completed.stdout) <= 65_536
+            and evidence.get("mode") == "offline-package-lock-only",
+        )
+
+        committed_manifest = copy.deepcopy(manifest)
+        committed_lock = copy.deepcopy(lock)
+        committed_manifest["dependencies"] = {
+            **committed_manifest.get("dependencies", {}),
+            "base-binding-fixture": "1.0.0",
+        }
+        committed_lock["packages"][""]["dependencies"] = dict(
+            committed_manifest["dependencies"]
+        )
+        committed_lock["packages"]["node_modules/base-binding-fixture"] = {
+            "version": "1.0.0"
+        }
+        legacy.atomic_write_json(repo / "package.json", committed_manifest)
+        legacy.atomic_write_json(repo / "package-lock.json", committed_lock)
+        _git(repo, "add", "package.json", "package-lock.json")
+        _git(repo, "commit", "-q", "-m", "commit task dependency change")
+        committed_run = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=str(repo),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env={
+                **os.environ,
+                "MURMUR_HARNESS_BASE_SHA": base_sha,
+            },
+            check=False,
+        )
+        try:
+            committed_evidence = json.loads(committed_run.stdout)
+        except json.JSONDecodeError:
+            committed_evidence = {}
+        changed_names = {
+            row.get("name")
+            for row in committed_evidence.get("changed_lock_entries", [])
+        }
+        test.true(
+            "NPM-LOCK committed task diff remains bound to immutable base",
+            committed_run.returncode == 0
+            and committed_evidence.get("base_sha") == base_sha
+            and "base-binding-fixture" in changed_names
+            and committed_evidence.get("base_package_json_sha256")
+            == hashlib.sha256(
+                legacy.git_bytes(repo, "show", f"{base_sha}:package.json")
+            ).hexdigest(),
+        )
+
+        removed_manifest = copy.deepcopy(committed_manifest)
+        removed_lock = copy.deepcopy(committed_lock)
+        removed_manifest["dependencies"].pop("rxjs")
+        removed_lock["packages"][""]["dependencies"].pop("rxjs")
+        rxjs_package_before = copy.deepcopy(
+            lock["packages"]["node_modules/rxjs"]
+        )
+        test.equal(
+            "NPM-LOCK removed direct fixture keeps package entry unchanged",
+            removed_lock["packages"]["node_modules/rxjs"],
+            rxjs_package_before,
+        )
+        legacy.atomic_write_json(repo / "package.json", removed_manifest)
+        legacy.atomic_write_json(repo / "package-lock.json", removed_lock)
+        removed_run = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=str(repo),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env={
+                **os.environ,
+                "MURMUR_HARNESS_BASE_SHA": base_sha,
+            },
+            check=False,
+        )
+        try:
+            removed_evidence = json.loads(removed_run.stdout)
+        except json.JSONDecodeError:
+            removed_evidence = {}
+        test.true(
+            "NPM-LOCK removed direct still reports transitive versions",
+            removed_run.returncode == 0
+            and "rxjs"
+            in removed_evidence.get(
+                "changed_manifest_dependency_names", []
+            )
+            and bool(
+                removed_evidence.get("versions_by_name", {}).get("rxjs")
+            ),
+        )
+
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-npm-lock-") as raw:
+        repo = Path(raw) / "repo"
+        _init_repo(repo)
+        manifest = {
+            "name": "fixture",
+            "version": "1.0.0",
+            "dependencies": {"example": "1.0.0"},
+            "devDependencies": {},
+            "scripts": {},
+        }
+        lock = {
+            "name": "fixture",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "packages": {
+                "": {
+                    "name": "fixture",
+                    "version": "1.0.0",
+                    "dependencies": {"example": "1.0.0"},
+                    "devDependencies": {},
+                }
+            },
+        }
+        legacy.atomic_write_json(repo / "package.json", manifest)
+        legacy.atomic_write_json(repo / "package-lock.json", lock)
+        _git(repo, "add", "package.json", "package-lock.json")
+        _git(repo, "commit", "-q", "-m", "add package fixture")
+        base_sha = _git(repo, "rev-parse", "HEAD")
+        bound_environment = {
+            **os.environ,
+            "MURMUR_HARNESS_BASE_SHA": base_sha,
+        }
+
+        duplicate = (
+            '{"name":"fixture","version":"1.0.0","version":"2.0.0",'
+            '"dependencies":{"example":"1.0.0"},"devDependencies":{},'
+            '"scripts":{}}\n'
+        )
+        (repo / "package.json").write_text(duplicate, encoding="utf-8")
+        duplicate_run = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=str(repo),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=bound_environment,
+            check=False,
+        )
+        test.true(
+            "NPM-LOCK duplicate JSON keys fail closed",
+            duplicate_run.returncode != 0
+            and b"duplicate JSON key" in duplicate_run.stderr,
+        )
+
+        legacy.atomic_write_json(repo / "package.json", manifest)
+        broken_lock = copy.deepcopy(lock)
+        broken_lock["packages"][""]["dependencies"] = {}
+        legacy.atomic_write_json(repo / "package-lock.json", broken_lock)
+        mismatch_run = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=str(repo),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=bound_environment,
+            check=False,
+        )
+        test.true(
+            "NPM-LOCK manifest/root mismatch fails before npm execution",
+            mismatch_run.returncode != 0
+            and b"lock root dependencies differ" in mismatch_run.stderr,
+        )
+
+        optional_manifest = copy.deepcopy(manifest)
+        optional_manifest["optionalDependencies"] = {
+            "optional-example": "1.0.0"
+        }
+        legacy.atomic_write_json(repo / "package.json", optional_manifest)
+        legacy.atomic_write_json(repo / "package-lock.json", lock)
+        optional_mismatch_run = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=str(repo),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=bound_environment,
+            check=False,
+        )
+        test.true(
+            "NPM-LOCK optional dependency mismatch fails closed",
+            optional_mismatch_run.returncode != 0
+            and b"lock root optionalDependencies differ"
+            in optional_mismatch_run.stderr,
+        )
+
+        peer_manifest = copy.deepcopy(manifest)
+        peer_manifest["peerDependencies"] = {"peer-example": "1.0.0"}
+        peer_manifest["peerDependenciesMeta"] = {
+            "peer-example": {"optional": True}
+        }
+        legacy.atomic_write_json(repo / "package.json", peer_manifest)
+        legacy.atomic_write_json(repo / "package-lock.json", lock)
+        peer_mismatch_run = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=str(repo),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=bound_environment,
+            check=False,
+        )
+        test.true(
+            "NPM-LOCK peer dependency mismatch fails closed",
+            peer_mismatch_run.returncode != 0
+            and b"lock root peerDependencies differ"
+            in peer_mismatch_run.stderr,
+        )
+
+        peer_lock = copy.deepcopy(lock)
+        peer_lock["packages"][""]["peerDependencies"] = {
+            "peer-example": "1.0.0"
+        }
+        legacy.atomic_write_json(repo / "package.json", peer_manifest)
+        legacy.atomic_write_json(repo / "package-lock.json", peer_lock)
+        peer_meta_mismatch_run = subprocess.run(
+            [sys.executable, str(script)],
+            cwd=str(repo),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=bound_environment,
+            check=False,
+        )
+        test.true(
+            "NPM-LOCK peer dependency metadata mismatch fails closed",
+            peer_meta_mismatch_run.returncode != 0
+            and b"lock root peerDependenciesMeta differ"
+            in peer_meta_mismatch_run.stderr,
+        )
 
 
 def reviewer_tool_guard_cases(test: Tests) -> None:
@@ -1128,6 +1456,33 @@ def probe_precedence_flow_cases(test: Tests) -> None:
             destination = repo / relative
             destination.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(source, destination)
+        owned_relative = "src/design-tokens/probe-precedence.scss"
+        owned_base = repo / owned_relative
+        owned_base.parent.mkdir(parents=True, exist_ok=True)
+        owned_base.write_text("/* base */\n", encoding="utf-8")
+        package_manifest = {
+            "name": "probe-precedence-fixture",
+            "version": "1.0.0",
+            "scripts": {},
+            "dependencies": {},
+            "devDependencies": {},
+        }
+        package_lock = {
+            "name": "probe-precedence-fixture",
+            "version": "1.0.0",
+            "lockfileVersion": 3,
+            "requires": True,
+            "packages": {
+                "": {
+                    "name": "probe-precedence-fixture",
+                    "version": "1.0.0",
+                    "dependencies": {},
+                    "devDependencies": {},
+                }
+            },
+        }
+        legacy.atomic_write_json(repo / "package.json", package_manifest)
+        legacy.atomic_write_json(repo / "package-lock.json", package_lock)
         _git(repo, "add", ".")
         _git(repo, "commit", "-q", "-m", "add exact v2 protocol")
         base = _git(repo, "rev-parse", "HEAD")
@@ -1166,7 +1521,7 @@ def probe_precedence_flow_cases(test: Tests) -> None:
             "git_common_dir": str(common.resolve()),
             "worktree_path": str(worktree.resolve()),
             "branch": branch,
-            "owned_paths": ["owned.txt"],
+            "owned_paths": [owned_relative],
             "claims": [],
             "reviewer": "fake",
             "expected_change": True,
@@ -1194,17 +1549,37 @@ def probe_precedence_flow_cases(test: Tests) -> None:
             },
         )
         harness_cli.set_v2_state(task_dir, "OPEN", phase="open")
-        owned = worktree / "owned.txt"
-        owned.write_text("base\nprobe precedence\n", encoding="utf-8")
+        owned = worktree / owned_relative
+        owned.write_text(
+            "/* base */\n/* probe precedence */\n", encoding="utf-8"
+        )
 
         saved_verdict = os.environ.get("MURMUR_HARNESS_FAKE_REVIEW_VERDICT")
         saved_probe = os.environ.get(
             "MURMUR_HARNESS_FAKE_REVIEW_PROBE_ID"
         )
+        saved_probe_rationale = os.environ.get(
+            "MURMUR_HARNESS_FAKE_REVIEW_PROBE_RATIONALE"
+        )
+        saved_proof_gaps = os.environ.get(
+            "MURMUR_HARNESS_FAKE_REVIEW_PROOF_GAPS_JSON"
+        )
+        original_load_config = legacy.load_config
+        selftest_config = copy.deepcopy(original_load_config())
+        selftest_config["canonical_checks"]["ng-lint"] = (
+            "python3 -c 'print(\"PLANNED_\" + \"NG_LINT_STREAM\")'"
+        )
+        selftest_config["canonical_checks"]["ng-build"] = (
+            "python3 -c 'print(\"PLANNED_\" + \"NG_BUILD_STREAM\")'"
+        )
+        selftest_config["canonical_checks"]["npm-lock"] = (
+            "python3 -c 'print(\"PLANNED_\" + \"NPM_LOCK_STREAM\")'"
+        )
+        legacy.load_config = lambda: copy.deepcopy(selftest_config)
         os.environ["MURMUR_HARNESS_FAKE_REVIEW_VERDICT"] = "PASS"
         os.environ[
             "MURMUR_HARNESS_FAKE_REVIEW_PROBE_ID"
-        ] = "harness-python"
+        ] = "ng-lint"
         try:
             with contextlib.redirect_stdout(io.StringIO()):
                 collected = harness_cli.verify_task(
@@ -1214,7 +1589,9 @@ def probe_precedence_flow_cases(test: Tests) -> None:
                 )
             state = harness_cli.load_v2_state(task_dir)
             attempt_dir = task_dir / "attempts" / str(state["attempt_id"])
-            probe_path = attempt_dir / "probes" / "harness-python.json"
+            plan = legacy.load_json(attempt_dir / "plan.json")
+            probe_path = attempt_dir / "probes" / "ng-lint.json"
+            probe_record = legacy.load_json(probe_path)
             probe_before = probe_path.read_bytes()
             probe_mtime_before = probe_path.stat().st_mtime_ns
             test.equal(
@@ -1222,7 +1599,189 @@ def probe_precedence_flow_cases(test: Tests) -> None:
                 collected,
                 "NEEDS_EVIDENCE",
             )
+            verifier.validate_probe_checkpoint(
+                probe_record,
+                verifier.canonical_check("ng-lint", legacy.load_config()),
+                plan,
+                task_dir,
+                allow_test_adapter=True,
+            )
+            test.equal(
+                "PROBE flow binds reviewer rationale to fresh execution",
+                (
+                    probe_record["source"],
+                    probe_record["request_contexts"][0]["rationale"],
+                ),
+                (
+                    "reviewer-probe",
+                    "selftest-only typed probe state transition",
+                ),
+            )
+            combined_context = copy.deepcopy(
+                probe_record["request_contexts"][0]
+            )
+            combined_context["review_kind"] = "combined"
+            combined_context["context_sha256"] = "f" * 64
+            specialist_context = copy.deepcopy(combined_context)
+            specialist_context["review_kind"] = "specialist"
+            specialist_context["context_sha256"] = "0" * 64
+            test.equal(
+                "PROBE multi-review contexts use validator canonical order",
+                [
+                    item["review_kind"]
+                    for item in verifier.canonical_probe_request_contexts(
+                        [specialist_context, combined_context]
+                    )
+                ],
+                ["combined", "specialist"],
+            )
+            check_records = [
+                legacy.load_json(path)
+                for path in sorted((attempt_dir / "checks").glob("*.json"))
+            ]
+            bound_prompt = verifier.combined_review_prompt(
+                contract,
+                plan,
+                verifier.snapshot_scoped_diff(
+                    worktree, contract, task_dir
+                )[1],
+                [*check_records, probe_record],
+                "combined",
+                worktree,
+                task_dir,
+                probes=[probe_record],
+            )
+            test.true(
+                "PROBE resume prompt exposes exact command output and rationale",
+                "PLANNED_NG_LINT_STREAM" in bound_prompt
+                and "selftest-only typed probe state transition" in bound_prompt
+                and json.dumps(probe_record["command"])[1:-1]
+                in bound_prompt,
+            )
+            test.true(
+                "PROBE every planned check exposes a bounded excerpt",
+                "PLANNED_NG_BUILD_STREAM" in bound_prompt
+                and '"excerpt_included": true' in bound_prompt,
+            )
+            forged_channel_checks = copy.deepcopy(check_records)
+            for item in forged_channel_checks:
+                if item["id"] == "ng-build":
+                    item["source"] = "reviewer-probe"
+            forged_channel_prompt = verifier.combined_review_prompt(
+                contract,
+                plan,
+                verifier.snapshot_scoped_diff(
+                    worktree, contract, task_dir
+                )[1],
+                forged_channel_checks,
+                "combined",
+                worktree,
+                task_dir,
+                probes=[probe_record],
+            )
+            forged_ng_build = next(
+                item
+                for item in forged_channel_checks
+                if item["id"] == "ng-build"
+            )
+            test.equal(
+                "PROBE record field cannot forge the stream channel",
+                (
+                    verifier._review_evidence_summary(
+                        forged_ng_build,
+                        task_dir,
+                        channel="planned-check",
+                    )["source"],
+                    "PLANNED_NG_BUILD_STREAM" in forged_channel_prompt,
+                ),
+                ("planned-check", True),
+            )
+            provenance_free = copy.deepcopy(probe_record)
+            provenance_free.pop("source")
+            provenance_free.pop("request_contexts")
+            test.raises(
+                "PROBE provenance-free legacy token fails closed",
+                lambda: verifier.validate_probe_checkpoint(
+                    provenance_free,
+                    verifier.canonical_check(
+                        "ng-lint", legacy.load_config()
+                    ),
+                    plan,
+                    task_dir,
+                    allow_test_adapter=True,
+                ),
+                "provenance",
+            )
+            corrupt_stream = copy.deepcopy(probe_record)
+            corrupt_stream["evidence"]["stdout_sha256"] = "f" * 64
+            test.raises(
+                "PROBE changed output hash fails before fresh review",
+                lambda: verifier.validate_probe_checkpoint(
+                    corrupt_stream,
+                    verifier.canonical_check(
+                        "ng-lint", legacy.load_config()
+                    ),
+                    plan,
+                    task_dir,
+                    allow_test_adapter=True,
+                ),
+                "hash changed",
+            )
+            forged_source = copy.deepcopy(probe_record)
+            forged_context = forged_source["request_contexts"][0]
+            forged_context["review_prompt_sha256"] = "f" * 64
+            forged_context["source_review"]["prompt_sha256"] = "f" * 64
+            forged_context["context_sha256"] = verifier.document_hash(
+                forged_context, "context_sha256"
+            )
+            test.raises(
+                "PROBE recomputed context cannot substitute source review",
+                lambda: verifier.validate_probe_checkpoint(
+                    forged_source,
+                    verifier.canonical_check(
+                        "ng-lint", legacy.load_config()
+                    ),
+                    plan,
+                    task_dir,
+                    allow_test_adapter=True,
+                ),
+                "prompt hash changed",
+            )
 
+            legacy_probe_record = copy.deepcopy(probe_record)
+            legacy_probe_record.pop("execution_number")
+            legacy.atomic_write_json(probe_path, legacy_probe_record)
+            verifier.validate_probe_checkpoint(
+                legacy_probe_record,
+                verifier.canonical_check(
+                    "ng-lint", legacy.load_config()
+                ),
+                plan,
+                task_dir,
+                allow_test_adapter=True,
+            )
+            test.true(
+                "PROBE pre-cap checkpoint remains resume-compatible",
+                "execution_number" not in legacy_probe_record,
+            )
+            probe_before = probe_path.read_bytes()
+            os.environ[
+                "MURMUR_HARNESS_FAKE_REVIEW_PROBE_RATIONALE"
+            ] = "changed rationale requires fresh empirical evidence"
+            proof_gap_a = {
+                "claim": "alpha",
+                "evidence_missing": "alpha evidence",
+                "how_to_prove": "run the planned probe",
+            }
+            proof_gap_b = {
+                "claim": "beta",
+                "evidence_missing": "beta evidence",
+                "how_to_prove": "run the planned probe",
+            }
+            os.environ[
+                "MURMUR_HARNESS_FAKE_REVIEW_PROOF_GAPS_JSON"
+            ] = json.dumps([proof_gap_a, proof_gap_b])
+            first_probe_execution = probe_record["evidence"]["execution_id"]
             with contextlib.redirect_stdout(io.StringIO()):
                 evidence_only = harness_cli.verify_task(
                     contract,
@@ -1230,14 +1789,82 @@ def probe_precedence_flow_cases(test: Tests) -> None:
                     allow_test_adapter=True,
                 )
             test.equal(
-                "PROBE flow PASS plus seen probe stays evidence-only",
+                "PROBE flow changed request context stays evidence-only",
                 evidence_only,
                 "NEEDS_EVIDENCE",
             )
+            refreshed_probe = legacy.load_json(probe_path)
             test.true(
-                "PROBE flow PASS plus seen probe does not rerun it",
+                "PROBE rephrased request reuses one diff-bound execution",
+                refreshed_probe["evidence"]["execution_id"]
+                == first_probe_execution
+                and refreshed_probe["request_contexts"][0]["rationale"]
+                == "selftest-only typed probe state transition",
+            )
+            test.equal(
+                "PROBE green execution remains single-shot",
+                refreshed_probe["execution_number"],
+                1,
+            )
+            test.equal(
+                "PROBE execution event is append-only and numbered",
+                [
+                    event["execution_number"]
+                    for event in [
+                        json.loads(line)
+                        for line in (task_dir / "events.jsonl").read_text(
+                            encoding="utf-8"
+                        ).splitlines()
+                    ]
+                    if event.get("event") == "probe-checkpoint"
+                    and event.get("attempt_id") == attempt_dir.name
+                    and event.get("probe_id") == "ng-lint"
+                ],
+                [1],
+            )
+            probe_before = probe_path.read_bytes()
+            probe_mtime_before = probe_path.stat().st_mtime_ns
+
+            os.environ[
+                "MURMUR_HARNESS_FAKE_REVIEW_PROOF_GAPS_JSON"
+            ] = json.dumps([proof_gap_b, proof_gap_a, proof_gap_a])
+            with contextlib.redirect_stdout(io.StringIO()):
+                repeated_request = harness_cli.verify_task(
+                    contract,
+                    task_dir,
+                    allow_test_adapter=True,
+                )
+            test.equal(
+                "PROBE repeated request stays evidence-only",
+                repeated_request,
+                "NEEDS_EVIDENCE",
+            )
+            test.true(
+                "PROBE repeated request cannot create a rerun loop",
                 probe_path.read_bytes() == probe_before
                 and probe_path.stat().st_mtime_ns == probe_mtime_before,
+            )
+            os.environ[
+                "MURMUR_HARNESS_FAKE_REVIEW_PROBE_RATIONALE"
+            ] = "third semantic request must stop at the hard cap"
+            with contextlib.redirect_stdout(io.StringIO()):
+                capped_request = harness_cli.verify_task(
+                    contract,
+                    task_dir,
+                    allow_test_adapter=True,
+                )
+            test.equal(
+                "PROBE third rephrasing stops at NEEDS_EVIDENCE",
+                capped_request,
+                "NEEDS_EVIDENCE",
+            )
+            test.true(
+                "PROBE single-shot rule prevents adversarial rationale loop",
+                probe_path.read_bytes() == probe_before
+                and probe_path.stat().st_mtime_ns == probe_mtime_before,
+            )
+            os.environ.pop(
+                "MURMUR_HARNESS_FAKE_REVIEW_PROOF_GAPS_JSON", None
             )
 
             (attempt_dir / "reviews" / "combined.json").unlink()
@@ -1268,7 +1895,8 @@ def probe_precedence_flow_cases(test: Tests) -> None:
             # original evidence/checkpoint path, including a bound evidence
             # document and the terminal complete phase.
             owned.write_text(
-                "base\nprobe-free fix evidence path\n", encoding="utf-8"
+                "/* base */\n/* probe-free fix evidence path */\n",
+                encoding="utf-8",
             )
             os.environ.pop("MURMUR_HARNESS_FAKE_REVIEW_PROBE_ID", None)
             with contextlib.redirect_stdout(io.StringIO()):
@@ -1298,7 +1926,1010 @@ def probe_precedence_flow_cases(test: Tests) -> None:
                     True,
                 ),
             )
+
+            # Reproduce the observed laundering attempt: a package/Angular
+            # reviewer asks for the globally-known but unrelated config audit.
+            # The result is rejected before the broker can execute it.
+            owned.write_text(
+                "/* base */\n/* reject unrelated config audit */\n",
+                encoding="utf-8",
+            )
+            os.environ["MURMUR_HARNESS_FAKE_REVIEW_VERDICT"] = "PASS"
+            os.environ[
+                "MURMUR_HARNESS_FAKE_REVIEW_PROBE_ID"
+            ] = "config-audit"
+            with contextlib.redirect_stdout(io.StringIO()):
+                unrelated = harness_cli.verify_task(
+                    contract,
+                    task_dir,
+                    allow_test_adapter=True,
+                )
+            unrelated_state = harness_cli.load_v2_state(task_dir)
+            unrelated_attempt = (
+                task_dir / "attempts" / str(unrelated_state["attempt_id"])
+            )
+            test.equal(
+                "PROBE unrelated config audit stays evidence-only",
+                (unrelated, unrelated_state["status"]),
+                ("NEEDS_EVIDENCE", "NEEDS_EVIDENCE"),
+            )
+            test.true(
+                "PROBE unrelated config audit executes no green token",
+                not (unrelated_attempt / "probes" / "config-audit.json").exists(),
+            )
+            unrelated_review_path = (
+                unrelated_attempt / "reviews" / "combined.json"
+            )
+            test.equal(
+                "PROBE fresh invalid request is durably checkpointed",
+                (
+                    unrelated_review_path.is_file(),
+                    legacy.load_json(unrelated_review_path)["result"][
+                        "probe_requests"
+                    ][0]["probe_id"],
+                    unrelated_state["reason"],
+                ),
+                (
+                    True,
+                    "config-audit",
+                    (
+                        "review requested probes outside the exact plan; "
+                        "no command was executed: config-audit"
+                    ),
+                ),
+            )
+
+            # Faithfully replay the production incident through verify_task:
+            # only package.json/package-lock.json change, the exact profile
+            # schedules npm-lock + Angular checks, and a reviewer requests the
+            # globally-known but plan-ineligible config-audit token.
+            package_worktree = root / "package-task" / "meetnotes"
+            package_worktree.parent.mkdir()
+            package_branch = "agent/v2/package-probe-precedence"
+            _git(
+                repo,
+                "worktree",
+                "add",
+                "-q",
+                "-b",
+                package_branch,
+                str(package_worktree),
+                base,
+            )
+            package_task_id = "package-probe-precedence"
+            package_task_dir = harness_cli.v2_task_dir(
+                common, package_task_id
+            )
+            package_task_dir.mkdir(parents=True)
+            package_contract: Dict[str, Any] = {
+                **contract,
+                "task_id": package_task_id,
+                "description": (
+                    "replay package-only unrelated-probe laundering"
+                ),
+                "contract_sha256": "",
+                "worktree_path": str(package_worktree.resolve()),
+                "branch": package_branch,
+                "owned_paths": ["package.json", "package-lock.json"],
+                "created_at": legacy.utc_now(),
+            }
+            package_contract["contract_sha256"] = verifier.document_hash(
+                package_contract, "contract_sha256"
+            )
+            legacy.validate_schema(
+                package_contract,
+                legacy.load_schema("v2-task"),
+                label="v2 package probe precedence contract",
+            )
+            legacy.atomic_write_json(
+                package_task_dir / "task.json", package_contract
+            )
+            legacy.atomic_write_json(
+                package_task_dir / "runtime.json",
+                {
+                    "schema_version": 2,
+                    "task_root": str(package_worktree.parent),
+                    "shared_node_modules": None,
+                    "server_worktree": None,
+                    "server_source": str(root / "murmur-server"),
+                    "server_revision": None,
+                },
+            )
+            harness_cli.set_v2_state(
+                package_task_dir, "OPEN", phase="open"
+            )
+            package_manifest["version"] = "1.0.1"
+            package_lock["version"] = "1.0.1"
+            package_lock["packages"][""]["version"] = "1.0.1"
+            legacy.atomic_write_json(
+                package_worktree / "package.json", package_manifest
+            )
+            legacy.atomic_write_json(
+                package_worktree / "package-lock.json", package_lock
+            )
+            with contextlib.redirect_stdout(io.StringIO()):
+                package_unrelated = harness_cli.verify_task(
+                    package_contract,
+                    package_task_dir,
+                    allow_test_adapter=True,
+                )
+            package_state = harness_cli.load_v2_state(package_task_dir)
+            package_attempt = (
+                package_task_dir
+                / "attempts"
+                / str(package_state["attempt_id"])
+            )
+            package_plan = legacy.load_json(
+                package_attempt / "plan.json"
+            )
+            test.equal(
+                "PROBE package-only flow schedules exact dependency evidence",
+                (
+                    package_plan["changed_paths"],
+                    [item["id"] for item in package_plan["checks"]],
+                ),
+                (
+                    ["package-lock.json", "package.json"],
+                    ["npm-lock", "ng-lint", "ng-build"],
+                ),
+            )
+            npm_record = legacy.load_json(
+                package_attempt / "checks" / "npm-lock.json"
+            )
+            package_check_records = [
+                legacy.load_json(path)
+                for path in sorted(
+                    (package_attempt / "checks").glob("*.json")
+                )
+            ]
+            package_prompt = verifier.combined_review_prompt(
+                package_contract,
+                package_plan,
+                verifier.snapshot_scoped_diff(
+                    package_worktree, package_contract, package_task_dir
+                )[1],
+                package_check_records,
+                "combined",
+                package_worktree,
+                package_task_dir,
+            )
+            test.true(
+                "PROBE every package check exposes bounded output",
+                "PLANNED_NPM_LOCK_STREAM" in package_prompt
+                and "PLANNED_NG_BUILD_STREAM" in package_prompt
+                and "PLANNED_NG_LINT_STREAM" in package_prompt,
+            )
+            test.equal(
+                "PROBE npm-lock execution binds the immutable task base",
+                npm_record["evidence"]["bound_environment"],
+                {"MURMUR_HARNESS_BASE_SHA": base},
+            )
+            tampered_npm_record = copy.deepcopy(npm_record)
+            tampered_npm_record["evidence"]["bound_environment"][
+                "MURMUR_HARNESS_BASE_SHA"
+            ] = "f" * 40
+            test.raises(
+                "PROBE changed npm-lock base binding fails closed",
+                lambda: verifier.validate_check_checkpoint(
+                    tampered_npm_record,
+                    package_plan["checks"][0],
+                    package_plan,
+                    package_task_dir,
+                ),
+                "runner-bound environment changed",
+            )
+            test.equal(
+                "PROBE package-only config audit stays evidence-only",
+                (package_unrelated, package_state["status"]),
+                ("NEEDS_EVIDENCE", "NEEDS_EVIDENCE"),
+            )
+            test.true(
+                "PROBE package-only flow executes no config-audit token",
+                not (
+                    package_attempt
+                    / "probes"
+                    / "config-audit.json"
+                ).exists(),
+            )
+            package_invalid_review = (
+                package_attempt / "reviews" / "combined.json"
+            )
+            test.equal(
+                "PROBE package-only fresh invalid review remains auditable",
+                (
+                    package_invalid_review.is_file(),
+                    legacy.load_json(package_invalid_review)["result"][
+                        "probe_requests"
+                    ][0]["probe_id"],
+                    package_state["reason"],
+                ),
+                (
+                    True,
+                    "config-audit",
+                    (
+                        "review requested probes outside the exact plan; "
+                        "no command was executed: config-audit"
+                    ),
+                ),
+            )
+
+            # A retryable probe checkpoint is excluded from green reviewer
+            # evidence, but it must still consume the same per-ID execution
+            # budget. Otherwise every resume forgets the timeout/BLOCKED
+            # attempt and loops forever at execution_number=1.
+            owned.write_text(
+                "/* base */\n/* retryable probe cap */\n",
+                encoding="utf-8",
+            )
+            os.environ["MURMUR_HARNESS_FAKE_REVIEW_VERDICT"] = "PASS"
+            os.environ[
+                "MURMUR_HARNESS_FAKE_REVIEW_PROBE_ID"
+            ] = "ng-lint"
+            os.environ[
+                "MURMUR_HARNESS_FAKE_REVIEW_PROBE_RATIONALE"
+            ] = "retryable probe must consume its bounded budget"
+            original_run_check = legacy.run_check
+            retryable_probe_runs = 0
+
+            def retryable_probe_run_check(
+                check_worktree: Path,
+                check_task_dir: Path,
+                check: Mapping[str, Any],
+                phase: str,
+                *,
+                bound_environment: Optional[
+                    Mapping[str, str]
+                ] = None,
+            ) -> Dict[str, Any]:
+                nonlocal retryable_probe_runs
+                evidence = original_run_check(
+                    check_worktree,
+                    check_task_dir,
+                    check,
+                    phase,
+                    bound_environment=bound_environment,
+                )
+                if phase.endswith("-probe"):
+                    retryable_probe_runs += 1
+                    return {
+                        **evidence,
+                        "passed": False,
+                        "outcome": "BLOCKED",
+                        "timed_out": True,
+                        "blocked_reason": "synthetic retryable probe",
+                    }
+                return evidence
+
+            legacy.run_check = retryable_probe_run_check
+            try:
+                with contextlib.redirect_stdout(io.StringIO()):
+                    retryable_first = harness_cli.verify_task(
+                        contract,
+                        task_dir,
+                        allow_test_adapter=True,
+                    )
+                retryable_first_state = harness_cli.load_v2_state(task_dir)
+                retryable_attempt = (
+                    task_dir
+                    / "attempts"
+                    / str(retryable_first_state["attempt_id"])
+                )
+                retryable_projection = (
+                    retryable_attempt / "probes" / "ng-lint.json"
+                )
+                rolled_back_projection = legacy.load_json(
+                    retryable_projection
+                )
+                (
+                    retryable_attempt / "reviews" / "combined.json"
+                ).unlink()
+                os.environ.pop(
+                    "MURMUR_HARNESS_FAKE_REVIEW_PROBE_ID", None
+                )
+                with contextlib.redirect_stdout(io.StringIO()):
+                    retryable_second = harness_cli.verify_task(
+                        contract,
+                        task_dir,
+                        allow_test_adapter=True,
+                    )
+                os.environ[
+                    "MURMUR_HARNESS_FAKE_REVIEW_PROBE_ID"
+                ] = "ng-lint"
+                # Reproduce the replacement bypass: restore execution 1 and
+                # remove its legacy-optional number after execution 2 exists.
+                # The append-only event must repair the projection and refuse
+                # a third process.
+                rolled_back_projection.pop("execution_number")
+                legacy.atomic_write_json(
+                    retryable_projection, rolled_back_projection
+                )
+                with contextlib.redirect_stdout(io.StringIO()):
+                    retryable_capped = harness_cli.verify_task(
+                        contract,
+                        task_dir,
+                        allow_test_adapter=True,
+                    )
+                numberless_latest = legacy.load_json(
+                    retryable_projection
+                )
+                numberless_latest.pop("execution_number")
+                legacy.atomic_write_json(
+                    retryable_projection, numberless_latest
+                )
+                with contextlib.redirect_stdout(io.StringIO()):
+                    retryable_capped_again = harness_cli.verify_task(
+                        contract,
+                        task_dir,
+                        allow_test_adapter=True,
+                    )
+            finally:
+                legacy.run_check = original_run_check
+            retryable_state = harness_cli.load_v2_state(task_dir)
+            retryable_attempt = (
+                task_dir
+                / "attempts"
+                / str(retryable_state["attempt_id"])
+            )
+            retryable_record = legacy.load_json(
+                retryable_attempt / "probes" / "ng-lint.json"
+            )
+            retryable_events = []
+            for line in (task_dir / "events.jsonl").read_text(
+                encoding="utf-8"
+            ).splitlines():
+                event = json.loads(line)
+                if (
+                    event.get("event") == "probe-checkpoint"
+                    and event.get("attempt_id") == retryable_attempt.name
+                    and event.get("probe_id") == "ng-lint"
+                    and event.get("execution_number") is not None
+                ):
+                    retryable_events.append(event)
+            test.equal(
+                "PROBE retryable outcomes consume two bounded executions",
+                (
+                    retryable_first,
+                    retryable_second,
+                    retryable_probe_runs,
+                    retryable_record["execution_number"],
+                    [
+                        event["execution_number"]
+                        for event in retryable_events
+                    ],
+                ),
+                (
+                    "PAUSED_RETRYABLE",
+                    "PAUSED_RETRYABLE",
+                    2,
+                    2,
+                    [1, 2],
+                ),
+            )
+            test.equal(
+                "PROBE rollback and number deletion cannot reset retry budget",
+                (
+                    retryable_capped,
+                    retryable_capped_again,
+                    retryable_probe_runs,
+                    retryable_state["status"],
+                    retryable_record["execution_number"],
+                ),
+                (
+                    "NEEDS_EVIDENCE",
+                    "NEEDS_EVIDENCE",
+                    2,
+                    "NEEDS_EVIDENCE",
+                    2,
+                ),
+            )
+            retryable_projection.unlink()
+            legacy.run_check = retryable_probe_run_check
+            try:
+                with contextlib.redirect_stdout(io.StringIO()):
+                    retryable_without_projection = (
+                        harness_cli.verify_task(
+                            contract,
+                            task_dir,
+                            allow_test_adapter=True,
+                        )
+                    )
+            finally:
+                legacy.run_check = original_run_check
+            test.equal(
+                "PROBE deleting latest projection cannot lower event high-water",
+                (
+                    retryable_without_projection,
+                    retryable_probe_runs,
+                    harness_cli.load_v2_state(task_dir)["status"],
+                    legacy.load_json(retryable_projection)[
+                        "execution_number"
+                    ],
+                ),
+                ("NEEDS_EVIDENCE", 2, "NEEDS_EVIDENCE", 2),
+            )
+
+            # Reserve the bounded slot before starting the command. An
+            # exception after the real process exits but before its result can
+            # be checkpointed must not permit unbounded re-execution.
+            owned.write_text(
+                "/* base */\n/* probe pre-run reservation */\n",
+                encoding="utf-8",
+            )
+            post_probe_crashes = 0
+
+            def crash_after_probe_run(
+                check_worktree: Path,
+                check_task_dir: Path,
+                check: Mapping[str, Any],
+                phase: str,
+                *,
+                bound_environment: Optional[
+                    Mapping[str, str]
+                ] = None,
+            ) -> Dict[str, Any]:
+                nonlocal post_probe_crashes
+                evidence = original_run_check(
+                    check_worktree,
+                    check_task_dir,
+                    check,
+                    phase,
+                    bound_environment=bound_environment,
+                )
+                if phase.endswith("-probe"):
+                    post_probe_crashes += 1
+                    raise legacy.HarnessError(
+                        "synthetic post-probe checkpoint crash"
+                    )
+                return evidence
+
+            def verify_after_probe_crash() -> str:
+                with contextlib.redirect_stdout(io.StringIO()):
+                    return harness_cli.verify_task(
+                        contract,
+                        task_dir,
+                        allow_test_adapter=True,
+                    )
+
+            legacy.run_check = crash_after_probe_run
+            try:
+                test.raises(
+                    "PROBE first post-process crash consumes reservation one",
+                    verify_after_probe_crash,
+                    "synthetic post-probe checkpoint crash",
+                )
+                crash_attempt = str(
+                    harness_cli.load_v2_state(task_dir)["attempt_id"]
+                )
+                (
+                    task_dir
+                    / "attempts"
+                    / crash_attempt
+                    / "reviews"
+                    / "combined.json"
+                ).unlink()
+                os.environ.pop(
+                    "MURMUR_HARNESS_FAKE_REVIEW_PROBE_ID", None
+                )
+                test.raises(
+                    "PROBE prior request survives missing fresh review request",
+                    verify_after_probe_crash,
+                    "synthetic post-probe checkpoint crash",
+                )
+                with contextlib.redirect_stdout(io.StringIO()):
+                    crash_capped = harness_cli.verify_task(
+                        contract,
+                        task_dir,
+                        allow_test_adapter=True,
+                    )
+            finally:
+                legacy.run_check = original_run_check
+            crash_reservations = []
+            for line in (task_dir / "events.jsonl").read_text(
+                encoding="utf-8"
+            ).splitlines():
+                event = json.loads(line)
+                if (
+                    event.get("event") == "probe-execution-reserved"
+                    and event.get("attempt_id") == crash_attempt
+                    and event.get("probe_id") == "ng-lint"
+                ):
+                    crash_reservations.append(event["execution_number"])
+            test.equal(
+                "PROBE interrupted executions stop at the same hard cap",
+                (
+                    crash_capped,
+                    post_probe_crashes,
+                    crash_reservations,
+                    harness_cli.load_v2_state(task_dir)["status"],
+                ),
+                ("NEEDS_EVIDENCE", 2, [1, 2], "NEEDS_EVIDENCE"),
+            )
+
+            # The state projection witnesses the high-water. Removing the
+            # latest reservation from the ledger while leaving its state event
+            # must be detected as a rewind, not interpreted as free budget.
+            full_event_documents = [
+                json.loads(line)
+                for line in (task_dir / "events.jsonl").read_text(
+                    encoding="utf-8"
+                ).splitlines()
+            ]
+            truncate_at = next(
+                index
+                for index, event in enumerate(full_event_documents)
+                if (
+                    event.get("event") == "probe-execution-reserved"
+                    and event.get("attempt_id") == crash_attempt
+                    and event.get("probe_id") == "ng-lint"
+                    and event.get("execution_number") == 2
+                )
+            )
+            event_documents = full_event_documents[:truncate_at]
+            legacy.atomic_write_bytes(
+                task_dir / "events.jsonl",
+                b"".join(
+                    legacy.canonical_json(event) + b"\n"
+                    for event in event_documents
+                ),
+            )
+            test.raises(
+                "PROBE witnessed event-tail rewind fails closed",
+                verify_after_probe_crash,
+                "newer than",
+            )
+            test.equal(
+                "PROBE witnessed rewind starts no third process",
+                post_probe_crashes,
+                2,
+            )
+            legacy.atomic_write_bytes(
+                task_dir / "events.jsonl",
+                b"".join(
+                    legacy.canonical_json(event) + b"\n"
+                    for event in full_event_documents
+                ),
+            )
+
+            # A deterministic failed probe remains NEEDS_FIX on every resume;
+            # it can never be omitted from aggregate evidence and briefly
+            # laundered into PASSED.
+            owned.write_text(
+                "/* base */\n/* deterministic probe failure */\n",
+                encoding="utf-8",
+            )
+            os.environ[
+                "MURMUR_HARNESS_FAKE_REVIEW_PROBE_ID"
+            ] = "ng-lint"
+            deterministic_probe_runs = 0
+
+            def deterministic_probe_failure(
+                check_worktree: Path,
+                check_task_dir: Path,
+                check: Mapping[str, Any],
+                phase: str,
+                *,
+                bound_environment: Optional[
+                    Mapping[str, str]
+                ] = None,
+            ) -> Dict[str, Any]:
+                nonlocal deterministic_probe_runs
+                evidence = original_run_check(
+                    check_worktree,
+                    check_task_dir,
+                    check,
+                    phase,
+                    bound_environment=bound_environment,
+                )
+                if phase.endswith("-probe"):
+                    deterministic_probe_runs += 1
+                    return {
+                        **evidence,
+                        "passed": False,
+                        "outcome": "FAIL",
+                        "exit_code": 1,
+                        "blocked_reason": "synthetic deterministic failure",
+                    }
+                return evidence
+
+            legacy.run_check = deterministic_probe_failure
+            try:
+                with contextlib.redirect_stdout(io.StringIO()):
+                    deterministic_first = harness_cli.verify_task(
+                        contract,
+                        task_dir,
+                        allow_test_adapter=True,
+                    )
+            finally:
+                legacy.run_check = original_run_check
+            os.environ.pop("MURMUR_HARNESS_FAKE_REVIEW_PROBE_ID", None)
+            with contextlib.redirect_stdout(io.StringIO()):
+                deterministic_resume = harness_cli.verify_task(
+                    contract,
+                    task_dir,
+                    allow_test_adapter=True,
+                )
+            test.equal(
+                "PROBE deterministic failure cannot degrade to evidence-only",
+                (
+                    deterministic_first,
+                    deterministic_resume,
+                    deterministic_probe_runs,
+                    harness_cli.load_v2_state(task_dir)["status"],
+                ),
+                ("NEEDS_FIX", "NEEDS_FIX", 1, "NEEDS_FIX"),
+            )
+
+            # Upgrade compatibility: an old numberless event proves that a
+            # process already ran. If its mutable projection disappeared, the
+            # new runner must fail closed rather than inventing slot zero.
+            owned.write_text(
+                "/* base */\n/* legacy probe event */\n",
+                encoding="utf-8",
+            )
+            os.environ[
+                "MURMUR_HARNESS_FAKE_REVIEW_PROBE_ID"
+            ] = "ng-lint"
+            with contextlib.redirect_stdout(io.StringIO()):
+                legacy_collected = harness_cli.verify_task(
+                    contract,
+                    task_dir,
+                    allow_test_adapter=True,
+                )
+            legacy_state = harness_cli.load_v2_state(task_dir)
+            legacy_attempt = str(legacy_state["attempt_id"])
+            legacy_projection = (
+                task_dir
+                / "attempts"
+                / legacy_attempt
+                / "probes"
+                / "ng-lint.json"
+            )
+            rewritten_events = []
+            last_state_document: Optional[Dict[str, Any]] = None
+            for line in (task_dir / "events.jsonl").read_text(
+                encoding="utf-8"
+            ).splitlines():
+                event = json.loads(line)
+                if event.get("event") == "state":
+                    event["state"].pop("probe_high_water", None)
+                    last_state_document = event["state"]
+                if (
+                    event.get("attempt_id") == legacy_attempt
+                    and event.get("probe_id") == "ng-lint"
+                    and event.get("event")
+                    == "probe-execution-reserved"
+                ):
+                    continue
+                if (
+                    event.get("attempt_id") == legacy_attempt
+                    and event.get("probe_id") == "ng-lint"
+                    and event.get("event") == "probe-checkpoint"
+                ):
+                    event = {
+                        "at": event["at"],
+                        "event": "probe-checkpoint",
+                        "attempt_id": legacy_attempt,
+                        "probe_id": "ng-lint",
+                        "record_path": str(legacy_projection),
+                        "passed": True,
+                    }
+                rewritten_events.append(event)
+            legacy.atomic_write_bytes(
+                task_dir / "events.jsonl",
+                b"".join(
+                    legacy.canonical_json(event) + b"\n"
+                    for event in rewritten_events
+                ),
+            )
+            if last_state_document is None:
+                raise AssertionError("missing state fixture")
+            legacy.atomic_write_json(
+                task_dir / "state.json", last_state_document
+            )
+            unexpected_legacy_probe_runs = 0
+
+            def count_unexpected_legacy_probe(
+                check_worktree: Path,
+                check_task_dir: Path,
+                check: Mapping[str, Any],
+                phase: str,
+                *,
+                bound_environment: Optional[
+                    Mapping[str, str]
+                ] = None,
+            ) -> Dict[str, Any]:
+                nonlocal unexpected_legacy_probe_runs
+                if phase.endswith("-probe"):
+                    unexpected_legacy_probe_runs += 1
+                return original_run_check(
+                    check_worktree,
+                    check_task_dir,
+                    check,
+                    phase,
+                    bound_environment=bound_environment,
+                )
+
+            legacy_events_snapshot = (
+                task_dir / "events.jsonl"
+            ).read_bytes()
+            legacy_state_snapshot = (task_dir / "state.json").read_bytes()
+            legacy_projection_snapshot = legacy_projection.read_bytes()
+            original_reserve_probe = (
+                harness_cli._reserve_probe_execution
+            )
+            migration_reservations = 0
+
+            def crash_after_first_migration_reservation(
+                *args: Any, **kwargs: Any
+            ) -> None:
+                nonlocal migration_reservations
+                original_reserve_probe(*args, **kwargs)
+                migration_reservations += 1
+                if migration_reservations == 1:
+                    raise legacy.HarnessError(
+                        "synthetic migration reservation crash"
+                    )
+
+            legacy.run_check = count_unexpected_legacy_probe
+            try:
+                harness_cli._reserve_probe_execution = (
+                    crash_after_first_migration_reservation
+                )
+                test.raises(
+                    "PROBE legacy migration crash preserves reservation",
+                    verify_after_probe_crash,
+                    "synthetic migration reservation crash",
+                )
+                harness_cli._reserve_probe_execution = (
+                    original_reserve_probe
+                )
+                with contextlib.redirect_stdout(io.StringIO()):
+                    migrated_resume = harness_cli.verify_task(
+                        contract,
+                        task_dir,
+                        allow_test_adapter=True,
+                    )
+            finally:
+                harness_cli._reserve_probe_execution = (
+                    original_reserve_probe
+                )
+                legacy.run_check = original_run_check
+            test.equal(
+                "PROBE legacy migration resumes without a second process",
+                (
+                    migrated_resume,
+                    migration_reservations,
+                    unexpected_legacy_probe_runs,
+                ),
+                ("NEEDS_EVIDENCE", 1, 0),
+            )
+
+            legacy.atomic_write_bytes(
+                task_dir / "events.jsonl", legacy_events_snapshot
+            )
+            legacy.atomic_write_bytes(
+                task_dir / "state.json", legacy_state_snapshot
+            )
+            legacy.atomic_write_bytes(
+                legacy_projection, legacy_projection_snapshot
+            )
+            ambiguous_events = [
+                json.loads(line)
+                for line in legacy_events_snapshot.decode(
+                    "utf-8"
+                ).splitlines()
+            ]
+            ambiguous_events.append(
+                {
+                    "at": legacy.utc_now(),
+                    "event": "probe-checkpoint",
+                    "attempt_id": legacy_attempt,
+                    "probe_id": "ng-lint",
+                    "record_path": str(legacy_projection),
+                    "passed": False,
+                }
+            )
+            legacy.atomic_write_bytes(
+                task_dir / "events.jsonl",
+                b"".join(
+                    legacy.canonical_json(event) + b"\n"
+                    for event in ambiguous_events
+                ),
+            )
+            legacy.run_check = count_unexpected_legacy_probe
+            try:
+                test.raises(
+                    "PROBE ambiguous multi-event legacy history fails closed",
+                    verify_after_probe_crash,
+                    "multiple legacy probe events cannot be migrated safely",
+                )
+            finally:
+                legacy.run_check = original_run_check
+            test.equal(
+                "PROBE failed legacy tail cannot be replaced by green projection",
+                unexpected_legacy_probe_runs,
+                0,
+            )
+
+            legacy.atomic_write_bytes(
+                task_dir / "events.jsonl", legacy_events_snapshot
+            )
+            legacy.atomic_write_bytes(
+                task_dir / "state.json", legacy_state_snapshot
+            )
+            legacy.atomic_write_bytes(
+                legacy_projection, legacy_projection_snapshot
+            )
+            legacy_projection.unlink()
+            legacy.run_check = count_unexpected_legacy_probe
+            try:
+                test.raises(
+                    "PROBE numberless event without projection fails closed",
+                    verify_after_probe_crash,
+                    "legacy probe event has no recoverable projection",
+                )
+            finally:
+                legacy.run_check = original_run_check
+            test.equal(
+                "PROBE legacy missing projection never resets to slot zero",
+                (
+                    legacy_collected,
+                    unexpected_legacy_probe_runs,
+                    harness_cli.load_v2_state(task_dir)["status"],
+                ),
+                ("NEEDS_EVIDENCE", 0, "NEEDS_EVIDENCE"),
+            )
+
+            # Essential closure path: the source review that requested a probe
+            # remains immutable while a fresh review consumes that evidence
+            # and advances the per-kind checkpoint to PASS.
+            closure_worktree = root / "closure-task" / "meetnotes"
+            closure_worktree.parent.mkdir()
+            closure_branch = "agent/v2/probe-closure"
+            _git(
+                repo,
+                "worktree",
+                "add",
+                "-q",
+                "-b",
+                closure_branch,
+                str(closure_worktree),
+                base,
+            )
+            closure_task_id = "probe-closure"
+            closure_task_dir = harness_cli.v2_task_dir(
+                common, closure_task_id
+            )
+            closure_task_dir.mkdir(parents=True)
+            closure_contract = {
+                **contract,
+                "task_id": closure_task_id,
+                "description": (
+                    "prove request to probe to fresh acceptance closure"
+                ),
+                "contract_sha256": "",
+                "worktree_path": str(closure_worktree.resolve()),
+                "branch": closure_branch,
+                "created_at": legacy.utc_now(),
+            }
+            closure_contract["contract_sha256"] = verifier.document_hash(
+                closure_contract, "contract_sha256"
+            )
+            legacy.validate_schema(
+                closure_contract,
+                legacy.load_schema("v2-task"),
+                label="v2 probe closure contract",
+            )
+            legacy.atomic_write_json(
+                closure_task_dir / "task.json", closure_contract
+            )
+            legacy.atomic_write_json(
+                closure_task_dir / "runtime.json",
+                {
+                    "schema_version": 2,
+                    "task_root": str(closure_worktree.parent),
+                    "shared_node_modules": None,
+                    "server_worktree": None,
+                    "server_source": str(root / "murmur-server"),
+                    "server_revision": None,
+                },
+            )
+            harness_cli.set_v2_state(
+                closure_task_dir, "OPEN", phase="open"
+            )
+            (
+                closure_worktree / owned_relative
+            ).write_text(
+                "/* base */\n/* probe closure */\n",
+                encoding="utf-8",
+            )
+            os.environ["MURMUR_HARNESS_FAKE_REVIEW_VERDICT"] = "PASS"
+            os.environ[
+                "MURMUR_HARNESS_FAKE_REVIEW_PROBE_ID"
+            ] = "ng-lint"
+            os.environ.pop(
+                "MURMUR_HARNESS_FAKE_REVIEW_PROOF_GAPS_JSON", None
+            )
+            os.environ.pop(
+                "MURMUR_HARNESS_FAKE_REVIEW_PROBE_RATIONALE", None
+            )
+            with contextlib.redirect_stdout(io.StringIO()):
+                closure_collected = harness_cli.verify_task(
+                    closure_contract,
+                    closure_task_dir,
+                    allow_test_adapter=True,
+                )
+            closure_state = harness_cli.load_v2_state(
+                closure_task_dir
+            )
+            closure_attempt = (
+                closure_task_dir
+                / "attempts"
+                / str(closure_state["attempt_id"])
+            )
+            closure_probe = legacy.load_json(
+                closure_attempt / "probes" / "ng-lint.json"
+            )
+            source_result_path = Path(
+                str(
+                    closure_probe["request_contexts"][0][
+                        "review_result_path"
+                    ]
+                )
+            )
+            source_result_bytes = source_result_path.read_bytes()
+            source_result_sha256 = legacy.sha256_file(
+                source_result_path
+            )
+            os.environ.pop(
+                "MURMUR_HARNESS_FAKE_REVIEW_PROBE_ID", None
+            )
+            with contextlib.redirect_stdout(io.StringIO()):
+                closure_passed = harness_cli.verify_task(
+                    closure_contract,
+                    closure_task_dir,
+                    allow_test_adapter=True,
+                )
+            closure_final_state = harness_cli.load_v2_state(
+                closure_task_dir
+            )
+            closure_final_review = legacy.load_json(
+                closure_attempt / "reviews" / "combined.json"
+            )
+            verified_closure = verifier.verify_v2_evidence(
+                closure_contract,
+                closure_task_dir,
+                allow_test_adapter=True,
+            )
+            test.equal(
+                "PROBE closure reaches exact verified PASS",
+                (
+                    closure_collected,
+                    closure_passed,
+                    closure_final_state["status"],
+                    verified_closure["verdict"],
+                ),
+                (
+                    "NEEDS_EVIDENCE",
+                    "PASSED",
+                    "PASSED",
+                    "PASSED",
+                ),
+            )
+            test.true(
+                "PROBE source review artifact stays immutable across fresh PASS",
+                closure_final_review["result_path"]
+                != str(source_result_path)
+                and source_result_path.read_bytes() == source_result_bytes
+                and legacy.sha256_file(source_result_path)
+                == source_result_sha256
+                and closure_probe["request_contexts"][0][
+                    "review_result_sha256"
+                ]
+                == source_result_sha256,
+            )
         finally:
+            legacy.load_config = original_load_config
             if saved_verdict is None:
                 os.environ.pop("MURMUR_HARNESS_FAKE_REVIEW_VERDICT", None)
             else:
@@ -1309,6 +2940,22 @@ def probe_precedence_flow_cases(test: Tests) -> None:
                 os.environ[
                     "MURMUR_HARNESS_FAKE_REVIEW_PROBE_ID"
                 ] = saved_probe
+            if saved_probe_rationale is None:
+                os.environ.pop(
+                    "MURMUR_HARNESS_FAKE_REVIEW_PROBE_RATIONALE", None
+                )
+            else:
+                os.environ[
+                    "MURMUR_HARNESS_FAKE_REVIEW_PROBE_RATIONALE"
+                ] = saved_probe_rationale
+            if saved_proof_gaps is None:
+                os.environ.pop(
+                    "MURMUR_HARNESS_FAKE_REVIEW_PROOF_GAPS_JSON", None
+                )
+            else:
+                os.environ[
+                    "MURMUR_HARNESS_FAKE_REVIEW_PROOF_GAPS_JSON"
+                ] = saved_proof_gaps
 
 
 def retry_cases(test: Tests) -> None:
@@ -1750,6 +3397,7 @@ def readonly_review_wall_timeout_cases(test: Tests) -> None:
                 contract=contract,
                 plan=plan,
                 worktree=repo,
+                task_dir=root,
                 attempt_dir=attempt_dir,
                 diff=b"diff --git a/owned.txt b/owned.txt\n",
                 checks=[],
@@ -1909,6 +3557,7 @@ def state_and_lock_cases(test: Tests) -> None:
             "status": "VERIFYING",
             "updated_at": "2000-01-01T00:00:00Z",
         }
+        stale_projection.pop("state_revision")
         legacy.atomic_write_json(task_dir / "state.json", stale_projection)
         test.equal(
             "STATE stale divergent projection is repaired from ledger",
@@ -1918,12 +3567,25 @@ def state_and_lock_cases(test: Tests) -> None:
         future_projection = {
             **recovered,
             "updated_at": "2999-01-01T00:00:00Z",
+            "state_revision": recovered["state_revision"] + 1,
         }
         legacy.atomic_write_json(task_dir / "state.json", future_projection)
         test.raises(
             "STATE projection newer than ledger fails closed",
             lambda: harness_cli.load_v2_state(task_dir),
             "newer than",
+        )
+        same_revision_projection = {
+            **recovered,
+            "status": "VERIFYING",
+        }
+        legacy.atomic_write_json(
+            task_dir / "state.json", same_revision_projection
+        )
+        test.raises(
+            "STATE equal timestamp divergence fails closed by revision",
+            lambda: harness_cli.load_v2_state(task_dir),
+            "same revision",
         )
         legacy.atomic_write_json(task_dir / "state.json", recovered)
 
@@ -3569,6 +5231,36 @@ def plan_and_probe_cases(test: Tests) -> None:
         verifier.attempt_id(changed) != verifier.attempt_id(angular),
     )
     test.equal("PLAN parent remains current immutable base", angular["base_sha"], base)
+    package_plan, _bundle = verifier.build_plan(
+        contract,
+        ROOT,
+        ["package.json", "package-lock.json"],
+        b"package diff",
+        tree,
+        legacy.load_config(),
+    )
+    test.equal(
+        "PROBE package plan exposes only its own canonical checks",
+        verifier.allowed_probe_ids(package_plan),
+        ["npm-lock", "ng-lint", "ng-build"],
+    )
+    test.true(
+        "PROBE package plan excludes unrelated config and Rust checks",
+        "config-audit" not in verifier.allowed_probe_ids(package_plan)
+        and "rust-lib" not in verifier.allowed_probe_ids(package_plan),
+    )
+    harness_plan, _bundle = verifier.build_plan(
+        contract,
+        ROOT,
+        [".agents/harness/cli.py"],
+        b"harness diff",
+        tree,
+        legacy.load_config(),
+    )
+    test.true(
+        "PROBE harness plan contextually permits config-audit",
+        "config-audit" in verifier.allowed_probe_ids(harness_plan),
+    )
 
     test.raises(
         "PROBE broker rejects arbitrary shell ids",
@@ -3682,9 +5374,9 @@ def main() -> int:
     open_branch_ownership_cases(test)
     standalone_driver_open_cases(test)
     profile_cases(test)
+    npm_lock_evidence_cases(test)
     reviewer_tool_guard_cases(test)
     verdict_cases(test)
-    probe_precedence_flow_cases(test)
     retry_cases(test)
     guardian_and_artifact_cases(test)
     readonly_review_wall_timeout_cases(test)
@@ -3698,6 +5390,7 @@ def main() -> int:
     import_cases(test)
     plan_and_probe_cases(test)
     clean_cases(test)
+    probe_precedence_flow_cases(test)
     if test.failures:
         print("v2 selftest: FAIL")
         for failure in test.failures:

--- a/.agents/harness/verifier.py
+++ b/.agents/harness/verifier.py
@@ -42,6 +42,7 @@ SEVERE_FINDINGS = {"MAJOR", "BLOCKER"}
 ALLOWED_PROBES = {
     "rust-lib",
     "protocol-server",
+    "npm-lock",
     "tauri-boot",
     "ng-lint",
     "ng-build",
@@ -53,6 +54,9 @@ ALLOWED_PROBES = {
     "hook-selftest",
     "config-audit",
 }
+MAX_PROBE_EXECUTIONS_PER_ID = 2
+DEFAULT_REVIEW_STREAM_BYTES = 2_048
+NPM_LOCK_REVIEW_STREAM_BYTES = 65_536
 TRANSIENT_HTTP_STATUSES = {408, 409, 425, 429, 500, 502, 503, 504}
 PROTOCOL_FILES = (
     "AGENTS.md",
@@ -158,8 +162,43 @@ def load_v2_state(task_dir: Path) -> Dict[str, Any]:
     projected_time = legacy.parse_timestamp(
         projected["updated_at"], "v2 state projection updated_at"
     )
-    if projected_time > event_time:
-        raise legacy.HarnessError("v2 state projection is newer than its event ledger")
+    event_revision = event_state.get("state_revision")
+    projected_revision = projected.get("state_revision")
+    for label, revision in (
+        ("event", event_revision),
+        ("projection", projected_revision),
+    ):
+        if revision is not None and (
+            isinstance(revision, bool)
+            or not isinstance(revision, int)
+            or revision < 1
+        ):
+            raise legacy.HarnessError(
+                f"v2 state {label} revision is malformed"
+            )
+    if event_revision is not None:
+        if projected_revision is not None:
+            if projected_revision > event_revision:
+                raise legacy.HarnessError(
+                    "v2 state projection is newer than its event ledger"
+                )
+            if (
+                projected_revision == event_revision
+                and projected != event_state
+            ):
+                raise legacy.HarnessError(
+                    "v2 state projection conflicts at the same revision"
+                )
+    elif projected_revision is not None:
+        raise legacy.HarnessError(
+            "v2 revised state projection has a legacy event ledger"
+        )
+    elif projected_time > event_time or (
+        projected_time == event_time and projected != event_state
+    ):
+        raise legacy.HarnessError(
+            "v2 state projection is newer than or conflicts with its event ledger"
+        )
     if projected != event_state:
         legacy.atomic_write_json(state_path, event_state)
     return event_state
@@ -370,6 +409,10 @@ def _angular_surface(paths: Sequence[str]) -> bool:
     return any(_matches(path, patterns) for path in paths)
 
 
+def _package_lock_surface(paths: Sequence[str]) -> bool:
+    return any(path in {"package.json", "package-lock.json"} for path in paths)
+
+
 def _ui_behavior_surface(paths: Sequence[str]) -> bool:
     for path in paths:
         if path.startswith("e2e/") or path == "playwright.config.ts":
@@ -439,6 +482,8 @@ def derive_profile(
 
     if _rust_surface(paths):
         require("rust-lib")
+    if _package_lock_surface(paths):
+        require("npm-lock")
     if _angular_surface(paths):
         require("ng-lint")
         require("ng-build")
@@ -492,6 +537,29 @@ def canonical_check(
         "command": command,
         "timeout_seconds": int(config.get("check_timeout_seconds", 1800)),
     }
+
+
+def allowed_probe_ids(plan: Mapping[str, Any]) -> List[str]:
+    """Return the only probes meaningful for this exact derived plan.
+
+    The static schema is a protocol vocabulary, not authority to execute every
+    check for every task.  A missing claim/profile must be amended explicitly;
+    an unrelated globally-green command can never stand in for missing proof.
+    """
+
+    checks = plan.get("checks", [])
+    if not isinstance(checks, list):
+        raise legacy.HarnessError("v2 plan checks are malformed")
+    result: List[str] = []
+    for check in checks:
+        if not isinstance(check, Mapping):
+            raise legacy.HarnessError("v2 plan check is malformed")
+        check_id = check.get("id")
+        if not isinstance(check_id, str) or check_id not in ALLOWED_PROBES:
+            raise legacy.HarnessError("v2 plan contains a non-canonical probe id")
+        if check_id not in result:
+            result.append(check_id)
+    return result
 
 
 def probe_evidence_hash(records: Sequence[Mapping[str, Any]]) -> str:
@@ -824,6 +892,105 @@ def review_result_state(result: Mapping[str, Any]) -> str:
     return "PASSED"
 
 
+def _bounded_stream_summary(
+    task_dir: Path,
+    raw_path: Any,
+    expected_hash: Any,
+    label: str,
+    limit: int,
+) -> Dict[str, Any]:
+    path = _artifact_inside(task_dir, raw_path, expected_hash, label)
+    size = path.stat().st_size
+    if size <= limit:
+        with path.open("rb") as handle:
+            excerpt = handle.read(limit + 1)
+        truncated = False
+    else:
+        head = limit // 2
+        tail = limit - head
+        omitted = size - limit
+        with path.open("rb") as handle:
+            prefix = handle.read(head)
+            handle.seek(-tail, os.SEEK_END)
+            suffix = handle.read(tail)
+        excerpt = prefix + (
+            f"\n... <{omitted} evidence bytes omitted> ...\n".encode("utf-8")
+        ) + suffix
+        truncated = True
+    return {
+        "sha256": expected_hash,
+        "bytes": size,
+        "truncated": truncated,
+        "excerpt_included": True,
+        "excerpt": excerpt.decode("utf-8", "replace"),
+    }
+
+
+def _review_evidence_summary(
+    item: Mapping[str, Any],
+    task_dir: Path,
+    *,
+    channel: str,
+) -> Dict[str, Any]:
+    evidence = item.get("evidence", item)
+    if not isinstance(evidence, Mapping):
+        raise legacy.HarnessError("v2 review check evidence is malformed")
+    check_id = item.get("id")
+    if channel not in {"planned-check", "reviewer-probe"}:
+        raise legacy.HarnessError(
+            f"invalid review evidence channel: {channel}"
+        )
+    limit = (
+        NPM_LOCK_REVIEW_STREAM_BYTES
+        if check_id == "npm-lock"
+        else DEFAULT_REVIEW_STREAM_BYTES
+    )
+    request_contexts = []
+    for context in item.get("request_contexts", []):
+        if not isinstance(context, Mapping):
+            raise legacy.HarnessError("v2 probe request context is malformed")
+        request_contexts.append(
+            {
+                key: context.get(key)
+                for key in (
+                    "review_kind",
+                    "review_vendor",
+                    "review_result_sha256",
+                    "review_prompt_sha256",
+                    "rationale",
+                    "proof_gaps",
+                    "context_sha256",
+                )
+            }
+        )
+    return {
+        "id": check_id,
+        "source": channel,
+        "command": item.get("command", evidence.get("command")),
+        "passed": evidence.get("passed"),
+        "outcome": evidence.get("outcome"),
+        "exit_code": evidence.get("exit_code"),
+        "duration_ms": evidence.get("duration_ms"),
+        "resource_wait_ms": evidence.get("resource_wait_ms", 0),
+        "log_sha256": evidence.get("log_sha256"),
+        "stdout": _bounded_stream_summary(
+            task_dir,
+            evidence.get("stdout_path"),
+            evidence.get("stdout_sha256"),
+            f"review-visible {check_id} stdout",
+            limit,
+        ),
+        "stderr": _bounded_stream_summary(
+            task_dir,
+            evidence.get("stderr_path"),
+            evidence.get("stderr_sha256"),
+            f"review-visible {check_id} stderr",
+            limit,
+        ),
+        "request_contexts": request_contexts,
+    }
+
+
 def combined_review_prompt(
     contract: Mapping[str, Any],
     plan: Mapping[str, Any],
@@ -831,7 +998,9 @@ def combined_review_prompt(
     checks: Sequence[Mapping[str, Any]],
     kind: str,
     worktree: Path,
+    task_dir: Path,
     *,
+    probes: Sequence[Mapping[str, Any]] = (),
     policy_text: Optional[str] = None,
 ) -> str:
     if policy_text is not None:
@@ -840,20 +1009,18 @@ def combined_review_prompt(
         policy = legacy.read_prompt("combined-reviewer")
     else:
         policy = legacy.read_prompt(kind + "-reviewer")
-    check_summary = []
-    for item in checks:
-        evidence = item.get("evidence", item)
-        check_summary.append(
-            {
-                "id": item.get("id"),
-                "passed": evidence.get("passed"),
-                "outcome": evidence.get("outcome"),
-                "exit_code": evidence.get("exit_code"),
-                "duration_ms": evidence.get("duration_ms"),
-                "resource_wait_ms": evidence.get("resource_wait_ms", 0),
-                "log_sha256": evidence.get("log_sha256"),
-            }
+    check_summary = [
+        _review_evidence_summary(
+            item, task_dir, channel="planned-check"
         )
+        for item in checks
+    ] + [
+        _review_evidence_summary(
+            item, task_dir, channel="reviewer-probe"
+        )
+        for item in probes
+    ]
+    eligible_probes = allowed_probe_ids(plan)
     return (
         f"{policy}\n\n"
         "## Exact v2 task\n"
@@ -865,15 +1032,21 @@ def combined_review_prompt(
         f"Diff SHA-256: {plan['diff_sha256']}\n"
         f"Plan SHA-256: {plan['plan_sha256']}\n"
         f"Protocol SHA-256: {plan['protocol_sha256']}\n"
-        f"Check evidence: {json.dumps(check_summary, sort_keys=True)}\n"
+        "Check and probe evidence (commands, hashes, bounded output, and any "
+        "source proof gaps): "
+        f"{json.dumps(check_summary, sort_keys=True)}\n"
+        f"Context-eligible probe IDs: {json.dumps(eligible_probes)}\n"
         "Pinned server checkout required: "
         f"{'yes' if plan.get('server_required') else 'no'}\n\n"
         "## Exact diff\n"
         f"{diff.decode('utf-8', 'replace')}\n\n"
         "Return every finding and every missing proof. PASS is forbidden when a "
         "MAJOR/BLOCKER remains. If an empirical proof is missing, use proof_gaps "
-        "and optionally a typed probe_requests entry from the schema allowlist; "
-        "never ask for or attempt arbitrary shell access."
+        "and optionally a typed probe_requests entry from the context-eligible "
+        "IDs above; never ask for or attempt arbitrary shell access. A prior "
+        "proof gap may disappear only when the exact shown probe command and "
+        "output address its recorded rationale; a green but unrelated command "
+        "is not evidence."
     )
 
 
@@ -882,11 +1055,13 @@ def invoke_readonly_review(
     contract: Mapping[str, Any],
     plan: Mapping[str, Any],
     worktree: Path,
+    task_dir: Path,
     attempt_dir: Path,
     diff: bytes,
     checks: Sequence[Mapping[str, Any]],
     review: Mapping[str, str],
     probe_evidence_sha256: str,
+    probes: Sequence[Mapping[str, Any]] = (),
     allow_test_adapter: bool = False,
     sleep: Callable[[float], None] = time.sleep,
 ) -> Dict[str, Any]:
@@ -901,7 +1076,14 @@ def invoke_readonly_review(
     retry_records.mkdir(parents=True, exist_ok=True)
     before = legacy.workspace_fingerprint(worktree)
     prompt = combined_review_prompt(
-        contract, plan, diff, checks, kind, worktree
+        contract,
+        plan,
+        diff,
+        checks,
+        kind,
+        worktree,
+        task_dir,
+        probes=probes,
     )
     prompt_sha256 = legacy.sha256_bytes(prompt.encode("utf-8"))
 
@@ -984,11 +1166,9 @@ def invoke_readonly_review(
     legacy.validate_schema(
         result, legacy.load_schema("v2-review"), label=f"{kind} v2 review"
     )
-    for request in result.get("probe_requests", []):
-        if request.get("probe_id") not in ALLOWED_PROBES:
-            raise legacy.HarnessError(
-                f"review requested non-allowlisted probe: {request.get('probe_id')}"
-            )
+    # invoke_model creates every result/invocation/log with a fresh UUID and
+    # exclusive-create semantics.  The per-kind review checkpoint may advance
+    # on resume, but these source artifacts remain immutable for probe binding.
     record = {
         "schema_version": 2,
         **evidence_binding(plan),
@@ -1040,6 +1220,58 @@ def check_record(
         "evidence": dict(evidence),
         "created_at": legacy.utc_now(),
     }
+
+
+def canonical_probe_request_contexts(
+    contexts: Sequence[Mapping[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Deduplicate and order bound probe requests in one canonical way."""
+
+    unique = {
+        str(context.get("context_sha256")): copy.deepcopy(dict(context))
+        for context in contexts
+    }
+    return sorted(
+        unique.values(),
+        key=lambda item: (
+            str(item.get("review_kind")),
+            str(item.get("review_vendor")),
+            str(item.get("context_sha256")),
+        ),
+    )
+
+
+def probe_request_contexts(
+    reviews: Sequence[Mapping[str, Any]], probe_id: str
+) -> List[Dict[str, Any]]:
+    """Bind a probe to the exact review claim that requested it."""
+
+    contexts: Dict[str, Dict[str, Any]] = {}
+    for review in reviews:
+        result = review.get("result", {})
+        if not isinstance(result, Mapping):
+            raise legacy.HarnessError("v2 source review result is malformed")
+        proof_gaps = copy.deepcopy(list(result.get("proof_gaps", [])))
+        for request in result.get("probe_requests", []):
+            if not isinstance(request, Mapping) or request.get("probe_id") != probe_id:
+                continue
+            context: Dict[str, Any] = {
+                "probe_id": probe_id,
+                "review_kind": review.get("kind"),
+                "review_vendor": review.get("vendor"),
+                "review_result_path": review.get("result_path"),
+                "review_result_sha256": review.get("result_sha256"),
+                "review_prompt_sha256": review.get("prompt_sha256"),
+                "rationale": request.get("rationale"),
+                "proof_gaps": proof_gaps,
+                "source_review": copy.deepcopy(dict(review)),
+                "context_sha256": "",
+            }
+            context["context_sha256"] = document_hash(
+                context, "context_sha256"
+            )
+            contexts[context["context_sha256"]] = context
+    return canonical_probe_request_contexts(list(contexts.values()))
 
 
 def aggregate_verdict(
@@ -1094,7 +1326,7 @@ def build_evidence(
     reviews: Sequence[Mapping[str, Any]],
 ) -> Dict[str, Any]:
     review_outcomes = aggregate_review_outcomes(reviews)
-    verdict, reason = aggregate_verdict(checks, reviews)
+    verdict, reason = aggregate_verdict([*checks, *probes], reviews)
     evidence: Dict[str, Any] = {
         "schema_version": 2,
         "task_id": contract["task_id"],
@@ -1181,6 +1413,18 @@ def validate_check_checkpoint(
         raise legacy.HarnessError("v2 check result id changed")
     if result.get("command") != declared.get("command"):
         raise legacy.HarnessError("v2 check result command changed")
+    expected_bound_environment = (
+        {"MURMUR_HARNESS_BASE_SHA": str(plan["base_sha"])}
+        if declared.get("id") == "npm-lock"
+        else {}
+    )
+    if (
+        result.get("bound_environment", {})
+        != expected_bound_environment
+    ):
+        raise legacy.HarnessError(
+            "v2 check runner-bound environment changed"
+        )
     log_path = _artifact_inside(
         task_dir,
         result.get("log_path"),
@@ -1223,6 +1467,172 @@ def validate_check_checkpoint(
         )
 
 
+def validate_probe_checkpoint(
+    record: Mapping[str, Any],
+    declared: Mapping[str, Any],
+    plan: Mapping[str, Any],
+    task_dir: Path,
+    *,
+    allow_test_adapter: bool = False,
+    review_schema: Optional[Mapping[str, Any]] = None,
+) -> None:
+    validate_check_checkpoint(record, declared, plan, task_dir)
+    probe_id = record.get("id")
+    if probe_id not in allowed_probe_ids(plan):
+        raise legacy.HarnessError(
+            f"v2 probe {probe_id} is outside the exact plan"
+        )
+    if record.get("source") != "reviewer-probe":
+        raise legacy.HarnessError("v2 probe has no reviewer-probe provenance")
+    execution_number = record.get("execution_number", 1)
+    if (
+        isinstance(execution_number, bool)
+        or not isinstance(execution_number, int)
+        or execution_number < 1
+        or execution_number > MAX_PROBE_EXECUTIONS_PER_ID
+    ):
+        raise legacy.HarnessError(
+            "v2 probe execution number is malformed or exceeds its bound"
+        )
+    contexts = record.get("request_contexts")
+    if not isinstance(contexts, list) or not contexts:
+        raise legacy.HarnessError("v2 probe request provenance is missing")
+    required_keys = {
+        "probe_id",
+        "review_kind",
+        "review_vendor",
+        "review_result_path",
+        "review_result_sha256",
+        "review_prompt_sha256",
+        "rationale",
+        "proof_gaps",
+        "source_review",
+        "context_sha256",
+    }
+    expected_reviews = {
+        (item.get("kind"), item.get("vendor"))
+        for item in plan.get("reviews", [])
+        if isinstance(item, Mapping)
+    }
+    seen: set[str] = set()
+    for context in contexts:
+        if not isinstance(context, Mapping) or set(context) != required_keys:
+            raise legacy.HarnessError("v2 probe request context is malformed")
+        if context.get("probe_id") != probe_id:
+            raise legacy.HarnessError("v2 probe request context id changed")
+        if (
+            context.get("review_kind"),
+            context.get("review_vendor"),
+        ) not in expected_reviews:
+            raise legacy.HarnessError(
+                "v2 probe request context review is outside the plan"
+            )
+        context_hash = context.get("context_sha256")
+        if (
+            not isinstance(context_hash, str)
+            or context_hash in seen
+            or context_hash != document_hash(context, "context_sha256")
+        ):
+            raise legacy.HarnessError(
+                "v2 probe request context hash is stale or duplicated"
+            )
+        seen.add(context_hash)
+        if not isinstance(context.get("rationale"), str):
+            raise legacy.HarnessError("v2 probe request rationale is malformed")
+        proof_gaps = context.get("proof_gaps")
+        if not isinstance(proof_gaps, list):
+            raise legacy.HarnessError("v2 probe source proof gaps are malformed")
+        source_review = context.get("source_review")
+        if not isinstance(source_review, Mapping):
+            raise legacy.HarnessError(
+                "v2 probe source review checkpoint is malformed"
+            )
+        source_fields = {
+            "review_kind": "kind",
+            "review_vendor": "vendor",
+            "review_result_path": "result_path",
+            "review_result_sha256": "result_sha256",
+            "review_prompt_sha256": "prompt_sha256",
+        }
+        for context_key, review_key in source_fields.items():
+            if context.get(context_key) != source_review.get(review_key):
+                raise legacy.HarnessError(
+                    "v2 probe source review checkpoint metadata changed"
+                )
+        source_result_summary = source_review.get("result")
+        if not isinstance(source_result_summary, Mapping):
+            raise legacy.HarnessError(
+                "v2 probe source review result summary is malformed"
+            )
+        if source_result_summary.get("proof_gaps") != proof_gaps:
+            raise legacy.HarnessError(
+                "v2 probe source proof gaps differ from its checkpoint"
+            )
+        expected_request = {
+            "probe_id": probe_id,
+            "rationale": context.get("rationale"),
+        }
+        if expected_request not in source_result_summary.get(
+            "probe_requests", []
+        ):
+            raise legacy.HarnessError(
+                "v2 probe request differs from its source review checkpoint"
+            )
+        source_declarations = [
+            item
+            for item in plan.get("reviews", [])
+            if isinstance(item, Mapping)
+            and item.get("kind") == context.get("review_kind")
+            and item.get("vendor") == context.get("review_vendor")
+        ]
+        if len(source_declarations) != 1:
+            raise legacy.HarnessError(
+                "v2 probe source review is not uniquely declared in the plan"
+            )
+        prompt_hash = context.get("review_prompt_sha256")
+        if not isinstance(prompt_hash, str) or not re.fullmatch(
+            r"[0-9a-f]{64}", prompt_hash
+        ):
+            raise legacy.HarnessError(
+                "v2 probe source review prompt hash is malformed"
+            )
+        validate_review_checkpoint(
+            source_review,
+            source_declarations[0],
+            plan,
+            task_dir,
+            expected_prompt_sha256=prompt_hash,
+            allow_test_adapter=allow_test_adapter,
+            review_schema=review_schema,
+        )
+        source_path = _artifact_inside(
+            task_dir,
+            context.get("review_result_path"),
+            context.get("review_result_sha256"),
+            f"probe {probe_id} source review result",
+        )
+        source_result = legacy.load_json(source_path)
+        legacy.validate_schema(
+            source_result,
+            (
+                dict(review_schema)
+                if review_schema is not None
+                else legacy.load_schema("v2-review")
+            ),
+            label=f"probe {probe_id} source review",
+        )
+        if source_result.get("proof_gaps") != proof_gaps:
+            raise legacy.HarnessError(
+                "v2 probe source proof gaps differ from the review artifact"
+            )
+        if expected_request not in source_result.get("probe_requests", []):
+            raise legacy.HarnessError(
+                "v2 probe request differs from the source review artifact"
+            )
+    if list(contexts) != canonical_probe_request_contexts(contexts):
+        raise legacy.HarnessError("v2 probe request contexts are not canonical")
+
+
 def validate_review_checkpoint(
     record: Mapping[str, Any],
     declared: Mapping[str, Any],
@@ -1247,6 +1657,15 @@ def validate_review_checkpoint(
     vendor = record.get("vendor")
     if not isinstance(label, str) or not isinstance(vendor, str):
         raise legacy.HarnessError("v2 review checkpoint label/vendor is malformed")
+    safe_kind = re.sub(
+        r"[^a-z0-9._-]+", "-", str(declared.get("kind", "")).lower()
+    )
+    if re.fullmatch(
+        rf"review-{re.escape(safe_kind)}-try-[12]", label
+    ) is None:
+        raise legacy.HarnessError(
+            "v2 review checkpoint label does not match review kind"
+        )
     raw_invocation_path = Path(str(record.get("invocation_path", "")))
     run_dir = raw_invocation_path.parent.parent
     expected_result = run_dir / "results" / f"{label}-{vendor}.json"
@@ -1644,15 +2063,25 @@ def verify_v2_evidence(
 
     probe_records = evidence.get("probes", [])
     probe_ids: set = set()
+    eligible_probe_ids = set(allowed_probe_ids(plan))
     for record in probe_records:
         probe_id = record.get("id")
-        if probe_id not in ALLOWED_PROBES or probe_id in probe_ids:
-            raise legacy.HarnessError("v2 probe evidence has a duplicate/non-allowlisted id")
+        if probe_id not in eligible_probe_ids or probe_id in probe_ids:
+            raise legacy.HarnessError(
+                "v2 probe evidence has a duplicate/id outside the exact plan"
+            )
         probe_ids.add(probe_id)
         if not binding_matches(record, plan):
             raise legacy.HarnessError(f"v2 probe {probe_id} binding is stale")
         declared = canonical_check(str(probe_id), profile_config)
-        validate_check_checkpoint(record, declared, plan, task_dir)
+        validate_probe_checkpoint(
+            record,
+            declared,
+            plan,
+            task_dir,
+            allow_test_adapter=allow_test_adapter,
+            review_schema=attested_schemas.get("v2-review"),
+        )
         result = record.get("evidence", {})
         if not result.get("passed") or result.get("exit_code") != 0:
             raise legacy.HarnessError(f"v2 probe {probe_id} is not green")
@@ -1719,9 +2148,11 @@ def verify_v2_evidence(
             contract,
             plan,
             diff,
-            [*check_records, *probe_records],
+            check_records,
             str(declared["kind"]),
             worktree,
+            task_dir,
+            probes=probe_records,
             policy_text=policy_text,
         )
         validate_review_checkpoint(


### PR DESCRIPTION
## Summary
- bind reviewer-requested probes to the exact planned check, source review, output, rationale, and proof gaps
- add bounded retry/resume-safe probe evidence and durable fail-closed state transitions
- add immutable-base offline npm lock evidence for package changes
- expose bounded check excerpts to fresh read-only reviewers

## Verification
- protected Codex-only harness PASS with hash-bound attestation
- v2 selftest: 288 assertions PASS
- v2 fault selftest: 39 assertions PASS
- agent config audit: 164 checks PASS
- composite harness selftest PASS

No Claude invocation was used.