### PR TITLE
fix(harness): scope Sherpa resources to Rust checks

### DIFF
--- a/.agents/harness/task_runner.py
+++ b/.agents/harness/task_runner.py
@@ -1545,10 +1545,11 @@ def command_needs_sherpa_archive(command: str, worktree: Optional[Path] = None) 
             "scripts/e2e-core.sh",
             "scripts/e2e-mix.sh",
             "scripts/harness-runtime-smoke",
-            # A runner-owned check script can compile Rust without exposing
-            # `src-tauri` in its command string. Match the checks directory so
-            # the pinned offline sherpa archive is available to those scripts.
-            ".agents/harness/checks/",
+            # The performance-contract script compiles Rust without exposing
+            # `src-tauri` in its command string. Match that capability
+            # explicitly; other runner-owned checks (for example npm-lock)
+            # must not inherit the heavyweight Sherpa input.
+            ".agents/harness/checks/perf-contracts.sh",
             "npm run dev",
             "npm run tauri",
             "npx tauri",

--- a/.agents/harness/v2_selftest.py
+++ b/.agents/harness/v2_selftest.py
@@ -811,6 +811,25 @@ def profile_cases(test: Tests) -> None:
             canonical_v2_selftest
         ),
     )
+    test.equal(
+        "PROFILE npm-lock check does not request the Sherpa archive",
+        legacy.command_needs_sherpa_archive(
+            "python3 -B .agents/harness/checks/npm-lock-evidence.py"
+        ),
+        False,
+    )
+    test.true(
+        "PROFILE performance contracts request the Sherpa archive",
+        legacy.command_needs_sherpa_archive(
+            "bash .agents/harness/checks/perf-contracts.sh"
+        ),
+    )
+    test.true(
+        "PROFILE client Rust checks request the Sherpa archive",
+        legacy.command_needs_sherpa_archive(
+            "(cd src-tauri && cargo test --lib)"
+        ),
+    )
     review_schema = legacy.load_schema("v2-review")
     schema_probe_ids = set(
         review_schema["properties"]["probe_requests"]["items"]["properties"][


### PR DESCRIPTION
Fixes the real Harness v2 dependency-task blocker where npm-lock was treated as a Rust check only because its runner-owned script lives under .agents/harness/checks. The Sherpa archive marker now targets perf-contracts explicitly while src-tauri and CI commands keep their existing resource behavior. Adds RED-to-GREEN assertions for npm-lock, perf-contracts, and client Rust checks. Protected harness run passed v2 selftest (291 assertions), config audit, composite selftest, and independent Codex review. No Claude invocation.