### PR TITLE
docs(research): preserve harness and repair findings

### DIFF
--- a/docs/research/2026-07-25-graph-engineering-note-gen-fanout.md
+++ b/docs/research/2026-07-25-graph-engineering-note-gen-fanout.md
@@ -1,0 +1,143 @@
+<!-- Generated 2026-07-25 via /research (murmur-researcher fan-out, 4 angles). Pricing/rate-limits/competitor state = point-in-time. -->
+# Research: "Graph engineering" u nas — czy warto zrobić cloud-path fan-out generacji notatki?
+
+**Trigger:** public post about graph-style agent orchestration (linear workflow → graf: fan-out/parallel → barrier → fan-in, dynamic routing; "9/10 kroków nie musiało czekać"). Pytanie: czy i jak wprowadzić równoległą (fan-out) generację **sekcji** notatki tylko na ścieżce chmurowej, zachowując serializację on-device.
+
+> **Aktualizacja 2026-07-28.** Ręczny `generate_digest` nie obcina już notatki
+> w połowie ani nie pomija spotkań bez śladu: naprawił to zmergowany PR #451.
+> Historyczny finding poniżej pozostaje użyteczny jako uzasadnienie decyzji,
+> ale nie opisuje już tej ścieżki na trunku. Osobny scheduler
+> `brief_runner::build_brief_corpus` nadal ma własny budżet i wymaga osobnej
+> oceny; nie należy przenosić dowodu z PR #451 automatycznie na scheduler.
+
+## TL;DR / Verdict
+
+**Sekcyjny fan-out generacji notatki, jako oryginalnie zaproponowany, NIE jest wart budowy.** Cztery niezależne kąty zbiegły się:
+
+- **Feasibility (A):** wykonalne warunkowo (seam czysty), ale tylko na `anthropic`; na domyślnym `claude_code` fan-out = N procesów Node = ryzyko OOM. Plus **landmina prywatności**: trzeba zsumować `CallMeta.redactions`, inaczej Privacy Receipt zaniża PII.
+- **Jakość (B):** dla typowego spotkania Murmur (30–90 min, mieści się w kontekście) to **latency-win, nie quality-win**. Dowody na przewagę dekompozycji dotyczą tylko (a) DŁUGICH transkryptów (lost-in-the-middle) i (b) metod z retrievalem per-aspekt (AMTSum), a **nie** ślepych N-promptów na tym samym pełnym transkrypcie.
+- **Koszt (C):** naiwny równoległy fan-out na `anthropic` = **~3,7× $**; **prompt caching NIE ratuje** prawdziwie równoległego fan-outu (cache dostępny dopiero po starcie pierwszej odpowiedzi). Note-gen to zadanie **w tle** — user na nie nie czeka, więc latency-win jest mało warty. Na `claude_code` (subskrypcja) = N× szybsze wypalanie rate-limitu + RAM.
+- **Multi-meeting (D):** synteza wielu spotkań **już shippuje** jako
+  single-pass. Historyczny silent-drop w ręcznym `generate_digest` został
+  naprawiony w #451 (whole-note-or-skip + jawny licznik pominiętych spotkań).
+  Nadal jest to właściwy reżim do oceny map-reduce, ale decyzja wymaga pomiaru
+  obecnego zachowania obu ścieżek, w tym schedulera.
+
+**Co jest warte roboty (w kolejności):** (1) **lepszy pojedynczy prompt** (per-section directives + chain-of-density na kompletność action-itemów) — tani quality-win teraz; (2) **eval-delta harness** żeby decydować danymi, nie wiarą; (3) jedyny fan-out wart eksploracji to **map-reduce digestu wielu spotkań**, zaczynając od pomiaru realnego drop-rate. Sekcyjny fan-out pojedynczej notatki — odłożyć/pominąć.
+
+## Co już mamy (z repo, z file:line)
+
+- **Note-gen ciała notatki = JEDNO wywołanie**, background job (flip do `Summarized`, nie foreground spinner): `pipeline.rs:2214-2279` (`provider.summarize_with_meta(&request)`), prompt wielosekcyjny w `summarize/template.rs:10` (`default_template`/`build_template`).
+- **Action items nie są generowane osobno — są PARSOWANE** z markdownu notatki: `summarize/action_items.rs:14`. Recall action-itemów zależy dziś w 100% od jednego prompta ciała.
+- **Seam fan-outu już istnieje i działa gdzie indziej:** timeline to osobne `complete_json` na żądanie (`commands/mod.rs:5422` → `summarize/timeline.rs:193`).
+- **Multi-meeting synthesis JUŻ shippuje jako single-pass fan-in:** ręczny
+  `commands/brief.rs::generate_digest` (Weekly Vault Digest) oraz scheduler w
+  `brief_runner.rs`. PR #451 wydzielił dla ręcznej ścieżki
+  `assemble_digest_corpus`: notatka wchodzi w całości albo jest pomijana, a
+  corpus dostaje jawny licznik pominięć. Scheduler ma oddzielny assembler i
+  nadal używa `take(remaining)`; jego zachowanie nie zostało naprawione ani
+  empirycznie ocenione przez #451.
+- **Twardy constraint:** `AppState::heavy_inference = Semaphore(1)` (`state.rs:374-385`) trzyma **tylko** krok NER-redakcji (`redact.rs:658`), NIE dyspozycję chmurową → fan-out chmurowy nie łamie ograniczenia, ale on-device i tak serializuje się (dowód: `local.rs:234`), więc fan-out on-device jest bezcelowy.
+- **Firewall per-call:** każde wywołanie chmurowe jedzie przez `RedactingProvider::complete_with_meta` (`redact.rs:872`): redakcja + `acquire_external_egress_lease` (`:916`) + jeden `EgressEntry` (`:922`). Consent gated **przy konstrukcji** providera (`mod.rs:193`), fail-closed.
+- **Eval infra gotowe do tej decyzji:** `eval/notes_bakeoff.rs:40,101` (`NoteMetrics` + `compare` A/B — komentarz `:14-18` szczerze mówi: proxy strukturalne, realna bramka = ślepy odczyt człowieka) + `eval/calibration.rs::coverage_fraction` (faithfulness: ułamek claim-linii z receiptem via `grounding::align_claims_to_segments`) + `summarize/action_items.rs` (ekstrakcja do liczenia kompletności).
+
+## Findings (per kąt)
+
+### A — Feasibility + seam (confidence: high, kodowy)
+- Seam = nowy orkiestrator `summarize/sectioned.rs::summarize_sectioned(...) -> Result<(String, CallMeta)>` **nad** traitem (nie metoda traitu), router w `pipeline.rs:2279`: `egress_is_cloud(&connection) && connection=="anthropic"` → fan-out; inaczej obecna liniowa ścieżka.
+- Firewall zachowany: N sekcji × `complete_with_meta`, każda redagowana + lease + ledger niezależnie.
+- **🚨 Korektność prywatności:** Privacy Receipt bierze `redacted_pii` z JEDNEGO `call_meta` (`pipeline.rs:2157`) → orkiestrator **musi zwrócić `CallMeta.redactions` = SUMA** po N + froncie, inaczej receipt zaniża PII (RED-before-GREEN dla testu). Tokeny też sumować.
+- `claude_code` spawnuje subprocess per-call (`claude_code.rs:825/877`), brak mutex-exclusion → N równoległych CLI strukturalnie dozwolone, ale N× runtime Node = RAM (historia OOM) + pułapka `has_unproven_process_group` (`perf.rs:616`) blokująca fail-closed cały kolejny egress jeśli jeden teardown padnie. **Rekomendacja: claude_code OFF albo cap=2.**
+- Fan-in: **deterministyczny merge wystarczy w v1** (front-matter z jednej sekcji + reszta docina nagłówek+ciało; orkiestrator gwarantuje start od `---`). Synteza modelowa (dedup) = +1 wywołanie chmurowe → odłożyć.
+
+### B — Czy to quality-win? (confidence: kierunek high, magnitudy med)
+- Map-reduce bije single-pass na completeness/wierności **głównie gdy dokument przekracza okno** kontekstu; poniżej progu single-pass jest tańszy i spójniejszy. Nowoczesne modele (~200k–1M) przesuwają próg tak wysoko, że notatki ze spotkań **prawie nigdy** go nie przekraczają.
+- Najmocniejszy realny argument ZA dekompozycją: **positional bias** — "Lost in the Middle" (Liu et al., TACL) + "positional bias of faithfulness" (Wan et al., 2410.23609): wierność spada dla treści ze **środka** długiego wejścia. Ale to bije tylko na DŁUGICH transkryptach.
+- Meeting-specific (AMTSum, 2311.04292): zysk aspektowy bierze się z **retrievalu rozproszonych zdań aspektu**, NIE z N ślepych promptów na całości → ślepy fan-out nie odtwarza mechanizmu.
+- **Tańsze alternatywy na kompletność bez N wywołań:** ustrukturyzowany prompt (nagłówek = dyrektywa "czego szukać") + **Chain-of-Density** (Adams et al., ACL 2023, dogęszczanie w jednym prompcie). Ostrzeżenie: wymuszony pure-JSON pogarsza małe modele (dotyczy `ollama`/`complete_json`).
+- Fan-in to **realny podatek**: multi-doc łączenie podnosi halucynację/sprzeczność (2410.13961); ten sam fakt raz jako "decyzja" raz "action item"; per-speaker bez TL;DR halucynuje ramę → **per-speaker to najgorszy kandydat na niezależną sekcję**.
+
+### C — Koszt/latencja + jak mierzyć (confidence: pricing med-high point-in-time)
+- 1h ≈ ~11k tok wejścia, nota ~1,2k wyjścia, N=5, Opus 4.8 ($5/$25 za M). Baseline ~$0,085/notę; **naiwny fan-out ×5 ~$0,31 (~3,7×)**; warm-then-fanout z 5-min cache ~$0,13 (~1,5×) ale połowa latency-winu znika (trzeba zserializować pierwsze wywołanie).
+- **Prompt caching nie ratuje prawdziwie równoległego fan-outu** (docs Anthropic: cache dostępny dopiero po starcie pierwszej odpowiedzi) — a `anthropic.rs:258-263` **dziś w ogóle nie ustawia `cache_control`** (tylko czyta `cache_read_input_tokens`), więc nawet warm-path wymaga przebudowy providera (transkrypt jako cacheowany prefix).
+- `claude_code`: brak cache między spawnami; N× wypalanie Pro/Max rate-limitu + N Node procesów na RAM-ograniczonym Macu → może być **wolniej**.
+- Blow-up jest **cały na wejściu** (zdublowany transkrypt); wyjście ~stałe.
+- Lepiej-ukształtowany fan-out (gdyby kiedykolwiek) = **chunk map-reduce dla bardzo długich spotkań** (każde wywołanie widzi 1/N transkryptu, nie N× całość) — odwrotny, korzystny profil kosztu.
+- **Egress transparency:** zostaw N wierszy w ledgerze (dokładność = własność bezpieczeństwa), ale **agreguj do wyświetlenia** — dowiąż `EgressEntry.meeting_id` (`egress_log.rs:41`, dziś `None`) + `call_kind="summarize_section"` żeby receipt zrolował N w jedną linię i **zsumował** redakcje.
+
+### D — Multi-meeting jako lepszy cel + konkurencja (confidence: kod high, konkurencja med)
+- Multi-meeting **nie jest greenfield** — shippuje jako single-pass, a ręczna
+  ścieżka ma już bezstratne budżetowanie z jawnym pominięciem (#451). To nadal
+  atrakcyjniejszy cel niż sekcyjny fan-out: per-meeting notatka **już jest
+  "map"**, więc dodatkowy fan-out ma sens dopiero po zmierzeniu przepełnienia
+  lub jakości reduce. Scheduler pozostaje osobnym miejscem do audytu.
+- **Konkurencja (point-in-time 2026-07-25):** cross-meeting **chat** = table-stakes (mają wszyscy: Granola, Fireflies/AskFred, Otter, Fathom, tl;dv, Circleback, Fellow; my też via Ask). Generowany **raport** cross-meeting = *emerging* table-stakes (Otter Weekly Insights, tl;dv Multi-Meeting Reports, Circleback Friday→Slack); Granola/Fireflies/Fathom **nie** generują standalone raportu. → nasz weekly/topic report to parytet, **nie moat sam w sobie**; moat = **owned `.md` z `[[wikilinkami]]` do źródeł**.
+
+## Fit z ograniczeniami Murmur
+
+| Constraint | Sekcyjny fan-out notatki | Multi-meeting map-reduce | Lepszy single prompt |
+|---|---|---|---|
+| Local-first / egress (#1 "loud+justified") | ❌ N× egress na jedną notatkę, receipt regresuje | ⚠️ N× tylko dla przepełnienia; per-meeting map często = już-istniejąca notatka (0 nowego egress) | ✅ 1 egress |
+| Obsidian owned `.md` | ✅ | ✅✅ (raport jako `.md` z `[[źródłami]]` = differentiator) | ✅ |
+| SQLite-canonical | ✅ (1 scalona nota) | ✅ (derived export) | ✅ |
+| Provider seam + redaction | ✅ (na `complete_with_meta`) | ✅ (reuse `provider_for(Role::Notes)`) | ✅ |
+| macOS/RAM | ❌ `claude_code`×N = OOM | ⚠️ ale N małe (tylko overflow) | ✅ |
+| CI honesty | merge assembler testowalny; jakość = ślepy odczyt na Macu | instrumentacja drop-rate testowalna; jakość = odczyt | metryki `notes_bakeoff` w `cargo test --lib` |
+
+## Opcje i tradeoffy
+
+- **Opcja 1 — Lepszy pojedynczy prompt (S, low risk).** Wzmocnić `template.rs`: jawne dyrektywy per-sekcja + chain-of-density krok "czy złapałeś każdy action item/decyzję?". 1 wywołanie, 1 egress, 0 podatku na spójność. **To baseline, który każdy fan-out musi pobić.** Natychmiast mierzalne przez `notes_bakeoff::compare`.
+- **Opcja 2 — Eval-delta harness (S, low risk).** Rozszerzyć `notes_bakeoff.rs` o `LinearVsFanoutComparison` (NoteMetrics delta + action-item completeness via `action_items.rs` + section-redundancy score) + reuse `calibration.rs::coverage_fraction` (faithfulness) + `#[ignore]` Mac-runner generujący notę obiema drogami. **De-risk każdej dalszej decyzji danymi.**
+- **Opcja 3 — Multi-meeting selektywny map-reduce (S→M).** Zostaw
+  single-pass, gdy mieści się w budżecie; przy przepełnieniu fan-out per-meeting
+  "map" (reuse istniejącej notatki jako mapy!) → reduce. Ręczny
+  `generate_digest` ma już whole-note-or-skip i liczniki po #451. Pierwszy
+  plaster powinien więc objąć scheduler
+  `brief_runner::build_brief_corpus`: usunąć jego mid-note `take(remaining)` i
+  dodać równoważne `meetings_included`/`meetings_omitted`.
+- **Opcja 4 — Celowany 2. pass na Action Items + Decyzje (M).** Jedno dodatkowe wyspecjalizowane wywołanie (razem AI+decyzje, wspólny kontekst) rekoncyliujące notatkę. 2× egress (nie N×). Tylko jeśli eval pokaże spadek recall na długich.
+- **Opcja 5 — Pełny 4-drożny sekcyjny fan-out + synteza (L, high risk).** ~4× egress/koszt, per-speaker halucynuje ramę, landmina redakcji. **Odłożyć/pominąć** — uzasadnione tylko gdy transkrypty regularnie wielogodzinne I latencja chmury boli (a note-gen jest w tle).
+
+## Rekomendacja i pierwszy krok
+
+**Nie budować sekcyjnego fan-outu (Opcja 5) teraz.** Zamiast tego, w kolejności wartość/koszt:
+
+1. **Opcja 1 (lepszy prompt) — zrób teraz.** Największy quality-win na jednostkę wysiłku, zero podatku prywatności.
+2. **Opcja 2 (eval harness) — równolegle.** Bez tego każda decyzja o fan-oucie jest na wiarę.
+3. **Opcja 3 (multi-meeting), pierwszy krok = spike pomiarowy.** Ręczny
+   `generate_digest` raportuje już nie-PII liczniki `included`/`omitted`.
+   Ujednolicić scheduler z tym assemblerem albo dodać mu równoważne liczniki,
+   następnie zmierzyć realne okno ≥80k. Jeśli pominięcia są częste,
+   map-reduce jest uzasadniony; jeśli nie, lepszym użyciem silnika jest
+   Opcja 1/4.
+
+Bar weryfikacji jakości (czego `cargo test` nie udowodni): **ślepy side-by-side odczyt na realnym Macu, po polsku i angielsku**, + realny pomiar wall-clock i RSS `claude_code`×N przed jakimkolwiek włączeniem fan-outu.
+
+## Otwarte pytania / czego nie zweryfikowano
+
+- **Rozkład długości realnych spotkań usera** — cała decyzja B/C zależy od % spotkań przekraczających próg lost-in-the-middle; brak telemetrii. To decyduje między "lepszy prompt wystarcza" a "potrzebny map-reduce".
+- **Realny omission-rate digestu** — ręczna ścieżka liczy pominięcia po #451,
+  ale nie zmierzono ich na realnym vaulcie; scheduler nadal wymaga osobnej
+  instrumentacji i testu.
+- **Realny token-count 1h transkryptu** (~11k = estymata) — skaluje wszystkie liczby $; można przypiąć recepturą inspekcji dev-DB.
+- **Koszt RAM N× `claude_code`** — oparty na komentarzach + historii OOM, nie zmierzony.
+- **Czy jakikolwiek interaktywny surface potrzebuje sub-20s note-latency** — jeśli nie, nawet warm-then-fanout (anthropic) traci uzasadnienie. Decyzja produktowa.
+- Konkretne magnitudy z literatury (AMTSum ROUGE, positional-faithfulness liczby) — kierunek potwierdzony, liczb nie wyekstrahowano z PDF; krążące ROUGE 0.3793 itp. = niezweryfikowane (nie było na pobranej stronie).
+
+## Sources
+
+**Kod (ten repo):** `pipeline.rs:2214-2279` (single-call note-gen) · `summarize/template.rs:10` (wielosekcyjny prompt) · `summarize/provider.rs:66-158` (trait/seam) · `summarize/mod.rs:68,193,349-361` (`egress_is_cloud`, consent-gate, `RedactingProvider` wrap) · `summarize/redact.rs:658,872-937` (per-call redakcja/lease/ledger + suma) · `summarize/anthropic.rs:258-263,117,172` (brak `cache_control`; czyta cache stats) · `summarize/claude_code.rs:669-676,825,877` (hermetyczny spawn per-call) · `summarize/action_items.rs:14` (parsowane, nie generowane) · `summarize/timeline.rs:193` + `commands/mod.rs:5422` (istniejący fan-out seam) · `commands/brief.rs:31,50-87` (manual digest: całe notatki albo pominięcie + liczniki po #451) · `brief_runner.rs:41-129` (automatyczny digest single-pass + mid-note `take(remaining)` truncation) · `summarize/digest.rs:10` (`[[Title]]` cytaty) · `summarize/threads.rs:19` (topic threads, no-LLM) · `commands/ask.rs:45,140,413` + `summarize/temporal.rs` (Ask-over-vault) · `state.rs:374-385` (`Semaphore(1)`) · `local.rs:234` (dowód serializacji) · `perf.rs:613-621` (egress lease, nie mutual-exclusion) · `egress_log.rs:22-43,137` + `storage/egress_store.rs:106` (ledger, `meeting_id` unwired) · `eval/notes_bakeoff.rs:40,101` + `eval/calibration.rs::coverage_fraction`.
+
+**Web (point-in-time 2026-07-25):**
+- Liu et al., *Lost in the Middle*, TACL — https://aclanthology.org/2024.tacl-1.9/
+- Wan et al., *On Positional Bias of Faithfulness for Long-form Summarization* (2410.23609) — https://arxiv.org/pdf/2410.23609
+- AMTSum, *Aspect-based Meeting Transcript Summarization* (2311.04292) — https://arxiv.org/abs/2311.04292
+- Adams et al., *Chain of Density* (ACL 2023) — https://aclanthology.org/2023.newsum-1.7/
+- *From Single to Multi: How LLMs Hallucinate in Multi-Document Summarization* (2410.13961) — https://arxiv.org/html/2410.13961v1
+- *Why Multi-Agent LLM Systems Fail* (orq.ai) — https://orq.ai/blog/why-do-multi-agent-llm-systems-fail
+- FutureAGI, *RAG Summarization 2026* — https://futureagi.com/blog/rag-summarization/
+- AWS, *Meeting summarization with Amazon Nova* — https://aws.amazon.com/blogs/machine-learning/meeting-summarization-and-action-item-extraction-with-amazon-nova/
+- Anthropic prompt-caching docs — https://platform.claude.com/docs/en/build-with-claude/prompt-caching
+- Anthropic pricing — https://platform.claude.com/docs/en/about-claude/pricing · CloudZero — https://www.cloudzero.com/blog/claude-api-pricing/
+- Claude Code limits — https://www.truefoundry.com/blog/claude-code-limits-explained · https://www.morphllm.com/claude-code-usage-limits
+- Granola chat — https://www.granola.ai/blog/chat-with-meetings-search-analyze-ai-2026 · Otter Weekly Insights — https://otter.ai/blog/otter-weekly-insights · tl;dv review — https://www.meetjamie.ai/blog/tldv-review · Circleback — https://circleback.ai/blog/best-ai-meeting-assistants · Fireflies AskFred — https://docs.fireflies.ai/askfred/overview

--- a/docs/research/2026-07-26-org-sharing-analysis.md
+++ b/docs/research/2026-07-26-org-sharing-analysis.md
@@ -1,0 +1,357 @@
+# Org ("Shared Brain") sharing — current end-to-end analysis
+
+**Original research:** 2026-07-26
+**Refreshed:** 2026-07-28
+**Operator source snapshot:** `meetnotes@cc09eedff6d550d45b134a4dd6e421ff41442a9d`
+and `murmur-server@8504c7bfb894007534676e7023eca0c022f17318`
+
+`meetnotes` is the local checkout name for the GitHub `murmur` repository; both
+names below refer to the same client history.
+
+The client pins that exact server revision in `.murmur-server-revision`. The sibling server checkout
+was on a dirty, older `feat/entitlement-backbone` worktree, so server claims below were read from the
+immutable `origin/main:<path>` objects at `8504c7b`, not from that checkout's working-tree files. A
+read-only operator `git ls-remote origin refs/heads/main` also resolved to
+`8504c7b` during this refresh. That network observation is explicitly
+unattested by this docs task; the committed `.murmur-server-revision` pin is the
+repository-local source used below.
+
+This is a source-and-history refresh, not a new certification run. Existing regression tests are
+named as code evidence, but no Rust/Angular/E2E gate and no live two-account Railway scenario was run
+for this document.
+
+---
+
+## 0. Current verdict
+
+| Area | Current state at the snapshots above |
+|---|---|
+| Org-route authentication | **Landed.** Org handlers take `AuthedUser`; per-org reads and writes use active membership or owner checks. |
+| Org-blob authorization | **Landed.** A protected org blob is available only to an active member. Anonymous, non-member, and removed-member reads collapse to 404. The former "public org blob" finding was false. |
+| Tombstone delivery | **Landed server-side.** A withdrawal is re-sequenced to the feed head, so a member whose cursor passed the live item can receive the tombstone. |
+| Local withdrawal convergence | **Landed client-side.** Feed tombstones, the slow anti-entropy pass, and local revoke share one eviction primitive that blanks plaintext and removes chunks, vectors, FTS tokens, and attachment BLOBs. |
+| Revoke crash recovery | **Landed client-side.** `revoke_pending -> server delete -> local eviction -> revoked`; an interruption remains re-drivable. |
+| Member-removal rotation | **Still open.** The client still sends no JSON body to a JSON-extracting endpoint and prepares only the owner's next-generation grant. |
+| Removed-from-only-org purge | **Still open.** The client's all-empty membership-list safety guard also prevents the legitimate last-org purge. |
+| Blob integrity | **Fail-closed at the client, incomplete at the relay.** AES-GCM open plus a plaintext-envelope hash check prevents corrupt bytes from being ingested. The server stores a separately computed ciphertext SHA-256 but does not re-check it on GET. |
+| Revision-stable identity | **Server transport only.** `docId` landed in server schema/DTO/feed, but the current client DTO neither sends nor reads it, so there is no end-to-end stable identity yet. |
+| Roles / history / controls | `owner|member` only; audit exists only on the server; unshare and org delete remain unavailable in the normal UI/client surface. |
+| Brain reach | Org content remains a separate retrieval partition. The dedicated org search can see it; normal vault retrieval, most MCP tools, graph, facts, export, and analytics cannot. |
+
+The headline from the original report therefore no longer holds: deletion is not structurally broken
+for new withdrawals on these revisions. The highest-severity remaining lifecycle issue is generation
+rotation after member removal, followed by the single-org membership-purge ambiguity.
+
+---
+
+## 1. Synchronization and withdrawal
+
+### 1.1 Publish and pull are still snapshot/poll based
+
+The author publishes a frozen, cleaned note body through
+`commands/org.rs::publish_org_body_with_policy`. The gate order remains:
+
+1. source lock/read gate;
+2. global org-egress consent;
+3. clean + optional regex scrub;
+4. seal an `OrgEnvelope` under the current OCK and open-verify it locally;
+5. atomically publish inline ciphertext;
+6. write a content-free egress-ledger row.
+
+An edit is still append-and-withdraw: publish `rev + 1` as a new item, then tombstone the predecessor.
+There is no PUT/PATCH item route, parent CAS, vector clock, CRDT, or server-side ciphertext merge.
+
+Inbound sync is still polling:
+
+- first background delay: 20 seconds;
+- steady tick: 60 seconds;
+- client page: `ORG_FEED_PAGE = 4`;
+- untargeted tick: one round-robin org;
+- background work is deferred during active recording.
+
+Evidence: `commands/org.rs::{ORG_SYNC_FIRST_DELAY_SECS,ORG_SYNC_TICK_SECS,ORG_FEED_PAGE,
+org_background_sync_tick,org_sync_one}` and `lib.rs`'s org-sync loop. The Settings "Sync now" path is
+targeted; `org_refresh` remains membership reconciliation rather than a feed drain.
+
+### 1.2 New tombstones are cursor-visible
+
+At server `8504c7b`, `store::orgs::tombstone_item` performs:
+
+```sql
+UPDATE org_items
+   SET tombstoned_at = now(), seq = DEFAULT
+ WHERE id = $1 AND org_id = $2 AND tombstoned_at IS NULL
+   AND ($4 OR author_user_id = $3)
+ RETURNING blob_id
+```
+
+It then nulls `blob_id` and deletes the ciphertext blob in the same transaction. The fresh identity
+value moves the tombstone beyond already-synced cursors; `store::orgs::feed` projects tombstones with
+no blob and no `content_sha256`.
+
+Landed provenance:
+
+- server `d76311a`, merged as PR #15 at `8ae01cd`;
+- present regression:
+  `crates/murmur-server/tests/orgs.rs::org_two_account_feed_round_trip`.
+
+That test now models the meaningful case: the reader completes a full pull, the author withdraws an
+older item, and the reader asks from the already-advanced cursor. This refresh inspected the test but
+did not execute it.
+
+### 1.3 The client now converges every local representation
+
+Client commit `303a4c7` (merged in PR #461) added:
+
+- a bounded, durable anti-entropy cursor (`org_state.reconcile_seq`) for tombstones created before
+  the server re-sequencing fix and other stale replicas;
+- `Db::evict_org_item`, the single withdrawal primitive;
+- atomic removal of plaintext title/markdown, chunks, int8 vectors, trigger-backed FTS tokens, and
+  `note_attachments`;
+- org-scoped `list_org_shares`;
+- a live `org-feed-updated` revalidation path in the open org-item viewer.
+
+Client commit `7ae780d` (merged in PR #464) tightened revoke ordering and recovery:
+
+```text
+revoke_pending -> server tombstone -> local eviction -> revoked
+```
+
+It also emits the feed-update event after a successful local revoke and repairs old
+`revoked + still-live replica` rows during the launch sweep.
+
+Present tests, not rerun for this refresh:
+
+- `commands/tests/lifecycle_tests.rs::
+  reconcile_sweep_evicts_a_tombstone_the_live_cursor_can_never_see`;
+- `commands/tests/lifecycle_tests.rs::
+  revoke_org_share_evicts_the_local_replica_on_the_publishing_device`;
+- `commands/tests/lifecycle_tests.rs::
+  an_interrupted_revoke_leaves_a_re_drivable_row_not_a_live_orphaned_replica`;
+- `storage/db_tests/tests.rs::evicting_an_org_item_purges_its_attachment_blobs_on_every_path`;
+- `e2e/org/org-item-withdrawn.spec.ts`.
+
+Some client comments and RED fixtures deliberately emulate the pre-fix server shape (a tombstone
+below the live cursor). They describe why anti-entropy is retained; they are not evidence that server
+`8504c7b` still fails to re-sequence new withdrawals.
+
+### 1.4 What deletion/revocation still does not solve
+
+- `IpcService.revokeOrgShare` still has no production caller in `src/app`; normal unshare remains
+  absent from the primary share UI.
+- The server has `DELETE /v1/orgs/{id}`, but the client has no corresponding HTTP method, Tauri
+  command, IPC method, or owner UI.
+- `org_leave` intentionally does not withdraw the departing author's already-published items.
+- Locking a source folder does not withdraw an already-published org snapshot. The lock dialog can
+  warn/revoke while unlocked, but `folder_active_shares_inner` returns an empty report once the folder
+  is sealed and not session-unlocked to avoid leaking locked titles.
+- Membership reconciliation still refuses to delete all local org rows when a successful server
+  response is `{"orgs":[]}`. That fail-safe protects against a hostile/transient empty response, but
+  also leaves a removed user's last org replica and cached OCK locally.
+
+---
+
+## 2. Authentication and authorization
+
+### 2.1 Org routes
+
+`auth/bearer.rs::AuthedUser::from_request_parts` hashes the bearer token, resolves the access session,
+rejects missing/malformed/expired tokens uniformly, and returns the bound user/device/family ids.
+Org routes then apply:
+
+- `routes/orgs.rs::require_member` for status, members, own key grants, feed, audit, and tombstone
+  entry;
+- `store::orgs::is_owner` for add/remove member, key-grant writes, generation bump, and org delete;
+- author-or-owner SQL authorization for item tombstones.
+
+Server PR #16 (`c0a2ff1`) changed `PUT /v1/orgs/{id}/key-grants` from member-writable to owner-only
+and deletes a removed member's grant rows in the same transaction as `removed_at`.
+
+Present tests, not rerun:
+
+- `orgs.rs::org_key_grants_are_owner_only`;
+- `orgs.rs::org_member_removal_drops_key_grants`;
+- the non-member and post-removal assertions in `org_two_account_feed_round_trip`.
+
+### 2.2 Blob GET
+
+`routes/blobs.rs::fetch` accepts an optional bearer because legacy unreferenced M0 blobs remain
+anonymous-compatible. That does **not** make a live org item blob public:
+
+1. `store::orgs::blob_access` first classifies whether a live, non-deleted org references the blob;
+2. if protected, it permits only an active member of a referencing org;
+3. missing/invalid bearer, non-member, and removed member all receive the same 404;
+4. a tombstone deletes the blob.
+
+`tests/orgs.rs::org_item_blobs_are_membership_gated` covers active member 200, non-member 404,
+anonymous 404, and removed-member 404. The gate was already present in server commit `e357883`; PR
+#16 retained the regression test. The original "unauthenticated org ciphertext" repair item must not
+be resurrected.
+
+One related compatibility boundary remains: truly unreferenced legacy M0 blobs are still served
+without auth, while `POST /v1/blobs` is now a 403 retirement shim. That is a legacy-blob policy, not a
+live-org-blob authorization defect.
+
+---
+
+## 3. Blob and content integrity — three values, not one
+
+The old docs and one current protocol comment blur plaintext identity and ciphertext integrity. The
+actual data flow has three separate checks:
+
+| Value/check | Producer | Consumer | Current meaning |
+|---|---|---|---|
+| `org_items.content_sha256` / feed `contentSha256` | Client | Client | SHA-256 of canonical **plaintext `OrgEnvelope`**. It derives the AAD nonce and is checked again after decrypt. The relay length-checks it at 32 bytes but cannot verify its meaning. |
+| `blobs.sha256` | Server inline publish | Currently no read path | SHA-256 of the opaque **ciphertext cell**, computed in `routes/orgs.rs::publish_item` and stored by `store::orgs::publish_inline_item`. |
+| AES-256-GCM tag + post-open hash comparison | Client seal/open | Client ingest | Wrong OCK, wrong AAD, or modified ciphertext fails open; a successfully opened envelope must also hash to the feed value before any local write. |
+
+Evidence:
+
+- plaintext hash contract:
+  `murmur-protocol/src/dto.rs::PublishItemRequest::content_sha256`,
+  `migrations/0006_orgs.sql`, and client `share/org_dto.rs::PublishItemRequest`;
+- separate ciphertext hash:
+  `routes/orgs.rs::publish_item` and `store/orgs.rs::publish_inline_item`;
+- fail-closed ingest:
+  client `commands/org.rs::org_sync_one` and `share/org_envelope.rs::open_org_envelope`.
+
+Two open issues remain:
+
+1. `store::get_blob` selects only `id,data,size_bytes`, and `routes/blobs.rs::fetch` returns those
+   bytes without recomputing/validating stored `blobs.sha256`. Client AEAD still prevents silent
+   plaintext ingestion, but the relay does not detect at-rest corruption before transfer.
+2. `murmur-protocol/src/dto.rs::OrgItemEntry::content_sha256` currently says "SHA-256 of the
+   ciphertext." That comment is wrong: the route puts the client-supplied plaintext-envelope hash in
+   that field. Treating it as ciphertext integrity in a future client would break AAD reconstruction.
+
+Separately, exposing the unkeyed plaintext-envelope hash to the relay creates a
+confirm-the-guess oracle for predictable note bodies. Removing it is a wire/AAD migration, not a
+rename: use an OCK-keyed or random nonce, preserve old-reader compatibility, and add cross-repo
+golden vectors first.
+
+---
+
+## 4. Member removal and key rotation remain incomplete
+
+The server half is stricter than the client half:
+
+- only the owner can write grants;
+- removing a member deletes that member's stored grants;
+- `store::orgs::bump_generation` requires exactly `current + 1` and a grant for every active member.
+
+The current client cannot satisfy that contract:
+
+1. `share/client.rs::org_bump_generation` POSTs no JSON body or content type, while
+   `routes/orgs.rs::bump_generation` requires `Json<BumpGenerationRequest>`. Source inspection
+   predicts an axum 415 before the handler runs.
+2. `commands/org.rs::org_remove_member_inner` wraps the new OCK only to the owner. In an org with
+   another active member, the server coverage check returns 409 even after the request-body fix.
+3. The client removes the member first, then rotates. Therefore a rotation failure leaves membership
+   and server blob access revoked and grant re-fetch closed, but future items remain on the old OCK
+   generation until rotation is repaired.
+4. Server `publish_item` records the request's generation but does not compare it with the org's
+   current generation. After rotation exists, a stale/malicious active client can still publish an
+   old-generation item unless the server enforces the active generation.
+
+`OrgMemberEntry.email` now gives the owner a lookup key for remaining members, but
+`KEY_LOOKUPS_PER_DAY = 20` is below `MAX_ORG_MEMBERS = 50`. A safe implementation must cache verified
+member identity keys and resolve the complete next-generation grant set before writing or activating
+any part of it.
+
+The predicted 415/409 sequence was not live-reproduced during this refresh.
+
+---
+
+## 5. Revision identity, roles, audit, and editing
+
+### 5.1 `docId` is only a server substrate today
+
+Server PR #17 (`8504c7b`) added nullable `org_items.doc_id`, request/feed DTO fields, and preservation
+of the value on tombstones. `tests/orgs.rs::org_doc_id_links_revisions_and_survives_a_tombstone`
+exists.
+
+The client at `cc09eed` still defines its own `share/org_dto.rs::{PublishItemRequest,OrgItemEntry}`
+without `doc_id`, never sends a stable id, never persists one, and never maps a tombstoned item to a
+successor. The server remains backward-compatible and stores `NULL`.
+
+Therefore:
+
+- a new server item id is still minted for every client edit;
+- recipient references held by item id still die on edit;
+- there is no end-to-end revision lineage or stable reference yet;
+- `docId` is deliberately metadata-only and did **not** change the AAD, signing, or conflict model.
+
+The original proposal to put `doc_id` directly into a new envelope/AAD version is no longer the
+smallest first step. First adopt the landed metadata field end to end; signatures, parent CAS, and
+cryptographic revision binding remain later work.
+
+### 5.2 Roles and authorship
+
+Roles remain `owner|member`; no route promotes, demotes, transfers ownership, or creates a reader.
+Any active member can publish; the server attributes the new item from the bearer. Destructive
+withdrawal is author-or-owner.
+
+The client only exposes edit-in-place when stored `author_user_id` matches the current session, but
+that is client policy over an append-only server API. `OrgEnvelope.author_hint` is a display label,
+not a content signature. A reader role would initially be a server ACL, not a cryptographic
+read-only guarantee, because every reader still has the shared OCK.
+
+### 5.3 Audit and owner controls
+
+The server records `org_audit` and exposes member-readable
+`GET /v1/orgs/{id}/audit`. The current client has no audit HTTP method, Tauri command, IPC method, or
+panel. The server also implements owner org deletion, but the client surface does not.
+
+---
+
+## 6. Brain, MCP, and egress remain deliberately separate
+
+`storage/org_store.rs::{search_org_chunks_knn,search_org_chunks_fts}` still feed the dedicated
+`tools.rs::search_org_brain_hits` seam. The main vault retrieval, graph, facts, Related, Obsidian
+export, analytics, and most MCP tools do not join the org partition. MCP has snippet search but no
+full-org-item read tool.
+
+Widening reach is still downstream of lifecycle correctness:
+
+- org content belongs to another member and needs distinct cloud-egress consent/provenance;
+- the current egress ledger cannot identify colleague-derived context;
+- in-meeting `AssistantScope::Vault` must not silently inherit connector/org content;
+- org items remain outside folder-lock ownership, so graph/link/export work needs a separate product
+  decision and lock-security review.
+
+---
+
+## 7. Current priority order
+
+1. Repair rotation atomically: complete grant set, JSON generation request, active-generation
+   enforcement, and multi-account tests.
+2. Resolve the authoritative-empty-membership ambiguity so a removed last-org member is purged
+   locally without allowing one bad response to wipe replicas.
+3. Correct the plaintext/ciphertext hash contract in protocol prose; decide whether relay GET should
+   verify `blobs.sha256`.
+4. Adopt server `docId` end to end in the client before building history/diff/CAS.
+5. Surface unshare, org delete, and audit activity.
+6. Only then widen Shared Brain into default Ask/MCP retrieval with separate egress consent and
+   provenance.
+
+Detailed, executable work sequencing is in
+`docs/research/2026-07-26-org-sharing-repair-plan.md`.
+
+---
+
+## 8. Verification boundary
+
+Recorded by operator source/ancestry inspection only; these are not outcomes of
+the Harness control-plane checks attached to this docs diff:
+
+- client HEAD and ancestry contain the convergence/revoke commits;
+- `.murmur-server-revision` pins `8504c7b`;
+- remote `main` resolved to the same server commit;
+- the cited implementations and regression tests are present.
+
+Not performed in this refresh:
+
+- `cargo test --lib`, Angular lint/build, server SQLx integration tests, or E2E;
+- a real app launch;
+- a real two-account Railway tombstone, blob-read, removal, or rotation scenario;
+- any deployment-state comparison beyond the pinned/current server source revision.

--- a/docs/research/2026-07-26-org-sharing-repair-plan.md
+++ b/docs/research/2026-07-26-org-sharing-repair-plan.md
@@ -1,0 +1,351 @@
+# Org ("Shared Brain") — current repair plan
+
+**Original plan:** 2026-07-26
+**Refreshed:** 2026-07-28
+**Baseline:** `meetnotes@cc09eed` + client-pinned `murmur-server@8504c7b`
+
+`meetnotes` is the local checkout name for the GitHub `murmur` repository.
+
+This plan supersedes the original phase status. It separates code that is in the baseline from work
+that remains open. "Landed" means present in the cited commit ancestry; it does not mean this refresh
+reran tests or live-reproduced the behavior.
+
+The plan intentionally does not preserve an old harness task id or any captured harness lifecycle
+recipe. Execution must use the repository's current workflow and derive checks from the actual diff
+at implementation time.
+
+---
+
+## 0. Status ledger
+
+### Landed in the baseline
+
+| Item | State and evidence |
+|---|---|
+| Tombstones reach already-synced members | **Landed server-side.** `store::orgs::tombstone_item` sets `seq = DEFAULT`; server `d76311a`, merged in PR #15 (`8ae01cd`). |
+| Masking tombstone test | **Landed.** `tests/orgs.rs::org_two_account_feed_round_trip` now pulls from the fully advanced reader cursor and matches the re-sequenced withdrawal by item id. |
+| Org-blob membership authorization | **Was already landed, not a defect.** `routes/blobs.rs::fetch` consults `store::orgs::blob_access`; server `e357883`. PR #16 retained `org_item_blobs_are_membership_gated`. |
+| Key-grant write authorization | **Landed.** `PUT /key-grants` is owner-only; server PR #16 (`c0a2ff1`). |
+| Removed member's stored grants | **Landed.** `store::orgs::remove_member` deletes their grant rows in the removal transaction; PR #16. |
+| Client anti-entropy and complete local eviction | **Landed.** Slow reconcile cursor, plaintext/chunk/vector/FTS/attachment eviction, org-scoped share list, and viewer revalidation; client `303a4c7`, merged in PR #461. |
+| Revoke crash window and event refresh | **Landed.** Re-drivable ordering plus orphan repair and immediate FE event; client `7ae780d`, merged in PR #464. |
+| Server `docId` transport | **Landed only on the server.** Schema/DTO/feed/tombstone preservation; server PR #17 (`8504c7b`). Client adoption remains open. |
+| Server revision pin | **Landed.** client `a395f09` pins `8504c7b`, merged in PR #467. |
+
+### Still open
+
+| Priority | Work |
+|---|---|
+| P0 | Make OCK rotation after member removal actually complete and enforce the active generation. |
+| P0 | Purge the local replica when the removed org was the user's only org, without trusting one unauthenticated-looking empty response. |
+| P1 | Correct and harden the plaintext-hash vs ciphertext-hash contract. |
+| P1 | Adopt server `docId` end to end in the client. |
+| P1 | Expose unshare, org deletion, and org audit in the product. |
+| P2 | Improve feed catch-up and unread state. |
+| P2 | Widen Shared Brain retrieval only with colleague-content egress consent/provenance. |
+| P3 | Reader/publisher roles, signed authorship, parent CAS, history/diff, comments, and folder subscriptions. |
+
+---
+
+## PHASE A — Finish removal and rotation
+
+### A1. Build the complete next-generation grant set before mutation
+
+Current defect:
+
+- `commands/org.rs::org_remove_member_inner` removes the member first;
+- it creates a new OCK but wraps it only to the owner;
+- server `store::orgs::bump_generation` requires a grant for every active member.
+
+The members response now includes email, but online key lookup is capped below the maximum org size
+(`KEY_LOOKUPS_PER_DAY = 20`, `MAX_ORG_MEMBERS = 50`). Do not implement a partial PUT loop.
+
+Required design:
+
+1. persist each verified member identity key when it is already fetched for invite/grant work;
+2. resolve and validate every remaining member's identity key before the destructive remove;
+3. build every N+1 wrapped grant in memory;
+4. refuse before server mutation if the set is incomplete;
+5. remove the member;
+6. PUT the complete N+1 grant set;
+7. bump generation;
+8. persist/cache the new generation only after server success.
+
+If atomic server orchestration is added instead, preserve the zero-knowledge boundary: the server may
+validate coverage and switch metadata, but never open OCK material.
+
+### A2. Send the generation JSON body
+
+`share/client.rs::org_bump_generation` currently POSTs an empty request.
+`routes/orgs.rs::bump_generation` requires:
+
+```json
+{ "generation": 2 }
+```
+
+Add the typed request and content type. The current source predicts 415 before the handler; this
+refresh did not live-reproduce it.
+
+### A3. Enforce active generation on publish
+
+`routes/orgs.rs::publish_item` currently clamps the supplied generation to at least one but does not
+compare it with `orgs.current_generation`. Once rotation works, reject an old/future generation with
+a content-free conflict. Otherwise an honest stale client or modified active client can keep
+creating old-generation items.
+
+### A4. Recovery semantics
+
+The present client order can leave "member removed, rotation not advanced." Make that state explicit
+and re-drivable:
+
+- store a pending rotation intent before the server remove;
+- retry only from durable, complete grant material;
+- never invent a second OCK after some N+1 grants were already written;
+- report membership removal and generation activation as distinct operator-visible states.
+
+### A5. Proof required
+
+Add/retain tests for:
+
+- 3-member org: remove one, remaining two have valid N+1 grants, generation advances once;
+- missing remaining-member identity: no member removal and no grant write;
+- interruption after remove or grant PUT: retry converges on the same N+1 intent;
+- removed member: feed/blob/grant reads remain 404;
+- stale-generation publish is rejected;
+- current-generation publish remains readable by every remaining member.
+
+A real two-account (preferably three-account) run against the deployed server remains required before
+claiming end-to-end rotation. Unit/SQLx tests alone are not that proof.
+
+---
+
+## PHASE B — Make membership loss purge locally
+
+### B1. Replace the ambiguous all-empty guard
+
+Current code in `commands/org.rs::reconcile_org_state_into_db_with_policy` keeps all local orgs when
+the server returns a successful empty list. This prevents a single hostile/transient empty response
+from wiping local replicas, but it also prevents the legitimate purge when the user was removed from
+their only org.
+
+Do not simply delete the guard. Give the client an authenticated/authoritative distinction, for
+example:
+
+- a signed/session-bound membership snapshot with a monotonic revision; or
+- targeted confirmation for each cached org after an empty list, requiring uniform member-gate 404
+  before local purge; or
+- two-phase quarantine followed by a confirmed purge, with org search disabled immediately.
+
+Network errors, invalid sessions, and parse failures must continue to keep cached state without
+destructive mutation.
+
+### B2. Proof required
+
+- valid empty membership response after last-org removal purges `org_state`, OCK cache, plaintext,
+  attachments, chunks, FTS, and vectors;
+- network/5xx/invalid JSON/expired session preserves the cached replica;
+- a non-empty list that omits one of several orgs purges only the omitted org;
+- no removed org remains searchable during any quarantine interval.
+
+---
+
+## PHASE C — Clarify and harden blob integrity
+
+### C1. Fix the contract text first
+
+There are two hashes:
+
+- feed `contentSha256`: canonical **plaintext `OrgEnvelope`** hash, supplied by the client;
+- `blobs.sha256`: opaque **ciphertext** hash, computed by the server during inline publish.
+
+Correct `murmur-protocol/src/dto.rs::OrgItemEntry::content_sha256`, whose current comment incorrectly
+calls the feed field a ciphertext hash. Keep client `share/org_dto.rs` and server migration/route
+comments consistent.
+
+### C2. Decide relay at-rest verification
+
+`store::get_blob` does not return `blobs.sha256`, and `routes/blobs.rs::fetch` does not recompute it.
+Client AES-GCM open plus post-open plaintext-hash comparison already fails closed, so this is
+hardening/diagnostics rather than a silent-plaintext-ingest vulnerability.
+
+Recommended small change:
+
+1. load the stored ciphertext SHA with the blob;
+2. recompute before serving;
+3. collapse mismatch to a content-free failure and log only blob id/stage;
+4. test DB corruption without returning corrupted bytes.
+
+Do not compare feed `contentSha256` to ciphertext bytes; that field is required to reconstruct the
+current AAD.
+
+### C3. Migrate away from the plaintext-hash oracle separately
+
+The relay-visible unkeyed plaintext hash is a confirm-the-guess oracle. Replacing it changes AAD and
+mixed-version decrypt behavior. Before that change:
+
+- move the shared org wire contract into the shared protocol boundary;
+- add frozen cross-repo org-envelope vectors;
+- define old/new reader behavior;
+- use an OCK-keyed or random nonce;
+- keep server ciphertext integrity separate from plaintext identity.
+
+---
+
+## PHASE D — Adopt revision-stable identity end to end
+
+Server `docId` support is present, nullable, and metadata-only. The client still omits the field.
+
+Required client slice:
+
+1. add optional `doc_id` to local publish/feed DTOs;
+2. create one stable random UUID per outbound source/share lineage;
+3. send the same value on republish/edit;
+4. persist `doc_id` on local org share/replica rows;
+5. map `doc_id -> current live item_id` transactionally when a successor arrives;
+6. make open viewer/pinned source/wikilink resolution follow the current live item;
+7. preserve item-id behavior for legacy rows with no `docId`.
+
+This slice does **not** require an envelope/AAD version bump. It exposes revision linkage metadata to
+the relay, as documented in server migration `0009_org_doc_id.sql`.
+
+Later, separately:
+
+- signed author identity per revision;
+- `parent_item_id` or opaque parent token;
+- server CAS with 409 on stale parent;
+- local revision history/diff and conflict UX.
+
+Do not call server `docId` alone conflict protection or cryptographic lineage.
+
+---
+
+## PHASE E — Give users the controls the server already supports
+
+### E1. Unshare
+
+Wire existing `IpcService.revokeOrgShare` into the normal share/detail UI. Use the already-landed
+crash-safe backend path and show `revoke_pending` vs complete honestly.
+
+### E2. Delete org
+
+Add the missing client HTTP method, Tauri command, IPC method, owner confirmation, and local purge
+for server `DELETE /v1/orgs/{id}`.
+
+### E3. Activity
+
+Expose member-readable `GET /v1/orgs/{id}/audit` through one client method, command, and panel.
+Keep events content-free and paginate from the server cursor.
+
+### E4. Lock interaction
+
+Decide explicitly whether "Lock anyway" leaves snapshots shared or requires revoke. Preserve the
+locked-title read gate: do not make `folder_active_shares` leak sealed titles merely to improve audit
+ergonomics.
+
+### E5. Proof required
+
+FE runtime coverage with mocked Tauri IPC:
+
+- unshare shows pending/completed states and an open viewer closes on withdrawal;
+- delete org removes it and local org content from every surface;
+- audit shows publish/tombstone/member events without note content;
+- a sealed-not-unlocked folder leaks no title or share existence detail.
+
+---
+
+## PHASE F — Catch up and signal
+
+Current throughput remains four items per 60-second tick for one round-robin org, and background org
+work pauses during recording.
+
+Improvements:
+
+1. bounded adaptive drain until caught up;
+2. fair head checks across joined orgs;
+3. immediate catch-up after recording stops;
+4. unread/update state;
+5. make "Refresh" terminology distinguish membership refresh from feed sync;
+6. user-visible retry for pending outbound work.
+
+Measure seeded 400-item and multi-org catch-up before/after. Do not infer performance from unit tests.
+
+---
+
+## PHASE G — One brain, with an egress boundary
+
+Only after Phases A–E:
+
+1. fuse org hits into selected vault/MCP retrieval as a distinct `SHARED BRAIN` provenance section;
+2. add full-org-item MCP read only through the existing membership/context gates;
+3. add an org-provenance field to the egress ledger;
+4. require separate consent before colleague content reaches a cloud model;
+5. keep `AssistantScope::Vault` free of org/connectors unless explicitly promoted;
+6. keep graph/link/export/fact integration out until the lock-domain product decision is made.
+
+This phase requires independent privacy/lock review because it expands where another person's
+decrypted content can flow.
+
+---
+
+## PHASE H — Roles, history, and product extensions
+
+Ordered later work:
+
+1. server-enforced `reader|publisher|owner` ACLs, labelled honestly as non-cryptographic while all
+   readers share the OCK;
+2. ownership transfer/promote/demote;
+3. signed org-item authorship;
+4. parent CAS + history/diff + conflict UX;
+5. OCK-sealed comments/annotations;
+6. folder-scoped subscriptions only with standing-consent and lock-boundary design;
+7. server quota/GC/rate-counter retention policy.
+
+Real-time CRDT/OT remains out of scope: whole-document E2EE cells and a relay that cannot merge
+plaintext make parent-CAS conflict handling the proportionate next step.
+
+---
+
+## Verification matrix for the next changes
+
+| Claim | Minimum evidence |
+|---|---|
+| Rotation works | Server SQLx tests + client Rust tests + real multi-account deployed run |
+| Removal purges locally | Rust lifecycle/DB tests across plaintext, attachments, FTS, vectors, OCK cache |
+| Blob bytes are integrity-checked | Corrupt stored blob fixture; server refuses bytes; client tamper-open remains fail-closed |
+| `docId` survives edit | Server + client mixed-version test; viewer/pinned link follows successor |
+| UI controls work | Mocked-Tauri browser runtime test, not compilation alone |
+| Org retrieval is privacy-safe | Egress-ledger/consent tests, isolation-tier tests, independent lock-security review |
+| Sync is faster | Seeded backlog measurement, including during/after recording |
+
+### Evidence present but not rerun during this refresh
+
+- server: `org_two_account_feed_round_trip`,
+  `org_item_blobs_are_membership_gated`,
+  `org_key_grants_are_owner_only`,
+  `org_member_removal_drops_key_grants`,
+  `org_doc_id_links_revisions_and_survives_a_tombstone`;
+- client:
+  `reconcile_sweep_evicts_a_tombstone_the_live_cursor_can_never_see`,
+  `revoke_org_share_evicts_the_local_replica_on_the_publishing_device`,
+  `an_interrupted_revoke_leaves_a_re_drivable_row_not_a_live_orphaned_replica`,
+  `evicting_an_org_item_purges_its_attachment_blobs_on_every_path`,
+  and `e2e/org/org-item-withdrawn.spec.ts`.
+
+No Rust, Angular, server SQLx, E2E, app-launch, or Railway scenario was
+executed for this documentation refresh. The Harness control-plane selftests
+listed in the task evidence are not product or server verification.
+
+---
+
+## Shipping order
+
+| Ship | Contents | Exit condition |
+|---|---|---|
+| A | Rotation + active-generation enforcement | Multi-account removal and future-item decrypt verified |
+| B | Authoritative membership-loss purge | Last-org removal purges; transient failure never wipes |
+| C | Hash contract correction + optional relay verification | Plaintext/ciphertext semantics unambiguous; corruption fails closed |
+| D | Client `docId` adoption | References survive a republish across mixed versions |
+| E | Unshare, delete-org, audit, lock copy | User can see and control lifecycle from the app |
+| F | Catch-up/unread | Backlog measurement meets an explicit target |
+| G | Retrieval + egress provenance/consent | Privacy review passes and isolation tiers stay intact |
+| H | Roles, signed lineage, history, comments | Each protocol change has vectors and compatibility proof |

--- a/docs/research/2026-07-27-harness-simplification-root-cause.md
+++ b/docs/research/2026-07-27-harness-simplification-root-cause.md
@@ -23,10 +23,45 @@
 > concurrently, and found substantive defects without discarding the
 > implementation.
 >
+> A larger transcript-navigation replacement then exercised the resumable loop
+> under sustained pressure in PR #519. Six exact-diff attempts stayed in one
+> worktree while independent reviews found an unbounded segment scan, a
+> speaker-map paging-budget bypass, a pre-projection meeting cap, and missing
+> rollback/feed evidence. The final diff passed 2,548 Rust tests, Clippy, a real
+> Tauri/MCP boot, all three independent reviews, and remote Rust/Web/release
+> parity. This is strong evidence that v2 removed the old work-loss failure
+> mode; it is not evidence that repeated semantic review is cheap.
+>
+> The discovery/triage replacement in PR #520 supplied a second high-risk
+> field run. Two failed review attempts preserved the implementation while
+> exposing a split visibility source in `query_database` and a missing
+> executor-boundary proof for two loopback-only tools. The corrected exact diff
+> passed 2,554 Rust tests plus combined, lock-security, and egress-security
+> reviews with no findings or proof gaps. This run also exposed a remaining
+> development-path defect: `open` did not provision the pinned sibling
+> `murmur-server` checkout, so focused Cargo commands could not resolve the path
+> dependency until verification prepared it. PR #521 fixed that failure
+> fail-fast at `open`, preserved the no-server task shape, and passed 409 v2
+> selftest assertions, the configuration audit, independent review, and remote
+> CI. This is a control-plane fix, not a reason to restore an automatic writer.
+>
+> The read-time Decisions/Risks/Open Questions replacement in PR #522 supplied
+> a third high-risk field run. Successive exact-diff reviews preserved the
+> worktree while catching Polish `i/lub` parsing, an initially unbounded storage
+> read, ambiguity about local-MCP-only reachability, and a missing coherent
+> relock-before-response proof. The final design has no registry table,
+> migration, write-time cache, or model-facing tool: it derives bounded
+> historical context from currently visible notes and revalidates visibility
+> before sending the loopback response. The final local run passed 2,560 Rust
+> tests and combined, lock-security, and egress-security reviews with no
+> findings or proof gaps.
+>
 > One measured performance cost remains: each fresh exact-diff attempt gets a
 > new absolute verification-snapshot path, which invalidates part of Cargo's
-> path-sensitive fingerprinting even when the task target is retained. This is
-> an optimization follow-up, not a trust or resumability failure. V2 stays
+> path-sensitive fingerprinting even when the task target is retained. The
+> R3 attempts measured roughly three to four-and-a-half minutes of repeated
+> partial/cold build time from this effect. This is an optimization follow-up,
+> not a trust or resumability failure. V2 stays
 > opt-in; v1 remains only for existing tasks and externally anchored changes to
 > protected control-plane paths. The diagnosis below is the decision record, not
 > current operator instructions. Current commands live in
@@ -847,10 +882,18 @@ Evidence accumulated by 2026-07-28:
   `receipt-selftest`, and `config-audit` checks passed under the real check
   sandbox. Exact historical assertion counts are deliberately omitted here:
   task evidence binds outcomes and log hashes, not parsed count fields.
+- PR #519 kept six transcript-navigation attempts in one worktree and ended with
+  2,548 Rust tests, Clippy, real Tauri/MCP boot, three clean independent
+  reviews, and green remote integration lanes;
+- PR #520 kept two failed discovery/triage reviews resumable, then passed 2,554
+  Rust tests and the combined, lock, and egress reviews;
+- PR #521 repaired the server-dependency `open` preflight found by #520 and
+  passed the complete harness selftest/config-audit/review/remote-CI chain;
+- PR #522 kept multiple read-time decision-context corrections in one worktree,
+  then passed 2,560 Rust tests and all three high-risk reviews locally.
 
-This is meaningful operational evidence, but it is not the full ten-task corpus
-and does not yet cover the required Rust, Angular, mixed, and high-risk task
-distribution.
+This is meaningful operational evidence across Rust, Angular/mixed, and
+high-risk tasks, but it is not yet the full ten-task shadow corpus.
 
 ### Phase 3: cut over and delete — pending shadow budgets
 
@@ -897,8 +940,8 @@ Measure over a rolling 20-task window:
    corpus before the second general reviewer is removed.
 4. The optimal warm/cold runtime timeout needs measurement on the actual Mac.
 5. The typed reviewer probe broker and its no-arbitrary-shell boundary are
-   implemented and worked in the interrupted/resumed docs task. Broader real
-   Rust and high-risk runs remain outstanding; unrestricted reviewer Bash is
+   implemented and have now worked in multiple real Rust and high-risk runs.
+   The ten-task shadow budget remains incomplete; unrestricted reviewer Bash is
    still not recommended.
 6. Merge queue configuration itself was not changed in this research; the
    workflow now has the required `merge_group` trigger after #499.
@@ -930,6 +973,13 @@ Measure over a rolling 20-task window:
 - [Murmur PR #496](https://github.com/murmur-io/murmur/pull/496)
 - [Murmur PR #499](https://github.com/murmur-io/murmur/pull/499)
 - [Murmur PR #501](https://github.com/murmur-io/murmur/pull/501)
+- [Murmur PR #513](https://github.com/murmur-io/murmur/pull/513)
+- [Murmur PR #515](https://github.com/murmur-io/murmur/pull/515)
+- [Murmur PR #516](https://github.com/murmur-io/murmur/pull/516)
+- [Murmur PR #519](https://github.com/murmur-io/murmur/pull/519)
+- [Murmur PR #520](https://github.com/murmur-io/murmur/pull/520)
+- [Murmur PR #521](https://github.com/murmur-io/murmur/pull/521)
+- [Murmur PR #522](https://github.com/murmur-io/murmur/pull/522)
 
 ### External primary sources
 

--- a/docs/research/2026-07-27-harness-simplification-root-cause.md
+++ b/docs/research/2026-07-27-harness-simplification-root-cause.md
@@ -1,7 +1,7 @@
 <!-- Generated 2026-07-27 via /research (murmur-researcher fan-out). Pricing/funding/version = point-in-time. -->
 # Research: Harness root cause and simplification
 
-> **Implementation update — 2026-07-28.** The recommended verifier-only
+> **Implementation update — 2026-07-29.** The recommended verifier-only
 > architecture is now on `murmur`. PR #496 landed the v2 engine; #499 activated
 > the generation-aware CLI and resumable evidence lifecycle; #501 made
 > verification snapshots self-contained under Seatbelt; #513 made the shared
@@ -54,7 +54,8 @@
 > historical context from currently visible notes and revalidates visibility
 > before sending the loopback response. The final local run passed 2,560 Rust
 > tests and combined, lock-security, and egress-security reviews with no
-> findings or proof gaps.
+> findings or proof gaps; the merge receipt, Web lane, Rust lane, and
+> release-parity gate also passed remotely before #522 was merged.
 >
 > One measured performance cost remains: each fresh exact-diff attempt gets a
 > new absolute verification-snapshot path, which invalidates part of Cargo's

--- a/docs/research/2026-07-27-harness-simplification-root-cause.md
+++ b/docs/research/2026-07-27-harness-simplification-root-cause.md
@@ -2,19 +2,35 @@
 # Research: Harness root cause and simplification
 
 > **Implementation update — 2026-07-28.** The recommended verifier-only
-> architecture is now on `murmur`: PR #496 landed the v2 engine, PR #499
-> activated the generation-aware CLI and resumable evidence lifecycle, and PR
-> #501 made verification snapshots self-contained under Seatbelt. Guarded
-> receipts, the base-revision CI verifier, `merge_group` wiring, doctor/metrics,
-> lossless cleanup, and the sherpa archive fix from PR #478 are all merged. A
-> real interrupted/resumed docs task preserved its exact diff, recovered a stale
-> lock, reached `NEEDS_FIX` instead of a terminal loss, and exposed the snapshot
-> bug subsequently fixed by #501. V2 remains opt-in while the broader real-task
-> and high-risk shadow budgets below are incomplete; v1 remains only for
-> existing tasks and externally anchored changes to protected control-plane
-> paths. The diagnosis below is the decision record, not current operator
-> instructions. Current commands live in `.agents/harness/README.md` and
-> `.agents/skills/harness/SKILL.md`.
+> architecture is now on `murmur`. PR #496 landed the v2 engine; #499 activated
+> the generation-aware CLI and resumable evidence lifecycle; #501 made
+> verification snapshots self-contained under Seatbelt; #513 made the shared
+> Cargo lane FIFO, visible, and garbage-collected; #515 made focused
+> security-regression evidence available to reviewers; and #516 bound unchanged
+> source context at sensitive egress seams into the immutable review input.
+> Guarded exact-diff receipts, base-revision CI verification, `merge_group`
+> wiring, doctor/metrics, lossless cleanup, and the sherpa archive fix from #478
+> are all merged.
+>
+> The resulting operator loop is deliberately small:
+> `open -> edit normally -> plan/verify -> commit -> clean`. There is no model
+> writer or automatic repair loop inside v2. `NEEDS_FIX` and `NEEDS_EVIDENCE`
+> preserve the same task worktree and make the next exact diff a fresh,
+> reviewable attempt. Real trials have now exercised an interrupted/resumed docs
+> task, a full-stack settings/glossary task, and a high-risk MCP visibility and
+> transport task. They preserved bytes across failed evidence, showed queue
+> owner/PID/position instead of a silent lane wait, ran specialist reviews
+> concurrently, and found substantive defects without discarding the
+> implementation.
+>
+> One measured performance cost remains: each fresh exact-diff attempt gets a
+> new absolute verification-snapshot path, which invalidates part of Cargo's
+> path-sensitive fingerprinting even when the task target is retained. This is
+> an optimization follow-up, not a trust or resumability failure. V2 stays
+> opt-in; v1 remains only for existing tasks and externally anchored changes to
+> protected control-plane paths. The diagnosis below is the decision record, not
+> current operator instructions. Current commands live in
+> `.agents/harness/README.md` and `.agents/skills/harness/SKILL.md`.
 
 ## TL;DR / Verdict
 

--- a/docs/research/2026-07-27-harness-simplification-root-cause.md
+++ b/docs/research/2026-07-27-harness-simplification-root-cause.md
@@ -1,0 +1,927 @@
+<!-- Generated 2026-07-27 via /research (murmur-researcher fan-out). Pricing/funding/version = point-in-time. -->
+# Research: Harness root cause and simplification
+
+> **Implementation update — 2026-07-28.** The recommended verifier-only
+> architecture is now on `murmur`: PR #496 landed the v2 engine, PR #499
+> activated the generation-aware CLI and resumable evidence lifecycle, and PR
+> #501 made verification snapshots self-contained under Seatbelt. Guarded
+> receipts, the base-revision CI verifier, `merge_group` wiring, doctor/metrics,
+> lossless cleanup, and the sherpa archive fix from PR #478 are all merged. A
+> real interrupted/resumed docs task preserved its exact diff, recovered a stale
+> lock, reached `NEEDS_FIX` instead of a terminal loss, and exposed the snapshot
+> bug subsequently fixed by #501. V2 remains opt-in while the broader real-task
+> and high-risk shadow budgets below are incomplete; v1 remains only for
+> existing tasks and externally anchored changes to protected control-plane
+> paths. The diagnosis below is the decision record, not current operator
+> instructions. Current commands live in `.agents/harness/README.md` and
+> `.agents/skills/harness/SKILL.md`.
+
+## TL;DR / Verdict
+
+The v1 harness is not suitable as Murmur's default feature-development loop.
+The field reports are directionally correct: the independent review primitive works,
+but the operations surrounding it make good work slow, fragile, and sometimes
+practically unrecoverable.
+
+The root cause is not "too much rigor" in the abstract. It is **architectural
+coupling**: one synchronous state machine currently acts as all of these at once:
+
+1. a model-driven developer and repair loop;
+2. a worktree manager;
+3. a semantic-risk classifier and test planner;
+4. a global build-resource scheduler;
+5. an evidence collector;
+6. a multi-reviewer adjudicator;
+7. a commit/PR provenance system.
+
+Those responsibilities fail differently, but the harness collapses most failures
+into one terminal `BLOCKED` state. A missing proof artifact, HTTP 429, reviewer
+timeout, occupied runtime port, interrupted process, stale instruction hash, test
+failure, and a genuinely unsafe implementation can all have effectively the same
+lifecycle consequence.
+
+The recommended direction is **Harness v2 as a thin, resumable verifier over an
+existing diff**, not another patch series on the current automatic writer loop:
+
+- development happens normally in an isolated worktree;
+- the harness derives the actual changed surfaces from the diff;
+- runner-owned checks execute once for that diff;
+- one fresh reviewer combines specification and adversarial review;
+- only lock/egress/protocol changes add a concurrent specialist reviewer;
+- every non-PASS result is resumable in the same worktree;
+- an exact-diff evidence receipt is still required before commit;
+- GitHub CI remains the integration/release-parity truth.
+
+This preserves the differentiating value that caught real defects while deleting
+the machinery responsible for most lost time.
+
+At the diagnosis snapshot, the separate symptom, "Claude says it will start the
+next task and then stops," had two operational causes:
+
+- **between turns:** there is no durable program queue or continuation mechanism in
+  the harness; `run` accepts one task, and Claude auto mode does not begin another
+  turn by itself;
+- **inside a command:** the Cargo lane waits silently, so an invoked command can
+  look frozen.
+
+Program continuation remains deliberately outside the verifier and should use a
+session-scoped Claude `/goal` (or, only if later justified, a tiny external
+queue). The silent wait is fixed in v2-era resource tooling: lane ownership and
+heartbeats are visible. Neither concern belongs in the trust receipt.
+
+**Current operating decision (2026-07-28):** do not open new v1 feature tasks.
+Use v2 selectively for changes that need an independently earned receipt; ordinary
+low-risk work stays outside the opt-in harness. Finish/import existing v1 tasks,
+and use externally anchored v1 only when a change owns protected harness or agent
+control-plane files that v2 must refuse to self-certify.
+
+Confidence: **high**. The conclusion is supported by current code, the local task
+corpus, live process/state evidence, GitHub state, and four independent research
+angles.
+
+## What Murmur already has
+
+The harness contains a good verification kernel. It should be retained rather than
+discarded:
+
+- the runner, not the writer, stages and derives the owned diff
+  (`.agents/harness/task_runner.py:1035-1065`);
+- deterministic checks run before review, and the runner verifies that review did
+  not mutate the tree (`.agents/harness/task_runner.py:3238-3379`);
+- reviewers are fresh and receive the exact diff plus check evidence
+  (`.agents/harness/task_runner.py:2619-2651`,
+  `.agents/harness/task_runner.py:3385-3431`);
+- commit trailers bind the parent and normalized diff, and CI recomputes them
+  (`.agents/harness/task_runner.py:4524-4556`,
+  `scripts/verify-harness-attestation:262-331`);
+- specialist lock/egress/protocol reviews already exist
+  (`.agents/harness/config.json:26-41`);
+- the implementer is not allowed to certify its own result
+  (`.agents/harness/prompts/implementer.md:7-14`).
+
+The reports are also right that this kernel has delivered real value. Independent
+reviewers caught defects that deterministic tests missed, including failures in
+orchestrator-authored code. Removing independent review would solve the wrong
+problem.
+
+### Implementation size at the diagnosis snapshot
+
+At the 2026-07-27 diagnosis snapshot, the primary v1 harness/control-plane
+scripts were already approximately 10.9k lines before counting all selftests and
+surrounding skills:
+
+- `.agents/harness/task_runner.py`: 6,999 lines;
+- `.agents/harness/hook_guard.py`: 2,108 lines;
+- `.agents/harness/resource_policy.py`: 703 lines;
+- `scripts/agent-resource-run`: 397 lines;
+- `scripts/harness-runtime-smoke.py`: 211 lines;
+- plus configuration, schemas, prompts, wrappers, and CI glue.
+
+Those counts are historical, not a current trunk inventory: #496/#499 added the
+separate v2 engine and its fault/selftests, and v1 also changed during the
+bootstrap. The architectural conclusion is unchanged: adding resume, mutation
+testing, prompt NLP, reviewer retries, parallel review, re-attestation, program
+scheduling, telemetry, and more terminal states directly to v1 would preserve the
+wrong abstraction and expand its invalid-state space.
+
+### Corrections to the supplied reports
+
+The reports describe real incidents, but several claims need to be reconciled with
+the current checkout and live GitHub state.
+
+| Claim | Current finding |
+|---|---|
+| `--base` defaults to `HEAD` | Fixed in code: init now fetches and defaults to `origin/murmur` (`task_runner.py:3987-4037`). CLI help and the local `pr-program` prose are stale and still say `HEAD` (`task_runner.py:6911`). |
+| Init never prunes worktrees | Both repositories are now pruned at init (`task_runner.py:700-713`, `4127-4131`). A discoverable archival `clean` path and routine GC are still missing. |
+| A timed-out writer always loses its tree | Fixed in current code: a timed-out writer can proceed as degraded (`task_runner.py:2468-2492`). Earlier degraded work can still be laundered out of the final attestation by a later clean round. |
+| Any trunk movement invalidates a harness PR | Too broad. The remote verifier explicitly permits a legitimate catch-up merge from the base branch (`scripts/verify-harness-attestation:78-128,291-331`). PR #477's attestation gate passed; its failing lane was web/E2E. The local `verify`/`close` lifecycle remains overly tied to the original base and one-parent shape. |
+| Harness-owned files have no supported workflow | Current code has `--kind harness` plus `seal-prepared` (`task_runner.py:3982`, `4217-4319`). The workflow is obscure, but O14 is not an open capability gap. |
+| A `BLOCKED` task's bytes are literally destroyed | Too strong in current code. Work generally remains staged, and `reap` archives Git-visible bytes under a hidden ref (`task_runner.py:4604-4805`). The real defect is that recovery is obscure, non-resumable, and easy to do incorrectly. |
+| PR #478 fixed the sherpa archive issue and is merged | This was false at the 2026-07-27 snapshot, but became true on 2026-07-28: PR #478 is merged and trunk contains the `.agents/harness/checks/` marker. |
+| The runner restored/deleted primary-checkout control-plane edits | Not supported by the inspected code. Staging/reset logic targets the isolated task worktree (`task_runner.py:1035-1065`). The incident needs separate reproduction; another agent or trunk update is currently more plausible. |
+
+These corrections do not change the verdict. They narrow the redesign to the
+failures that still exist.
+
+## Findings
+
+Every finding in this section describes Harness v1 at the 2026-07-27 diagnosis
+snapshot unless a later status paragraph explicitly says that v2 landed the
+repair. Current operator instructions live in `.agents/harness/README.md` and
+the Harness skill, not in this historical diagnosis.
+
+### 1. The strongest observed v1 root cause was stale state without liveness
+
+At the 2026-07-27 snapshot, the local v1 task corpus contained 122 task
+directories:
+
+| Persisted state | Count |
+|---|---:|
+| `REAPED` | 34 |
+| `BLOCKED` | 31 |
+| `CLOSED` | 17 |
+| `INITIALIZED` | 14 |
+| `FAILED` | 12 |
+| `CHECKING` | 9 |
+| `RUNNING` | 4 |
+| `PASSED` | 1 |
+
+All 27 persisted non-terminal tasks (`INITIALIZED`, `CHECKING`, `RUNNING`) had no
+`run.lock`. Only seven still had a worktree; twenty had neither a live runner nor
+the worktree implied by their state. These are **ghost tasks**, not merely old task
+records.
+
+The current `ux-p4-settings-ia-20260727` task was a concrete reproduction:
+
+- state remained `CHECKING`, round 2;
+- round-2 writer, vocabulary, lint, and build evidence had completed;
+- Playwright output continued but no final check event was persisted;
+- there was no task lock and no harness runner process;
+- an outer Claude process was observed sleeping and polling `status` for that ghost
+  instead of starting or resuming work.
+
+The code explains the persistence:
+
+- `status` prints persisted JSON and does not reconcile it with `run.lock`
+  (`task_runner.py:4322-4337`);
+- cancellation can bypass the `HarnessError` path that writes a terminal state,
+  while `finally` removes the lock (`task_runner.py:3532-3548,6985-6999`);
+- another `run` refuses a prior non-`INITIALIZED` state and converts it to terminal
+  `BLOCKED` rather than resuming (`task_runner.py:3158-3193`).
+
+This is the highest-confidence explanation for the observed "polling forever"
+failure. A persisted phase without a live owner is being treated as progress.
+
+Confidence: **high**. Sources: current task store and code paths above.
+
+### 2. Risk classification is incorrectly used as the test planner
+
+The current model conflates four independent decisions:
+
+1. which language/build surface changed;
+2. whether the content is security-sensitive;
+3. whether a behavioral runtime/performance claim is being made;
+4. which evidence is required for the receipt.
+
+`classify_risks()` classifies broad owned paths, and
+`required_risk_evidence()` maps those semantic flags directly to commands
+(`task_runner.py:548-630`). The configuration maps:
+
+- lock/egress/protocol to `rust-lib`;
+- runtime to `tauri-boot`;
+- performance to `perf-contracts`
+  (`.agents/harness/config.json:35-50`).
+
+`transcribe/**` is classified as runtime and performance
+(`config.json:92-118`). Therefore a Rust string-rendering fix can schedule a
+full application boot and performance contracts while omitting `cargo test --lib`.
+This exactly confirms P0-1.
+
+Adding another risk glob is not the right fix. **Test selection must begin with the
+actual changed language surface**, while risk classification should decide only
+specialist review and non-suppressible security evidence.
+
+Recommended separation:
+
+- changed Rust source -> `rust-lib` minimum;
+- changed Angular source -> `ng-lint` + `ng-build`; Playwright when behavior/UI is
+  involved;
+- changed shared protocol -> client and server protocol tests;
+- actual sensitive lock/egress/protocol path -> specialist review;
+- runtime boot/performance -> explicit claim/profile, never inferred merely from a
+  directory name.
+
+Confidence: **high**. Sources: code/config and the R1/R2 task evidence.
+
+### 3. The prose contract can demand evidence that no authorized role can create
+
+The writer is explicitly told that runner-owned checks are authoritative
+(`implementer.md:7-14`). Claude reviewers are launched with only
+`Read,Grep,Glob`, no Bash (`task_runner.py:2363-2372`). Codex reviewers use a
+read-only workspace profile (`task_runner.py:2292-2344`).
+
+At the same time, the spec reviewer must reject missing evidence. A prompt that
+says "run clippy" or "prove RED-before-GREEN" therefore creates a structurally
+unsatisfiable contract:
+
+- the writer's claim is not authoritative;
+- the runner did not schedule the command;
+- the reviewer is not allowed to run it;
+- the reviewer correctly blocks.
+
+This confirms P0-2, P0-3, O11, and O13. It also explains why repeated rounds with
+correct code could never satisfy the contract.
+
+Do not fix this with prompt scanning or a generic mutation engine:
+
+- prose should contain behavior and acceptance criteria only;
+- executable evidence should be a typed profile owned by the runner;
+- init/verify should print the fully resolved check/reviewer plan;
+- missing evidence should yield resumable `NEEDS_EVIDENCE`;
+- a reviewer that needs a targeted empirical probe should request an allowlisted
+  runner-owned check, not receive unrestricted Bash.
+
+For ordinary bug fixes, the first slice should require a regression test plus the
+appropriate language suite. A true RED proof can later be an explicit
+`regression-proof` profile that applies only the test patch to an ephemeral base.
+If it cannot be reproduced safely, record a `proof_gap`; never substitute writer
+prose as evidence.
+
+Claude's sandbox supports exact write paths rather than disabling isolation, so a
+bounded runner-owned probe is compatible with the security boundary:
+[Claude sandbox documentation](https://code.claude.com/docs/en/sandboxing).
+
+Confidence: **high**.
+
+### 4. `BLOCKED` is an overloaded terminal state
+
+`BLOCKED` is terminal (`task_runner.py:44-46`). Current paths use it for:
+
+- interrupted/prior incomplete runs;
+- writer self-report;
+- environment probes;
+- deterministic check failure after repair exhaustion;
+- reviewer uncertainty or failure;
+- model errors and timeouts;
+- instruction drift;
+- harness exceptions
+  (`task_runner.py:3158-3548`).
+
+There is no `resume`, `retry`, `amend`, or `salvage` subcommand in the CLI
+(`task_runner.py:6881-6973`).
+
+This turns recoverable facts into destructive lifecycle outcomes. The correct
+model is an append-only attempt ledger in a persistent task:
+
+```text
+OPEN -> VERIFYING -> PASS -> COMMITTED -> CLOSED
+            |
+            +-> NEEDS_FIX
+            +-> NEEDS_EVIDENCE
+            +-> PAUSED_RETRYABLE
+            +-> INTERRUPTED
+```
+
+Only `CLOSED` and explicit `ABANDONED` should be terminal. Every other state keeps
+the worktree and can be resumed from the last durable phase, provided the diff hash
+still matches.
+
+Confidence: **high**.
+
+### 5. Writer self-report has too much lifecycle authority
+
+The runner exits before staging or deterministic checks whenever the writer
+returns `status=blocked` (`task_runner.py:3197-3228`).
+
+The local corpus contains 18 writer-terminal blocks:
+
+- 9 treated inability to write `.git/index.lock` or stage as fatal, even though the
+  runner owns staging;
+- 6 treated occupied runtime/check infrastructure as the writer's blocker;
+- 3 represented genuine scope or implementation uncertainty.
+
+Thus 15/18 were boundary confusion rather than evidence that the produced tree was
+invalid. The runner should inspect and stage a valid owned diff even when the
+writer's narrative says "blocked." Writer status is useful feedback, not a trust
+verdict.
+
+Confidence: **high**. Source: aggregate local model/event logs.
+
+### 6. Reviews are duplicated, serial, and can skip the adversarial review
+
+Every default task requires both spec and adversarial review
+(`config.json:26-29`). They run in a serial loop and short-circuit on the first
+non-PASS (`task_runner.py:3381-3438`).
+
+Observed across the local corpus:
+
+- 49 review rounds;
+- 20/49 ran spec review but never reached adversarial review;
+- the longest review round ran five reviewers sequentially for 35.6 minutes;
+- recorded reviewer time totals 6.2 hours.
+
+This is both slower and weaker than the intended invariant: the adversarial
+reviewer does not always get to try to break the change.
+
+The default topology should be:
+
+1. one fresh reviewer combining acceptance/spec coverage and adversarial
+   correctness;
+2. one additional specialist only for actual lock/egress/protocol paths;
+3. independent reviewers run concurrently, capped at 2-3;
+4. aggregate the worst verdict; never short-circuit.
+
+This is a hypothesis that must be evaluated against the historical caught-defect
+set before the separate spec process is deleted. Independence means "fresh and
+separate from the writer," not "two sequential generalists."
+
+Confidence: **high** for current cost/topology, **medium** until the combined
+reviewer replay is measured.
+
+### 7. Two current trust-plane defects can overstate PASS
+
+These must be fixed even if v1 is otherwise frozen.
+
+#### Earlier degraded writer rounds disappear
+
+`create_attestation()` reads `writer_runs[-1]`
+(`task_runner.py:2919-2931`). If round 1 timed out and round 2 completed cleanly,
+the attestation can omit degradation even though the final tree contains work from
+round 1. Repair prompts and reviewer context likewise focus on the current round.
+
+The receipt must aggregate provenance from **every contributing attempt**.
+
+#### PASS can contain unresolved MAJOR/BLOCKER findings
+
+The review schema permits any verdict/findings combination
+(`.agents/harness/schemas/review.schema.json:7-24`). Runtime logic primarily
+consumes `verdict`, and the attestation review summary omits the findings array
+(`task_runner.py:2955-2974`).
+
+The invariant must be:
+
+```text
+PASS => no unresolved BLOCKER or MAJOR findings
+```
+
+All findings must be included in the evidence bundle. This should auto-block now,
+not merely print a warning later; the historical corpus already contains
+MAJOR/BLOCKER findings inside PASS verdicts.
+
+Confidence: **high**.
+
+### 8. Model and infrastructure failures are classified as verdict failures
+
+A reviewer process error or timeout is fatal; writer timeout has a degraded path,
+but reviewers do not (`task_runner.py:2466-2511`). The parser retains only model
+and session ID, discarding useful terminal reason, cost, turns, and usage
+(`task_runner.py:2189-2219`). Four observed HTTP 429 results became terminal
+blocks.
+
+Anthropic classifies rate limits and 5xx errors as transient and its official SDKs
+retry them with exponential backoff, honoring `retry-after` when present:
+[Claude API errors](https://platform.claude.com/docs/en/api/errors).
+
+The harness should:
+
+- perform one bounded retry for 429/5xx/network failure and reviewer timeout;
+- honor `retry-after`;
+- then enter `PAUSED_RETRYABLE`, preserving the diff and prior evidence;
+- never rerun the writer or completed checks solely because a reviewer API call
+  failed;
+- record terminal reason, duration, cost, turns, and usage in the attempt ledger.
+
+Confidence: **high**.
+
+### 9. The global Cargo lane should remain, but waiting must be observable
+
+Serializing the heavy Cargo build on this Mac is reasonable. The defect is that
+both lane implementations poll silently and reveal ownership only after the full
+deadline (`scripts/agent-resource-run:223-264`,
+`task_runner.py:1690-1728`). Check evidence is written only after the command
+completes, so historical lane wait and command runtime cannot be separated.
+
+Every resource acquisition should immediately emit:
+
+```text
+waiting for cargo lane:
+  owner_pid=<pid>
+  task=<task-id>
+  command=<short command>
+  since=<timestamp>
+  heartbeat=<timestamp>
+```
+
+Repeat at 30-second intervals. Separate at least `cargo` and `runtime-ports`
+resources; do not serialize unrelated read-only work behind one opaque mutex.
+
+Lane contention can explain an invoked command appearing frozen. It cannot explain
+Claude ending a turn without issuing the next command.
+
+Confidence: **high**.
+
+### 10. "Claude says next and stops" is not a harness task transition
+
+The harness wrapper executes one Python command, and `run` accepts exactly one task
+ID (`scripts/agent-harness:1`, `task_runner.py:6918-6925`). There is no program
+queue, `next`, or durable dispatcher. `.claude/settings.json` configures
+`PreToolUse` and `PostToolUse`, but no Stop continuation
+(`.claude/settings.json:35-54`).
+
+Claude's official documentation is explicit:
+
+- auto mode approves tool use within a turn but does not start another turn;
+- `/goal` keeps working across turns until a measurable condition is met;
+- `/goal` is session-scoped and supported from Claude Code 2.1.139;
+- non-interactive default text output can itself look stuck, so
+  `--output-format stream-json --verbose` should be used.
+
+Source: [Claude Code `/goal`](https://code.claude.com/docs/en/goal).
+The installed Claude Code version observed during this research was 2.1.220.
+
+Immediate recommendation for a multi-PR program:
+
+```text
+/goal Continue until every item in <program manifest> is in a stable state
+(merged, needs-user-authority, or explicitly abandoned), and surface the next
+task action within 60 seconds of the prior item stabilizing.
+```
+
+Do not install a permanent repository-wide Stop hook as the first fix. A
+session-scoped goal is easier to bound and inspect. If programs must survive
+process/session loss, add a tiny external `program.json` queue after task liveness
+is repaired; do not put multi-PR orchestration back into the verifier.
+
+Confidence: **high** for the missing mechanism, **medium** for the exact reason a
+particular historical Claude turn ended because the outer transcript was not
+available.
+
+### 11. The primary-checkout orchestrator has an avoidable blast radius
+
+Current hook protections are activated when the working directory belongs to an
+active task. The primary checkout normally does not, so branch surgery and
+unserialized operations there do not receive the same task guard
+(`hook_guard.py:469-490,643-705`).
+
+At the same time, the instruction hash reads live control-plane files from that
+checkout (`task_runner.py:633-697`). Normal harness development or trunk movement
+can therefore invalidate an in-flight task's control-plane fingerprint.
+
+The driver should run in a dedicated long-lived orchestrator worktree and should
+never merge locally:
+
+- create PRs and merge server-side;
+- fetch the resulting trunk;
+- leave the user's primary checkout and live dev app untouched;
+- snapshot a small immutable verification protocol bundle per attempt instead of
+  hashing mutable live source throughout a long task.
+
+Confidence: **high** for the code architecture; the reported O17 deletion event
+was not reproduced.
+
+### 12. Runtime/performance checks are behavior claims, not directory defaults
+
+The current `runtime` inference can schedule `tauri-boot` for broad Rust changes.
+Port occupancy is checked only in the check phase, after the writer, and the cold
+boot uses a fixed 240-second wait (`scripts/harness-runtime-smoke.py:119-145`).
+This explains both the late "installed Murmur owns the port" block and the cold
+build timeout/warm rerun pass.
+
+V2 should:
+
+- require runtime/performance profiles explicitly;
+- run port and prerequisite preflight before any model work;
+- distinguish cold and warm boot budgets;
+- keep the correct rule that unknown processes are never killed;
+- treat occupied user-owned ports as `PAUSED_RETRYABLE`, not a verdict.
+
+Confidence: **high**.
+
+### 13. The measured v1 cost was incompatible with a default development loop
+
+The 2026-07-27 aggregate local snapshot contained:
+
+- 274 recorded model invocations;
+- writers: 162 invocations, 19.4 model-hours, median 227 s, p90 1,138 s;
+- reviewers: 112 invocations, 6.2 model-hours, median 117 s, p90 428 s;
+- deterministic checks: 430 executions, 13.0 hours;
+- `rust-lib`: 6.53 hours;
+- Playwright: 2.71 hours.
+
+The 176 Claude invocations with terminal billing metadata total approximately
+$975.81 and 7,885 turns. The UX P0-P4 attempts alone consumed approximately
+$224.44, 1,861 Claude turns, and at least 6.1 serialized hours; only P0 completed
+the harness lifecycle.
+
+These are not clean product KPIs: the corpus includes harness development,
+selftests, retries, and earlier task generations, and Codex cost is not included.
+They are nevertheless decisive operational evidence that the current loop cannot
+be the default way to build features.
+
+Confidence: **high** for the aggregate, with the scope caveat above.
+
+## Target design: Harness v2
+
+### System boundary
+
+```text
+developer/orchestrator worktree
+  writes and iterates normally
+            |
+            v
+thin verifier on exact diff
+  surface checks -> fresh review(s) -> evidence receipt
+            |
+            v
+normal commit / PR
+            |
+            v
+GitHub CI or merge queue on current trunk
+```
+
+The verifier should not own feature decomposition, automatic repair, multi-PR
+scheduling, local merging, or publication.
+
+### Responsibility map
+
+| Component | Owns | Does not own |
+|---|---|---|
+| Developer agent | implementation, targeted inner-loop tests, fixing findings | final verdict |
+| Worktree helper | create/list/archive/clean, optional sibling repo only when touched | checks or review |
+| Verification runner | actual-diff classification, canonical checks, evidence, resource lanes | implementation decisions |
+| Fresh reviewer | acceptance + adversarial correctness; targeted probe requests | arbitrary shell, staging, mutation |
+| Security specialist | lock/egress/protocol review when actual sensitive paths changed | general duplicate review |
+| GitHub CI / merge queue | integration with latest trunk, full release-parity gate | local implementation |
+| Operator | push, PR, merge, credentials/signing/publication | routine verifier internals |
+
+### Two profiles, not an open-ended risk matrix
+
+#### Standard
+
+Derived from actual changed files:
+
+- Rust source: `cargo test --lib` once per final diff;
+- Angular source: `ng lint` + `ng build`;
+- behavioral UI change: relevant Playwright smoke;
+- shared protocol: client + server protocol tests;
+- one fresh combined spec/adversarial reviewer.
+
+The full `scripts/ci.sh` remains a PR/release-parity gate, not a repair-round
+inner loop.
+
+#### High-risk
+
+Standard profile plus one concurrent cross-vendor specialist for actual:
+
+- lock/crypto/content visibility;
+- cloud egress/redaction/ledger;
+- shared protocol/wire format.
+
+`runtime` and `performance` are explicit optional claim profiles. They are not
+semantic risk flags.
+
+### Minimal command surface
+
+```text
+harness open <task> --prompt-file <path> --owned <path>...
+harness plan <task>
+harness verify <task>
+harness resume <task>
+harness status <task>
+harness commit <task> -m <message>
+harness clean <task>
+```
+
+`verify` is idempotent for an unchanged diff. A changed diff invalidates only the
+affected check/review receipts. No automatic writer or repair rounds exist in the
+verifier.
+
+If a model-assisted repair convenience is retained, it should be a separate
+command that operates on the same worktree and prior findings:
+
+```text
+harness amend <task>
+```
+
+It must not be part of the trust state machine.
+
+### Evidence model
+
+Each attempt snapshots:
+
+- base and head/diff identity;
+- actual changed files and resolved profile;
+- small immutable protocol bundle version;
+- a runner-owned, shallow, self-contained Git repository for the exact planned
+  tree, with non-empty or unsafe object alternates rejected;
+- check IDs, commands, exit codes, duration, stdout/stderr digests;
+- reviewer identity/session, verdict, all findings, and proof gaps;
+- model degradation from every contributing attempt;
+- retry/infra classification and resource-wait duration.
+
+The commit receipt remains presence-and-consistency evidence, not a signing
+system:
+
+```text
+Harness-Version: 2
+Harness-Task: <id>
+Harness-Verdict: PASS
+Harness-Base: <actual parent>
+Harness-Diff-Sha256: <exact normalized diff>
+Harness-Evidence-Sha256: <checks + reviews + protocol bundle>
+Harness-Writer-Degraded: <optional aggregate>
+```
+
+Do not replace the exact diff hash with `git patch-id`: Git documents patch IDs as
+stable under line-number and whitespace changes, which is useful for advisory
+equivalence but not exact security/provenance identity:
+[git patch-id](https://git-scm.com/docs/git-patch-id).
+
+### Moving trunk
+
+The current remote receipt verifier already supports a legitimate catch-up merge.
+The local lifecycle should stop insisting that the worktree remain at the original
+single-parent tree after verification.
+
+For sustained multi-PR programs, GitHub's merge queue is the cleaner integration
+solution: it tests queued changes against the latest target without requiring each
+author to update and rerun the branch manually. PR #499 added the distinct
+`merge_group` workflow trigger and its local attestation self-check; only
+enabling and configuring the repository merge queue remains optional future
+operator work, not a Harness v2 prerequisite:
+[GitHub merge queue documentation](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue).
+
+## Fit with Murmur constraints
+
+### Local-first and privacy
+
+No hosted scheduler, telemetry SaaS, or durable-execution service is needed.
+Task state, logs, diffs, and receipts remain local. Existing source-code review
+egress does not expand to note/audio/user data.
+
+### Obsidian-native, SQLite-canonical, provider seam
+
+Unaffected. This is a development control-plane redesign. It must not create new
+product data stores or AI-provider paths.
+
+### macOS and heavy local builds
+
+Keep OS sandboxing and the serialized Cargo lane. Add visibility and bounded
+runner-owned probes instead of widening reviewers to unrestricted Bash or `.git`.
+Runtime/TCC/ScreenCaptureKit evidence remains explicit Mac evidence rather than a
+directory-name inference.
+
+### Lock model and cloud egress
+
+Keep mandatory specialist review for actual lock/crypto/content-read and egress
+paths. Simplification must reduce duplicate general review, not security-specific
+coverage.
+
+### CI honesty
+
+Local verification is a change-specific evidence set. `scripts/ci.sh` and GitHub
+remain full integration/release gates. Since PR #499, `scripts/ci.sh` runs
+`scripts/verify-harness-attestation --selftest`, GitHub verifies receipts from the
+base revision, and the workflow handles `merge_group`. This closes the local
+self-check and merge-queue wiring gaps identified in the original snapshot.
+
+### One-person operation
+
+Avoid Temporal/Restate/DBOS, a database-backed scheduler, signing infrastructure,
+approval workflows, or an always-on service. Borrow checkpoint/retry semantics,
+not their operational footprint.
+
+## Options and tradeoffs
+
+### Option A: patch all open v1 defects
+
+Effort: **L**
+Risk: **very high**
+Unlocks: incremental compatibility, but preserves the monolith.
+
+This would add more states and heuristics to an already large control plane:
+resume, salvage, mutation testing, prompt analysis, retry policy, parallel review,
+re-attestation, queueing, telemetry, and expanded selftests. It fixes incidents
+one at a time without correcting responsibility boundaries.
+
+**Reject.**
+
+### Option B: thin resumable verifier v2
+
+Effort: **M**
+Risk: **medium**
+Unlocks: normal development speed while preserving independent, exact-diff
+verification.
+
+This was the recommended option and is now built beside v1. It reuses the proven
+diff/check/receipt primitives without carrying the automatic writer/repair
+topology into v2.
+
+### Option C: retire the harness entirely
+
+Effort: **S**
+Risk: **medium/high**
+Unlocks: immediate speed and simplicity.
+
+Normal feature branches, project CI, a fresh adversarial reviewer, and specialist
+security review would still be much better than unreviewed work. However, this
+loses enforced exact-diff receipts and makes it easier to accidentally bypass the
+verdict, which already happened operationally.
+
+Use this only as the **temporary low-risk operating mode** while Option B is built,
+not as the target.
+
+## Recommendation and first step
+
+### Decision
+
+Option B was selected and landed in PRs #496 and #499. Do not revive the proposed
+23-defect patch list as 23 independent v1 fixes. The remaining work is shadow
+validation, migration, and eventual deletion of obsolete v1 topology.
+
+### Phase 0: safety bridge and freeze — substantially landed
+
+The diagnosis proposed freezing new v1 low/normal tasks and making only the
+changes needed to stop false PASS and work loss while v2 was built:
+
+1. any changed `src-tauri/src/**` schedules `rust-lib` — **landed in v2**;
+2. aggregate degraded provenance across every contributing attempt — **landed
+   in v2**;
+3. enforce `PASS => no unresolved MAJOR/BLOCKER` — **landed in v2**;
+4. detect stale non-terminal state from missing/dead `run.lock` and resume from
+   the existing diff/check cursor — **landed in v2**;
+5. one bounded retry for 429/reviewer timeout, then `PAUSED_RETRYABLE` —
+   **landed in v2**;
+6. visible lane owner within two seconds and every 30 seconds — **landed in the
+   shared resource tooling**;
+7. land or replace the then-open #478 sherpa marker fix (merged 2026-07-28).
+
+The related `--prompt-file`, runtime preflight, and lossless archival `clean`
+capabilities landed in v2 where applicable. They are not a mandate to broaden
+the compatibility-only v1 state machine. Prompt NLP, a generic mutation engine,
+and more inferred risk flags remain intentionally absent.
+
+### Phase 1: build v2 beside v1 — landed in #496/#499
+
+Use a separate metadata namespace and dual receipt support. Reuse:
+
+- worktree/diff derivation;
+- canonical check execution;
+- fresh reviewer adapters;
+- exact receipt verification.
+
+Do not reuse:
+
+- automatic writer/repair loop;
+- serial spec + adversarial topology;
+- terminal `BLOCKED`;
+- prose command requirements;
+- runtime/performance path inference;
+- live mutable instruction hashing;
+- unconditional sibling-server worktree creation;
+- PR/program orchestration.
+
+### Phase 2: adversarial shadow — in progress
+
+Before replacing v1:
+
+1. replay the historical set of caught MAJOR defects through the combined reviewer;
+2. run at least ten real tasks: two Rust, two Angular, one mixed, and at least one
+   lock/egress/protocol task;
+3. fault-inject HTTP 429, reviewer timeout, kill during a check, occupied ports,
+   lane contention, and trunk movement;
+4. prove no scenario reruns the writer or loses the diff;
+5. compare defects caught, not merely green selftests.
+
+Evidence accumulated by 2026-07-28:
+
+- a real docs task was interrupted during review, then `resume` repaired its
+  stale lock without changing the bound diff or discarding the interrupted log;
+- the resumed reviewer returned `NEEDS_FIX` and requested typed probes instead
+  of turning missing evidence into a terminal task;
+- the requested `harness-v2-selftest` probe exposed a verification snapshot that
+  borrowed objects from the standalone driver; PR #501 replaced it with a
+  self-contained snapshot and added direct/inherited Seatbelt, reconstruction,
+  exact-tree, and scoped-cleanup regressions;
+- task `continuity-research-refresh-v2` preserved the interrupted diff; the
+  corrective control-plane task
+  `harness-v2-selfcontained-probe-v4-20260728` carried the independently
+  reviewed #501 receipt;
+- the externally anchored `harness-v2-selftest`, `hook-selftest`,
+  `receipt-selftest`, and `config-audit` checks passed under the real check
+  sandbox. Exact historical assertion counts are deliberately omitted here:
+  task evidence binds outcomes and log hashes, not parsed count fields.
+
+This is meaningful operational evidence, but it is not the full ten-task corpus
+and does not yet cover the required Rust, Angular, mixed, and high-risk task
+distribution.
+
+### Phase 3: cut over and delete — pending shadow budgets
+
+- finish already `PASSED`/`COMMITTED` tasks with v1;
+- import live/stale worktrees into v2 as `OPEN` or `NEEDS_EVIDENCE` without
+  rerunning writers;
+- retain v1 read-only verification/close support for 30 days;
+- archive, then explicitly GC selected old tasks;
+- delete the v1 automatic writer/repair and serial-review machinery after the
+  shadow budgets pass.
+
+The migration rule from that snapshot remains: archive and classify the legacy
+task store before GC; never bulk-delete it merely because persisted state is
+stale. Current counts must come from `agent-harness doctor`, not this document.
+
+### Success budgets
+
+Measure over a rolling 20-task window:
+
+- preflight and resolved plan visible in <=15 s, excluding a bounded remote fetch;
+- lane owner visible in <=2 s and repeated every 30 s;
+- zero diffs lost or writers rerun because of timeout, 429, occupied port,
+  instruction drift, failed check, missing evidence, or trunk movement;
+- zero terminal infrastructure failures;
+- non-runtime verification p50 <=10 min, p90 <=20 min;
+- high-risk verification p90 <=30 min;
+- end-to-end non-runtime task p90 <=45 min;
+- >=90% of tasks reach `PASS`, `NEEDS_FIX`, or `NEEDS_EVIDENCE` without operator
+  cleanup;
+- 100% of PASS commits have a recomputable exact-diff receipt;
+- combined reviewer catches the historical MAJOR set at least as well as the
+  current two-general-reviewer topology;
+- with `/goal` active, the next program action begins within 60 s of the prior
+  task reaching a stable state.
+
+## Open questions / not verified
+
+1. The exact outer Claude transcript where it announced R2 and stopped was not
+   available. The missing continuation mechanism and live ghost polling were
+   verified; the exact turn-ending cause remains unknown.
+2. The reported deletion/restoration of uncommitted control-plane files was not
+   reproduced and is not explained by the inspected runner paths.
+3. A combined spec/adversarial reviewer must be tested on the historical defect
+   corpus before the second general reviewer is removed.
+4. The optimal warm/cold runtime timeout needs measurement on the actual Mac.
+5. The typed reviewer probe broker and its no-arbitrary-shell boundary are
+   implemented and worked in the interrupted/resumed docs task. Broader real
+   Rust and high-risk runs remain outstanding; unrestricted reviewer Bash is
+   still not recommended.
+6. Merge queue configuration itself was not changed in this research; the
+   workflow now has the required `merge_group` trigger after #499.
+7. The local task corpus spans harness development and selftests, so its aggregate
+   cost/state counts are operational evidence, not a clean production success
+   rate.
+
+## Sources
+
+### Repository and local evidence
+
+- `.agents/harness/task_runner.py:44-46,548-697,1035-1065,1298-1320,1690-2025,2189-2219,2292-2372,2466-2511,2619-2651,2919-3023,3142-3548,3699-3948,3982-4319,4322-4337,4524-4805,4889-5070,6881-6999`
+- `.agents/harness/cli.py` and
+  `.agents/harness/v2_{selftest,fault_selftest}.py`
+- `.agents/harness/config.json:26-50,67-125`
+- `.agents/harness/prompts/implementer.md:5-14`
+- `.agents/harness/schemas/review.schema.json:7-24`
+- `.agents/harness/hook_guard.py:286-330,469-490,643-705`
+- `scripts/agent-resource-run:223-264,356-368`
+- `scripts/harness-runtime-smoke.py:119-145`
+- `scripts/verify-harness-attestation:20-27,78-128,262-331`
+- `.github/workflows/ci.yml:33-44,73-111`
+- `.claude/settings.json:35-54`
+- `.git/agent-harness/tasks/*/{state.json,events.jsonl,logs/*.jsonl}` aggregate
+  and `ux-p4-settings-ia-20260727` task evidence, inspected 2026-07-27
+- [Murmur PR #477](https://github.com/murmur-io/murmur/pull/477)
+- [Murmur PR #478](https://github.com/murmur-io/murmur/pull/478)
+- [Murmur PR #481](https://github.com/murmur-io/murmur/pull/481)
+- [Murmur PR #496](https://github.com/murmur-io/murmur/pull/496)
+- [Murmur PR #499](https://github.com/murmur-io/murmur/pull/499)
+- [Murmur PR #501](https://github.com/murmur-io/murmur/pull/501)
+
+### External primary sources
+
+- [Claude Code: Keep Claude working toward a goal](https://code.claude.com/docs/en/goal)
+- [Claude Code hooks reference](https://code.claude.com/docs/en/hooks)
+- [Claude Code sandbox configuration](https://code.claude.com/docs/en/sandboxing)
+- [Claude API errors and retries](https://platform.claude.com/docs/en/api/errors)
+- [GitHub merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue)
+- [Git worktree](https://git-scm.com/docs/git-worktree)
+- [Git patch-id](https://git-scm.com/docs/git-patch-id)
+- [AWS Builders' Library: timeouts, retries, and backoff with jitter](https://aws.amazon.com/builders-library/timeouts-retries-and-backoff-with-jitter/)

--- a/docs/research/2026-07-27-mcp-longtranscript-repair-plan.md
+++ b/docs/research/2026-07-27-mcp-longtranscript-repair-plan.md
@@ -1,0 +1,683 @@
+# Murmur — MCP + Note-Pipeline Repair Plan
+
+**Scope:** 21 reported defects, originally verified against the 2026-07-27
+trunk snapshot (post-v1.0.3, post-#453/#454/#455/#457). The status table below
+is refreshed against `murmur` at `cc09eed` on 2026-07-28.
+That base and the remote-state column are an operator-captured Git/GitHub
+snapshot, not evidence produced by this docs task's control-plane checks.
+**Verdict distribution at the original snapshot:** 18 CONFIRMED, 3 PARTIAL.
+**Zero were fully ALREADY_FIXED or NOT_A_DEFECT.** Section 0 now contains six
+claim-level corrections/clarifications; some are stale premises inside otherwise
+valid items, not six additional verdict changes.
+**Current execution model:** rebuild remaining batches sequentially from fresh
+`origin/murmur`. Harness v2 is verifier-only: implement in its isolated
+worktree, derive the exact-diff plan, then `verify`/`resume`; there is no
+harness-owned writer or repair loop. Actual lock/content-read changes require a
+fresh `lock-security` specialist. Old branch attestations and green CI do not
+transfer to a rebuilt composition.
+
+---
+
+## Status update — 2026-07-28
+
+| PR | Plan intent | Remote state | Current interpretation |
+|---|---|---|---|
+| #480 | R2 attribution contract | **MERGED** | Landed on trunk. |
+| #481 | R1 transcript renderer | **MERGED** | Landed on trunk. |
+| #482 | R4 fact-registry integrity | **MERGED** | Landed on trunk. |
+| #483 | R3 provenance demarcation | **MERGED** | Landed on trunk. |
+| #484 | R5 commitments owner recall | **MERGED** | Landed on trunk. |
+| #485 | R7/R8 payload bounds | **MERGED** | Landed on trunk; preserve its bounds in every rebuild. |
+| #486 | R10 located transcript search | **OPEN**, Rust/full gate failing | Rebuild with a read address accepted by `get_meeting`, global totals, and strict caps. |
+| #487 | R12/R13 discovery and triage | **OPEN**, green CI | Do not merge as-is: independent audit found a sealed-folder oracle and discovery-after-cap gaps. |
+| #488 | R16 org relevance floor | **OPEN**, green CI | Do not merge as-is: thresholds and substring/AND-path behavior are not correctly pinned. |
+| #489 | R15 render-time channel dedup | **OPEN**, green CI | Defer/rebuild; the default heuristic can delete real short or repeated speech. |
+| #490 | speaker/voiceprint mapping (out-of-plan companion to R17) | **OPEN**, green CI | Rebuild with a meeting-scoped gated reader and plain-`others` cluster handling. |
+| #491 | R6 decisions registry | **OPEN**, green CI | Do not merge as-is: seal/relock and deterministic persistence findings remain. |
+| #492 | R9 chapters | **OPEN**, green CI | Combine with navigation-address work so chapter/search/read share one segment space. |
+| #493 | R14 domain glossary | **OPEN**, Rust/full gate failing | Rebuild after closing the glossary egress/accounting and settings-loss gaps. |
+| #494 | R17 diarization/grounding settings | **OPEN**, green CI | Rebuild after #493; grounding is not wired through the Rust DTO. |
+| — | R11 triage columns | **No standalone PR** | Re-scope with discovery/navigation work; do not infer it from #487's raw-size field. |
+
+The open heads are parallel snapshots, not a safe stack. In particular,
+#486/#487/#489/#490/#492 overlap in `mcp.rs`/`tools.rs`, use incompatible tool
+counts or offset spaces, and have no combined runtime or lock proof. Their
+current CI status is recorded for diagnosis only; it is not an acceptance
+verdict. The do-not-merge details come from an independent, read-only operator
+session audit on 2026-07-28; that audit was not itself a persisted Harness
+receipt, so this document treats it as an explicit recommendation that must be
+re-proved by each rebuilt exact diff.
+
+---
+
+## 0. Already handled / report is stale — do NOT re-fix
+
+At this 2026-07-28 refresh, ten reported defects are fully closed: **#1**
+(#453 + #485), **#3** (#480), **#4** (#483), **#5** (#480 + #483),
+**#10** and **#13** (#485), **#12** (#481), **#15** (#485), **#16**
+(#484), and **#17** (#482). Two retain open remainders: **#2** has its
+renderer half closed by #481 but its default-on product decision remains R17,
+and **#19** has the vector floor from #457 but no sound keyword floor. The
+remaining nine — **#6, #7, #8, #9, #11, #14, #18, #20, and #21** — remain
+wholly open. The original-snapshot verdict distribution (18 CONFIRMED,
+3 PARTIAL, zero fully fixed) is historical evidence, not the current queue.
+The claim-level corrections below were measured against an older build or a
+wrong premise. **Do not scope new work against a closed claim.**
+
+| Item | Stale claim | Evidence on trunk |
+|---|---|---|
+| **#1** | "20 pages × 19.5k = 390k of note tax" | The original repeated-note tax was fixed in `da63840` (PR #453). The two surviving sub-claims (note ignored `maxChars`; no `includeNote`) were subsequently resolved by R7 in merged PR #485. Later navigation work must preserve those bounds. |
+| **#2** | "No diarization; 6 participants collapse to Me/Others" | **PREMISE WRONG.** Murmur ships full N-way offline diarization: `transcribe/diarize.rs::Diarizer` (pyannote-segmentation-3.0 → CAM++ → FastClustering `num_clusters=-1`) + `relabel_others` → `others-{N}`, wired in `pipeline.rs` (`asr_diarize` stage), with cross-meeting voiceprint re-ID (`compute_cluster_voiceprints`/`suggest_voiceprint_labels`, gated read `db.rs::list_voiceprints_visible`), a DER/EER harness (`eval/diarization.rs`) and a Settings toggle. The reporter saw Me/Others because **`settings/config.rs` defaults `diarize_others: false`** and because turning it ON currently makes MCP *worse* (see #2b). |
+| **#19** | "Semantic junk: 'Kongo' matched 'Kong'" | **PARTLY MITIGATED** in `83b40c2` (PR #457): KNN rows below `ORG_KNN_SEARCH_COSINE_FLOOR = 0.78` are dropped. Exact FTS5 token matching cannot produce `Kongo` from `Kong`, so the historical observation most likely came from the vector/body path rather than exact FTS. Remaining: the keyword fallback still lacks a sound relevance contract, substring-based filtering can create false hits, no score is exposed, and boilerplate is unfiltered. Open PR #488 does not close this as written; its threshold and AND-path tests are insufficient. |
+| **#11** | "Wrong id is indistinguishable from empty" | **Partly wrong** — the two outcomes *are* textually distinct today (`No outline for document {id} (…)` vs `No data for document {id}.`). The real defect is the **dead end** (all three stated causes are false for a meeting id, and there is no redirect) → batch **R12**. |
+| **#21** | "Wrong folder name is indistinguishable from an empty folder" | **Partly wrong** — `No note folder named "{folder}".` vs `No rows matched in "{name}".` already differ. The real defect is **no discovery surface** → batch **R12**. |
+| **#18** | (implicit) "the repo has a vocabulary gate" | `scripts/check-vocabulary.mjs` is **UI-copy jargon policing** (`BANNED = [['egress',…],['GGUF',…]]`, reads `src/app/core/copy/glossary.ts`). Zero relation to transcription vocabulary. Do not mistake it for an existing glossary. |
+
+---
+
+## 1. The root-cause map (read before sequencing)
+
+Three **upstream** defects author damage that many downstream items only mitigate:
+
+```
+U1  diarize_others = false by default        →  one collapsed `others` lane
+      └─ #3 name-guessing (prompt fills the gap with vocatives)
+      └─ #16 "me" is ambiguous; owner rollups can't merge
+      └─ #2b when you DO enable it, others-N renders as "Unknown" (regression)
+
+U2  no per-region echo arming (align.rs MAX_SPREAD_S=0.2 on drifting clocks)
+      └─ #14 duplicate Me/Others pairs, AEC also silently inert
+      └─ #13 ~40% scaffolding is partly duplicated speech
+      └─ note quality: the SUMMARIZER sees the duplicated feed too
+
+U3  no domain glossary / no ASR bias / entity keys are lowercase-only
+      └─ #18 mangled proper nouns
+      └─ #7 "Konnect" and "Connect" become two permanent, unmergeable entity rows
+      └─ #6/#17 durable junk facts inherit the mangling
+```
+
+**Honesty bar:** #3, #16, #13, #7 are *mitigations*. They stop the system from stating false precision — they do **not** restore who-said-what, de-duplicate the audio, or repair a mangled proper noun. Only U1 (diarization on + voiceprints), U2 (piecewise alignment), U3 (glossary + canonicalization) address the source, and **all three need a real Mac with real recordings to prove**.
+
+---
+
+## 2. Batches
+
+Ordered trust-first, then value/cost within each tier.
+
+### PHASE 0 — cheap correctness (land first, unblocks the cost work)
+
+---
+
+#### R1 · Transcript renderer truth
+**Status:** **MERGED in PR #481.** The body below is the pre-merge design and
+RED specification; its "today"/"RED on trunk" wording describes the old base.
+**Defects:** #2(b) `others-N` → "Unknown"; #12 13-decimal timestamps
+**Size:** XS · **Deps:** none · **Lock review:** no
+
+**Touch list**
+- `src-tauri/src/tools.rs::format_structured_transcript` (the sole call site is `tools.rs` `ToolCall::GetMeeting`, verified by grep)
+- `src-tauri/src/transcribe/diarize.rs::cluster_index_of_tag` (reuse; may need `pub(crate)`)
+- new private `tools.rs::secs(f64) -> String`
+
+**Fix**
+1. Replace `Some("others") => "Others", _ => "Unknown"` with a parse of the `others-{N}` tag → `Speaker {N+1}`; plain `others` → `Others`; genuinely-absent speaker → `Unknown`. Today, enabling diarization *degrades* the MCP transcript (Others → Unknown) while `summarize/template.rs` and `summarize/timeline.rs` consume the identical tag correctly — two consumers of one tag disagree.
+2. `fn secs(v) { let r = (v*10.0).round()/10.0; if r.fract()==0.0 { format!("{}", r as i64) } else { format!("{r:.1}") } }`, used for both `start_s`/`end_s`. Root cause of the long decimals is confirmed: `pipeline.rs` `segment.start_s += offset_s` and `audio/merge.rs::82` `start_s: seg.start_s + offset_s` — f64 addition of a non-representable wall-clock offset. Affects essentially every `others` segment.
+
+**RED-before-GREEN**
+- `others-0`/`others-1` fixture must NOT render "Unknown" (RED on trunk).
+- Fixture `start_s: 3659.3188999159997` must render `[3659.3–` (RED on trunk).
+- The integer-collapse branch keeps `[12–15]` / `[5–8]` byte-identical, so `tools.rs::get_meeting_structured_transcript_default` and `mcp.rs::mcp_get_meeting_transcript_format_switches` stay green **with zero edits** — verify this, it is the whole reason for the `fract()` branch.
+
+**Risk** — None to lock model or wire format (one-call-site free-text renderer). Behavior: `TOTAL_CHARS` shrinks ~24%, so an agent holding a cached char offset across the upgrade lands elsewhere; self-correcting because `TOTAL_CHARS` is re-disclosed every call. Leave the `"plain"` branch untouched so `get_meeting_transcript_format_plain_is_byte_identical` holds.
+
+**Value:** reclaims ~28k chars (~7k tokens) on a 1h meeting *and* fixes a trust regression. Best value/cost in the whole program.
+
+---
+
+### PHASE 1 — trust: what the note claims
+
+> These outrank everything below. A note that reads as a meeting record but is half pasted document, guessed names, and hardened guesses is more dangerous than an expensive one.
+
+---
+
+#### R2 · Note fidelity: attribution contract + epistemic strength
+**Status:** **MERGED in PR #480.** The body below is the pre-merge design and
+RED specification.
+**Defects:** #3 (name guessing), #5 (hedge → spec) — prompt half
+**Size:** S · **Deps:** none (but same file as R3 → sequence) · **Lock review:** no
+
+**Touch list**
+- `src-tauri/src/pipeline.rs::build_transcript_feed` — `TranscriptFeed.labeled: bool` → lane shape
+- `src-tauri/src/pipeline.rs::summarize_and_export` — call site of `template::build_template`
+- `src-tauri/src/summarize/template.rs::{build_template, speaker_attribution_directive, default_template, style_variant_with_keys}`
+- tests: `template.rs::build_template_adds_attribution_only_when_labeled`, `pipeline.rs::feed_multi_speaker_is_labeled_timeline_format`, `redact.rs:1269`
+
+**Fix**
+1. **#3 root cause is the prompt itself.** `labeled = distinct.len() >= 2` is `true` for a normal dual-stream meeting (`me` + one collapsed `others` lane holding 4 people), so `speaker_attribution_directive()` fires and says verbatim *"use a participant's real NAME when it is clearly stated in the conversation"* + *"List the distinct speakers under the `participants` front-matter"*. With one lane covering N people the only way to comply is to guess from vocatives. The trailing "never invent a speaker the tags do not support" is far weaker and contradicts the naming clause.
+   Replace the bool with the **lane shape** (`diarized_others: bool` = any `others-N` present). Two directives:
+   - **collapsed** (`me` + `others` only) → *no personal-name attribution at all*; attribute to `me`/`others`; never put a guessed name in `participants`; a vocative may be written as `(inferred from "…")`, never as a record.
+   - **diarized** (`others-0/1/…`) → keep today's directive (rename it as the diarized variant so the byte-pinned test gains a sibling rather than changing).
+2. **#5** — add to the shared body rules in `style_variant_with_keys` **and** `default_template` (they must stay in lockstep): *"Preserve epistemic strength: when the transcript's only support for a claim is hedged ('I don't know', 'I think', 'probably', 'I forgot'), keep the hedge or mark the item `(to confirm)`; never state an unconfirmed guess as a fact or a decision."* Reuse the exact `(to confirm)` token `summarize/recipes.rs` already ships so the vocabulary is single-sourced.
+3. Cheap deterministic backstop for #3 (optional, same PR): drop any `participants:` front-matter entry whose name never appears in the transcript text. Pure, local, zero egress.
+
+**RED-before-GREEN**
+- Collapsed-lane prompt contains the no-name clause and does **not** contain `"use a participant's real NAME"` (RED on trunk).
+- Diarized-lane prompt is byte-identical to today's.
+- Body rules contain the hedge clause for every built-in style.
+
+**Risk** — No lock/wire/egress risk (prompt text + one internal struct field). **Real behavior change users will notice:** notes on dual-stream meetings stop carrying personal names. Frame it in the release note as *removing false precision*, and pair it with the U1 decision (R17). Prompt byte-identity tests must be updated deliberately — they exist to make prompt drift a conscious act.
+
+**What it does NOT solve:** who actually said what. That is U1.
+
+---
+
+#### R3 · Provenance demarcation + deterministic grounding backstops
+**Status:** **MERGED in PR #483.** The body below is the pre-merge design and
+RED specification.
+**Defects:** #4 (undemarcated user-notes/document material), #5 (deterministic half)
+**Size:** M · **Deps:** R2 (same file, sequential) · **Lock review:** no
+
+**Touch list**
+- `src-tauri/src/summarize/template.rs::render_user_content` (the user-notes block)
+- `src-tauri/src/summarize/grounding.rs::{is_skipped_heading, annotate_unverified, content_tokens, GROUND_MIN_COVERAGE, NEGATOR_TOKENS, has_negator}`
+- `src-tauri/src/summarize/recall_net::append_possible_missed_items` (precedent to copy)
+- `src-tauri/src/facts.rs::extract_fact_candidates` (skip hedge/foreign-marked lines)
+
+**Fix**
+1. **Prompt.** The current block is headed *"The user's own in-meeting notes (SKELETON — build the note around these)"* and says *"Never invent content that is not grounded in the transcript **OR THESE NOTES**"* — it explicitly widens the grounding set to the pasted document, with no instruction that Decisions/Key points come from the recording. Admitted whenever `config.notes_mode == "enhance"`, which is the **default**. Rewrite it as a provenance contract: Summary / Key points / Decisions / Action items come **exclusively from the TRANSCRIPT**; anything from the user's notes the transcript does not cover goes verbatim under one section headed exactly `## From my notes` (and later `## From attached materials`); a document's open question never lands under Decisions.
+2. **Deterministic backstop (the trustworthy half).** Add the new heading(s) to `grounding.rs::is_skipped_heading` (which already protects `my notes` / `related prior notes` / `also discussed` + PL variants). Add an enhance-mode pass that, for each line under a recording-only section, computes transcript token coverage with the existing `content_tokens` / `GROUND_MIN_COVERAGE` math and **annotates** (v1: do not move) below-floor lines with `> from your notes, not the recording`. Reuse `annotate_unverified`'s non-destructive, idempotent line walk.
+3. **#5 deterministic half.** Add `HEDGE_TOKENS` + `has_hedge()` beside `NEGATOR_TOKENS`/`has_negator` (proof the pattern is implementable — it already exists for negation). When a note line's best-matching segment (already computed by `align_claims_to_segments`) is hedged and the line is not, append `> unconfirmed in the recording`. Feed the same signal into `facts.rs` so hedge-marked lines produce no fact candidates. Gate behind the existing `ground_summary` opt-in until calibrated.
+
+**RED-before-GREEN**
+- A note whose `## Decisions` contains a user-notes-only claim must not survive unmarked (RED on trunk).
+- Note line "The flag is a Boolean" vs segment "a Boolean, true, false, probably" must earn the `unconfirmed` marker (RED on trunk).
+- Idempotence: running the pass twice yields byte-identical markdown.
+
+**Risk** — All local string ops on plaintext the pipeline just produced; markers are sealed with the note exactly like `> unverified`. Keep `## Action items` line positions byte-stable so `action_items::parse_action_items` does not shift. Prefer annotate-in-place over move for v1 — a move could relocate a legitimately abstractive but grounded sentence. False-positive risk on the hedge half (a hedge in the best-matching segment does not always govern the claim) → annotation-only, opt-in.
+
+**Why this matters more than any cost item:** today, receipts do **not** repair it. An unsourced line simply gets no `ClaimAlignment` — absence of a chip, indistinguishable from a paraphrase.
+
+---
+
+#### R4 · Fact-registry integrity: no junk owners, and make junk correctable
+**Status:** **MERGED in PR #482.** The body below is the pre-merge design and
+RED specification.
+**Defects:** #17
+**Size:** S (guard) + M (forget command) · **Deps:** none · **Lock review:** no
+
+**Touch list**
+- `src-tauri/src/facts.rs::candidates_from_triples` (+ signature: accept a person roster)
+- `src-tauri/src/commands/mod.rs::build_and_persist_entities` (pass `payload.people`, not the merged vec)
+- `src-tauri/src/commands/facts.rs::persist_facts_for_meeting`
+- `src-tauri/src/summarize/template.rs::front_matter_list` (roster source, already `pub(crate)`)
+- `src-tauri/src/summarize/mod.rs` provider ids (`PROVIDER_CLAUDE_CODE`, `ollama`, `gateway`, `anthropic`) for the blocklist
+- `src-tauri/src/storage/facts_store.rs` + `lib.rs::generate_handler!` (new `forget_entity_fact`)
+
+**Fix**
+Today `candidates_from_triples` validates **only the entity** (resolved against the meeting's known entities, "never invent"); `predicate` and `object` are taken verbatim with `.trim()` + non-empty, and `confidence` is **hardcoded 1.0**. There is no roster check, allowlist, or blocklist anywhere. The ingestion path is real and traceable: `pipeline.rs::fold_manual_notes` folds the user's typed companion-note text (including pasted agent/CLI output) into the markdown that `extract_fact_candidates` consumes.
+1. Extend `candidates_from_triples(triples, entities, roster)`; for a person-valued predicate set (`owner`, `assignee`, `właściciel`, `odpowiedzialny`, `role`, `rola`), reject objects not plausibly a person.
+2. Belt-and-braces 5-line static blocklist of tool/provider ids — this alone would have stopped `owner: claude_code`.
+3. **Add `forget_entity_fact(id)`** mirroring `forget_user_fact` (bitemporal invalidate, registered in `generate_handler!`). Today entity facts are **uncorrectable** — `facts_store.rs` exposes forget/clear for *user* facts only; only a later meeting asserting a different owner for the same `(entity, subject, predicate)` key can close one.
+
+**RED-before-GREEN** — triple `(M1 Advanced Mode, owner, claude_code)` with
+roster `["Person A","Person B"]` yields zero candidates (RED on trunk). Second
+test: `forget_entity_fact` closes an open row and
+`dossier.rs::render_structured` stops printing it.
+
+**Risk** — **The one to be careful about:** a legitimate owner who did not
+attend ("the external owner will pick it up") would be dropped — silently
+losing a real fact is worse than the junk it prevents. Mitigate with roster =
+union of note participants **+ all visible Person entities** (a superset that
+still excludes `claude_code`), or keep the fact with reduced `confidence` (the
+column exists, currently a constant 1.0) and have `render_structured` mark
+low-confidence rows. No lock risk — `candidates_from_triples` is a pure pre-DB
+filter that can only narrow writes. No wire risk (`FactCandidate` is internal).
+The extractor is best-effort by contract, so a stricter filter can never fail
+the note pipeline.
+
+**Note the vault-only surface:** `export/obsidian.rs::inject_provenance_frontmatter` writes `ai-provider: claude_code`, but `pipeline.rs` applies it to a **local** binding *after* the DB `upsert_note`, so the DB copy has no provider key today. It would become live the moment anything re-ingests the vault file — and `commands/links.rs::link_meeting_entities` already re-feeds the stored `note.markdown` to the same extractor. **The guard therefore belongs in the extractor, not the note writer.**
+
+---
+
+#### R5 · Commitments: recall, owner normalization, navigable source
+**Status:** **MERGED in PR #484.** The body below is the pre-merge design and
+RED specification.
+**Defects:** #16
+**Size:** XS/S (part A) + M (part B) · **Deps:** complementary to R2; independent to land · **Lock review:** no
+
+**Touch list**
+- `src-tauri/src/tools.rs::format_commitments`, `tools_spec`, `ToolCall::GetOpenCommitments`
+- `src-tauri/src/mcp.rs` inputSchema + `dispatch_tool` `"get_open_commitments"` arm
+- `src-tauri/src/storage/db.rs::list_open_commitments`
+- `src-tauri/src/storage/db.rs::list_people` (`open_commitment_count`) and `src-tauri/src/summarize/dossier.rs::{build_dossier_data, render_structured}` — **these three predicates are bound identical by `list_people`'s own doc comment; they move together or the /people badge and the dossier disagree**
+- `src-tauri/src/summarize/action_items.rs::{extract_owner, find_date, is_iso_date}` (+ new `normalize_owner`)
+- `src-tauri/src/settings/config.rs::AppConfig` (new `user_display_name`)
+- `src-tauri/src/commands/tests/ask_vault_tests.rs` (the in-app agentic loop parses the same string)
+
+**Fix — part A (ship first, XS/S)**
+- Emit `id:{c.meeting_id}` alongside `[[{c.meeting_title}]]` — `Commitment` already carries `meeting_id` (populated at `db.rs::list_open_commitments`), `format_commitments` just never prints it, so an agent cannot navigate programmatically.
+- Emit an explicit `due —` when `due_date` is None instead of silently omitting the segment.
+- Add `since` / `until` / `meetingId` / `overdueOnly` / `limit` / `offset`; disclose the total **and** the currently-silent `list_meetings_visible(1000, …)` cap in the reply header, the way `page_text_disclosed` discloses `TOTAL_CHARS`.
+- Fix the MCP description, which over-promises "owner, due date and source meeting".
+
+**Fix — part B (M, the recall fix)**
+`list_open_commitments` filters with raw exact equality:
+`o.trim().to_lowercase() == want`. So `owner="Person A"` drops
+`"Person A (others-9)"` and `"others-10 -> Person A"` — the reported 4-of-7
+(57%) recall is exactly what this code produces. The `(others-9)` residue is
+the **diarization cluster tag leaking through the prompt**:
+`speaker_attribution_directive` says *"otherwise keep the tag label"*, and
+`action_items.rs::extract_owner` takes the head before the em-dash verbatim
+with only a ≤40-char guard.
+- Add `normalize_owner(raw)`: strip `[[ ]]`/`| alias`, strip leading/trailing `(others-N)`/`(me)`, strip an `others-N ->`/`others-N:` prefix, collapse whitespace.
+- Apply at **read time** in `list_open_commitments` (this is what fixes *existing* vaults) **and** at ingest in `extract_owner` (fixes future notes). Do both.
+- Keep the match case-insensitive **equality on the normalized form** — do not go fuzzy.
+- `me` is genuinely ambiguous: there is no recording-account identity on this path (`AppConfig` has no user/display name; `AccountStatus` is opt-in and unused here). Add optional `user_display_name` (Settings → "Your name", falling back to the signed-in account's local-part) and resolve normalized `me`/`ja` to it. When unset, **do not merge** — label it `me (unresolved — set your name in Settings)`.
+
+**RED-before-GREEN** — seed notes with `Person A`,
+`Person A (others-9)`, `others-10 -> Person A`; `owner="Person A"` must return
+3/3 (RED: returns 1). Second test: `me` from two different meetings is NOT
+merged when `user_display_name` is unset. Unit tests on `normalize_owner` for
+all three reported variants.
+
+**Risk** — No lock risk (stays inside the `list_meetings_visible` + `get_note_if_visible` double gate; normalization widens *which visible items match a filter*, never which meetings are read). `format_commitments` output shape changes → an MCP parsing change for regex-consuming clients, and the in-app loop consumes the same string. `user_display_name` follows the additive `set_setting` + default `""` rule and **must never be logged**.
+
+**Does NOT solve:** low due-date coverage (~1 of ~110). `find_date` only matches a literal `YYYY-MM-DD` substring — no natural-language or relative dates. Scope NL date parsing separately, or just stop over-promising in the description (part A does the latter).
+
+---
+
+#### R6 · Decisions & risks become first-class registry rows
+**Status:** **OPEN as PR #491; do not merge as-is.** Rebuild as a bounded
+read-time projection from canonical visible notes. The table/migration design
+below is pre-audit provenance and is not the current implementation direction.
+**Defects:** #6
+**Size:** M · **Deps:** R2 + R3 (garbage-in otherwise) · **Lock review:** **YES**
+
+**Touch list**
+- new `src-tauri/src/summarize/note_sections.rs::parse_labeled_bullets` (sibling of `action_items.rs::parse_action_items`)
+- `src-tauri/src/commands/facts.rs::persist_facts_for_meeting`
+- `src-tauri/src/storage/db.rs::Db::migrate` (additive `CREATE TABLE IF NOT EXISTS note_decisions`)
+- `src-tauri/src/facts.rs::{EntityKnowledgeDiff, build_knowledge_diff}`
+- `src-tauri/src/tools.rs::format_knowledge_diff`
+- `src-tauri/src/storage/seal_store.rs` (purge in the seal tx)
+
+**Fix**
+The only writer into the fact registry is the LLM triple extractor, and `facts.rs::EXTRACT_SYSTEM` narrows it by design to short key-value attributes (*"predicate is a short, stable attribute (e.g. \"status\", \"owner\", \"deadline\", \"role\")"*, *"Only durable state worth tracking across meetings"*). The note **does** carry `## Decisions` / `## Risks & open questions`, but `grep -rl Decisions src-tauri/src` returns only prompt-authoring sites — **zero parsers**. Hence a 5-decision note legitimately reports `0 total decision(s) on record` (`format_knowledge_diff` prints `kd.ledger.len()`, which is supersessions of extracted triples).
+- Deterministic pure parser returning `(section, bullet_text)` pairs.
+- **Prefer a new additive table** over routing into `facts`: keys on `meeting_id`, guarded `CREATE TABLE IF NOT EXISTS` per rust-tauri §4.
+- Surface as a fourth list on `EntityKnowledgeDiff` (serde camelCase → additive for the FE) and render it.
+
+**RED-before-GREEN** — a note with 3 `## Decisions` bullets must report 3, not 0 (RED on trunk). Plus the lock test below.
+
+**Risk — LOCK MODEL (blocking review).** Facts are purged on seal and every read is gated via the `meeting_id` anchor (`Db::list_facts_visible`). Any new decisions store **must** carry `meeting_id`, be purged in the **same atomic seal transaction**, and be read through a `visibility_clause` gate — otherwise it is a straight sealed-content leak. Second risk: routing free-text decision bullets through `reconcile_facts` would mint spurious supersessions (every re-wording under the same `(subject, predicate)` key closes the previous one → false bitemporal history). A reserved predicate namespace or the separate table avoids polluting the `status`/`owner` key space.
+
+**Does NOT solve:** decision *quality*. If R2/R3 have not landed, this makes a wrong decision durable and queryable — which is why it is sequenced after them.
+
+---
+
+### PHASE 2 — payload cost
+
+---
+
+#### R7 · get_meeting payload budget
+**Status:** **MERGED in PR #485.** The body below is the pre-merge design and
+RED specification; later work must preserve these bounds.
+**Defects:** #1 (surviving half), #13 (compact format), #10 (format-stamped header)
+**Size:** S · **Deps:** **R1** (reuse `secs()`; land after so `TOTAL_CHARS` shifts once) · **Lock review:** no
+
+**Touch list**
+- `src-tauri/src/tools.rs::ToolCall::GetMeeting` (variant fields + arm), `format_structured_transcript`, new `format_compact_transcript`, `page_text_disclosed`, `tool_specs`
+- `src-tauri/src/mcp.rs` `get_meeting` inputSchema (~:245), description (~:244), `dispatch_tool` arm, `mcp_body_window`
+- in-app arg parser at `tools.rs` (~:2170)
+- tests: `mcp.rs::mcp_get_meeting_transcript_format_switches` (exact-string), `tools.rs::get_meeting_note_only_on_first_window`, `get_meeting_structured_transcript_default`, `get_meeting_transcript_format_plain_is_byte_identical`
+
+**Fix**
+1. **#1a — the advertised bound is a lie for the note.** `page_text_disclosed(&full_transcript, offset, max_chars)` windows the *transcript only*; `n.markdown` is interpolated whole, so `get_meeting(id, maxChars: 200)` still ships ~19.5k. Window the note too (`NOTE (TOTAL_CHARS: N (showing 0..M))`), keeping the `(0,0)` default unwindowed so the legacy in-app path stays byte-identical.
+2. **#1b — add `include_note: bool` (default `true`)**; guard becomes `Some(n) if *offset == 0 && *include_note`. Plumb from **both** parsers. Do **not** split into `get_meeting_note`/`get_meeting_transcript` tools — that doubles an 11-tool catalog and duplicates the `meeting_is_visible` gate for what one bool solves.
+3. **#13 — add an opt-in `"compact"` transcriptFormat**: fold runs of consecutive same-speaker segments into `[run_start–run_end] Speaker: <joined text>`. Switch the 2-way `if transcript_format == "plain"` to a 3-way match; **default stays `structured`** — making compact the default would move every agent's offset space with no version signal.
+4. **#10 — stamp the format into the header**: `TRANSCRIPT (format={transcript_format}, {h}):`, plus one sentence in both descriptions that offset/maxChars/TOTAL_CHARS live in the *currently selected* format's char space.
+
+**RED-before-GREEN**
+- `includeNote: false` at `offset == 0` returns no `NOTE:` section (RED).
+- `maxChars: 200` yields a reply whose note section is ≤ ~200 chars (RED: ~19.5k).
+- Compact: two consecutive `me` segments + one `others` yields **2** lines, not 3; `plain` and `structured` byte-unchanged.
+
+**Risk** — Free-text MCP payload, not `murmur-protocol` → no client/server compat coupling. **The exact-string assertion in `mcp_get_meeting_transcript_format_switches` must be updated in the same commit.** Lock: the note still comes from `db.get_note_if_visible(mid, unlocked)` **inside** the `meeting_is_visible` `Ok(true)` arm — do not move that read out of the arm. Compact merges segment boundaries → never use a compact reply as a seek/citation source (grounding already works off typed Segments, so nothing regresses).
+
+**Overlap warning the report missed:** R1 alone reclaims ~28k of the claimed 46k. **Re-measure #13's incremental value (~18k) against a real vault before sizing it as a win.**
+
+---
+
+#### R8 · Bound get_entity_dossier
+**Status:** **MERGED in PR #485.** The body below is the pre-merge design and
+RED specification; later work must preserve these bounds.
+**Defects:** #15
+**Size:** S · **Deps:** none · **Lock review:** no
+
+**Touch list**
+- `src-tauri/src/tools.rs::{ToolCall::GetEntityDossier, tools_spec}` + the three other constructors: `orchestrate.rs:212`, `voice_action.rs:858`, `tools.rs` in-app dispatch (~:2226)
+- `src-tauri/src/mcp.rs` inputSchema + `dispatch_tool` `"get_entity_dossier"` arm (reuse `mcp_body_window`)
+- `src-tauri/src/summarize/dossier.rs::{build_dossier_data, format_dossier_client}`
+
+**Fix** — `build_dossier_data` does `corpus.push_str(&note.markdown)` — the **whole note body per mentioning meeting**, capped only by `format_dossier_client`'s `let budget = 200_000usize;` (~50k tokens). The paging machinery already exists (`mcp_body_window`, `MCP_DEFAULT_WINDOW_CHARS = 6000`, `page_text_disclosed`) and is applied to `get_meeting`/`get_document` — the dossier arm simply bypasses both. Add `noteDetail: none|summary|full` (default **summary**), `offset`, `maxChars`. Always emit `render_structured` (small, deterministic). `full` routes the corpus through `page_text_disclosed`, whose `TOTAL_CHARS` **is** the requested `estimatedFullChars` — no new format needed. Put the un-windowed total in the overview header regardless of mode.
+
+**RED-before-GREEN** — a 3-meeting entity in `summary` mode returns a reply an order of magnitude shorter than the full corpus, and the disclosed total equals the un-windowed length (RED on trunk). `mcp.rs::get_entity_dossier_is_visibility_gated_and_egress_free` stays green.
+
+**Risk** — No lock risk: every gate (`entity_is_visible`, `entity_mentions_visible`, `get_note_if_visible`, `list_facts_visible`) is untouched, and shrinking a payload can only reduce disclosure. **Deliberate default change** from full-corpus to `summary` for existing MCP clients — same class as `MCP_DEFAULT_WINDOW_CHARS`; note it in the tool description. `ToolCall` field additions are compile-error-visible across the three other constructors.
+
+---
+
+### PHASE 3 — composability (search and read must connect)
+
+---
+
+#### R9 · Chapters over MCP
+**Status:** **OPEN as PR #492; rebuild with R10.** Chapter, search, and read
+must share one stable segment-address space; do not merge this parallel head.
+**Defects:** #8
+**Size:** M · **Deps:** none · **Lock review:** **YES**
+
+**Touch list**
+- `src-tauri/src/storage/db.rs` — new gated `get_timeline_data_visible(meeting_id, unlocked)` (**`get_timeline_data` is a raw ungated `SELECT data FROM timelines` — never call it from `execute_tool`**)
+- `src-tauri/src/tools.rs` — `ToolCall::GetMeetingChapters`, `tool_specs`, arm; new shared char-offset prefix-sum helper
+- `src-tauri/src/summarize/timeline.rs::repair_coverage` (reuse)
+- `src-tauri/src/commands/export.rs::export_canvas_inner` (the precedent: gate → `get_timeline_data` → `repair_coverage` → topic spans)
+- `src-tauri/src/mcp.rs::tools_spec` + `GatedToolExecutor::run` dispatch
+
+**Fix** — Chapters exist and are persisted (`timelines` table, `MeetingTimeline { speakers, topics }`; the FE "chapter list" is literally `meeting-timeline.component.ts::chapters` over `topics`) and are absent from all 11 MCP tools. Mirror `ToolCall::GetDocumentOutline`: gate first, on not-visible return the **same masking sentinel shape** as `get_meeting`; else parse, `repair_coverage`, render. Derive char offsets by prefix-summing `format_structured_transcript` per segment and mapping each `TopicSpan` `[startS,endS]` to first/last overlapping segment → `offsetStart`/`offsetEnd`/`charCount` — **build this helper once and share it with R10**. Add `chapter: Option<usize>` to `ToolCall::GetMeeting` resolving to the same window.
+
+**RED-before-GREEN** — sealed-not-unlocked meeting → sentinel with **no topic label leaked** (copy `get_document_outline_tool_is_gated_and_maps_sections`). A chapter window round-trips to the same chars as an explicit `offset`/`maxChars` call.
+
+**Risk — LOCK MODEL (blocking review).** Topic labels + speaker names are LLM-derived **content**; this is a NEW content read path and must route through `meeting_is_visible`/`visibility_clause`. `timelines.data` is blanked only while sealed — relying on blanking alone is exactly the mistake `get_meeting_detail`'s masked-DTO comment warns about. Masked-reply indistinguishability must hold.
+
+**Availability honesty (not a bug, a UX contract):** `commands/meetings.rs::get_timeline` is READ-ONLY cached-or-empty and **never generates** (generation moved to `commands::generate_timeline`, auto-fired by the FE only for cheap cloud providers, behind a click for on-device, per the OOM fix). On-device users have no cached timeline → the tool must say so honestly, not imply the meeting has no chapters.
+
+---
+
+#### R10 · Segment-level search (search and read compose)
+**Status:** **OPEN as PR #486; rebuild with R9.** The replacement must return
+an address accepted by `get_meeting`, disclose global totals, and preserve
+strict response caps.
+**Defects:** #9
+**Size:** M · **Deps:** **R9** (shared offset helper + per-hit chapter label) · **Lock review:** **YES**
+
+**Touch list**
+- `src-tauri/src/storage/mcp_store.rs` — new `search_segments_visible(query, meeting_id, limit, max_per_meeting, unlocked)`
+- `src-tauri/src/storage/db.rs::{fts_match_query, fts_match_query_any, visibility_clause, search_visible_impl, search_snippet, excerpt}` (copy the predicate, **do not re-derive**)
+- `src-tauri/src/storage/models.rs` — new `SegmentHit`
+- `src-tauri/src/tools.rs` — `ToolCall::SearchTranscript`, `tool_specs`, arm; mirror `format_hit_location`
+- `src-tauri/src/mcp.rs::tools_spec` + dispatch
+
+**Fix** — The data is already there: `fts_segments` is a real FTS5 virtual table with ai/ad/au triggers, and `segments` carries `idx`, `start_s`, `end_s`, `text`, `speaker`. The reader throws it away: `search_visible_impl` `GROUP BY meeting_id` with `MIN(rank)`, then `search_snippet` re-finds the text with `… WHERE meeting_id=?1 AND text LIKE ?2 ORDER BY idx LIMIT 1` → exactly one ~130-char excerpt from the *first* matching segment, no idx/time/count. `SearchHit` has no position field and `format_hits` prints none. **The asymmetry proves the fix is expected:** document hits in the same output already carry `(§section · p.page)` via `format_hit_location`.
+New tool renders `- [meeting:{id}] @{mm:ss} (seg {idx}, offset {n}) {Speaker}: {snippet}` plus `({shown} of {hitCount} matches)` per meeting.
+
+**Cheaper partial if M is too big (S):** keep `search_meetings`' shape but thread the matching segment's `start_s` + `idx` + total match count through `SearchHit` and render them. That alone kills the blind-116k-char-paging problem.
+
+**RED-before-GREEN** — a query matching 5 segments in one meeting returns 5 located hits with a disclosed count (RED: one unlocated snippet). Sealed-not-unlocked meeting contributes nothing. Empty query matches nothing (preserve the R1/`da63840` guard).
+
+**Risk — LOCK MODEL (blocking review).** Raw segment text is sealed content; the new reader must carry the **identical** `visibility_clause` predicate as `search_visible_impl` — copy it. `fts_segments_au` re-indexing blanked text on seal is defense-in-depth, **not** the gate. Additive tool → no wire impact; the cheaper variant adds optional fields to a `Serialize`d `SearchHit`.
+
+---
+
+#### R11 · Triage columns on list_recent_meetings
+**Status:** **OPEN design with no standalone PR.** Re-scope it with the
+discovery/navigation replacement; #487's raw-size field is not this batch.
+**Defects:** #20
+**Size:** S · **Deps:** none · **Lock review:** **YES**
+
+**Touch list**
+- `src-tauri/src/storage/meetings_store.rs::list_meetings_visible` → new `list_meetings_visible_triage` (**reuse the exact predicate, do not fork the SQL**)
+- `src-tauri/src/storage/models.rs` — new `MeetingTriageRow`
+- `src-tauri/src/storage/graph_store.rs::{list_entities_visible, entity_mentions_visible}` (participants)
+- `src-tauri/src/tools.rs::ToolCall::ListRecentMeetings` arm; `src-tauri/src/mcp.rs` description
+
+**Fix** — The arm formats exactly `- {title} · {started_at} · {status:?} · id:{id}`. **`duration_s` and `ended_at` are already fetched and thrown away.** Add: `transcriptChars` (`SELECT COALESCE(SUM(LENGTH(s.text)),0) … WHERE s.meeting_id = m.id` — a PK-prefix range scan, cheap at the clamped `limit` 1..=100), `hasNote` (`EXISTS` — `notes` is already joined for the visibility predicate), and ≤5 participant names via the gated `entity_mentions` path. `statusDetail` has **no backing column** (`MeetingStatus` is a bare enum; `recording_store.rs`/`audio/spill.rs` set `Error` with no reason) — derive it (`Error (no transcript)` / `Error (partial transcript)`), which answers the real triage question. A real reason string needs an additive `meetings.status_detail TEXT` via `add_column_if_missing` — scope separately.
+
+**RED-before-GREEN** — a sealed-and-not-unlocked meeting contributes **no** triage row (not a masked one). A meeting with a note and 12k of transcript renders both figures.
+
+**Risk — LOCK MODEL (blocking review); this is why it is S, not XS.** Every added field is metadata about a meeting and must ride the same `visibility_clause`-derived predicate; forking the SQL is exactly how size/participants leak. Two traps: (a) `list_meetings_visible` keeps a meeting with **zero** notes, so one recorded into an already-sealed folder can appear — its `segments.text` is blanked on seal so `SUM(LENGTH(text))` correctly reports ~0, but participants must go through the gated mention path; (b) a per-meeting attendee list is exactly the metadata the masked DTO withholds elsewhere — never emit it for a non-visible meeting.
+
+---
+
+### PHASE 4 — discovery (stop dead-ending the agent)
+
+---
+
+#### R12 · Folder discovery + the meeting-id dead end
+**Status:** **OPEN as part of PR #487; do not merge as-is.** Rebuild after
+closing the sealed-folder existence oracle and discovery-after-cap gaps.
+**Defects:** #21, #11
+**Size:** S · **Deps:** R9 (only to name `get_meeting_chapters` in the redirect; otherwise none) · **Lock review:** **YES**
+
+**Touch list**
+- `src-tauri/src/storage/folders_store.rs` — new `list_note_folders_visible(unlocked)` wrapping `list_note_folders` (**which is ungated and returns sealed folders — the same shape as the `list_folders` trap from PR #321**)
+- `src-tauri/src/storage/notes_store.rs::{get_note_folder_schema, list_notes_visible}` (reuse)
+- `src-tauri/src/tools.rs` — `ToolCall::ListNoteFolders` + arm; `QueryDatabase` `Ok(None)` message; `GetDocumentOutline` empty arm
+- `src-tauri/src/storage/meetings_store.rs::meeting_is_visible`, `db.get_meeting`
+- `src-tauri/src/mcp.rs::tools_spec` (12th tool) + dispatch
+
+**Fix**
+1. **#21** — new `list_note_folders` tool emitting `name · <n> rows · columns: <key:kind, …>` from `list_notes_visible(Some(id), unlocked).len()` + `get_note_folder_schema(id)`, filtered to `!(locked && !unlocked.contains(id))`. Append **visible-only** names to `No note folder named "X". Available: A, B, C.`
+2. **#11** — inside the **existing** `Ok(entries) if entries.is_empty()` arm only (never before the doc gate), probe `db.meeting_is_visible(id, unlocked)? && db.get_meeting(id).ok().flatten().is_some()` → redirect `"{id} is a MEETING, not a document — read it with get_meeting."`; otherwise return the existing sentinel **byte-identical**. Ids are NOT distinguishable by format (both are `uuid::Uuid::new_v4()`), only by table lookup — and `meeting_is_visible` returns **true for a nonexistent id**, which is precisely why the `get_meeting` conjunct is mandatory.
+
+**RED-before-GREEN**
+- Sealed meeting id → output **equals** the old sentinel, contains neither `"MEETING"` nor the title.
+- Random uuid → old sentinel.
+- Visible meeting id → the redirect.
+- Sealed note folder's name appears in **neither** the tool output **nor** the not-found error; its row count and schema never surface.
+- The two existing sealed-document assertions pass unchanged.
+
+**Risk — LOCK MODEL (blocking review); this is the one place where the naive fix IS a leak.** The masked sentinel is *deliberately* indistinguishable between locked / absent / heading-less (pinned by `get_document_outline_tool_is_gated_and_maps_sections` + the `mcp.rs` twin). A type-check that answers "this is a meeting" for a **sealed** meeting newly discloses its existence — the guard ordering above closes that. Three leaks to avoid on the folder side: sealed folder **name** (MCP is a different trust boundary from the FE, and `query_database` already promises "Sealed-and-locked note folders are excluded"), sealed folder **row count** (volume/existence metadata), sealed folder **column schema** (explicitly refused today by `commands/notes.rs::get_note_folder_schema` — exposing it would contradict a shipped gate). **The "available names" error message is the easiest place to regress.**
+
+---
+
+#### R13 · Entity discovery + did-you-mean
+**Status:** **OPEN as part of PR #487; do not merge as-is.** Its replacement
+must preserve every visibility gate and operate before bounded discovery is
+truncated.
+**Defects:** #7 (parts 1 and 2; part 3 → R14)
+**Size:** S · **Deps:** none · **Lock review:** **YES**
+
+**Touch list**
+- `src-tauri/src/tools.rs` — `ToolCall::ListEntities { query: Option<String> }` + arm + `tool_specs`; the `Ok(None)` branches of the `GetEntityDossier` / `KnowledgeDiff` arms
+- `src-tauri/src/storage/db.rs::list_entities_visible` (**already gated, already mention-counted, capped at `MAX_VISIBLE_ENTITIES = 500`** — reuse, never `list_entities`)
+- `src-tauri/src/mcp.rs::tools_spec` + dispatch
+
+**Fix** — There is no entity lister among the 11 tools, and resolution is exact-token: `graph_store.rs::entities_matching_query` filters with `db.rs::name_matches_query_tokens`, which requires the entity's name tokens to appear as a **contiguous window** inside the query (`name_tokens.len() > query_tokens.len() ⇒ false`, then exact `a == b`), and additionally drops names shorter than `MIN_ENTITY_NAME_LEN = 3` — so an entity literally named "KO" is **unreachable by name from every tool, by design, forever**. Zero-hit replies are the bare `No visible entity matching "{entity}".` with no suggestions.
+Add the lister; replace both bare not-found strings with a top-k suggestion list scored by prefix / initialism / edit distance over `list_entities_visible`.
+
+**RED-before-GREEN** — `get_entity_dossier("Kong Operatorr")` returns a suggestion list containing "Kong Operator" (RED: bare not-found). A sealed-only entity's name appears in neither the lister nor the suggestions.
+
+**Risk — LOCK MODEL (blocking review).** `entities_matching_query`'s visibility predicate (`visibility_clause("n", unlocked)` over `entity_mentions → meetings → notes`) is what stops a sealed-only entity's **name** from leaking. A did-you-mean list built from anything other than `list_entities_visible` is an existence oracle for sealed content.
+
+**Does NOT solve:** the fragmentation itself. "Konnect" and "Connect" remain two permanent rows until R14 lands aliases + canonicalization.
+
+---
+
+### PHASE 5 — upstream root causes (XL / needs a real Mac)
+
+---
+
+#### R14 · Domain glossary program (+ entity aliases)
+**Status:** **OPEN as PR #493; do not merge as-is.** Rebuild a bounded,
+omission-safe glossary through the existing redaction/accounting seam, then
+canonicalize whole aliases locally before persistence. The broad staged design
+below predates the egress and settings-loss audit.
+**Defects:** #18, #7 part 3
+**Size:** **L (4 stages, ship each alone)** · **Deps:** Stage 1(d) canonicalization **before** the alias table · **Lock review:** advisory · **Egress review: MANDATORY**
+
+**Stage 1 (M) — fix the NOTE, where the durable damage is authored. ~60% of the value, zero ASR risk, fully headless.**
+- `settings/config.rs::AppConfig` — `glossary: Vec<GlossaryTerm { canonical, aliases }>`, `#[serde(default)]`, **user-authored only**. Not a DB table: it is workspace-scoped, must survive folder seals, and must never derive from sealed content.
+- `summarize/template.rs::render_user_content` — emit a `CANONICAL SPELLINGS (use these exact forms)` block right after the existing `EXISTING NOTE TITLES` block (same renderer → the byte-identical-when-empty contract already used for `related_context`/`user_notes`/`live_bullets` applies verbatim).
+- `summarize/template.rs` formatting rules (every `template_for_style` variant) — *preserve proper-noun spellings exactly; never introduce an abbreviation or acronym that does not appear in the transcript.* **This alone kills "Kong Operator" → "KO".**
+- **`fn canonicalize(name, glossary)`** (case/diacritic-folded, longest-alias-wins) applied in `summarize/graph.rs::clean` **and** again in `commands/mod.rs::build_and_persist_entities` immediately before each `upsert_entity`. This is the real fix for #7: `graph_store.rs::upsert_entity` keys on `(name_ci, kind)` where `name_ci = name.to_lowercase()` and keeps first-seen casing; `graph.rs::clean` only trims/dedups with `eq_ignore_ascii_case`; `facts.rs::norm` is `trim().to_lowercase()`. There is **no rename/merge/alias command anywhere** (`commands/graph.rs` exposes only reads).
+- Backfill: re-point `entity_mentions` from alias rows onto the canonical row — **`INSERT OR IGNORE` remap, leave the orphan row in place, never a `DELETE`** (additive-migration rule). This is the only user-row mutation in the whole program.
+
+**Stage 2 (S) — ASR bias. Real but secondary.** Thread `Option<&str>` into `transcribe/whisper.rs::{build_params, transcribe_with}` and call `params.set_initial_prompt(...)`. The seam exists and is unused (`wake.rs` header: *"⚠️ NOT WIRED: … the Whisper `set_initial_prompt` bias …"*). **Hard budget: whisper.cpp caps the prompt at `min(n_max_text_ctx, n_text_ctx/2)` = 224 tokens** (`n_text_ctx = 448`) regardless of our `BATCH_N_MAX_TEXT_CTX = 16384` — roughly 30–50 terms, then it silently truncates. Needs an explicit cap + truncation-order rule. **Good news the report did not know:** batch transcription is already chunked (`pipeline.rs` VAD `speech_regions` → `decode_windows` with `MAX_WINDOW_S = 120`, and `transcribe_with` does `create_state()` per call), so the prompt re-seeds every ≤120 s — the "prompt decays over a long recording" objection is largely neutralized. Just as well, since `carry_initial_prompt` is **not reachable**: whisper-rs 0.16 keeps `FullParams.fp` `pub(crate)` with no setter.
+
+**Stage 3 (S)** — `ToolCall::ListGlossary` + `mcp.rs::tools_spec` entry returning canonical→aliases so an agent can resolve a surface form. Read-only, no meeting content → **no `visibility_clause` gate needed; state that explicitly in the doc comment** so a future reviewer does not read it as an omission.
+
+**Stage 4 (S)** — Settings list editor: component directory, signals, `mur-input` + `primitives.css`, no new deps.
+
+**Stage 5 (M, folds in #7 part 3)** — additive `CREATE TABLE IF NOT EXISTS entity_aliases (entity_id, alias_ci, created_at, PRIMARY KEY(entity_id, alias_ci))`; widen `entities_matching_query` with a LEFT JOIN **under the identical `visibility_clause("n", unlocked)` predicate**; relax `MIN_ENTITY_NAME_LEN` **for alias hits only** (a global relaxation re-admits the noise it was added to suppress).
+
+**RED-before-GREEN** — `canonicalize("Konnect", [{canonical:"Kong Connect", aliases:["Konnect","KO"]}])` → `"Kong Connect"`; two notes spelling it differently produce ONE entity row (RED: two). Glossary block byte-absent when the glossary is empty. Alias JOIN: a sealed-only entity is not reachable by alias.
+
+**Risk — EGRESS is the load-bearing risk and the report ignores it.** The
+glossary rides `render_user_content` to a cloud provider exactly like
+`vault_titles`, which already needed a dedicated **VAULT-TITLE FIREWALL** in
+`summarize/redact.rs` (design B — FILTER, not mask+restore) with a RED
+regression for an `[[Example Person]].md` person-page leak. A glossary is *by
+construction* the user's most sensitive internal proper nouns (codenames,
+clients, unreleased projects). **`RedactingProvider` MUST be extended to filter
+person-like glossary terms on the same path, with its own RED test, and the
+egress ledger must account for it. Shipping Stage 1(b) without touching
+`redact.rs` opens a new silent egress channel.**
+**Lock:** low *if and only if* the glossary stays user-authored. Auto-deriving aliases from meeting text would make a workspace-scoped, seal-surviving artifact carry sealed-derived strings — a leak (contrast `correction_log`, which is per-meeting derived and correctly purged on seal).
+**⚠️ NOT PROVABLE HEADLESS:** Stage 2 effectiveness. `set_initial_prompt` is a soft probabilistic bias with a known failure mode of hallucinating prompt terms into silence/low-confidence spans, and it interacts with the existing anti-hallucination temperature ladder (`BATCH_ENTROPY_THOLD` / `BATCH_LOGPROB_THOLD` / `BATCH_NO_SPEECH_THOLD`). **Needs a real recording on a real Mac, A/B with the prompt off.**
+
+---
+
+#### R15 · Dual-channel echo: render-time mitigation, then per-region arming
+**Status:** **OPEN as PR #489; defer or rebuild.** Do not merge the default
+heuristic: independent audit showed it can hide real short or repeated speech.
+The proposal below is historical design, not a current ship recommendation.
+**Defects:** #14
+**Size:** S (step 1) + M (step 2) · **Deps:** R1 (shares the renderer) · **Lock review:** advisory (step 1), **warranted (step 2)**
+
+**Step 1 (historical proposal; do not ship before real loss evidence)**
+- `tools.rs::ToolCall::GetMeeting` — add `channel: 'merged'|'mic'|'system'` (default `merged`) + `mcp.rs` inputSchema.
+- The original proposal added pure `tools.rs::dedup_rendered(segs)` using
+  `merge.rs::{norm_tokens, token_lcs, jaccard}` and assumed that suppressing a
+  rendering was non-destructive. That assumption is false at the consumption
+  boundary: a heuristic can hide genuine short or repeated speech from the
+  caller even when stored bytes survive. Keep merged rendering byte-identical
+  by default unless real dual-stream evidence establishes an opt-in rule.
+
+**Step 2 (M, root cause)** — `audio/align.rs::estimate_stream_offset` returns `None` (⇒ zero dedup for the **entire** meeting) when `spread > MAX_SPREAD_S` (0.2 s) between three disjoint 30 s windows. `merge.rs`'s own header states the cpal and ScreenCaptureKit clocks drift *"seconds per hour"* — so on a ~1 h recording the start-vs-end lag exceeds 0.2 s (often exceeds the ±2 s `MAX_LAG_ENV` search range entirely) and the estimator **rejects its own measurement**. `suppress_cross_stream_echo` then short-circuits: `if !leak_armed || others_refs.is_empty() { return (segments, 0); }`. **Long meetings — the ones with the most bleed — are exactly the ones guaranteed to have the deduper off.** The same `leak` also gates offline AEC in `pipeline.rs`, so on the reported recording **both were silently inert**.
+Replace the global estimate with a **piecewise profile**: rolling window (e.g. 30 s every 60 s), per-window arming, drop the `MAX_SPREAD_S` all-or-nothing rejection (a drifting lag is a legitimate measurement, not a failed one), widen/drift-adjust `MAX_LAG_ENV`. `suppress_cross_stream_echo` arms per segment via `leak_at(seg.start_s)`.
+**CRITICAL CONSTRAINT:** keep a `fn global_leak(&self) -> Option<EchoLeak>` reproducing today's median-plus-spread semantics **exactly** and feed *that* to `align.rs::archive_delays`, so the playback mix is bit-for-bit unchanged.
+
+**RED-before-GREEN** — Step 1: the exact `merge.rs::no_dedup_without_leak_evidence` fixture (byte-identical text at 5.0/`others` and 5.4/`me`, both surviving with `n == 0`) must render the sentence **once**. Step 2: a new synthetic fixture with a deliberately **drifting** delay must fail on current code and pass after; the three existing `align.rs` tests (`recovers_synthetic_echo_offset`, `independent_streams_yield_none`, `archive_delays_prefers_measured_leak`) stay green.
+
+**Risk** — Step 1 is lock-neutral (inside the gated arm, mutates no stored data, additive schema field) but **the "only drop `me`" invariant must hold or genuine user speech disappears** — the same class as the lock-security finding recorded in `ebe9068`; review it as such. **The gate was tightened deliberately** (`99632bb` "gate ALL dedup on leak evidence", `ebe9068` "relaxed-tier dedup uses order-preserving token-LCS only") after a content-loss finding — **do not simply loosen it in the stored pipeline.** Step 2 is higher risk: `estimate_stream_offset` is load-bearing for `archive_delays` (wrong padding desyncs playback — the documented 51 s→8 s class) and for AEC; recordings that get zero dedup today will start getting some, so more `me` segments will be dropped. **⚠️ Final proof needs real dual-stream recordings on a real Mac.**
+
+**Does NOT solve — two things, and the report is right about both:**
+1. **Step 1 does not improve the note.** The summarizer consumes the stored merged segments, not the MCP rendering. Only step 2 improves note quality.
+2. **Divergence is unreachable by any text rule.** `[271.76] Others: "I built them."` vs `[271.85] Me: "I don't know."` is 3 tokens (below `ECHO_MIN_TOKENS = 4`) and shares no content — Whisper hallucinating on low-SNR acoustic bleed. Only acoustic cancellation or headphones fixes it.
+
+---
+
+#### R17 · Product decision: default diarization ON
+**Status:** **OPEN as part of PR #494; rebuild only after the safe #493
+replacement.** Keep the default OFF until real DER/EER, model-download, and RAM
+evidence exists; the current head also fails to wire grounding through Rust.
+**Defects:** #2(a) — the reason the reporter saw Me/Others at all
+**Size:** XS code, **XL to verify** · **Deps:** R1 (else enabling it makes MCP worse), R2 (attribution contract keys off lane shape) · **Lock review:** no
+
+`settings/config.rs` defaults `diarize_others: false` and `voiceprint_enabled: false`, and nothing prompts the user — a fresh install **never** diarizes. Flipping the default (or adding a one-time prompt when a system stream is present) is a one-line change but carries: a ~40 MB first-use model download (`transcribe/model.rs::ensure_diarization_models`), a second ML runtime load (mitigated — the diarizer loads lazily only after Whisper is dropped, never co-resident), and interaction with the known recording-time RAM pressure.
+**⚠️ Cannot be validated headless.** Requires a real multi-speaker recording on a real Mac, with an RSS-over-time measurement, before flipping. **This is the single highest-leverage fix for #3/#16 quality — every downstream mitigation is second-best to it.** Treat R2's collapsed-lane directive as the safe interim.
+
+---
+
+### PHASE 6 — calibration-dependent
+
+---
+
+#### R16 · org_search: keyword floor, exposed score, boilerplate
+**Status:** **OPEN as PR #488; do not merge as-is.** Rebuild only the
+SQLite/FTS exact-token coverage floor (strict AND, then OR requiring
+`ceil(unique_terms/2)` before ordering and limit). Defer raw scores and
+boilerplate heuristics; the broader proposal below is pre-audit provenance.
+**Defects:** #19 (surviving three-quarters)
+**Size:** M · **Deps:** none · **Lock review:** no
+
+**Touch list**
+- `src-tauri/src/storage/models.rs::OrgChunkHit` (+ `score: f32`)
+- `src-tauri/src/storage/org_store.rs::{search_org_chunks_knn, search_org_chunks_fts}`
+- `src-tauri/src/embed.rs::{fuse_org_hits, ORG_KNN_SEARCH_COSINE_FLOOR}` (+ new `ORG_REL_FLOOR`)
+- `src-tauri/src/tools.rs::{search_org_brain_hits, format_org_hits, gather_note_enhance_citations}` (shares the reader)
+- `src-tauri/src/mcp.rs` tool descriptions + `mcp.rs::tool_catalog_nudges_org_search_as_a_fallback`
+
+**Fix**
+1. **No floor on the keyword leg.** `search_org_chunks_fts` orders by `bm25(...) ASC LIMIT ?2` with no minimum — and `83b40c2` *added* the AND→OR fallback (`fts_match_query_any`, stopwords + <3-char tokens dropped). The reported 7-token query is near-certain to fire the OR leg, so **any** org note containing "kong" matches with no floor. **The reported symptom plausibly still reproduces, now via FTS rather than KNN.** Add a *relative* cut in `search_org_brain_hits` (`score >= TOP_SCORE * ORG_REL_FLOOR`) — absolute bm25 is corpus-dependent — plus gate the OR fallback behind a minimum matched-content-word ratio.
+2. **No score anywhere.** `OrgChunkHit` is `{item_id, author_hint, title, snippet, content_sha256}`, and `fuse_org_hits` computes an RRF score then **discards it** (`filter_map(|(id, _score)| …)`). Carry it through and render it (`- [org · author] (0.61) title — snippet`) so an agent can self-triage.
+3. **Boilerplate filter** (`grep -rn boilerplate src-tauri/src` → zero hits): index-time chunk-quality heuristic. **Ship as a separate follow-up** — riskier than 1–2, do not couple.
+
+**RED-before-GREEN** — seed one on-topic item + one whose body is UI chrome; the chrome item must be absent for the multi-token query (RED on trunk).
+
+**Risk** — No lock model (org items live outside the folder-lock domain; keep the `tombstoned = 0 AND os.context_enabled = 1` predicate untouched). **Real risk is recall regression** — a floor that is too aggressive silently hides legitimate colleague notes, and the existing 0.78 KNN floor is itself **PROVISIONAL and uncalibrated** (per MEMORY). `OrgChunkHit`'s shape change also touches `gather_note_enhance_citations` (the Notes find-related path). **⚠️ Needs a real org corpus to calibrate — do not tune the constants headless.** The doc-nudge complaint is accurate and *enforced by a test* (`tool_catalog_nudges_org_search_as_a_fallback`): revisit the nudge only after the floor lands.
+
+---
+
+## 3. Dependency graph
+
+The graph is retained as design provenance. Edges labelled **LANDED** were
+satisfied by #480–#485; they are not queued work.
+
+```
+[LANDED] R1 ──────────► R7 (#485)
+R1 (#481) ────────────► R15 step1 (open/defer)
+R1 (#481) ────────────► R17 (open; diarization ON requires renderer truth)
+
+[LANDED] R2 (#480) ───► R3 (#483)
+R2/R3 (landed) ───────► R6 (#491 open; rebuild required)
+R2 (#480) ────────────► R17 (#494 open; rebuild required)
+
+[LANDED SOURCE] R4 (#482) ──► R6 (#491 open; rebuild required)
+
+R9 (chapters) ──► R10 (shared char-offset prefix-sum helper + per-hit chapter label)
+             └──► R12 (redirect can name get_meeting_chapters; optional)
+
+R14 Stage 1(d) canonicalize ──► R14 Stage 5 aliases ──► R13 did-you-mean gets materially better
+R14 Stage 1(b) glossary-in-prompt ──► MUST NOT LAND without redact.rs firewall extension
+
+[LANDED] R5 (#484): read-time normalization and its coordinated readers shipped.
+```
+
+---
+
+## 4. Lock-security review required (blocking)
+
+| Batch | Why | The indistinguishability rule to hold |
+|---|---|---|
+| **R6** | new decisions store | `meeting_id`-anchored, purged in the **same atomic seal tx**, read via `visibility_clause` |
+| **R9** | topic labels + speaker names are LLM-derived content; `get_timeline_data` is ungated | sealed → the **same sentinel** as `get_meeting`, no label leaks |
+| **R10** | raw segment text | copy `search_visible_impl`'s predicate verbatim; empty-query guard preserved |
+| **R11** | size/participants are metadata about a possibly-sealed meeting | sealed → **no row at all**, not a masked one |
+| **R12** | **highest leak risk in the program** | sealed meeting id → byte-identical old sentinel; sealed folder name/rowcount/schema in neither output nor error |
+| **R13** | entity names are an existence oracle | suggestions sourced only from `list_entities_visible` |
+| **R14 St.5** | alias JOIN | identical `visibility_clause("n", unlocked)`; `MIN_ENTITY_NAME_LEN` relaxed for alias rows only |
+
+Advisory (content read path touched, not a new gate): **R15 step 1**, **R7**.
+
+---
+
+## 5. Cannot be verified headless — say so plainly
+
+| Item | Why | The honest bar |
+|---|---|---|
+| **R14 Stage 2** (whisper `set_initial_prompt`) | soft probabilistic bias; interacts with the temperature ladder; known hallucinate-into-silence failure mode | real recording, real Mac, A/B with the prompt off |
+| **R15 step 2** (piecewise alignment) | clock drift is a property of real cpal↔ScreenCaptureKit capture; `archive_delays` desync is audible, not assertable | real dual-stream recordings ≥1 h; synthetic drift fixture for RED, real recording for the verdict |
+| **R17** (diarization default ON) | model download, second ML runtime, RAM interaction with the known recording-time pressure | real multi-speaker recording + RSS-over-time on a real Mac |
+| **R16** (org thresholds) | bm25 is corpus-dependent; the existing 0.78 KNN floor is itself uncalibrated | a real org/vault corpus; do not tune constants headless |
+| **R5** due-date coverage | depends on how people actually write dates | real vault sample before scoping NL date parsing |
+
+The deterministic portions of the remaining batches are checkable with
+`cargo test --lib` plus the applicable Angular gates. Those checks do not by
+themselves prove runtime composition, content preservation, lock
+indistinguishability, or real-model quality; the exact-diff reviewer,
+lock-security specialist, and the real-Mac bars above remain separate evidence.
+
+---
+
+## 6. What this program does NOT fix
+
+1. **Who said what.** R2 removes false name attribution; it does not add attribution. Only R17 + voiceprints do.
+2. **The note still sees duplicated speech.** R15 step 1 cleans the *MCP rendering* only — the summarizer consumes stored segments. Note quality improves only with R15 step 2.
+3. **Whisper divergence hallucinations** (`"I built them."` / `"I don't know."`) are unreachable by any text-similarity rule. Acoustic cancellation or headphones.
+4. **Existing junk facts** survive R4's guard. They need `forget_entity_fact` (in R4) plus a manual sweep; there is no automatic repair.
+5. **Existing fragmented entities** ("Konnect" vs "Connect") survive R13; only R14's canonicalize + backfill merges them, and the backfill is remap-only — orphan rows remain by design.
+6. **R7's compact format is worth ~18k, not ~46k**, once R1 has landed. Re-measure before selling it.
+7. **`## Decisions` correctness** is bounded by R2/R3. R6 makes decisions queryable; it does not make them true.
+8. **`me` stays ambiguous** across users until `user_display_name` is actually set; R5 deliberately refuses to merge rather than merge wrongly.


### PR DESCRIPTION
Preserves the five completed engineering reports that informed the Harness v2 simplification and the current MCP/org repair program. Documentation only; no runtime or control-plane behavior changes.

Local evidence: staged diff check PASS; secret-pattern scan PASS.