### PR TITLE
fix(harness): make Cargo lane FIFO and clean runtime

### DIFF
--- a/.agents/harness/cli.py
+++ b/.agents/harness/cli.py
@@ -3966,9 +3966,15 @@ def cmd_clean(args: argparse.Namespace) -> int:
     try:
         state = load_v2_state(task_dir)
         if state.get("status") in verifier.V2_TERMINAL_STATES:
+            removed = legacy.prune_task_runtime(task_dir)
+            runtime_note = (
+                f"; pruned runtime: {', '.join(removed)}"
+                if removed
+                else ""
+            )
             print(
                 f"{contract['task_id']}: {state['status']} "
-                "(cleanup already complete)"
+                f"(cleanup already complete{runtime_note})"
             )
             return 0
         worktree = Path(str(contract["worktree_path"]))
@@ -4034,6 +4040,7 @@ def cmd_clean(args: argparse.Namespace) -> int:
                 intent_sha256=intent["intent_sha256"],
             )
         _execute_clean_intent(contract, task_dir, intent)
+        removed = legacy.prune_task_runtime(task_dir)
         final = str(intent["final_status"])
         set_v2_state(
             task_dir,
@@ -4044,6 +4051,7 @@ def cmd_clean(args: argparse.Namespace) -> int:
             tree_sha=intent["tree_sha"],
             previous_status=intent["previous_status"],
             clean_intent_sha256=intent["intent_sha256"],
+            runtime_removed=removed,
         )
     finally:
         release_v2_run_lock(lock)

--- a/.agents/harness/resource_lane.py
+++ b/.agents/harness/resource_lane.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Crash-safe FIFO admission for Murmur's workspace-wide Cargo lane."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import fcntl
+import json
+import os
+from pathlib import Path
+import stat
+import time
+from typing import Any, IO, List, Optional
+import uuid
+
+
+QUEUE_DIRECTORY = "cargo-queue"
+ADMIN_LOCK = "admin.lock"
+SEQUENCE_FILE = "sequence"
+TICKET_SUFFIX = ".ticket"
+
+
+class LaneQueueError(RuntimeError):
+    """The FIFO metadata cannot be used safely."""
+
+
+@dataclass
+class LaneTicket:
+    queue_root: Path
+    path: Path
+    handle: IO[str]
+    sequence: int
+    queued_at: str
+    queued_epoch: float
+    released: bool = False
+
+
+def _ensure_real_directory(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    metadata = path.lstat()
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        raise LaneQueueError(
+            f"resource queue path is not a real directory: {path}"
+        )
+
+
+def _open_regular(path: Path, flags: int) -> IO[str]:
+    descriptor = os.open(
+        path,
+        flags | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+    )
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise LaneQueueError(
+                f"resource queue file is not regular: {path}"
+            )
+        return os.fdopen(descriptor, "r+", encoding="utf-8")
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _admin(queue_root: Path) -> IO[str]:
+    handle = _open_regular(
+        queue_root / ADMIN_LOCK,
+        os.O_RDWR | os.O_CREAT,
+    )
+    fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+    return handle
+
+
+def _live_names_locked(queue_root: Path) -> List[str]:
+    live: List[str] = []
+    for path in sorted(queue_root.glob(f"*{TICKET_SUFFIX}")):
+        try:
+            metadata = path.lstat()
+        except FileNotFoundError:
+            continue
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+            raise LaneQueueError(
+                f"resource queue ticket is not a regular file: {path}"
+            )
+        try:
+            candidate = _open_regular(path, os.O_RDWR)
+        except FileNotFoundError:
+            continue
+        try:
+            try:
+                fcntl.flock(
+                    candidate.fileno(),
+                    fcntl.LOCK_EX | fcntl.LOCK_NB,
+                )
+            except BlockingIOError:
+                live.append(path.name)
+                continue
+        finally:
+            candidate.close()
+        path.unlink(missing_ok=True)
+    return live
+
+
+def _next_sequence_locked(queue_root: Path) -> int:
+    sequence_path = queue_root / SEQUENCE_FILE
+    current = 0
+    if sequence_path.exists() or sequence_path.is_symlink():
+        with _open_regular(sequence_path, os.O_RDWR) as handle:
+            raw = handle.read().strip()
+        try:
+            current = int(raw or "0")
+        except ValueError as exc:
+            raise LaneQueueError(
+                f"resource queue sequence is malformed: {sequence_path}"
+            ) from exc
+        if current < 0:
+            raise LaneQueueError(
+                f"resource queue sequence is negative: {sequence_path}"
+            )
+    sequence = current + 1
+    temporary = (
+        queue_root
+        / f".sequence-{os.getpid()}-{uuid.uuid4().hex}.tmp"
+    )
+    descriptor = os.open(
+        temporary,
+        os.O_WRONLY
+        | os.O_CREAT
+        | os.O_EXCL
+        | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+    )
+    try:
+        payload = f"{sequence}\n".encode("ascii")
+        if os.write(descriptor, payload) != len(payload):
+            raise LaneQueueError("short resource queue sequence write")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    try:
+        os.replace(temporary, sequence_path)
+        directory = os.open(queue_root, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        temporary.unlink(missing_ok=True)
+    return sequence
+
+
+def join_lane_queue(
+    resource_root: Path,
+    *,
+    task: str,
+    command: str,
+) -> LaneTicket:
+    """Append one flock-backed ticket to the FIFO."""
+
+    _ensure_real_directory(resource_root)
+    queue_root = resource_root / QUEUE_DIRECTORY
+    _ensure_real_directory(queue_root)
+    admin = _admin(queue_root)
+    handle: Optional[IO[str]] = None
+    path: Optional[Path] = None
+    try:
+        _live_names_locked(queue_root)
+        sequence = _next_sequence_locked(queue_root)
+        queued_at = time.strftime(
+            "%Y-%m-%dT%H:%M:%SZ",
+            time.gmtime(),
+        )
+        path = queue_root / (
+            f"{sequence:020d}-{os.getpid()}-{uuid.uuid4().hex}"
+            f"{TICKET_SUFFIX}"
+        )
+        handle = _open_regular(
+            path,
+            os.O_RDWR | os.O_CREAT | os.O_EXCL,
+        )
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        json.dump(
+            {
+                "schema_version": 1,
+                "sequence": sequence,
+                "pid": os.getpid(),
+                "task": task,
+                "command": command,
+                "queued_at": queued_at,
+            },
+            handle,
+            sort_keys=True,
+        )
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+        return LaneTicket(
+            queue_root,
+            path,
+            handle,
+            sequence,
+            queued_at,
+            time.time(),
+        )
+    except BaseException:
+        if handle is not None:
+            handle.close()
+        if path is not None:
+            path.unlink(missing_ok=True)
+        raise
+    finally:
+        admin.close()
+
+
+def lane_queue_status(ticket: LaneTicket) -> dict[str, Any]:
+    """Return one-based position after reaping dead waiters."""
+
+    if ticket.released:
+        raise LaneQueueError("resource lane ticket was already released")
+    admin = _admin(ticket.queue_root)
+    try:
+        live = _live_names_locked(ticket.queue_root)
+        try:
+            position = live.index(ticket.path.name) + 1
+        except ValueError as exc:
+            raise LaneQueueError(
+                f"live resource queue ticket disappeared: {ticket.path}"
+            ) from exc
+        return {
+            "position": position,
+            "depth": len(live),
+            "sequence": ticket.sequence,
+            "queued_at": ticket.queued_at,
+            "wait_seconds": max(
+                0.0,
+                time.time() - ticket.queued_epoch,
+            ),
+        }
+    finally:
+        admin.close()
+
+
+def leave_lane_queue(ticket: LaneTicket) -> None:
+    """Idempotently remove only the caller's ticket."""
+
+    if ticket.released:
+        return
+    admin = _admin(ticket.queue_root)
+    try:
+        ticket.path.unlink(missing_ok=True)
+        ticket.handle.close()
+        ticket.released = True
+    finally:
+        admin.close()

--- a/.agents/harness/task_runner.py
+++ b/.agents/harness/task_runner.py
@@ -34,6 +34,8 @@ import uuid
 from pathlib import Path, PurePosixPath
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
+import resource_lane
+
 
 HARNESS_ROOT = Path(__file__).resolve().parent
 SCHEMAS_DIR = HARNESS_ROOT / "schemas"
@@ -2167,13 +2169,20 @@ def _cargo_lane_owner(lock_handle: Any) -> Dict[str, Any]:
     }
 
 
-def _print_cargo_lane_wait(lock_handle: Any) -> None:
+def _print_cargo_lane_wait(
+    lock_handle: Any,
+    queue_status: Mapping[str, Any],
+) -> None:
     owner = _cargo_lane_owner(lock_handle)
     print(
         "agent-harness: waiting for Cargo lane "
         "owner_pid={owner_pid} task={task} command={command} since={since} "
+        "queue_position={queue_position}/{queue_depth} queued_since={queued_since} "
         "heartbeat={heartbeat}".format(
             **owner,
+            queue_position=queue_status["position"],
+            queue_depth=queue_status["depth"],
+            queued_since=queue_status["queued_at"],
             heartbeat=utc_now(),
         ),
         file=sys.stderr,
@@ -2200,33 +2209,51 @@ def acquire_cargo_lane(
     resource_root = shared_resource_root_for_task(task_dir)
     resource_root.mkdir(parents=True, exist_ok=True)
     lock_path = resource_root / "cargo.lock"
+    ticket = resource_lane.join_lane_queue(
+        resource_root,
+        task=task_dir.name,
+        command=command,
+    )
     lock_handle = lock_path.open("a+", encoding="utf-8")
     deadline = time.monotonic() + timeout_seconds
     next_heartbeat: Optional[float] = None
     try:
         while True:
-            try:
-                fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-                break
-            except BlockingIOError:
-                now = time.monotonic()
-                if next_heartbeat is None or now >= next_heartbeat:
-                    _print_cargo_lane_wait(lock_handle)
-                    next_heartbeat = now + max(0.01, heartbeat_seconds)
-                if now >= deadline:
-                    owner = _cargo_lane_owner(lock_handle)
-                    raise HarnessError(
-                        "timed out waiting for the shared Cargo build lane "
-                        "owner_pid={owner_pid} task={task} command={command} "
-                        "since={since}".format(**owner)
+            queue_status = resource_lane.lane_queue_status(ticket)
+            acquired = False
+            if queue_status["position"] == 1:
+                try:
+                    fcntl.flock(
+                        lock_handle.fileno(),
+                        fcntl.LOCK_EX | fcntl.LOCK_NB,
                     )
-                time.sleep(
-                    min(
-                        0.1,
-                        max(0.0, deadline - now),
-                        max(0.01, next_heartbeat - now),
+                    acquired = True
+                except BlockingIOError:
+                    pass
+            if acquired:
+                break
+            now = time.monotonic()
+            if next_heartbeat is None or now >= next_heartbeat:
+                _print_cargo_lane_wait(lock_handle, queue_status)
+                next_heartbeat = now + max(0.01, heartbeat_seconds)
+            if now >= deadline:
+                owner = _cargo_lane_owner(lock_handle)
+                raise HarnessError(
+                    "timed out waiting for the shared Cargo build lane "
+                    "owner_pid={owner_pid} task={task} command={command} "
+                    "since={since} queue_position={position}/{depth} "
+                    "queued_since={queued_at}".format(
+                        **owner,
+                        **queue_status,
                     )
                 )
+            time.sleep(
+                min(
+                    0.1,
+                    max(0.0, deadline - now),
+                    max(0.01, next_heartbeat - now),
+                )
+            )
         lock_handle.seek(0)
         lock_handle.truncate()
         json.dump(
@@ -2244,8 +2271,10 @@ def acquire_cargo_lane(
         )
         lock_handle.write("\n")
         lock_handle.flush()
+        resource_lane.leave_lane_queue(ticket)
         return lock_handle
     except BaseException:
+        resource_lane.leave_lane_queue(ticket)
         lock_handle.close()
         raise
 

--- a/.agents/harness/v2_selftest.py
+++ b/.agents/harness/v2_selftest.py
@@ -3731,6 +3731,23 @@ def standalone_driver_lane_cases(test: Tests) -> None:
                 "LANE independent-clone wait is visible",
                 "waiting for lane" in blocked.stderr,
             )
+            test.true(
+                "LANE visible wait reports FIFO position and enqueue time",
+                "queue_position=1/1" in blocked.stderr
+                and "queued_since=" in blocked.stderr,
+            )
+            test.equal(
+                "LANE timed-out waiter removes its FIFO ticket",
+                list(
+                    (
+                        driver_root
+                        / legacy.resource_lane.QUEUE_DIRECTORY
+                    ).glob(
+                        f"*{legacy.resource_lane.TICKET_SUFFIX}"
+                    )
+                ),
+                [],
+            )
         finally:
             release_marker.write_text("release\n", encoding="utf-8")
             if holder.poll() is None:
@@ -3751,6 +3768,268 @@ def standalone_driver_lane_cases(test: Tests) -> None:
             released.returncode,
             0,
         )
+
+
+def fifo_lane_cases(test: Tests) -> None:
+    """Mixed lane clients must enter in ticket order and reap dead waiters."""
+
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-fifo-lane-") as raw:
+        root = Path(raw)
+        repo = root / "meetnotes"
+        _init_repo(repo)
+        common = Path(
+            _git(
+                repo,
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-common-dir",
+            )
+        )
+        task_dirs: Dict[str, Path] = {}
+        for label in ("holder", "older", "newer"):
+            task_dir = (
+                common / "agent-harness" / "v2" / "tasks" / label
+            )
+            task_dir.mkdir(parents=True)
+            task_dirs[label] = task_dir
+        resource_root = legacy.shared_resource_root_for_task(
+            task_dirs["holder"]
+        )
+        queue_root = (
+            resource_root / legacy.resource_lane.QUEUE_DIRECTORY
+        )
+        runner = ROOT / "scripts" / "agent-resource-run"
+        library = str(Path(__file__).resolve().parent)
+
+        holder_code = (
+            "import pathlib,sys,time;"
+            f"sys.path.insert(0,{library!r});"
+            "import task_runner;"
+            "lease=task_runner.acquire_cargo_lane("
+            "pathlib.Path(sys.argv[1]),5,command='fifo-holder');"
+            "print('ready',flush=True);"
+            "marker=pathlib.Path(sys.argv[2]);deadline=time.monotonic()+10;"
+            "\nwhile not marker.exists() and time.monotonic()<deadline:"
+            "\n time.sleep(0.01)"
+            "\ntask_runner.release_cargo_lane(lease)"
+        )
+        task_waiter_code = (
+            "import os,pathlib,sys,time;"
+            f"sys.path.insert(0,{library!r});"
+            "import task_runner;"
+            "lease=task_runner.acquire_cargo_lane("
+            "pathlib.Path(sys.argv[1]),5,command='fifo-'+sys.argv[3]);"
+            "fd=os.open(sys.argv[2],os.O_WRONLY|os.O_CREAT|os.O_APPEND,0o600);"
+            "os.write(fd,(sys.argv[3]+'\\n').encode());os.close(fd);"
+            "time.sleep(0.05);task_runner.release_cargo_lane(lease)"
+        )
+        append_code = (
+            "import os,sys,time;"
+            "fd=os.open(sys.argv[1],os.O_WRONLY|os.O_CREAT|os.O_APPEND,0o600);"
+            "os.write(fd,(sys.argv[2]+'\\n').encode());os.close(fd);"
+            "time.sleep(0.05)"
+        )
+
+        def queue_depth() -> int:
+            if not queue_root.is_dir():
+                return 0
+            return len(
+                list(
+                    queue_root.glob(
+                        f"*{legacy.resource_lane.TICKET_SUFFIX}"
+                    )
+                )
+            )
+
+        def wait_for_depth(expected: int) -> bool:
+            deadline = time.monotonic() + 3
+            while time.monotonic() < deadline:
+                if queue_depth() == expected:
+                    return True
+                time.sleep(0.01)
+            return queue_depth() == expected
+
+        def resource_waiter(order: Path, label: str) -> subprocess.Popen[str]:
+            environment = os.environ.copy()
+            environment["MURMUR_HARNESS_TASK"] = f"fifo-{label}"
+            return subprocess.Popen(
+                [
+                    str(runner),
+                    "--deadline-seconds",
+                    "5",
+                    "--",
+                    sys.executable,
+                    "-c",
+                    append_code,
+                    str(order),
+                    label,
+                ],
+                cwd=str(repo),
+                env=environment,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        def task_waiter(order: Path, label: str) -> subprocess.Popen[str]:
+            return subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    task_waiter_code,
+                    str(task_dirs[label]),
+                    str(order),
+                    label,
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+
+        def run_order_case(
+            name: str,
+            older_factory: Any,
+            newer_factory: Any,
+        ) -> None:
+            marker = root / f"release-{name}"
+            order = root / f"order-{name}"
+            holder = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    holder_code,
+                    str(task_dirs["holder"]),
+                    str(marker),
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            older: Optional[subprocess.Popen[str]] = None
+            newer: Optional[subprocess.Popen[str]] = None
+            try:
+                ready = (
+                    holder.stdout.readline().strip()
+                    if holder.stdout
+                    else ""
+                )
+                older = older_factory(order, "older")
+                older_joined = wait_for_depth(1)
+                newer = newer_factory(order, "newer")
+                newer_joined = wait_for_depth(2)
+                marker.write_text("release\n", encoding="utf-8")
+                older_result = older.wait(timeout=5)
+                newer_result = newer.wait(timeout=5)
+                holder_result = holder.wait(timeout=5)
+                test.equal(f"FIFO {name} holder acquired", ready, "ready")
+                test.true(f"FIFO {name} older ticket is visible", older_joined)
+                test.true(f"FIFO {name} newer ticket is visible", newer_joined)
+                test.equal(f"FIFO {name} older exits green", older_result, 0)
+                test.equal(f"FIFO {name} newer exits green", newer_result, 0)
+                test.equal(f"FIFO {name} holder exits green", holder_result, 0)
+                test.equal(
+                    f"FIFO {name} preserves admission order",
+                    order.read_text(encoding="utf-8").splitlines(),
+                    ["older", "newer"],
+                )
+            finally:
+                marker.write_text("release\n", encoding="utf-8")
+                for process in (newer, older, holder):
+                    if process is not None and process.poll() is None:
+                        process.terminate()
+                        process.wait(timeout=3)
+
+        run_order_case(
+            "resource-before-harness",
+            resource_waiter,
+            task_waiter,
+        )
+        run_order_case(
+            "harness-before-resource",
+            task_waiter,
+            resource_waiter,
+        )
+
+        marker = root / "release-stale-holder"
+        stale_order = root / "order-stale"
+        holder = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                holder_code,
+                str(task_dirs["holder"]),
+                str(marker),
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stale_code = (
+            "import pathlib,sys,time;"
+            f"sys.path.insert(0,{library!r});"
+            "import task_runner;"
+            "root=task_runner.shared_resource_root_for_task("
+            "pathlib.Path(sys.argv[1]));"
+            "ticket=task_runner.resource_lane.join_lane_queue("
+            "root,task='stale',command='killed-waiter');"
+            "print('queued',flush=True);"
+            "\nwhile True:\n time.sleep(1)"
+        )
+        stale: Optional[subprocess.Popen[str]] = None
+        survivor: Optional[subprocess.Popen[str]] = None
+        try:
+            holder_ready = (
+                holder.stdout.readline().strip() if holder.stdout else ""
+            )
+            stale = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    stale_code,
+                    str(task_dirs["older"]),
+                ],
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            stale_ready = (
+                stale.stdout.readline().strip() if stale.stdout else ""
+            )
+            survivor = resource_waiter(stale_order, "newer")
+            survivor_joined = wait_for_depth(2)
+            stale.kill()
+            stale.wait(timeout=3)
+            marker.write_text("release\n", encoding="utf-8")
+            survivor_result = survivor.wait(timeout=5)
+            holder_result = holder.wait(timeout=5)
+            test.equal("FIFO stale holder acquired", holder_ready, "ready")
+            test.equal("FIFO stale waiter armed", stale_ready, "queued")
+            test.true(
+                "FIFO live waiter queues behind stale candidate",
+                survivor_joined,
+            )
+            test.equal(
+                "FIFO SIGKILL stale waiter does not block successor",
+                survivor_result,
+                0,
+            )
+            test.equal("FIFO stale holder exits green", holder_result, 0)
+            test.equal(
+                "FIFO successor runs exactly once after stale reap",
+                stale_order.read_text(encoding="utf-8").splitlines(),
+                ["newer"],
+            )
+            test.equal(
+                "FIFO stale ticket is removed",
+                queue_depth(),
+                0,
+            )
+        finally:
+            marker.write_text("release\n", encoding="utf-8")
+            for process in (survivor, stale, holder):
+                if process is not None and process.poll() is None:
+                    process.terminate()
+                    process.wait(timeout=3)
 
 
 def sherpa_workspace_cache_cases(test: Tests) -> None:
@@ -5517,6 +5796,27 @@ def clean_cases(test: Tests) -> None:
                 "server_revision": None,
             },
         )
+        checks_root = task_dir / "runtime" / "checks"
+        for name in ("cargo-target", "cargo-home", "npm-cache"):
+            disposable = checks_root / name
+            disposable.mkdir(parents=True)
+            (disposable / "cache.bin").write_bytes(b"private cache\n")
+        profile = checks_root / "profiles" / "check.sb"
+        profile.parent.mkdir(parents=True)
+        profile.write_text("(version 1)\n", encoding="utf-8")
+        evidence = task_dir / "attempts" / "evidence.json"
+        evidence.parent.mkdir()
+        evidence.write_text('{"passed":true}\n', encoding="utf-8")
+        shared_cache = (
+            root
+            / ".murmur-agent-tasks"
+            / ".resources"
+            / "target"
+            / "sherpa-onnx-prebuilt"
+            / "archive.tar.bz2"
+        )
+        shared_cache.parent.mkdir(parents=True)
+        shared_cache.write_bytes(b"shared pinned archive\n")
         harness_cli.set_v2_state(task_dir, "OPEN", phase="open")
         previous = Path.cwd()
         try:
@@ -5540,6 +5840,56 @@ def clean_cases(test: Tests) -> None:
             "CLEAN archive preserves untracked dirty bytes",
             _git(repo, "show", f"{archive_ref}:untracked.txt"),
             "dirty untracked",
+        )
+        test.equal(
+            "CLEAN records first-pass disposable runtime removal",
+            state["runtime_removed"],
+            ["cargo-home", "cargo-target", "npm-cache"],
+        )
+        test.true(
+            "CLEAN removes task-private Cargo and npm caches",
+            all(
+                not (checks_root / name).exists()
+                for name in ("cargo-target", "cargo-home", "npm-cache")
+            ),
+        )
+        test.true(
+            "CLEAN preserves attested sandbox profiles",
+            profile.is_file(),
+        )
+        test.true("CLEAN preserves task evidence", evidence.is_file())
+        test.equal(
+            "CLEAN preserves workspace shared pinned cache",
+            shared_cache.read_bytes(),
+            b"shared pinned archive\n",
+        )
+
+        late_cache = checks_root / "cargo-target"
+        late_cache.mkdir()
+        (late_cache / "late.bin").write_bytes(b"late\n")
+        previous = Path.cwd()
+        try:
+            os.chdir(repo)
+            with contextlib.redirect_stdout(io.StringIO()):
+                harness_cli.cmd_clean(
+                    argparse.Namespace(
+                        task_id="clean-selftest",
+                        abandon=False,
+                    )
+                )
+        finally:
+            os.chdir(previous)
+        test.true(
+            "CLEAN terminal retry prunes late private runtime",
+            not late_cache.exists(),
+        )
+        test.true(
+            "CLEAN terminal retry still preserves profiles and evidence",
+            profile.is_file() and evidence.is_file(),
+        )
+        test.true(
+            "CLEAN terminal retry preserves shared pinned cache",
+            shared_cache.is_file(),
         )
 
 
@@ -5882,6 +6232,7 @@ def main() -> int:
     readonly_review_wall_timeout_cases(test)
     state_and_lock_cases(test)
     standalone_driver_lane_cases(test)
+    fifo_lane_cases(test)
     sherpa_workspace_cache_cases(test)
     verification_snapshot_cases(test)
     snapshot_node_modules_manifest_cases(test)

--- a/scripts/agent-resource-run
+++ b/scripts/agent-resource-run
@@ -20,6 +20,12 @@ import subprocess
 import sys
 import time
 
+HARNESS_LIBRARY = (
+    Path(__file__).resolve().parent.parent / ".agents" / "harness"
+)
+sys.path.insert(0, str(HARNESS_LIBRARY))
+import resource_lane
+
 
 TIMEOUT_EXIT = 124
 SUPERVISOR_EXIT = 125
@@ -286,13 +292,17 @@ def lane_owner(lane_handle):
     }
 
 
-def print_lane_wait(lane_handle):
+def print_lane_wait(lane_handle, queue_status):
     owner = lane_owner(lane_handle)
     print(
         "agent-resource-run: waiting for lane "
         "owner_pid={owner_pid} task={task} command={command} since={since} "
+        "queue_position={queue_position}/{queue_depth} queued_since={queued_since} "
         "heartbeat={heartbeat}".format(
             **owner,
+            queue_position=queue_status["position"],
+            queue_depth=queue_status["depth"],
+            queued_since=queue_status["queued_at"],
             heartbeat=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         ),
         file=sys.stderr,
@@ -311,56 +321,91 @@ def acquire_lane(
     heartbeat_seconds,
 ):
     next_heartbeat = None
-    while True:
-        if supervisor.signal_received is not None:
-            return False
-        try:
-            fcntl.flock(lane_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-            lane_handle.seek(0)
-            lane_handle.truncate()
-            json.dump(
-                {
-                    "pid": os.getpid(),
-                    "cwd": str(Path.cwd()),
-                    "acquired_epoch": int(time.time()),
-                    "task": task,
-                    "command": command,
-                    "since": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-                },
-                lane_handle,
-                sort_keys=True,
-            )
-            lane_handle.write("\n")
-            lane_handle.flush()
-            os.fsync(lane_handle.fileno())
-            return True
-        except OSError as error:
-            if error.errno not in (errno.EACCES, errno.EAGAIN):
-                raise
-
-        now = time.monotonic()
-        if next_heartbeat is None or now >= next_heartbeat:
-            print_lane_wait(lane_handle)
-            next_heartbeat = now + heartbeat_seconds
-
-        remaining = absolute_deadline - now
-        if remaining <= 0:
-            owner = ""
-            try:
+    ticket = resource_lane.join_lane_queue(
+        lane_path.parent,
+        task=task,
+        command=command,
+    )
+    acquired = False
+    try:
+        while True:
+            if supervisor.signal_received is not None:
+                return False
+            queue_status = resource_lane.lane_queue_status(ticket)
+            if queue_status["position"] == 1:
+                try:
+                    fcntl.flock(
+                        lane_handle.fileno(),
+                        fcntl.LOCK_EX | fcntl.LOCK_NB,
+                    )
+                    acquired = True
+                except OSError as error:
+                    if error.errno not in (errno.EACCES, errno.EAGAIN):
+                        raise
+            if acquired:
                 lane_handle.seek(0)
-                owner = lane_handle.read().strip()
-            except OSError:
-                pass
-            suffix = " (owner: {})".format(owner) if owner else ""
-            print(
-                "agent-resource-run: aggregate deadline exceeded waiting for lane {}{}".format(
-                    lane_path, suffix
-                ),
-                file=sys.stderr,
+                lane_handle.truncate()
+                json.dump(
+                    {
+                        "pid": os.getpid(),
+                        "cwd": str(Path.cwd()),
+                        "acquired_epoch": int(time.time()),
+                        "task": task,
+                        "command": command,
+                        "since": time.strftime(
+                            "%Y-%m-%dT%H:%M:%SZ",
+                            time.gmtime(),
+                        ),
+                    },
+                    lane_handle,
+                    sort_keys=True,
+                )
+                lane_handle.write("\n")
+                lane_handle.flush()
+                os.fsync(lane_handle.fileno())
+                resource_lane.leave_lane_queue(ticket)
+                return True
+
+            now = time.monotonic()
+            if next_heartbeat is None or now >= next_heartbeat:
+                print_lane_wait(lane_handle, queue_status)
+                next_heartbeat = now + heartbeat_seconds
+
+            remaining = absolute_deadline - now
+            if remaining <= 0:
+                owner = ""
+                try:
+                    lane_handle.seek(0)
+                    owner = lane_handle.read().strip()
+                except OSError:
+                    pass
+                suffix = " (owner: {})".format(owner) if owner else ""
+                print(
+                    "agent-resource-run: aggregate deadline exceeded waiting for "
+                    "lane {}{} queue_position={}/{} queued_since={}".format(
+                        lane_path,
+                        suffix,
+                        queue_status["position"],
+                        queue_status["depth"],
+                        queue_status["queued_at"],
+                    ),
+                    file=sys.stderr,
+                )
+                return False
+            until_heartbeat = max(
+                0.0,
+                next_heartbeat - time.monotonic(),
             )
-            return False
-        until_heartbeat = max(0.0, next_heartbeat - time.monotonic())
-        time.sleep(min(POLL_SECONDS, remaining, until_heartbeat or POLL_SECONDS))
+            time.sleep(
+                min(
+                    POLL_SECONDS,
+                    remaining,
+                    until_heartbeat or POLL_SECONDS,
+                )
+            )
+    finally:
+        if not acquired:
+            resource_lane.leave_lane_queue(ticket)
 
 
 def survivor_lock_guard(supervisor, lane_fd):


### PR DESCRIPTION
## Summary
- admit both harness checks and `agent-resource-run` through one crash-safe FIFO ticket queue
- expose queue position and enqueue time while waiting, and reap timed-out/SIGKILL waiters
- prune task-private runtime caches on initial and idempotent v2 clean while preserving profiles, evidence, archives, and the shared Sherpa cache

## Verification
- `python3 .agents/harness/v2_selftest.py` — PASS (382 assertions)
- `scripts/agent-config-audit --ci` — PASS (164 checks)
- `scripts/agent-harness selftest --ci` — PASS
- independent v1 harness spec + adversarial reviews — PASS

Codex-only verification; no Claude invocation.