### PR TITLE
fix(org): enforce lexical coverage floor

### DIFF
--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -7251,6 +7251,97 @@ pub(crate) fn fts_match_query(q: &str) -> Option<String> {
     )
 }
 
+/// Canonical content terms under the exact FTS tokenizer used by every production content index.
+///
+/// Rust splitting/lowercasing cannot model `unicode61 remove_diacritics 2`: distinct strings such
+/// as precomposed `résumé`, decomposed `re\u{301}sume\u{301}`, and `resume` are one FTS token and
+/// must never receive multiple fallback coverage votes. A connection-local TEMP FTS table tokenizes
+/// the ORIGINAL query, while `fts5vocab(..., 'instance')` exposes canonical tokens in occurrence
+/// order. Tokens that are not Unicode-alphanumeric or are too short are discarded; the survivors
+/// are stopword-filtered, first-seen deduplicated, and bounded before callers build MATCH SQL.
+pub(crate) fn fts_unicode61_content_terms(
+    conn: &Connection,
+    q: &str,
+    max_terms: usize,
+) -> Result<Vec<String>> {
+    if max_terms == 0 {
+        return Ok(Vec::new());
+    }
+    conn.execute_batch(
+        "CREATE VIRTUAL TABLE IF NOT EXISTS temp.murmur_query_tokenizer USING fts5(
+             text,
+             tokenize = 'unicode61 remove_diacritics 2'
+         );
+         CREATE VIRTUAL TABLE IF NOT EXISTS temp.murmur_query_vocab_instance USING fts5vocab(
+             murmur_query_tokenizer,
+             'instance'
+         );",
+    )
+    .map_err(map_err)?;
+
+    // Keep query text transaction-local. Any early error rolls the TEMP insert back on Drop; the
+    // successful path explicitly rolls back too, so no prior query survives for a later read.
+    let tx = conn.unchecked_transaction().map_err(map_err)?;
+    let result = (|| -> Result<Vec<String>> {
+        let mut canonical_terms = Vec::new();
+        let mut seen = HashSet::new();
+        tx.execute("DELETE FROM temp.murmur_query_tokenizer", [])
+            .map_err(map_err)?;
+        tx.execute(
+            "INSERT INTO temp.murmur_query_tokenizer(text) VALUES (?1)",
+            rusqlite::params![q],
+        )
+        .map_err(map_err)?;
+
+        let mut stmt = tx
+            .prepare(
+                "SELECT term
+                   FROM temp.murmur_query_vocab_instance
+                  ORDER BY doc, offset",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(map_err)?;
+        for row in rows {
+            let canonical = row.map_err(map_err)?;
+            if canonical.chars().count() < 3
+                || !canonical.chars().all(|ch| ch.is_alphanumeric())
+                || crate::summarize::related_context::is_stopword(&canonical)
+            {
+                continue;
+            }
+            if seen.insert(canonical.clone()) {
+                canonical_terms.push(canonical);
+                if canonical_terms.len() == max_terms {
+                    break;
+                }
+            }
+        }
+        Ok(canonical_terms)
+    })();
+    tx.rollback().map_err(map_err)?;
+    result
+}
+
+fn fts_match_content_terms(terms: &[String], separator: &str) -> Option<String> {
+    if terms.is_empty() {
+        return None;
+    }
+    Some(
+        terms
+            .iter()
+            .map(|term| format!("\"{}\"", term.replace('"', "\"\"")))
+            .collect::<Vec<_>>()
+            .join(separator),
+    )
+}
+
+/// Exact-token OR expression over an already-normalized content-term list.
+pub(crate) fn fts_match_content_terms_any(terms: &[String]) -> Option<String> {
+    fts_match_content_terms(terms, " OR ")
+}
+
 /// The OR-joined twin of [`fts_match_query`]: the same tokenize-and-quote defusal, but terms are
 /// joined with `OR` instead of implicit AND. Used for RELEVANCE filtering (Brain v2 L2.2), where the
 /// "query" is a whole natural-language question and a short fact row should match on ANY shared

--- a/src-tauri/src/storage/db_tests/tests.rs
+++ b/src-tauri/src/storage/db_tests/tests.rs
@@ -11295,6 +11295,204 @@ fn s2_and_to_or_fallback_recovers_multiword_miss_org() {
     );
 }
 
+/// ORG SEARCH RELEVANCE FLOOR: the OR fallback is allowed only when at least
+/// `ceil(unique_content_terms / 2)` exact FTS tokens match ONE chunk. This uses a real, file-backed
+/// SQLCipher handle (the production `Db::open_with_key` path), not a Rust substring approximation.
+/// It pins the two reported coverage boundaries, duplicate-query-term resistance, exact-token
+/// matching (`Kong` != `Kongo`), the SQL-construction term bound, and the existing two-term
+/// cross-language fallback.
+#[test]
+fn org_fts_or_fallback_requires_ceil_half_exact_unique_content_terms() {
+    const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    let path = unique_temp_path("murmur-org-fts-coverage", "sqlite");
+    let _ = std::fs::remove_file(&path);
+    let db = Db::open_with_key(&path, TEST_DEK).unwrap();
+    seed_org_state(&db, "org-1");
+
+    let ingest = |item_id: &str, title: &str, body: &str, tag: u8| {
+        db.upsert_org_item(
+            item_id,
+            "org-1",
+            u64::from(tag),
+            "anna",
+            title,
+            body,
+            "2026-07-10T09:00:00Z",
+            1,
+            1,
+            &sha32(tag),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+    };
+
+    // Six unique content terms => threshold 3. One exact token is noise; three is signal.
+    ingest("six-one", "One of six", "Kong travel diary", 1);
+    ingest(
+        "six-three",
+        "Three of six",
+        "hybrid source operator decision",
+        2,
+    );
+    // A second matching chunk for the same item must not duplicate the returned item.
+    db.lock()
+        .execute(
+            "INSERT INTO org_chunks (item_id, chunk_idx, text) VALUES (?1, ?2, ?3)",
+            rusqlite::params!["six-three", 99_i64, "hybrid source operator follow-up"],
+        )
+        .unwrap();
+    // A prefix/substring is not an exact unicode61 token match for `kong`.
+    ingest("six-kongo", "Kongo is different", "Kongo travel diary", 3);
+    let six = db
+        .search_org_chunks_fts("hybrid mode source truth kong operator", 10)
+        .unwrap();
+    let six_ids: Vec<&str> = six.iter().map(|hit| hit.item_id.as_str()).collect();
+    assert_eq!(
+        six_ids,
+        vec!["six-three"],
+        "1/6 and Kongo-prefix noise must be rejected while 3/6 survives: {six_ids:?}"
+    );
+
+    // Result bounds stay hard after SQL coverage qualification and per-item dedup.
+    ingest(
+        "six-three-b",
+        "Another three of six",
+        "mode truth operator decision",
+        7,
+    );
+    let bounded = db
+        .search_org_chunks_fts("hybrid mode source truth kong operator", 1)
+        .unwrap();
+    assert_eq!(
+        bounded.len(),
+        1,
+        "the requested result bound must stay hard"
+    );
+
+    // Three unique content terms => threshold 2.
+    ingest("three-one", "One of three", "violet memo", 4);
+    ingest("three-two", "Two of three", "violet ember memo", 5);
+    let three = db.search_org_chunks_fts("violet quartz ember", 10).unwrap();
+    let three_ids: Vec<&str> = three.iter().map(|hit| hit.item_id.as_str()).collect();
+    assert_eq!(
+        three_ids,
+        vec!["three-two"],
+        "1/3 must be rejected while 2/3 survives: {three_ids:?}"
+    );
+
+    // Repeating `violet` cannot turn one matched token into multiple coverage votes.
+    let duplicate = db
+        .search_org_chunks_fts("violet violet quartz ember", 10)
+        .unwrap();
+    let duplicate_ids: Vec<&str> = duplicate.iter().map(|hit| hit.item_id.as_str()).collect();
+    assert_eq!(
+        duplicate_ids,
+        vec!["three-two"],
+        "duplicate query terms must neither inflate coverage nor the threshold: {duplicate_ids:?}"
+    );
+
+    // One-term exact token sanity: `Kong` must not match `Kongo`.
+    let kong = db.search_org_chunks_fts("kong", 10).unwrap();
+    let kong_ids: Vec<&str> = kong.iter().map(|hit| hit.item_id.as_str()).collect();
+    assert_eq!(kong_ids, vec!["six-one"], "Kong != Kongo: {kong_ids:?}");
+
+    // Existing cross-language AND→OR recovery remains: 2 terms => ceil(2/2) = 1.
+    ingest(
+        "parcel-fallback",
+        "Parcel fallback",
+        "parcel size delivery schedule",
+        6,
+    );
+    let fallback = db.search_org_chunks_fts("etykieta parcel", 10).unwrap();
+    assert!(
+        fallback.iter().any(|hit| hit.item_id == "parcel-fallback"),
+        "the existing two-term fallback must still recover a one-token domain match"
+    );
+
+    // Fallback SQL construction is bounded independently of the full strict expression. A query
+    // with 65 unique content terms uses its first bounded 32 fallback terms; matching 16 of those
+    // reaches ceil(32 / 2) without SQLite prepare-limit errors.
+    let first_half = (0..16)
+        .map(|index| format!("term{index:03}"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    ingest("bounded-query", "Bounded query", &first_half, 8);
+    let overlong_query = (0..65)
+        .map(|index| format!("term{index:03}"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let overlong = db.search_org_chunks_fts(&overlong_query, 10).unwrap();
+    assert!(
+        overlong.iter().any(|hit| hit.item_id == "bounded-query"),
+        "overlong query must use a bounded term list for fallback SQL: {overlong:?}"
+    );
+
+    // The strict phase remains the full original query: once a row matching all 65 terms exists,
+    // strict AND returns it and the fallback must not also admit a row matching only the first 16.
+    ingest("strict-full-query", "Strict full query", &overlong_query, 11);
+    let strict_overlong = db.search_org_chunks_fts(&overlong_query, 10).unwrap();
+    let strict_ids = strict_overlong
+        .iter()
+        .map(|hit| hit.item_id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        strict_ids,
+        vec!["strict-full-query"],
+        "full strict AND must not truncate to the fallback term cap: {strict_ids:?}"
+    );
+
+    // Unicode lowercase expansion and unicode61 diacritic folding must agree with the coverage
+    // list. `İİİ`/`iii` and precomposed/decomposed `résumé`/`resume` are each one logical FTS token,
+    // never multiple votes.
+    let unicode_terms = {
+        let conn = db.lock();
+        fts_unicode61_content_terms(
+            &conn,
+            "İİİ iii résumé resume re\u{301}sume\u{301} quartz ember",
+            32,
+        )
+        .unwrap()
+    };
+    assert_eq!(
+        unicode_terms,
+        vec!["iii", "resume", "quartz", "ember"],
+        "canonical terms must use SQLite unicode61 single-token identity"
+    );
+    ingest("unicode-i", "Unicode I", "iii memo", 9);
+    let unicode_i = db
+        .search_org_chunks_fts("İİİ iii quartz ember", 10)
+        .unwrap();
+    assert!(
+        unicode_i.iter().all(|hit| hit.item_id != "unicode-i"),
+        "equivalent lowercase-expanding terms must count once, not satisfy 2/3: {unicode_i:?}"
+    );
+    ingest("unicode-accent", "Unicode accent", "resume memo", 10);
+    let unicode_accent = db
+        .search_org_chunks_fts("résumé resume quartz ember", 10)
+        .unwrap();
+    assert!(
+        unicode_accent
+            .iter()
+            .all(|hit| hit.item_id != "unicode-accent"),
+        "unicode61-equivalent diacritic terms must count once, not satisfy 2/3: {unicode_accent:?}"
+    );
+    let unicode_decomposed = db
+        .search_org_chunks_fts("résumé re\u{301}sume\u{301} quartz ember", 10)
+        .unwrap();
+    assert!(
+        unicode_decomposed
+            .iter()
+            .all(|hit| hit.item_id != "unicode-accent"),
+        "decomposed and precomposed unicode61-equivalent terms must count once, not satisfy 2/3: \
+         {unicode_decomposed:?}"
+    );
+
+    drop(db);
+    let _ = std::fs::remove_file(path);
+}
+
 /// S2 Test D (precision preserved — the QA "No meetings match" guard): a query whose content words
 /// appear in NONE of the corpus notes stays EMPTY even after the OR fallback (no shared content
 /// word ⇒ the OR built from the query's own content words matches nothing).

--- a/src-tauri/src/storage/org_store.rs
+++ b/src-tauri/src/storage/org_store.rs
@@ -25,8 +25,15 @@ use rusqlite::OptionalExtension;
 
 use crate::embed::Embedder;
 use crate::error::Result;
-use crate::storage::db::{fts_match_query, fts_match_query_any, map_err, Db};
+use crate::storage::db::{
+    fts_match_content_terms_any, fts_match_query, fts_unicode61_content_terms, map_err, Db,
+};
 use crate::storage::models::OrgChunkHit;
+
+/// Keep the fallback comfortably below SQLite's compound-SELECT and bind-parameter ceilings.
+/// Natural-language org queries should never approach this; taking the first bounded unique terms
+/// also prevents an untrusted query from making SQL preparation scale without bound.
+const MAX_ORG_FTS_CONTENT_TERMS: usize = 32;
 
 /// Chunk/vector material for one org item, prepared before entering the short feed-commit
 /// transaction. Keeping model inference on this side of the transaction is load-bearing: recording
@@ -1777,10 +1784,10 @@ impl Db {
             return Ok(Vec::new());
         }
         let q = query.trim();
+        let conn = self.lock();
         let Some(and_expr) = fts_match_query(q) else {
             return Ok(Vec::new()); // punctuation-only / empty query → no hits, never an FTS error.
         };
-        let conn = self.lock();
         // Over-fetch a bounded multiple of `limit` so per-item dedup has candidates, but keep the SQL
         // LIMIT as the hard bound (spike #2). 8× is generous for a per-item dedup at small `limit`.
         let sql_cap = limit.saturating_mul(8).clamp(limit, 512);
@@ -1813,13 +1820,83 @@ impl Db {
             }
             Ok(out)
         };
-        // S2 AND→OR fallback: implicit-AND matched nothing ⇒ retry with the content-word OR twin.
-        // Fires only on an empty AND result — never widens a successful query.
+        // Preserve the full pre-fallback strict query exactly. In particular, do not cap,
+        // deduplicate, or stopword-filter it: the bounded canonical list belongs only to the
+        // fallback and a row matching merely the first 32 terms must not satisfy a longer strict
+        // query. Only an empty strict result may activate the fallback.
         let mut rows_vec = run(&mut stmt, &and_expr)?;
         if rows_vec.is_empty() {
-            if let Some(any_expr) = fts_match_query_any(q) {
-                if any_expr != and_expr {
-                    rows_vec = run(&mut stmt, &any_expr)?;
+            let terms =
+                fts_unicode61_content_terms(&conn, q, MAX_ORG_FTS_CONTENT_TERMS)?;
+            let Some(any_expr) = fts_match_content_terms_any(&terms) else {
+                return Ok(Vec::new());
+            };
+            if any_expr != and_expr {
+                // Relevance floor: an OR candidate must match at least ceil(unique_terms / 2)
+                // EXACT FTS tokens in one chunk. Each UNION branch is one unique query term and
+                // returns a rowid only when unicode61 MATCH sees that whole token (`Kong` therefore
+                // does not match `Kongo`). GROUP/HAVING qualifies coverage before BM25 ORDER/LIMIT;
+                // Rust never inspects snippets or performs substring matching.
+                let branches = terms
+                    .iter()
+                    .map(|_| {
+                        "SELECT rowid AS chunk_rowid
+                           FROM fts_org_chunks
+                          WHERE fts_org_chunks MATCH ?"
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" UNION ALL ");
+                let threshold = i64::try_from(terms.len().div_ceil(2)).map_err(|_| {
+                    crate::error::AppError::InvalidArg(
+                        "org search query has too many unique content terms".to_string(),
+                    )
+                })?;
+                let fallback_sql = format!(
+                    "WITH matched_terms(chunk_rowid) AS ({branches}),
+                          qualified_chunks(chunk_rowid) AS (
+                              SELECT chunk_rowid
+                                FROM matched_terms
+                               GROUP BY chunk_rowid
+                              HAVING COUNT(*) >= ?
+                          )
+                     SELECT oi.item_id, oi.author_hint, oi.title, oc.text, oi.content_sha256,
+                            bm25(fts_org_chunks) AS rank
+                       FROM fts_org_chunks
+                       JOIN qualified_chunks qc ON qc.chunk_rowid = fts_org_chunks.rowid
+                       JOIN org_chunks oc ON oc.id = fts_org_chunks.rowid
+                       JOIN org_items oi ON oi.item_id = oc.item_id
+                       JOIN org_state os ON os.org_id = oi.org_id
+                      WHERE fts_org_chunks MATCH ?
+                        AND oi.tombstoned = 0
+                        AND os.context_enabled = 1
+                      ORDER BY rank ASC, oi.item_id ASC
+                      LIMIT ?"
+                );
+                let mut params: Vec<rusqlite::types::Value> = terms
+                    .iter()
+                    // `terms` contains only Unicode alphanumerics, but quote each one to pin exact
+                    // FTS-token semantics and keep it inert as MATCH syntax.
+                    .map(|term| rusqlite::types::Value::Text(format!("\"{term}\"")))
+                    .collect();
+                params.push(rusqlite::types::Value::Integer(threshold));
+                params.push(rusqlite::types::Value::Text(any_expr));
+                params.push(rusqlite::types::Value::Integer(sql_cap));
+
+                let mut fallback_stmt = conn.prepare(&fallback_sql).map_err(map_err)?;
+                let fallback_rows = fallback_stmt
+                    .query_map(rusqlite::params_from_iter(params.iter()), |row| {
+                        Ok(OrgChunkHit {
+                            item_id: row.get(0)?,
+                            author_hint: row.get(1)?,
+                            title: row.get(2)?,
+                            snippet: row.get(3)?,
+                            content_sha256: row.get::<_, Option<Vec<u8>>>(4)?.unwrap_or_default(),
+                        })
+                    })
+                    .map_err(map_err)?;
+                rows_vec.clear();
+                for row in fallback_rows {
+                    rows_vec.push(row.map_err(map_err)?);
                 }
             }
         }

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -1480,7 +1480,7 @@ pub(crate) fn search_org_brain(db: &Db, config: &AppConfig, query: &str) -> Resu
     }
     let hits = search_org_brain_hits(db, config, query)?;
     if hits.is_empty() {
-        return Ok(format!("No org-brain results for \"{q}\"."));
+        return Ok("No org-brain results.".to_string());
     }
     Ok(neutralize_murmur_fences(&format_org_hits(&hits)))
 }
@@ -4286,6 +4286,10 @@ mod tests {
             semantic_search_enabled: false,
             ..AppConfig::default()
         };
+        assert!(
+            !cfg.org_egress_consented,
+            "fixture must prove publish consent is not the joined member's read gate"
+        );
 
         let hits = search_org_brain_hits(&db, &cfg, "nebula pricing rollout").unwrap();
         assert!(
@@ -4387,6 +4391,148 @@ mod tests {
         assert!(
             out.contains("Launch plan"),
             "MCP org_search must find the item: {out}"
+        );
+    }
+
+    /// ORG SEARCH FLOOR THROUGH THE REAL TOOL SEAM: `execute_tool` with semantic
+    /// retrieval disabled must use only the SQL/FTS leg, surface a 3/6 exact-token hit, reject 1/6
+    /// and `Kongo` substring noise, and return the normal no-results sentinel when the only candidate
+    /// covers 1/3 terms. `tmp_db()` is file-backed SQLCipher via `Db::open_with_key`.
+    #[test]
+    fn mcp_org_search_lexical_floor_rejects_noise_without_semantic() {
+        let db = tmp_db();
+        seed_org(&db);
+        let cfg = AppConfig {
+            semantic_search_enabled: false,
+            ..AppConfig::default()
+        };
+        ingest_org(
+            &db,
+            "it-signal",
+            "erin",
+            "Signal",
+            "hybrid source operator decision",
+            &[31u8; 32],
+        );
+        ingest_org(
+            &db,
+            "it-one",
+            "mallory",
+            "One-token noise",
+            "Kong travel diary",
+            &[32u8; 32],
+        );
+        ingest_org(
+            &db,
+            "it-prefix",
+            "mallory",
+            "Substring noise",
+            "Kongo travel diary",
+            &[33u8; 32],
+        );
+
+        let out = execute_tool(
+            &ToolCall::OrgBrainSearch {
+                query: "hybrid mode source truth kong operator".into(),
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            out.contains("Signal") && out.contains("[org · erin]"),
+            "the lexical 3/6 hit must surface with provenance: {out}"
+        );
+        assert!(
+            !out.contains("One-token noise") && !out.contains("Substring noise"),
+            "1/6 and Kong/Kongo substring noise must not reach tool output: {out}"
+        );
+
+        ingest_org(
+            &db,
+            "it-three-one",
+            "mallory",
+            "One of three",
+            "violet memo",
+            &[34u8; 32],
+        );
+        let no_results = execute_tool(
+            &ToolCall::OrgBrainSearch {
+                query: "violet quartz ember".into(),
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            no_results.starts_with("No org-brain results"),
+            "a lexical 1/3-only corpus must return the normal no-results sentinel: {no_results}"
+        );
+
+        // The per-instance context gate applies at the final rendered tool sink.
+        db.set_org_context_enabled("org-1", false).unwrap();
+        let disabled = execute_tool(
+            &ToolCall::OrgBrainSearch {
+                query: "hybrid source operator".into(),
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            disabled.starts_with("No org-brain results")
+                && !disabled.contains("Signal")
+                && !disabled.contains("hybrid source operator"),
+            "disabled org content must not reach the tool sink: {disabled}"
+        );
+        db.set_org_context_enabled("org-1", true).unwrap();
+
+        // Tombstoning purges the matching chunk and the SQL predicate remains defense-in-depth.
+        db.tombstone_org_item("it-signal").unwrap();
+        let tombstoned = execute_tool(
+            &ToolCall::OrgBrainSearch {
+                query: "hybrid source operator".into(),
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            tombstoned.starts_with("No org-brain results")
+                && !tombstoned.contains("Signal")
+                && !tombstoned.contains("hybrid source operator"),
+            "tombstoned org content must not reach the tool sink: {tombstoned}"
+        );
+
+        // Membership is the local ORG_READ authorization boundary. A stale replica without
+        // `org_state` is invisible even though the matching plaintext row still exists.
+        let departed = tmp_db();
+        ingest_org(
+            &departed,
+            "it-departed",
+            "mallory",
+            "Departed secret",
+            "hybrid source operator",
+            &[35u8; 32],
+        );
+        let departed_out = execute_tool(
+            &ToolCall::OrgBrainSearch {
+                query: "hybrid source operator".into(),
+            },
+            &departed,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            departed_out.starts_with("No org-brain results")
+                && !departed_out.contains("Departed secret")
+                && !departed_out.contains("hybrid source operator"),
+            "non-member replica content must not reach the tool sink: {departed_out}"
         );
     }
 


### PR DESCRIPTION
## Summary

- preserve the full existing strict FTS implicit-AND query, then fall back only when strict returns no rows
- canonicalize the original fallback query through SQLite FTS5 unicode61/remove_diacritics=2, deduplicate exact canonical tokens, cap at 32, and require ceil-half coverage within one chunk
- keep membership/context/tombstone gates, BM25 ordering, item deduplication, and result bounds intact
- return a generic non-reflecting zero-result sentinel

## Regression coverage

- 6-term and 3-term ceil-half thresholds
- duplicate and prefix false positives, item deduplication, and hard result limit
- Polish fallback and 65-term fallback cap while strict remains untruncated
- Turkish-I and precomposed/decomposed diacritic canonical equivalence
- semantic-off tool results plus disabled-context, tombstone, joined-unconsented, and stale-nonmember non-disclosure

## Verification

- Harness v2 exact-diff PASS
- rust-lib: 2475 passed, 0 failed, 15 ignored
- combined Codex review: PASS, no findings or proof gaps
- lock-security Codex review: PASS, no findings or proof gaps
- Harness diff SHA-256: c35942b0419a28c8a1138bee94e9d42aacd214edd7da561836c1b50ad0ed80cb
- Harness evidence SHA-256: 03df8b9a6cea63f1961fa87738ce4bc6d9f1337d633506800523411fdce8cb34

Supersedes #488.