### PR TITLE
fix(harness): surface focused security test evidence

### DIFF
--- a/.agents/harness/v2_selftest.py
+++ b/.agents/harness/v2_selftest.py
@@ -1463,6 +1463,200 @@ def verdict_cases(test: Tests) -> None:
     )
 
 
+def focused_review_evidence_cases(test: Tests) -> None:
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-focused-evidence-") as raw:
+        task_dir = Path(raw)
+        logs = task_dir / "logs"
+        logs.mkdir()
+        padding = "x" * (verifier.DEFAULT_REVIEW_STREAM_BYTES + 128)
+        lock_lines = [
+            "test tools::tests::org_read_requires_member ... ok",
+            "test storage::tests::context_disabled_hides_org_item ... ok",
+            "test storage::tests::tombstone_removes_org_item ... ok",
+            "test mcp::tests::revocation_stops_locked_tail ... ok",
+        ]
+        egress_lines = [
+            "test summarize::tests::remote_ollama_requires_consent ... ok",
+            "test summarize::tests::egress_ledger_is_content_free ... ok",
+        ]
+        nonmatching = "test unrelated::tests::middle_secret_sentinel ... ok"
+        stdout = logs / "rust.stdout.log"
+        stdout.write_text(
+            "HEAD\n"
+            + padding
+            + "\n"
+            + nonmatching
+            + "\n"
+            + "\n".join(lock_lines + egress_lines)
+            + "\n"
+            + padding
+            + "\nTAIL\n",
+            encoding="utf-8",
+        )
+        stderr = logs / "rust.stderr.log"
+        stderr.write_text("", encoding="utf-8")
+
+        def item_for(path: Path) -> Dict[str, Any]:
+            return {
+                "id": "rust-lib",
+                "command": "cargo test --lib",
+                "evidence": {
+                    "passed": True,
+                    "outcome": "PASS",
+                    "exit_code": 0,
+                    "duration_ms": 1,
+                    "resource_wait_ms": 0,
+                    "log_sha256": "0" * 64,
+                    "stdout_path": str(path),
+                    "stdout_sha256": legacy.sha256_file(path),
+                    "stderr_path": str(stderr),
+                    "stderr_sha256": legacy.sha256_file(stderr),
+                },
+            }
+
+        item = item_for(stdout)
+        lock_summary = verifier._review_evidence_summary(
+            item,
+            task_dir,
+            channel="planned-check",
+            review_kind="lock-security",
+        )
+        lock_inventory = lock_summary["stdout"]["focused_test_inventory"]
+        test.true(
+            "FOCUSED EVIDENCE surfaces security tests from truncated middle",
+            all(line in lock_inventory["excerpt"] for line in lock_lines)
+            and all(line not in lock_summary["stdout"]["excerpt"] for line in lock_lines),
+        )
+        test.true(
+            "FOCUSED EVIDENCE omits nonmatching middle output",
+            nonmatching not in lock_inventory["excerpt"]
+            and nonmatching not in lock_summary["stdout"]["excerpt"],
+        )
+        egress_inventory = verifier._review_evidence_summary(
+            item,
+            task_dir,
+            channel="reviewer-probe",
+            review_kind="egress-security",
+        )["stdout"]["focused_test_inventory"]
+        test.true(
+            "FOCUSED EVIDENCE is specialist-specific",
+            all(line in egress_inventory["excerpt"] for line in egress_lines)
+            and lock_lines[0] not in egress_inventory["excerpt"],
+        )
+
+        many = logs / "many.stdout.log"
+        many.write_text(
+            "".join(
+                f"test org::tests::case_{index:04d} ... ok\n"
+                for index in range(
+                    verifier.SPECIALIST_TEST_FOCUS_LINES_PER_TERM + 20
+                )
+            ),
+            encoding="utf-8",
+        )
+        bounded = verifier._review_evidence_summary(
+            item_for(many),
+            task_dir,
+            channel="planned-check",
+            review_kind="lock-security",
+        )["stdout"]["focused_test_inventory"]
+        test.equal(
+            "FOCUSED EVIDENCE bounds each term deterministically",
+            (
+                bounded["included_lines"],
+                bounded["matching_lines_total"],
+                bounded["truncated"],
+            ),
+            (
+                verifier.SPECIALIST_TEST_FOCUS_LINES_PER_TERM,
+                verifier.SPECIALIST_TEST_FOCUS_LINES_PER_TERM + 20,
+                True,
+            ),
+        )
+
+        overlapping = logs / "overlapping.stdout.log"
+        overlapping.write_text(
+            "".join(
+                f"test org::tests::org_only_{index:04d} ... ok\n"
+                for index in range(
+                    verifier.SPECIALIST_TEST_FOCUS_LINES_PER_TERM
+                )
+            )
+            + "".join(
+                f"test org::member::tests::overlap_{index:04d} ... ok\n"
+                for index in range(
+                    verifier.SPECIALIST_TEST_FOCUS_LINES_PER_TERM + 4
+                )
+            ),
+            encoding="utf-8",
+        )
+        overlapping_inventory = verifier._review_evidence_summary(
+            item_for(overlapping),
+            task_dir,
+            channel="planned-check",
+            review_kind="lock-security",
+        )["stdout"]["focused_test_inventory"]
+        test.true(
+            "FOCUSED EVIDENCE overlapping terms retain independent hard caps",
+            overlapping_inventory["per_term_included"]["org"]
+            == verifier.SPECIALIST_TEST_FOCUS_LINES_PER_TERM
+            and overlapping_inventory["per_term_included"]["member"]
+            == verifier.SPECIALIST_TEST_FOCUS_LINES_PER_TERM
+            and all(
+                count <= verifier.SPECIALIST_TEST_FOCUS_LINES_PER_TERM
+                for count in overlapping_inventory["per_term_included"].values()
+            ),
+        )
+
+        byte_pressure = logs / "byte-pressure.stdout.log"
+        long_name = "z" * 4_000
+        byte_pressure.write_text(
+            "".join(
+                f"test org::tests::{long_name}_{index:02d} ... ok\n"
+                for index in range(
+                    verifier.SPECIALIST_TEST_FOCUS_LINES_PER_TERM
+                )
+            ),
+            encoding="utf-8",
+        )
+        first_byte_summary = verifier._review_evidence_summary(
+            item_for(byte_pressure),
+            task_dir,
+            channel="planned-check",
+            review_kind="lock-security",
+        )["stdout"]["focused_test_inventory"]
+        second_byte_summary = verifier._review_evidence_summary(
+            item_for(byte_pressure),
+            task_dir,
+            channel="planned-check",
+            review_kind="lock-security",
+        )["stdout"]["focused_test_inventory"]
+        test.true(
+            "FOCUSED EVIDENCE byte pressure is bounded complete and deterministic",
+            first_byte_summary["matching_lines_total"]
+            == verifier.SPECIALIST_TEST_FOCUS_LINES_PER_TERM
+            and first_byte_summary["included_lines"]
+            < first_byte_summary["matching_lines_total"]
+            and first_byte_summary["included_bytes"]
+            <= verifier.SPECIALIST_TEST_FOCUS_BYTES
+            and first_byte_summary["truncated"]
+            and first_byte_summary == second_byte_summary,
+        )
+
+        corrupt_item = item_for(stdout)
+        corrupt_item["evidence"]["stdout_sha256"] = "f" * 64
+        test.raises(
+            "FOCUSED EVIDENCE remains bound to raw artifact hash",
+            lambda: verifier._review_evidence_summary(
+                corrupt_item,
+                task_dir,
+                channel="planned-check",
+                review_kind="lock-security",
+            ),
+            "hash changed",
+        )
+
+
 def probe_precedence_flow_cases(test: Tests) -> None:
     """Pin review-defect precedence through the real v2 verify transition."""
 
@@ -1710,6 +1904,7 @@ def probe_precedence_flow_cases(test: Tests) -> None:
                         forged_ng_build,
                         task_dir,
                         channel="planned-check",
+                        review_kind="combined",
                     )["source"],
                     "PLANNED_NG_BUILD_STREAM" in forged_channel_prompt,
                 ),
@@ -6227,6 +6422,7 @@ def main() -> int:
     npm_lock_evidence_cases(test)
     reviewer_tool_guard_cases(test)
     verdict_cases(test)
+    focused_review_evidence_cases(test)
     retry_cases(test)
     guardian_and_artifact_cases(test)
     readonly_review_wall_timeout_cases(test)

--- a/.agents/harness/verifier.py
+++ b/.agents/harness/verifier.py
@@ -57,6 +57,33 @@ ALLOWED_PROBES = {
 MAX_PROBE_EXECUTIONS_PER_ID = 2
 DEFAULT_REVIEW_STREAM_BYTES = 2_048
 NPM_LOCK_REVIEW_STREAM_BYTES = 65_536
+SPECIALIST_TEST_FOCUS_LINES_PER_TERM = 12
+SPECIALIST_TEST_FOCUS_BYTES = 32_768
+SPECIALIST_TEST_FOCUS_TERMS = {
+    "lock-security": (
+        "lock",
+        "unlock",
+        "seal",
+        "visibility",
+        "org",
+        "member",
+        "context",
+        "tombstone",
+        "revok",
+    ),
+    "egress-security": (
+        "egress",
+        "consent",
+        "redact",
+        "provider",
+        "ollama",
+        "anthropic",
+        "gateway",
+        "remote",
+        "loopback",
+        "ledger",
+    ),
+}
 TRANSIENT_HTTP_STATUSES = {408, 409, 425, 429, 500, 502, 503, 504}
 PROTOCOL_FILES = (
     "AGENTS.md",
@@ -898,6 +925,8 @@ def _bounded_stream_summary(
     expected_hash: Any,
     label: str,
     limit: int,
+    *,
+    test_focus_terms: Sequence[str] = (),
 ) -> Dict[str, Any]:
     path = _artifact_inside(task_dir, raw_path, expected_hash, label)
     size = path.stat().st_size
@@ -917,13 +946,84 @@ def _bounded_stream_summary(
             f"\n... <{omitted} evidence bytes omitted> ...\n".encode("utf-8")
         ) + suffix
         truncated = True
-    return {
+    summary = {
         "sha256": expected_hash,
         "bytes": size,
         "truncated": truncated,
         "excerpt_included": True,
         "excerpt": excerpt.decode("utf-8", "replace"),
     }
+    if test_focus_terms:
+        normalized_terms = tuple(
+            dict.fromkeys(term.strip().lower() for term in test_focus_terms if term.strip())
+        )
+        per_term_total = {term: 0 for term in normalized_terms}
+        per_term_lines: Dict[str, List[str]] = {
+            term: [] for term in normalized_terms
+        }
+        focused_bytes = 0
+        matching_lines_total = 0
+        test_outcome = re.compile(
+            r"^test .+ \.\.\. (?:ok|FAILED|ignored)$"
+        )
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            for raw_line in handle:
+                line = raw_line.rstrip("\r\n")
+                if not test_outcome.fullmatch(line):
+                    continue
+                lowered = line.lower()
+                matched = tuple(
+                    term for term in normalized_terms if term in lowered
+                )
+                if not matched:
+                    continue
+                matching_lines_total += 1
+                for term in matched:
+                    per_term_total[term] += 1
+                    bucket = per_term_lines[term]
+                    if len(bucket) >= SPECIALIST_TEST_FOCUS_LINES_PER_TERM:
+                        continue
+                    if bucket:
+                        entry = "\n" + line
+                    else:
+                        separator = "\n" if any(per_term_lines.values()) else ""
+                        entry = f"{separator}[{term}]\n{line}"
+                    encoded_size = len(entry.encode("utf-8"))
+                    if (
+                        focused_bytes + encoded_size
+                        > SPECIALIST_TEST_FOCUS_BYTES
+                    ):
+                        continue
+                    bucket.append(line)
+                    focused_bytes += encoded_size
+        focused_sections = [
+            f"[{term}]\n" + "\n".join(per_term_lines[term])
+            for term in normalized_terms
+            if per_term_lines[term]
+        ]
+        focused_excerpt = "\n".join(focused_sections)
+        per_term_included = {
+            term: len(per_term_lines[term]) for term in normalized_terms
+        }
+        unique_lines = {
+            line for lines in per_term_lines.values() for line in lines
+        }
+        summary["focused_test_inventory"] = {
+            "source_sha256": expected_hash,
+            "terms": list(normalized_terms),
+            "matching_lines_total": matching_lines_total,
+            "included_lines": len(unique_lines),
+            "included_occurrences": sum(per_term_included.values()),
+            "included_bytes": len(focused_excerpt.encode("utf-8")),
+            "truncated": any(
+                per_term_total[term] > per_term_included[term]
+                for term in normalized_terms
+            ),
+            "per_term_total": per_term_total,
+            "per_term_included": per_term_included,
+            "excerpt": focused_excerpt,
+        }
+    return summary
 
 
 def _review_evidence_summary(
@@ -931,6 +1031,7 @@ def _review_evidence_summary(
     task_dir: Path,
     *,
     channel: str,
+    review_kind: str,
 ) -> Dict[str, Any]:
     evidence = item.get("evidence", item)
     if not isinstance(evidence, Mapping):
@@ -944,6 +1045,11 @@ def _review_evidence_summary(
         NPM_LOCK_REVIEW_STREAM_BYTES
         if check_id == "npm-lock"
         else DEFAULT_REVIEW_STREAM_BYTES
+    )
+    test_focus_terms = (
+        SPECIALIST_TEST_FOCUS_TERMS.get(review_kind, ())
+        if check_id in {"rust-lib", "protocol-server"}
+        else ()
     )
     request_contexts = []
     for context in item.get("request_contexts", []):
@@ -979,6 +1085,7 @@ def _review_evidence_summary(
             evidence.get("stdout_sha256"),
             f"review-visible {check_id} stdout",
             limit,
+            test_focus_terms=test_focus_terms,
         ),
         "stderr": _bounded_stream_summary(
             task_dir,
@@ -1011,12 +1118,12 @@ def combined_review_prompt(
         policy = legacy.read_prompt(kind + "-reviewer")
     check_summary = [
         _review_evidence_summary(
-            item, task_dir, channel="planned-check"
+            item, task_dir, channel="planned-check", review_kind=kind
         )
         for item in checks
     ] + [
         _review_evidence_summary(
-            item, task_dir, channel="reviewer-probe"
+            item, task_dir, channel="reviewer-probe", review_kind=kind
         )
         for item in probes
     ]


### PR DESCRIPTION
## Summary
- keep the existing hash-bound head/tail reviewer excerpts
- add a bounded specialist-focused Rust test inventory derived from the same immutable stdout artifact
- surface lock/org/revocation and egress/provider/consent outcomes that occur in the truncated middle of large suites
- cap each focus term at 12 outcomes and the whole inventory at 32 KiB

## Verification
- sealed legacy harness task `harness-review-focus-evidence-r3-20260728`: PASS
- `python3 .agents/harness/v2_selftest.py`: 389 assertions PASS
- independent review caught and forced fixes for overlapping-term caps and real byte-pressure coverage
- zero Claude invocations