### PR TITLE
feat(settings): add workspace glossary and grounded defaults

### DIFF
--- a/e2e/settings-notes/glossary-round-trip.spec.ts
+++ b/e2e/settings-notes/glossary-round-trip.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+const STORED_GLOSSARY = "Konnect = Connect, Kinect\nFastMCP = Fast MCP";
+const UPDATED_GLOSSARY =
+  "Kong Operator = KO\nMurmur Protocol = MeetNotes Protocol";
+
+async function openNotesSettings(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  await page.getByText("Notes", { exact: true }).first().click();
+  await expect(page.getByLabel("Workspace glossary")).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+test("workspace glossary loads and saves only after blur, then survives a Settings remount", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    save_config: (args: any) => {
+      const w = window as any;
+      w.__glossarySaves = w.__glossarySaves || [];
+      w.__glossarySaves.push(args.config?.glossary ?? null);
+      w.__demoConfig = Object.assign({}, w.__demoConfig, args.config);
+      return null;
+    },
+  });
+  await page.addInitScript((glossary: string) => {
+    (window as any).__demoConfig = Object.assign(
+      {},
+      (window as any).__demoConfig ?? {},
+      { glossary },
+    );
+  }, STORED_GLOSSARY);
+
+  await page.goto("/settings");
+  await openNotesSettings(page);
+
+  const textarea = page.getByLabel("Workspace glossary");
+  await expect(textarea).toHaveValue(STORED_GLOSSARY);
+
+  await textarea.fill(UPDATED_GLOSSARY);
+  await page.waitForTimeout(650);
+  expect(
+    await page.evaluate(() => (window as any).__glossarySaves ?? []),
+  ).toEqual([]);
+
+  await textarea.blur();
+  await expect
+    .poll(
+      async () =>
+        await page.evaluate(() => (window as any).__glossarySaves ?? []),
+      { timeout: 10_000 },
+    )
+    .toEqual([UPDATED_GLOSSARY]);
+
+  await page.getByRole("button", { name: "Back to Murmur" }).click();
+  await page.getByLabel("Settings", { exact: true }).click();
+  await openNotesSettings(page);
+  await expect(page.getByLabel("Workspace glossary")).toHaveValue(
+    UPDATED_GLOSSARY,
+  );
+});

--- a/e2e/settings-notes/ground-summary-toggle.spec.ts
+++ b/e2e/settings-notes/ground-summary-toggle.spec.ts
@@ -1,0 +1,117 @@
+import { expect, test } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+const CONFIG_WITH_GROUNDING_OFF = {
+  providerId: "claude_code",
+  anthropicModel: "claude-opus-4-8",
+  ollamaBaseUrl: "http://localhost:11434",
+  ollamaModel: "llama3.1",
+  claudeBinary: "claude",
+  captureSystemAudio: true,
+  vadEnabled: true,
+  keepHiresMasters: false,
+  diarizeOthers: true,
+  voiceprintEnabled: false,
+  aecEnabled: false,
+  postAecEnabled: false,
+  modelSize: "small",
+  liveAsrEngine: "whisper",
+  brainIdleTimeoutSecs: 300,
+  brainReadyTimeoutSecs: 90,
+  brainHardCapSecs: 180,
+  voiceTrigger: false,
+  onboarded: true,
+  sharingChoiceMade: true,
+  noteStyle: "standard",
+  notesMode: "enhance",
+  autoOrganize: false,
+  noteLanguage: "auto",
+  groundSummary: false,
+  mcpRequireToken: true,
+  lockRequireBiometric: true,
+  relockOnScreenshare: true,
+  cloudEgressConsented: false,
+  brainBackend: "off",
+  realtimeReactions: false,
+  proactiveHintsEnabled: true,
+  userMemoryEnabled: true,
+  semanticSearchEnabled: true,
+};
+
+test.describe("Notes settings — local grounding toggle", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockTauri(
+      page,
+      {
+        save_config: (args: { config: unknown }) => {
+          (
+            window as unknown as { __savedGroundingConfig?: unknown }
+          ).__savedGroundingConfig = args.config;
+          return null;
+        },
+      },
+      { get_config: CONFIG_WITH_GROUNDING_OFF },
+    );
+    await page.goto("/settings");
+    await page.getByText("Notes", { exact: true }).first().click();
+  });
+
+  test("live-loads OFF and saves each explicit choice without enabling voiceprints", async ({
+    page,
+  }) => {
+    const toggle = page.getByRole("checkbox", {
+      name: /Flag potentially unsupported claims/,
+    });
+
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+    await expect(toggle).not.toBeChecked();
+
+    await toggle.check();
+    await expect(toggle).toBeChecked();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (
+              window as unknown as {
+                __savedGroundingConfig?: {
+                  groundSummary?: boolean;
+                  voiceprintEnabled?: boolean;
+                };
+              }
+            ).__savedGroundingConfig,
+        ),
+      )
+      .toMatchObject({ groundSummary: true, voiceprintEnabled: false });
+
+    await toggle.uncheck();
+    await expect(toggle).not.toBeChecked();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (
+              window as unknown as {
+                __savedGroundingConfig?: {
+                  groundSummary?: boolean;
+                  voiceprintEnabled?: boolean;
+                };
+              }
+            ).__savedGroundingConfig,
+        ),
+      )
+      .toMatchObject({ groundSummary: false, voiceprintEnabled: false });
+  });
+
+  test("describes a local uncalibrated review cue, not proof", async ({ page }) => {
+    await expect(
+      page.getByText(/conservative thresholds are not yet calibrated/),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/not proof that a claim is true or false/),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/runs locally and adds no cloud request/),
+    ).toBeVisible();
+  });
+});

--- a/src-tauri/examples/e2e_core.rs
+++ b/src-tauri/examples/e2e_core.rs
@@ -11,6 +11,10 @@ use meetnotes_lib::export;
 use meetnotes_lib::summarize::provider::{MeetingMeta, SummarizeRequest};
 use meetnotes_lib::transcribe::Transcriber;
 
+const E2E_GLOSSARY: &str = "Murmur = MeetNotes, Meet Notes";
+const E2E_GLOSSARY_PROMPT_LINE: &str =
+    r#"- {"canonical":"Murmur","aliases":["MeetNotes","Meet Notes"]}"#;
+
 #[tokio::main]
 async fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -55,6 +59,14 @@ async fn main() {
         .last()
         .map(|s| s.end_s as i64)
         .unwrap_or(0);
+    let rendered_glossary =
+        meetnotes_lib::summarize::template::render_glossary_for_prompt(E2E_GLOSSARY)
+            .expect("the deterministic glossary fixture must contain one bounded entry");
+    assert_eq!(
+        rendered_glossary.trim_end(),
+        E2E_GLOSSARY_PROMPT_LINE,
+        "the core fixture must use the exact production glossary renderer"
+    );
     let req = SummarizeRequest {
         transcript: transcript.full_text.clone(),
         meta: MeetingMeta {
@@ -68,7 +80,23 @@ async fn main() {
         related_context: None,
         user_notes: None,
         live_bullets: None,
+        glossary: Some(rendered_glossary),
     };
+
+    // Exercise the real bounded glossary renderer locally without invoking any provider. Identical
+    // fixture bytes must produce identical prompt bytes, with one canonical spelling and its aliases.
+    let glossary_prompt = meetnotes_lib::summarize::template::render_prompt(&req);
+    assert_eq!(
+        glossary_prompt,
+        meetnotes_lib::summarize::template::render_prompt(&req),
+        "the deterministic glossary fixture must render byte-identically"
+    );
+    assert_eq!(
+        glossary_prompt.matches(E2E_GLOSSARY_PROMPT_LINE).count(),
+        1,
+        "the bounded glossary fixture must render exactly once"
+    );
+    eprintln!("[e2e] deterministic workspace glossary rendered locally (no egress)");
 
     println!("provider mode: deterministic-stub (no egress)");
     eprintln!("[e2e] using deterministic local stub (no provider egress)");

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -533,10 +533,15 @@ pub struct AppConfigDto {
     pub vad_enabled: bool,
     #[serde(default)]
     pub keep_hires_masters: bool,
+    /// Omission means PRESERVE the stored value so an older/partial client cannot reset an
+    /// explicit opt-out. `get_config` always returns `Some`, while either explicit boolean remains
+    /// a real user choice.
     #[serde(default)]
-    pub diarize_others: bool,
+    pub diarize_others: Option<bool>,
+    /// Voice biometrics are an independent opt-in. Omission must preserve an existing enrollment
+    /// choice rather than silently revoking it during an older/partial settings save.
     #[serde(default)]
-    pub voiceprint_enabled: bool,
+    pub voiceprint_enabled: Option<bool>,
     #[serde(default)]
     pub aec_enabled: bool,
     #[serde(default = "default_true")]
@@ -592,6 +597,15 @@ pub struct AppConfigDto {
     #[serde(default)]
     pub note_assist_actions_off: Vec<String>,
     pub note_language: String,
+    /// On-device post-generation support marker. Settable from Settings. The thresholds are not
+    /// calibrated, so the marker is a review cue rather than proof. Omission means PRESERVE the
+    /// stored value; an explicit `false` remains a durable opt-out.
+    #[serde(default)]
+    pub ground_summary: Option<bool>,
+    /// Workspace glossary update. Omission means PRESERVE the stored value so an older or partial
+    /// client cannot erase it; `Some("")` is an explicit clear.
+    #[serde(default)]
+    pub glossary: Option<String>,
     /// E3/security: default true (matches AppConfig::default) when the FE omits it on an older
     /// payload — an omitted flag must FAIL CLOSED (require a token), never silently disable MCP
     /// auth. Was `#[serde(default)]` (=false), which let a partial save flip the token requirement
@@ -3853,6 +3867,9 @@ pub(crate) async fn build_and_persist_entities(
     let entities_started = std::time::Instant::now();
     let payload =
         crate::summarize::graph::extract_entities(provider.as_ref(), title, markdown).await?;
+    // The glossary never enters this existing graph-provider call. Canonicalize its response
+    // locally, before the first DB entity/mention, fact reference, or vault-stub write.
+    let payload = crate::summarize::graph::canonicalize_with_glossary(payload, &config.glossary);
     tracing::info!(
         target: "perf",
         stage = "extract_entities",
@@ -4905,8 +4922,8 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         capture_system_audio: c.capture_system_audio,
         vad_enabled: c.vad_enabled,
         keep_hires_masters: c.keep_hires_masters,
-        diarize_others: c.diarize_others,
-        voiceprint_enabled: c.voiceprint_enabled,
+        diarize_others: Some(c.diarize_others),
+        voiceprint_enabled: Some(c.voiceprint_enabled),
         aec_enabled: c.aec_enabled,
         post_aec_enabled: c.post_aec_enabled,
         audio_storage_limit_gb: c.audio_storage_limit_gb,
@@ -4926,6 +4943,8 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         note_assist_enhance: c.note_assist_enhance,
         note_assist_actions_off: c.note_assist_actions_off.clone(),
         note_language: c.note_language.clone(),
+        ground_summary: Some(c.ground_summary),
+        glossary: Some(c.glossary.clone()),
         mcp_require_token: c.mcp_require_token,
         lock_require_biometric: c.lock_require_biometric,
         relock_on_screenshare: c.relock_on_screenshare,
@@ -5019,8 +5038,8 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         capture_system_audio: d.capture_system_audio,
         vad_enabled: d.vad_enabled,
         keep_hires_masters: d.keep_hires_masters,
-        diarize_others: d.diarize_others,
-        voiceprint_enabled: d.voiceprint_enabled,
+        diarize_others: d.diarize_others.unwrap_or(current.diarize_others),
+        voiceprint_enabled: d.voiceprint_enabled.unwrap_or(current.voiceprint_enabled),
         aec_enabled: d.aec_enabled,
         post_aec_enabled: d.post_aec_enabled,
         // Recording-storage cap + auto-prune ARE settable from the DTO (the Storage UI owns them).
@@ -5094,6 +5113,10 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         } else {
             d.note_language
         },
+        ground_summary: d.ground_summary.unwrap_or(current.ground_summary),
+        // Omission-safe update semantics: clients predating the glossary preserve the live value,
+        // while an explicit empty string intentionally clears it.
+        glossary: d.glossary.unwrap_or_else(|| current.glossary.clone()),
         mcp_require_token: d.mcp_require_token,
         lock_require_biometric: d.lock_require_biometric,
         relock_on_screenshare: d.relock_on_screenshare,
@@ -5223,11 +5246,6 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         // toggle yet) — PRESERVE the live value so a settings save can neither enable nor clear it;
         // it round-trips through the dedicated K_MEMORY_CONSOLIDATION_ENABLED load/save keys.
         memory_consolidation_enabled: current.memory_consolidation_enabled,
-        // Tier 3b (B) grounding: NOT yet carried on the settings DTO (the FE toggle is a follow-up),
-        // so PRESERVE the live value here — a normal settings save can neither enable nor clear it,
-        // and it round-trips through the dedicated K_GROUND_SUMMARY load/save keys. Mirrors the
-        // preserve-only discipline used for consent + embedder id.
-        ground_summary: current.ground_summary,
         // Brain v2 L3: the grammar-constraint gate, the JIT-Ask flag, and the loop-compaction
         // flag are NOT carried on the settings DTO (no FE toggles yet) — PRESERVE the live values
         // so a settings save can neither enable nor clear them; each round-trips through its
@@ -9603,5 +9621,64 @@ mod connector_dto_tests {
             !out.clickup_consented,
             "a settings save must NEVER grant ClickUp egress consent"
         );
+    }
+}
+
+// ─── diarization + grounding settings DTO contract ────────────────────────────────────────────
+#[cfg(test)]
+mod analysis_defaults_dto_tests {
+    use super::*;
+
+    #[test]
+    fn config_to_dto_exposes_the_real_defaults_without_enabling_voiceprints() {
+        let dto = config_to_dto(&AppConfig::default());
+        assert_eq!(dto.diarize_others, Some(true));
+        assert_eq!(dto.ground_summary, Some(true));
+        assert!(
+            dto.voiceprint_enabled == Some(false),
+            "default analysis aids must not opt users into voice biometrics"
+        );
+    }
+
+    #[test]
+    fn omitted_dto_flags_preserve_explicit_stored_choices() {
+        let current = AppConfig {
+            diarize_others: false,
+            ground_summary: false,
+            voiceprint_enabled: true,
+            ..AppConfig::default()
+        };
+        let mut json = serde_json::to_value(config_to_dto(&current)).unwrap();
+        let object = json.as_object_mut().unwrap();
+        object.remove("diarizeOthers");
+        object.remove("groundSummary");
+        object.remove("voiceprintEnabled");
+
+        let dto: AppConfigDto = serde_json::from_value(json).unwrap();
+        assert_eq!(dto.diarize_others, None);
+        assert_eq!(dto.ground_summary, None);
+        assert_eq!(dto.voiceprint_enabled, None);
+
+        let out = dto_to_config(dto, &current);
+        assert!(!out.diarize_others);
+        assert!(!out.ground_summary);
+        assert!(
+            out.voiceprint_enabled,
+            "an omitted voiceprint flag must not revoke an explicit opt-in"
+        );
+    }
+
+    #[test]
+    fn explicit_dto_choices_apply() {
+        let current = AppConfig::default();
+        let mut dto = config_to_dto(&current);
+        dto.diarize_others = Some(false);
+        dto.ground_summary = Some(false);
+        dto.voiceprint_enabled = Some(true);
+
+        let out = dto_to_config(dto, &current);
+        assert!(!out.diarize_others);
+        assert!(!out.ground_summary);
+        assert!(out.voiceprint_enabled);
     }
 }

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -10078,6 +10078,52 @@
         );
     }
 
+    /// Glossary updates are omission-safe across the Rust IPC boundary. This is intentionally an
+    /// `Option<String>` on `AppConfigDto`: an older/partial client that omits `glossary` preserves
+    /// the live value, while an explicit empty string clears and a non-empty value replaces it.
+    #[test]
+    fn glossary_dto_distinguishes_omitted_empty_and_value() {
+        let current = AppConfig {
+            glossary: "Konnect = Connect".to_string(),
+            ..Default::default()
+        };
+
+        let out = config_to_dto(&current);
+        assert_eq!(
+            out.glossary.as_deref(),
+            Some("Konnect = Connect"),
+            "get_config must carry the stored glossary to Settings"
+        );
+
+        let mut old_client_json = serde_json::to_value(config_to_dto(&AppConfig::default())).unwrap();
+        old_client_json
+            .as_object_mut()
+            .unwrap()
+            .remove("glossary");
+        let omitted: AppConfigDto = serde_json::from_value(old_client_json).unwrap();
+        assert_eq!(
+            dto_to_config(omitted, &current).glossary,
+            "Konnect = Connect",
+            "omission must preserve the live value"
+        );
+
+        let mut clear = config_to_dto(&current);
+        clear.glossary = Some(String::new());
+        assert_eq!(
+            dto_to_config(clear, &current).glossary,
+            "",
+            "Some(empty) is an intentional clear"
+        );
+
+        let mut set = config_to_dto(&current);
+        set.glossary = Some("FastMCP = Fast MCP".to_string());
+        assert_eq!(
+            dto_to_config(set, &current).glossary,
+            "FastMCP = Fast MCP",
+            "Some(value) replaces the live value"
+        );
+    }
+
     /// Proactive brain P1 — the mute toggle round-trips through the settings DTO: `config_to_dto`
     /// carries it OUT (the FE reads `proactiveHintsEnabled`) and `dto_to_config` takes it IN (the
     /// FE sets it), so Settings can actually mute the backend scanner.
@@ -12392,6 +12438,78 @@
             state.config.lock().unwrap().gateway_base_url,
             "https://gw.example.com/v1",
             "valid URL must be persisted and visible in the in-memory config cache"
+        );
+    }
+
+    #[test]
+    fn save_config_inner_preserves_omitted_glossary_and_accepts_explicit_clear() {
+        let state = build_state("cfg-glossary-omission");
+        {
+            let mut current = state.config.lock().unwrap();
+            current.glossary = "Konnect = Connect".to_string();
+            current.save(&state.db).unwrap();
+        }
+
+        let mut old_client_json =
+            serde_json::to_value(config_to_dto(&AppConfig::default())).unwrap();
+        old_client_json
+            .as_object_mut()
+            .unwrap()
+            .remove("glossary");
+        let omitted: AppConfigDto = serde_json::from_value(old_client_json).unwrap();
+        save_config_inner(&state, omitted).unwrap();
+        assert_eq!(state.config.lock().unwrap().glossary, "Konnect = Connect");
+        assert_eq!(
+            AppConfig::load(&state.db).unwrap().glossary,
+            "Konnect = Connect",
+            "an older client save must preserve the durable glossary"
+        );
+
+        let mut clear = config_to_dto(&state.config.lock().unwrap());
+        clear.glossary = Some(String::new());
+        save_config_inner(&state, clear).unwrap();
+        assert_eq!(state.config.lock().unwrap().glossary, "");
+        assert_eq!(
+            AppConfig::load(&state.db).unwrap().glossary,
+            "",
+            "an explicit empty value must clear cache and storage"
+        );
+    }
+
+    #[test]
+    fn save_config_inner_preserves_omitted_analysis_and_voiceprint_choices() {
+        let state = build_state("cfg-analysis-omission");
+        {
+            let mut current = state.config.lock().unwrap();
+            current.diarize_others = false;
+            current.ground_summary = false;
+            current.voiceprint_enabled = true;
+            current.save(&state.db).unwrap();
+        }
+
+        let mut old_client_json =
+            serde_json::to_value(config_to_dto(&state.config.lock().unwrap())).unwrap();
+        let object = old_client_json.as_object_mut().unwrap();
+        object.remove("diarizeOthers");
+        object.remove("groundSummary");
+        object.remove("voiceprintEnabled");
+        let omitted: AppConfigDto = serde_json::from_value(old_client_json).unwrap();
+
+        save_config_inner(&state, omitted).unwrap();
+        let cached = state.config.lock().unwrap().clone();
+        assert!(!cached.diarize_others);
+        assert!(!cached.ground_summary);
+        assert!(
+            cached.voiceprint_enabled,
+            "an older client save must not revoke an explicit voiceprint opt-in"
+        );
+
+        let durable = AppConfig::load(&state.db).unwrap();
+        assert!(!durable.diarize_others);
+        assert!(!durable.ground_summary);
+        assert!(
+            durable.voiceprint_enabled,
+            "omitted DTO fields must preserve all three durable choices"
         );
     }
 

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -2310,6 +2310,10 @@ async fn summarize_and_export(
             None
         },
         live_bullets: live_bullets.clone(),
+        // Deterministic, bounded prompt-only projection of the user-authored workspace glossary.
+        // `None` for absent/blank keeps the pre-feature prompt byte-identical. Cloud dispatch still
+        // goes through this request's one existing RedactingProvider seam.
+        glossary: template::render_glossary_for_prompt(&config.glossary),
     };
 
     let (generated, call_meta) = provider.summarize_with_meta(&request).await?;

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -123,7 +123,10 @@ pub struct AppConfig {
     /// 16 kHz playback mix. Default OFF — on, it roughly doubles audio disk use per recording.
     pub keep_hires_masters: bool,
     /// Run N-way speaker diarization on the system ("others") stream to label remote speakers
-    /// (others-0/1/2). Default OFF; requires system-audio capture + downloads ~40 MB of models.
+    /// (others-0/1/2). Default ON; requires system-audio capture + downloads ~40 MB of models.
+    /// Existing configs that predate the field inherit the same ON default; a stored `false`
+    /// remains an explicit opt-out.
+    #[serde(default = "default_true")]
     pub diarize_others: bool,
     /// Capture a per-cluster VOICE BIOMETRIC (speaker embedding) for the diarized "others" clusters,
     /// stored on-device (SQLCipher, folder-lock-sealed, NEVER egressed) so a remote speaker can later
@@ -250,6 +253,14 @@ pub struct AppConfig {
     pub note_assist_actions_off: Vec<String>,
     /// Summary note language: "auto" (match the meeting) | "en" | "pl" | "de" | ... .
     pub note_language: String,
+    /// Workspace glossary used to keep domain names stable in generated notes. Each non-empty line
+    /// is either `Canonical` or `Canonical = alias, alias`. This is user-authored prompt content:
+    /// the pipeline bounds and structures it before use, and the cloud path applies the same
+    /// regex + on-device name-redaction firewall as every other prompt field.
+    ///
+    /// `serde(default)` keeps configs written before this field existed loadable.
+    #[serde(default)]
+    pub glossary: String,
     /// Require an `Authorization: Bearer <token>` on EVERY MCP method (E3) — including
     /// initialize / tools/list / ping, not just tools/call. Default ON (fail-closed): an
     /// unauthenticated localhost process must not be able to even enumerate the meeting tools.
@@ -534,13 +545,11 @@ pub struct AppConfig {
     /// by this meeting's OWN transcript segments with a non-destructive `> unverified` blockquote
     /// (`> unverified (low audio confidence)` when the best-overlapping segments were acoustically
     /// shaky). NON-DESTRUCTIVE: the original line stays byte-identical (action-item parsing is
-    /// unaffected); it only APPENDS a marker. Default OFF / OPT-IN (`#[serde(default)]` ⇒ `false`):
-    /// the overlap thresholds are UNCALIBRATED placeholders, so an over-flag would `> unverified` a
-    /// legitimately-abstractive sentence and degrade the note 100% of users read — it must stay opt-in
-    /// until a gold-label precision/recall pass on real data justifies flipping the default. PRESERVE-
-    /// ONLY on the settings DTO for now (the FE toggle is a follow-up) — a normal settings save neither
-    /// grants nor clears it; it round-trips through the load/save keys.
-    #[serde(default)]
+    /// unaffected); it only APPENDS a marker. The overlap thresholds remain UNCALIBRATED, so a
+    /// marker is a conservative review cue, never proof that a sentence is true or false. Default
+    /// ON, but user-disableable in Settings. Existing configs that predate the field inherit the
+    /// same ON default; a stored `false` stays OFF.
+    #[serde(default = "default_true")]
     pub ground_summary: bool,
     /// Brain v2 L3 — gate for the TINY-schema grammar constraint on the on-device structured
     /// decode (`GenOptions::use_grammar_constraint` → mistralrs `Constraint::JsonSchema`, schemas
@@ -663,7 +672,7 @@ impl Default for AppConfig {
             capture_system_audio: true,
             vad_enabled: true,
             keep_hires_masters: false,
-            diarize_others: false,
+            diarize_others: true,
             voiceprint_enabled: false,
             aec_enabled: false,
             post_aec_enabled: false,
@@ -689,6 +698,7 @@ impl Default for AppConfig {
             note_assist_actions_off: Vec::new(),
             auto_organize: false,
             note_language: "auto".to_string(),
+            glossary: String::new(),
             mcp_require_token: true,
             lock_require_biometric: true,
             relock_on_screenshare: true,
@@ -730,7 +740,7 @@ impl Default for AppConfig {
             proactive_hints_enabled: true,
             user_memory_enabled: true,
             memory_consolidation_enabled: true,
-            ground_summary: false,
+            ground_summary: true,
             brain_heavy_grammar_enabled: false,
             ask_jit_retrieval: false,
             loop_transcript_compaction: true,
@@ -787,6 +797,7 @@ const K_NOTE_ASSIST_ENHANCE: &str = "note_assist_enhance";
 const K_NOTE_ASSIST_ACTIONS_OFF: &str = "note_assist_actions_off";
 const K_AUTO_ORGANIZE: &str = "auto_organize";
 const K_NOTE_LANGUAGE: &str = "note_language";
+const K_GLOSSARY: &str = "glossary";
 const K_MCP_REQUIRE_TOKEN: &str = "mcp_require_token";
 const K_LOCK_REQUIRE_BIOMETRIC: &str = "lock_require_biometric";
 const K_RELOCK_ON_SCREENSHARE: &str = "relock_on_screenshare";
@@ -839,10 +850,9 @@ const K_ROLE_ASK_EFFORT: &str = "role_ask_effort";
 /// ACTION-ITEM RECALL NET (opt-in) — see [`action_item_recall_net_enabled`]. Deliberately a
 /// STANDALONE settings row rather than an `AppConfig` field: `commands::dto_to_config` builds
 /// `AppConfig` as an EXHAUSTIVE struct literal, so a new field would have to be threaded through
-/// that file too. Keeping the flag as its own key gives the SAME semantics as the preserve-only
-/// `ground_summary` discipline for free — a normal settings save neither grants nor clears it
-/// (`AppConfig::save` never writes this key), and it round-trips durably. Promoting it to a real
-/// `AppConfig` field + a Settings toggle is the follow-up, alongside `ground_summary`'s.
+/// that file too. Keeping the flag as its own key makes it preserve-only: a normal settings save
+/// neither grants nor clears it (`AppConfig::save` never writes this key), and it round-trips
+/// durably. Promoting it to a real `AppConfig` field + Settings toggle is a separate follow-up.
 const K_ACTION_ITEM_RECALL_NET: &str = "action_item_recall_net";
 /// P1 — WHO chose the current `model_size`: `"auto"` (Murmur's recommendation) or `"user"` (a
 /// deliberate pick). STANDALONE rows for the same reason as [`K_ACTION_ITEM_RECALL_NET`]: an
@@ -1003,6 +1013,9 @@ impl AppConfig {
             if !v.is_empty() {
                 cfg.note_language = v;
             }
+        }
+        if let Some(v) = db.get_setting(K_GLOSSARY)? {
+            cfg.glossary = v;
         }
         if let Some(v) = db.get_setting(K_MCP_REQUIRE_TOKEN)? {
             cfg.mcp_require_token = v == "true";
@@ -1303,6 +1316,7 @@ impl AppConfig {
             &serde_json::to_string(&self.note_assist_actions_off).unwrap_or_else(|_| "[]".into()),
         )?;
         db.set_setting(K_NOTE_LANGUAGE, &self.note_language)?;
+        db.set_setting(K_GLOSSARY, &self.glossary)?;
         db.set_setting(
             K_MCP_REQUIRE_TOKEN,
             if self.mcp_require_token {
@@ -1725,11 +1739,11 @@ fn opt(value: Option<String>) -> Option<String> {
 /// ACTION-ITEM RECALL NET — is the opt-in transcript cue scan
 /// ([`crate::summarize::recall_net::append_possible_missed_items`]) enabled?
 ///
-/// Default OFF / OPT-IN, mirroring `ground_summary`: a lexical cue scan is deliberately
-/// LOW-PRECISION, so an always-on version would append noisy "Possible missed items" quotes to the
-/// note 100% of users read. It must stay opt-in until the cue list + overlap thresholds are
-/// calibrated against real meetings. OFF is BYTE-IDENTICAL to the previous pipeline (the scan never
-/// runs and the meeting's segments are not even fetched).
+/// Default OFF / OPT-IN: this feature APPENDS candidate quotes to the note, unlike grounding's
+/// non-destructive review markers. Its lexical cue scan is deliberately LOW-PRECISION, so an
+/// always-on version would add noisy "Possible missed items" to the note 100% of users read. It
+/// must stay opt-in until calibrated against real meetings. OFF is BYTE-IDENTICAL to the previous
+/// pipeline (the scan never runs and the meeting's segments are not even fetched).
 ///
 /// FAIL-CLOSED: an absent key, any value other than `"true"`, or a DB read error all read as OFF —
 /// a storage hiccup can never silently switch a note-content feature on.
@@ -2403,38 +2417,36 @@ mod tests {
         assert!(AppConfig::load(&db).unwrap().vault_audit_weekly_enabled);
     }
 
-    /// Tier 3b (B): `ground_summary` defaults OFF / opt-in (empty DB ⇒ false, thresholds uncalibrated),
-    /// and both an explicit ON and an explicit OFF round-trip through save/load — so an opt-IN persists
-    /// across reload despite the default-false.
+    /// The two analysis aids default ON on a fresh settings DB, while explicit opt-outs remain
+    /// durable. `voiceprint_enabled` is deliberately outside this pair and stays OFF by default.
     #[test]
-    fn ground_summary_defaults_off_and_round_trips_both_ways() {
+    fn diarization_and_grounding_default_on_and_round_trip_opt_outs() {
         let db = temp_db();
-        // Empty DB (no stored key) ⇒ the default (OFF / opt-in until calibrated).
+        let fresh = AppConfig::load(&db).unwrap();
+        assert!(fresh.diarize_others, "diarization defaults ON");
+        assert!(fresh.ground_summary, "grounding defaults ON");
         assert!(
-            !AppConfig::load(&db).unwrap().ground_summary,
-            "ground_summary must default OFF on a fresh DB (opt-in until calibrated)"
+            !fresh.voiceprint_enabled,
+            "the privacy-sensitive voiceprint feature stays OFF"
         );
 
-        // Explicit ON persists (a maintainer/user opt-in).
         AppConfig {
-            ground_summary: true,
-            ..Default::default()
-        }
-        .save(&db)
-        .unwrap();
-        assert!(
-            AppConfig::load(&db).unwrap().ground_summary,
-            "an explicit ground_summary opt-in must persist"
-        );
-
-        // Explicit OFF persists.
-        AppConfig {
+            diarize_others: false,
             ground_summary: false,
             ..Default::default()
         }
         .save(&db)
         .unwrap();
-        assert!(!AppConfig::load(&db).unwrap().ground_summary);
+        let opted_out = AppConfig::load(&db).unwrap();
+        assert!(
+            !opted_out.diarize_others,
+            "an explicit diarization opt-out persists"
+        );
+        assert!(
+            !opted_out.ground_summary,
+            "an explicit grounding opt-out persists"
+        );
+        assert!(!opted_out.voiceprint_enabled);
     }
 
     /// ACTION-ITEM RECALL NET: defaults OFF / opt-in on a fresh DB (the cue scan is low-precision
@@ -2473,25 +2485,22 @@ mod tests {
         );
     }
 
-    /// A config payload that OMITS `ground_summary` (persisted before the field existed) deserializes
-    /// it as `false` via `#[serde(default)]` — matching `AppConfig::default` (opt-in until calibrated).
+    /// Historical JSON that predates the two fields gets the same values as `AppConfig::default`.
+    /// This catches the bool-serde trap where plain `#[serde(default)]` would silently yield false.
     #[test]
-    fn missing_ground_summary_deserializes_off() {
-        // A minimal payload carrying only the no-serde-default fields; `ground_summary` is omitted.
-        let json = r#"{
-            "providerId":"claude_code","vaultPath":null,"vaultSubfolder":null,
-            "whisperModelPath":null,"language":null,"anthropicModel":"claude-opus-4-8",
-            "ollamaBaseUrl":"http://localhost:11434","ollamaModel":"llama3.1","claudeBinary":"claude",
-            "inputDevice":null,"captureSystemAudio":false,"vadEnabled":true,"keepHiresMasters":false,
-            "diarizeOthers":false,"aecEnabled":false,"postAecEnabled":true,"modelSize":"large-v3","voiceTrigger":false,
-            "onboarded":false,"noteStyle":"standard","autoOrganize":false,"noteLanguage":"auto",
-            "mcpRequireToken":true,"lockRequireBiometric":true,"relockOnScreenshare":true,
-            "cloudEgressConsented":false
-        }"#;
-        let cfg: AppConfig = serde_json::from_str(json).unwrap();
+    fn missing_diarization_and_grounding_match_struct_defaults() {
+        let expected = AppConfig::default();
+        let mut json = serde_json::to_value(&expected).unwrap();
+        let object = json.as_object_mut().unwrap();
+        object.remove("diarizeOthers");
+        object.remove("groundSummary");
+
+        let cfg: AppConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(cfg.diarize_others, expected.diarize_others);
+        assert_eq!(cfg.ground_summary, expected.ground_summary);
         assert!(
-            !cfg.ground_summary,
-            "serde default for ground_summary must be false (opt-in)"
+            !cfg.voiceprint_enabled,
+            "omitting analysis flags must never enable voiceprints"
         );
     }
 
@@ -2832,6 +2841,7 @@ mod tests {
             provider_id: "ollama".to_string(),
             vault_path: Some("/vault".to_string()),
             language: Some("en".to_string()),
+            glossary: "Konnect = Connect, Kinect\nFastMCP".to_string(),
             ..Default::default()
         };
         cfg.save(&db).unwrap();
@@ -2840,6 +2850,39 @@ mod tests {
         assert_eq!(loaded.provider_id, "ollama");
         assert_eq!(loaded.vault_path.as_deref(), Some("/vault"));
         assert_eq!(loaded.language.as_deref(), Some("en"));
+        assert_eq!(
+            loaded.glossary, "Konnect = Connect, Kinect\nFastMCP",
+            "the user-authored glossary must round-trip byte-for-byte"
+        );
+    }
+
+    #[test]
+    fn glossary_defaults_empty_and_explicit_clear_round_trips() {
+        let db = temp_db();
+        assert_eq!(AppConfig::load(&db).unwrap().glossary, "");
+
+        AppConfig {
+            glossary: "Kong Operator = Kong, KO".to_string(),
+            ..Default::default()
+        }
+        .save(&db)
+        .unwrap();
+        assert_eq!(
+            AppConfig::load(&db).unwrap().glossary,
+            "Kong Operator = Kong, KO"
+        );
+
+        AppConfig {
+            glossary: String::new(),
+            ..Default::default()
+        }
+        .save(&db)
+        .unwrap();
+        assert_eq!(
+            AppConfig::load(&db).unwrap().glossary,
+            "",
+            "an explicit empty value clears the stored glossary"
+        );
     }
 
     #[test]

--- a/src-tauri/src/summarize/graph.rs
+++ b/src-tauri/src/summarize/graph.rs
@@ -3,6 +3,8 @@
 
 use crate::error::Result;
 use crate::summarize::provider::SummarizerProvider;
+use tokenizers::normalizers::NFKC;
+use tokenizers::{NormalizedString, Normalizer};
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -78,6 +80,99 @@ fn clean(v: Vec<String>) -> Vec<String> {
     out
 }
 
+/// NFKC + Unicode lowercase + whitespace normalization for exact glossary matching. `tokenizers`
+/// is already a direct app dependency for the on-device models, so this adds no new crate.
+fn glossary_match_key(value: &str) -> String {
+    let mut normalized = NormalizedString::from(value);
+    if NFKC.normalize(&mut normalized).is_err() {
+        return value
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+            .to_lowercase();
+    }
+    normalized
+        .get()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+#[derive(Debug)]
+struct AliasCandidate {
+    key: String,
+    canonical: String,
+    chars: usize,
+    entry_order: usize,
+    alias_order: usize,
+}
+
+/// Canonicalize graph entities locally, after the existing extraction response and before any DB,
+/// vault-stub, mention, or fact write. Only a whole payload item may match an alias: `"Kinect"`
+/// becomes `"Konnect"`, while `"Kinect Platform"` is deliberately untouched.
+pub(crate) fn canonicalize_with_glossary(
+    mut payload: GraphPayload,
+    raw_glossary: &str,
+) -> GraphPayload {
+    let glossary = crate::summarize::template::bounded_glossary(raw_glossary);
+    if glossary.entries.is_empty() {
+        return payload;
+    }
+
+    let mut candidates = Vec::new();
+    for (entry_order, entry) in glossary.entries.into_iter().enumerate() {
+        for (alias_order, alias) in std::iter::once(entry.canonical.as_str())
+            .chain(entry.aliases.iter().map(String::as_str))
+            .enumerate()
+        {
+            let key = glossary_match_key(alias);
+            if key.is_empty() {
+                continue;
+            }
+            candidates.push(AliasCandidate {
+                chars: key.chars().count(),
+                key,
+                canonical: entry.canonical.clone(),
+                entry_order,
+                alias_order,
+            });
+        }
+    }
+    // Longest alias wins; ties retain explicit config order and then alias order. Whole-item
+    // matching makes overlaps rare, but the order remains stable even for duplicate declarations.
+    candidates.sort_by(|a, b| {
+        b.chars
+            .cmp(&a.chars)
+            .then(a.entry_order.cmp(&b.entry_order))
+            .then(a.alias_order.cmp(&b.alias_order))
+    });
+
+    fn canonicalize(values: &mut Vec<String>, candidates: &[AliasCandidate]) {
+        let mut out = Vec::new();
+        for value in values.drain(..) {
+            let key = glossary_match_key(&value);
+            let resolved = candidates
+                .iter()
+                .find(|candidate| candidate.key == key)
+                .map(|candidate| candidate.canonical.clone())
+                .unwrap_or(value);
+            let resolved_key = glossary_match_key(&resolved);
+            if !out
+                .iter()
+                .any(|existing: &String| glossary_match_key(existing) == resolved_key)
+            {
+                out.push(resolved);
+            }
+        }
+        *values = out;
+    }
+
+    canonicalize(&mut payload.people, &candidates);
+    canonicalize(&mut payload.projects, &candidates);
+    payload
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -106,5 +201,63 @@ mod tests {
         let p = parse(r).unwrap();
         assert_eq!(p.people, vec!["Anna Kowalska"]);
         assert_eq!(p.projects, vec!["Atlas"]);
+    }
+
+    #[test]
+    fn glossary_canonicalizes_exact_whole_aliases_and_dedups() {
+        let payload = GraphPayload {
+            people: vec![
+                "Dani".to_string(),
+                "Danny".to_string(),
+                "Dani Team".to_string(),
+            ],
+            projects: vec![
+                "Kinect".to_string(),
+                "CONNECT".to_string(),
+                "Kinect Platform".to_string(),
+            ],
+        };
+        let canonicalized = canonicalize_with_glossary(
+            payload,
+            "Danny = Dani\nKonnect = Connect, Kinect\nKinect Platform Canonical = KPC",
+        );
+        assert_eq!(
+            canonicalized.people,
+            vec!["Danny", "Dani Team"],
+            "alias + canonical collapse, but a larger string containing the alias stays untouched"
+        );
+        assert_eq!(
+            canonicalized.projects,
+            vec!["Konnect", "Kinect Platform"],
+            "case-insensitive exact aliases collapse and substring-like values do not"
+        );
+    }
+
+    #[test]
+    fn glossary_matching_is_nfkc_and_unicode_lowercase_normalized() {
+        let payload = GraphPayload {
+            people: Vec::new(),
+            projects: vec![
+                "CAFE\u{301}".to_string(), // decomposed acute
+                "ＣＡＦÉ".to_string(),     // full-width compatibility chars
+            ],
+        };
+        let canonicalized = canonicalize_with_glossary(payload, "Café = Cafe\u{301}, ＣＡＦÉ");
+        assert_eq!(
+            canonicalized.projects,
+            vec!["Café"],
+            "canonically/compatibly equivalent aliases dedup to the configured spelling"
+        );
+    }
+
+    #[test]
+    fn duplicate_alias_resolution_is_deterministic_by_config_order() {
+        let payload = GraphPayload {
+            people: Vec::new(),
+            projects: vec!["KO".to_string()],
+        };
+        let canonicalized =
+            canonicalize_with_glossary(payload, "Kong Operator = KO\nKnowledge Ops = KO");
+        assert_eq!(canonicalized.projects, vec!["Kong Operator"]);
     }
 }

--- a/src-tauri/src/summarize/ollama.rs
+++ b/src-tauri/src/summarize/ollama.rs
@@ -354,10 +354,11 @@ fn ollama_recovery_key(base_url: &str, model: &str) -> String {
 /// Parse only after the owned generation task has dropped its model lease.
 fn parse_generate_response(raw: RawGenerateResponse) -> crate::error::Result<String> {
     if !raw.status.is_success() {
+        // The response body is untrusted provider content and may reflect prompt bytes. This error
+        // crosses into callers that can log it, so retain only the content-free HTTP status.
         return Err(AppError::Summarize(format!(
-            "Ollama API returned {}: {}",
-            raw.status,
-            String::from_utf8_lossy(&raw.body).trim()
+            "Ollama API returned HTTP {}; response body omitted",
+            raw.status.as_u16()
         )));
     }
     let parsed: GenerateResponse = serde_json::from_slice(&raw.body)
@@ -394,6 +395,15 @@ fn generate_body(model: &str, prompt: &str, system: Option<&str>) -> serde_json:
             "keep_alive": 0,
         }),
     }
+}
+
+/// Exact text-field mapping used by raw `/api/generate` completions.
+///
+/// Ollama accepts the instruction and user content as distinct JSON fields. The egress ledger
+/// shares this helper so its `system_bytes` / `user_bytes` accounting cannot drift from the
+/// production request body.
+pub(crate) fn completion_prompt_parts<'a>(system: &'a str, user: &'a str) -> (&'a str, &'a str) {
+    (system, user)
 }
 
 fn loopback_ollama_base_url(base_url: &str) -> Option<String> {
@@ -544,7 +554,8 @@ impl SummarizerProvider for OllamaProvider {
 
     async fn complete(&self, system: &str, user: &str) -> crate::error::Result<String> {
         // Own prompt strings/body before admission; no formatting or parsing pins residency.
-        let body = generate_body(&self.model, user, Some(system));
+        let (system, prompt) = completion_prompt_parts(system, user);
+        let body = generate_body(&self.model, prompt, Some(system));
         Ok(parse_generate_response(self.generate_owned(body).await?)?
             .trim()
             .to_string())
@@ -554,6 +565,19 @@ impl SummarizerProvider for OllamaProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn generate_http_error_keeps_status_but_omits_untrusted_body() {
+        let error = parse_generate_response(RawGenerateResponse {
+            status: reqwest::StatusCode::SERVICE_UNAVAILABLE,
+            body: br#"{"error":"provider-body-secret"}"#.to_vec(),
+        })
+        .expect_err("non-success Ollama status must fail");
+        let diagnostic = format!("{error:?} / {error}");
+        assert!(diagnostic.contains("HTTP 503"), "{diagnostic}");
+        assert!(!diagnostic.contains("provider-body-secret"), "{diagnostic}");
+        assert!(diagnostic.contains("body omitted"), "{diagnostic}");
+    }
 
     #[test]
     fn every_generate_body_requests_immediate_model_unload() {
@@ -872,6 +896,7 @@ mod tests {
             related_context: None,
             user_notes: None,
             live_bullets: None,
+            glossary: None,
         };
         let res =
             tokio::time::timeout(std::time::Duration::from_secs(10), provider.summarize(&req))

--- a/src-tauri/src/summarize/provider.rs
+++ b/src-tauri/src/summarize/provider.rs
@@ -53,6 +53,11 @@ pub struct SummarizeRequest {
     /// this string EGRESSES to the provider in the prompt — `RedactingProvider` MUST scrub it
     /// alongside the transcript (summarize/redact.rs) before egress.
     pub live_bullets: Option<String>,
+    /// Bounded, structured workspace glossary rendered locally from Settings. `None` means the
+    /// user prompt is byte-identical to the pre-glossary prompt. When present this EGRESSES in the
+    /// note-generation prompt and MUST pass the same shared regex + name-redaction batch as the
+    /// transcript. It is never included in the separate graph-extraction call.
+    pub glossary: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -60,6 +65,15 @@ pub struct SummarizeRequest {
 pub enum Availability {
     Available,
     Unavailable { reason: String },
+}
+
+/// Canonical system prompt used by the trait's free-text JSON fallback. Kept as a helper so the
+/// egress ledger can measure the exact bytes the default path sends without reimplementing it.
+pub(crate) fn default_json_system_prompt(system: &str, schema: &Value) -> String {
+    format!(
+        "{system}\n\nRespond with ONLY a single JSON object matching this schema (no prose, no code fences):\n{}",
+        serde_json::to_string(schema).unwrap_or_default()
+    )
 }
 
 #[async_trait]
@@ -126,10 +140,7 @@ pub trait SummarizerProvider: Send + Sync {
     ) -> Result<(Value, CallMeta)> {
         // Default: embed the schema as a system-prompt instruction and call complete_with_meta
         // so token usage is captured even on the free-text path.
-        let sys = format!(
-            "{system}\n\nRespond with ONLY a single JSON object matching this schema (no prose, no code fences):\n{}",
-            serde_json::to_string(schema).unwrap_or_default()
-        );
+        let sys = default_json_system_prompt(system, schema);
         let (reply, meta) = self.complete_with_meta(&sys, user).await?;
         let v = crate::reason::parse_first_json::<Value>(&reply)?;
         Ok((v, meta))
@@ -283,6 +294,7 @@ mod tests {
             related_context: None,
             user_notes: None,
             live_bullets: None,
+            glossary: None,
         };
         let (text, meta) = p.summarize_with_meta(&req).await.unwrap();
         assert_eq!(text, "note body");

--- a/src-tauri/src/summarize/redact.rs
+++ b/src-tauri/src/summarize/redact.rs
@@ -7,11 +7,12 @@
 //!
 //! Field coverage (the firewall's egress contract — kept in sync with the doc-comment on
 //! [`RedactingProvider::summarize_with_meta`]): EVERY `SummarizeRequest` field that reaches the
-//! inner provider is scrubbed there before egress — `transcript` / `related_context` / `user_notes`
-//! (regex + NER), `template` / `meta.title_hint` (regex), and `vault_titles` (FILTERED: any title
-//! the firewall would alter is dropped, since a masked wikilink target is useless). Only the
-//! non-PII format flags (`meta.date_iso`, `meta.language`, `meta.duration_s`) pass verbatim. A new
-//! string field is caught by `every_string_field_of_summarize_request_is_scrubbed_or_exempt`.
+//! inner provider is scrubbed there before egress — `transcript` / `related_context` /
+//! `user_notes` / `live_bullets` / `glossary` / `template` / `meta.title_hint` use one shared
+//! regex map and one global NER batch; `vault_titles` are FILTERED when the firewall would alter
+//! them (a masked wikilink target is useless). Only the non-PII format flags (`meta.date_iso`,
+//! `meta.language`, `meta.duration_s`) pass verbatim. A new string field is caught by
+//! `every_string_field_of_summarize_request_is_scrubbed_or_exempt`.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -526,8 +527,214 @@ fn count_redactions(map: &HashMap<String, String>, name_count: usize) -> Redacti
     counts
 }
 
-/// Provider decorator: redacts PII from inputs, restores it in outputs, and records a
-/// content-free egress audit entry per call.
+/// Run the NER layer ONCE for all fields of one provider call. Real NER token numbering starts at
+/// `NAME_1` per invocation, so redacting fields separately can assign the same token to different
+/// names and restore the wrong person. A deterministic boundary keeps field identity without
+/// influencing token numbering; if a redactor alters it, fail closed before egress.
+type RedactedNameBatch = (Vec<Option<String>>, Vec<(String, String)>);
+
+fn redact_names_batch(
+    names: &dyn NameRedactor,
+    fields: Vec<Option<String>>,
+) -> Result<RedactedNameBatch> {
+    let present: Vec<&String> = fields.iter().filter_map(Option::as_ref).collect();
+    if present.is_empty() {
+        return Ok((fields, Vec::new()));
+    }
+
+    let boundary = (0_u16..=u16::MAX)
+        .map(|nonce| format!("\u{241e}MURMUR_NAME_FIELD_{nonce}\u{241f}"))
+        .find(|candidate| present.iter().all(|field| !field.contains(candidate)))
+        .ok_or_else(|| {
+            AppError::Summarize("unable to allocate a safe name-redaction boundary".into())
+        })?;
+    let joined = present
+        .iter()
+        .map(|field| field.as_str())
+        .collect::<Vec<_>>()
+        .join(&boundary);
+
+    let (redacted, pairs) = names.redact_names(&joined);
+    let pieces: Vec<String> = redacted.split(&boundary).map(str::to_string).collect();
+    if pieces.len() != present.len() {
+        return Err(AppError::Summarize(
+            "name redactor altered the field boundary; cloud dispatch refused".into(),
+        ));
+    }
+
+    let mut token_names: HashMap<&str, &str> = HashMap::new();
+    for (token, name) in &pairs {
+        if joined.contains(token) {
+            return Err(AppError::Summarize(
+                "prompt contained a reserved name-redaction token; cloud dispatch refused".into(),
+            ));
+        }
+        if let Some(existing) = token_names.insert(token.as_str(), name.as_str()) {
+            if existing != name {
+                return Err(AppError::Summarize(
+                    "name redactor emitted a colliding restore token; cloud dispatch refused"
+                        .into(),
+                ));
+            }
+        }
+    }
+
+    let mut pieces = pieces.into_iter();
+    let restored_shape = fields
+        .into_iter()
+        .map(|field| field.map(|_| pieces.next().unwrap_or_default()))
+        .collect();
+    Ok((restored_shape, pairs))
+}
+
+/// Exhaustive rendering class for every provider the redaction wrapper is allowed to dispatch.
+///
+/// This deliberately has no catch-all variant. A newly added cloud provider cannot silently inherit
+/// another provider's prompt-byte accounting; it must be classified here before it can dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProviderEgressClass {
+    SplitSystemUser,
+    Ollama,
+}
+
+fn provider_egress_class(provider_id: &str) -> Result<ProviderEgressClass> {
+    match provider_id {
+        crate::summarize::PROVIDER_CLAUDE_CODE
+        | crate::summarize::PROVIDER_ANTHROPIC
+        | crate::summarize::PROVIDER_GATEWAY => Ok(ProviderEgressClass::SplitSystemUser),
+        crate::summarize::PROVIDER_OLLAMA => Ok(ProviderEgressClass::Ollama),
+        _ => Err(AppError::InvalidArg(
+            "cloud provider has no registered egress rendering class; dispatch refused".into(),
+        )),
+    }
+}
+
+/// Render the exact two byte streams the wrapped provider sends for a note summary. Anthropic,
+/// Gateway, and Claude Code use a system/user split; remote Ollama sends the same combined prompt
+/// its provider implementation builds with `render_prompt`.
+fn rendered_summarize_egress(
+    class: ProviderEgressClass,
+    req: &SummarizeRequest,
+) -> (String, String) {
+    match class {
+        ProviderEgressClass::Ollama => (
+            String::new(),
+            crate::summarize::template::render_prompt(req),
+        ),
+        ProviderEgressClass::SplitSystemUser => {
+            let system = if req.template.trim().is_empty() {
+                crate::summarize::template::default_template()
+            } else {
+                req.template.clone()
+            };
+            let user = crate::summarize::template::render_user_content(req);
+            (system, user)
+        }
+    }
+}
+
+/// Return the exact two text fields sent by a raw completion.
+///
+/// Unlike note summarization, Ollama completion does **not** concatenate the channels:
+/// `OllamaProvider::complete` serializes them as distinct `/api/generate` JSON fields
+/// (`system` and `prompt`). Keeping this provider-class match explicit prevents summary rendering
+/// semantics from being incorrectly reused for completion receipts.
+fn rendered_complete_egress<'a>(
+    class: ProviderEgressClass,
+    system: &'a str,
+    user: &'a str,
+) -> (&'a str, &'a str) {
+    match class {
+        ProviderEgressClass::SplitSystemUser => (system, user),
+        ProviderEgressClass::Ollama => {
+            crate::summarize::ollama::completion_prompt_parts(system, user)
+        }
+    }
+}
+
+/// Turn a provider failure into the only diagnostic that may cross the firewall back to callers.
+///
+/// Provider errors can embed response bodies, reflected prompts, URLs, or SDK debug output. The
+/// application logs propagated errors in several outer lifecycle paths, so returning the original
+/// value would make the ledger content-free while still leaking through ordinary diagnostics. Keep
+/// only the typed failure category; the exact call outcome remains in the `summarize_error` receipt.
+fn ollama_http_status(error: &AppError) -> Option<u16> {
+    let AppError::Summarize(message) = error else {
+        return None;
+    };
+    let suffix = message.strip_prefix("Ollama API returned HTTP ")?;
+    let digits: String = suffix.chars().take_while(char::is_ascii_digit).collect();
+    let status = digits.parse::<u16>().ok()?;
+    (100..=599).contains(&status).then_some(status)
+}
+
+fn content_free_dispatch_error(provider_id: &str, error: &AppError) -> AppError {
+    if provider_id == crate::summarize::PROVIDER_OLLAMA {
+        if let Some(status) = ollama_http_status(error) {
+            return AppError::Summarize(format!(
+                "remote Ollama returned HTTP {status}; response details omitted"
+            ));
+        }
+        if matches!(
+            error,
+            AppError::Summarize(message)
+                if message.starts_with("failed to parse Ollama response")
+        ) {
+            return AppError::Summarize(
+                "remote Ollama returned a malformed response; details omitted".into(),
+            );
+        }
+        if matches!(
+            error,
+            AppError::Summarize(message)
+                if message.starts_with("Ollama response contained no text")
+        ) {
+            return AppError::Summarize(
+                "remote Ollama returned an empty response; details omitted".into(),
+            );
+        }
+    }
+
+    match error {
+        AppError::Auth(_) => AppError::Auth(
+            "cloud provider authentication failed after protected dispatch; details omitted".into(),
+        ),
+        AppError::Unavailable(_) => AppError::Unavailable(
+            "cloud provider was unavailable after protected dispatch; details omitted".into(),
+        ),
+        AppError::Summarize(_) => AppError::Summarize(
+            "cloud provider response failed after protected dispatch; details omitted".into(),
+        ),
+        _ => AppError::Summarize(
+            "cloud provider dispatch failed after protected dispatch; details omitted".into(),
+        ),
+    }
+}
+
+/// Count only placeholders that are present in the exact rendered prompt streams. Fields retained
+/// on `SummarizeRequest` but not rendered today (for example `related_context`) and filtered vault
+/// titles therefore cannot inflate the privacy receipt.
+fn count_rendered_redactions(
+    map: &HashMap<String, String>,
+    name_pairs: &[(String, String)],
+    system: &str,
+    user: &str,
+) -> RedactionCounts {
+    let mut rendered_map = HashMap::new();
+    for (token, original) in map {
+        if system.contains(token) || user.contains(token) {
+            rendered_map.insert(token.clone(), original.clone());
+        }
+    }
+    let rendered_names = name_pairs
+        .iter()
+        .filter(|(token, _)| system.contains(token) || user.contains(token))
+        .count();
+    count_redactions(&rendered_map, rendered_names)
+}
+
+/// Provider decorator: redacts PII from inputs, restores it in outputs, and records one
+/// content-free egress audit entry per provider dispatch, including failed summary responses.
 ///
 /// Two layers, both restored in the reply: the always-on regex scrubbers (emails/cards/phones,
 /// via [`redact`]/[`restore`]) and the [`NameRedactor`] seam. The name layer defaults to
@@ -535,8 +742,9 @@ fn count_redactions(map: &HashMap<String, String>, name_count: usize) -> Redacti
 /// installed via [`with_name_redactor`](RedactingProvider::with_name_redactor).
 ///
 /// The egress audit sink defaults to [`NoopEgressSink`] in `new`/`with_name_redactor`, preserving
-/// byte-identical behaviour for all existing callers and tests. `with_name_redactor_and_sink` is
-/// the full constructor used by `make_provider` to wire the live `DbEgressSink`.
+/// byte-identical behaviour for callers that expose a registered provider identity.
+/// `with_name_redactor_and_sink` is the full constructor used by `make_provider` to wire the live
+/// `DbEgressSink`; unknown or mismatched identities fail closed before dispatch.
 pub struct RedactingProvider {
     inner: Arc<dyn SummarizerProvider>,
     names: Arc<dyn NameRedactor>,
@@ -555,9 +763,23 @@ pub struct RedactingProvider {
 }
 
 impl RedactingProvider {
+    /// Validate both the configured audit identity and the inner provider identity before any
+    /// content preparation, egress lease, or provider dispatch. This closes two fail-open shapes:
+    /// an unknown provider inheriting split-prompt accounting, and a configured id that does not
+    /// describe the inner provider whose bytes actually leave the device.
+    fn validated_egress_class(&self) -> Result<ProviderEgressClass> {
+        let class = provider_egress_class(&self.provider_id)?;
+        if self.provider_id != self.inner.id() {
+            return Err(AppError::InvalidArg(
+                "redaction wrapper provider identity mismatch; dispatch refused".into(),
+            ));
+        }
+        Ok(class)
+    }
+
     /// Wrap `inner` with the regex firewall and the DEFAULT (no-op) name redactor and NO-OP sink.
-    /// Name egress and audit logging are unchanged — this is the back-compat constructor; all
-    /// existing callers and tests are unaffected.
+    /// Name egress and audit logging are unchanged. Content calls still require the inner to expose
+    /// one of the registered cloud-provider ids so prompt accounting cannot fail open.
     pub fn new(inner: Arc<dyn SummarizerProvider>) -> Self {
         Self {
             provider_id: inner.id().to_string(),
@@ -573,7 +795,7 @@ impl RedactingProvider {
 
     /// Wrap `inner` with the regex firewall and an EXPLICIT name redactor (Phase 3b drop-in /
     /// tests). The name layer scrubs before egress and restores in the reply, alongside the regex
-    /// layer. Sink defaults to no-op — back-compat for all existing call sites.
+    /// layer. Sink defaults to no-op for registered-provider call sites.
     pub fn with_name_redactor(
         inner: Arc<dyn SummarizerProvider>,
         names: Arc<dyn NameRedactor>,
@@ -593,10 +815,12 @@ impl RedactingProvider {
     /// Full constructor used by `make_provider`: regex firewall + name redactor + egress sink.
     ///
     /// - `sink` receives one content-free [`EgressEntry`] per call (counts + meta, NO content).
+    /// - `provider_id` must be a registered cloud provider and match `inner.id()`; every content
+    ///   operation checks this before dispatch.
     /// - `provider_id` / `destination` / `model_requested` are forwarded into every entry.
     ///
-    /// Existing tests and callers that use `new`/`with_name_redactor` are byte-identical —
-    /// only `make_provider` wires the live `DbEgressSink` through this path.
+    /// Existing registered-provider callers that use `new`/`with_name_redactor` remain
+    /// byte-identical; only `make_provider` wires the live `DbEgressSink` through this path.
     pub fn with_name_redactor_and_sink(
         inner: Arc<dyn SummarizerProvider>,
         names: Arc<dyn NameRedactor>,
@@ -689,11 +913,10 @@ impl SummarizerProvider for RedactingProvider {
     ///
     /// FIREWALL CONTRACT — every `SummarizeRequest` field that EGRESSES to the inner (cloud)
     /// provider is scrubbed here before the `req.clone()` is forwarded. The classification:
-    /// - `transcript`, `related_context`, `user_notes`, `live_bullets` — full firewall: regex
-    ///   (email/card/phone) via the shared map + the NER name layer, tokens restored in the reply.
-    /// - `template` (rides the SYSTEM prompt) and `meta.title_hint` (rides `render_user_content`) —
-    ///   regex layer via the shared map, tokens restored in the reply (defense-in-depth; low-risk
-    ///   instruction/label strings).
+    /// - `transcript`, `related_context`, `user_notes`, `live_bullets`, `glossary`, `template`,
+    ///   and `meta.title_hint` — full firewall: one shared regex map followed by ONE coherent NER
+    ///   batch for the entire call, so per-call `NAME_n` numbering cannot collide across fields.
+    ///   Both token layers are restored in the reply.
     /// - `vault_titles` (the `[[wikilink]]` target list embedded in `render_user_content`, incl.
     ///   auto-created `[[Person Name]].md` pages) — FILTERED: any title the firewall would alter
     ///   is DROPPED before egress (design B — see the inline rationale below). With NO NER model
@@ -704,41 +927,29 @@ impl SummarizerProvider for RedactingProvider {
     ///   as a PHONE and garble the note). Any NEW string field MUST be classified here and is
     ///   caught by `every_string_field_of_summarize_request_is_scrubbed_or_exempt`.
     async fn summarize_with_meta(&self, req: &SummarizeRequest) -> Result<(String, CallMeta)> {
-        // Shared regex map across the transcript AND the Phase-4 `related_context` so a value
-        // redacted in either restores consistently in the reply. With `related_context = None`
-        // (the default + flag-OFF case) the map is built from the transcript alone, exactly as the
-        // old `redact(&req.transcript)` did — egress stays byte-identical.
+        let egress_class = self.validated_egress_class()?;
+
+        // One regex map for every PII-bearing field in the request, followed below by one global
+        // name-redactor batch. A repeated value therefore receives one stable token everywhere.
         let mut map = HashMap::new();
         let mut rev = HashMap::new();
         let red_transcript = redact_into(&req.transcript, &mut map, &mut rev);
-        // The related-context corpus EGRESSES to the provider in the prompt — scrub it through the
-        // SAME firewall as the transcript so emails/cards/phones never leave un-redacted.
         let red_related = req
             .related_context
             .as_ref()
             .map(|c| redact_into(c, &mut map, &mut rev));
-        // ENHANCE-MY-NOTES: the typed notes ride the prompt in enhance mode — scrub them
-        // through the SAME shared map as the transcript so a value redacted anywhere
-        // restores consistently in the reply.
         let red_notes = req
             .user_notes
             .as_ref()
             .map(|c| redact_into(c, &mut map, &mut rev));
-        // Brain v2 L4: the running live bullets ride the prompt as the "Live notes (auto)"
-        // section — scrub them through the SAME shared map as the transcript they were derived
-        // from, so a value redacted anywhere restores consistently in the reply.
         let red_bullets = req
             .live_bullets
             .as_ref()
             .map(|c| redact_into(c, &mut map, &mut rev));
-        // DEFENSE-IN-DEPTH — the note-format `template` rides the prompt as the SYSTEM message
-        // (anthropic/gateway/claude_code providers) and `meta.title_hint` rides
-        // `render_user_content`; both previously egressed VERBATIM inside `req.clone()`. Scrub them
-        // through the SAME shared regex map so any email/card/phone is tokenized before egress and
-        // restored in the reply. (Regex layer only, per the firewall's honest-scope note — these are
-        // low-risk instruction/label strings, not meeting-body text.) The production case (a clean
-        // built-in template, `title_hint = None`) is byte-identical: `redact_into` leaves PII-free
-        // text untouched and adds no map entry.
+        let red_glossary = req
+            .glossary
+            .as_ref()
+            .map(|c| redact_into(c, &mut map, &mut rev));
         let red_template = redact_into(&req.template, &mut map, &mut rev);
         let red_title_hint = req
             .meta
@@ -760,47 +971,64 @@ impl SummarizerProvider for RedactingProvider {
         //     `restore_names` could then resolve a wikilink to the WRONG person's page. Filtering
         //     sidesteps that entirely and gives a hard guarantee: no title the firewall flags reaches
         //     the provider.
-        // The predicate uses standalone `redact` + the active name layer purely as DETECTORS (their
-        // scrubbed output is discarded — no title tokens enter the shared restore map). A clean vault
-        // (no PII in any title) is byte-identical: every title survives the filter unchanged.
+        // Regex-detectable PII titles are filtered before the shared NER batch. The remaining titles
+        // join that ONE batch as detectors; any title whose output changes is dropped.
         //
         // P0.1 (Brain v2) — the NO-NER fallback: when the active name layer is the no-op (no NER
         // model on this install), the NER detector below flags NOTHING, so an auto-created
         // `[[Anna Kowalska]].md` person page would egress verbatim. The conservative SYNTACTIC
         // detector `title_looks_like_person_name` covers that gap — active ONLY under the no-op, so
         // model-present installs keep the unchanged NER behavior.
-        let titles = req.vault_titles.clone();
-        let (red_transcript, red_related, red_notes, red_bullets, name_pairs, red_titles) = self
+        let titles: Vec<String> = req
+            .vault_titles
+            .iter()
+            .filter(|title| redact(title.as_str()).0 == title.as_str())
+            .cloned()
+            .collect();
+        let (
+            red_transcript,
+            red_related,
+            red_notes,
+            red_bullets,
+            red_glossary,
+            red_template,
+            red_title_hint,
+            name_pairs,
+            red_titles,
+        ) = self
             .run_name_redactor(move |names| {
-                let (red_transcript, mut name_pairs) = names.redact_names(&red_transcript);
-                let red_related = red_related.map(|c| {
-                    let (c2, more) = names.redact_names(&c);
-                    name_pairs.extend(more);
-                    c2
-                });
-                let red_notes = red_notes.map(|c| {
-                    let (c2, more) = names.redact_names(&c);
-                    name_pairs.extend(more);
-                    c2
-                });
-                let red_bullets = red_bullets.map(|c| {
-                    let (c2, more) = names.redact_names(&c);
-                    name_pairs.extend(more);
-                    c2
-                });
+                let mut fields = vec![
+                    Some(red_transcript),
+                    red_related,
+                    red_notes,
+                    red_bullets,
+                    red_glossary,
+                    Some(red_template),
+                    red_title_hint,
+                ];
+                fields.extend(titles.iter().cloned().map(Some));
+                let (fields, name_pairs) = redact_names_batch(names, fields)?;
+                let mut fields = fields.into_iter();
+                let red_transcript = fields.next().flatten().unwrap_or_default();
+                let red_related = fields.next().flatten();
+                let red_notes = fields.next().flatten();
+                let red_bullets = fields.next().flatten();
+                let red_glossary = fields.next().flatten();
+                let red_template = fields.next().flatten().unwrap_or_default();
+                let red_title_hint = fields.next().flatten();
                 let noop_ner = names.is_noop();
                 let red_titles = titles
                     .into_iter()
-                    .filter(|title| {
-                        let (regex_scrubbed, _) = redact(title);
-                        if regex_scrubbed.as_str() != title {
-                            return false;
+                    .zip(fields)
+                    .filter_map(|(original, redacted)| {
+                        let redacted = redacted.unwrap_or_default();
+                        if (noop_ner && title_looks_like_person_name(&original))
+                            || redacted != original
+                        {
+                            None
+                        } else {
+                            Some(original)
                         }
-                        if noop_ner && title_looks_like_person_name(title) {
-                            return false;
-                        }
-                        let (name_scrubbed, name_hits) = names.redact_names(title);
-                        name_scrubbed.as_str() == title && name_hits.is_empty()
                     })
                     .collect();
                 Ok((
@@ -808,25 +1036,27 @@ impl SummarizerProvider for RedactingProvider {
                     red_related,
                     red_notes,
                     red_bullets,
+                    red_glossary,
+                    red_template,
+                    red_title_hint,
                     name_pairs,
                     red_titles,
                 ))
             })
             .await?;
 
-        // Byte sizes of the REDACTED content (sizes, never the text itself).
-        let user_bytes = red_transcript.len()
-            + red_related.as_ref().map(|c| c.len()).unwrap_or(0)
-            + red_notes.as_ref().map(|c| c.len()).unwrap_or(0)
-            + red_bullets.as_ref().map(|c| c.len()).unwrap_or(0);
         let mut r = req.clone();
         r.transcript = red_transcript;
         r.related_context = red_related;
         r.user_notes = red_notes;
         r.live_bullets = red_bullets;
+        r.glossary = red_glossary;
         r.template = red_template;
         r.meta.title_hint = red_title_hint;
         r.vault_titles = red_titles;
+        let (rendered_system, rendered_user) = rendered_summarize_egress(egress_class, &r);
+        let system_bytes = rendered_system.len();
+        let user_bytes = rendered_user.len();
         if self.recording_token.is_none()
             && self.ner_heavy.is_some()
             && !self.names.is_noop()
@@ -842,12 +1072,35 @@ impl SummarizerProvider for RedactingProvider {
         // wins and no network call starts.
         let _egress_lease =
             crate::perf::acquire_external_egress_lease(self.recording_token.as_ref())?;
-        let (out, meta) = self.inner.summarize_with_meta(&r).await?;
+        // Count only tokens present in the exact rendered bytes handed to the provider. Compute
+        // this BEFORE dispatch so a failed HTTP response, malformed body, or empty provider reply
+        // still leaves one truthful, content-free receipt for the bytes that were attempted.
+        let redactions =
+            count_rendered_redactions(&map, &name_pairs, &rendered_system, &rendered_user);
+        let (out, meta) = match self.inner.summarize_with_meta(&r).await {
+            Ok(result) => result,
+            Err(error) => {
+                // The error text may contain a remote response body (or even reflected content), so
+                // never put it in the ledger OR propagate it to an outer caller that may log it.
+                // The static call kind is the audit outcome; the returned error preserves only a
+                // typed, content-free category.
+                self.sink.record(EgressEntry {
+                    provider_id: self.provider_id.clone(),
+                    destination: self.destination.clone(),
+                    model_requested: self.model_requested.clone(),
+                    call_kind: "summarize_error",
+                    meta: CallMeta::default(),
+                    redactions: redactions.clone(),
+                    system_bytes,
+                    user_bytes,
+                    meeting_id: None,
+                });
+                return Err(content_free_dispatch_error(&self.provider_id, &error));
+            }
+        };
         // Restore both layers in the reply (disjoint token namespaces; order-independent).
         let out = restore_names(&out, &name_pairs);
         let out = restore(&out, &map);
-        // Count PII placeholders by prefix in the redaction map + name pairs length.
-        let redactions = count_redactions(&map, name_pairs.len());
         self.sink.record(EgressEntry {
             provider_id: self.provider_id.clone(),
             destination: self.destination.clone(),
@@ -855,7 +1108,7 @@ impl SummarizerProvider for RedactingProvider {
             call_kind: "summarize",
             meta: meta.clone(),
             redactions: redactions.clone(),
-            system_bytes: 0, // summarize has no separate system prompt
+            system_bytes,
             user_bytes,
             meeting_id: None,
         });
@@ -870,22 +1123,22 @@ impl SummarizerProvider for RedactingProvider {
 
     /// Redact inputs, call inner provider (capturing `CallMeta`), restore outputs, record egress.
     async fn complete_with_meta(&self, system: &str, user: &str) -> Result<(String, CallMeta)> {
+        let egress_class = self.validated_egress_class()?;
+
         // Shared map so a value redacted in either prompt restores consistently.
         let mut map = HashMap::new();
         let mut rev = HashMap::new();
         let rsys = redact_into(system, &mut map, &mut rev);
         let ruser = redact_into(user, &mut map, &mut rev);
-        // Byte sizes of the REDACTED content (sizes, never the text itself).
-        let system_bytes = rsys.len();
-        let user_bytes = ruser.len();
-        // Name layer on each prompt (default no-op → unchanged). A stable-token NameRedactor maps
-        // the same name to the same token across both prompts, so the merged pairs restore cleanly.
+        // One coherent NER batch across both channels prevents NAME_n collisions when the same
+        // implementation restarts numbering per call.
         let noop_ner = self.names.is_noop();
         let (rsys, ruser, name_pairs) = self
             .run_name_redactor(move |names| {
-                let (rsys, mut name_pairs) = names.redact_names(&rsys);
-                let (ruser, more) = names.redact_names(&ruser);
-                name_pairs.extend(more);
+                let (mut fields, name_pairs) =
+                    redact_names_batch(names, vec![Some(rsys), Some(ruser)])?;
+                let rsys = fields.remove(0).unwrap_or_default();
+                let ruser = fields.remove(0).unwrap_or_default();
                 Ok((rsys, ruser, name_pairs))
             })
             .await?;
@@ -901,6 +1154,13 @@ impl SummarizerProvider for RedactingProvider {
         } else {
             (rsys, ruser)
         };
+        // Measure the exact final provider fields, after both NER and the no-NER title fallback.
+        // Remote Ollama sends these as separate `system` and `prompt` JSON values; only its
+        // summarize surface uses one combined prompt.
+        let (rendered_system, rendered_user) =
+            rendered_complete_egress(egress_class, &rsys, &ruser);
+        let system_bytes = rendered_system.len();
+        let user_bytes = rendered_user.len();
         if self.recording_token.is_none()
             && self.ner_heavy.is_some()
             && !noop_ner
@@ -912,13 +1172,31 @@ impl SummarizerProvider for RedactingProvider {
         }
         // NER/model work is complete. Never hold a local-model lease across the cloud await; hold
         // only the affine egress lease across the actual provider future.
+        // Compute this before dispatch: even a provider failure must leave one content-free receipt
+        // bound to the exact scrubbed bytes that were attempted.
+        let redactions =
+            count_rendered_redactions(&map, &name_pairs, rendered_system, rendered_user);
         let _egress_lease =
             crate::perf::acquire_external_egress_lease(self.recording_token.as_ref())?;
-        let (out, meta) = self.inner.complete_with_meta(&rsys, &ruser).await?;
+        let (out, meta) = match self.inner.complete_with_meta(&rsys, &ruser).await {
+            Ok(result) => result,
+            Err(error) => {
+                self.sink.record(EgressEntry {
+                    provider_id: self.provider_id.clone(),
+                    destination: self.destination.clone(),
+                    model_requested: self.model_requested.clone(),
+                    call_kind: "complete_error",
+                    meta: CallMeta::default(),
+                    redactions: redactions.clone(),
+                    system_bytes,
+                    user_bytes,
+                    meeting_id: None,
+                });
+                return Err(content_free_dispatch_error(&self.provider_id, &error));
+            }
+        };
         let out = restore_names(&out, &name_pairs);
         let out = restore(&out, &map);
-        // Count PII placeholders by prefix in the redaction map + name pairs length.
-        let redactions = count_redactions(&map, name_pairs.len());
         self.sink.record(EgressEntry {
             provider_id: self.provider_id.clone(),
             destination: self.destination.clone(),
@@ -949,22 +1227,21 @@ impl SummarizerProvider for RedactingProvider {
         user: &str,
         schema: &Value,
     ) -> Result<(Value, CallMeta)> {
+        let egress_class = self.validated_egress_class()?;
+
         // Shared map so a value redacted in either prompt restores consistently in the reply.
         let mut map = HashMap::new();
         let mut rev = HashMap::new();
         let rsys = redact_into(system, &mut map, &mut rev);
         let ruser = redact_into(user, &mut map, &mut rev);
-        // Byte sizes of the REDACTED content (sizes, never the text itself).
-        let system_bytes = rsys.len();
-        let user_bytes = ruser.len();
-        // Name layer on each prompt (default no-op → unchanged). A stable-token NameRedactor maps
-        // the same name to the same token across both prompts, so the merged pairs restore cleanly.
+        // One coherent NER batch across both channels, identical to `complete_with_meta`.
         let noop_ner = self.names.is_noop();
         let (rsys, ruser, name_pairs) = self
             .run_name_redactor(move |names| {
-                let (rsys, mut name_pairs) = names.redact_names(&rsys);
-                let (ruser, more) = names.redact_names(&ruser);
-                name_pairs.extend(more);
+                let (mut fields, name_pairs) =
+                    redact_names_batch(names, vec![Some(rsys), Some(ruser)])?;
+                let rsys = fields.remove(0).unwrap_or_default();
+                let ruser = fields.remove(0).unwrap_or_default();
                 Ok((rsys, ruser, name_pairs))
             })
             .await?;
@@ -978,6 +1255,17 @@ impl SummarizerProvider for RedactingProvider {
         } else {
             (rsys, ruser)
         };
+        // Gateway sends `system` as-is and carries the schema in response_format. Every provider
+        // on the trait default appends the schema instruction to the actual system prompt.
+        let rendered_system = if self.inner.supports_native_json() {
+            rsys.clone()
+        } else {
+            crate::summarize::provider::default_json_system_prompt(&rsys, schema)
+        };
+        let (rendered_system, rendered_user) =
+            rendered_complete_egress(egress_class, &rendered_system, &ruser);
+        let system_bytes = rendered_system.len();
+        let user_bytes = rendered_user.len();
         if self.recording_token.is_none()
             && self.ner_heavy.is_some()
             && !noop_ner
@@ -989,12 +1277,32 @@ impl SummarizerProvider for RedactingProvider {
         }
         // Forward to the INNER's own complete_json_with_meta — dispatches to the gateway's native
         // json_schema+meta override, or the trait default for anthropic/claude_code/ollama.
+        // Count before dispatch so the error receipt remains exact even when no response meta exists.
+        let redactions =
+            count_rendered_redactions(&map, &name_pairs, rendered_system, rendered_user);
         let _egress_lease =
             crate::perf::acquire_external_egress_lease(self.recording_token.as_ref())?;
-        let (value, meta) = self
+        let (value, meta) = match self
             .inner
             .complete_json_with_meta(&rsys, &ruser, schema)
-            .await?;
+            .await
+        {
+            Ok(result) => result,
+            Err(error) => {
+                self.sink.record(EgressEntry {
+                    provider_id: self.provider_id.clone(),
+                    destination: self.destination.clone(),
+                    model_requested: self.model_requested.clone(),
+                    call_kind: "complete_json_error",
+                    meta: CallMeta::default(),
+                    redactions: redactions.clone(),
+                    system_bytes,
+                    user_bytes,
+                    meeting_id: None,
+                });
+                return Err(content_free_dispatch_error(&self.provider_id, &error));
+            }
+        };
         // Restore PII in the returned Value via a JSON string round-trip. The ⟪TOKEN⟫ placeholders
         // are embedded verbatim in the JSON string values, so serialization preserves them and
         // the regex replacements find them correctly.
@@ -1011,7 +1319,6 @@ impl SummarizerProvider for RedactingProvider {
         })?;
         // Record a content-free audit entry with the REAL meta so timeline/graph calls
         // show actual token usage in the egress ledger (not the former CallMeta::default()).
-        let redactions = count_redactions(&map, name_pairs.len());
         self.sink.record(EgressEntry {
             provider_id: self.provider_id.clone(),
             destination: self.destination.clone(),
@@ -1078,6 +1385,30 @@ mod tests {
         }
     }
 
+    /// Mimics the real redactor's per-invocation numbering: the first name in EACH call is
+    /// `NAME_1`. Separate field calls would therefore collide; one batch yields NAME_1 + NAME_2.
+    struct ResettingNumberNameRedactor(std::sync::Arc<std::sync::atomic::AtomicUsize>);
+
+    impl NameRedactor for ResettingNumberNameRedactor {
+        fn redact_names(&self, text: &str) -> (String, Vec<(String, String)>) {
+            use std::sync::atomic::Ordering;
+            self.0.fetch_add(1, Ordering::SeqCst);
+            let mut hits: Vec<(usize, &str)> = ["Anna Kowalska", "Bob Smith"]
+                .into_iter()
+                .filter_map(|name| text.find(name).map(|offset| (offset, name)))
+                .collect();
+            hits.sort_by_key(|(offset, _)| *offset);
+            let mut out = text.to_string();
+            let mut pairs = Vec::new();
+            for (idx, (_, name)) in hits.into_iter().enumerate() {
+                let token = format!("\u{27ea}NAME_{}\u{27eb}", idx + 1);
+                out = out.replace(name, &token);
+                pairs.push((token, name.to_string()));
+            }
+            (out, pairs)
+        }
+    }
+
     /// Inner provider that ECHOES the text it received, so a test can assert (a) the scrubbed text
     /// is what actually reached the provider and (b) the reply is de-tokenized on the way back.
     struct EchoProvider;
@@ -1085,7 +1416,7 @@ mod tests {
     #[async_trait]
     impl SummarizerProvider for EchoProvider {
         fn id(&self) -> &str {
-            "echo"
+            crate::summarize::PROVIDER_ANTHROPIC
         }
         async fn availability(&self) -> Availability {
             Availability::Available
@@ -1095,6 +1426,32 @@ mod tests {
         }
         async fn complete(&self, system: &str, user: &str) -> Result<String> {
             Ok(format!("{system}\n---\n{user}"))
+        }
+    }
+
+    struct DispatchCounterProvider {
+        provider_id: &'static str,
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl SummarizerProvider for DispatchCounterProvider {
+        fn id(&self) -> &str {
+            self.provider_id
+        }
+
+        async fn availability(&self) -> Availability {
+            Availability::Available
+        }
+
+        async fn summarize(&self, _req: &SummarizeRequest) -> Result<String> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(String::new())
+        }
+
+        async fn complete(&self, _system: &str, _user: &str) -> Result<String> {
+            self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(String::new())
         }
     }
 
@@ -1122,6 +1479,56 @@ mod tests {
         ModelLifecycleTestGuard { _serial: serial }
     }
 
+    static PROXY_ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Temporarily route reqwest's system HTTP proxy to a controlled loopback listener.
+    ///
+    /// The production factory must receive a genuinely remote-classified URL, while the regression
+    /// must never use external DNS/network. Environment mutation is serialized and restored on
+    /// every exit path, including panic unwinding.
+    struct ScopedProxyEnv {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        saved: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    }
+
+    impl ScopedProxyEnv {
+        fn install(proxy_url: &str) -> Self {
+            const KEYS: [&str; 6] = [
+                "HTTP_PROXY",
+                "http_proxy",
+                "ALL_PROXY",
+                "all_proxy",
+                "NO_PROXY",
+                "no_proxy",
+            ];
+            let lock = PROXY_ENV_TEST_LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let saved = KEYS
+                .into_iter()
+                .map(|key| (key, std::env::var_os(key)))
+                .collect();
+            for key in ["HTTP_PROXY", "http_proxy", "ALL_PROXY", "all_proxy"] {
+                std::env::set_var(key, proxy_url);
+            }
+            for key in ["NO_PROXY", "no_proxy"] {
+                std::env::remove_var(key);
+            }
+            Self { _lock: lock, saved }
+        }
+    }
+
+    impl Drop for ScopedProxyEnv {
+        fn drop(&mut self) {
+            for (key, value) in &self.saved {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
     fn sample_req(transcript: &str) -> SummarizeRequest {
         use crate::summarize::provider::MeetingMeta;
         SummarizeRequest {
@@ -1137,7 +1544,110 @@ mod tests {
             related_context: None,
             user_notes: None,
             live_bullets: None,
+            glossary: None,
         }
+    }
+
+    #[test]
+    fn unknown_provider_class_refuses_before_dispatch() {
+        let _lifecycle = model_lifecycle_test_guard();
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let entries = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let provider = RedactingProvider::with_name_redactor_and_sink(
+            Arc::new(DispatchCounterProvider {
+                provider_id: "future-cloud-provider",
+                calls: calls.clone(),
+            }),
+            Arc::new(NoopNameRedactor),
+            Arc::new(CaptureEgressSink(entries.clone())),
+            "future-cloud-provider".to_string(),
+            "future.example".to_string(),
+            "future-model".to_string(),
+        );
+
+        let error =
+            block_on(provider.summarize_with_meta(&sample_req("must-not-dispatch@corp.example")))
+                .expect_err("an unclassified provider must fail closed");
+        assert!(matches!(error, AppError::InvalidArg(_)), "{error:?}");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "unknown provider must be rejected before inner dispatch"
+        );
+        assert!(
+            entries.lock().unwrap().is_empty(),
+            "a refused pre-dispatch call is not an egress event"
+        );
+    }
+
+    #[test]
+    fn configured_and_inner_provider_id_mismatch_refuses_before_dispatch() {
+        let _lifecycle = model_lifecycle_test_guard();
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let entries = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let provider = RedactingProvider::with_name_redactor_and_sink(
+            Arc::new(DispatchCounterProvider {
+                provider_id: crate::summarize::PROVIDER_ANTHROPIC,
+                calls: calls.clone(),
+            }),
+            Arc::new(NoopNameRedactor),
+            Arc::new(CaptureEgressSink(entries.clone())),
+            crate::summarize::PROVIDER_OLLAMA.to_string(),
+            "remote-ollama.example".to_string(),
+            "remote-model".to_string(),
+        );
+
+        let error =
+            block_on(provider.summarize_with_meta(&sample_req("must-not-dispatch@corp.example")))
+                .expect_err("a configured/inner provider mismatch must fail closed");
+        assert!(matches!(error, AppError::InvalidArg(_)), "{error:?}");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "provider identity mismatch must be rejected before inner dispatch"
+        );
+        assert!(
+            entries.lock().unwrap().is_empty(),
+            "a refused pre-dispatch call is not an egress event"
+        );
+    }
+
+    #[test]
+    fn remote_glossary_provider_requires_factory_consent_before_dispatch() {
+        let _lifecycle = model_lifecycle_test_guard();
+        let config = crate::settings::AppConfig {
+            ollama_base_url: "https://remote-ollama.example".to_string(),
+            cloud_egress_consented: false,
+            ..crate::settings::AppConfig::default()
+        };
+        let mut request = sample_req("consent-gate-prompt@corp.example");
+        request.glossary =
+            Some("- {\"canonical\":\"Murmur\",\"aliases\":[\"MeetNotes\"]}\n".to_string());
+
+        let error = crate::summarize::make_provider(
+            crate::summarize::PROVIDER_OLLAMA,
+            &config,
+            &Arc::new(tokio::sync::Semaphore::new(1)),
+        )
+        .map(|_| ())
+        .expect_err("remote Ollama must not even be constructed without cloud consent");
+        assert!(matches!(error, AppError::Unavailable(_)), "{error:?}");
+        assert!(
+            error.to_string().contains(crate::errcode::CLOUD_CONSENT),
+            "the factory must fail at the explicit consent seam: {error}"
+        );
+        assert!(
+            request
+                .glossary
+                .as_deref()
+                .unwrap()
+                .contains("\"canonical\":\"Murmur\""),
+            "the fixture proves a real glossary-bearing request was pending when construction failed"
+        );
     }
 
     #[test]
@@ -1160,7 +1670,7 @@ mod tests {
         #[async_trait]
         impl SummarizerProvider for CaptureProvider {
             fn id(&self) -> &str {
-                "capture"
+                crate::summarize::PROVIDER_ANTHROPIC
             }
             async fn availability(&self) -> Availability {
                 Availability::Available
@@ -1208,7 +1718,7 @@ mod tests {
         #[async_trait]
         impl SummarizerProvider for CaptureProvider {
             fn id(&self) -> &str {
-                "capture"
+                crate::summarize::PROVIDER_ANTHROPIC
             }
             async fn availability(&self) -> Availability {
                 Availability::Available
@@ -1235,6 +1745,65 @@ mod tests {
         assert!(sent.contains("\u{27ea}NAME_1\u{27eb}"));
         // ...but the caller still gets the real names back.
         assert!(out.contains("Anna Kowalska") && out.contains("Bob Smith"));
+    }
+
+    #[test]
+    fn summarize_redacts_all_fields_in_one_collision_free_name_batch() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let _lifecycle = model_lifecycle_test_guard();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let captured = Arc::new(std::sync::Mutex::new(None));
+
+        struct CaptureGlossaryEcho(Arc<std::sync::Mutex<Option<SummarizeRequest>>>);
+        #[async_trait]
+        impl SummarizerProvider for CaptureGlossaryEcho {
+            fn id(&self) -> &str {
+                "anthropic"
+            }
+            async fn availability(&self) -> Availability {
+                Availability::Available
+            }
+            async fn summarize(&self, req: &SummarizeRequest) -> Result<String> {
+                *self.0.lock().unwrap() = Some(req.clone());
+                Ok(format!(
+                    "{}\n{}",
+                    req.transcript,
+                    req.glossary.as_deref().unwrap_or("")
+                ))
+            }
+            async fn complete(&self, _system: &str, _user: &str) -> Result<String> {
+                Ok(String::new())
+            }
+        }
+
+        let provider = RedactingProvider::with_name_redactor(
+            Arc::new(CaptureGlossaryEcho(captured.clone())),
+            Arc::new(ResettingNumberNameRedactor(calls.clone())),
+        );
+        let mut req = sample_req("Anna Kowalska owns the rollout.");
+        req.glossary = Some("- canonical: Bob Smith\n".to_string());
+        let restored = block_on(provider.summarize(&req)).unwrap();
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "all request fields must share one NER invocation"
+        );
+        let sent = captured.lock().unwrap().clone().unwrap();
+        assert!(sent.transcript.contains("\u{27ea}NAME_1\u{27eb}"));
+        assert!(
+            sent.glossary
+                .as_deref()
+                .unwrap()
+                .contains("\u{27ea}NAME_2\u{27eb}"),
+            "a second field must not restart at NAME_1"
+        );
+        assert!(!sent.transcript.contains("Anna Kowalska"));
+        assert!(!sent.glossary.unwrap().contains("Bob Smith"));
+        assert!(restored.contains("Anna Kowalska"));
+        assert!(restored.contains("Bob Smith"));
+        assert!(!restored.contains("NAME_"));
     }
 
     /// TIER 0 PII (lock-security): a real NAME that occupies a `(speaker)` tag rides `req.transcript`
@@ -1277,7 +1846,7 @@ mod tests {
         #[async_trait]
         impl SummarizerProvider for CaptureProvider {
             fn id(&self) -> &str {
-                "capture"
+                crate::summarize::PROVIDER_ANTHROPIC
             }
             async fn availability(&self) -> Availability {
                 Availability::Available
@@ -1363,7 +1932,7 @@ mod tests {
             #[async_trait]
             impl SummarizerProvider for CaptureProvider {
                 fn id(&self) -> &str {
-                    "capture"
+                    crate::summarize::PROVIDER_ANTHROPIC
                 }
                 async fn availability(&self) -> Availability {
                     Availability::Available
@@ -1413,7 +1982,7 @@ mod tests {
             Arc::new(EchoProvider),
             Arc::new(FixtureNameRedactor),
             Arc::new(NoopEgressSink),
-            "echo".into(),
+            crate::summarize::PROVIDER_ANTHROPIC.into(),
             "test".into(),
             "m".into(),
             heavy.clone(),
@@ -1436,7 +2005,7 @@ mod tests {
             Arc::new(EchoProvider),
             Arc::new(FixtureNameRedactor),
             Arc::new(NoopEgressSink),
-            "echo".into(),
+            crate::summarize::PROVIDER_ANTHROPIC.into(),
             "test".into(),
             "m".into(),
             heavy,
@@ -1469,7 +2038,7 @@ mod tests {
     #[async_trait]
     impl SummarizerProvider for EchoMetaProvider {
         fn id(&self) -> &str {
-            "echo-meta"
+            crate::summarize::PROVIDER_ANTHROPIC
         }
         async fn availability(&self) -> Availability {
             Availability::Available
@@ -1577,6 +2146,780 @@ mod tests {
         );
     }
 
+    /// A provider can fail only after it accepted the scrubbed prompt bytes. Both completion
+    /// surfaces must therefore write exactly one error receipt before returning a content-free
+    /// diagnostic; success-only ledger writes would silently lose evidence of real egress.
+    #[test]
+    fn failed_complete_surfaces_record_exact_content_free_receipts() {
+        let _lifecycle = model_lifecycle_test_guard();
+
+        struct FailingCompletionProvider;
+
+        #[async_trait]
+        impl SummarizerProvider for FailingCompletionProvider {
+            fn id(&self) -> &str {
+                crate::summarize::PROVIDER_ANTHROPIC
+            }
+
+            async fn availability(&self) -> Availability {
+                Availability::Available
+            }
+
+            async fn summarize(&self, _req: &SummarizeRequest) -> Result<String> {
+                Ok(String::new())
+            }
+
+            async fn complete(&self, _system: &str, _user: &str) -> Result<String> {
+                Err(AppError::Summarize("provider-response-body-secret".into()))
+            }
+
+            async fn complete_json_with_meta(
+                &self,
+                _system: &str,
+                _user: &str,
+                _schema: &serde_json::Value,
+            ) -> Result<(serde_json::Value, CallMeta)> {
+                Err(AppError::Summarize(
+                    "provider-json-response-body-secret".into(),
+                ))
+            }
+        }
+
+        let captured = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let provider = RedactingProvider::with_name_redactor_and_sink(
+            Arc::new(FailingCompletionProvider),
+            Arc::new(NoopNameRedactor),
+            Arc::new(CaptureEgressSink(captured.clone())),
+            crate::summarize::PROVIDER_ANTHROPIC.to_string(),
+            "api.anthropic.com".to_string(),
+            "test-model".to_string(),
+        );
+        let system = "System contact system@corp.example.";
+        let user = "Bounded user prompt.";
+        let (redacted_system, redaction_map) = redact(system);
+
+        let complete_error = block_on(provider.complete_with_meta(system, user))
+            .expect_err("the fixture provider must fail after dispatch");
+        let complete_diagnostic = format!("{complete_error:?} / {complete_error}");
+        assert!(
+            !complete_diagnostic.contains("provider-response-body-secret"),
+            "{complete_diagnostic}"
+        );
+        assert!(
+            complete_diagnostic.contains("details omitted"),
+            "{complete_diagnostic}"
+        );
+        {
+            let entries = captured.lock().unwrap();
+            assert_eq!(entries.len(), 1, "one failed complete, one receipt");
+            let entry = &entries[0];
+            assert_eq!(entry.call_kind, "complete_error");
+            assert_eq!(entry.meta, CallMeta::default());
+            assert_eq!(entry.system_bytes, redacted_system.len());
+            assert_eq!(entry.user_bytes, user.len());
+            assert_eq!(entry.redactions, count_redactions(&redaction_map, 0));
+            let debug = format!("{entry:?}");
+            assert!(!debug.contains(system), "{debug}");
+            assert!(!debug.contains("provider-response-body-secret"), "{debug}");
+        }
+
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"answer": {"type": "string"}}
+        });
+        let json_error = block_on(provider.complete_json_with_meta(system, user, &schema))
+            .expect_err("the JSON fixture provider must fail after dispatch");
+        let json_diagnostic = format!("{json_error:?} / {json_error}");
+        assert!(
+            !json_diagnostic.contains("provider-json-response-body-secret"),
+            "{json_diagnostic}"
+        );
+        assert!(
+            json_diagnostic.contains("details omitted"),
+            "{json_diagnostic}"
+        );
+        let entries = captured.lock().unwrap();
+        assert_eq!(entries.len(), 2, "two failed dispatches, two receipts");
+        let entry = &entries[1];
+        assert_eq!(entry.call_kind, "complete_json_error");
+        assert_eq!(entry.meta, CallMeta::default());
+        assert_eq!(
+            entry.system_bytes,
+            crate::summarize::provider::default_json_system_prompt(&redacted_system, &schema).len()
+        );
+        assert_eq!(entry.user_bytes, user.len());
+        assert_eq!(entry.redactions, count_redactions(&redaction_map, 0));
+        let debug = format!("{entry:?}");
+        assert!(!debug.contains(system), "{debug}");
+        assert!(
+            !debug.contains("provider-json-response-body-secret"),
+            "{debug}"
+        );
+    }
+
+    #[test]
+    fn summarize_receipt_measures_exact_rendered_prompts_and_visible_redactions() {
+        let _lifecycle = model_lifecycle_test_guard();
+        let sent = Arc::new(std::sync::Mutex::new(None));
+        let entries = Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        struct CaptureSummaryMeta(Arc<std::sync::Mutex<Option<SummarizeRequest>>>);
+        #[async_trait]
+        impl SummarizerProvider for CaptureSummaryMeta {
+            fn id(&self) -> &str {
+                "anthropic"
+            }
+            async fn availability(&self) -> Availability {
+                Availability::Available
+            }
+            async fn summarize(&self, req: &SummarizeRequest) -> Result<String> {
+                Ok(req.transcript.clone())
+            }
+            async fn complete(&self, _system: &str, _user: &str) -> Result<String> {
+                Ok(String::new())
+            }
+            async fn summarize_with_meta(
+                &self,
+                req: &SummarizeRequest,
+            ) -> Result<(String, CallMeta)> {
+                *self.0.lock().unwrap() = Some(req.clone());
+                Ok((req.transcript.clone(), CallMeta::default()))
+            }
+        }
+
+        let provider = RedactingProvider::with_name_redactor_and_sink(
+            Arc::new(CaptureSummaryMeta(sent.clone())),
+            Arc::new(NoopNameRedactor),
+            Arc::new(CaptureEgressSink(entries.clone())),
+            "anthropic".to_string(),
+            "api.anthropic.com".to_string(),
+            "test-model".to_string(),
+        );
+        let mut req = sample_req("Ping transcript@corp.example.");
+        req.template = "System contact system@corp.example.".to_string();
+        req.glossary = Some("- canonical: glossary@corp.example; aliases: Glossary\n".to_string());
+        // Retained on the request but intentionally NOT rendered in the Stage-1 prompt.
+        req.related_context = Some("hidden@corp.example".to_string());
+        // Filtered entirely, so it must neither egress nor inflate the rendered-redaction count.
+        req.vault_titles = vec!["Offer title@corp.example".to_string()];
+
+        let (_, meta) = block_on(provider.summarize_with_meta(&req)).unwrap();
+        let sent = sent.lock().unwrap().clone().unwrap();
+        let expected_system = sent.template.clone();
+        let expected_user = crate::summarize::template::render_user_content(&sent);
+        let entries = entries.lock().unwrap();
+        let entry = entries.first().expect("one summarize receipt");
+
+        assert_eq!(entry.system_bytes, expected_system.len());
+        assert_eq!(entry.user_bytes, expected_user.len());
+        assert!(
+            entry.user_bytes > sent.transcript.len(),
+            "receipt measures the rendered metadata/glossary/transcript prompt, not raw fields"
+        );
+        assert_eq!(
+            entry.redactions.email, 3,
+            "system + transcript + glossary egress; hidden related context and dropped title do not"
+        );
+        assert_eq!(meta.redactions.as_ref(), Some(&entry.redactions));
+        for pii in [
+            "system@corp.example",
+            "transcript@corp.example",
+            "glossary@corp.example",
+            "hidden@corp.example",
+            "title@corp.example",
+        ] {
+            assert!(
+                !format!("{expected_system}\n{expected_user}").contains(pii),
+                "{pii} must not appear in the exact rendered egress"
+            );
+        }
+    }
+
+    /// Remote Ollama is cloud egress but uses one combined `/api/generate` prompt rather than the
+    /// system/user split used by Anthropic, Gateway, and Claude Code. The content-free receipt must
+    /// therefore bind its byte count and scrub count to that exact combined prompt.
+    #[test]
+    fn remote_ollama_receipt_binds_exact_combined_prompt() {
+        let _lifecycle = model_lifecycle_test_guard();
+        let sent = Arc::new(std::sync::Mutex::new(None));
+        let entries = Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        struct CaptureRemoteOllama(Arc<std::sync::Mutex<Option<SummarizeRequest>>>);
+        #[async_trait]
+        impl SummarizerProvider for CaptureRemoteOllama {
+            fn id(&self) -> &str {
+                crate::summarize::PROVIDER_OLLAMA
+            }
+
+            async fn availability(&self) -> Availability {
+                Availability::Available
+            }
+
+            async fn summarize(&self, req: &SummarizeRequest) -> Result<String> {
+                Ok(req.transcript.clone())
+            }
+
+            async fn complete(&self, _system: &str, _user: &str) -> Result<String> {
+                Ok(String::new())
+            }
+
+            async fn summarize_with_meta(
+                &self,
+                req: &SummarizeRequest,
+            ) -> Result<(String, CallMeta)> {
+                *self.0.lock().unwrap() = Some(req.clone());
+                Ok((req.transcript.clone(), CallMeta::default()))
+            }
+        }
+
+        let provider = RedactingProvider::with_name_redactor_and_sink(
+            Arc::new(CaptureRemoteOllama(sent.clone())),
+            Arc::new(NoopNameRedactor),
+            Arc::new(CaptureEgressSink(entries.clone())),
+            crate::summarize::PROVIDER_OLLAMA.to_string(),
+            "ollama.example".to_string(),
+            "remote-test-model".to_string(),
+        );
+        let mut req = sample_req("Ping transcript@corp.example.");
+        req.template = "System contact system@corp.example.".to_string();
+        req.glossary = Some("- canonical: glossary@corp.example; aliases: Glossary\n".to_string());
+        req.related_context = Some("hidden@corp.example".to_string());
+        req.vault_titles = vec!["Offer title@corp.example".to_string()];
+
+        let (_, meta) = block_on(provider.summarize_with_meta(&req)).unwrap();
+        let sent = sent.lock().unwrap().clone().expect("inner was called");
+        let combined = crate::summarize::template::render_prompt(&sent);
+        let entries = entries.lock().unwrap();
+        let entry = entries.first().expect("one remote Ollama receipt");
+
+        assert_eq!(entries.len(), 1, "one receipt for one remote Ollama call");
+        assert_eq!(entry.provider_id, crate::summarize::PROVIDER_OLLAMA);
+        assert_eq!(entry.destination, "ollama.example");
+        assert_eq!(entry.call_kind, "summarize");
+        assert_eq!(
+            entry.system_bytes, 0,
+            "Ollama has no separate system channel"
+        );
+        assert_eq!(
+            entry.user_bytes,
+            combined.len(),
+            "receipt bytes must equal the exact combined prompt sent by OllamaProvider"
+        );
+        assert!(combined.contains("System contact"));
+        assert!(combined.contains("WORKSPACE GLOSSARY"));
+        assert!(combined.contains("Ping "));
+        assert_eq!(
+            entry.redactions.email, 3,
+            "combined template + transcript + glossary egress; hidden context and dropped title do not"
+        );
+        assert_eq!(meta.redactions.as_ref(), Some(&entry.redactions));
+        for pii in [
+            "system@corp.example",
+            "transcript@corp.example",
+            "glossary@corp.example",
+            "hidden@corp.example",
+            "title@corp.example",
+        ] {
+            assert!(
+                !combined.contains(pii),
+                "{pii} must not appear in the exact combined remote Ollama egress"
+            );
+        }
+    }
+
+    /// RED-before-GREEN through the PRODUCTION egress seam: once the remote Ollama server has
+    /// received the combined prompt, an HTTP failure, malformed body, or empty completion must
+    /// still produce exactly one durable, content-free error receipt. This deliberately uses
+    /// `make_provider` with consent enabled plus the real `DbEgressSink`; constructing the wrapper
+    /// or an in-memory capture sink directly would not prove the production factory wiring.
+    /// Before the fix, the `?` on the inner provider result returned before `sink.record`, leaving
+    /// no evidence that bytes had left the device.
+    #[test]
+    fn remote_ollama_failures_record_one_exact_content_free_error_receipt() {
+        use std::io::{Read, Write};
+
+        let _lifecycle = model_lifecycle_test_guard();
+        let db = Arc::new(
+            crate::storage::Db::open_with_key(
+                std::path::Path::new(":memory:"),
+                "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            )
+            .unwrap(),
+        );
+        crate::summarize::egress_log::set_egress_sink(Arc::new(
+            crate::summarize::egress_log::DbEgressSink::new(db.clone()),
+        ));
+        let cases: [(&str, &str, &str, &[u8]); 3] = [
+            (
+                "http-status",
+                "503 Service Unavailable",
+                "provider-http-body-secret",
+                br#"{"error":"provider-http-body-secret"}"#,
+            ),
+            (
+                "malformed-body",
+                "200 OK",
+                "provider-malformed-body-secret",
+                b"provider-malformed-body-secret",
+            ),
+            (
+                "empty-completion",
+                "200 OK",
+                "provider-empty-body-secret",
+                br#"{"response":"   ","diagnostic":"provider-empty-body-secret"}"#,
+            ),
+        ];
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            for (case, status, body_sentinel, response_body) in cases {
+                let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+                listener.set_nonblocking(true).unwrap();
+                let addr = listener.local_addr().unwrap();
+                let status = status.to_string();
+                let response_body = response_body.to_vec();
+                let server = std::thread::spawn(move || {
+                    let started = std::time::Instant::now();
+                    let (mut socket, _) = loop {
+                        match listener.accept() {
+                            Ok(accepted) => break accepted,
+                            Err(error)
+                                if error.kind() == std::io::ErrorKind::WouldBlock
+                                    && started.elapsed() < std::time::Duration::from_secs(10) =>
+                            {
+                                std::thread::sleep(std::time::Duration::from_millis(10));
+                            }
+                            Err(error) => panic!("controlled Ollama fixture did not connect: {error}"),
+                        }
+                    };
+                    socket.set_nonblocking(false).unwrap();
+                    socket
+                        .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+                        .unwrap();
+                    let mut request = Vec::new();
+                    let mut buf = [0u8; 4096];
+                    loop {
+                        let read = socket.read(&mut buf).unwrap();
+                        if read == 0 {
+                            break;
+                        }
+                        request.extend_from_slice(&buf[..read]);
+                        let Some(header_end) =
+                            request.windows(4).position(|window| window == b"\r\n\r\n")
+                        else {
+                            continue;
+                        };
+                        let headers = String::from_utf8_lossy(&request[..header_end]);
+                        let content_len = headers
+                            .lines()
+                            .find_map(|line| {
+                                let (name, value) = line.split_once(':')?;
+                                name.eq_ignore_ascii_case("content-length")
+                                    .then(|| value.trim().parse::<usize>().ok())
+                                    .flatten()
+                            })
+                            .unwrap_or(0);
+                        if request.len() >= header_end + 4 + content_len {
+                            break;
+                        }
+                    }
+                    write!(
+                        socket,
+                        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        response_body.len()
+                    )
+                    .unwrap();
+                    socket.write_all(&response_body).unwrap();
+                    String::from_utf8(request).unwrap()
+                });
+
+                // The production target stays genuinely remote-classified. Reqwest reaches it only
+                // through this case's scoped, loopback-only HTTP proxy, so the test uses neither
+                // external DNS nor network and does not need a test-only classification bypass.
+                let model = format!("factory-integration-{case}");
+                let config = crate::settings::AppConfig {
+                    ollama_base_url: "http://ollama.remote.invalid".to_string(),
+                    ollama_model: model.clone(),
+                    cloud_egress_consented: true,
+                    ..crate::settings::AppConfig::default()
+                };
+                assert!(
+                    crate::summarize::egress_is_cloud(crate::summarize::PROVIDER_OLLAMA, &config),
+                    "{case}: fixture URL must traverse the production remote-Ollama branch"
+                );
+                let _proxy =
+                    ScopedProxyEnv::install(&format!("http://127.0.0.1:{}", addr.port()));
+                let provider = crate::summarize::make_provider(
+                    crate::summarize::PROVIDER_OLLAMA,
+                    &config,
+                    &Arc::new(tokio::sync::Semaphore::new(1)),
+                )
+                .unwrap();
+                let prompt_sentinel = format!("{case}-prompt@corp.example");
+                let mut req = sample_req(&format!("Ping {prompt_sentinel}."));
+                req.template = "System contact system@corp.example.".to_string();
+                req.glossary =
+                    Some("- canonical: glossary@corp.example; aliases: Glossary\n".to_string());
+                req.related_context = Some("hidden@corp.example".to_string());
+                req.vault_titles = vec!["Offer title@corp.example".to_string()];
+
+                let error = tokio::time::timeout(
+                    std::time::Duration::from_secs(10),
+                    provider.summarize_with_meta(&req),
+                )
+                .await
+                .expect("the controlled remote-Ollama fixture must respond within 10 seconds")
+                .expect_err("each fixture must fail after the request was accepted");
+                let request = server.join().unwrap();
+                let sent_body = request.split("\r\n\r\n").nth(1).expect("HTTP request body");
+                let sent: serde_json::Value = serde_json::from_str(sent_body).unwrap();
+                let combined = sent
+                    .get("prompt")
+                    .and_then(serde_json::Value::as_str)
+                    .expect("Ollama combined prompt");
+
+                let rows = {
+                    let conn = db.lock();
+                    let mut statement = conn
+                        .prepare(
+                            "SELECT provider_id, destination, model_requested, call_kind, model_served,
+                                    prompt_tokens, completion_tokens, total_tokens, cached_tokens,
+                                    redactions_email, redactions_card, redactions_phone, redactions_name,
+                                    system_bytes, user_bytes, meeting_id
+                               FROM egress_log
+                              WHERE model_requested = ?1",
+                        )
+                        .unwrap();
+                    statement
+                        .query_map(rusqlite::params![model], |row| {
+                            Ok((
+                                row.get::<_, String>(0)?,
+                                row.get::<_, String>(1)?,
+                                row.get::<_, String>(2)?,
+                                row.get::<_, String>(3)?,
+                                row.get::<_, Option<String>>(4)?,
+                                row.get::<_, Option<i64>>(5)?,
+                                row.get::<_, Option<i64>>(6)?,
+                                row.get::<_, Option<i64>>(7)?,
+                                row.get::<_, Option<i64>>(8)?,
+                                row.get::<_, i64>(9)?,
+                                row.get::<_, i64>(10)?,
+                                row.get::<_, i64>(11)?,
+                                row.get::<_, i64>(12)?,
+                                row.get::<_, i64>(13)?,
+                                row.get::<_, i64>(14)?,
+                                row.get::<_, Option<String>>(15)?,
+                            ))
+                        })
+                        .unwrap()
+                        .collect::<std::result::Result<Vec<_>, _>>()
+                        .unwrap()
+                };
+                assert_eq!(
+                    rows.len(),
+                    1,
+                    "{case}: one failed production dispatch must yield exactly one durable receipt"
+                );
+                let entry = &rows[0];
+                assert_eq!(entry.0, crate::summarize::PROVIDER_OLLAMA, "{case}");
+                assert_eq!(entry.2, model, "{case}");
+                assert_eq!(entry.3, "summarize_error", "{case}");
+                assert_eq!(
+                    (&entry.4, entry.5, entry.6, entry.7, entry.8),
+                    (&None, None, None, None, None),
+                    "{case}: a failed response has no provider metadata"
+                );
+                assert_eq!(entry.13, 0, "{case}");
+                assert_eq!(
+                    entry.14,
+                    combined.len() as i64,
+                    "{case}: receipt must measure the exact combined prompt actually sent"
+                );
+                assert_eq!(entry.9, 3, "{case}");
+                assert_eq!((entry.10, entry.11, entry.12), (0, 0, 0), "{case}");
+                assert_eq!(entry.1, "ollama.remote.invalid", "{case}");
+                assert!(entry.15.is_none(), "{case}");
+                let durable_text_fields = format!(
+                    "{} {} {} {} {:?} {:?}",
+                    entry.0, entry.1, entry.2, entry.3, entry.4, entry.15
+                );
+
+                for secret in [
+                    "system@corp.example",
+                    "glossary@corp.example",
+                    "hidden@corp.example",
+                    "title@corp.example",
+                    prompt_sentinel.as_str(),
+                    body_sentinel,
+                ] {
+                    assert!(
+                        !durable_text_fields.contains(secret),
+                        "{case}: durable receipt must stay content-free"
+                    );
+                    assert!(
+                        !combined.contains(secret),
+                        "{case}: exact remote prompt must be redacted"
+                    );
+                }
+                // Outer pipeline/command paths log propagated errors with `%error`. This is the exact
+                // Display boundary they observe: it must retain only a typed/category/status diagnostic,
+                // never the untrusted provider body or any prompt field.
+                let caller_log = format!("summarize failed: {error}");
+                for secret in [prompt_sentinel.as_str(), body_sentinel] {
+                    assert!(
+                        !error.to_string().contains(secret),
+                        "{case}: returned diagnostic must be content-free"
+                    );
+                    assert!(
+                        !format!("{error:?}").contains(secret),
+                        "{case}: Debug diagnostic must be content-free"
+                    );
+                    assert!(
+                        !caller_log.contains(secret),
+                        "{case}: caller logging boundary must be content-free"
+                    );
+                }
+                match case {
+                    "http-status" => assert!(caller_log.contains("HTTP 503"), "{caller_log}"),
+                    "malformed-body" => assert!(caller_log.contains("malformed"), "{caller_log}"),
+                    "empty-completion" => assert!(caller_log.contains("empty"), "{caller_log}"),
+                    _ => unreachable!(),
+                }
+                assert!(
+                    caller_log.contains("details omitted"),
+                    "{case}: diagnostic must make suppression explicit"
+                );
+            }
+        });
+    }
+
+    /// Ollama has two different production renderings at `/api/generate`: summaries use one
+    /// locally combined `prompt`, while raw completions use distinct JSON `system` and `prompt`
+    /// fields. Bind both completion receipt surfaces to the fields observed at the real HTTP
+    /// boundary on success and failure; inventing a combined completion stream would make the
+    /// audit row disagree with the request Murmur actually sent.
+    #[test]
+    fn ollama_completion_receipts_match_exact_generate_fields_on_success_and_failure() {
+        use std::io::{Read, Write};
+
+        #[derive(Clone, Copy)]
+        enum Surface {
+            Complete,
+            CompleteJson,
+        }
+
+        fn start_generate_fixture(
+            status: &str,
+            response_body: &[u8],
+        ) -> (String, std::thread::JoinHandle<serde_json::Value>) {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = listener.local_addr().unwrap();
+            let status = status.to_string();
+            let response_body = response_body.to_vec();
+            let server = std::thread::spawn(move || {
+                let (mut socket, _) = listener.accept().unwrap();
+                socket
+                    .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+                    .unwrap();
+                let mut request = Vec::new();
+                let mut buf = [0u8; 4096];
+                loop {
+                    let read = socket.read(&mut buf).unwrap();
+                    if read == 0 {
+                        break;
+                    }
+                    request.extend_from_slice(&buf[..read]);
+                    let Some(header_end) =
+                        request.windows(4).position(|window| window == b"\r\n\r\n")
+                    else {
+                        continue;
+                    };
+                    let headers = String::from_utf8_lossy(&request[..header_end]);
+                    let content_len = headers
+                        .lines()
+                        .find_map(|line| {
+                            let (name, value) = line.split_once(':')?;
+                            name.eq_ignore_ascii_case("content-length")
+                                .then(|| value.trim().parse::<usize>().ok())
+                                .flatten()
+                        })
+                        .unwrap_or(0);
+                    if request.len() >= header_end + 4 + content_len {
+                        break;
+                    }
+                }
+                write!(
+                    socket,
+                    "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    response_body.len()
+                )
+                .unwrap();
+                socket.write_all(&response_body).unwrap();
+                let body = request
+                    .windows(4)
+                    .position(|window| window == b"\r\n\r\n")
+                    .map(|offset| &request[offset + 4..])
+                    .expect("HTTP request body");
+                serde_json::from_slice(body).unwrap()
+            });
+            (format!("http://{addr}"), server)
+        }
+
+        let _lifecycle = model_lifecycle_test_guard();
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"answer": {"type": "string"}},
+            "required": ["answer"]
+        });
+        let cases = [
+            ("complete-success", Surface::Complete, true),
+            ("complete-failure", Surface::Complete, false),
+            ("json-success", Surface::CompleteJson, true),
+            ("json-failure", Surface::CompleteJson, false),
+        ];
+
+        for (label, surface, succeeds) in cases {
+            let response_body: &[u8] = match (surface, succeeds) {
+                (Surface::Complete, true) => br#"{"response":"ok"}"#,
+                (Surface::CompleteJson, true) => br#"{"response":"{\"answer\":\"ok\"}"}"#,
+                (_, false) => br#"{"error":"provider-response-body-secret"}"#,
+            };
+            let status = if succeeds {
+                "200 OK"
+            } else {
+                "503 Service Unavailable"
+            };
+            let (base_url, server) = start_generate_fixture(status, response_body);
+            let entries = Arc::new(std::sync::Mutex::new(Vec::new()));
+            let provider = RedactingProvider::with_name_redactor_and_sink(
+                Arc::new(crate::summarize::ollama::OllamaProvider::new(
+                    base_url,
+                    format!("boundary-{label}"),
+                )),
+                Arc::new(NoopNameRedactor),
+                Arc::new(CaptureEgressSink(entries.clone())),
+                crate::summarize::PROVIDER_OLLAMA.to_string(),
+                "controlled-loopback-fixture".to_string(),
+                format!("boundary-{label}"),
+            );
+            let system = format!("System {label} contact system@corp.example.");
+            let user = format!("User {label} contact user@corp.example.");
+
+            let error = match surface {
+                Surface::Complete => match block_on(provider.complete_with_meta(&system, &user)) {
+                    Ok(_) => None,
+                    Err(error) => Some(error),
+                },
+                Surface::CompleteJson => {
+                    match block_on(provider.complete_json_with_meta(&system, &user, &schema)) {
+                        Ok(_) => None,
+                        Err(error) => Some(error),
+                    }
+                }
+            };
+            assert_eq!(
+                error.is_none(),
+                succeeds,
+                "{label}: fixture outcome must match the case"
+            );
+
+            let sent = server.join().unwrap();
+            let sent_system = sent
+                .get("system")
+                .and_then(serde_json::Value::as_str)
+                .expect("completion system field");
+            let sent_prompt = sent
+                .get("prompt")
+                .and_then(serde_json::Value::as_str)
+                .expect("completion prompt field");
+            assert_eq!(
+                sent.get("stream"),
+                Some(&serde_json::Value::Bool(false)),
+                "{label}"
+            );
+            assert_eq!(
+                sent.get("keep_alive"),
+                Some(&serde_json::json!(0)),
+                "{label}"
+            );
+            assert!(
+                !sent_system.contains("system@corp.example")
+                    && !sent_prompt.contains("user@corp.example"),
+                "{label}: exact HTTP fields must be redacted"
+            );
+            match surface {
+                Surface::Complete => assert!(
+                    !sent_system.contains("Respond with ONLY"),
+                    "{label}: free-text completion must not gain a JSON instruction"
+                ),
+                Surface::CompleteJson => assert!(
+                    sent_system.contains("Respond with ONLY a single JSON object"),
+                    "{label}: JSON fallback schema instruction belongs in the system field"
+                ),
+            }
+
+            let entries = entries.lock().unwrap();
+            assert_eq!(entries.len(), 1, "{label}: one dispatch, one receipt");
+            let entry = &entries[0];
+            assert_eq!(
+                entry.call_kind,
+                match (surface, succeeds) {
+                    (Surface::Complete, true) => "complete",
+                    (Surface::Complete, false) => "complete_error",
+                    (Surface::CompleteJson, true) => "complete_json",
+                    (Surface::CompleteJson, false) => "complete_json_error",
+                },
+                "{label}"
+            );
+            assert_eq!(
+                entry.system_bytes,
+                sent_system.len(),
+                "{label}: system_bytes must equal the actual JSON system field"
+            );
+            assert_eq!(
+                entry.user_bytes,
+                sent_prompt.len(),
+                "{label}: user_bytes must equal the actual JSON prompt field"
+            );
+            assert_eq!(
+                entry.redactions.email, 2,
+                "{label}: both exact HTTP fields contain one scrubbed email"
+            );
+            assert_eq!(
+                (
+                    entry.redactions.card,
+                    entry.redactions.phone,
+                    entry.redactions.name
+                ),
+                (0, 0, 0),
+                "{label}"
+            );
+            let receipt_debug = format!("{entry:?}");
+            for secret in [
+                "system@corp.example",
+                "user@corp.example",
+                "provider-response-body-secret",
+            ] {
+                assert!(
+                    !receipt_debug.contains(secret),
+                    "{label}: receipt must remain content-free"
+                );
+            }
+            if let Some(error) = error {
+                let diagnostic = format!("{error:?} / {error}");
+                assert!(diagnostic.contains("HTTP 503"), "{label}: {diagnostic}");
+                assert!(
+                    diagnostic.contains("details omitted")
+                        && !diagnostic.contains("provider-response-body-secret"),
+                    "{label}: {diagnostic}"
+                );
+            }
+        }
+    }
+
     /// Tier 4c (v1.1) — RED-before-GREEN: `summarize_with_meta` must SURFACE the firewall's scrub
     /// count to the CALLER via `CallMeta.redactions`, so the per-note privacy receipt reports a
     /// REAL number equal to what actually left the device redacted. RED on the pre-change code
@@ -1655,7 +2998,7 @@ mod tests {
         #[async_trait]
         impl SummarizerProvider for RecordingJsonProvider {
             fn id(&self) -> &str {
-                "recording-json"
+                crate::summarize::PROVIDER_GATEWAY
             }
             async fn availability(&self) -> Availability {
                 Availability::Available
@@ -1791,7 +3134,7 @@ mod tests {
     #[async_trait]
     impl SummarizerProvider for CapturingInner {
         fn id(&self) -> &str {
-            "capture-full"
+            crate::summarize::PROVIDER_ANTHROPIC
         }
         async fn availability(&self) -> Availability {
             Availability::Available
@@ -2116,6 +3459,7 @@ mod tests {
             related_context: Some("s-related@leak.example".to_string()), // SCRUBBED (regex + NER)
             user_notes: Some("s-notes@leak.example".to_string()),        // SCRUBBED (regex + NER)
             live_bullets: Some("s-bullets@leak.example".to_string()),    // SCRUBBED (regex + NER)
+            glossary: Some("- canonical: s-glossary@leak.example; aliases: Alias".to_string()), // SCRUBBED (regex + NER)
         };
         let inner = std::sync::Arc::new(CapturingInner(std::sync::Mutex::new(None)));
         let provider = RedactingProvider::new(inner.clone());
@@ -2130,6 +3474,7 @@ mod tests {
             "s-related@leak.example",
             "s-notes@leak.example",
             "s-bullets@leak.example",
+            "s-glossary@leak.example",
         ] {
             assert!(
                 !egress.contains(sentinel),

--- a/src-tauri/src/summarize/redact.rs
+++ b/src-tauri/src/summarize/redact.rs
@@ -2809,15 +2809,9 @@ mod tests {
             let user = format!("User {label} contact user@corp.example.");
 
             let error = match surface {
-                Surface::Complete => match block_on(provider.complete_with_meta(&system, &user)) {
-                    Ok(_) => None,
-                    Err(error) => Some(error),
-                },
+                Surface::Complete => block_on(provider.complete_with_meta(&system, &user)).err(),
                 Surface::CompleteJson => {
-                    match block_on(provider.complete_json_with_meta(&system, &user, &schema)) {
-                        Ok(_) => None,
-                        Err(error) => Some(error),
-                    }
+                    block_on(provider.complete_json_with_meta(&system, &user, &schema)).err()
                 }
             };
             assert_eq!(

--- a/src-tauri/src/summarize/template.rs
+++ b/src-tauri/src/summarize/template.rs
@@ -45,7 +45,11 @@ pub fn validate_note_template(name: &str, tone: &str, t: &NoteTemplate) -> Resul
     // … and fields that never do (any `{{` is refused).
     let plain_fields: [&str; 2] = [name, tone];
 
-    for f in plain_fields.iter().copied().chain(dsl_fields.iter().copied()) {
+    for f in plain_fields
+        .iter()
+        .copied()
+        .chain(dsl_fields.iter().copied())
+    {
         for tok in FORBIDDEN_TEMPLATE_TOKENS {
             if f.contains(tok) {
                 return Err(AppError::InvalidArg(format!(
@@ -282,7 +286,12 @@ fn style_variant_with_keys(tone: &str, body_sections: &str, extra_keys: &[String
     let extra = extra_keys
         .iter()
         .filter(|k| !k.contains("{{"))
-        .map(|k| format!("- {}: (fill in from the meeting, or omit if unknown)\n", k.trim()))
+        .map(|k| {
+            format!(
+                "- {}: (fill in from the meeting, or omit if unknown)\n",
+                k.trim()
+            )
+        })
         .collect::<String>();
     format!(
         r#"You are a meticulous meeting-notes writer for an Obsidian vault.
@@ -351,7 +360,9 @@ pub fn language_name(note_language: &str) -> Option<String> {
 /// front-matter KEYS stay English so Obsidian keeps parsing them.
 pub fn language_directive(note_language: &str) -> String {
     let target = match language_name(note_language) {
-        None => "the SAME language as the meeting transcript below (match the speakers)".to_string(),
+        None => {
+            "the SAME language as the meeting transcript below (match the speakers)".to_string()
+        }
         Some(name) => name,
     };
     format!(
@@ -464,6 +475,111 @@ tags do not support."
 /// the true OOM backstop).
 const LOCAL_NOTE_MAX_CHARS: usize = 40_000;
 
+/// Workspace-glossary limits. The raw Settings value may be arbitrarily large, but the provider
+/// prompt and the local alias map are both derived from this one bounded representation.
+pub(crate) const GLOSSARY_MAX_ENTRIES: usize = 64;
+pub(crate) const GLOSSARY_MAX_ALIASES_PER_ENTRY: usize = 8;
+pub(crate) const GLOSSARY_MAX_TERM_CHARS: usize = 80;
+pub(crate) const GLOSSARY_MAX_RENDERED_BYTES: usize = 4_096;
+const GLOSSARY_TRUNCATION_MARKER: &str = "- [additional glossary entries or aliases omitted]\n";
+
+/// One parsed line of the workspace glossary. The canonical form is what generated graph entities
+/// are rewritten to; aliases are match-only and never become a separate store.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct GlossaryEntry {
+    pub(crate) canonical: String,
+    pub(crate) aliases: Vec<String>,
+}
+
+/// The single bounded representation shared by the note prompt and local graph canonicalization.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct BoundedGlossary {
+    pub(crate) entries: Vec<GlossaryEntry>,
+    pub(crate) rendered: String,
+    pub(crate) truncated: bool,
+}
+
+fn clean_glossary_term(raw: &str) -> Option<String> {
+    let term = raw.split_whitespace().collect::<Vec<_>>().join(" ");
+    if term.is_empty()
+        || term.chars().count() > GLOSSARY_MAX_TERM_CHARS
+        || term.chars().any(char::is_control)
+    {
+        return None;
+    }
+    Some(term)
+}
+
+/// Parse `Canonical` / `Canonical = alias, alias` lines into a deterministic bounded structure.
+///
+/// Input order is preserved. Once either the entry count or rendered-byte budget is exhausted, the
+/// remaining input is ignored and a fixed marker is appended. The marker budget is reserved up
+/// front, so `rendered.len()` can never exceed [`GLOSSARY_MAX_RENDERED_BYTES`].
+pub(crate) fn bounded_glossary(raw: &str) -> BoundedGlossary {
+    let content_budget =
+        GLOSSARY_MAX_RENDERED_BYTES.saturating_sub(GLOSSARY_TRUNCATION_MARKER.len());
+    let mut bounded = BoundedGlossary::default();
+
+    for raw_line in raw.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let (canonical_raw, aliases_raw) = line.split_once('=').unwrap_or((line, ""));
+        let Some(canonical) = clean_glossary_term(canonical_raw) else {
+            continue;
+        };
+
+        let mut aliases = Vec::new();
+        for raw_alias in aliases_raw.split(',') {
+            let Some(alias) = clean_glossary_term(raw_alias) else {
+                continue;
+            };
+            if alias == canonical || aliases.iter().any(|seen| seen == &alias) {
+                continue;
+            }
+            if aliases.len() == GLOSSARY_MAX_ALIASES_PER_ENTRY {
+                bounded.truncated = true;
+                break;
+            }
+            aliases.push(alias);
+        }
+
+        if bounded.entries.len() == GLOSSARY_MAX_ENTRIES {
+            bounded.truncated = true;
+            break;
+        }
+        let entry = GlossaryEntry { canonical, aliases };
+        // JSON escaping keeps user-authored punctuation data, never prompt structure. Struct field
+        // order is fixed, so identical Settings bytes produce identical provider bytes.
+        let rendered_line = format!(
+            "- {}\n",
+            serde_json::to_string(&entry).expect("glossary strings always serialize")
+        );
+        if bounded.rendered.len() + rendered_line.len() > content_budget {
+            bounded.truncated = true;
+            break;
+        }
+        bounded.rendered.push_str(&rendered_line);
+        bounded.entries.push(entry);
+    }
+
+    if bounded.truncated {
+        bounded.rendered.push_str(GLOSSARY_TRUNCATION_MARKER);
+    }
+    bounded
+}
+
+/// Render the bounded glossary carried on [`SummarizeRequest`]. `None` is load-bearing: the
+/// no-glossary note prompt stays byte-identical to the pre-feature prompt.
+///
+/// Public so the deterministic no-egress core example can exercise the exact production renderer
+/// instead of maintaining a second fixture-only parser.
+pub fn render_glossary_for_prompt(raw: &str) -> Option<String> {
+    let bounded = bounded_glossary(raw);
+    (!bounded.entries.is_empty()).then_some(bounded.rendered)
+}
+
 pub fn render_prompt(req: &SummarizeRequest) -> String {
     // `render_prompt` serves ONLY the on-device combined-prompt providers (local mistralrs +
     // Ollama); cloud providers (Anthropic, Claude Code) render via `render_user_content` directly.
@@ -507,6 +623,16 @@ pub fn render_user_content(req: &SummarizeRequest) -> String {
     ));
     if let Some(lang) = &req.meta.language {
         out.push_str(&format!("- language: {lang}\n"));
+    }
+
+    if let Some(glossary) = req.glossary.as_deref().filter(|g| !g.is_empty()) {
+        out.push_str(
+            "\nWORKSPACE GLOSSARY (canonical spellings; use only when the transcript clearly \
+             refers to a listed alias)\n\
+             Prefer each `canonical` spelling over its listed aliases. Do not invent a glossary \
+             match and do not use this section as evidence that a person or project attended.\n",
+        );
+        out.push_str(glossary);
     }
 
     out.push_str("\nEXISTING NOTE TITLES (valid [[wikilink]] targets — link only these):\n");
@@ -697,13 +823,8 @@ pub fn is_known_template_var(ident: &str) -> bool {
 
 /// The front-matter keys Murmur OWNS: it renders each one deterministically, so a model-emitted line
 /// for the same key is dropped during the merge rather than duplicated.
-const OWNED_FRONT_MATTER_KEYS: [&str; 5] = [
-    "title",
-    "date",
-    "duration_minutes",
-    "tags",
-    "participants",
-];
+const OWNED_FRONT_MATTER_KEYS: [&str; 5] =
+    ["title", "date", "duration_minutes", "tags", "participants"];
 
 /// Bound on how many items a list variable renders (a runaway entity list must not turn the
 /// front-matter block into the note) and on how many model-emitted lines survive the merge.
@@ -1146,7 +1267,10 @@ pub fn assemble_note_with_template(
     let mut lines = deterministic_front_matter_lines(template, vars);
     let owned: std::collections::HashSet<String> = lines
         .iter()
-        .filter_map(|l| l.split_once(':').map(|(k, _)| k.trim().to_ascii_lowercase()))
+        .filter_map(|l| {
+            l.split_once(':')
+                .map(|(k, _)| k.trim().to_ascii_lowercase())
+        })
         .collect();
     lines.extend(preserved_front_matter_lines(&model_yaml, &owned));
 
@@ -1205,7 +1329,9 @@ fn preserved_front_matter_lines(
                 if c == "---" {
                     break;
                 }
-                let Some(item) = c.strip_prefix('-') else { break };
+                let Some(item) = c.strip_prefix('-') else {
+                    break;
+                };
                 // Unwrap the model's own quoting so the re-emitted flow list quotes ONCE.
                 items.push(
                     item.trim()
@@ -1275,6 +1401,7 @@ mod tests {
             related_context: related,
             user_notes: None,
             live_bullets: None,
+            glossary: None,
         }
     }
 
@@ -1290,6 +1417,98 @@ mod tests {
         // Reconstruct the exact expected string to pin byte-identity.
         let expected = "MEETING METADATA\n- date: 2026-06-28\n- duration_minutes: 30\n- language: en\n\nEXISTING NOTE TITLES (valid [[wikilink]] targets — link only these):\n- Roadmap\n\nTRANSCRIPT\nWe shipped v2 and agreed Anna owns the rollout.\n";
         assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn empty_glossary_keeps_user_prompt_byte_identical() {
+        let base = render_user_content(&req(None));
+        for raw in ["", "   \n\t", "# comment only"] {
+            let mut with_empty = req(None);
+            with_empty.glossary = render_glossary_for_prompt(raw);
+            assert_eq!(
+                render_user_content(&with_empty),
+                base,
+                "empty/comment-only glossary must not add even a blank section"
+            );
+        }
+    }
+
+    #[test]
+    fn glossary_renderer_is_structured_and_deterministically_bounded() {
+        let mut raw = "Konnect = Connect, Kinect, Connect\n".to_string();
+        for i in 0..100 {
+            raw.push_str(&format!("Canonical {i} = Alias {i}\n"));
+        }
+        let bounded = bounded_glossary(&raw);
+
+        assert!(
+            bounded.truncated,
+            "more than 64 valid entries must truncate"
+        );
+        assert_eq!(bounded.entries.len(), GLOSSARY_MAX_ENTRIES);
+        assert!(
+            bounded.rendered.len() <= GLOSSARY_MAX_RENDERED_BYTES,
+            "rendered prompt field must stay within its explicit byte budget"
+        );
+        assert!(bounded
+            .rendered
+            .starts_with("- {\"canonical\":\"Konnect\",\"aliases\":[\"Connect\",\"Kinect\"]}\n"));
+        assert!(
+            bounded.rendered.ends_with(GLOSSARY_TRUNCATION_MARKER),
+            "truncation must be explicit to the provider"
+        );
+        assert_eq!(
+            bounded.entries[0].aliases,
+            vec!["Connect", "Kinect"],
+            "duplicate aliases are removed without changing order"
+        );
+
+        let rerendered = bounded_glossary(&raw);
+        assert_eq!(
+            bounded, rerendered,
+            "same input must produce identical bytes"
+        );
+    }
+
+    #[test]
+    fn glossary_renderer_enforces_alias_and_utf8_byte_budgets() {
+        let aliases = (0..20)
+            .map(|i| format!("Alias {i}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let alias_bounded = bounded_glossary(&format!("Canonical = {aliases}"));
+        assert_eq!(
+            alias_bounded.entries[0].aliases.len(),
+            GLOSSARY_MAX_ALIASES_PER_ENTRY
+        );
+        assert!(alias_bounded.truncated);
+        assert!(alias_bounded.rendered.ends_with(GLOSSARY_TRUNCATION_MARKER));
+
+        let multibyte_term = "Ż".repeat(GLOSSARY_MAX_TERM_CHARS - 2);
+        let raw = (0..40)
+            .map(|i| format!("{multibyte_term}{i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let byte_bounded = bounded_glossary(&raw);
+        assert!(byte_bounded.truncated);
+        assert!(
+            byte_bounded.rendered.len() <= GLOSSARY_MAX_RENDERED_BYTES,
+            "the byte budget must hold even when terms contain multi-byte Unicode"
+        );
+        assert!(byte_bounded.rendered.ends_with(GLOSSARY_TRUNCATION_MARKER));
+    }
+
+    #[test]
+    fn rendered_glossary_precedes_titles_and_transcript() {
+        let mut request = req(None);
+        request.glossary =
+            render_glossary_for_prompt("Konnect = Connect, Kinect\nFastMCP = Fast MCP");
+        let out = render_user_content(&request);
+        let glossary = out.find("WORKSPACE GLOSSARY").unwrap();
+        let titles = out.find("EXISTING NOTE TITLES").unwrap();
+        let transcript = out.find("\nTRANSCRIPT\n").unwrap();
+        assert!(glossary < titles && titles < transcript);
+        assert!(out.contains("- {\"canonical\":\"Konnect\",\"aliases\":[\"Connect\",\"Kinect\"]}"));
     }
 
     /// mem-2 (P0.2): the ON-DEVICE note prompt (`render_prompt`, used only by local mistralrs +
@@ -1498,8 +1717,14 @@ mod tests {
             "whiteboard.png",
             "synthesis",
         );
-        assert!(fm.starts_with("---\n"), "front-matter must start with ---: {fm}");
-        assert!(fm.trim_end().ends_with("---"), "front-matter must close with ---: {fm}");
+        assert!(
+            fm.starts_with("---\n"),
+            "front-matter must start with ---: {fm}"
+        );
+        assert!(
+            fm.trim_end().ends_with("---"),
+            "front-matter must close with ---: {fm}"
+        );
         // The colon + quotes in the title are quoted+escaped, never bare.
         assert!(fm.contains("title: \"Q3: Planning \\\"board\\\"\""), "{fm}");
         assert!(fm.contains("date: 2026-07-25"));
@@ -1787,20 +2012,34 @@ Formatting rules:
              After the closing"
         ));
         // Ordered sections, in order, with instructions.
-        let out_at = body.find("## Outcome\nOne line: what we agreed.").expect("s1");
+        let out_at = body
+            .find("## Outcome\nOne line: what we agreed.")
+            .expect("s1");
         let next_at = body
             .find("## Next steps\n- [ ] Owner — action")
             .expect("s2");
         assert!(out_at < next_at, "sections render in author order");
-        assert!(body.contains("# <title>\n\n## Outcome"), "title heads the body");
+        assert!(
+            body.contains("# <title>\n\n## Outcome"),
+            "title heads the body"
+        );
 
         // Registered → build_template resolves it (pipeline's exact call) + appends the language
         // directive; unlabeled adds no speaker directive.
         set_saved_templates(vec![t.clone()]);
         let built = build_template("tpl-client-call", "auto", false, false);
-        assert!(built.starts_with(&body), "build_template renders the saved body");
-        assert!(built.contains("OUTPUT LANGUAGE:"), "language directive appended");
-        assert!(!built.contains("SPEAKER ATTRIBUTION"), "no attribution when unlabeled");
+        assert!(
+            built.starts_with(&body),
+            "build_template renders the saved body"
+        );
+        assert!(
+            built.contains("OUTPUT LANGUAGE:"),
+            "language directive appended"
+        );
+        assert!(
+            !built.contains("SPEAKER ATTRIBUTION"),
+            "no attribution when unlabeled"
+        );
         // Cleanup so the process-global registry doesn't leak into other tests.
         set_saved_templates(vec![]);
     }
@@ -1874,8 +2113,14 @@ Formatting rules:
         let vars = hostile_vars();
         let (front, _scaffold) = render_template(None, &vars);
 
-        assert!(front.starts_with("---\n"), "front-matter must open with ---: {front}");
-        assert!(front.trim_end().ends_with("---"), "…and close with ---: {front}");
+        assert!(
+            front.starts_with("---\n"),
+            "front-matter must open with ---: {front}"
+        );
+        assert!(
+            front.trim_end().ends_with("---"),
+            "…and close with ---: {front}"
+        );
         assert_eq!(fence_lines(&front), 2, "exactly ONE yaml document: {front}");
         assert!(!front.contains("<%") && !front.contains("%>"), "{front}");
         assert!(!front.contains("{{"), "{front}");
@@ -1890,7 +2135,10 @@ Formatting rules:
             .find(|l| l.starts_with("participants:"))
             .expect("participants line");
         assert!(participants.contains("\"admin: true\""), "{participants}");
-        assert!(participants.contains("\"tp.system.prompt()\""), "{participants}");
+        assert!(
+            participants.contains("\"tp.system.prompt()\""),
+            "{participants}"
+        );
         assert!(participants.contains("\"Ann: the CFO\""), "{participants}");
         assert!(participants.contains("Bob"), "{participants}");
         assert!(!participants.contains('\n'), "single-line: {participants}");
@@ -1898,7 +2146,11 @@ Formatting rules:
         // The same holds for the FULL assembled note (front-matter + the model's body).
         let note = assemble_note_with_template(None, &vars, "---\ntitle: guessed\n---\n\n# Body\n");
         assert!(note.starts_with("---\n"), "{note}");
-        assert_eq!(fence_lines(&note), 2, "assembled note is one yaml doc: {note}");
+        assert_eq!(
+            fence_lines(&note),
+            2,
+            "assembled note is one yaml doc: {note}"
+        );
         assert!(!note.contains("<%") && !note.contains("%>"), "{note}");
         assert!(note.contains("# Body"), "the model body survives: {note}");
         // Murmur's deterministic title WINS over the model's guess.
@@ -1956,14 +2208,24 @@ Formatting rules:
         for v in TEMPLATE_VARS {
             assert!(is_known_template_var(v), "{v} must be known");
         }
-        for v in ["meeting_id", "transcript", "note", "audio_path", "folder", ""] {
+        for v in [
+            "meeting_id",
+            "transcript",
+            "note",
+            "audio_path",
+            "folder",
+            "",
+        ] {
             assert!(!is_known_template_var(v), "{v} must NOT be a template var");
         }
         assert!(!TEMPLATE_VARS.contains(&"meeting_id"));
         // Every allowlisted ident actually resolves (no half-wired var).
         let vars = hostile_vars();
         for v in TEMPLATE_VARS {
-            assert!(resolve_var_inline(&vars, v, None).is_some(), "{v} unresolved");
+            assert!(
+                resolve_var_inline(&vars, v, None).is_some(),
+                "{v} unresolved"
+            );
             assert!(resolve_var_yaml(&vars, v, None).is_some(), "{v} unresolved");
         }
         // The grammar itself compiles (the renderer/validator share it).
@@ -2003,7 +2265,10 @@ Formatting rules:
         }
         // The refusal NAMES the allowlist so the user can fix it.
         let msg = format!("{:?}", validate_note_template(&mid.name, &mid.tone, &mid));
-        assert!(msg.contains("participants"), "error must list the allowlist: {msg}");
+        assert!(
+            msg.contains("participants"),
+            "error must list the allowlist: {msg}"
+        );
     }
 
     /// The DSL's FIELD SCOPE is enforced, not merely documented: `name` and `tone` are never
@@ -2032,8 +2297,14 @@ Formatting rules:
             "`{{{{}}}}` in the name must be refused; got {err:?}"
         );
         // The refusal explains WHERE variables are supported.
-        let msg = format!("{:?}", validate_note_template("Weekly {{title}}", &named.tone, &named));
-        assert!(msg.contains("SECTIONS"), "error must name the supported fields: {msg}");
+        let msg = format!(
+            "{:?}",
+            validate_note_template("Weekly {{title}}", &named.tone, &named)
+        );
+        assert!(
+            msg.contains("SECTIONS"),
+            "error must name the supported fields: {msg}"
+        );
     }
 
     /// A section instruction reaches the model VERBATIM in the prompt, so the model can echo the raw
@@ -2043,14 +2314,18 @@ Formatting rules:
     #[test]
     fn placeholders_echoed_by_the_model_are_resolved_in_the_body() {
         let vars = hostile_vars();
-        let model = "---\ntitle: guess\n---\n\n# Q3\n\nAttendees: {{participants}}\nOn {{date:YYYY}}.\n";
+        let model =
+            "---\ntitle: guess\n---\n\n# Q3\n\nAttendees: {{participants}}\nOn {{date:YYYY}}.\n";
         let note = assemble_note_with_template(None, &vars, model);
 
         assert!(
             !note.contains("{{"),
             "no placeholder may survive into the user's note: {note}"
         );
-        assert!(note.contains("Attendees: admin: true, tp.system.prompt()"), "{note}");
+        assert!(
+            note.contains("Attendees: admin: true, tp.system.prompt()"),
+            "{note}"
+        );
         assert!(note.contains("On 2026."), "{note}");
         // Resolution in the body is still sanitized — the fence/Templater tokens stay stripped.
         assert!(!note.contains("<%") && !note.contains("%>"), "{note}");
@@ -2089,14 +2364,19 @@ Formatting rules:
             .lines()
             .find(|l| l.starts_with("participants:"))
             .expect("participants line");
-        for quoted in ["\"No\"", "\"yes\"", "\"Off\"", "\"null\"", "\"~\"", "\"3.14\""] {
+        for quoted in [
+            "\"No\"", "\"yes\"", "\"Off\"", "\"null\"", "\"~\"", "\"3.14\"",
+        ] {
             assert!(
                 participants.contains(quoted),
                 "{quoted} must be quoted, not re-typed by YAML: {participants}"
             );
         }
         // A plain name still renders BARE — the guard must not over-quote everything.
-        assert!(participants.contains("Anna,") || participants.contains("Anna]"), "{participants}");
+        assert!(
+            participants.contains("Anna,") || participants.contains("Anna]"),
+            "{participants}"
+        );
         // The ISO date is not a number, so it stays bare (Obsidian parses it as a date).
         assert!(front.contains("date: 2026-07-26"), "{front}");
         // duration_minutes is a REAL number and must stay unquoted.
@@ -2164,13 +2444,19 @@ Formatting rules:
 
         // The prompt still ASKS for the plain key, and no longer asks for the ones Murmur fills.
         let prompt = render_saved_template(&t);
-        assert!(prompt.contains("- project: (fill in from the meeting"), "{prompt}");
+        assert!(
+            prompt.contains("- project: (fill in from the meeting"),
+            "{prompt}"
+        );
         assert!(!prompt.contains("- client:"), "{prompt}");
         assert!(!prompt.contains("- slug:"), "{prompt}");
 
         // The body scaffold resolves its vars and heads with the real title.
         assert!(scaffold.starts_with("# Q3 planning\n"), "{scaffold}");
-        assert!(scaffold.contains("Attendees: admin: true, tp.system.prompt()"), "{scaffold}");
+        assert!(
+            scaffold.contains("Attendees: admin: true, tp.system.prompt()"),
+            "{scaffold}"
+        );
         assert!(!scaffold.contains("{{"), "{scaffold}");
     }
 
@@ -2194,7 +2480,10 @@ Formatting rules:
         let note = assemble_note_with_template(None, &vars, model);
 
         assert_eq!(fence_lines(&note), 2, "one yaml doc: {note}");
-        assert!(note.contains("murmur_enhanced: true"), "stamp preserved: {note}");
+        assert!(
+            note.contains("murmur_enhanced: true"),
+            "stamp preserved: {note}"
+        );
         assert_eq!(
             note.lines().filter(|l| l.starts_with("title:")).count(),
             1,
@@ -2206,7 +2495,10 @@ Formatting rules:
         assert!(note.contains("project: \"tp.system\""), "{note}");
         assert!(!note.contains("empty:"), "dangling key dropped: {note}");
         assert!(!note.contains("bad key!"), "unsafe key dropped: {note}");
-        assert!(!note.contains("- someone"), "orphan list item dropped: {note}");
+        assert!(
+            !note.contains("- someone"),
+            "orphan list item dropped: {note}"
+        );
         assert!(note.contains("# Real body"), "{note}");
     }
 

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -120,9 +120,9 @@ export interface AppConfigDto {
    * Speaker voiceprints — recognise the SAME diarized speaker across meetings,
    * fully on-device. OPT-IN, default false: captures a voice fingerprint of remote
    * participants (never egressed, but a biometric nonetheless). Settable and
-   * round-tripped on every `save_config` like `diarizeOthers`; an omitted key
-   * serde-defaults to false in the backend, so the FE MUST always send it or a
-   * normal save silently disables it. Mirrors Rust `AppConfigDto.voiceprint_enabled`.
+   * round-tripped on every `save_config` like `diarizeOthers`. The backend treats an
+   * omitted key as PRESERVE for older/partial clients; Settings still sends the explicit
+   * current choice. Mirrors Rust `AppConfigDto.voiceprint_enabled`.
    */
   voiceprintEnabled: boolean;
   aecEnabled: boolean;
@@ -198,6 +198,17 @@ export interface AppConfigDto {
   notesMode: string;
   autoOrganize: boolean;
   noteLanguage: string;
+  /**
+   * Run the local post-generation support scan. Its conservative, uncalibrated markers are
+   * review cues, not proof that a claim is true or false. Default true.
+   */
+  groundSummary: boolean;
+  /**
+   * Workspace glossary for canonical domain spellings, one `Canonical = alias, alias` entry per
+   * line. OPTIONAL on the wire: omission preserves the backend's stored value, while an explicit
+   * empty string clears it. Settings always loads and sends the real string.
+   */
+  glossary?: string;
   /**
    * Stage E security flags. These are part of the `get_config` / `save_config`
    * round-trip (Rust `AppConfigDto`), so the FE MUST read the current values and

--- a/src/app/features/onboarding/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding/onboarding.component.ts
@@ -677,7 +677,8 @@ export class OnboardingComponent implements OnInit {
       captureSystemAudio: base?.captureSystemAudio ?? true,
       vadEnabled: base?.vadEnabled ?? true,
       keepHiresMasters: base?.keepHiresMasters ?? false,
-      diarizeOthers: base?.diarizeOthers ?? false,
+      // Mirrors backend default diarize_others = true. Voiceprints remain a separate opt-in.
+      diarizeOthers: base?.diarizeOthers ?? true,
       voiceprintEnabled: base?.voiceprintEnabled ?? false,
       aecEnabled: base?.aecEnabled ?? false,
       postAecEnabled: base?.postAecEnabled ?? false,
@@ -707,6 +708,8 @@ export class OnboardingComponent implements OnInit {
       notesMode: base?.notesMode ?? "enhance",
       autoOrganize: base?.autoOrganize ?? false,
       noteLanguage: base?.noteLanguage ?? "auto",
+      // Preserve the Settings-owned choice; a truly missing historical field follows the backend.
+      groundSummary: base?.groundSummary ?? true,
       // Stage E security flags — read the current values from the snapshot and send
       // them back unchanged so onboarding never resets them (the backend's serde
       // defaults would otherwise clobber mcpRequireToken / cloudEgressConsented to

--- a/src/app/features/settings/sections/settings-notes-section/settings-notes-section.component.html
+++ b/src/app/features/settings/sections/settings-notes-section/settings-notes-section.component.html
@@ -121,6 +121,26 @@
               </span>
             </label>
 
+            <label class="field">
+              <span class="field-label">Workspace glossary</span>
+              <textarea
+                class="glossary-input"
+                formControlName="glossary"
+                rows="7"
+                maxlength="16384"
+                spellcheck="false"
+                placeholder="Konnect = Connect, Kinect&#10;FastMCP = Fast MCP&#10;Kong Operator = KO"
+              ></textarea>
+              <span class="field-help text-muted">
+                One canonical spelling per line; optional aliases follow an equals
+                sign and commas. Murmur sends at most 64 entries, 8 aliases each and
+                4 KB of structured glossary text. It only corrects exact listed
+                aliases in the local knowledge graph — never substrings. Before a
+                cloud note call, glossary text passes the same email, phone, card and
+                on-device name protection (when installed) as the transcript.
+              </span>
+            </label>
+
             <label class="toggle-row">
               <span class="toggle-copy">
                 <span class="toggle-title">Organize into thematic subfolders</span>
@@ -130,6 +150,20 @@
                 </span>
               </span>
               <mur-toggle formControlName="autoOrganize" />
+            </label>
+
+            <label class="toggle-row">
+              <span class="toggle-copy">
+                <span class="toggle-title">Flag potentially unsupported claims</span>
+                <span class="text-secondary toggle-sub">
+                  After writing the note, Murmur checks it against this meeting's
+                  transcript and marks lines that may need review. The conservative
+                  thresholds are not yet calibrated, so a marker is not proof that
+                  a claim is true or false. This check runs locally and adds no
+                  cloud request.
+                </span>
+              </span>
+              <mur-toggle formControlName="groundSummary" />
             </label>
           </div>
 </div>

--- a/src/app/features/settings/sections/settings-notes-section/settings-notes-section.component.scss
+++ b/src/app/features/settings/sections/settings-notes-section/settings-notes-section.component.scss
@@ -42,6 +42,10 @@
   font-size: 0.9rem;
   font-weight: 550;
 }
+.glossary-input {
+  font-family: var(--font-mono);
+  resize: vertical;
+}
 
 /* --- Capture-system-audio toggle row --- */
 .toggle-row {

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -156,7 +156,8 @@ export class SettingsStore {
     captureSystemAudio: false,
     vadEnabled: true,
     keepHiresMasters: false,
-    diarizeOthers: false,
+    // Local analysis default ON; voiceprints remain an independent privacy opt-in.
+    diarizeOthers: true,
     // Speaker voiceprints — cross-meeting on-device re-identification. Opt-in, default off.
     voiceprintEnabled: false,
     aecEnabled: false,
@@ -181,6 +182,10 @@ export class SettingsStore {
     notesMode: "enhance",
     autoOrganize: false,
     noteLanguage: "auto",
+    groundSummary: true,
+    // Workspace glossary is a larger text field: commit on blur so auto-save never writes every
+    // intermediate keystroke. Empty is intentional and clears the backend value.
+    glossary: this.fb.nonNullable.control("", { updateOn: "blur" }),
     // Phase H — brain / in-meeting voice assistant.
     brainBackend: "cloud" as BrainBackend,
     realtimeReactions: false,
@@ -1488,7 +1493,8 @@ export class SettingsStore {
         captureSystemAudio: cfg.captureSystemAudio ?? true,
         vadEnabled: cfg.vadEnabled ?? true,
         keepHiresMasters: cfg.keepHiresMasters ?? false,
-        diarizeOthers: cfg.diarizeOthers ?? false,
+        // Mirrors backend default diarize_others = true; explicit false is preserved by ??.
+        diarizeOthers: cfg.diarizeOthers ?? true,
         voiceprintEnabled: cfg.voiceprintEnabled ?? false,
         aecEnabled: cfg.aecEnabled ?? false,
         // Mirrors backend default post_aec_enabled = false (settings/config.rs, AppConfig::default).
@@ -1509,6 +1515,9 @@ export class SettingsStore {
         notesMode: cfg.notesMode ?? "enhance",
         autoOrganize: cfg.autoOrganize ?? false,
         noteLanguage: cfg.noteLanguage ?? "auto",
+        // Mirrors backend default ground_summary = true; explicit false remains OFF.
+        groundSummary: cfg.groundSummary ?? true,
+        glossary: cfg.glossary ?? "",
         brainBackend: cfg.brainBackend ?? "cloud",
         realtimeReactions: cfg.realtimeReactions ?? false,
         proactiveHintsEnabled: cfg.proactiveHintsEnabled ?? true,
@@ -2257,6 +2266,10 @@ export class SettingsStore {
       notesMode: v.notesMode,
       autoOrganize: v.autoOrganize,
       noteLanguage: v.noteLanguage,
+      groundSummary: v.groundSummary,
+      // Always explicit from Settings: empty clears. Other/older clients can omit the optional
+      // wire key and the Rust merge preserves the stored value.
+      glossary: v.glossary,
       // Phase H — brain / in-meeting voice assistant.
       brainBackend: v.brainBackend,
       realtimeReactions: v.realtimeReactions,


### PR DESCRIPTION
Supersedes #493 and #494 with one coherent, freshly verified implementation on the simplified Harness v2.

## Summary

- add a bounded optional workspace glossary with omission-safe persistence
- apply glossary terms locally to exact graph canonicalization and pass note prompts through the shared redaction firewall
- bind content-free egress receipts to the exact provider prompt fields, including combined remote Ollama summaries and split Ollama completions
- default diarization and local note grounding on while keeping voiceprints opt-in
- preserve stored settings for legacy callers and make Settings send explicit current choices
- add durable Rust lifecycle, egress, mocked-Tauri Playwright, and production fixture regressions

## Verification

- cargo test --lib: 2499 passed, 0 failed, 15 ignored
- Angular lint: PASS
- Angular production build: PASS
- Playwright: 344 passed, 2 skipped
- combined Codex review: PASS, no proof gaps
- egress-security Codex review: PASS, no proof gaps
- Claude was not used

## Harness provenance

- task: notes-settings-glossary-defaults-v2-20260728-r5
- exact diff: 806f8ab957e1c961c9eefc46a6b884316f8d64ee0aabcd598bf15d7438f32663
- evidence: 6bec36702933d055e9b400e4ac1b3c7ca2847f047eb0a5e3731a7612b92391a0
- attested task commit: 0f20003b0bcd52cf0a6b55bedaad9a7242184f74
- clean automatic catch-up merge: 4f6ba2ab59e1620d8e11b29471c78b2f59423514