### PR TITLE
fix(mcp): revoke responses before visibility changes

### DIFF
--- a/src-tauri/src/commands/lock.rs
+++ b/src-tauri/src/commands/lock.rs
@@ -43,10 +43,43 @@ pub fn lock_folder(
     state: State<'_, AppState>,
     folder_id: String,
 ) -> Result<(), AppError> {
-    lock_folder_inner(state.inner(), folder_id)?;
+    // Initial sealing revokes content just as a session relock does. Shut down every registered
+    // MCP content socket BEFORE waiting on the lifecycle mutex, otherwise a slow reader can keep
+    // receiving a pre-lock payload after the command has made the folder private.
+    let mcp_revocation = crate::mcp::begin_visibility_revocation(
+        &app,
+        crate::mcp::VisibilityRevokingEntrypoint::LockFolder,
+    );
+    lock_folder_with_visibility_revocation(state.inner(), &folder_id, mcp_revocation)?;
     // The seal purged ALL pending audit findings — ping the FE inbox (count-only).
     emit_audit_updated_after_purge(&app, state.inner());
     Ok(())
+}
+
+/// Run the initial seal under an already-closed MCP response gate. Reopen admission only once the
+/// folder is durably marked locked and absent from the session unlock set. If sealing fails before
+/// that logical transition, dropping the incomplete revocation deliberately leaves the gate closed.
+pub(crate) fn lock_folder_with_visibility_revocation(
+    state: &AppState,
+    folder_id: &str,
+    mcp_revocation: crate::mcp::VisibilityRevocation,
+) -> Result<(), AppError> {
+    let result = lock_folder_inner(state, folder_id.to_string());
+    let logically_revoked = state
+        .db
+        .folder_by_id(folder_id)
+        .ok()
+        .flatten()
+        .is_some_and(|folder| folder.locked)
+        && state
+            .unlocked_folders
+            .lock()
+            .map(|folders| !folders.contains(folder_id))
+            .unwrap_or(false);
+    if logically_revoked {
+        crate::mcp::finish_visibility_revocation(mcp_revocation);
+    }
+    result
 }
 
 /// Inner of [`lock_folder`] taking `&AppState` (so the lifecycle stress test can drive it without a
@@ -616,6 +649,12 @@ pub fn relock_folder(
     state: State<'_, AppState>,
     folder_id: String,
 ) -> Result<(), AppError> {
+    // Cancel response admission and shutdown active content sockets BEFORE waiting on lifecycle.
+    // A slow MCP reader can therefore never delay the privacy transition.
+    let mcp_revocation = crate::mcp::begin_visibility_revocation(
+        &app,
+        crate::mcp::VisibilityRevokingEntrypoint::RelockFolder,
+    );
     // BLK-1: serialize with the rest of the lock state machine (it re-blanks the same columns
     // `remove_lock` is mid-restoring).
     let _lifecycle = lifecycle_guard(state.inner());
@@ -639,6 +678,9 @@ pub fn relock_folder(
             .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?;
         g.remove(&folder_id);
     }
+    // Epoch + session membership now authoritatively hide this folder. New MCP responses may be
+    // admitted against that post-revocation snapshot while physical cleanup continues.
+    crate::mcp::finish_visibility_revocation(mcp_revocation);
     if let Ok(mut cache) = state.verify_cache.lock() {
         cache.clear();
     }
@@ -668,12 +710,41 @@ pub fn relock_folder(
 /// Stage E, and exposed as a command). Re-blanks the plaintext markdown of every sealed note.
 #[tauri::command]
 pub fn relock_all(app: AppHandle, state: State<'_, AppState>) -> Result<(), AppError> {
-    relock_all_inner(&state)?;
+    relock_all_with_visibility_gate(&app, state.inner())?;
     // The relock-all purged ALL pending audit findings — ping the FE inbox (count-only). The
     // off-thread `relock_all_inner` callers emit from their own handles (screen-share) or are
     // app teardown (window-close/exit — nothing left to notify).
     emit_audit_updated_after_purge(&app, state.inner());
     Ok(())
+}
+
+/// App-facing relock-all wrapper. Every production entrypoint (manual command, screen-share,
+/// window close, app exit) uses this wrapper so response shutdown always precedes lifecycle
+/// acquisition. Tests that exercise only the storage state machine may continue to call
+/// [`relock_all_inner`] directly without constructing a Tauri runtime.
+pub(crate) fn relock_all_with_visibility_gate(
+    app: &AppHandle,
+    state: &AppState,
+) -> Result<(), AppError> {
+    let mcp_revocation = crate::mcp::begin_visibility_revocation(
+        app,
+        crate::mcp::VisibilityRevokingEntrypoint::RelockAll,
+    );
+    let prior_epoch = state.seal_epoch.load(std::sync::atomic::Ordering::SeqCst);
+    let result = relock_all_inner(state);
+    // `relock_all_inner` deliberately keeps logical revocation even when a later vault/DB cleanup
+    // fails. Reopen only if the epoch advanced and the unlock authority is observably empty.
+    let logically_revoked = state.seal_epoch.load(std::sync::atomic::Ordering::SeqCst)
+        != prior_epoch
+        && state
+            .unlocked_folders
+            .lock()
+            .map(|folders| folders.is_empty())
+            .unwrap_or(false);
+    if logically_revoked {
+        crate::mcp::finish_visibility_revocation(mcp_revocation);
+    }
+    result
 }
 
 /// Inner relock-all usable without a command boundary (Stage E screen-share watcher, window-close,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -480,6 +480,10 @@ pub fn run() {
                 }
             };
             app.manage(state);
+            // One Tauri-managed, process-local cancellation authority is shared by the MCP
+            // transport and every relock entrypoint. It contains socket clones and content-free
+            // lease ids only; no meeting data or authentication material.
+            app.manage(std::sync::Arc::new(crate::mcp::McpResponseGate::new()));
 
             // PRE-WINDOW legacy-recovery guard. Historical paired crash artifacts are plaintext and
             // cannot be honestly presented as protected by an already-locked folder. Publish their
@@ -732,14 +736,11 @@ pub fn run() {
             }
             setup_tray(app.handle())?;
             // Localhost MCP server (read-only meeting tools for Claude Desktop/Code; no egress).
-            // Share the session unlock set so sealed-and-not-unlocked notes stay invisible.
-            // Must mirror `AppState::db_path` exactly (same dir + filename) so the MCP server opens
-            // the SAME DB the app did — `app_dir_name()` keeps the dev/release split consistent.
-            if let Some(db_path) = dirs::data_dir()
-                .map(|b| b.join(crate::state::app_dir_name()).join("meetnotes.sqlite"))
+            // Pass the AppHandle so the server resolves the ONE managed AppState for every request:
+            // DB, live session unlock set, seal epoch, and lifecycle guard cannot drift into an
+            // independently-opened/snapshotted authority.
             {
                 let state = app.state::<AppState>();
-                let unlocked = state.unlocked_folders.clone();
                 let require_token = state
                     .config
                     .lock()
@@ -747,7 +748,7 @@ pub fn run() {
                     // Poisoned config ⇒ fail CLOSED (require the token) — aligned with the
                     // reasoner-dispatch poison posture (unreadable config never relaxes auth).
                     .unwrap_or(true);
-                crate::mcp::spawn(db_path, unlocked, require_token);
+                crate::mcp::spawn(app.handle().clone(), require_token);
             }
             // Brain v2 L1.1 — TOPIC-CHUNK startup backfill: index topic segments for every VISIBLE
             // meeting that has a transcript, content-hash idempotent (an already-indexed vault is a
@@ -1041,9 +1042,9 @@ fn relock_and_zeroize_on_lifecycle(handle: &tauri::AppHandle, ctx: &str) {
     if ctx == LIFECYCLE_CTX_APP_EXIT {
         crate::commands::stop_all_capture(state.inner());
     }
-    // relock_all_inner clears the unlock set, zeroizes the cached KEK, re-blanks all sealed notes,
-    // and (as of B12) checkpoints the WAL.
-    if let Err(e) = crate::commands::relock_all_inner(state.inner()) {
+    // The wrapper first cancels every active MCP content socket, then clears the unlock set,
+    // zeroizes the cached KEK, re-blanks all sealed notes, and checkpoints the WAL.
+    if let Err(e) = crate::commands::relock_all_with_visibility_gate(handle, state.inner()) {
         tracing::warn!(target: "lock", error = %e, ctx, "lifecycle relock_all failed");
     }
     // Belt-and-suspenders WAL checkpoint in case relock_all short-circuited before its own.

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -2,14 +2,22 @@
 //! (Claude Desktop / Code) with NO egress. Read-only tools over the SQLite DB. Implements the
 //! MCP JSON-RPC essentials (initialize / tools/list / tools/call) over HTTP POST.
 
+use std::collections::HashMap;
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::{Shutdown, TcpListener, TcpStream};
+#[cfg(test)]
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard, TryLockError};
+use std::time::{Duration, Instant};
 
+use serde::Serialize;
 use serde_json::{json, Value};
 use subtle::ConstantTimeEq;
-use tiny_http::{Header, Method, Response, Server};
+use tauri::{AppHandle, Manager};
 
+use crate::state::AppState;
 use crate::storage::Db;
 
 /// Fixed localhost port for the MCP server.
@@ -18,11 +26,447 @@ pub const MCP_PORT: u16 = 8765;
 /// Max request body we will read (E5). The MCP JSON-RPC requests are tiny; cap hard so a
 /// malicious local client can't OOM us with an unbounded body.
 const MAX_BODY_BYTES: u64 = 1 << 20; // 1 MiB
+const MAX_HEADER_BYTES: usize = 32 << 10;
+const MAX_REQUEST_LINE_BYTES: usize = 8 << 10;
+const MAX_HEADER_COUNT: usize = 64;
+const MAX_RESPONSE_BYTES: usize = 8 << 20;
+// A JSON string byte can expand to six bytes (`\u00XX`). Keeping tool text to one MiB leaves
+// ample room for that worst-case escaping plus the bounded JSON-RPC id and envelope.
+const MAX_TOOL_TEXT_BYTES: usize = 1 << 20;
+const MAX_TOOL_WINDOW_CHARS: usize = MAX_TOOL_TEXT_BYTES / 4;
+const MAX_JSONRPC_ID_BYTES: usize = 256;
+const RESPONSE_CHUNK_BYTES: usize = 4096;
+const MAX_ACTIVE_CONNECTIONS: usize = 32;
+const READ_TIMEOUT: Duration = Duration::from_secs(5);
+const WRITE_TIMEOUT: Duration = Duration::from_secs(2);
+const REQUEST_DEADLINE: Duration = Duration::from_secs(10);
 
 /// The only `Host` header values we accept (E2). A request whose Host is anything else — a DNS
 /// name resolving to 127.0.0.1, a `0.0.0.0` rebinding, an external host — is rejected, which
 /// blocks DNS-rebinding attacks against the localhost server.
 const ALLOWED_HOSTS: &[&str] = &["127.0.0.1:8765", "localhost:8765"];
+
+/// Content-free JSON-RPC refusal returned when the lock/session lifecycle changed after a tool
+/// materialized content but before the server could send it. Never include the tool name, meeting
+/// id, title, query, or any dispatch error here: the stale payload is discarded as a whole.
+const VISIBILITY_RETRY_CODE: i64 = -32002;
+const VISIBILITY_RETRY_MESSAGE: &str = "content visibility changed; retry the request";
+
+#[derive(Debug, PartialEq, Eq)]
+struct VisibilitySnapshot {
+    seal_epoch: u64,
+    unlocked_folders: HashSet<String>,
+}
+
+/// The exact shared visibility authority used for one MCP request. Production constructs this only
+/// from Tauri's managed [`AppState`]; tests inject the same three content-free synchronization
+/// primitives without needing a real application/runtime.
+struct RpcContext<'a> {
+    db: Option<&'a Db>,
+    lifecycle: &'a Mutex<()>,
+    seal_epoch: &'a AtomicU64,
+    unlocked_folders: &'a Mutex<HashSet<String>>,
+}
+
+impl<'a> RpcContext<'a> {
+    fn from_state(state: &'a AppState) -> Self {
+        Self {
+            db: Some(&state.db),
+            lifecycle: &state.lifecycle,
+            seal_epoch: &state.seal_epoch,
+            unlocked_folders: state.unlocked_folders.as_ref(),
+        }
+    }
+
+    /// Capture epoch + live unlock membership while excluding every lock lifecycle mutation.
+    /// A poisoned unlock-set mutex fails closed instead of silently substituting an empty set.
+    fn visibility_snapshot(
+        &self,
+        deadline: Instant,
+    ) -> std::result::Result<VisibilitySnapshot, ()> {
+        let _lifecycle = lock_before_deadline(self.lifecycle, deadline, true)?;
+        let unlocked_folders =
+            lock_before_deadline(self.unlocked_folders, deadline, false)?.clone();
+        Ok(VisibilitySnapshot {
+            seal_epoch: self.seal_epoch.load(Ordering::SeqCst),
+            unlocked_folders,
+        })
+    }
+}
+
+/// Acquire a synchronization boundary without letting mutex contention silently extend the
+/// connection's one absolute deadline. Lifecycle poisoning is recoverable because the mutex
+/// carries no data; content-bearing mutexes fail closed on poison.
+fn lock_before_deadline<'a, T>(
+    mutex: &'a Mutex<T>,
+    deadline: Instant,
+    recover_poison: bool,
+) -> std::result::Result<MutexGuard<'a, T>, ()> {
+    loop {
+        match mutex.try_lock() {
+            Ok(guard) => return Ok(guard),
+            Err(TryLockError::Poisoned(error)) if recover_poison => return Ok(error.into_inner()),
+            Err(TryLockError::Poisoned(_)) => return Err(()),
+            Err(TryLockError::WouldBlock) => {
+                let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                    return Err(());
+                };
+                if remaining.is_zero() {
+                    return Err(());
+                }
+                std::thread::sleep(remaining.min(Duration::from_millis(1)));
+            }
+        }
+    }
+}
+
+enum RpcReply {
+    Immediate(Value),
+    Content(PendingContentReply),
+}
+
+struct PendingContentReply {
+    id: Value,
+    snapshot: VisibilitySnapshot,
+    outcome: std::result::Result<String, ToolError>,
+}
+
+#[derive(Serialize)]
+struct BorrowedTextContent<'a> {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    text: &'a str,
+}
+
+#[derive(Serialize)]
+struct BorrowedTextResult<'a> {
+    content: [BorrowedTextContent<'a>; 1],
+}
+
+#[derive(Serialize)]
+struct BorrowedTextResponse<'a> {
+    jsonrpc: &'static str,
+    id: &'a Value,
+    result: BorrowedTextResult<'a>,
+}
+
+#[derive(Serialize)]
+struct BorrowedRpcErrorBody<'a> {
+    code: i64,
+    message: &'a str,
+}
+
+#[derive(Serialize)]
+struct BorrowedRpcErrorResponse<'a> {
+    jsonrpc: &'static str,
+    id: &'a Value,
+    error: BorrowedRpcErrorBody<'a>,
+}
+
+struct ActiveResponse {
+    stream: Arc<TcpStream>,
+    cancellation: Arc<ResponseCancellation>,
+}
+
+struct ResponseCancellation {
+    state: Mutex<ResponseWriteState>,
+    drained: Condvar,
+}
+
+struct ResponseWriteState {
+    cancelled: bool,
+    in_flight_chunks: usize,
+}
+
+struct ResponseGateState {
+    open: bool,
+    revocations_in_flight: u64,
+    next_id: u64,
+    active: HashMap<u64, ActiveResponse>,
+}
+
+/// Tauri-managed cancellation authority for content-bearing MCP responses.
+///
+/// Registering a stream is a short mutex-only operation performed while the caller holds
+/// [`AppState::lifecycle`]. Revocation flips every lease's content-free cancellation bit and takes
+/// the cloned sockets while holding this mutex, then releases it before calling `shutdown(2)`.
+/// Consequently neither the lifecycle mutex nor this gate mutex is ever held across network I/O.
+///
+/// A successful TCP write is the disclosure commit point: bytes already accepted by the kernel
+/// were sent while the client was authorized and cannot be recalled. Revocation prevents any new
+/// chunk syscall from starting and waits for every already-admitted syscall to return before the
+/// logical visibility transition, so that transition linearizes after all pre-revocation commits.
+pub(crate) struct McpResponseGate {
+    inner: Mutex<ResponseGateState>,
+}
+
+impl McpResponseGate {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Mutex::new(ResponseGateState {
+                open: true,
+                revocations_in_flight: 0,
+                next_id: 1,
+                active: HashMap::new(),
+            }),
+        }
+    }
+
+    fn register(self: &Arc<Self>, stream: TcpStream) -> Option<ResponseLease> {
+        let cancellation = Arc::new(ResponseCancellation {
+            state: Mutex::new(ResponseWriteState {
+                cancelled: false,
+                in_flight_chunks: 0,
+            }),
+            drained: Condvar::new(),
+        });
+        let id = {
+            let mut inner = self
+                .inner
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if !inner.open {
+                return None;
+            }
+            let mut id = inner.next_id.max(1);
+            while inner.active.contains_key(&id) {
+                id = id.wrapping_add(1).max(1);
+            }
+            inner.next_id = id.wrapping_add(1).max(1);
+            inner.active.insert(
+                id,
+                ActiveResponse {
+                    stream: Arc::new(stream),
+                    cancellation: Arc::clone(&cancellation),
+                },
+            );
+            id
+        };
+        Some(ResponseLease {
+            gate: Arc::clone(self),
+            id,
+            cancellation,
+        })
+    }
+
+    /// Close admission and cancel every registered content response. Socket shutdown happens only
+    /// after the gate mutex has been released, so a slow client can never pin a lock lifecycle.
+    pub(crate) fn close_and_shutdown(&self) {
+        let active = {
+            let mut inner = self
+                .inner
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            inner.revocations_in_flight = inner.revocations_in_flight.saturating_add(1);
+            inner.open = false;
+            inner
+                .active
+                .iter()
+                .map(|(id, active)| {
+                    (
+                        *id,
+                        Arc::clone(&active.stream),
+                        Arc::clone(&active.cancellation),
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+        // Cancel every response before potentially waiting on any one of them. Then shutdown all
+        // socket clones so a checked write already inside the kernel returns promptly. Finally wait
+        // until those checked chunks have left their syscalls. A successful pre-cancel syscall is
+        // already a disclosure to the then-authorized client; TCP cannot retract it. Only after all
+        // such syscalls drain may the caller perform the logical visibility transition.
+        for (_, _, cancellation) in &active {
+            cancellation.cancel();
+        }
+        for (_, stream, _) in &active {
+            let _ = stream.shutdown(Shutdown::Both);
+        }
+        for (_, _, cancellation) in &active {
+            cancellation.wait_until_drained();
+        }
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for (id, _, cancellation) in active {
+            if inner
+                .active
+                .get(&id)
+                .is_some_and(|active| Arc::ptr_eq(&active.cancellation, &cancellation))
+            {
+                inner.active.remove(&id);
+            }
+        }
+    }
+
+    /// Reopen content response admission after the caller completed logical visibility revocation.
+    fn finish_revocation(&self) {
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        inner.revocations_in_flight = inner.revocations_in_flight.saturating_sub(1);
+        inner.open = inner.revocations_in_flight == 0;
+    }
+
+    #[cfg(test)]
+    fn active_count(&self) -> usize {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active
+            .len()
+    }
+}
+
+struct ResponseLease {
+    gate: Arc<McpResponseGate>,
+    id: u64,
+    cancellation: Arc<ResponseCancellation>,
+}
+
+/// One visibility-revocation admission lease. Dropping it without `complete` deliberately leaves
+/// the gate closed (fail closed after a failed/poisoned logical revocation). Concurrent relocks
+/// each own a lease, so one cannot reopen response admission while another still waits on the
+/// lifecycle mutex.
+pub(crate) struct VisibilityRevocation {
+    gate: Option<Arc<McpResponseGate>>,
+}
+
+/// Every production lock entrypoint that can make previously readable local content invisible.
+/// Passing the reason at the gate boundary makes the call-chain audit finite and testable: an
+/// epoch bump that merely expands visibility (`remove_lock`) or preserves it (`move_note` into a
+/// session-unlocked folder) is intentionally not in this list.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum VisibilityRevokingEntrypoint {
+    LockFolder,
+    RelockFolder,
+    RelockAll,
+}
+
+impl VisibilityRevocation {
+    pub(crate) fn complete(mut self) {
+        if let Some(gate) = self.gate.take() {
+            gate.finish_revocation();
+        }
+    }
+}
+
+impl ResponseLease {
+    #[cfg(test)]
+    fn is_cancelled(&self) -> bool {
+        self.cancellation.is_cancelled()
+    }
+
+    fn begin_chunk(&self) -> Option<ChunkWriteGuard> {
+        self.cancellation.begin_chunk()
+    }
+}
+
+impl Drop for ResponseLease {
+    fn drop(&mut self) {
+        let mut inner = self
+            .gate
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if inner
+            .active
+            .get(&self.id)
+            .is_some_and(|active| Arc::ptr_eq(&active.cancellation, &self.cancellation))
+        {
+            inner.active.remove(&self.id);
+        }
+        drop(inner);
+        self.cancellation.cancel();
+    }
+}
+
+struct ChunkWriteGuard {
+    cancellation: Arc<ResponseCancellation>,
+}
+
+impl ResponseCancellation {
+    fn begin_chunk(self: &Arc<Self>) -> Option<ChunkWriteGuard> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if state.cancelled {
+            return None;
+        }
+        state.in_flight_chunks = state.in_flight_chunks.saturating_add(1);
+        Some(ChunkWriteGuard {
+            cancellation: Arc::clone(self),
+        })
+    }
+
+    fn cancel(&self) {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .cancelled = true;
+    }
+
+    #[cfg(test)]
+    fn is_cancelled(&self) -> bool {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .cancelled
+    }
+
+    fn wait_until_drained(&self) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while state.in_flight_chunks != 0 {
+            state = self
+                .drained
+                .wait(state)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+    }
+}
+
+impl Drop for ChunkWriteGuard {
+    fn drop(&mut self) {
+        let mut state = self
+            .cancellation
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.in_flight_chunks = state.in_flight_chunks.saturating_sub(1);
+        if state.in_flight_chunks == 0 {
+            self.cancellation.drained.notify_all();
+        }
+    }
+}
+
+struct ConnectionPermit {
+    active: Arc<AtomicUsize>,
+}
+
+impl Drop for ConnectionPermit {
+    fn drop(&mut self) {
+        self.active.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+#[derive(Debug)]
+struct ParsedHttpRequest {
+    method: String,
+    headers: Vec<(String, String)>,
+    body: String,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct HttpParseError {
+    status: u16,
+    message: &'static str,
+}
 
 /// The only `Origin` header values we accept when one is present (E5). A browser page on another
 /// origin (or a `null` opaque origin) must not be able to script this server. Requests with NO
@@ -35,35 +479,40 @@ fn origin_allowed(origin: &str) -> bool {
     )
 }
 
-/// Case-insensitive fetch of a single request header value. Compares the header field name
-/// ASCII-case-insensitively against `name` (avoids `tiny_http::HeaderField::equiv`, which requires
-/// a `'static` argument).
-fn header_value(req: &tiny_http::Request, name: &str) -> Option<String> {
-    req.headers()
+fn single_header<'a>(
+    headers: &'a [(String, String)],
+    name: &str,
+) -> std::result::Result<Option<&'a str>, HttpParseError> {
+    let mut values = headers
         .iter()
-        .find(|h| h.field.as_str().as_str().eq_ignore_ascii_case(name))
-        .map(|h| h.value.as_str().to_string())
+        .filter(|(field, _)| field.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.as_str());
+    let first = values.next();
+    if values.next().is_some() {
+        return Err(HttpParseError {
+            status: 400,
+            message: "duplicate security header",
+        });
+    }
+    Ok(first)
 }
-
-/// Shared session unlock set: folder ids whose sealed notes are decrypted into the markdown
-/// column for this session (so MCP can read them as plaintext + the visibility filter lets them
-/// through). Sealed-and-not-unlocked notes stay invisible.
-pub type UnlockedSet = Arc<Mutex<HashSet<String>>>;
 
 /// Spawn the MCP server on a background thread. Best-effort: a bind failure is logged; the app
-/// continues normally. `unlocked` is shared with the command surface so visibility tracks the
-/// live session state. `require_token` gates `tools/call` behind a bearer token (default ON —
+/// continues normally. The background thread resolves Tauri's managed [`AppState`] for every
+/// request, so DB reads, the session unlock set, lifecycle guard, and seal epoch are the SAME
+/// authority as the command surface. `require_token` gates `tools/call` behind a bearer token
+/// (default ON —
 /// `AppConfig::mcp_require_token` defaults `true`, and `lib.rs` fails CLOSED to `true` on a
 /// poisoned/unreadable config).
-pub fn spawn(db_path: PathBuf, unlocked: UnlockedSet, require_token: bool) {
+pub fn spawn(app: AppHandle, require_token: bool) {
     let _ = std::thread::Builder::new()
         .name("murmur-mcp".into())
-        .spawn(move || run(db_path, unlocked, require_token));
+        .spawn(move || run(app, require_token));
 }
 
-fn run(db_path: PathBuf, unlocked: UnlockedSet, require_token: bool) {
+fn run(app: AppHandle, require_token: bool) {
     let addr = format!("127.0.0.1:{MCP_PORT}");
-    let server = match Server::http(&addr) {
+    let listener = match TcpListener::bind(&addr) {
         Ok(s) => s,
         Err(e) => {
             tracing::warn!(target: "mcp", error = %e, "MCP server failed to bind {addr}");
@@ -86,95 +535,948 @@ fn run(db_path: PathBuf, unlocked: UnlockedSet, require_token: bool) {
     } else {
         None
     };
+    let Some(gate) = app.try_state::<Arc<McpResponseGate>>() else {
+        tracing::error!(target: "mcp", "MCP response gate is unavailable — refusing to start");
+        return;
+    };
+    let gate = Arc::clone(gate.inner());
+    let expected_token = expected_token.map(Arc::new);
+    let active_connections = Arc::new(AtomicUsize::new(0));
     tracing::info!(target: "mcp", "MCP server listening on http://{addr}");
-    for mut req in server.incoming_requests() {
-        if *req.method() != Method::Post {
-            let _ = req.respond(
-                Response::from_string("Murmur MCP server — POST JSON-RPC here.")
-                    .with_status_code(200),
-            );
-            continue;
-        }
-
-        // E2: reject any request whose Host header is not exactly one of our loopback hosts.
-        // A missing Host on HTTP/1.1 is non-conformant — reject it too (fail-closed).
-        match header_value(&req, "Host") {
-            Some(h) if ALLOWED_HOSTS.contains(&h.trim()) => {}
-            _ => {
-                let _ = req.respond(Response::from_string("forbidden host").with_status_code(403));
-                continue;
-            }
-        }
-
-        // E5: if an Origin header is present it must be on the loopback allow-list. We never
-        // reflect it; a cross-origin / null Origin is refused outright.
-        if let Some(origin) = header_value(&req, "Origin") {
-            if !origin_allowed(origin.trim()) {
-                let _ =
-                    req.respond(Response::from_string("forbidden origin").with_status_code(403));
-                continue;
-            }
-        }
-
-        // Extract the bearer token (if any) from the Authorization header before consuming body.
-        let auth = header_value(&req, "Authorization");
-        // E5: cap the body so a local client cannot stream an unbounded payload. `Read::take`
-        // needs a `Sized` reader; `req.as_reader()` is `&mut dyn Read`, so take a `&mut` of it
-        // (which is `Sized` + `Read`) before `.take(..)`.
-        let mut body = String::new();
-        {
-            use std::io::Read as _;
-            let reader = req.as_reader();
-            let _ = reader.take(MAX_BODY_BYTES).read_to_string(&mut body);
-        }
-        match handle_rpc(
-            &db_path,
-            &body,
-            &unlocked,
-            expected_token.as_deref(),
-            auth.as_deref(),
-        ) {
-            Some(resp) => {
-                // The header pair is a compile-time ASCII constant so this never errors, but we do
-                // NOT unwrap on the per-request server loop (a panic here would kill the MCP thread
-                // for the whole session). Fall back to a header-less 200 in the impossible Err case.
-                let resp_body = resp.to_string();
-                match Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]) {
-                    Ok(h) => {
-                        let _ = req.respond(
-                            Response::from_string(resp_body)
-                                .with_status_code(200)
-                                .with_header(h),
-                        );
-                    }
-                    Err(_) => {
-                        let _ = req.respond(Response::from_string(resp_body).with_status_code(200));
-                    }
-                }
-            }
-            // Notification (no id) → 202, no body.
-            None => {
-                let _ = req.respond(Response::from_string("").with_status_code(202));
-            }
+    loop {
+        let app = app.clone();
+        let gate = Arc::clone(&gate);
+        let expected_token = expected_token.clone();
+        let accepted = accept_bounded_connection(
+            &listener,
+            Arc::clone(&active_connections),
+            REQUEST_DEADLINE,
+            move |stream, deadline| {
+                handle_connection(stream, app, gate, expected_token, deadline);
+            },
+            |job| {
+                std::thread::Builder::new()
+                    .name("murmur-mcp-connection".into())
+                    .spawn(job)
+                    .map(|_| ())
+            },
+        );
+        if let Err(error) = accepted {
+            tracing::warn!(target: "mcp", error = %error, "MCP listener/worker admission failed");
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConnectionAdmission {
+    Spawned,
+    RejectedOverload,
+}
+
+/// The production accept/admission boundary, factored only so the complete listener -> permit ->
+/// worker wiring can be exercised on an ephemeral loopback port. The absolute deadline begins
+/// immediately after `accept`, before overload handling or thread creation.
+fn accept_bounded_connection<F, S>(
+    listener: &TcpListener,
+    active: Arc<AtomicUsize>,
+    request_budget: Duration,
+    handle: F,
+    spawn: S,
+) -> std::io::Result<ConnectionAdmission>
+where
+    F: FnOnce(TcpStream, Instant) + Send + 'static,
+    S: FnOnce(Box<dyn FnOnce() + Send>) -> std::io::Result<()>,
+{
+    let (mut stream, _) = listener.accept()?;
+    let deadline = Instant::now() + request_budget;
+    if !try_acquire_connection(&active) {
+        reject_overloaded_connection(&mut stream, deadline)?;
+        return Ok(ConnectionAdmission::RejectedOverload);
+    }
+    spawn_connection_worker(active, move || handle(stream, deadline), spawn)?;
+    Ok(ConnectionAdmission::Spawned)
+}
+
+/// Keep the accept-loop overload path under the same per-syscall and absolute write deadline as
+/// worker responses. `write_http_response` arms the remaining deadline before its first syscall.
+fn reject_overloaded_connection(stream: &mut TcpStream, deadline: Instant) -> std::io::Result<()> {
+    write_http_response(
+        stream,
+        503,
+        "text/plain; charset=utf-8",
+        b"too many active connections",
+        None,
+        deadline,
+    )
+}
+
+fn spawn_connection_worker<F, S>(active: Arc<AtomicUsize>, job: F, spawn: S) -> std::io::Result<()>
+where
+    F: FnOnce() + Send + 'static,
+    S: FnOnce(Box<dyn FnOnce() + Send>) -> std::io::Result<()>,
+{
+    // Construct the permit before handing the closure to the spawner. If thread creation fails,
+    // the rejected closure is dropped and the captured permit releases the already-counted slot.
+    let permit = ConnectionPermit { active };
+    spawn(Box::new(move || {
+        let _permit = permit;
+        job();
+    }))
+}
+
+fn try_acquire_connection(active: &AtomicUsize) -> bool {
+    let mut current = active.load(Ordering::SeqCst);
+    loop {
+        if current >= MAX_ACTIVE_CONNECTIONS {
+            return false;
+        }
+        match active.compare_exchange(current, current + 1, Ordering::SeqCst, Ordering::SeqCst) {
+            Ok(_) => return true,
+            Err(observed) => current = observed,
+        }
+    }
+}
+
+fn handle_connection(
+    mut stream: TcpStream,
+    app: AppHandle,
+    gate: Arc<McpResponseGate>,
+    expected_token: Option<Arc<String>>,
+    deadline: Instant,
+) {
+    if stream.set_read_timeout(Some(READ_TIMEOUT)).is_err()
+        || stream.set_write_timeout(Some(WRITE_TIMEOUT)).is_err()
+    {
+        return;
+    }
+    let request = match parse_http_request(&mut stream, deadline) {
+        Ok(request) => request,
+        Err(error) => {
+            let _ = write_http_response(
+                &mut stream,
+                error.status,
+                "text/plain; charset=utf-8",
+                error.message.as_bytes(),
+                None,
+                deadline,
+            );
+            return;
+        }
+    };
+    if request.method != "POST" {
+        let _ = write_http_response(
+            &mut stream,
+            200,
+            "text/plain; charset=utf-8",
+            b"Murmur MCP server - POST JSON-RPC here.",
+            None,
+            deadline,
+        );
+        return;
+    }
+
+    match single_header(&request.headers, "Host") {
+        Ok(Some(host)) if ALLOWED_HOSTS.contains(&host.trim()) => {}
+        _ => {
+            let _ = write_http_response(
+                &mut stream,
+                403,
+                "text/plain; charset=utf-8",
+                b"forbidden host",
+                None,
+                deadline,
+            );
+            return;
+        }
+    }
+    match single_header(&request.headers, "Origin") {
+        Ok(Some(origin)) if !origin_allowed(origin.trim()) => {
+            let _ = write_http_response(
+                &mut stream,
+                403,
+                "text/plain; charset=utf-8",
+                b"forbidden origin",
+                None,
+                deadline,
+            );
+            return;
+        }
+        Err(_) => {
+            let _ = write_http_response(
+                &mut stream,
+                400,
+                "text/plain; charset=utf-8",
+                b"duplicate security header",
+                None,
+                deadline,
+            );
+            return;
+        }
+        _ => {}
+    }
+    let auth = match single_header(&request.headers, "Authorization") {
+        Ok(auth) => auth,
+        Err(error) => {
+            let _ = write_http_response(
+                &mut stream,
+                error.status,
+                "text/plain; charset=utf-8",
+                error.message.as_bytes(),
+                None,
+                deadline,
+            );
+            return;
+        }
+    };
+    let state = app.state::<AppState>();
+    let context = RpcContext::from_state(state.inner());
+    let reply = handle_rpc(
+        &context,
+        &request.body,
+        expected_token.as_deref().map(String::as_str),
+        auth,
+        deadline,
+    );
+    // Synchronous DB dispatch is not preemptible. If it returns after the transport's one absolute
+    // deadline, discard the result before serialization, visibility admission, or any response
+    // write can disclose it.
+    match reply_before_deadline(reply, deadline) {
+        Some(reply) => send_rpc_reply(&mut stream, reply, state.inner(), &gate, deadline),
+        None => {
+            let _ = write_http_response(&mut stream, 202, "application/json", b"", None, deadline);
+        }
+    }
+}
+
+fn reply_before_deadline(reply: Option<RpcReply>, deadline: Instant) -> Option<RpcReply> {
+    (Instant::now() < deadline).then_some(reply).flatten()
+}
+
+/// Revalidate and register a content stream as one lifecycle-linearized operation, then release
+/// every mutex before the first socket write. A concurrent revocation either closes admission
+/// before registration or cancels and shuts down the registered clone.
+fn send_rpc_reply(
+    stream: &mut TcpStream,
+    reply: RpcReply,
+    state: &AppState,
+    gate: &Arc<McpResponseGate>,
+    deadline: Instant,
+) {
+    if Instant::now() >= deadline {
+        return;
+    }
+    match reply {
+        RpcReply::Immediate(response) => {
+            let body = response.to_string();
+            if Instant::now() >= deadline {
+                return;
+            }
+            let _ = write_http_response(
+                stream,
+                200,
+                "application/json",
+                body.as_bytes(),
+                None,
+                deadline,
+            );
+        }
+        RpcReply::Content(pending) => {
+            let registration_stream = match stream.try_clone() {
+                Ok(stream) => stream,
+                Err(_) => return,
+            };
+            let Ok(lifecycle) = lock_before_deadline(&state.lifecycle, deadline, true) else {
+                return;
+            };
+            if visibility_is_current(
+                &pending.snapshot,
+                &state.seal_epoch,
+                state.unlocked_folders.as_ref(),
+                deadline,
+            ) != Ok(true)
+            {
+                drop(lifecycle);
+                let refusal = rpc_err(pending.id, VISIBILITY_RETRY_CODE, VISIBILITY_RETRY_MESSAGE)
+                    .to_string();
+                let _ = write_http_response(
+                    stream,
+                    200,
+                    "application/json",
+                    refusal.as_bytes(),
+                    None,
+                    deadline,
+                );
+                return;
+            }
+            let Some(lease) = gate.register(registration_stream) else {
+                drop(lifecycle);
+                let refusal = rpc_err(pending.id, VISIBILITY_RETRY_CODE, VISIBILITY_RETRY_MESSAGE)
+                    .to_string();
+                let _ = write_http_response(
+                    stream,
+                    200,
+                    "application/json",
+                    refusal.as_bytes(),
+                    None,
+                    deadline,
+                );
+                return;
+            };
+            drop(lifecycle);
+            // Serialize only after deadline-bounded lifecycle admission. If admission expires, no
+            // content body is rendered, no response lease exists, and no write syscall begins.
+            let body = match content_reply_body(&pending) {
+                Ok(body) => body,
+                Err(_) => return,
+            };
+            if Instant::now() >= deadline {
+                return;
+            }
+            if body.len() > MAX_RESPONSE_BYTES {
+                // `handle_tool_call` bounds tool text and ids before this serialization, so this is
+                // defense in depth for a future envelope change. The consumed id avoids cloning an
+                // attacker-controlled JSON value merely to report a transport refusal.
+                let refusal = rpc_err(
+                    Value::Null,
+                    -32000,
+                    "MCP response exceeds the local transport limit",
+                )
+                .to_string();
+                let _ = write_http_response(
+                    stream,
+                    200,
+                    "application/json",
+                    refusal.as_bytes(),
+                    Some(&lease),
+                    deadline,
+                );
+                return;
+            }
+            let _ = write_http_response(
+                stream,
+                200,
+                "application/json",
+                body.as_bytes(),
+                Some(&lease),
+                deadline,
+            );
+        }
+    }
+}
+
+fn content_reply_body(
+    pending: &PendingContentReply,
+) -> std::result::Result<String, serde_json::Error> {
+    match &pending.outcome {
+        Ok(text) => serde_json::to_string(&BorrowedTextResponse {
+            jsonrpc: "2.0",
+            id: &pending.id,
+            result: BorrowedTextResult {
+                content: [BorrowedTextContent { kind: "text", text }],
+            },
+        }),
+        Err((code, message)) => serde_json::to_string(&BorrowedRpcErrorResponse {
+            jsonrpc: "2.0",
+            id: &pending.id,
+            error: BorrowedRpcErrorBody {
+                code: *code,
+                message,
+            },
+        }),
+    }
+}
+
+#[cfg(test)]
+fn content_reply_value(pending: PendingContentReply) -> Value {
+    match pending.outcome {
+        Ok(text) => text_result(pending.id, text),
+        Err((code, message)) => rpc_err(pending.id, code, &message),
+    }
+}
+
+fn visibility_is_current(
+    snapshot: &VisibilitySnapshot,
+    seal_epoch: &AtomicU64,
+    unlocked_folders: &Mutex<HashSet<String>>,
+    deadline: Instant,
+) -> std::result::Result<bool, ()> {
+    if seal_epoch.load(Ordering::SeqCst) != snapshot.seal_epoch {
+        return Ok(false);
+    }
+    let live = lock_before_deadline(unlocked_folders, deadline, false)?;
+    Ok(*live == snapshot.unlocked_folders)
+}
+
+#[cfg(test)]
+fn finalize_content_reply(
+    pending: PendingContentReply,
+    seal_epoch: &AtomicU64,
+    unlocked_folders: &Mutex<HashSet<String>>,
+) -> Value {
+    if visibility_is_current(
+        &pending.snapshot,
+        seal_epoch,
+        unlocked_folders,
+        Instant::now() + REQUEST_DEADLINE,
+    ) != Ok(true)
+    {
+        return rpc_err(pending.id, VISIBILITY_RETRY_CODE, VISIBILITY_RETRY_MESSAGE);
+    }
+    content_reply_value(pending)
+}
+
+fn parse_http_request(
+    stream: &mut TcpStream,
+    deadline: Instant,
+) -> std::result::Result<ParsedHttpRequest, HttpParseError> {
+    parse_http_request_until(stream, deadline)
+}
+
+fn parse_http_request_until(
+    stream: &mut TcpStream,
+    deadline: Instant,
+) -> std::result::Result<ParsedHttpRequest, HttpParseError> {
+    let mut reader = BufReader::new(stream);
+    let request_line = read_http_line(&mut reader, MAX_REQUEST_LINE_BYTES, deadline)?;
+    let request_line = std::str::from_utf8(&request_line).map_err(|_| HttpParseError {
+        status: 400,
+        message: "request line is not ASCII",
+    })?;
+    if !request_line.is_ascii() {
+        return Err(HttpParseError {
+            status: 400,
+            message: "request line is not ASCII",
+        });
+    }
+    let mut parts = request_line.split(' ');
+    let method = parts.next().unwrap_or_default();
+    let target = parts.next().unwrap_or_default();
+    let version = parts.next().unwrap_or_default();
+    if parts.next().is_some()
+        || method.is_empty()
+        || target.is_empty()
+        || version != "HTTP/1.1"
+        || !method.bytes().all(is_http_token_byte)
+        || !target.starts_with('/')
+        || !target.bytes().all(|byte| (0x21..=0x7e).contains(&byte))
+    {
+        return Err(HttpParseError {
+            status: 400,
+            message: "malformed HTTP request line",
+        });
+    }
+
+    let mut headers = Vec::new();
+    let mut header_bytes = request_line.len() + 2;
+    loop {
+        let line = read_http_line(&mut reader, MAX_HEADER_BYTES, deadline)?;
+        header_bytes = header_bytes.saturating_add(line.len() + 2);
+        if header_bytes > MAX_HEADER_BYTES {
+            return Err(HttpParseError {
+                status: 431,
+                message: "request headers too large",
+            });
+        }
+        if line.is_empty() {
+            break;
+        }
+        if headers.len() >= MAX_HEADER_COUNT {
+            return Err(HttpParseError {
+                status: 431,
+                message: "too many request headers",
+            });
+        }
+        let line = std::str::from_utf8(&line).map_err(|_| HttpParseError {
+            status: 400,
+            message: "request header is not valid ASCII",
+        })?;
+        if !line.is_ascii()
+            || line
+                .as_bytes()
+                .first()
+                .is_some_and(|byte| matches!(byte, b' ' | b'\t'))
+        {
+            return Err(HttpParseError {
+                status: 400,
+                message: "malformed request header",
+            });
+        }
+        let Some((name, value)) = line.split_once(':') else {
+            return Err(HttpParseError {
+                status: 400,
+                message: "malformed request header",
+            });
+        };
+        if name.is_empty() || !name.bytes().all(is_http_token_byte) {
+            return Err(HttpParseError {
+                status: 400,
+                message: "malformed request header",
+            });
+        }
+        let value = value.trim();
+        if value
+            .bytes()
+            .any(|byte| (byte < 0x20 && byte != b'\t') || byte == 0x7f)
+        {
+            return Err(HttpParseError {
+                status: 400,
+                message: "malformed request header",
+            });
+        }
+        headers.push((name.to_string(), value.to_string()));
+    }
+
+    if single_header(&headers, "Transfer-Encoding")?.is_some() {
+        return Err(HttpParseError {
+            status: 400,
+            message: "transfer encoding is unsupported",
+        });
+    }
+    let content_length = match single_header(&headers, "Content-Length")? {
+        Some(raw) => {
+            if raw.is_empty() || !raw.bytes().all(|byte| byte.is_ascii_digit()) {
+                return Err(HttpParseError {
+                    status: 400,
+                    message: "invalid content length",
+                });
+            }
+            raw.parse::<u64>().map_err(|_| HttpParseError {
+                status: 400,
+                message: "invalid content length",
+            })?
+        }
+        None if method == "POST" => {
+            return Err(HttpParseError {
+                status: 411,
+                message: "content length required",
+            })
+        }
+        None => 0,
+    };
+    if content_length > MAX_BODY_BYTES {
+        return Err(HttpParseError {
+            status: 413,
+            message: "request body too large",
+        });
+    }
+    let body_len = usize::try_from(content_length).map_err(|_| HttpParseError {
+        status: 413,
+        message: "request body too large",
+    })?;
+    let mut body = vec![0_u8; body_len];
+    let mut offset = 0;
+    while offset < body.len() {
+        arm_absolute_read_deadline(&mut reader, deadline)?;
+        let read = reader
+            .read(&mut body[offset..])
+            .map_err(|error| request_read_error(error, deadline))?;
+        if read == 0 {
+            return Err(HttpParseError {
+                status: 400,
+                message: "incomplete request body",
+            });
+        }
+        offset += read;
+    }
+    let body = String::from_utf8(body).map_err(|_| HttpParseError {
+        status: 400,
+        message: "request body is not UTF-8",
+    })?;
+    Ok(ParsedHttpRequest {
+        method: method.to_string(),
+        headers,
+        body,
+    })
+}
+
+fn read_http_line(
+    reader: &mut BufReader<&mut TcpStream>,
+    limit: usize,
+    deadline: Instant,
+) -> std::result::Result<Vec<u8>, HttpParseError> {
+    let mut line = Vec::new();
+    loop {
+        arm_absolute_read_deadline(reader, deadline)?;
+        let available = reader
+            .fill_buf()
+            .map_err(|error| request_read_error(error, deadline))?;
+        if available.is_empty() {
+            return Err(HttpParseError {
+                status: 400,
+                message: "malformed HTTP line ending",
+            });
+        }
+        let take = available
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map(|index| index + 1)
+            .unwrap_or(available.len());
+        if line.len().saturating_add(take) > limit {
+            return Err(HttpParseError {
+                status: 431,
+                message: "request headers too large",
+            });
+        }
+        let terminated = available.get(take.saturating_sub(1)) == Some(&b'\n');
+        line.extend_from_slice(&available[..take]);
+        reader.consume(take);
+        if terminated {
+            break;
+        }
+    }
+    if !line.ends_with(b"\r\n") {
+        return Err(HttpParseError {
+            status: 400,
+            message: "malformed HTTP line ending",
+        });
+    }
+    line.truncate(line.len() - 2);
+    Ok(line)
+}
+
+fn arm_absolute_read_deadline(
+    reader: &mut BufReader<&mut TcpStream>,
+    deadline: Instant,
+) -> std::result::Result<(), HttpParseError> {
+    let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+        return Err(HttpParseError {
+            status: 408,
+            message: "request deadline exceeded",
+        });
+    };
+    if remaining.is_zero() {
+        return Err(HttpParseError {
+            status: 408,
+            message: "request deadline exceeded",
+        });
+    }
+    reader
+        .get_mut()
+        .set_read_timeout(Some(READ_TIMEOUT.min(remaining)))
+        .map_err(|_| HttpParseError {
+            status: 400,
+            message: "failed to configure request deadline",
+        })
+}
+
+fn request_read_error(error: std::io::Error, deadline: Instant) -> HttpParseError {
+    if matches!(
+        error.kind(),
+        std::io::ErrorKind::TimedOut | std::io::ErrorKind::WouldBlock
+    ) && Instant::now() >= deadline
+    {
+        HttpParseError {
+            status: 408,
+            message: "request deadline exceeded",
+        }
+    } else {
+        HttpParseError {
+            status: 400,
+            message: "failed to read request",
+        }
+    }
+}
+
+fn is_http_token_byte(byte: u8) -> bool {
+    matches!(
+        byte,
+        b'!' | b'#'
+            | b'$'
+            | b'%'
+            | b'&'
+            | b'\''
+            | b'*'
+            | b'+'
+            | b'-'
+            | b'.'
+            | b'^'
+            | b'_'
+            | b'`'
+            | b'|'
+            | b'~'
+            | b'0'..=b'9'
+            | b'A'..=b'Z'
+            | b'a'..=b'z'
+    )
+}
+
+fn write_http_response(
+    stream: &mut TcpStream,
+    status: u16,
+    content_type: &str,
+    body: &[u8],
+    lease: Option<&ResponseLease>,
+    deadline: Instant,
+) -> std::io::Result<()> {
+    let reason = match status {
+        200 => "OK",
+        202 => "Accepted",
+        400 => "Bad Request",
+        403 => "Forbidden",
+        408 => "Request Timeout",
+        411 => "Length Required",
+        413 => "Payload Too Large",
+        431 => "Request Header Fields Too Large",
+        503 => "Service Unavailable",
+        _ => "Error",
+    };
+    let headers = format!(
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\nX-Content-Type-Options: nosniff\r\n\r\n",
+        body.len()
+    );
+    write_cancellable_until(stream, headers.as_bytes(), lease, deadline)?;
+    write_cancellable_until(stream, body, lease, deadline)?;
+    flush_cancellable_until(stream, lease, deadline)?;
+    let _ = stream.shutdown(Shutdown::Write);
+    Ok(())
+}
+
+fn flush_cancellable_until(
+    stream: &mut TcpStream,
+    lease: Option<&ResponseLease>,
+    deadline: Instant,
+) -> std::io::Result<()> {
+    flush_cancellable_until_with_io(stream, lease, deadline, || {}, TcpStream::flush)
+}
+
+fn flush_cancellable_until_with_io<B, F>(
+    stream: &mut TcpStream,
+    lease: Option<&ResponseLease>,
+    deadline: Instant,
+    before_flush: B,
+    flush_once: F,
+) -> std::io::Result<()>
+where
+    B: FnOnce(),
+    F: FnOnce(&mut TcpStream) -> std::io::Result<()>,
+{
+    let syscall_guard = match lease {
+        Some(lease) => Some(lease.begin_chunk().ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::Interrupted,
+                "MCP response visibility revoked",
+            )
+        })?),
+        None => None,
+    };
+    arm_absolute_write_deadline(stream, deadline)?;
+    before_flush();
+    let result = flush_once(stream);
+    drop(syscall_guard);
+    result?;
+    ensure_before_deadline(deadline)
+}
+
+#[cfg(test)]
+fn write_cancellable(
+    stream: &mut TcpStream,
+    bytes: &[u8],
+    lease: Option<&ResponseLease>,
+) -> std::io::Result<()> {
+    write_cancellable_until(stream, bytes, lease, Instant::now() + REQUEST_DEADLINE)
+}
+
+fn write_cancellable_until(
+    stream: &mut TcpStream,
+    bytes: &[u8],
+    lease: Option<&ResponseLease>,
+    deadline: Instant,
+) -> std::io::Result<()> {
+    write_cancellable_until_with_io(
+        stream,
+        bytes,
+        lease,
+        deadline,
+        |_| {},
+        |_, _| {},
+        TcpStream::write,
+    )
+}
+
+#[cfg(test)]
+fn write_cancellable_with_hook<F>(
+    stream: &mut TcpStream,
+    bytes: &[u8],
+    lease: Option<&ResponseLease>,
+    after_chunk_admitted: F,
+) -> std::io::Result<()>
+where
+    F: FnMut(usize),
+{
+    write_cancellable_until_with_io(
+        stream,
+        bytes,
+        lease,
+        Instant::now() + REQUEST_DEADLINE,
+        after_chunk_admitted,
+        |_, _| {},
+        TcpStream::write,
+    )
+}
+
+#[cfg(test)]
+fn write_cancellable_until_with_hook<F>(
+    stream: &mut TcpStream,
+    bytes: &[u8],
+    lease: Option<&ResponseLease>,
+    deadline: Instant,
+    after_chunk_admitted: F,
+) -> std::io::Result<()>
+where
+    F: FnMut(usize),
+{
+    write_cancellable_until_with_io(
+        stream,
+        bytes,
+        lease,
+        deadline,
+        after_chunk_admitted,
+        |_, _| {},
+        TcpStream::write,
+    )
+}
+
+fn write_cancellable_until_with_io<B, A, W>(
+    stream: &mut TcpStream,
+    bytes: &[u8],
+    lease: Option<&ResponseLease>,
+    deadline: Instant,
+    mut before_write: B,
+    mut after_write: A,
+    mut write_once: W,
+) -> std::io::Result<()>
+where
+    B: FnMut(usize),
+    A: FnMut(usize, usize),
+    W: FnMut(&mut TcpStream, &[u8]) -> std::io::Result<usize>,
+{
+    let mut syscall_index = 0;
+    for chunk in bytes.chunks(RESPONSE_CHUNK_BYTES) {
+        let mut offset = 0;
+        while offset < chunk.len() {
+            arm_absolute_write_deadline(stream, deadline)?;
+            let syscall_guard = match lease {
+                Some(lease) => Some(lease.begin_chunk().ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::Interrupted,
+                        "MCP response visibility revoked",
+                    )
+                })?),
+                None => None,
+            };
+            // Test-only callers coordinate exact races immediately before and after one actual
+            // write syscall. Production passes no-op hooks.
+            before_write(syscall_index);
+            let result = write_once(stream, &chunk[offset..]);
+            drop(syscall_guard);
+            match result {
+                Ok(0) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::WriteZero,
+                        "failed to write the complete MCP response",
+                    ))
+                }
+                Ok(written) if written <= chunk.len() - offset => {
+                    offset += written;
+                    after_write(syscall_index, written);
+                    ensure_before_deadline(deadline)?;
+                }
+                Ok(_) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "MCP response writer reported an invalid byte count",
+                    ))
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(error) => return Err(error),
+            }
+            syscall_index = syscall_index.saturating_add(1);
+        }
+    }
+    Ok(())
+}
+
+fn arm_absolute_write_deadline(stream: &TcpStream, deadline: Instant) -> std::io::Result<()> {
+    let remaining = deadline
+        .checked_duration_since(Instant::now())
+        .filter(|remaining| !remaining.is_zero())
+        .ok_or_else(request_deadline_error)?;
+    stream.set_write_timeout(Some(WRITE_TIMEOUT.min(remaining)))
+}
+
+fn ensure_before_deadline(deadline: Instant) -> std::io::Result<()> {
+    if Instant::now() < deadline {
+        Ok(())
+    } else {
+        Err(request_deadline_error())
+    }
+}
+
+fn request_deadline_error() -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::TimedOut,
+        "MCP absolute request deadline exceeded",
+    )
+}
+
+/// Close all active content responses before a caller waits for the lock lifecycle. This helper is
+/// intentionally content-free and no-op only before setup has managed the gate (when no MCP
+/// listener can exist yet).
+pub(crate) fn begin_visibility_revocation(
+    app: &AppHandle,
+    entrypoint: VisibilityRevokingEntrypoint,
+) -> VisibilityRevocation {
+    let gate = app
+        .try_state::<Arc<McpResponseGate>>()
+        .map(|gate| Arc::clone(gate.inner()));
+    begin_visibility_revocation_for_gate(gate, entrypoint)
+}
+
+fn begin_visibility_revocation_for_gate(
+    gate: Option<Arc<McpResponseGate>>,
+    _entrypoint: VisibilityRevokingEntrypoint,
+) -> VisibilityRevocation {
+    if let Some(gate) = &gate {
+        gate.close_and_shutdown();
+    }
+    VisibilityRevocation { gate }
+}
+
+/// Reopen content response admission only after the caller has advanced the seal epoch and revoked
+/// the relevant session unlock membership.
+pub(crate) fn finish_visibility_revocation(revocation: VisibilityRevocation) {
+    revocation.complete();
 }
 
 /// Returns Some(response) for JSON-RPC requests, None for notifications.
 /// `expected_token` is `Some` only when enforcement is on; `auth` is the raw Authorization header.
 fn handle_rpc(
-    db_path: &Path,
+    context: &RpcContext<'_>,
     body: &str,
-    unlocked: &UnlockedSet,
     expected_token: Option<&str>,
     auth: Option<&str>,
-) -> Option<Value> {
+    deadline: Instant,
+) -> Option<RpcReply> {
     let req: Value = match serde_json::from_str(body) {
         Ok(v) => v,
-        Err(_) => return Some(rpc_err(Value::Null, -32700, "parse error")),
+        Err(_) => {
+            return Some(RpcReply::Immediate(rpc_err(
+                Value::Null,
+                -32700,
+                "parse error",
+            )))
+        }
     };
     // Notifications have no "id" → no response.
-    let id = req.get("id")?.clone();
+    let id = req.get("id")?;
+    if !jsonrpc_id_is_bounded(id) {
+        return Some(RpcReply::Immediate(rpc_err(
+            Value::Null,
+            -32600,
+            "invalid request id",
+        )));
+    }
+    let id = id.clone();
     let method = req.get("method").and_then(Value::as_str).unwrap_or("");
 
     // E3: when enforcement is on, require a valid bearer token before ANY method — including
@@ -182,7 +1484,11 @@ fn handle_rpc(
     // process cannot even enumerate the tools. The check runs first, before any dispatch.
     if let Some(expected) = expected_token {
         if !bearer_ok(auth, expected) {
-            return Some(rpc_err(id, -32001, "unauthorized: bearer token required"));
+            return Some(RpcReply::Immediate(rpc_err(
+                id,
+                -32001,
+                "unauthorized: bearer token required",
+            )));
         }
     }
 
@@ -195,11 +1501,13 @@ fn handle_rpc(
         "tools/list" => json!({ "tools": tools_spec() }),
         "ping" => json!({}),
         "tools/call" => {
-            return Some(handle_tool_call(db_path, id, req.get("params"), unlocked));
+            return Some(handle_tool_call(context, id, req.get("params"), deadline));
         }
-        _ => return Some(rpc_err(id, -32601, "method not found")),
+        _ => return Some(RpcReply::Immediate(rpc_err(id, -32601, "method not found"))),
     };
-    Some(json!({ "jsonrpc": "2.0", "id": id, "result": result }))
+    Some(RpcReply::Immediate(
+        json!({ "jsonrpc": "2.0", "id": id, "result": result }),
+    ))
 }
 
 /// Bearer-token check in CONSTANT TIME (E5): the Authorization header must be `Bearer <expected>`
@@ -228,6 +1536,40 @@ fn rpc_err(id: Value, code: i64, msg: &str) -> Value {
     json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": msg } })
 }
 
+struct SerializedByteBudget {
+    remaining: usize,
+}
+
+impl Write for SerializedByteBudget {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        if bytes.len() > self.remaining {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "serialized JSON value exceeds its byte budget",
+            ));
+        }
+        self.remaining -= bytes.len();
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn jsonrpc_id_is_bounded(id: &Value) -> bool {
+    match id {
+        Value::Null | Value::Number(_) | Value::String(_) => {
+            let mut budget = SerializedByteBudget {
+                remaining: MAX_JSONRPC_ID_BYTES,
+            };
+            serde_json::to_writer(&mut budget, id).is_ok()
+        }
+        Value::Bool(_) | Value::Array(_) | Value::Object(_) => false,
+    }
+}
+
+#[cfg(test)]
 fn text_result(id: Value, text: String) -> Value {
     json!({ "jsonrpc": "2.0", "id": id, "result": { "content": [{ "type": "text", "text": text }] } })
 }
@@ -298,11 +1640,11 @@ fn tools_spec() -> Value {
 type ToolError = (i64, String);
 
 fn handle_tool_call(
-    db_path: &Path,
+    context: &RpcContext<'_>,
     id: Value,
     params: Option<&Value>,
-    unlocked: &UnlockedSet,
-) -> Value {
+    deadline: Instant,
+) -> RpcReply {
     let name = params
         .and_then(|p| p.get("name"))
         .and_then(Value::as_str)
@@ -311,15 +1653,40 @@ fn handle_tool_call(
         .and_then(|p| p.get("arguments"))
         .cloned()
         .unwrap_or_else(|| json!({}));
-    let db = match Db::open(db_path) {
-        Ok(d) => d,
-        Err(e) => return rpc_err(id, -32000, &format!("db open failed: {e}")),
+    let snapshot = match context.visibility_snapshot(deadline) {
+        Ok(snapshot) => snapshot,
+        Err(()) => {
+            return RpcReply::Immediate(rpc_err(
+                id,
+                VISIBILITY_RETRY_CODE,
+                VISIBILITY_RETRY_MESSAGE,
+            ))
+        }
     };
-    // Snapshot the session unlock set so every query in this call sees a consistent view.
-    let unlocked_set = unlocked.lock().map(|g| g.clone()).unwrap_or_default();
-    match dispatch_tool(&db, name, &args, &unlocked_set) {
-        Ok(text) => text_result(id, text),
-        Err((code, msg)) => rpc_err(id, code, &msg),
+    let Some(db) = context.db else {
+        return RpcReply::Immediate(rpc_err(id, -32000, "database unavailable"));
+    };
+    let outcome = bound_tool_outcome(dispatch_tool(db, name, &args, &snapshot.unlocked_folders));
+    RpcReply::Content(PendingContentReply {
+        id,
+        snapshot,
+        outcome,
+    })
+}
+
+fn bound_tool_outcome(
+    outcome: std::result::Result<String, ToolError>,
+) -> std::result::Result<String, ToolError> {
+    match outcome {
+        Ok(text) if text.len() > MAX_TOOL_TEXT_BYTES => Err((
+            -32000,
+            "MCP tool result exceeds the local transport limit; request a smaller page".into(),
+        )),
+        Err((code, message)) if message.len() > MAX_TOOL_TEXT_BYTES => Err((
+            code,
+            "MCP tool error exceeds the local transport limit".into(),
+        )),
+        other => other,
     }
 }
 
@@ -363,7 +1730,7 @@ fn mcp_body_window(args: &Value) -> (usize, usize) {
     let max_chars = if max_chars == 0 {
         MCP_DEFAULT_WINDOW_CHARS
     } else {
-        max_chars
+        max_chars.min(MAX_TOOL_WINDOW_CHARS)
     };
     (offset, max_chars)
 }
@@ -466,7 +1833,7 @@ fn dispatch_tool(
                     .unwrap_or("summary")
                     .to_string(),
                 offset: mcp_usize_arg(args, "offset"),
-                max_chars: mcp_usize_arg(args, "maxChars"),
+                max_chars: mcp_usize_arg(args, "maxChars").min(MAX_TOOL_WINDOW_CHARS),
             }
         }
         // Brain v3 PR-6 — the KNOWLEDGE DIFF / decision ledger for one entity. Routes through the
@@ -550,18 +1917,36 @@ fn dispatch_tool(
 mod tests {
     use super::*;
 
-    fn empty_unlocked() -> UnlockedSet {
-        Arc::new(Mutex::new(HashSet::new()))
+    fn tcp_pair() -> (TcpStream, TcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let client = TcpStream::connect(address).unwrap();
+        let (server, _) = listener.accept().unwrap();
+        (client, server)
+    }
+
+    fn parse_raw_request(raw: &[u8]) -> std::result::Result<ParsedHttpRequest, HttpParseError> {
+        let (mut client, mut server) = tcp_pair();
+        client.write_all(raw).unwrap();
+        client.shutdown(Shutdown::Write).unwrap();
+        parse_http_request(&mut server, Instant::now() + REQUEST_DEADLINE)
     }
 
     fn rpc(body: &str) -> Option<Value> {
-        handle_rpc(
-            &PathBuf::from("/nonexistent.sqlite"),
-            body,
-            &empty_unlocked(),
-            None,
-            None,
-        )
+        rpc_auth(body, None, None)
+    }
+
+    fn finish_test_reply(context: &RpcContext<'_>, reply: RpcReply) -> Value {
+        match reply {
+            RpcReply::Immediate(response) => response,
+            RpcReply::Content(pending) => {
+                let _lifecycle = context
+                    .lifecycle
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                finalize_content_reply(pending, context.seal_epoch, context.unlocked_folders)
+            }
+        }
     }
 
     #[test]
@@ -658,13 +2043,23 @@ mod tests {
     }
 
     fn rpc_auth(body: &str, expected: Option<&str>, auth: Option<&str>) -> Option<Value> {
+        let lifecycle = Mutex::new(());
+        let seal_epoch = AtomicU64::new(0);
+        let unlocked_folders = Mutex::new(HashSet::new());
+        let context = RpcContext {
+            db: None,
+            lifecycle: &lifecycle,
+            seal_epoch: &seal_epoch,
+            unlocked_folders: &unlocked_folders,
+        };
         handle_rpc(
-            &PathBuf::from("/nonexistent.sqlite"),
+            &context,
             body,
-            &empty_unlocked(),
             expected,
             auth,
+            Instant::now() + REQUEST_DEADLINE,
         )
+        .map(|reply| finish_test_reply(&context, reply))
     }
 
     #[test]
@@ -680,9 +2075,9 @@ mod tests {
     #[test]
     fn token_required_gates_every_method() {
         // E3: with enforcement ON, EVERY method (initialize / tools/list / ping / tools/call)
-        // requires a valid bearer token. NOTE: every assertion here STOPS before
-        // `handle_tool_call` reaches `Db::open` (real Keychain), because the unauthorized branch
-        // returns early in `handle_rpc` — exactly the security-critical path we want to prove.
+        // requires a valid bearer token. NOTE: every assertion here STOPS before tool dispatch,
+        // because the unauthorized branch returns early in `handle_rpc` — exactly the
+        // security-critical path we want to prove.
         for method in ["initialize", "tools/list", "ping", "tools/call"] {
             let body = format!(
                 r#"{{"jsonrpc":"2.0","id":7,"method":"{method}","params":{{"name":"list_recent_meetings","arguments":{{}}}}}}"#
@@ -720,6 +2115,928 @@ mod tests {
         assert!(!bearer_ok(Some("Bearer abc"), "abcd")); // length mismatch
         assert!(!bearer_ok(Some("Bearer abd"), "abc")); // same length, different bytes
         assert!(!bearer_ok(None, "abc"));
+    }
+
+    #[test]
+    fn strict_http_parser_accepts_one_bounded_post() {
+        let body = br#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#;
+        let request = format!(
+            "POST /mcp HTTP/1.1\r\nHost: localhost:8765\r\nOrigin: http://localhost\r\nAuthorization: Bearer abc\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            std::str::from_utf8(body).unwrap()
+        );
+        let parsed = parse_raw_request(request.as_bytes()).unwrap();
+        assert_eq!(parsed.method, "POST");
+        assert_eq!(parsed.body.as_bytes(), body);
+        assert_eq!(
+            single_header(&parsed.headers, "host").unwrap(),
+            Some("localhost:8765")
+        );
+        assert_eq!(
+            single_header(&parsed.headers, "origin").unwrap(),
+            Some("http://localhost")
+        );
+    }
+
+    #[test]
+    fn strict_http_parser_rejects_malformed_and_oversized_inputs() {
+        let cases: Vec<(Vec<u8>, u16)> = vec![
+            (
+                b"POST / HTTP/1.0\r\nHost: localhost:8765\r\nContent-Length: 0\r\n\r\n"
+                    .to_vec(),
+                400,
+            ),
+            (
+                b"POST / HTTP/1.1\nHost: localhost:8765\nContent-Length: 0\n\n".to_vec(),
+                400,
+            ),
+            (
+                b"POST / HTTP/1.1\r\nHost: localhost:8765\r\nTransfer-Encoding: chunked\r\nContent-Length: 0\r\n\r\n"
+                    .to_vec(),
+                400,
+            ),
+            (
+                b"POST / HTTP/1.1\r\nHost: localhost:8765\r\nX-Bad: value\x7f\r\nContent-Length: 0\r\n\r\n"
+                    .to_vec(),
+                400,
+            ),
+            (
+                b"POST / HTTP/1.1\r\nHost: localhost:8765\r\nContent-Length: +0\r\n\r\n"
+                    .to_vec(),
+                400,
+            ),
+            (
+                b"POST / HTTP/1.1\r\nHost: localhost:8765\r\nContent-Length: \r\n\r\n"
+                    .to_vec(),
+                400,
+            ),
+            (
+                format!(
+                    "POST / HTTP/1.1\r\nHost: localhost:8765\r\nContent-Length: {}\r\n\r\n",
+                    MAX_BODY_BYTES + 1
+                )
+                .into_bytes(),
+                413,
+            ),
+            (
+                b"POST / HTTP/1.1\r\nHost: localhost:8765\r\n\r\n".to_vec(),
+                411,
+            ),
+        ];
+        for (raw, expected_status) in cases {
+            let error = parse_raw_request(&raw).unwrap_err();
+            assert_eq!(error.status, expected_status, "raw={raw:?}");
+        }
+
+        let oversized_header = format!(
+            "POST / HTTP/1.1\r\nHost: localhost:8765\r\nX-Fill: {}\r\nContent-Length: 0\r\n\r\n",
+            "x".repeat(MAX_HEADER_BYTES)
+        );
+        assert_eq!(
+            parse_raw_request(oversized_header.as_bytes())
+                .unwrap_err()
+                .status,
+            431
+        );
+    }
+
+    #[test]
+    fn strict_http_security_headers_fail_closed_on_duplicates() {
+        let headers = vec![
+            ("Host".to_string(), "localhost:8765".to_string()),
+            ("hOsT".to_string(), "evil.example:8765".to_string()),
+        ];
+        assert_eq!(single_header(&headers, "host").unwrap_err().status, 400);
+        let origins = vec![
+            ("Origin".to_string(), "http://localhost".to_string()),
+            ("Origin".to_string(), "null".to_string()),
+        ];
+        assert_eq!(single_header(&origins, "origin").unwrap_err().status, 400);
+    }
+
+    #[test]
+    fn failed_worker_spawn_releases_the_reserved_connection_slot() {
+        let active = Arc::new(AtomicUsize::new(1));
+        let result = spawn_connection_worker(
+            Arc::clone(&active),
+            || panic!("a rejected worker must never run"),
+            |job| {
+                drop(job);
+                Err(std::io::Error::other("injected spawn failure"))
+            },
+        );
+        assert!(result.is_err());
+        assert_eq!(
+            active.load(Ordering::SeqCst),
+            0,
+            "failed thread creation leaked a connection slot"
+        );
+    }
+
+    #[test]
+    fn absolute_request_deadline_evicts_all_slowloris_connection_slots() {
+        use std::sync::mpsc;
+        use std::time::{Duration, Instant};
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let active = Arc::new(AtomicUsize::new(0));
+        let started = Instant::now();
+        let (result_tx, result_rx) = mpsc::channel();
+        let mut workers = Vec::new();
+        let mut drippers = Vec::new();
+        for _ in 0..MAX_ACTIVE_CONNECTIONS {
+            let mut client = TcpStream::connect(address).unwrap();
+            let worker_tx = result_tx.clone();
+            let mut worker = None;
+            let admission = accept_bounded_connection(
+                &listener,
+                Arc::clone(&active),
+                Duration::from_millis(250),
+                move |mut server, deadline| {
+                    worker_tx
+                        .send(parse_http_request(&mut server, deadline))
+                        .unwrap();
+                },
+                |job| {
+                    worker = Some(std::thread::spawn(job));
+                    Ok(())
+                },
+            )
+            .unwrap();
+            assert_eq!(admission, ConnectionAdmission::Spawned);
+            workers.push(worker.expect("worker spawner must return its handle"));
+            drippers.push(std::thread::spawn(move || {
+                for byte in b"POST / HTTP/1.1\r\nHost: localhost:8765\r\n" {
+                    if client.write_all(&[*byte]).is_err() {
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(20));
+                }
+            }));
+        }
+        drop(result_tx);
+        assert_eq!(active.load(Ordering::SeqCst), MAX_ACTIVE_CONNECTIONS);
+        assert!(
+            !try_acquire_connection(&active),
+            "the bounded admission path accepted a 33rd live worker"
+        );
+        let mut overload_client = TcpStream::connect(address).unwrap();
+        let overload = accept_bounded_connection(
+            &listener,
+            Arc::clone(&active),
+            Duration::from_millis(250),
+            |_, _| panic!("an overloaded connection must never reach its handler"),
+            |_| panic!("an overloaded connection must never reach its worker spawner"),
+        )
+        .unwrap();
+        assert_eq!(overload, ConnectionAdmission::RejectedOverload);
+        let mut overload_response = String::new();
+        overload_client
+            .read_to_string(&mut overload_response)
+            .unwrap();
+        assert!(overload_response.starts_with("HTTP/1.1 503 Service Unavailable\r\n"));
+
+        for _ in 0..MAX_ACTIVE_CONNECTIONS {
+            let error = result_rx.recv().unwrap().unwrap_err();
+            assert_eq!(error.status, 408);
+        }
+        for worker in workers {
+            worker.join().unwrap();
+        }
+        assert_eq!(
+            active.load(Ordering::SeqCst),
+            0,
+            "deadline-expired workers leaked their connection permits"
+        );
+        let _recovery_client = TcpStream::connect(address).unwrap();
+        let mut recovery = None;
+        let recovery_admission = accept_bounded_connection(
+            &listener,
+            Arc::clone(&active),
+            Duration::from_millis(250),
+            |_, _| {},
+            |job| {
+                recovery = Some(std::thread::spawn(job));
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(recovery_admission, ConnectionAdmission::Spawned);
+        recovery
+            .expect("recovery worker must be spawned")
+            .join()
+            .unwrap();
+        assert_eq!(active.load(Ordering::SeqCst), 0);
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "absolute deadline did not release all connection slots: {:?}",
+            started.elapsed()
+        );
+        for dripper in drippers {
+            dripper.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn one_deadline_rejects_late_dispatch_and_bounds_cumulative_writes() {
+        use std::time::Duration;
+
+        let late = Some(RpcReply::Immediate(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": { "secret": "must be discarded" }
+        })));
+        assert!(
+            reply_before_deadline(late, Instant::now() - Duration::from_millis(1)).is_none(),
+            "a synchronous dispatch result survived past the absolute deadline"
+        );
+
+        let (_client, mut server) = tcp_pair();
+        let mut admitted_chunks = 0;
+        let error = write_cancellable_until_with_hook(
+            &mut server,
+            &vec![b'x'; RESPONSE_CHUNK_BYTES * 4],
+            None,
+            Instant::now() + Duration::from_millis(40),
+            |_| {
+                admitted_chunks += 1;
+                std::thread::sleep(Duration::from_millis(25));
+            },
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+        assert!(
+            admitted_chunks < 4,
+            "per-write timeouts replaced, instead of sharing, the absolute deadline"
+        );
+    }
+
+    #[test]
+    fn lifecycle_contention_expires_before_snapshot_registration_or_write() {
+        use std::time::Duration;
+
+        let lifecycle = Mutex::new(());
+        let epoch = AtomicU64::new(0);
+        let unlocked = Mutex::new(HashSet::new());
+        let context = RpcContext {
+            db: None,
+            lifecycle: &lifecycle,
+            seal_epoch: &epoch,
+            unlocked_folders: &unlocked,
+        };
+        let lifecycle_guard = lifecycle.lock().unwrap();
+        let began = Instant::now();
+        assert!(
+            context
+                .visibility_snapshot(Instant::now() + Duration::from_millis(40))
+                .is_err(),
+            "snapshot admission ignored the absolute request deadline"
+        );
+        assert!(began.elapsed() < Duration::from_millis(200));
+        drop(lifecycle_guard);
+
+        let db_path =
+            crate::storage::db::unique_temp_path("murmur-mcp-lifecycle-deadline", "sqlite");
+        let state = AppState::init_at(&db_path, TEST_DEK).unwrap();
+        let gate = Arc::new(McpResponseGate::new());
+        let (mut client, mut server) = tcp_pair();
+        let pending = PendingContentReply {
+            id: json!(1),
+            snapshot: VisibilitySnapshot {
+                seal_epoch: state.seal_epoch.load(Ordering::SeqCst),
+                unlocked_folders: HashSet::new(),
+            },
+            outcome: Ok("SECRET_MUST_NOT_RENDER_OR_WRITE".into()),
+        };
+        let state_lifecycle = state.lifecycle.lock().unwrap();
+        let began = Instant::now();
+        send_rpc_reply(
+            &mut server,
+            RpcReply::Content(pending),
+            &state,
+            &gate,
+            Instant::now() + Duration::from_millis(40),
+        );
+        assert!(
+            began.elapsed() < Duration::from_millis(200),
+            "content admission waited beyond its absolute deadline: {:?}",
+            began.elapsed()
+        );
+        assert_eq!(
+            gate.active_count(),
+            0,
+            "expired admission registered a lease"
+        );
+        drop(state_lifecycle);
+
+        client.set_nonblocking(true).unwrap();
+        let mut leaked = [0_u8; 1];
+        assert!(
+            matches!(
+                client.read(&mut leaked),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock
+            ),
+            "expired lifecycle admission started a response write"
+        );
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn overload_rejection_arms_the_same_absolute_write_deadline() {
+        use std::time::Duration;
+
+        let (mut client, mut server) = tcp_pair();
+        let deadline = Instant::now() + Duration::from_millis(250);
+        reject_overloaded_connection(&mut server, deadline).unwrap();
+        let configured = server
+            .write_timeout()
+            .unwrap()
+            .expect("overload response must arm a write timeout");
+        assert!(configured > Duration::ZERO);
+        assert!(configured <= Duration::from_millis(250));
+
+        let mut response = String::new();
+        client.read_to_string(&mut response).unwrap();
+        assert!(response.starts_with("HTTP/1.1 503 Service Unavailable\r\n"));
+
+        let (mut late_client, mut late_server) = tcp_pair();
+        let error = reject_overloaded_connection(
+            &mut late_server,
+            Instant::now() - Duration::from_millis(1),
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+        late_client.set_nonblocking(true).unwrap();
+        let mut leaked = [0_u8; 1];
+        assert!(
+            matches!(
+                late_client.read(&mut leaked),
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock
+            ),
+            "an already-expired overload response started a write syscall"
+        );
+    }
+
+    #[test]
+    fn revocation_prevents_a_new_flush_or_drains_an_admitted_flush() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let gate = Arc::new(McpResponseGate::new());
+        let (_client, mut server) = tcp_pair();
+        let lease = gate.register(server.try_clone().unwrap()).unwrap();
+        gate.close_and_shutdown();
+        let prevented_calls = AtomicUsize::new(0);
+        let error = flush_cancellable_until_with_io(
+            &mut server,
+            Some(&lease),
+            Instant::now() + Duration::from_secs(1),
+            || panic!("a cancelled flush must not pass admission"),
+            |stream| {
+                let _ = stream;
+                prevented_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::Interrupted);
+        assert_eq!(prevented_calls.load(Ordering::SeqCst), 0);
+
+        let gate = Arc::new(McpResponseGate::new());
+        let (_client, mut server) = tcp_pair();
+        let lease = gate.register(server.try_clone().unwrap()).unwrap();
+        let flush_calls = Arc::new(AtomicUsize::new(0));
+        let writer_calls = Arc::clone(&flush_calls);
+        let (admitted_tx, admitted_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let writer = std::thread::spawn(move || {
+            flush_cancellable_until_with_io(
+                &mut server,
+                Some(&lease),
+                Instant::now() + Duration::from_secs(2),
+                || {
+                    admitted_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                },
+                |stream| {
+                    let _ = stream;
+                    writer_calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                },
+            )
+        });
+        admitted_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+
+        let revoke_gate = Arc::clone(&gate);
+        let (revoked_tx, revoked_rx) = mpsc::channel();
+        let revoker = std::thread::spawn(move || {
+            revoke_gate.close_and_shutdown();
+            revoked_tx.send(()).unwrap();
+        });
+        assert!(
+            revoked_rx.recv_timeout(Duration::from_millis(50)).is_err(),
+            "revocation returned while an admitted flush was in flight"
+        );
+        release_tx.send(()).unwrap();
+        writer.join().unwrap().unwrap();
+        revoked_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        revoker.join().unwrap();
+        assert_eq!(flush_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn revocation_prevents_a_second_syscall_after_a_partial_write() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        const PAYLOAD: &[u8] = b"A_SECRET_AFTER_FIRST_PARTIAL_WRITE";
+        let gate = Arc::new(McpResponseGate::new());
+        let (mut client, mut server) = tcp_pair();
+        let lease = gate.register(server.try_clone().unwrap()).unwrap();
+        let writes = Arc::new(AtomicUsize::new(0));
+        let writer_writes = Arc::clone(&writes);
+        let (first_write_tx, first_write_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+
+        let writer = std::thread::spawn(move || {
+            let mut first_write_tx = Some(first_write_tx);
+            let mut release_rx = Some(release_rx);
+            write_cancellable_until_with_io(
+                &mut server,
+                PAYLOAD,
+                Some(&lease),
+                Instant::now() + Duration::from_secs(2),
+                |_| {},
+                |syscall_index, _| {
+                    if syscall_index == 0 {
+                        first_write_tx.take().unwrap().send(()).unwrap();
+                        release_rx.take().unwrap().recv().unwrap();
+                    }
+                },
+                move |stream, remaining| {
+                    let call = writer_writes.fetch_add(1, Ordering::SeqCst);
+                    let write_len = if call == 0 { 1 } else { remaining.len() };
+                    stream.write(&remaining[..write_len])
+                },
+            )
+        });
+        first_write_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+
+        let revoke_gate = Arc::clone(&gate);
+        let (revoked_tx, revoked_rx) = mpsc::channel();
+        let revoker = std::thread::spawn(move || {
+            revoke_gate.close_and_shutdown();
+            revoked_tx.send(()).unwrap();
+        });
+        revoked_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        release_tx.send(()).unwrap();
+        assert!(
+            writer.join().unwrap().is_err(),
+            "the writer continued after response revocation"
+        );
+        revoker.join().unwrap();
+        assert_eq!(
+            writes.load(Ordering::SeqCst),
+            1,
+            "a second write syscall started after response revocation"
+        );
+
+        client
+            .set_read_timeout(Some(Duration::from_millis(250)))
+            .unwrap();
+        let mut delivered = Vec::new();
+        let _ = client.read_to_end(&mut delivered);
+        assert_eq!(delivered, b"A");
+        assert!(!delivered
+            .windows(b"SECRET".len())
+            .any(|window| window == b"SECRET"));
+    }
+
+    #[test]
+    fn tool_payload_is_bounded_before_json_rendering() {
+        let oversized = "x".repeat(MAX_TOOL_TEXT_BYTES + 1);
+        let error = bound_tool_outcome(Ok(oversized)).unwrap_err();
+        assert_eq!(error.0, -32000);
+        assert!(error.1.contains("smaller page"));
+
+        let args = json!({ "maxChars": u64::MAX });
+        assert_eq!(mcp_body_window(&args).1, MAX_TOOL_WINDOW_CHARS);
+
+        // Worst-case JSON escaping remains below the transport cap without cloning the text into
+        // an intermediate `Value`.
+        let pending = PendingContentReply {
+            id: json!("bounded-id"),
+            snapshot: VisibilitySnapshot {
+                seal_epoch: 0,
+                unlocked_folders: HashSet::new(),
+            },
+            outcome: Ok("\u{0001}".repeat(MAX_TOOL_TEXT_BYTES)),
+        };
+        let body = content_reply_body(&pending).unwrap();
+        assert!(body.len() <= MAX_RESPONSE_BYTES);
+    }
+
+    #[test]
+    fn oversized_or_structured_jsonrpc_ids_are_rejected_before_dispatch() {
+        let oversized = "x".repeat(MAX_JSONRPC_ID_BYTES + 1);
+        let response = rpc(&json!({
+            "jsonrpc": "2.0",
+            "id": oversized,
+            "method": "tools/call",
+            "params": { "name": "search_meetings", "arguments": { "query": "x" } }
+        })
+        .to_string())
+        .unwrap();
+        assert_eq!(response["error"]["code"], -32600);
+        assert!(response["id"].is_null());
+
+        let response =
+            rpc(r#"{"jsonrpc":"2.0","id":{"nested":"value"},"method":"initialize"}"#).unwrap();
+        assert_eq!(response["error"]["code"], -32600);
+
+        // A long numeric token may normalize into serde_json's compact Number representation.
+        // The security boundary is the representation we will actually clone/render: prove it is
+        // measured and remains within budget even when the raw token was much longer.
+        let oversized_number = "9".repeat(MAX_JSONRPC_ID_BYTES + 1);
+        let response = rpc(&format!(
+            r#"{{"jsonrpc":"2.0","id":{oversized_number},"method":"initialize"}}"#
+        ))
+        .unwrap();
+        assert!(response["id"].is_number());
+        assert!(
+            serde_json::to_string(&response["id"]).unwrap().len() <= MAX_JSONRPC_ID_BYTES,
+            "an accepted numeric id rendered beyond its pre-clone byte budget"
+        );
+        assert!(jsonrpc_id_is_bounded(&json!(u64::MAX)));
+    }
+
+    #[test]
+    fn response_gate_register_vs_revoke_never_leaves_a_live_lease() {
+        use std::sync::Barrier;
+
+        for _ in 0..128 {
+            let gate = Arc::new(McpResponseGate::new());
+            let (_client, server) = tcp_pair();
+            let barrier = Arc::new(Barrier::new(3));
+            let register_gate = Arc::clone(&gate);
+            let register_barrier = Arc::clone(&barrier);
+            let register = std::thread::spawn(move || {
+                register_barrier.wait();
+                register_gate.register(server)
+            });
+            let revoke_gate = Arc::clone(&gate);
+            let revoke_barrier = Arc::clone(&barrier);
+            let revoke = std::thread::spawn(move || {
+                revoke_barrier.wait();
+                revoke_gate.close_and_shutdown();
+            });
+            barrier.wait();
+            let lease = register.join().unwrap();
+            revoke.join().unwrap();
+            assert_eq!(gate.active_count(), 0);
+            assert!(lease
+                .as_ref()
+                .map(ResponseLease::is_cancelled)
+                .unwrap_or(true));
+            assert!(gate.register(tcp_pair().1).is_none());
+        }
+    }
+
+    #[test]
+    fn response_gate_ids_wrap_without_overwriting_or_cross_dropping_leases() {
+        let gate = Arc::new(McpResponseGate::new());
+        let first = gate.register(tcp_pair().1).unwrap();
+        assert_eq!(first.id, 1);
+        gate.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .next_id = u64::MAX;
+
+        let at_max = gate.register(tcp_pair().1).unwrap();
+        let after_wrap = gate.register(tcp_pair().1).unwrap();
+        assert_eq!(at_max.id, u64::MAX);
+        assert_eq!(after_wrap.id, 2, "wrapped allocation reused live id 1");
+        assert_eq!(gate.active_count(), 3);
+
+        drop(first);
+        assert_eq!(
+            gate.active_count(),
+            2,
+            "dropping the old id removed a different live response"
+        );
+        assert!(!after_wrap.is_cancelled());
+        drop(at_max);
+        drop(after_wrap);
+        assert_eq!(gate.active_count(), 0);
+    }
+
+    #[test]
+    fn every_visibility_revoking_epoch_entrypoint_cancels_active_leases() {
+        for entrypoint in [
+            VisibilityRevokingEntrypoint::LockFolder,
+            VisibilityRevokingEntrypoint::RelockFolder,
+            VisibilityRevokingEntrypoint::RelockAll,
+        ] {
+            let gate = Arc::new(McpResponseGate::new());
+            let (_client, server) = tcp_pair();
+            let lease = gate
+                .register(server)
+                .expect("test response must register before revocation");
+            let revocation =
+                begin_visibility_revocation_for_gate(Some(Arc::clone(&gate)), entrypoint);
+            assert!(lease.is_cancelled(), "{entrypoint:?} left a live response");
+            assert_eq!(gate.active_count(), 0, "{entrypoint:?} left a socket");
+            assert!(
+                gate.register(tcp_pair().1).is_none(),
+                "{entrypoint:?} reopened before logical revocation"
+            );
+            finish_visibility_revocation(revocation);
+            assert!(
+                gate.register(tcp_pair().1).is_some(),
+                "{entrypoint:?} did not reopen after logical revocation"
+            );
+        }
+    }
+
+    #[test]
+    fn concurrent_revocations_cannot_reopen_each_other() {
+        let gate = Arc::new(McpResponseGate::new());
+        gate.close_and_shutdown();
+        gate.close_and_shutdown();
+        gate.finish_revocation();
+        assert!(
+            gate.register(tcp_pair().1).is_none(),
+            "one completed relock must not reopen while another revoke is in flight"
+        );
+        gate.finish_revocation();
+        let lease = gate
+            .register(tcp_pair().1)
+            .expect("the final completed revocation reopens admission");
+        drop(lease);
+    }
+
+    #[test]
+    fn concurrent_revocations_both_wait_for_the_same_admitted_chunk() {
+        use std::sync::mpsc;
+        use std::time::{Duration, Instant};
+
+        let gate = Arc::new(McpResponseGate::new());
+        let (_client, server) = tcp_pair();
+        let lease = gate.register(server).unwrap();
+        let chunk = lease.begin_chunk().unwrap();
+        let cancellation = Arc::clone(&lease.cancellation);
+        let mut completions = Vec::new();
+        let mut revokers = Vec::new();
+        for _ in 0..2 {
+            let revoke_gate = Arc::clone(&gate);
+            let (done_tx, done_rx) = mpsc::channel();
+            completions.push(done_rx);
+            revokers.push(std::thread::spawn(move || {
+                revoke_gate.close_and_shutdown();
+                done_tx.send(()).unwrap();
+            }));
+        }
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while !cancellation.is_cancelled() && Instant::now() < deadline {
+            std::thread::yield_now();
+        }
+        assert!(cancellation.is_cancelled());
+        for completion in &completions {
+            assert!(
+                completion.try_recv().is_err(),
+                "a concurrent revoke returned before the shared chunk drained"
+            );
+        }
+        drop(chunk);
+        for completion in completions {
+            completion.recv_timeout(Duration::from_secs(1)).unwrap();
+        }
+        for revoker in revokers {
+            revoker.join().unwrap();
+        }
+    }
+
+    #[test]
+    fn incomplete_logical_revocation_leaves_admission_closed_fail_closed() {
+        let gate = Arc::new(McpResponseGate::new());
+        let revocation = begin_visibility_revocation_for_gate(
+            Some(Arc::clone(&gate)),
+            VisibilityRevokingEntrypoint::LockFolder,
+        );
+        drop(revocation);
+        assert!(
+            gate.register(tcp_pair().1).is_none(),
+            "a failed lock must not silently reopen content admission"
+        );
+    }
+
+    #[test]
+    fn revocation_drains_admitted_chunk_before_visibility_can_change() {
+        use std::sync::mpsc;
+        use std::time::{Duration, Instant};
+
+        const MARKER: &[u8] = b"SECRET_AT_REVOKE_BOUNDARY";
+        for (target_chunk, marker_offset) in [
+            (0, 0),
+            (0, RESPONSE_CHUNK_BYTES - MARKER.len()),
+            (1, 0),
+            (1, RESPONSE_CHUNK_BYTES - MARKER.len()),
+        ] {
+            let gate = Arc::new(McpResponseGate::new());
+            let (mut client, mut server) = tcp_pair();
+            server
+                .set_write_timeout(Some(Duration::from_secs(2)))
+                .unwrap();
+            let lease = gate
+                .register(server.try_clone().unwrap())
+                .expect("boundary response must register");
+            let cancellation = Arc::clone(&lease.cancellation);
+            let mut payload = vec![b'B'; (target_chunk + 1) * RESPONSE_CHUNK_BYTES];
+            let marker_start = target_chunk * RESPONSE_CHUNK_BYTES + marker_offset;
+            payload[marker_start..marker_start + MARKER.len()].copy_from_slice(MARKER);
+
+            let (admitted_tx, admitted_rx) = mpsc::channel();
+            let (release_tx, release_rx) = mpsc::channel();
+            let writer = std::thread::spawn(move || {
+                let mut admitted_tx = Some(admitted_tx);
+                let mut release_rx = Some(release_rx);
+                write_cancellable_with_hook(&mut server, &payload, Some(&lease), |chunk_index| {
+                    if chunk_index == target_chunk {
+                        admitted_tx
+                            .take()
+                            .expect("target chunk admitted once")
+                            .send(())
+                            .unwrap();
+                        release_rx
+                            .take()
+                            .expect("target chunk released once")
+                            .recv()
+                            .unwrap();
+                    }
+                })
+            });
+            admitted_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+
+            let revoke_gate = Arc::clone(&gate);
+            let (revoked_tx, revoked_rx) = mpsc::channel();
+            let revoker = std::thread::spawn(move || {
+                revoke_gate.close_and_shutdown();
+                revoked_tx.send(()).unwrap();
+            });
+            let cancellation_deadline = Instant::now() + Duration::from_secs(1);
+            while !cancellation.is_cancelled() && Instant::now() < cancellation_deadline {
+                std::thread::yield_now();
+            }
+            assert!(
+                cancellation.is_cancelled(),
+                "revocation never cancelled chunk {target_chunk}"
+            );
+            assert!(
+                revoked_rx.try_recv().is_err(),
+                "revocation returned while admitted chunk {target_chunk} was still in flight"
+            );
+
+            release_tx.send(()).unwrap();
+            assert!(
+                writer.join().unwrap().is_err(),
+                "a chunk admitted before cancellation wrote after socket shutdown"
+            );
+            revoked_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+            revoker.join().unwrap();
+
+            client
+                .set_read_timeout(Some(Duration::from_millis(250)))
+                .unwrap();
+            let mut delivered = Vec::new();
+            let _ = client.read_to_end(&mut delivered);
+            assert!(
+                !delivered
+                    .windows(MARKER.len())
+                    .any(|window| window == MARKER),
+                "secret at chunk {target_chunk} offset {marker_offset} crossed revocation"
+            );
+        }
+    }
+
+    #[test]
+    fn slow_reader_is_cancelled_before_lifecycle_wait_and_receives_no_secret_tail() {
+        use std::sync::mpsc;
+        use std::time::{Duration, Instant};
+
+        let gate = Arc::new(McpResponseGate::new());
+        let (mut client, mut server) = tcp_pair();
+        server
+            .set_write_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
+        let lifecycle = Arc::new(Mutex::new(()));
+        let lease = {
+            let _lifecycle = lifecycle.lock().unwrap();
+            gate.register(server.try_clone().unwrap()).unwrap()
+        };
+        let (started_tx, started_rx) = mpsc::channel();
+        let writer = std::thread::spawn(move || {
+            let first = vec![b'A'; RESPONSE_CHUNK_BYTES];
+            write_cancellable(&mut server, &first, Some(&lease)).unwrap();
+            started_tx.send(()).unwrap();
+            let mut rest = vec![b'B'; 32 << 20];
+            rest.extend_from_slice(b"SECRET_TAIL_AFTER_REVOKE");
+            let _ = write_cancellable(&mut server, &rest, Some(&lease));
+        });
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+
+        let began = Instant::now();
+        gate.close_and_shutdown();
+        let _lifecycle = lifecycle.lock().unwrap();
+        assert!(
+            began.elapsed() < Duration::from_millis(250),
+            "slow MCP reader delayed lifecycle acquisition: {:?}",
+            began.elapsed()
+        );
+        drop(_lifecycle);
+        writer.join().unwrap();
+
+        client
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+        let mut delivered = Vec::new();
+        let _ = client.read_to_end(&mut delivered);
+        assert!(
+            !delivered
+                .windows(b"SECRET_TAIL_AFTER_REVOKE".len())
+                .any(|window| window == b"SECRET_TAIL_AFTER_REVOKE"),
+            "a payload tail was written after response revocation"
+        );
+        assert_eq!(gate.active_count(), 0);
+    }
+
+    #[test]
+    fn initial_lock_cancels_slow_response_before_lifecycle_and_leaks_no_tail() {
+        use crate::storage::models::Folder;
+        use std::sync::mpsc;
+        use std::time::{Duration, Instant};
+
+        let db_path = crate::storage::db::unique_temp_path("murmur-mcp-initial-lock", "sqlite");
+        let state = AppState::init_at(&db_path, TEST_DEK).unwrap();
+        state
+            .db
+            .insert_folder(&Folder {
+                id: "private".into(),
+                name: "Private".into(),
+                path: "Private".into(),
+                parent_id: None,
+                locked: false,
+                created_at: "2026-07-28T00:00:00Z".into(),
+            })
+            .unwrap();
+        *state.master_kek.lock().unwrap() = Some(zeroize::Zeroizing::new([0x42; 32]));
+
+        let gate = Arc::new(McpResponseGate::new());
+        let (mut client, mut server) = tcp_pair();
+        server
+            .set_write_timeout(Some(Duration::from_secs(10)))
+            .unwrap();
+        let lease = gate.register(server.try_clone().unwrap()).unwrap();
+        let (started_tx, started_rx) = mpsc::channel();
+        let writer = std::thread::spawn(move || {
+            write_cancellable(&mut server, &vec![b'A'; RESPONSE_CHUNK_BYTES], Some(&lease))
+                .unwrap();
+            started_tx.send(()).unwrap();
+            let mut rest = vec![b'B'; 32 << 20];
+            rest.extend_from_slice(b"SECRET_TAIL_AFTER_INITIAL_LOCK");
+            let _ = write_cancellable(&mut server, &rest, Some(&lease));
+        });
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+
+        let began = Instant::now();
+        let revocation = begin_visibility_revocation_for_gate(
+            Some(Arc::clone(&gate)),
+            VisibilityRevokingEntrypoint::LockFolder,
+        );
+        crate::commands::lock_folder_with_visibility_revocation(&state, "private", revocation)
+            .unwrap();
+        assert!(
+            began.elapsed() < Duration::from_secs(1),
+            "slow MCP reader delayed initial lock: {:?}",
+            began.elapsed()
+        );
+        assert!(state.db.folder_by_id("private").unwrap().unwrap().locked);
+        writer.join().unwrap();
+
+        client
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
+        let mut delivered = Vec::new();
+        let _ = client.read_to_end(&mut delivered);
+        assert!(
+            !delivered
+                .windows(b"SECRET_TAIL_AFTER_INITIAL_LOCK".len())
+                .any(|window| window == b"SECRET_TAIL_AFTER_INITIAL_LOCK"),
+            "a payload tail was delivered after initial folder lock"
+        );
+        assert_eq!(gate.active_count(), 0);
+        drop(state);
+        let _ = std::fs::remove_file(db_path);
     }
 
     #[test]
@@ -774,6 +3091,300 @@ mod tests {
         })
         .unwrap();
         db.set_note_folder(mid, folder).unwrap();
+    }
+
+    /// Once a content-bearing result has been materialized, a relock/epoch change before JSON-RPC
+    /// response production discards the whole payload and emits only the generic retry error.
+    #[test]
+    fn content_response_revalidation_discards_materialized_secret_after_epoch_bump() {
+        use crate::storage::models::Folder;
+
+        let (db, p) = temp_db();
+        db.insert_folder(&Folder {
+            id: "f-lock".into(),
+            name: "Private".into(),
+            path: "Private".into(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-07-28T00:00:00Z".into(),
+        })
+        .unwrap();
+        seed(
+            &db,
+            "secret-meeting",
+            "SECRET lifecycle title",
+            "SECRET lifecycle body",
+            Some("f-lock"),
+        );
+        db.set_folder_locked("f-lock", true, None).unwrap();
+
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f-lock".to_string());
+        let lifecycle = Mutex::new(());
+        let epoch = AtomicU64::new(0);
+        let unlocked = Mutex::new(unlocked);
+        let context = RpcContext {
+            db: Some(&db),
+            lifecycle: &lifecycle,
+            seal_epoch: &epoch,
+            unlocked_folders: &unlocked,
+        };
+        let params = json!({
+            "name": "search_meetings",
+            "arguments": { "query": "SECRET" }
+        });
+        let pending = match handle_tool_call(
+            &context,
+            json!(1),
+            Some(&params),
+            Instant::now() + REQUEST_DEADLINE,
+        ) {
+            RpcReply::Content(pending) => pending,
+            RpcReply::Immediate(response) => {
+                panic!("content call unexpectedly finalized early: {response}")
+            }
+        };
+        assert!(
+            pending
+                .outcome
+                .as_ref()
+                .is_ok_and(|text| text.contains("SECRET")),
+            "the regression must materialize secret content before simulating relock"
+        );
+
+        {
+            let _lifecycle = lifecycle.lock().unwrap();
+            epoch.fetch_add(1, Ordering::SeqCst);
+            unlocked.lock().unwrap().clear();
+        }
+        let response = {
+            let _lifecycle = lifecycle.lock().unwrap();
+            finalize_content_reply(pending, &epoch, &unlocked)
+        };
+        assert!(
+            !response.to_string().contains("SECRET"),
+            "a response produced after the visibility epoch changed leaked materialized content"
+        );
+        assert_eq!(response["error"]["code"], VISIBILITY_RETRY_CODE);
+        assert_eq!(
+            response["error"]["message"],
+            Value::String(VISIBILITY_RETRY_MESSAGE.into())
+        );
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn visibility_epoch_prevents_unlock_set_aba() {
+        let mut original = HashSet::new();
+        original.insert("f-lock".to_string());
+        let snapshot = VisibilitySnapshot {
+            seal_epoch: 41,
+            unlocked_folders: original.clone(),
+        };
+        let epoch = AtomicU64::new(41);
+        let unlocked = Mutex::new(original);
+        {
+            let mut folders = unlocked.lock().unwrap();
+            folders.clear();
+            epoch.fetch_add(1, Ordering::SeqCst);
+            folders.insert("f-lock".to_string());
+        }
+        assert!(
+            visibility_is_current(
+                &snapshot,
+                &epoch,
+                &unlocked,
+                Instant::now() + REQUEST_DEADLINE,
+            ) == Ok(false),
+            "same-looking unlock membership must not hide an intervening revoke"
+        );
+    }
+
+    #[test]
+    fn content_response_revalidation_returns_materialized_result_without_lifecycle_change() {
+        let (db, p) = temp_db();
+        seed(
+            &db,
+            "visible-meeting",
+            "SECRET unchanged title",
+            "SECRET unchanged body",
+            None,
+        );
+        let lifecycle = Mutex::new(());
+        let epoch = AtomicU64::new(7);
+        let unlocked = Mutex::new(HashSet::new());
+        let context = RpcContext {
+            db: Some(&db),
+            lifecycle: &lifecycle,
+            seal_epoch: &epoch,
+            unlocked_folders: &unlocked,
+        };
+        let params = json!({
+            "name": "search_meetings",
+            "arguments": { "query": "SECRET" }
+        });
+        let pending = match handle_tool_call(
+            &context,
+            json!(2),
+            Some(&params),
+            Instant::now() + REQUEST_DEADLINE,
+        ) {
+            RpcReply::Content(pending) => pending,
+            RpcReply::Immediate(response) => {
+                panic!("content call unexpectedly finalized early: {response}")
+            }
+        };
+        let response = {
+            let _lifecycle = lifecycle.lock().unwrap();
+            finalize_content_reply(pending, &epoch, &unlocked)
+        };
+        assert!(
+            response.to_string().contains("SECRET unchanged title"),
+            "an unchanged lifecycle must return the gated result: {response}"
+        );
+        assert!(response.get("result").is_some());
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn org_read_gates_hold_through_the_production_tcp_response_sink() {
+        use crate::storage::OrgState;
+
+        const QUERY: &str = "quartz permission boundary";
+        const STALE_MARKER: &str = "STALE_ORG_SECRET_MARKER";
+
+        let db_path = crate::storage::db::unique_temp_path("murmur-mcp-org-tcp-gates", "sqlite");
+        let state = AppState::init_at(&db_path, TEST_DEK).unwrap();
+        state
+            .db
+            .set_setting("semantic_search_enabled", "false")
+            .unwrap();
+        let gate = Arc::new(McpResponseGate::new());
+
+        let rpc_over_tcp = |query: &str| {
+            let context = RpcContext::from_state(&state);
+            let request = json!({
+                "jsonrpc": "2.0",
+                "id": 17,
+                "method": "tools/call",
+                "params": {
+                    "name": "org_search",
+                    "arguments": { "query": query }
+                }
+            })
+            .to_string();
+            let deadline = Instant::now() + REQUEST_DEADLINE;
+            let reply = handle_rpc(&context, &request, None, None, deadline)
+                .expect("org_search request must produce a response");
+            assert!(
+                matches!(&reply, RpcReply::Content(_)),
+                "org_search must traverse the content-response gate"
+            );
+            let (mut client, mut server) = tcp_pair();
+            send_rpc_reply(&mut server, reply, &state, &gate, deadline);
+            let mut wire = String::new();
+            client.read_to_string(&mut wire).unwrap();
+            assert!(wire.starts_with("HTTP/1.1 200 OK\r\n"));
+            wire
+        };
+
+        // Simulate a stale/unauthorized decrypted replica row written outside the normal
+        // member-gated feed commit. With no local org_state membership it must still disappear at
+        // the authoritative reader and therefore at the new TCP sink.
+        state
+            .db
+            .upsert_org_item(
+                "org-stale",
+                "org-1",
+                1,
+                "mallory",
+                STALE_MARKER,
+                QUERY,
+                "2026-07-28T00:00:00Z",
+                1,
+                1,
+                &[0x31; 32],
+                None,
+                None,
+                Some(&crate::embed::StubEmbedder),
+            )
+            .unwrap();
+        let non_member = rpc_over_tcp(QUERY);
+        assert!(
+            !non_member.contains(STALE_MARKER) && !non_member.contains(QUERY),
+            "a stale replica bypassed local membership at the TCP sink: {non_member}"
+        );
+
+        state
+            .db
+            .upsert_org_state(&OrgState {
+                org_id: "org-1".into(),
+                name: "Acme".into(),
+                role: "member".into(),
+                joined_at: "2026-07-28T00:00:00Z".into(),
+                consented: false,
+                last_seq: 0,
+                generation: 1,
+                context_enabled: true,
+            })
+            .unwrap();
+        let joined = rpc_over_tcp(QUERY);
+        assert!(
+            joined.contains(STALE_MARKER) && joined.contains("[org · mallory]"),
+            "joined+enabled control did not reach the production TCP sink: {joined}"
+        );
+
+        state.db.set_org_context_enabled("org-1", false).unwrap();
+        let disabled = rpc_over_tcp(QUERY);
+        assert!(
+            !disabled.contains(STALE_MARKER) && !disabled.contains(QUERY),
+            "context-disabled org content reached the TCP sink: {disabled}"
+        );
+
+        state.db.set_org_context_enabled("org-1", true).unwrap();
+        state.db.tombstone_org_item("org-stale").unwrap();
+        let tombstoned = rpc_over_tcp(QUERY);
+        assert!(
+            !tombstoned.contains(STALE_MARKER) && !tombstoned.contains(QUERY),
+            "tombstoned org content reached the TCP sink: {tombstoned}"
+        );
+
+        // The authoritative org reader pushes down a 20-hit bound, and the generic MCP transport
+        // applies its independent byte cap before disclosure.
+        for index in 0..25_u8 {
+            let item_id = format!("org-bounded-{index:02}");
+            let title = format!("Bounded sink item {index:02}");
+            state
+                .db
+                .upsert_org_item(
+                    &item_id,
+                    "org-1",
+                    u64::from(index) + 10,
+                    "bounded-author",
+                    &title,
+                    "bounded sink marker safe shared content",
+                    "2026-07-28T00:00:00Z",
+                    1,
+                    1,
+                    &[index; 32],
+                    None,
+                    None,
+                    Some(&crate::embed::StubEmbedder),
+                )
+                .unwrap();
+        }
+        let bounded = rpc_over_tcp("bounded sink marker");
+        let disclosed_hits = bounded.matches("[org · bounded-author]").count();
+        assert!(
+            (1..=20).contains(&disclosed_hits),
+            "org reader did not preserve its 20-hit bound at the TCP sink: {disclosed_hits}"
+        );
+        assert!(
+            bounded.len() <= MAX_RESPONSE_BYTES,
+            "bounded org results exceeded the transport response cap"
+        );
+
+        let _ = std::fs::remove_file(db_path);
     }
 
     /// Flag OFF (the default): `search_semantic` DEGRADES to gated keyword (FTS/BM25) matching —
@@ -850,8 +3461,7 @@ mod tests {
         // what this test owns; real-model loading is covered by the embedder tests / Mac bake-off.
         let emb = crate::embed::StubEmbedder;
         db.index_meeting_chunks("open", &[], &emb).unwrap();
-        db.index_meeting_chunks("sealed", &[], &emb)
-            .unwrap();
+        db.index_meeting_chunks("sealed", &[], &emb).unwrap();
         // Seal the folder AFTER indexing (a stray vec row now exists for a sealed meeting).
         db.set_folder_locked("f-lock", true, None).unwrap();
 
@@ -1286,7 +3896,10 @@ mod tests {
             &HashSet::new(),
         )
         .unwrap_err();
-        assert_eq!(err.0, -32602, "malformed timestamp must be InvalidArg: {err:?}");
+        assert_eq!(
+            err.0, -32602,
+            "malformed timestamp must be InvalidArg: {err:?}"
+        );
         assert!(
             err.1.contains("from"),
             "the error must name the offending argument (from): {}",

--- a/src-tauri/src/screenshare.rs
+++ b/src-tauri/src/screenshare.rs
@@ -180,8 +180,8 @@ fn captured_on_main(app: &AppHandle) -> bool {
 /// React to a share-start rising edge: relock everything + emit the UI event.
 fn on_capture_started(app: &AppHandle) {
     let state = app.state::<AppState>();
-    // relock_all_inner takes &AppState; State derefs to it.
-    let secured = match crate::commands::relock_all_inner(&state) {
+    // The wrapper shuts down active MCP content sockets before it waits on the lock lifecycle.
+    let secured = match crate::commands::relock_all_with_visibility_gate(app, state.inner()) {
         Ok(()) => true,
         Err(e) => {
             tracing::error!(


### PR DESCRIPTION
Replaces the MCP HTTP serving path with a strict loopback-only std::net transport and closes content-response races with folder/session visibility revocation.

The response gate now linearizes snapshot/revalidation/registration with the shared AppState lifecycle, cancels individual write and flush syscalls, drains admitted operations before lock visibility changes, and applies one absolute request deadline across parsing, dispatch acceptance, lifecycle admission, serialization and I/O.

Verification for the exact diff:
- cargo test --lib: 2500 passed, 0 failed, 15 ignored
- focused MCP suite: 49 passed, 0 failed
- Codex combined review: PASS
- Codex lock-security review: PASS
- Codex egress-security review: PASS
- Harness v2 evidence SHA-256: 1fdee4f03251b6a82874bc0b5640fb4ab6eec159c06595d83ebd393f7aec8980

The lock/seal implementation itself is unchanged; wrappers only order MCP response revocation around the existing verify-before-destroy operations.