### PR TITLE
feat(mcp): add loss-safe transcript navigation

### DIFF
--- a/src-tauri/src/audio/merge.rs
+++ b/src-tauri/src/audio/merge.rs
@@ -28,7 +28,7 @@
 //! - If ScreenCaptureKit permission is denied / system capture is off, there is no system
 //!   stream at all and the caller falls back to mic-only (everything "me").
 
-use std::time::Instant;
+use std::{collections::HashSet, time::Instant};
 
 use crate::transcribe::types::Segment;
 
@@ -140,6 +140,34 @@ const ECHO_RELAXED_AFTER_S: f64 = 4.0;
 const ECHO_RELAXED_SIMILARITY: f32 = 0.7;
 const ECHO_CONCAT_MAX: usize = 3;
 const ECHO_CONCAT_MAX_GAP_S: f64 = 1.0;
+/// The capture-lane projection requested by transcript readers.
+///
+/// This is deliberately owned by the audio merge seam: `Segment.speaker` is the persisted lane
+/// marker, and this module already owns the load-bearing distinction between the local microphone
+/// (`me`) and the clean system side (`others` / `others-N`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RenderChannel {
+    Merged,
+    Mic,
+    System,
+}
+
+/// SQL form of the canonical persisted-tag rule used by [`RenderChannel::System`].
+///
+/// The system lane is intentionally any attributed row that is not `me`, not merely labels with
+/// an `others` prefix. That keeps diarizer and future/noncanonical capture tags visible. DB search
+/// interpolates this exact predicate before its candidate-meeting cap so search and rendering
+/// cannot silently disagree about which persisted rows belong to the system lane.
+pub(crate) const SYSTEM_SPEAKER_SQL_PREDICATE: &str =
+    "AND s.speaker IS NOT NULL AND s.speaker <> 'me'";
+
+/// Raw persisted rows, the ingest-cleaned summary projection, and the raw indices hidden only from
+/// the default merged presentation.
+pub struct EchoClassifiedSegments {
+    pub stored: Vec<Segment>,
+    pub merged: Vec<Segment>,
+    pub suppressed_indices: Vec<i64>,
+}
 
 /// Lowercased Unicode-alphanumeric tokens ("Zamknijmy budżet!" → ["zamknijmy","budżet"]).
 fn norm_tokens(text: &str) -> Vec<String> {
@@ -184,7 +212,11 @@ fn token_lcs(a: &[String], b: &[String]) -> f32 {
     dp[a.len()][b.len()] as f32 / shorter as f32
 }
 
-/// Is this segment on the clean (system) side? Diarization may have relabelled to others-N.
+/// Is this segment on the clean (system) side?
+///
+/// Keep this in lockstep with [`SYSTEM_SPEAKER_SQL_PREDICATE`]: any non-null tag except `me`
+/// belongs to the system lane. Diarization commonly writes `others-N`, but that prefix is not the
+/// semantic boundary.
 fn is_others(seg: &Segment) -> bool {
     seg.speaker
         .as_deref()
@@ -195,6 +227,7 @@ fn is_others(seg: &Segment) -> bool {
 /// One candidate = a run of 1..=ECHO_CONCAT_MAX consecutive `others` segments (close in time).
 struct Candidate {
     start_s: f64,
+    end_s: f64,
     tokens: Vec<String>,
     text_norm: String,
 }
@@ -216,6 +249,7 @@ fn build_candidates(others: &[&Segment]) -> Vec<Candidate> {
             text.push_str(&others[i + k].text.to_lowercase());
             out.push(Candidate {
                 start_s: others[i].start_s,
+                end_s: others[i + k].end_s,
                 tokens: tokens.clone(),
                 text_norm: norm_tokens(&text).join(" "),
             });
@@ -224,24 +258,21 @@ fn build_candidates(others: &[&Segment]) -> Vec<Candidate> {
     out
 }
 
-/// Drop `me` segments that are echo copies of `others` speech. Returns the cleaned,
-/// re-indexed segments + the suppressed count. See the tier rules in the header comment.
-pub fn suppress_cross_stream_echo(
-    segments: Vec<Segment>,
-    leak: Option<&crate::audio::align::EchoLeak>,
-) -> (Vec<Segment>, usize) {
-    // Echo only exists when the user is on speakers, which is exactly what a measured leak means.
-    // No leak ⇒ no echo ⇒ NOTHING is deduplicated (headphones / unreliable-offset recordings are
-    // returned untouched). This gates BOTH tiers — the strict tier is no longer ungated.
-    let leak_armed = leak
-        .map(|l| l.correlation >= crate::audio::align::MIN_CORR)
-        .unwrap_or(false);
+/// Compute the conservative echo drop-mask without mutating or re-indexing the stored segments.
+///
+/// The storage-time caller below arms this only with measured acoustic leak evidence. The cleaned
+/// merged projection is computed once from this mask. Read-time renderers consume only the
+/// persisted outcome and never repeat this content/timestamp heuristic.
+fn cross_stream_echo_drop_mask(
+    segments: &[Segment],
+    min_start_lag_s: f64,
+    min_end_lag_s: f64,
+) -> Vec<bool> {
     let others_refs: Vec<&Segment> = segments.iter().filter(|s| is_others(s)).collect();
-    if !leak_armed || others_refs.is_empty() {
-        return (segments, 0);
+    if others_refs.is_empty() {
+        return vec![false; segments.len()];
     }
     let candidates = build_candidates(&others_refs);
-
     let mut drop = vec![false; segments.len()];
     for (i, seg) in segments.iter().enumerate() {
         if seg.speaker.as_deref() != Some(SPEAKER_ME) {
@@ -256,18 +287,14 @@ pub fn suppress_cross_stream_echo(
             if cand.tokens.len() < ECHO_MIN_TOKENS {
                 continue;
             }
-            // `delta` = how much LATER the `me` (echo) copy starts than the `others` source.
-            // Echo lags, so both windows run from a small causal back-tolerance forward.
-            // (leak evidence is already guaranteed — the fn early-returned otherwise.)
             let delta = seg.start_s - cand.start_s;
-            let strict_hit = (-ECHO_CAUSAL_BACK_S..=ECHO_STRICT_FWD_S).contains(&delta)
+            let end_delta = seg.end_s - cand.end_s;
+            if delta < min_start_lag_s || end_delta < min_end_lag_s {
+                continue;
+            }
+            let strict_hit = delta <= ECHO_STRICT_FWD_S
                 && jaccard(&me_tokens, &cand.tokens) >= ECHO_STRICT_JACCARD;
-            // Relaxed tier uses ORDER-PRESERVING signals only (equality, contiguous substring,
-            // or token-LCS): acoustic echo is the SAME speech, so Whisper decodes it in the same
-            // word order. An order-INSENSITIVE metric (multiset coverage) was dropped because it
-            // eats a genuine `me` line whose words merely reappear — reordered — in a nearby
-            // `others` segment (lock-security finding). Content-loss beats garbled-echo recall.
-            let relaxed_hit = (-ECHO_CAUSAL_BACK_S..=ECHO_RELAXED_AFTER_S).contains(&delta)
+            let relaxed_hit = delta <= ECHO_RELAXED_AFTER_S
                 && (me_norm == cand.text_norm
                     || cand.text_norm.contains(&me_norm)
                     || me_norm.contains(&cand.text_norm)
@@ -278,17 +305,81 @@ pub fn suppress_cross_stream_echo(
             }
         }
     }
+    drop
+}
 
-    let suppressed = drop.iter().filter(|d| **d).count();
-    let mut out: Vec<Segment> = segments
-        .into_iter()
-        .zip(drop)
-        .filter_map(|(s, d)| if d { None } else { Some(s) })
-        .collect();
-    for (i, seg) in out.iter_mut().enumerate() {
-        seg.idx = i as i64;
+/// Select the transcript lane for a read-only renderer without touching stored segment indices.
+///
+/// `Merged` is the canonical stored view. It never guesses from text and timestamps whether a
+/// persisted segment is echo: that is information-theoretically ambiguous with genuine repetition.
+/// Acoustic-leak-evidenced suppression belongs to ingest, before persistence. `Mic` and `System`
+/// expose their original persisted lanes for diagnosis. An unattributed legacy segment belongs to
+/// neither raw lane but remains present in `Merged`.
+pub(crate) fn select_render_channel<'a>(
+    segments: &'a [Segment],
+    channel: RenderChannel,
+    echo_suppressed: &HashSet<i64>,
+) -> Vec<&'a Segment> {
+    match channel {
+        RenderChannel::Mic => segments
+            .iter()
+            .filter(|seg| seg.speaker.as_deref() == Some(SPEAKER_ME))
+            .collect(),
+        RenderChannel::System => segments.iter().filter(|seg| is_others(seg)).collect(),
+        RenderChannel::Merged => segments
+            .iter()
+            .filter(|segment| !echo_suppressed.contains(&segment.idx))
+            .collect(),
     }
-    (out, suppressed)
+}
+
+/// Classify acoustic echo once at ingest while preserving every raw captured row.
+///
+/// The returned `suppressed_indices` are explicit provenance for storage/presentation. They are
+/// produced only when the caller supplies measured [`EchoLeak`] evidence above the established
+/// correlation floor. `merged` is the cleaned projection used by the summarizer; `stored` retains
+/// all original lane rows and stable raw indices for later mic/system inspection.
+pub fn classify_cross_stream_echo(
+    segments: Vec<Segment>,
+    leak: Option<&crate::audio::align::EchoLeak>,
+) -> EchoClassifiedSegments {
+    let leak_armed = leak
+        .map(|leak| leak.correlation >= crate::audio::align::MIN_CORR)
+        .unwrap_or(false);
+    let drop = if leak_armed && segments.iter().any(is_others) {
+        cross_stream_echo_drop_mask(&segments, -ECHO_CAUSAL_BACK_S, f64::NEG_INFINITY)
+    } else {
+        vec![false; segments.len()]
+    };
+    let suppressed_indices = segments
+        .iter()
+        .zip(&drop)
+        .filter_map(|(segment, drop)| drop.then_some(segment.idx))
+        .collect::<Vec<_>>();
+    let mut merged = segments
+        .iter()
+        .zip(&drop)
+        .filter_map(|(segment, drop)| (!drop).then_some(segment.clone()))
+        .collect::<Vec<_>>();
+    for (idx, segment) in merged.iter_mut().enumerate() {
+        segment.idx = idx as i64;
+    }
+    EchoClassifiedSegments {
+        stored: segments,
+        merged,
+        suppressed_indices,
+    }
+}
+
+/// Drop `me` segments that are echo copies of `others` speech. Returns the cleaned,
+/// re-indexed segments + the suppressed count. See the tier rules in the header comment.
+pub fn suppress_cross_stream_echo(
+    segments: Vec<Segment>,
+    leak: Option<&crate::audio::align::EchoLeak>,
+) -> (Vec<Segment>, usize) {
+    let classified = classify_cross_stream_echo(segments, leak);
+    let suppressed = classified.suppressed_indices.len();
+    (classified.merged, suppressed)
 }
 
 #[cfg(test)]
@@ -595,6 +686,130 @@ mod tests {
             "the clean copy survives"
         );
         assert_eq!(out[0].idx, 0, "re-indexed");
+    }
+
+    /// The read projection never mutates or re-indexes persisted segments. Echo classification
+    /// requires acoustic evidence at ingest; once rows are stored, merged keeps every row while
+    /// the raw views filter only by capture lane.
+    #[test]
+    fn render_channel_preserves_all_stored_segments_and_raw_lanes() {
+        let segs = vec![
+            seg_sp(
+                5.0,
+                7.0,
+                "the contract is now signed by both parties",
+                "others",
+            ),
+            seg_sp(5.4, 7.3, "the contract is now signed by both parties", "me"),
+            seg_sp(10.0, 11.0, "I built them", "others"),
+            seg_sp(10.1, 11.1, "I do not know", "me"),
+        ];
+        let merged = select_render_channel(&segs, RenderChannel::Merged, &HashSet::new());
+        assert_eq!(
+            merged.len(),
+            4,
+            "read-time projection keeps every stored row"
+        );
+        assert!(
+            merged.iter().any(|seg| seg.text == "I do not know"),
+            "distinct simultaneous speech survives"
+        );
+        assert_eq!(
+            merged
+                .iter()
+                .filter(|seg| seg.text.contains("contract"))
+                .count(),
+            2
+        );
+        assert_eq!(
+            select_render_channel(&segs, RenderChannel::Mic, &HashSet::new()).len(),
+            2
+        );
+        assert_eq!(
+            select_render_channel(&segs, RenderChannel::System, &HashSet::new()).len(),
+            2
+        );
+        assert_eq!(
+            merged[2].idx, segs[2].idx,
+            "rendering never re-indexes persisted segments"
+        );
+    }
+
+    /// A persisted system tag is not required to use the conventional `others[-N]` vocabulary.
+    /// The canonical boundary is exactly non-null and not `me`, matching the SQL predicate used by
+    /// transcript search.
+    #[test]
+    fn system_render_channel_includes_noncanonical_non_me_tag() {
+        let segs = vec![
+            seg_sp(1.0, 2.0, "custom remote lane", "remote-custom"),
+            seg_sp(2.0, 3.0, "local lane", "me"),
+            Segment {
+                idx: 2,
+                start_s: 3.0,
+                end_s: 4.0,
+                text: "legacy unattributed lane".into(),
+                speaker: None,
+                confidence: None,
+            },
+        ];
+
+        let system = select_render_channel(&segs, RenderChannel::System, &HashSet::new());
+        assert_eq!(system.len(), 1);
+        assert_eq!(system[0].speaker.as_deref(), Some("remote-custom"));
+        assert_eq!(system[0].text, "custom remote lane");
+    }
+
+    /// Text plus timing cannot distinguish echo from genuine repetition. Both overlapping and
+    /// turn-taking persisted repetitions survive the canonical read projection. An ordinary
+    /// overlapping echo is removed only by the separate ingest path when acoustic leak evidence is
+    /// present, and its cleaned output remains stable through the canonical projection.
+    #[test]
+    fn render_channel_never_guesses_echo_without_acoustic_evidence() {
+        let mut overlapping = vec![
+            seg_sp(5.0, 7.0, "we should ship the release today", "others"),
+            seg_sp(5.25, 7.25, "We should ship the release today!", "me"),
+        ];
+        overlapping[0].idx = 7;
+        overlapping[1].idx = 8;
+        assert_eq!(
+            select_render_channel(&overlapping, RenderChannel::Merged, &HashSet::new()).len(),
+            2,
+            "overlapping same-content stored speech survives"
+        );
+
+        let turn_taking = vec![
+            seg_sp(5.0, 7.0, "we should ship the release today", "others"),
+            seg_sp(7.2, 9.2, "We should ship the release today!", "me"),
+        ];
+        assert_eq!(
+            select_render_channel(&turn_taking, RenderChannel::Merged, &HashSet::new()).len(),
+            2,
+            "genuine non-overlapping repetition survives"
+        );
+
+        let classified = classify_cross_stream_echo(overlapping, Some(&leak(0.9)));
+        assert_eq!(
+            classified.suppressed_indices.len(),
+            1,
+            "acoustic leak evidence identifies the echo"
+        );
+        assert_eq!(classified.stored.len(), 2, "both raw rows are retained");
+        let hidden = classified
+            .suppressed_indices
+            .iter()
+            .copied()
+            .collect::<HashSet<_>>();
+        assert_eq!(
+            select_render_channel(&classified.stored, RenderChannel::Merged, &hidden).len(),
+            1,
+            "merged filters only the explicit ingest provenance"
+        );
+        assert_eq!(
+            select_render_channel(&classified.stored, RenderChannel::Mic, &hidden).len(),
+            1,
+            "the raw mic lane still exposes the marked captured row"
+        );
+        assert_eq!(classified.merged.len(), 1, "summary feed stays echo-clean");
     }
 
     /// HEADPHONES IMMUNITY (RED-before-GREEN): with NO measured leak, echo is physically

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -5,7 +5,7 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::io::{BufRead, BufReader, Read, Write};
-use std::net::{Shutdown, TcpListener, TcpStream};
+use std::net::{Ipv4Addr, Shutdown, SocketAddrV4, TcpListener, TcpStream};
 #[cfg(test)]
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
@@ -22,6 +22,14 @@ use crate::storage::Db;
 
 /// Fixed localhost port for the MCP server.
 pub const MCP_PORT: u16 = 8765;
+/// The production listener has no configurable/wildcard bind. Keeping the literal loopback IP in a
+/// typed socket address prevents DNS, proxy, environment, and config state from widening this
+/// local-only disclosure boundary.
+const MCP_BIND_IP: Ipv4Addr = Ipv4Addr::LOCALHOST;
+
+fn mcp_listener_addr() -> SocketAddrV4 {
+    SocketAddrV4::new(MCP_BIND_IP, MCP_PORT)
+}
 
 /// Max request body we will read (E5). The MCP JSON-RPC requests are tiny; cap hard so a
 /// malicious local client can't OOM us with an unbounded body.
@@ -511,8 +519,8 @@ pub fn spawn(app: AppHandle, require_token: bool) {
 }
 
 fn run(app: AppHandle, require_token: bool) {
-    let addr = format!("127.0.0.1:{MCP_PORT}");
-    let listener = match TcpListener::bind(&addr) {
+    let addr = mcp_listener_addr();
+    let listener = match TcpListener::bind(addr) {
         Ok(s) => s,
         Err(e) => {
             tracing::warn!(target: "mcp", error = %e, "MCP server failed to bind {addr}");
@@ -638,8 +646,23 @@ fn try_acquire_connection(active: &AtomicUsize) -> bool {
 }
 
 fn handle_connection(
-    mut stream: TcpStream,
+    stream: TcpStream,
     app: AppHandle,
+    gate: Arc<McpResponseGate>,
+    expected_token: Option<Arc<String>>,
+    deadline: Instant,
+) {
+    let state = app.state::<AppState>();
+    handle_connection_with_state(stream, state.inner(), gate, expected_token, deadline);
+}
+
+/// Production connection pipeline with the Tauri state lookup factored out. Keeping HTTP parsing,
+/// host/origin/auth checks, JSON-RPC dispatch, visibility revalidation, and the response gate in one
+/// function lets an ephemeral-loopback test exercise the real listener path without constructing a
+/// GUI runtime.
+fn handle_connection_with_state(
+    mut stream: TcpStream,
+    state: &AppState,
     gate: Arc<McpResponseGate>,
     expected_token: Option<Arc<String>>,
     deadline: Instant,
@@ -728,8 +751,7 @@ fn handle_connection(
             return;
         }
     };
-    let state = app.state::<AppState>();
-    let context = RpcContext::from_state(state.inner());
+    let context = RpcContext::from_state(state);
     let reply = handle_rpc(
         &context,
         &request.body,
@@ -741,7 +763,7 @@ fn handle_connection(
     // deadline, discard the result before serialization, visibility admission, or any response
     // write can disclose it.
     match reply_before_deadline(reply, deadline) {
-        Some(reply) => send_rpc_reply(&mut stream, reply, state.inner(), &gate, deadline),
+        Some(reply) => send_rpc_reply(&mut stream, reply, state, &gate, deadline),
         None => {
             let _ = write_http_response(&mut stream, 202, "application/json", b"", None, deadline);
         }
@@ -1582,9 +1604,19 @@ fn tools_spec() -> Value {
             "inputSchema": { "type": "object", "properties": { "query": { "type": "string" } }, "required": ["query"] }
         },
         {
+            "name": "search_transcript",
+            "description": "Located lexical search inside visible transcript segments. Every hit includes a timestamp, stable stored segment id, speaker and character offsets in the exact structured transcript channel accepted by get_meeting. Counts are computed after channel projection within at most 20 matching meetings.",
+            "inputSchema": { "type": "object", "properties": { "query": { "type": "string" }, "meetingId": { "type": "string", "description": "Optional meeting id scope." }, "limit": { "type": "number", "description": "Maximum hits overall (default 20, max 100)." }, "maxPerMeeting": { "type": "number", "description": "Maximum hits per meeting (default 5, max 20)." }, "channel": { "type": "string", "enum": ["merged", "mic", "system"], "description": "Structured transcript channel whose offsets are returned (default merged)." } }, "required": ["query"] }
+        },
+        {
             "name": "get_meeting",
-            "description": "Get a meeting's AI note (summary) and transcript by id (from a search hit labelled 'meeting:...'). The transcript is STRUCTURED by default — one line per segment, '[<start_s>–<end_s>] <Speaker>: <text>' with Me/Others/Unknown speakers and raw-second timestamps; pass transcriptFormat 'plain' for the old flat text. The transcript is returned as a WINDOW (default first 6000 chars) prefixed with 'TOTAL_CHARS: <N> (showing <start>..<end>)'; page a long transcript by passing offset + maxChars.",
-            "inputSchema": { "type": "object", "properties": { "meetingId": { "type": "string" }, "transcriptFormat": { "type": "string", "enum": ["structured", "plain", "compact"], "description": "Transcript rendering (default 'structured'). 'compact' merges consecutive same-speaker segments into one line — same words, far less per-segment scaffolding. NOTE each format is a DIFFERENT character space, so offset/maxChars/TOTAL_CHARS only mean anything within the format you asked for." }, "offset": { "type": "number", "description": "Chars to skip into the transcript, in the SELECTED format's char space (default 0)." }, "maxChars": { "type": "number", "description": "Max chars to return from offset (default: a bounded 6000-char window with the total disclosed). Bounds the NOTE section too." }, "includeNote": { "type": "boolean", "description": "Include the AI note (default true). Pass false for transcript only — e.g. you already read the note, or you are paging and only want speech." } }, "required": ["meetingId"] }
+            "description": "Get a meeting's AI note (summary) and transcript by id. The transcript is STRUCTURED by default — one line per segment, '[<start_s>–<end_s>] <Speaker>: <text>'. The response stamps format and channel because each pair has its own character-offset space. Merged is the canonical stored transcript (ingest removes echoes only when acoustic leak is measured); mic and system expose its stored capture lanes. The transcript is returned as a bounded, disclosed window and can be paged with offset + maxChars.",
+            "inputSchema": { "type": "object", "properties": { "meetingId": { "type": "string" }, "transcriptFormat": { "type": "string", "enum": ["structured", "plain", "compact"], "description": "Transcript rendering (default structured). Each format is a different character space." }, "channel": { "type": "string", "enum": ["merged", "mic", "system"], "description": "Capture-lane projection (default merged). Keep this equal to the channel from search_transcript or get_meeting_chapters when using their offsets." }, "offset": { "type": "number", "description": "Chars to skip into the transcript, in the selected format and channel coordinate." }, "maxChars": { "type": "number", "description": "Max chars to return from offset (default: a bounded 6000-char window with the total disclosed). Bounds the NOTE section too." }, "includeNote": { "type": "boolean", "description": "Include the AI note (default true). Pass false for transcript only." } }, "required": ["meetingId"] }
+        },
+        {
+            "name": "get_meeting_chapters",
+            "description": "Get the visible timeline topic map for one meeting. Each topic carries a character range in the same structured transcript channel accepted by get_meeting, so a long meeting can be navigated without blind paging.",
+            "inputSchema": { "type": "object", "properties": { "meetingId": { "type": "string" }, "channel": { "type": "string", "enum": ["merged", "mic", "system"], "description": "Structured transcript channel whose offsets are returned (default merged)." } }, "required": ["meetingId"] }
         },
         {
             "name": "get_document",
@@ -1735,6 +1767,13 @@ fn mcp_body_window(args: &Value) -> (usize, usize) {
     (offset, max_chars)
 }
 
+fn mcp_transcript_channel(
+    args: &Value,
+) -> std::result::Result<crate::tools::TranscriptChannel, ToolError> {
+    crate::tools::TranscriptChannel::parse(args.get("channel").and_then(Value::as_str))
+        .map_err(|err| (-32602, err.to_string()))
+}
+
 fn dispatch_tool(
     db: &Db,
     name: &str,
@@ -1757,6 +1796,29 @@ fn dispatch_tool(
                 .unwrap_or("")
                 .to_string(),
         },
+        "search_transcript" => {
+            let query = args.get("query").and_then(Value::as_str).unwrap_or("");
+            ToolCall::SearchTranscript {
+                query: query.to_string(),
+                meeting_id: args
+                    .get("meetingId")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string),
+                limit: args
+                    .get("limit")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(20)
+                    .clamp(1, 100) as usize,
+                max_per_meeting: args
+                    .get("maxPerMeeting")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(5)
+                    .clamp(1, 20) as usize,
+                channel: mcp_transcript_channel(args)?,
+            }
+        }
         "get_meeting" => ToolCall::GetMeeting {
             meeting_id: args
                 .get("meetingId")
@@ -1771,6 +1833,8 @@ fn dispatch_tool(
                 .filter(|f| *f == "plain" || *f == "compact")
                 .unwrap_or("structured")
                 .to_string(),
+            channel: mcp_transcript_channel(args)?,
+            include_speaker_map: true,
             // Brain v3 audit Fix 2 — bound + DISCLOSE the default MCP window (no paging args → a
             // 6000-char disclosed window, not the whole transcript) so a huge transcript can't flood
             // the client; explicit offset/maxChars are honored verbatim.
@@ -1781,6 +1845,14 @@ fn dispatch_tool(
                 .get("includeNote")
                 .and_then(Value::as_bool)
                 .unwrap_or(true),
+        },
+        "get_meeting_chapters" => ToolCall::GetMeetingChapters {
+            meeting_id: args
+                .get("meetingId")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string(),
+            channel: mcp_transcript_channel(args)?,
         },
         "get_document" => ToolCall::GetDocument {
             document_id: args
@@ -1957,10 +2029,10 @@ mod tests {
     }
 
     #[test]
-    fn tools_list_has_eleven_tools() {
+    fn tools_list_has_thirteen_tools() {
         let r = rpc(r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#).unwrap();
         let tools = r["result"]["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 11);
+        assert_eq!(tools.len(), 13);
         // The Phase 2b semantic tool is advertised.
         assert!(tools.iter().any(|t| t["name"] == "search_semantic"));
         // The Phase 5a open-commitments rollup tool is advertised.
@@ -1993,6 +2065,14 @@ mod tests {
         assert_eq!(
             outline["inputSchema"]["required"][0], "documentId",
             "the MCP outline tool must advertise the documentId arg (parity with the tool surface)"
+        );
+        assert!(
+            tools.iter().any(|t| t["name"] == "search_transcript"),
+            "located transcript search must be advertised"
+        );
+        assert!(
+            tools.iter().any(|t| t["name"] == "get_meeting_chapters"),
+            "chapter navigation must be advertised"
         );
     }
 
@@ -3041,6 +3121,12 @@ mod tests {
 
     #[test]
     fn host_allow_list_is_loopback_only() {
+        let production_addr = mcp_listener_addr();
+        assert_eq!(*production_addr.ip(), Ipv4Addr::LOCALHOST);
+        assert!(
+            production_addr.ip().is_loopback(),
+            "the production listener address cannot be widened by config or DNS"
+        );
         // E2: only the two exact loopback authorities are accepted.
         assert!(ALLOWED_HOSTS.contains(&"127.0.0.1:8765"));
         assert!(ALLOWED_HOSTS.contains(&"localhost:8765"));
@@ -3171,6 +3257,245 @@ mod tests {
             Value::String(VISIBILITY_RETRY_MESSAGE.into())
         );
         let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn transcript_navigation_response_gate_discards_search_and_chapters_after_relock() {
+        use crate::storage::models::{Folder, MeetingTimeline, TopicSpan};
+        use crate::transcribe::types::Segment;
+
+        const FOLDER_ID: &str = "f-nav-race";
+        const MEETING_ID: &str = "m-nav-race";
+        const TITLE: &str = "RACE_PRIVATE_TITLE";
+        const SECRET: &str = "race private transcript needle";
+        const ORDINARY_SPEECH: &str = "race private ordinary speaker";
+        const TOPIC: &str = "RACE_PRIVATE_CHAPTER";
+        const ENROLLED_NAME: &str = "RACE_PRIVATE_ENROLLED_NAME";
+
+        let db_path = crate::storage::db::unique_temp_path("murmur-mcp-nav-race", "sqlite");
+        let state = AppState::init_at(&db_path, TEST_DEK).unwrap();
+        state
+            .db
+            .insert_folder(&Folder {
+                id: FOLDER_ID.into(),
+                name: "Private navigation race".into(),
+                path: "Private navigation race".into(),
+                parent_id: None,
+                locked: false,
+                created_at: "2026-07-28T00:00:00Z".into(),
+            })
+            .unwrap();
+        seed(
+            &state.db,
+            MEETING_ID,
+            TITLE,
+            "private note",
+            Some(FOLDER_ID),
+        );
+        state
+            .db
+            .insert_segments(
+                MEETING_ID,
+                &[
+                    Segment {
+                        idx: 17,
+                        start_s: 5.0,
+                        end_s: 8.0,
+                        text: SECRET.into(),
+                        speaker: Some("others-0".into()),
+                        confidence: None,
+                    },
+                    Segment {
+                        idx: 18,
+                        start_s: 9.0,
+                        end_s: 11.0,
+                        text: ORDINARY_SPEECH.into(),
+                        speaker: Some("others".into()),
+                        confidence: None,
+                    },
+                ],
+            )
+            .unwrap();
+        state
+            .db
+            .insert_voiceprint(
+                "vp-nav-race",
+                MEETING_ID,
+                0,
+                Some(ENROLLED_NAME),
+                &[0.1, 0.2],
+                "2026-07-28T00:00:00Z",
+            )
+            .unwrap();
+        state
+            .db
+            .set_timeline_data(
+                MEETING_ID,
+                &serde_json::to_string(&MeetingTimeline {
+                    speakers: Vec::new(),
+                    topics: vec![TopicSpan {
+                        label: TOPIC.into(),
+                        start_s: 4.5,
+                        end_s: 11.5,
+                    }],
+                })
+                .unwrap(),
+            )
+            .unwrap();
+        state.db.set_folder_locked(FOLDER_ID, true, None).unwrap();
+        let gate = Arc::new(McpResponseGate::new());
+
+        let cases = [
+            (
+                "search_transcript",
+                json!({
+                    "query": "race private",
+                    "meetingId": MEETING_ID,
+                    "channel": "system"
+                }),
+                SECRET,
+            ),
+            (
+                "get_meeting_chapters",
+                json!({ "meetingId": MEETING_ID, "channel": "system" }),
+                TOPIC,
+            ),
+        ];
+        for (case_index, (name, arguments, materialized_marker)) in cases.into_iter().enumerate() {
+            {
+                let _lifecycle = state
+                    .lifecycle
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                state
+                    .unlocked_folders
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .insert(FOLDER_ID.into());
+            }
+            let context = RpcContext::from_state(&state);
+            let request = json!({
+                "jsonrpc": "2.0",
+                "id": 90 + case_index,
+                "method": "tools/call",
+                "params": { "name": name, "arguments": arguments }
+            })
+            .to_string();
+            let deadline = Instant::now() + REQUEST_DEADLINE;
+            let reply = handle_rpc(&context, &request, None, None, deadline)
+                .expect("navigation tool must produce a response");
+            match &reply {
+                RpcReply::Content(pending) => {
+                    let text = pending
+                        .outcome
+                        .as_ref()
+                        .unwrap_or_else(|error| panic!("{name} failed before relock: {error:?}"));
+                    assert!(
+                        text.contains(materialized_marker),
+                        "{name} must materialize protected content before the deterministic relock"
+                    );
+                    if name == "search_transcript" {
+                        for expected in [
+                            SECRET,
+                            ORDINARY_SPEECH,
+                            TITLE,
+                            ENROLLED_NAME,
+                            "Speaker 1",
+                            "Others",
+                            "shown=2",
+                            "total=2",
+                            "candidateMeetings",
+                            "seg 17",
+                            "seg 18",
+                            "@00:05",
+                            "@00:09",
+                            "(5.0s)",
+                            "(9.0s)",
+                            "offset ",
+                            "channel=system",
+                        ] {
+                            assert!(
+                                text.contains(expected),
+                                "search race fixture did not materialize {expected:?}: {text}"
+                            );
+                        }
+                    } else {
+                        for expected in [
+                            TOPIC,
+                            ENROLLED_NAME,
+                            "Speaker 1",
+                            "offset ",
+                            "channel=system",
+                        ] {
+                            assert!(
+                                text.contains(expected),
+                                "chapter race fixture did not materialize {expected:?}: {text}"
+                            );
+                        }
+                    }
+                }
+                RpcReply::Immediate(response) => {
+                    panic!("{name} unexpectedly bypassed the response gate: {response}")
+                }
+            }
+
+            {
+                let _lifecycle = state
+                    .lifecycle
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                state.seal_epoch.fetch_add(1, Ordering::SeqCst);
+                state
+                    .unlocked_folders
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .remove(FOLDER_ID);
+            }
+
+            let (mut client, mut server) = tcp_pair();
+            send_rpc_reply(&mut server, reply, &state, &gate, deadline);
+            drop(server);
+            let mut wire = String::new();
+            client.read_to_string(&mut wire).unwrap();
+            let (_, body) = wire.split_once("\r\n\r\n").expect("complete HTTP reply");
+            let response: Value = serde_json::from_str(body).expect("JSON-RPC response");
+            assert_eq!(
+                response["error"]["code"], VISIBILITY_RETRY_CODE,
+                "{name} must fail closed after relock: {response}"
+            );
+            let serialized = response.to_string();
+            for forbidden in [
+                SECRET,
+                ORDINARY_SPEECH,
+                TITLE,
+                TOPIC,
+                ENROLLED_NAME,
+                "Speaker 1",
+                "Others",
+                "shown=",
+                "total=",
+                "counted=",
+                "candidateMeetings",
+                "scanTruncated",
+                "[meeting:m-nav-race]",
+                "seg 17",
+                "seg 18",
+                "@00:05",
+                "@00:09",
+                "(5.0s)",
+                "(9.0s)",
+                "offset",
+                "channel=",
+            ] {
+                assert!(
+                    !serialized.contains(forbidden),
+                    "{name} leaked materialized navigation metadata after relock: {serialized}"
+                );
+            }
+        }
+
+        drop(state);
+        let _ = std::fs::remove_file(db_path);
     }
 
     #[test]
@@ -3384,6 +3709,226 @@ mod tests {
             "bounded org results exceeded the transport response cap"
         );
 
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn transcript_navigation_round_trips_through_production_listener_and_session_visibility() {
+        use crate::storage::models::{Folder, MeetingTimeline, TopicSpan};
+        use crate::transcribe::types::Segment;
+
+        const MEETING_ID: &str = "mcp-nav-private";
+        const FOLDER_ID: &str = "mcp-nav-folder";
+        const SECRET: &str = "unique navigation needle";
+
+        let db_path = crate::storage::db::unique_temp_path("murmur-mcp-nav-listener", "sqlite");
+        let state = Arc::new(AppState::init_at(&db_path, TEST_DEK).unwrap());
+        state
+            .db
+            .insert_folder(&Folder {
+                id: FOLDER_ID.into(),
+                name: "Private navigation".into(),
+                path: "Private navigation".into(),
+                parent_id: None,
+                locked: false,
+                created_at: "2026-07-28T00:00:00Z".into(),
+            })
+            .unwrap();
+        seed(
+            &state.db,
+            MEETING_ID,
+            "Private navigation meeting",
+            "private note",
+            Some(FOLDER_ID),
+        );
+        let segments = vec![
+            Segment {
+                idx: 4,
+                start_s: 2.0,
+                end_s: 3.0,
+                text: "mic lane preface".into(),
+                speaker: Some("me".into()),
+                confidence: None,
+            },
+            Segment {
+                idx: 8,
+                start_s: 5.0,
+                end_s: 8.0,
+                text: SECRET.into(),
+                speaker: Some("others".into()),
+                confidence: None,
+            },
+        ];
+        state.db.insert_segments(MEETING_ID, &segments).unwrap();
+        state
+            .db
+            .set_timeline_data(
+                MEETING_ID,
+                &serde_json::to_string(&MeetingTimeline {
+                    speakers: Vec::new(),
+                    topics: vec![TopicSpan {
+                        label: "Navigation topic".into(),
+                        start_s: 4.5,
+                        end_s: 8.5,
+                    }],
+                })
+                .unwrap(),
+            )
+            .unwrap();
+        state.db.set_folder_locked(FOLDER_ID, true, None).unwrap();
+
+        let gate = Arc::new(McpResponseGate::new());
+        let active = Arc::new(AtomicUsize::new(0));
+        let rpc_over_production_listener = |name: &str, arguments: Value| -> String {
+            let listener = TcpListener::bind(SocketAddrV4::new(MCP_BIND_IP, 0))
+                .expect("ephemeral production-loopback listener");
+            let mut client =
+                TcpStream::connect(listener.local_addr().unwrap()).expect("loopback client");
+            client
+                .set_read_timeout(Some(READ_TIMEOUT))
+                .expect("client read timeout");
+            let body = json!({
+                "jsonrpc": "2.0",
+                "id": 73,
+                "method": "tools/call",
+                "params": { "name": name, "arguments": arguments }
+            })
+            .to_string();
+            let request = format!(
+                "POST /mcp HTTP/1.1\r\nHost: localhost:8765\r\nContent-Length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            client.write_all(request.as_bytes()).unwrap();
+            client.shutdown(Shutdown::Write).unwrap();
+
+            let worker_state = Arc::clone(&state);
+            let worker_gate = Arc::clone(&gate);
+            let admission = accept_bounded_connection(
+                &listener,
+                Arc::clone(&active),
+                REQUEST_DEADLINE,
+                move |stream, deadline| {
+                    handle_connection_with_state(
+                        stream,
+                        worker_state.as_ref(),
+                        worker_gate,
+                        None,
+                        deadline,
+                    );
+                },
+                |job| {
+                    job();
+                    Ok(())
+                },
+            )
+            .expect("production listener admission");
+            assert_eq!(admission, ConnectionAdmission::Spawned);
+
+            let mut wire = String::new();
+            client.read_to_string(&mut wire).unwrap();
+            let (headers, body) = wire.split_once("\r\n\r\n").expect("complete HTTP response");
+            assert!(headers.starts_with("HTTP/1.1 200 OK"), "{headers}");
+            let payload: Value = serde_json::from_str(body).expect("JSON-RPC response");
+            payload["result"]["content"][0]["text"]
+                .as_str()
+                .unwrap_or_else(|| panic!("missing MCP text content: {payload}"))
+                .to_string()
+        };
+
+        let get_args = json!({
+            "meetingId": MEETING_ID,
+            "transcriptFormat": "structured",
+            "channel": "system",
+            "includeNote": false
+        });
+        let search_args = json!({
+            "query": "navigation needle",
+            "meetingId": MEETING_ID,
+            "channel": "system"
+        });
+        let chapters_args = json!({ "meetingId": MEETING_ID, "channel": "system" });
+
+        let locked_meeting = rpc_over_production_listener("get_meeting", get_args.clone());
+        let locked_search = rpc_over_production_listener("search_transcript", search_args.clone());
+        let locked_chapters =
+            rpc_over_production_listener("get_meeting_chapters", chapters_args.clone());
+        assert_eq!(locked_meeting, format!("No data for meeting {MEETING_ID}."));
+        assert_eq!(
+            locked_search,
+            "No transcript passages match \"navigation needle\"."
+        );
+        assert_eq!(
+            locked_chapters,
+            format!("No chapter map for meeting {MEETING_ID}.")
+        );
+        for masked in [&locked_meeting, &locked_search, &locked_chapters] {
+            assert!(
+                !masked.contains(SECRET) && !masked.contains("Navigation topic"),
+                "sealed content crossed the production connection path: {masked}"
+            );
+        }
+
+        // Mirror the final visibility transition of `unlock_folder`: the folder remains sealed on
+        // disk but becomes readable for this process session.
+        {
+            let _lifecycle = state
+                .lifecycle
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            state
+                .unlocked_folders
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .insert(FOLDER_ID.into());
+        }
+        let structured_system = "[5–8] Others: unique navigation needle";
+        let expected_range = format!("offset 0..{}", structured_system.chars().count());
+        let open_meeting = rpc_over_production_listener("get_meeting", get_args.clone());
+        let open_search = rpc_over_production_listener("search_transcript", search_args.clone());
+        let open_chapters =
+            rpc_over_production_listener("get_meeting_chapters", chapters_args.clone());
+        assert!(
+            open_meeting.contains("format=structured, channel=system")
+                && open_meeting.contains(structured_system),
+            "channel-specific get_meeting did not traverse the full connection path: {open_meeting}"
+        );
+        assert!(
+            open_search.contains("channel=system")
+                && open_search.contains(SECRET)
+                && open_search.contains(&expected_range),
+            "search offset did not address the selected production MCP channel: {open_search}"
+        );
+        assert!(
+            open_chapters.contains("channel=system")
+                && open_chapters.contains("Navigation topic")
+                && open_chapters.contains(&expected_range),
+            "chapter offset did not address the selected production MCP channel: {open_chapters}"
+        );
+
+        {
+            let _lifecycle = state
+                .lifecycle
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            state.seal_epoch.fetch_add(1, Ordering::SeqCst);
+            state
+                .unlocked_folders
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .remove(FOLDER_ID);
+        }
+        let relocked_search = rpc_over_production_listener("search_transcript", search_args);
+        assert_eq!(
+            relocked_search,
+            "No transcript passages match \"navigation needle\"."
+        );
+        assert!(
+            !relocked_search.contains(SECRET),
+            "relocked transcript leaked through the production listener: {relocked_search}"
+        );
+
+        drop(state);
         let _ = std::fs::remove_file(db_path);
     }
 
@@ -4186,7 +4731,7 @@ mod tests {
             "default must carry a timestamp token: {def}"
         );
         assert!(
-            def.contains("TRANSCRIPT (format=structured, TOTAL_CHARS:"),
+            def.contains("TRANSCRIPT (format=structured, channel=merged, TOTAL_CHARS:"),
             "the MCP default now discloses the transcript window total: {def}"
         );
 
@@ -4202,8 +4747,46 @@ mod tests {
         .unwrap();
         assert_eq!(
             plain,
-            "NOTE (TOTAL_CHARS: 1 (showing 0..1)):\nn\n[end of content]\n\nTRANSCRIPT (format=plain, TOTAL_CHARS: 15 (showing 0..15)):\nopening remarks\n[end of content]"
+            "NOTE (TOTAL_CHARS: 1 (showing 0..1)):\nn\n[end of content]\n\nTRANSCRIPT (format=plain, channel=merged, TOTAL_CHARS: 15 (showing 0..15)):\nopening remarks\n[end of content]"
         );
+        let invalid = dispatch_tool(
+            &db,
+            "get_meeting",
+            &json!({ "meetingId": "mm", "channel": "invented" }),
+            &HashSet::new(),
+        )
+        .unwrap_err();
+        assert_eq!(
+            invalid.0, -32602,
+            "invalid channel is a transport arg error"
+        );
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn mcp_transcript_search_empty_queries_are_successful_zero_hits() {
+        let (db, p) = temp_db();
+        seed(
+            &db,
+            "m-empty-query",
+            "Must stay hidden",
+            "must stay hidden too",
+            None,
+        );
+        for query in ["", " \t\n "] {
+            let out = dispatch_tool(
+                &db,
+                "search_transcript",
+                &json!({ "query": query, "meetingId": "m-empty-query" }),
+                &HashSet::new(),
+            )
+            .expect("MCP empty query must not become a JSON-RPC argument error");
+            assert_eq!(out, "No transcript passages match \"\".");
+            assert!(
+                !out.contains("m-empty-query") && !out.contains("Must stay hidden"),
+                "scoped empty query disclosed meeting existence: {out}"
+            );
+        }
         let _ = std::fs::remove_file(&p);
     }
 

--- a/src-tauri/src/orchestrate.rs
+++ b/src-tauri/src/orchestrate.rs
@@ -232,6 +232,11 @@ fn tool_label(call: &ToolCall) -> &'static str {
         ToolCall::KnowledgeDiff { .. } => "Knowledge diff",
         ToolCall::GetOpenCommitments { .. } => "Open commitments",
         ToolCall::GetMeeting { .. } => "Meeting",
+        // MCP-only variants: `map_to_tool_call` never constructs these. Exhaustive labels keep the
+        // transport enum compile-safe without admitting transcript payloads to this cloud-capable
+        // note-orchestration corpus.
+        ToolCall::SearchTranscript { .. } => "Transcript matches",
+        ToolCall::GetMeetingChapters { .. } => "Meeting chapters",
         ToolCall::GetDocument { .. } => "Document",
         // Brain v3 audit Fix 3(b) — the document outline (structural map; explicit tool).
         ToolCall::GetDocumentOutline { .. } => "Document outline",
@@ -362,6 +367,20 @@ mod tests {
         AppConfig {
             provider_id: "anthropic".to_string(),
             ..Default::default()
+        }
+    }
+
+    #[test]
+    fn transcript_navigation_is_not_admitted_to_cloud_capable_note_orchestration() {
+        for tool in ["search_transcript", "get_meeting_chapters"] {
+            assert!(
+                map_to_tool_call(&RetrievalQuery {
+                    tool: tool.to_string(),
+                    query: "private transcript".into(),
+                })
+                .is_none(),
+                "{tool} is MCP-only and must not enter the provider-bound corpus"
+            );
         }
     }
 

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -15,12 +15,17 @@ use crate::error::{AppError, Result};
 use crate::events::{StatusPayload, EVENT_STATUS};
 use crate::settings::AppConfig;
 use crate::state::AppState;
-use crate::storage::models::{MeetingStatus, NoteRecord};
+use crate::storage::models::{MeetingStatus, NoteRecord, StoredTranscriptSegment};
 use crate::summarize::provider::{MeetingMeta, SummarizeRequest};
 use crate::summarize::roles::Role;
 use crate::summarize::{provider_for, template};
 use crate::transcribe::{self, Transcriber};
 use crate::{audio, export};
+
+type AsrDiarizeOutput = (
+    crate::audio::merge::EchoClassifiedSegments,
+    Vec<crate::transcribe::diarize::ClusterVoiceprint>,
+);
 
 pub struct PipelineResult {
     pub note_markdown: String,
@@ -1739,18 +1744,15 @@ async fn run_inner(
     // `with_stage_watchdog` for why the timeout does NOT kill the underlying blocking compute.
     let asr_watchdog = asr_watchdog_bound(duration_s);
     let asr_diarize_started = std::time::Instant::now();
-    let (merged_segments, echo_suppressed, cluster_voiceprints) = with_stage_watchdog(
+    let (classified_transcript, cluster_voiceprints) =
+        with_stage_watchdog(
         asr_watchdog,
         "asr_diarize",
         crate::perf::run_heavy_maybe_recording(
             &state.heavy_inference,
             None,
             crate::perf::ResidentModelKind::Whisper,
-            move || -> Result<(
-                Vec<crate::transcribe::types::Segment>,
-                usize,
-                Vec<crate::transcribe::diarize::ClusterVoiceprint>,
-            )> {
+            move || -> Result<AsrDiarizeOutput> {
         use crate::audio::merge::{merge_streams, StreamInput, SPEAKER_ME, SPEAKER_OTHERS};
 
         let transcriber = Transcriber::load(&model_path_owned)?;
@@ -1842,11 +1844,12 @@ async fn run_inner(
 
         // Anchor each stream's segments to its capture-start host instant → absolute timeline,
         // merge sorted by absolute start, drop empty (e.g. muted-mic) segments, label "me"/"others" —
-        // then drop mic-echo copies of others' speech (speakers → mic bleed; leak-gated). `leak` is
-        // Copy, captured by this move closure.
-        let (merged, echo_suppressed) =
-            crate::audio::merge::suppress_cross_stream_echo(merge_streams(streams), leak.as_ref());
-                Ok((merged, echo_suppressed, cluster_voiceprints))
+        // classify mic-echo copies of others' speech (speakers → mic bleed; leak-gated). Every raw
+        // capture row remains in storage with explicit provenance; only the merged presentation and
+        // summarizer projection omit a measured echo copy. `leak` is Copy, captured by this closure.
+        let classified =
+            crate::audio::merge::classify_cross_stream_echo(merge_streams(streams), leak.as_ref());
+                Ok((classified, cluster_voiceprints))
             },
         ),
     )
@@ -1889,16 +1892,20 @@ async fn run_inner(
     }
 
     if has_system {
-        tracing::info!(target: "transcribe", segments = merged_segments.len(), "merged mic + system streams (me/others)");
+        tracing::info!(target: "transcribe", segments = classified_transcript.merged.len(), "merged mic + system streams (me/others)");
     }
 
     // ATOMIC replace (delete + insert in one tx), not a keyed `INSERT OR REPLACE`: a fresh meeting
     // is byte-identical (nothing to delete), but a RE-RUN of the pipeline over the same meeting
     // (`retry_transcription` / disk salvage after a partial prior run) must not leave a stale
     // higher-idx tail from the previous transcript interleaved into the new one.
-    state.db.replace_segments(meeting_id, &merged_segments)?;
+    // This seam also builds the summarizer feed from the classifier's CLEANED projection. Keeping
+    // persistence and feed construction together prevents a future refactor from feeding the raw
+    // stored rows (including a leak-qualified mic echo) to the summarizer.
+    let (feed, echo_suppressed) =
+        persist_classified_transcript(&state.db, meeting_id, classified_transcript)?;
     if echo_suppressed > 0 {
-        tracing::info!(target: "transcribe", suppressed = echo_suppressed, "cross-stream echo segments removed");
+        tracing::info!(target: "transcribe", suppressed = echo_suppressed, "cross-stream echo segments marked and hidden from merged transcript");
         let _ = app.emit(
             crate::events::EVENT_ECHO_SUPPRESSED,
             crate::events::EchoSuppressedPayload {
@@ -1919,7 +1926,6 @@ async fn run_inner(
     // text`, the exact shape the timeline already consumes) when the meeting has ≥2 distinct speakers
     // — so the note can attribute owners/decisions — and stays byte-identical flat text for the
     // default solo-`me` meeting. `retrieval_text` is always the flat join (RAG query unchanged).
-    let feed = build_transcript_feed(&merged_segments);
 
     if feed.summary_text.trim().is_empty() {
         return Err(AppError::Transcribe(
@@ -2092,6 +2098,37 @@ pub(crate) fn build_transcript_feed(
         labeled,
         diarized_others,
     }
+}
+
+/// Persist the classifier's raw capture rows with explicit echo provenance, then build the
+/// summarizer feed only from its cleaned merged projection.
+///
+/// This is the production seam between leak classification, canonical storage, and model input.
+/// Keeping the two projections in one typed value makes it impossible for the caller to persist
+/// only the cleaned rows or accidentally summarize the raw echo-bearing rows.
+fn persist_classified_transcript(
+    db: &crate::storage::Db,
+    meeting_id: &str,
+    classified: crate::audio::merge::EchoClassifiedSegments,
+) -> Result<(TranscriptFeed, usize)> {
+    let crate::audio::merge::EchoClassifiedSegments {
+        stored,
+        merged,
+        suppressed_indices,
+    } = classified;
+    let echo_suppressed = suppressed_indices.len();
+    let suppressed_indices = suppressed_indices
+        .into_iter()
+        .collect::<std::collections::HashSet<_>>();
+    let stored = stored
+        .into_iter()
+        .map(|segment| StoredTranscriptSegment {
+            echo_suppressed: suppressed_indices.contains(&segment.idx),
+            segment,
+        })
+        .collect::<Vec<_>>();
+    db.replace_segments_with_echo_provenance(meeting_id, &stored)?;
+    Ok((build_transcript_feed(&merged), echo_suppressed))
 }
 
 /// Resolve the summarize step's (config, NOTES provider) from the LIVE state — the egress
@@ -3913,6 +3950,58 @@ mod tests {
         }
     }
 
+    /// The real post-ASR seam must keep the two projections distinct: leak-qualified echo remains
+    /// available in canonical raw storage with provenance, while the exact feed handed to the
+    /// summarizer contains only the cleaned merged projection.
+    #[test]
+    fn classified_echo_persists_both_raw_rows_but_builds_cleaned_summary_feed() {
+        let db_path = temp_db_path("classified-echo-seam");
+        let db = crate::storage::Db::open_with_key(&db_path, TEST_DEK).unwrap();
+        db.insert_meeting(&guard_test_meeting("m-classified-echo"))
+            .unwrap();
+        let phrase = "the contract is now signed by both parties";
+        let classified = crate::audio::merge::classify_cross_stream_echo(
+            vec![
+                seg(11, 5.0, 7.0, Some("others"), phrase),
+                seg(29, 5.4, 7.3, Some("me"), phrase),
+            ],
+            Some(&crate::audio::align::EchoLeak {
+                offset_s: 0.4,
+                correlation: 0.9,
+            }),
+        );
+        assert_eq!(
+            classified.suppressed_indices,
+            vec![29],
+            "measured leak evidence marks only the mic echo"
+        );
+
+        let (feed, suppressed) =
+            persist_classified_transcript(&db, "m-classified-echo", classified).unwrap();
+        assert_eq!(suppressed, 1);
+
+        let stored = db
+            .get_segments_with_echo_provenance("m-classified-echo")
+            .unwrap();
+        assert_eq!(stored.len(), 2, "both raw capture rows remain canonical");
+        assert_eq!(stored[0].segment.idx, 11);
+        assert_eq!(stored[0].segment.speaker.as_deref(), Some("others"));
+        assert!(!stored[0].echo_suppressed);
+        assert_eq!(stored[1].segment.idx, 29);
+        assert_eq!(stored[1].segment.speaker.as_deref(), Some("me"));
+        assert!(stored[1].echo_suppressed);
+
+        assert_eq!(
+            feed.summary_text, phrase,
+            "the production summarizer input contains only the cleaned system copy"
+        );
+        assert_eq!(feed.retrieval_text, phrase);
+        assert_eq!(feed.summary_text.matches(phrase).count(), 1);
+
+        drop(db);
+        let _ = std::fs::remove_file(db_path);
+    }
+
     /// The default mono-`me` meeting (one distinct label, incl. `None`→`me`): NOT labeled;
     /// `summary_text` == `retrieval_text` == the exact legacy flat join. Guards no-regression on the
     /// artifact 100% of users read. RED on any change that tags a single-speaker meeting.
@@ -3966,8 +4055,20 @@ mod tests {
     fn feed_diarized_others_tracks_lane_shape_not_speaker_count() {
         // Collapsed: mic + one merged remote lane — the shape that produced the bad note.
         let collapsed = build_transcript_feed(&[
-            seg(0, 0.0, 2.0, Some("me"), "so what do we do about the migration"),
-            seg(1, 2.0, 6.0, Some("others"), "Anna, can you take the walkthrough"),
+            seg(
+                0,
+                0.0,
+                2.0,
+                Some("me"),
+                "so what do we do about the migration",
+            ),
+            seg(
+                1,
+                2.0,
+                6.0,
+                Some("others"),
+                "Anna, can you take the walkthrough",
+            ),
             seg(2, 6.0, 9.0, Some("others"), "sure, I'll do it"),
         ]);
         assert!(collapsed.labeled, "still labeled — 2 distinct tags");
@@ -3978,7 +4079,13 @@ mod tests {
 
         // Diarized: the remote side really was split per-voice.
         let diarized = build_transcript_feed(&[
-            seg(0, 0.0, 2.0, Some("me"), "so what do we do about the migration"),
+            seg(
+                0,
+                0.0,
+                2.0,
+                Some("me"),
+                "so what do we do about the migration",
+            ),
             seg(1, 2.0, 6.0, Some("others-0"), "I'll take the walkthrough"),
             seg(2, 6.0, 9.0, Some("others-1"), "I'd rather we wait"),
         ]);

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -13,8 +13,9 @@ use crate::storage::models::{
     Analytics, BacklinkSource, Commitment, CorrectionRecord, DayCount, DocChunkHit,
     DocOutlineEntry, DocumentInfo, DocumentSummary, EntityKind, GraphNode, Meeting,
     MeetingActionSummary, MeetingStatus, NoteCitation, NoteTemplate, NoteTemplateSection,
-    PendingShareAccept, PeopleList, PersonCard, PropertyKind, PropertyValue, RecipeRecord, SavedView,
-    SearchHit, StatusCount,
+    PendingShareAccept, PeopleList, PersonCard, PropertyKind, PropertyValue, RecipeRecord,
+    SavedView, SearchHit, StatusCount, StoredTranscriptSegment, TranscriptSegmentHit,
+    VisibleSpeakerLabel,
 };
 use crate::transcribe::types::Segment;
 
@@ -376,6 +377,7 @@ impl Db {
                start_s REAL NOT NULL,
                end_s REAL NOT NULL,
                text TEXT NOT NULL,
+               echo_suppressed INTEGER NOT NULL DEFAULT 0,
                PRIMARY KEY (meeting_id, idx),
                FOREIGN KEY (meeting_id) REFERENCES meetings(id) ON DELETE CASCADE
              );
@@ -653,6 +655,15 @@ impl Db {
         // pattern) — NULL for legacy rows transcribed before dual-stream, which read back as
         // `speaker: None` (unattributed). NOT per-remote-person diarization; see types::Segment.
         Self::add_column_if_missing(&conn, "segments", "speaker", "TEXT")?;
+        // Explicit presentation-only echo provenance. It is written only by the ingest path after
+        // measured acoustic leak evidence. Legacy rows default visible; read-time renderers never
+        // infer this flag from text or timestamps.
+        Self::add_column_if_missing(
+            &conn,
+            "segments",
+            "echo_suppressed",
+            "INTEGER NOT NULL DEFAULT 0",
+        )?;
         // Phase F0 LOCK-SAFETY: link each correction-log example to the meeting it derived from, so
         // the gated reader can join meetings→folders for a visibility check and the seal/delete paths
         // can purge a sealed meeting's rows. Guarded ALTER (idempotent); NULL for legacy/unattributed
@@ -3641,7 +3652,8 @@ impl Db {
                 .map(|(i, m)| (m.id.clone(), 1.0 / (i as f64 + 1.0)))
                 .collect();
         }
-        let knn_scored = self.knn_meeting_distances(query_vec, limit, min_cosine, unlocked, range)?;
+        let knn_scored =
+            self.knn_meeting_distances(query_vec, limit, min_cosine, unlocked, range)?;
         let graph_scored: Vec<(String, f64)> = graph
             .iter()
             .enumerate()
@@ -4957,28 +4969,90 @@ impl Db {
         Ok(())
     }
 
+    /// Atomically persist every raw capture-lane row plus explicit ingest-time echo provenance.
+    ///
+    /// The provenance bit affects only the default merged presentation. Raw mic/system readers
+    /// retain every row and stable raw index. Callers without measured acoustic evidence continue
+    /// using [`Self::replace_segments`], whose omitted column resets to the legacy-safe default 0.
+    pub fn replace_segments_with_echo_provenance(
+        &self,
+        meeting_id: &str,
+        segments: &[StoredTranscriptSegment],
+    ) -> Result<()> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        tx.execute(
+            "DELETE FROM segments WHERE meeting_id = ?1",
+            rusqlite::params![meeting_id],
+        )
+        .map_err(map_err)?;
+        {
+            let mut stmt = tx
+                .prepare(
+                    "INSERT INTO segments
+                       (meeting_id, idx, start_s, end_s, text, speaker, confidence, echo_suppressed)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                )
+                .map_err(map_err)?;
+            for stored in segments {
+                let segment = &stored.segment;
+                stmt.execute(rusqlite::params![
+                    meeting_id,
+                    segment.idx,
+                    segment.start_s,
+                    segment.end_s,
+                    segment.text,
+                    segment.speaker,
+                    segment.confidence,
+                    i64::from(stored.echo_suppressed),
+                ])
+                .map_err(map_err)?;
+            }
+        }
+        tx.commit().map_err(map_err)?;
+        Ok(())
+    }
+
     // `delete_unsealed_segments` moved to `storage::seal_store` (God-file split) — still callable as inherent `db.method()` cross-file.
 
     /// All segments for a meeting, ordered by `idx`.
     pub fn get_segments(&self, meeting_id: &str) -> Result<Vec<Segment>> {
+        Ok(self
+            .get_segments_with_echo_provenance(meeting_id)?
+            .into_iter()
+            .map(|stored| stored.segment)
+            .collect())
+    }
+
+    /// All raw stored segment rows plus their explicit ingest-time echo provenance.
+    ///
+    /// The additive column defaults to false for every legacy row. This reader is intentionally
+    /// ungated like `get_segments`; callers must first pass the meeting visibility boundary.
+    pub fn get_segments_with_echo_provenance(
+        &self,
+        meeting_id: &str,
+    ) -> Result<Vec<StoredTranscriptSegment>> {
         let conn = self.lock();
         let mut stmt = conn
             .prepare(
-                "SELECT idx, start_s, end_s, text, speaker, confidence
+                "SELECT idx, start_s, end_s, text, speaker, confidence, echo_suppressed
                    FROM segments WHERE meeting_id = ?1 ORDER BY idx",
             )
             .map_err(map_err)?;
         let rows = stmt
             .query_map(rusqlite::params![meeting_id], |row| {
-                Ok(Segment {
-                    idx: row.get(0)?,
-                    start_s: row.get(1)?,
-                    end_s: row.get(2)?,
-                    text: row.get(3)?,
-                    // NULL (legacy / unattributed rows) → None.
-                    speaker: row.get(4)?,
-                    // NULL (legacy / Fast-path rows) → None; a stored REAL → Some(f32).
-                    confidence: row.get(5)?,
+                Ok(StoredTranscriptSegment {
+                    segment: Segment {
+                        idx: row.get(0)?,
+                        start_s: row.get(1)?,
+                        end_s: row.get(2)?,
+                        text: row.get(3)?,
+                        // NULL (legacy / unattributed rows) → None.
+                        speaker: row.get(4)?,
+                        // NULL (legacy / Fast-path rows) → None; a stored REAL → Some(f32).
+                        confidence: row.get(5)?,
+                    },
+                    echo_suppressed: row.get::<_, i64>(6)? != 0,
                 })
             })
             .map_err(map_err)?;
@@ -5020,6 +5094,38 @@ impl Db {
         )
         .optional()
         .map_err(map_err)
+    }
+
+    /// Visibility-gated timeline read for MCP chapter navigation.
+    ///
+    /// Topic labels and speaker names are derived note content. The plaintext timeline being
+    /// blanked on seal is only defense-in-depth; this query independently applies the same meeting
+    /// visibility predicate as search and `get_meeting`. Locked and absent meetings both return
+    /// `None`, so the caller cannot turn chapter availability into an existence oracle.
+    pub fn get_timeline_data_visible(
+        &self,
+        meeting_id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Option<String>> {
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let sql = format!(
+            "SELECT t.data
+               FROM timelines t
+               JOIN meetings m ON m.id = t.meeting_id
+              WHERE m.id = ?1
+                AND (
+                      NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+                   OR EXISTS (
+                        SELECT 1 FROM notes n
+                         LEFT JOIN folders f ON f.id = n.folder_id
+                         WHERE n.meeting_id = m.id AND {visible}
+                      )
+                    )"
+        );
+        conn.query_row(&sql, rusqlite::params![meeting_id], |row| row.get(0))
+            .optional()
+            .map_err(map_err)
     }
 
     pub fn set_timeline_data(&self, meeting_id: &str, data: &str) -> Result<()> {
@@ -5690,6 +5796,143 @@ impl Db {
         self.search_visible_impl(query, limit, unlocked, None)
     }
 
+    /// Visibility-gated transcript FTS hits that retain their stored segment id.
+    ///
+    /// Unlike `search_visible_impl`, this does not collapse a meeting to one snippet. It first
+    /// applies the persisted channel predicate before selecting at most `max_meetings` recent
+    /// visible meetings with a transcript match, then returns at most `max_segments` matching
+    /// segment ids inside those meetings. Independent `max_meetings + 1` and `max_segments + 1`
+    /// sentinels report meeting-set and raw-row truncation. The tool layer joins those ids against
+    /// the canonical channel projection and must disclose either bound rather than presenting a
+    /// bounded post-projection count as the corpus-wide total.
+    pub(crate) fn search_transcript_segments_visible(
+        &self,
+        query: &str,
+        meeting_id: Option<&str>,
+        channel: crate::audio::merge::RenderChannel,
+        max_meetings: i64,
+        max_segments: usize,
+        unlocked: &HashSet<String>,
+    ) -> Result<(Vec<TranscriptSegmentHit>, bool, bool)> {
+        let Some(and_expr) = fts_match_query(query.trim()) else {
+            return Ok((Vec::new(), false, false));
+        };
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let channel_filter = match channel {
+            crate::audio::merge::RenderChannel::Merged => "AND s.echo_suppressed = 0",
+            crate::audio::merge::RenderChannel::Mic => "AND s.speaker = 'me'",
+            crate::audio::merge::RenderChannel::System => {
+                crate::audio::merge::SYSTEM_SPEAKER_SQL_PREDICATE
+            }
+        };
+        let scope = if meeting_id.is_some() {
+            "AND m.id = :meeting_id"
+        } else {
+            ""
+        };
+        let sql = format!(
+            "WITH segment_hits(rid, meeting_id, idx) AS (
+                 SELECT s.rowid, s.meeting_id, s.idx
+                   FROM fts_segments
+                   JOIN segments s ON s.rowid = fts_segments.rowid
+                  WHERE fts_segments MATCH :query
+                    AND s.text <> ''
+                    {channel_filter}
+             ),
+             candidate_visible_hit_meetings(id, started_at) AS (
+                 SELECT m.id, m.started_at
+                   FROM segment_hits h
+                   JOIN meetings m ON m.id = h.meeting_id
+                  WHERE (
+                          NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+                       OR EXISTS (
+                            SELECT 1 FROM notes n
+                             LEFT JOIN folders f ON f.id = n.folder_id
+                             WHERE n.meeting_id = m.id AND {visible}
+                          )
+                        )
+                    {scope}
+                  GROUP BY m.id, m.started_at
+                  ORDER BY m.started_at DESC, m.id DESC
+                  LIMIT :meeting_probe_limit
+             ),
+             visible_hit_meetings(id, started_at) AS (
+                 SELECT id, started_at
+                   FROM candidate_visible_hit_meetings
+                  ORDER BY started_at DESC, id DESC
+                  LIMIT :max_meetings
+             )
+             SELECT s.meeting_id,
+                    COALESCE(m.title, '(untitled)'),
+                    s.idx,
+                    (
+                      SELECT COUNT(*) > :max_meetings
+                        FROM candidate_visible_hit_meetings
+                    )
+               FROM segment_hits h
+               JOIN visible_hit_meetings vm ON vm.id = h.meeting_id
+               JOIN segments s ON s.rowid = h.rid
+               JOIN meetings m ON m.id = s.meeting_id
+              ORDER BY vm.started_at DESC, s.meeting_id ASC, s.idx ASC
+              LIMIT :row_probe_limit"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let map_row = |row: &rusqlite::Row<'_>| {
+            Ok((
+                TranscriptSegmentHit {
+                    meeting_id: row.get(0)?,
+                    meeting_title: row.get(1)?,
+                    seg_idx: row.get(2)?,
+                },
+                row.get::<_, i64>(3)? != 0,
+            ))
+        };
+        let max_meetings = max_meetings.clamp(1, 20);
+        let meeting_probe_limit = max_meetings.saturating_add(1);
+        let max_segments = max_segments.clamp(1, 5_000);
+        let row_probe_limit = i64::try_from(max_segments.saturating_add(1)).unwrap_or(5_001);
+        let rows = match meeting_id {
+            Some(mid) => stmt
+                .query_map(
+                    rusqlite::named_params! {
+                        ":query": and_expr,
+                        ":meeting_id": mid,
+                        ":meeting_probe_limit": meeting_probe_limit,
+                        ":max_meetings": max_meetings,
+                        ":row_probe_limit": row_probe_limit,
+                    },
+                    map_row,
+                )
+                .map_err(map_err)?
+                .collect::<std::result::Result<Vec<_>, _>>(),
+            None => stmt
+                .query_map(
+                    rusqlite::named_params! {
+                        ":query": and_expr,
+                        ":meeting_probe_limit": meeting_probe_limit,
+                        ":max_meetings": max_meetings,
+                        ":row_probe_limit": row_probe_limit,
+                    },
+                    map_row,
+                )
+                .map_err(map_err)?
+                .collect::<std::result::Result<Vec<_>, _>>(),
+        };
+        let mut rows = rows.map_err(map_err)?;
+        let meeting_truncated = rows
+            .first()
+            .map(|(_, meeting_truncated)| *meeting_truncated)
+            .unwrap_or(false);
+        let raw_rows_truncated = rows.len() > max_segments;
+        rows.truncate(max_segments);
+        Ok((
+            rows.into_iter().map(|(hit, _)| hit).collect(),
+            meeting_truncated,
+            raw_rows_truncated,
+        ))
+    }
+
     /// Brain v2 L1.5 — [`Self::search_visible`] with an optional `started_at` window
     /// (`(from_iso, to_iso_exclusive)`, from `summarize::temporal`). TEMPORAL FALLBACK: when a
     /// window is present and the lexical FTS match finds nothing inside it (the common shape of a
@@ -6229,7 +6472,8 @@ impl Db {
                 if let Some(want) = owner_lc.as_deref() {
                     match item.owner.as_deref() {
                         Some(o)
-                            if crate::summarize::action_items::normalize_owner(o).to_lowercase()
+                            if crate::summarize::action_items::normalize_owner(o)
+                                .to_lowercase()
                                 == want => {}
                         _ => continue,
                     }
@@ -6633,6 +6877,58 @@ impl Db {
             });
         }
         Ok(out)
+    }
+
+    /// Visibility-gated speaker names for one meeting, without loading biometric embeddings.
+    ///
+    /// A voiceprint label is personal content. This query applies the same meeting gate as the full
+    /// voiceprint reader and returns only the latest non-empty label for each cluster. The MCP
+    /// transcript renderer never needs, reads, or serializes the CAM++ embedding blob.
+    pub fn list_visible_speaker_labels_for_meeting(
+        &self,
+        meeting_id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Vec<VisibleSpeakerLabel>> {
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let sql = format!(
+            "SELECT vp.cluster_index, vp.label
+               FROM speaker_voiceprints vp
+               JOIN meetings m ON m.id = vp.meeting_id
+              WHERE vp.meeting_id = ?1
+                AND TRIM(COALESCE(vp.label, '')) <> ''
+                AND NOT EXISTS (
+                      SELECT 1
+                        FROM speaker_voiceprints newer
+                       WHERE newer.meeting_id = vp.meeting_id
+                         AND newer.cluster_index = vp.cluster_index
+                         AND TRIM(COALESCE(newer.label, '')) <> ''
+                         AND (
+                              newer.created_at > vp.created_at
+                           OR (newer.created_at = vp.created_at AND newer.id > vp.id)
+                         )
+                    )
+                AND (
+                      NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+                   OR EXISTS (
+                        SELECT 1 FROM notes n
+                         LEFT JOIN folders f ON f.id = n.folder_id
+                         WHERE n.meeting_id = m.id AND {visible}
+                      )
+                    )
+              ORDER BY vp.cluster_index ASC"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![meeting_id], |row| {
+                Ok(VisibleSpeakerLabel {
+                    cluster_index: row.get(0)?,
+                    label: row.get(1)?,
+                })
+            })
+            .map_err(map_err)?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(map_err)
     }
 
     /// ENROLL (Phase 2): bind a person `label` to the voiceprint of ONE diarized cluster of
@@ -7449,6 +7745,199 @@ fn excerpt(text: &str, q: &str) -> String {
         s.push('…');
     }
     s
+}
+
+#[cfg(test)]
+mod echo_provenance_regression_tests {
+    use super::*;
+
+    fn mem_db() -> Db {
+        register_vec_extension();
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+        let db = Db {
+            conn: Mutex::new(conn),
+        };
+        db.migrate().unwrap();
+        db
+    }
+
+    fn meeting(id: &str) -> Meeting {
+        Meeting {
+            id: id.to_string(),
+            started_at: "2026-07-29T09:00:00Z".to_string(),
+            ended_at: None,
+            title: Some("Echo provenance regression".to_string()),
+            duration_s: 60,
+            audio_path: None,
+            status: MeetingStatus::Transcribed,
+            folder_id: None,
+        }
+    }
+
+    fn stored(
+        idx: i64,
+        start_s: f64,
+        end_s: f64,
+        text: &str,
+        speaker: Option<&str>,
+        confidence: Option<f32>,
+        echo_suppressed: bool,
+    ) -> StoredTranscriptSegment {
+        StoredTranscriptSegment {
+            segment: Segment {
+                idx,
+                start_s,
+                end_s,
+                text: text.to_string(),
+                speaker: speaker.map(str::to_string),
+                confidence,
+            },
+            echo_suppressed,
+        }
+    }
+
+    fn canonical_stored(rows: &[StoredTranscriptSegment]) -> Vec<u8> {
+        serde_json::to_vec(rows).expect("stored transcript rows serialize")
+    }
+
+    #[test]
+    fn echo_provenance_round_trips_exact_sparse_rows_in_idx_order() {
+        let db = mem_db();
+        db.insert_meeting(&meeting("m-echo-roundtrip")).unwrap();
+        let rows = vec![
+            stored(
+                42,
+                90_001.125,
+                90_004.875,
+                "Zażółć gęślą jaźń 🫧",
+                None,
+                None,
+                true,
+            ),
+            stored(
+                3,
+                0.000_976_562_5,
+                1.234_567_890_125,
+                "先に届いた system row",
+                Some("remote-custom"),
+                Some(0.8125),
+                false,
+            ),
+            stored(
+                900,
+                123_456.789_062_5,
+                123_460.000_000_25,
+                "local sparse tail",
+                Some("me"),
+                Some(0.0),
+                false,
+            ),
+        ];
+        db.replace_segments_with_echo_provenance("m-echo-roundtrip", &rows)
+            .unwrap();
+
+        let actual = db
+            .get_segments_with_echo_provenance("m-echo-roundtrip")
+            .unwrap();
+        let expected = vec![rows[1].clone(), rows[0].clone(), rows[2].clone()];
+        assert_eq!(
+            canonical_stored(&actual),
+            canonical_stored(&expected),
+            "sparse ids, f64 timestamps, Unicode, nullable fields, ordering, and both provenance \
+             flags must round-trip exactly"
+        );
+    }
+
+    #[test]
+    fn echo_provenance_replace_rolls_back_delete_and_partial_insert_on_constraint_failure() {
+        let db = mem_db();
+        db.insert_meeting(&meeting("m-echo-rollback")).unwrap();
+        let before = vec![
+            stored(
+                7,
+                1.25,
+                2.5,
+                "original system",
+                Some("remote-custom"),
+                Some(0.75),
+                false,
+            ),
+            stored(19, 3.75, 5.5, "original marked mic", Some("me"), None, true),
+        ];
+        db.replace_segments_with_echo_provenance("m-echo-rollback", &before)
+            .unwrap();
+
+        let duplicate_idx = vec![
+            stored(
+                4,
+                10.0,
+                11.0,
+                "first fresh row",
+                Some("others"),
+                None,
+                false,
+            ),
+            stored(
+                4,
+                12.0,
+                13.0,
+                "duplicate primary key",
+                Some("me"),
+                None,
+                true,
+            ),
+        ];
+        assert!(
+            db.replace_segments_with_echo_provenance("m-echo-rollback", &duplicate_idx)
+                .is_err(),
+            "the second duplicate idx must fail after the transaction deleted and inserted once"
+        );
+
+        let after = db
+            .get_segments_with_echo_provenance("m-echo-rollback")
+            .unwrap();
+        assert_eq!(
+            canonical_stored(&after),
+            canonical_stored(&before),
+            "the failed replacement must roll back both DELETE and partial INSERT byte-exactly"
+        );
+    }
+
+    #[test]
+    fn system_search_uses_the_same_non_null_non_me_rule_as_rendering() {
+        let db = mem_db();
+        db.insert_meeting(&meeting("m-noncanonical-system"))
+            .unwrap();
+        db.replace_segments_with_echo_provenance(
+            "m-noncanonical-system",
+            &[stored(
+                8,
+                1.0,
+                2.0,
+                "noncanonical predicate sentinel",
+                Some("remote-custom"),
+                None,
+                false,
+            )],
+        )
+        .unwrap();
+
+        let (hits, meetings_truncated, rows_truncated) = db
+            .search_transcript_segments_visible(
+                "noncanonical predicate sentinel",
+                None,
+                crate::audio::merge::RenderChannel::System,
+                20,
+                100,
+                &HashSet::new(),
+            )
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].meeting_id, "m-noncanonical-system");
+        assert_eq!(hits[0].seg_idx, 8);
+        assert!(!meetings_truncated && !rows_truncated);
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -608,6 +608,44 @@ pub struct SearchHit {
     pub matched_in: String,
 }
 
+/// One visibility-gated FTS transcript match before presentation-channel projection.
+///
+/// The tool layer joins this stable stored segment id against the canonical rendered projection.
+/// That is what lets the final hit carry a character offset in the exact same coordinate system as
+/// `get_meeting`, while a `merged` projection may safely omit an echoed raw segment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TranscriptSegmentHit {
+    pub meeting_id: String,
+    pub meeting_title: String,
+    pub seg_idx: i64,
+}
+
+/// One persisted raw capture-lane segment plus explicit presentation-only echo provenance.
+///
+/// `echo_suppressed` is set only by the ingest path after measured acoustic leak evidence. Legacy
+/// rows and deserialized payloads that predate the field default to visible, so read-time rendering
+/// never guesses from text/timestamps and never hides old data.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StoredTranscriptSegment {
+    #[serde(flatten)]
+    pub segment: crate::transcribe::types::Segment,
+    #[serde(default)]
+    pub echo_suppressed: bool,
+}
+
+/// A visibility-gated enrolled speaker label without the biometric embedding.
+///
+/// Transcript rendering needs only the cluster-to-name mapping. Keeping this DTO separate from the
+/// full voiceprint row prevents a read-only text response from loading CAM++ biometric vectors.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VisibleSpeakerLabel {
+    pub cluster_index: i64,
+    pub label: String,
+}
+
 /// Lightweight metadata for one uploaded document — the FE list DTO. Carries NO text (the text is
 /// gated content surfaced only by `get_document`, never in the list). `created_at` is epoch millis.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -32,6 +32,43 @@ use crate::error::{AppError, Result};
 use crate::settings::AppConfig;
 use crate::storage::Db;
 
+/// The persisted capture-lane projection used by every transcript coordinate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TranscriptChannel {
+    Merged,
+    Mic,
+    System,
+}
+
+impl TranscriptChannel {
+    pub(crate) fn parse(value: Option<&str>) -> Result<Self> {
+        match value {
+            None | Some("") | Some("merged") => Ok(Self::Merged),
+            Some("mic") => Ok(Self::Mic),
+            Some("system") => Ok(Self::System),
+            Some(other) => Err(AppError::InvalidArg(format!(
+                "unsupported transcript channel \"{other}\"; expected merged, mic, or system"
+            ))),
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Merged => "merged",
+            Self::Mic => "mic",
+            Self::System => "system",
+        }
+    }
+
+    fn render_channel(self) -> crate::audio::merge::RenderChannel {
+        match self {
+            Self::Merged => crate::audio::merge::RenderChannel::Merged,
+            Self::Mic => crate::audio::merge::RenderChannel::Mic,
+            Self::System => crate::audio::merge::RenderChannel::System,
+        }
+    }
+}
+
 /// The BRAIN CASCADE tier a [`GatedToolExecutor`] runs at (Phase 5). It is the STRUCTURAL escalation
 /// boundary: which tools the model may reach this turn is decided by CODE (`specs()` filter +
 /// `run()` allowlist), not prompt-trust. A weak model that mis-judges scope STILL cannot reach a
@@ -141,6 +178,11 @@ pub enum ToolCall {
     GetMeeting {
         meeting_id: String,
         transcript_format: String,
+        /// Capture lane whose rendered text defines this call's offset coordinate.
+        channel: TranscriptChannel,
+        /// Enrolled names are authorized only for the local MCP presentation path. The
+        /// cloud-capable in-app executor always sets this false.
+        include_speaker_map: bool,
         /// Brain v3 PR-2 — agent PAGING: skip this many chars into the TRANSCRIPT before returning
         /// (default 0 = today's behavior). Lets the agentic loop iterate a long transcript past the
         /// per-result budget. The NOTE is always returned in full (it's short).
@@ -156,6 +198,22 @@ pub enum ToolCall {
         /// so a 19.5k note prefix consumed the ENTIRE budget and the transcript window — the thing
         /// actually asked for — was cut away entirely.
         include_note: bool,
+    },
+    /// MCP-only located lexical search inside transcript segments. Every returned offset addresses
+    /// the canonical structured projection for `channel`. Intentionally absent from [`tool_specs`]
+    /// and [`GatedToolExecutor`]: this payload cannot enter an in-app/cloud agent loop.
+    SearchTranscript {
+        query: String,
+        meeting_id: Option<String>,
+        limit: usize,
+        max_per_meeting: usize,
+        channel: TranscriptChannel,
+    },
+    /// MCP-only gated timeline topic map projected onto structured transcript character offsets.
+    /// Intentionally absent from the in-app agent catalog for the same no-egress boundary.
+    GetMeetingChapters {
+        meeting_id: String,
+        channel: TranscriptChannel,
     },
     /// The full body of one standalone note OR imported/uploaded document by id (Feature D). Gated
     /// by [`Db::get_document_if_visible`] — a sealed-and-not-session-unlocked document is invisible
@@ -300,13 +358,17 @@ pub fn tool_specs() -> Vec<ToolSpec> {
             name: "get_meeting".into(),
             description: "Fetch one meeting's AI note and full transcript by its id (from a prior \
                           search hit). For a very long transcript, page through it with offset + \
-                          maxChars.".into(),
+                          maxChars. The in-app assistant always receives the conservative merged \
+                          capture view; raw mic/system lanes are available only over local MCP."
+                .into(),
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
                     "meetingId": { "type": "string", "description": "The meeting id from a prior search result." },
+                    "transcriptFormat": { "type": "string", "enum": ["structured", "plain", "compact"], "description": "Transcript rendering (default structured)." },
                     "offset": { "type": "integer", "description": "Chars to skip into the transcript (default 0)." },
-                    "maxChars": { "type": "integer", "description": "Max transcript chars to return from offset (default all)." }
+                    "maxChars": { "type": "integer", "description": "Max transcript chars to return from offset (default all)." },
+                    "includeNote": { "type": "boolean", "description": "Include the note on the first page (default true)." }
                 },
                 "required": ["meetingId"]
             }),
@@ -660,6 +722,8 @@ pub fn execute_tool(
         ToolCall::GetMeeting {
             meeting_id,
             transcript_format,
+            channel,
+            include_speaker_map,
             offset,
             max_chars,
             include_note,
@@ -685,13 +749,18 @@ pub fn execute_tool(
                         .map(|t| format!("TITLE: [[{t}]]\n\n"))
                         .unwrap_or_default();
                     let note = db.get_note_if_visible(mid, unlocked).ok().flatten();
-                    let segs = db.get_segments(mid).unwrap_or_default();
+                    let stored = db
+                        .get_segments_with_echo_provenance(mid)
+                        .unwrap_or_default();
+                    let (segs, echo_suppressed) = split_stored_segments(stored);
+                    let projection = TranscriptProjection::new(&segs, *channel, &echo_suppressed);
                     // Feature D: DEFAULT to the STRUCTURED per-segment transcript (speaker + raw-second
                     // timestamps). `transcript_format == "plain"` keeps the LEGACY byte-identical flat
                     // space-join for backward compatibility; every other value (incl. absent/default,
                     // which the MCP/dispatch layer maps to "structured") uses the structured renderer.
                     let full_transcript = match transcript_format.as_str() {
-                        "plain" => segs
+                        "plain" => projection
+                            .segments
                             .iter()
                             .map(|s| s.text.trim())
                             .filter(|t| !t.is_empty())
@@ -700,8 +769,8 @@ pub fn execute_tool(
                         // #13 — OPT-IN compact rendering. Default stays `structured`: making
                         // compact the default would silently move every agent's offset space with
                         // no version signal to notice it by.
-                        "compact" => format_compact_transcript(&segs),
-                        _ => format_structured_transcript(&segs),
+                        "compact" => format_compact_transcript(&projection.segments),
+                        _ => projection.text.clone(),
                     };
                     // B1 — decide "no data" on the RAW content BEFORE windowing. A note-less
                     // meeting whose transcript is empty (INCLUDING a nonexistent id, which
@@ -723,11 +792,35 @@ pub fn execute_tool(
                     // offsets in one and then switches lands ~40% off target. Naming the format
                     // beside TOTAL_CHARS makes the space the offsets belong to self-describing.
                     let transcript_section = match &disclosure {
-                        Some(h) => {
-                            format!("TRANSCRIPT (format={transcript_format}, {h}):\n{transcript}")
-                        }
-                        None => format!("TRANSCRIPT (format={transcript_format}):\n{transcript}"),
+                        Some(h) => format!(
+                            "TRANSCRIPT (format={transcript_format}, channel={}, {h}):\n{transcript}",
+                            channel.as_str()
+                        ),
+                        None => format!(
+                            "TRANSCRIPT (format={transcript_format}, channel={}):\n{transcript}",
+                            channel.as_str()
+                        ),
                     };
+                    // Enrolled labels are a first-page prefix, like the note: later transcript
+                    // pages keep the exact transcript coordinate and never repeat personal names.
+                    // When paging is bounded, apply the SAME char-safe disclosure budget to this
+                    // added content instead of prepending an unbounded map outside `max_chars`.
+                    let speaker_map = if *include_speaker_map && *offset == 0 {
+                        let full_map = speaker_map_header(db, mid, &projection.lines, unlocked)?;
+                        if full_map.is_empty() || *max_chars == 0 {
+                            full_map
+                        } else {
+                            let (body, map_disclosure) =
+                                page_text_disclosed(full_map.trim_end(), 0, *max_chars);
+                            match map_disclosure {
+                                Some(h) => format!("SPEAKER MAP ({h}):\n{body}\n\n"),
+                                None => format!("{body}\n\n"),
+                            }
+                        }
+                    } else {
+                        String::new()
+                    };
+                    let transcript_section = format!("{speaker_map}{transcript_section}");
                     // E1 — the NOTE is a whole-note prefix, NOT part of the transcript window, so
                     // emit it ONLY on the first window (`offset == 0`). Paging a long transcript
                     // (`offset > 0`) must never re-ship the full note on every page.
@@ -745,13 +838,34 @@ pub fn execute_tool(
                                 Some(h) => format!("NOTE ({h}):\n{body}"),
                                 None => format!("NOTE:\n{body}"),
                             };
-                            Ok(format!("{title_line}{note_section}\n\n{transcript_section}"))
+                            Ok(format!(
+                                "{title_line}{note_section}\n\n{transcript_section}"
+                            ))
                         }
                         _ => Ok(format!("{title_line}{transcript_section}")),
                     }
                 }
             }
         }
+        ToolCall::SearchTranscript {
+            query,
+            meeting_id,
+            limit,
+            max_per_meeting,
+            channel,
+        } => format_transcript_search(
+            db,
+            query,
+            meeting_id.as_deref(),
+            *limit,
+            *max_per_meeting,
+            *channel,
+            unlocked,
+        ),
+        ToolCall::GetMeetingChapters {
+            meeting_id,
+            channel,
+        } => format_meeting_chapters(db, meeting_id, *channel, unlocked),
         ToolCall::GetDocument {
             document_id,
             offset,
@@ -856,14 +970,12 @@ pub fn execute_tool(
                 Err(e) => return Err(AppError::Storage(format!("entity resolve failed: {e}"))),
             };
             match crate::summarize::dossier::build_dossier_data(db, &id, unlocked) {
-                Ok(Some(data)) => Ok(
-                    crate::summarize::dossier::format_dossier_client_windowed(
-                        &data,
-                        note_detail,
-                        *offset,
-                        *max_chars,
-                    ),
-                ),
+                Ok(Some(data)) => Ok(crate::summarize::dossier::format_dossier_client_windowed(
+                    &data,
+                    note_detail,
+                    *offset,
+                    *max_chars,
+                )),
                 Ok(None) => Ok(format!("No visible entity matching \"{entity}\".")),
                 Err(e) => Err(AppError::Storage(format!("dossier build failed: {e}"))),
             }
@@ -1977,20 +2089,79 @@ fn speaker_label(tag: Option<&str>) -> std::borrow::Cow<'static, str> {
     }
 }
 
-fn format_structured_transcript(segs: &[crate::transcribe::types::Segment]) -> String {
-    segs.iter()
-        .filter(|s| !s.text.trim().is_empty())
-        .map(|s| {
-            format!(
-                "[{}–{}] {}: {}",
-                secs(s.start_s),
-                secs(s.end_s),
-                speaker_label(s.speaker.as_deref()),
-                s.text.trim()
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
+struct ProjectedTranscriptLine<'a> {
+    segment: &'a crate::transcribe::types::Segment,
+    speaker: String,
+    text: String,
+    start_char: usize,
+    end_char: usize,
+}
+
+/// The ONE transcript projection used by body rendering, located search, and chapter offsets.
+///
+/// Offsets count Unicode scalar values (the same unit as `page_text_disclosed`) and address the
+/// exact `structured` text returned by `get_meeting` for the stamped channel.
+struct TranscriptProjection<'a> {
+    segments: Vec<&'a crate::transcribe::types::Segment>,
+    lines: Vec<ProjectedTranscriptLine<'a>>,
+    text: String,
+}
+
+impl<'a> TranscriptProjection<'a> {
+    fn new(
+        segs: &'a [crate::transcribe::types::Segment],
+        channel: TranscriptChannel,
+        echo_suppressed: &HashSet<i64>,
+    ) -> Self {
+        let segments = crate::audio::merge::select_render_channel(
+            segs,
+            channel.render_channel(),
+            echo_suppressed,
+        );
+        let mut lines = Vec::new();
+        let mut rendered = Vec::new();
+        let mut cursor = 0usize;
+        for segment in segments
+            .iter()
+            .copied()
+            .filter(|s| !s.text.trim().is_empty())
+        {
+            let speaker = speaker_label(segment.speaker.as_deref()).into_owned();
+            let text = segment.text.trim().to_string();
+            let line = format!(
+                "[{}–{}] {speaker}: {text}",
+                secs(segment.start_s),
+                secs(segment.end_s)
+            );
+            let start_char = cursor;
+            let end_char = start_char.saturating_add(line.chars().count());
+            cursor = end_char.saturating_add(1);
+            rendered.push(line);
+            lines.push(ProjectedTranscriptLine {
+                segment,
+                speaker,
+                text,
+                start_char,
+                end_char,
+            });
+        }
+        Self {
+            segments,
+            lines,
+            text: rendered.join("\n"),
+        }
+    }
+}
+
+fn split_stored_segments(
+    stored: Vec<crate::storage::models::StoredTranscriptSegment>,
+) -> (Vec<crate::transcribe::types::Segment>, HashSet<i64>) {
+    let echo_suppressed = stored
+        .iter()
+        .filter_map(|row| row.echo_suppressed.then_some(row.segment.idx))
+        .collect();
+    let segments = stored.into_iter().map(|row| row.segment).collect();
+    (segments, echo_suppressed)
 }
 
 /// Render the transcript COMPACTLY: fold each run of consecutive same-speaker segments into ONE
@@ -2005,7 +2176,7 @@ fn format_structured_transcript(segs: &[crate::transcribe::types::Segment]) -> S
 /// not a citation source — merging runs destroys per-segment boundaries, so a compact reply must
 /// never be used to seek audio. (Nothing regresses: grounding and receipts work off typed
 /// `Segment`s, never this rendered string.)
-fn format_compact_transcript(segs: &[crate::transcribe::types::Segment]) -> String {
+fn format_compact_transcript(segs: &[&crate::transcribe::types::Segment]) -> String {
     let mut out: Vec<String> = Vec::new();
     let mut run: Option<(String, f64, f64, Vec<String>)> = None;
     for s in segs.iter().filter(|s| !s.text.trim().is_empty()) {
@@ -2039,6 +2210,360 @@ fn format_compact_transcript(segs: &[crate::transcribe::types::Segment]) -> Stri
         ));
     }
     out.join("\n")
+}
+
+fn one_line_bounded(value: &str, max_chars: usize) -> String {
+    let collapsed = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() <= max_chars {
+        collapsed
+    } else {
+        let mut out: String = collapsed
+            .chars()
+            .take(max_chars.saturating_sub(1))
+            .collect();
+        out.push('…');
+        out
+    }
+}
+
+const MAX_SPEAKER_MAP_ENTRIES: usize = 20;
+const MAX_TRANSCRIPT_SEARCH_RAW_HITS: usize = 500;
+
+/// Return a bounded one-line excerpt centered on a lexical query hit.
+///
+/// FTS selects the candidate segment, but callers need the excerpt itself to retain the evidence
+/// that caused the hit. Unicode case folding is mapped back to source scalar positions so slicing
+/// stays panic-free and uses the same character unit as transcript offsets.
+fn query_centered_excerpt(value: &str, query: &str, max_chars: usize) -> String {
+    let collapsed = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    let source = collapsed.chars().collect::<Vec<_>>();
+    if source.len() <= max_chars {
+        return collapsed;
+    }
+    if max_chars == 0 {
+        return String::new();
+    }
+
+    let mut folded = Vec::new();
+    let mut folded_to_source = Vec::new();
+    for (source_idx, ch) in source.iter().copied().enumerate() {
+        for lower in ch.to_lowercase() {
+            folded.push(lower);
+            folded_to_source.push(source_idx);
+        }
+    }
+    let folded_query = query
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+        .chars()
+        .collect::<Vec<_>>();
+    let mut needles = Vec::new();
+    if !folded_query.is_empty() {
+        needles.push(folded_query);
+    }
+    let mut terms = query
+        .split(|ch: char| !ch.is_alphanumeric())
+        .filter(|term| !term.is_empty())
+        .map(|term| term.to_lowercase().chars().collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    terms.sort_by_key(|term| std::cmp::Reverse(term.len()));
+    needles.extend(terms);
+
+    let hit = needles.iter().find_map(|needle| {
+        (needle.len() <= folded.len()).then(|| {
+            folded
+                .windows(needle.len())
+                .position(|window| window == needle)
+                .map(|start| {
+                    (
+                        folded_to_source[start],
+                        folded_to_source[start + needle.len() - 1] + 1,
+                    )
+                })
+        })?
+    });
+    let Some((hit_start, hit_end)) = hit else {
+        return one_line_bounded(&collapsed, max_chars);
+    };
+
+    // Reserve room for both truncation markers. If the centered window reaches an outer edge, the
+    // unused marker slot simply makes the excerpt one character shorter than the hard maximum.
+    let content_budget = max_chars.saturating_sub(2).max(1);
+    let hit_center = hit_start.saturating_add(hit_end.saturating_sub(hit_start) / 2);
+    let mut start = hit_center.saturating_sub(content_budget / 2);
+    start = start.min(source.len().saturating_sub(content_budget));
+    let mut end = start.saturating_add(content_budget).min(source.len());
+    if hit_end.saturating_sub(hit_start) <= content_budget {
+        if start > hit_start {
+            start = hit_start;
+            end = start.saturating_add(content_budget).min(source.len());
+        }
+        if end < hit_end {
+            end = hit_end;
+            start = end.saturating_sub(content_budget);
+        }
+    }
+
+    let mut out = String::new();
+    if start > 0 {
+        out.push('…');
+    }
+    out.extend(source[start..end].iter());
+    if end < source.len() {
+        out.push('…');
+    }
+    out
+}
+
+/// Render enrolled names for only the diarized speakers present in this disclosed channel.
+///
+/// The DB reader returns labels only, never biometric embeddings, and independently applies the
+/// meeting visibility predicate. The map is intentionally outside the transcript body so it does
+/// not move the stamped character coordinate.
+fn speaker_map_header(
+    db: &Db,
+    meeting_id: &str,
+    lines: &[ProjectedTranscriptLine<'_>],
+    unlocked: &HashSet<String>,
+) -> Result<String> {
+    let rendered_clusters: HashSet<i64> = lines
+        .iter()
+        .filter_map(|line| {
+            crate::transcribe::diarize::cluster_index_of_tag(line.segment.speaker.as_deref()?, true)
+        })
+        .collect();
+    if rendered_clusters.is_empty() {
+        return Ok(String::new());
+    }
+    let mut mappings = db
+        .list_visible_speaker_labels_for_meeting(meeting_id, unlocked)?
+        .into_iter()
+        .filter(|row| rendered_clusters.contains(&row.cluster_index))
+        .filter_map(|row| {
+            let label = one_line_bounded(&row.label, 100);
+            let speaker_n = row.cluster_index.checked_add(1)?;
+            (!label.is_empty()).then_some((speaker_n, format!("- Speaker {speaker_n} = {label}")))
+        })
+        .collect::<Vec<_>>();
+    mappings.sort_by_key(|(speaker_n, _)| *speaker_n);
+    mappings.dedup_by_key(|(speaker_n, _)| *speaker_n);
+    if mappings.is_empty() {
+        Ok(String::new())
+    } else {
+        let total = mappings.len();
+        mappings.truncate(MAX_SPEAKER_MAP_ENTRIES);
+        let truncation = if total > mappings.len() {
+            format!(
+                "\n[speaker map truncated: showing {} of {total} matching enrolled labels]",
+                mappings.len()
+            )
+        } else {
+            String::new()
+        };
+        Ok(format!(
+            "SPEAKERS (enrolled names; unlisted speakers are unidentified):\n{}{truncation}\n\n",
+            mappings
+                .iter()
+                .map(|(_, mapping)| mapping.as_str())
+                .collect::<Vec<_>>()
+                .join("\n"),
+        ))
+    }
+}
+
+fn transcript_timestamp(start_s: f64) -> String {
+    let total = start_s.max(0.0).floor() as u64;
+    format!("{:02}:{:02}", total / 60, total % 60)
+}
+
+fn format_transcript_search(
+    db: &Db,
+    query: &str,
+    meeting_id: Option<&str>,
+    limit: usize,
+    max_per_meeting: usize,
+    channel: TranscriptChannel,
+    unlocked: &HashSet<String>,
+) -> Result<String> {
+    let query = query.trim();
+    if query.is_empty() {
+        return Ok("No transcript passages match \"\".".to_string());
+    }
+    let limit = limit.clamp(1, 100);
+    let max_per_meeting = max_per_meeting.clamp(1, 20);
+    let (raw_hits, candidate_meetings_truncated, raw_hits_truncated) = db
+        .search_transcript_segments_visible(
+            query,
+            meeting_id,
+            channel.render_channel(),
+            20,
+            MAX_TRANSCRIPT_SEARCH_RAW_HITS,
+            unlocked,
+        )?;
+    if raw_hits.is_empty() {
+        return Ok(format!("No transcript passages match \"{query}\"."));
+    }
+
+    let mut sections = Vec::new();
+    let mut total_matches = 0usize;
+    let mut shown = 0usize;
+    let mut cursor = 0usize;
+    while cursor < raw_hits.len() {
+        let meeting_id = raw_hits[cursor].meeting_id.clone();
+        let meeting_title = raw_hits[cursor].meeting_title.clone();
+        let start = cursor;
+        while cursor < raw_hits.len() && raw_hits[cursor].meeting_id == meeting_id {
+            cursor += 1;
+        }
+        let matching_indices: HashSet<i64> = raw_hits[start..cursor]
+            .iter()
+            .map(|hit| hit.seg_idx)
+            .collect();
+        let stored = db.get_segments_with_echo_provenance(&meeting_id)?;
+        let (segments, echo_suppressed) = split_stored_segments(stored);
+        let projection = TranscriptProjection::new(&segments, channel, &echo_suppressed);
+        let projected_hits = projection
+            .lines
+            .iter()
+            .filter(|line| matching_indices.contains(&line.segment.idx))
+            .collect::<Vec<_>>();
+        total_matches = total_matches.saturating_add(projected_hits.len());
+        if projected_hits.is_empty() || shown >= limit {
+            continue;
+        }
+
+        let mut lines = Vec::new();
+        for line in projected_hits
+            .into_iter()
+            .take(max_per_meeting)
+            .take(limit.saturating_sub(shown))
+        {
+            lines.push(format!(
+                "- offset {}..{} · @{} ({:.1}s) · seg {} · {} — {}",
+                line.start_char,
+                line.end_char,
+                transcript_timestamp(line.segment.start_s),
+                line.segment.start_s,
+                line.segment.idx,
+                line.speaker,
+                query_centered_excerpt(&line.text, query, 240)
+            ));
+            shown += 1;
+        }
+        if !lines.is_empty() {
+            let speaker_map = speaker_map_header(db, &meeting_id, &projection.lines, unlocked)?;
+            sections.push(format!(
+                "[meeting:{meeting_id}] [[{}]]\n{speaker_map}{}",
+                one_line_bounded(&meeting_title, 160),
+                lines.join("\n")
+            ));
+        }
+    }
+
+    if total_matches == 0 && !candidate_meetings_truncated && !raw_hits_truncated {
+        return Ok(format!("No transcript passages match \"{query}\"."));
+    }
+    let any_truncated = candidate_meetings_truncated || raw_hits_truncated;
+    let count_disclosure = if any_truncated {
+        format!(
+            "shown={shown}, counted={total_matches}, candidateMeetings<=20, \
+             candidateMeetingsTruncated={candidate_meetings_truncated}, \
+             rawCandidatesScanned={}, scanTruncated={raw_hits_truncated}, exactTotal=false",
+            raw_hits.len(),
+        )
+    } else {
+        format!(
+            "shown={shown}, total={total_matches}, candidateMeetings<=20, \
+             candidateMeetingsTruncated=false, rawCandidatesScanned={}, \
+             scanTruncated=false, exactTotal=true",
+            raw_hits.len(),
+        )
+    };
+    let count_explanation = if candidate_meetings_truncated && raw_hits_truncated {
+        "counted is exact after selected-channel projection only within both bounded candidate \
+         meetings and the bounded raw-row scan; additional selected-channel meetings and raw \
+         candidates were not evaluated."
+    } else if candidate_meetings_truncated {
+        "counted is exact after selected-channel projection only within the bounded candidate \
+         meetings; additional selected-channel meetings were not evaluated."
+    } else if raw_hits_truncated {
+        "counted is exact after channel projection only within the bounded raw-candidate scan; \
+         undisclosed raw candidates were not evaluated."
+    } else {
+        "Counts are exact after channel projection within the bounded candidate-meeting set."
+    };
+    let sections = if sections.is_empty() {
+        "No passages from the bounded raw-candidate scan survive the selected channel projection."
+            .to_string()
+    } else {
+        sections.join("\n\n")
+    };
+    Ok(format!(
+        "TRANSCRIPT SEARCH (format=structured, channel={}, {count_disclosure})\n\
+         {count_explanation}\n\n{sections}",
+        channel.as_str(),
+    ))
+}
+
+fn format_meeting_chapters(
+    db: &Db,
+    meeting_id: &str,
+    channel: TranscriptChannel,
+    unlocked: &HashSet<String>,
+) -> Result<String> {
+    let Some(raw_timeline) = db.get_timeline_data_visible(meeting_id, unlocked)? else {
+        // Keep sealed and absent meetings indistinguishable. A visible meeting without a generated
+        // timeline may disclose only that the derived map is unavailable.
+        return match db.meeting_is_visible(meeting_id, unlocked)?
+            && db.get_meeting(meeting_id)?.is_some()
+        {
+            true => Ok(format!(
+                "No chapter map has been generated for meeting {meeting_id}."
+            )),
+            false => Ok(format!("No chapter map for meeting {meeting_id}.")),
+        };
+    };
+    let timeline: crate::storage::models::MeetingTimeline = serde_json::from_str(&raw_timeline)
+        .map_err(|_| AppError::Storage("meeting chapter map is unavailable".into()))?;
+    let stored = db.get_segments_with_echo_provenance(meeting_id)?;
+    let (segments, echo_suppressed) = split_stored_segments(stored);
+    let projection = TranscriptProjection::new(&segments, channel, &echo_suppressed);
+    if timeline.topics.is_empty() {
+        return Ok(format!(
+            "CHAPTERS (format=structured, channel={}):\nNo recorded chapters.",
+            channel.as_str()
+        ));
+    }
+
+    let mut rows = Vec::new();
+    for topic in timeline.topics {
+        let overlaps = projection
+            .lines
+            .iter()
+            .filter(|line| line.segment.end_s > topic.start_s && line.segment.start_s < topic.end_s)
+            .collect::<Vec<_>>();
+        let prefix = format!(
+            "- [{}–{}] {}",
+            secs(topic.start_s),
+            secs(topic.end_s),
+            one_line_bounded(&topic.label, 200)
+        );
+        match (overlaps.first(), overlaps.last()) {
+            (Some(first), Some(last)) => rows.push(format!(
+                "{prefix} · offset {}..{}",
+                first.start_char, last.end_char
+            )),
+            _ => rows.push(prefix),
+        }
+    }
+    let speaker_map = speaker_map_header(db, meeting_id, &projection.lines, unlocked)?;
+    Ok(format!(
+        "CHAPTERS (format=structured, channel={}):\n{speaker_map}{}",
+        channel.as_str(),
+        rows.join("\n")
+    ))
 }
 
 /// Render a list of search hits (FTS or hybrid) into the tool text payload — one line per meeting.
@@ -2198,12 +2723,8 @@ impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
             .filter(|s| scope.allows(&s.name))
             .filter(|s| match s.name.as_str() {
                 // Connectors require the AppHandle (async sidecar / consent path).
-                "web_search"
-                | "calendar_lookup"
-                | "jira_search"
-                | "slack_search"
-                | "notion_search"
-                | "clickup_search" => has_app,
+                "web_search" | "calendar_lookup" | "jira_search" | "slack_search"
+                | "notion_search" | "clickup_search" => has_app,
                 // Shared Brain: advertised ONLY when an org is joined + org egress is consented
                 // (fail-closed). Unlike the connectors it is egress-free (a local read), so it needs
                 // NO AppHandle — it runs on the DB + config alone.
@@ -2326,6 +2847,11 @@ impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
                     &ToolCall::GetMeeting {
                         meeting_id: s("meetingId"),
                         transcript_format: fmt,
+                        // Raw mic/system lanes are a local MCP diagnostic surface. The in-app
+                        // assistant may not select them, even if an unadvertised argument is
+                        // injected directly into this executor.
+                        channel: TranscriptChannel::Merged,
+                        include_speaker_map: false,
                         offset: u("offset"),
                         max_chars: u("maxChars"),
                         // Absent ⇒ true, so an existing caller is byte-identical.
@@ -4794,9 +5320,11 @@ mod tests {
             &ToolCall::GetMeeting {
                 meeting_id: "m1".into(),
                 transcript_format: "structured".into(),
+                channel: TranscriptChannel::Merged,
+                include_speaker_map: false,
                 offset: 0,
                 max_chars: 0,
-                            include_note: true,
+                include_note: true,
             },
             &db,
             &HashSet::new(),
@@ -4884,9 +5412,11 @@ mod tests {
             &ToolCall::GetMeeting {
                 meeting_id: "m2".into(),
                 transcript_format: "plain".into(),
+                channel: TranscriptChannel::Merged,
+                include_speaker_map: false,
                 offset: 0,
                 max_chars: 0,
-                            include_note: true,
+                include_note: true,
             },
             &db,
             &HashSet::new(),
@@ -4905,7 +5435,9 @@ mod tests {
         // agent that mapped offsets in one and switched to the other silently landed ~40% off
         // target. What this test protects is the TRANSCRIPT BODY: the legacy flat join must stay
         // byte-identical, which it does.
-        let expected = format!("NOTE:\nthe note\n\nTRANSCRIPT (format=plain):\n{legacy_transcript}");
+        let expected = format!(
+            "NOTE:\nthe note\n\nTRANSCRIPT (format=plain, channel=merged):\n{legacy_transcript}"
+        );
         assert_eq!(
             out, expected,
             "plain format must render the legacy join byte-identically"
@@ -4973,9 +5505,11 @@ mod tests {
             &ToolCall::GetMeeting {
                 meeting_id: "m-diar".into(),
                 transcript_format: "structured".into(),
+                channel: TranscriptChannel::Merged,
+                include_speaker_map: false,
                 offset: 0,
                 max_chars: 0,
-                            include_note: true,
+                include_note: true,
             },
             &db,
             &HashSet::new(),
@@ -5030,9 +5564,11 @@ mod tests {
             &ToolCall::GetMeeting {
                 meeting_id: "m-prec".into(),
                 transcript_format: "structured".into(),
+                channel: TranscriptChannel::Merged,
+                include_speaker_map: false,
                 offset: 0,
                 max_chars: 0,
-                            include_note: true,
+                include_note: true,
             },
             &db,
             &HashSet::new(),
@@ -5481,9 +6017,11 @@ mod tests {
             &ToolCall::GetMeeting {
                 meeting_id: "does-not-exist".into(),
                 transcript_format: "structured".into(),
+                channel: TranscriptChannel::Merged,
+                include_speaker_map: false,
                 offset: 0,
                 max_chars: 6000,
-                            include_note: true,
+                include_note: true,
             },
             &db,
             &HashSet::new(),
@@ -5531,6 +6069,8 @@ mod tests {
                 &ToolCall::GetMeeting {
                     meeting_id: "m-budget".into(),
                     transcript_format: "structured".into(),
+                    channel: TranscriptChannel::Merged,
+                    include_speaker_map: false,
                     offset: 0,
                     max_chars: max,
                     include_note: include,
@@ -5552,7 +6092,10 @@ mod tests {
 
         // includeNote:true + a small maxChars ⇒ the note is WINDOWED, not shipped whole.
         let bounded = call(true, 200);
-        assert!(bounded.contains("NOTE ("), "the note window is disclosed: {bounded}");
+        assert!(
+            bounded.contains("NOTE ("),
+            "the note window is disclosed: {bounded}"
+        );
         assert!(
             bounded.len() < long_note.len(),
             "maxChars must bound the note; reply {} vs note {}",
@@ -5570,9 +6113,30 @@ mod tests {
         db.insert_segments(
             "m-compact",
             &[
-                Segment { idx: 0, start_s: 1.0, end_s: 2.0, text: "first half".into(), speaker: Some("me".into()), confidence: None },
-                Segment { idx: 1, start_s: 2.0, end_s: 3.0, text: "second half".into(), speaker: Some("me".into()), confidence: None },
-                Segment { idx: 2, start_s: 3.0, end_s: 4.0, text: "their turn".into(), speaker: Some("others".into()), confidence: None },
+                Segment {
+                    idx: 0,
+                    start_s: 1.0,
+                    end_s: 2.0,
+                    text: "first half".into(),
+                    speaker: Some("me".into()),
+                    confidence: None,
+                },
+                Segment {
+                    idx: 1,
+                    start_s: 2.0,
+                    end_s: 3.0,
+                    text: "second half".into(),
+                    speaker: Some("me".into()),
+                    confidence: None,
+                },
+                Segment {
+                    idx: 2,
+                    start_s: 3.0,
+                    end_s: 4.0,
+                    text: "their turn".into(),
+                    speaker: Some("others".into()),
+                    confidence: None,
+                },
             ],
         )
         .unwrap();
@@ -5580,6 +6144,8 @@ mod tests {
             &ToolCall::GetMeeting {
                 meeting_id: "m-compact".into(),
                 transcript_format: "compact".into(),
+                channel: TranscriptChannel::Merged,
+                include_speaker_map: false,
                 offset: 0,
                 max_chars: 0,
                 include_note: false,
@@ -5598,6 +6164,999 @@ mod tests {
         );
         // #10 — the format is stamped so the offset space is self-describing.
         assert!(out.contains("format=compact"), "format stamped: {out}");
+    }
+
+    #[test]
+    fn transcript_search_offsets_round_trip_through_the_same_channel_projection() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        seed_meeting(&db, "m-nav", "Navigation", "note", None);
+        let segments = vec![
+            Segment {
+                idx: 7,
+                start_s: 5.0,
+                end_s: 7.0,
+                text: "the contract is now signed by both parties".into(),
+                speaker: Some("others".into()),
+                confidence: None,
+            },
+            Segment {
+                idx: 9,
+                start_s: 7.2,
+                end_s: 8.9,
+                text: "my separate reply has landed safely".into(),
+                speaker: Some("me".into()),
+                confidence: None,
+            },
+        ];
+        db.insert_segments("m-nav", &segments).unwrap();
+
+        let projection =
+            TranscriptProjection::new(&segments, TranscriptChannel::Merged, &HashSet::new());
+        assert_eq!(
+            projection.lines.len(),
+            2,
+            "merged preserves both canonical stored segments"
+        );
+        let expected_range = format!(
+            "offset {}..{}",
+            projection.lines[0].start_char, projection.lines[0].end_char
+        );
+        let search = execute_tool(
+            &ToolCall::SearchTranscript {
+                query: "contract signed".into(),
+                meeting_id: Some("m-nav".into()),
+                limit: 20,
+                max_per_meeting: 5,
+                channel: TranscriptChannel::Merged,
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            search.contains("format=structured, channel=merged, shown=1, total=1"),
+            "counts must be post-projection: {search}"
+        );
+        assert!(
+            search.contains(&expected_range),
+            "search range must address the canonical structured body: {search}"
+        );
+
+        let meeting = execute_tool(
+            &ToolCall::GetMeeting {
+                meeting_id: "m-nav".into(),
+                transcript_format: "structured".into(),
+                channel: TranscriptChannel::Merged,
+                include_speaker_map: false,
+                offset: 0,
+                max_chars: 0,
+                include_note: false,
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            meeting.ends_with(&projection.text),
+            "get_meeting must expose the exact searched coordinate: {meeting}"
+        );
+
+        let mic = execute_tool(
+            &ToolCall::SearchTranscript {
+                query: "separate reply".into(),
+                meeting_id: Some("m-nav".into()),
+                limit: 20,
+                max_per_meeting: 5,
+                channel: TranscriptChannel::Mic,
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            mic.contains("channel=mic, shown=1, total=1") && mic.contains(" · Me — "),
+            "the raw mic lane remains inspectable: {mic}"
+        );
+    }
+
+    #[test]
+    fn explicit_echo_provenance_hides_only_merged_and_legacy_rows_default_visible() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        seed_meeting(&db, "m-echo", "Echo provenance", "note", None);
+        let rows = vec![
+            crate::storage::models::StoredTranscriptSegment {
+                segment: Segment {
+                    idx: 40,
+                    start_s: 5.0,
+                    end_s: 7.0,
+                    text: "the measured echo phrase has four words".into(),
+                    speaker: Some("others".into()),
+                    confidence: None,
+                },
+                echo_suppressed: false,
+            },
+            crate::storage::models::StoredTranscriptSegment {
+                segment: Segment {
+                    idx: 41,
+                    start_s: 5.3,
+                    end_s: 7.3,
+                    text: "the measured echo phrase has four words".into(),
+                    speaker: Some("me".into()),
+                    confidence: None,
+                },
+                echo_suppressed: true,
+            },
+        ];
+        db.replace_segments_with_echo_provenance("m-echo", &rows)
+            .unwrap();
+
+        let stored = db.get_segments_with_echo_provenance("m-echo").unwrap();
+        assert_eq!(stored.len(), 2, "raw storage retains both capture lanes");
+        assert_eq!(
+            stored.iter().map(|row| row.segment.idx).collect::<Vec<_>>(),
+            vec![40, 41],
+            "raw indices remain stable"
+        );
+        assert!(
+            !stored[0].echo_suppressed && stored[1].echo_suppressed,
+            "only ingest may set the explicit provenance bit"
+        );
+
+        let call = |channel| {
+            execute_tool(
+                &ToolCall::GetMeeting {
+                    meeting_id: "m-echo".into(),
+                    transcript_format: "structured".into(),
+                    channel,
+                    include_speaker_map: false,
+                    offset: 0,
+                    max_chars: 0,
+                    include_note: false,
+                },
+                &db,
+                &HashSet::new(),
+                &cfg,
+            )
+            .unwrap()
+        };
+        let merged = call(TranscriptChannel::Merged);
+        assert_eq!(
+            merged
+                .matches("the measured echo phrase has four words")
+                .count(),
+            1,
+            "merged filters only the persisted flag: {merged}"
+        );
+        let mic = call(TranscriptChannel::Mic);
+        assert!(
+            mic.contains("Me: the measured echo phrase has four words"),
+            "raw mic disclosure retains a flagged row: {mic}"
+        );
+
+        let search = execute_tool(
+            &ToolCall::SearchTranscript {
+                query: "measured echo phrase".into(),
+                meeting_id: Some("m-echo".into()),
+                limit: 20,
+                max_per_meeting: 5,
+                channel: TranscriptChannel::Merged,
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            search.contains("channel=merged, shown=1, total=1"),
+            "search counts must use the same persisted projection: {search}"
+        );
+
+        seed_meeting(&db, "m-legacy-echo", "Legacy repetition", "note", None);
+        let legacy = rows.into_iter().map(|row| row.segment).collect::<Vec<_>>();
+        db.insert_segments("m-legacy-echo", &legacy).unwrap();
+        let legacy_rows = db
+            .get_segments_with_echo_provenance("m-legacy-echo")
+            .unwrap();
+        assert!(
+            legacy_rows.iter().all(|row| !row.echo_suppressed),
+            "omitted provenance defaults visible for legacy rows"
+        );
+        let legacy_merged = execute_tool(
+            &ToolCall::GetMeeting {
+                meeting_id: "m-legacy-echo".into(),
+                transcript_format: "structured".into(),
+                channel: TranscriptChannel::Merged,
+                include_speaker_map: false,
+                offset: 0,
+                max_chars: 0,
+                include_note: false,
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert_eq!(
+            legacy_merged
+                .matches("the measured echo phrase has four words")
+                .count(),
+            2,
+            "legacy overlap is never guessed away from text/timestamps: {legacy_merged}"
+        );
+    }
+
+    #[test]
+    fn transcript_search_bounds_high_frequency_candidates_and_discloses_inexact_count() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        seed_meeting(&db, "m-many-hits", "Many bounded hits", "note", None);
+        let segments = (0..(MAX_TRANSCRIPT_SEARCH_RAW_HITS + 5))
+            .map(|idx| Segment {
+                idx: idx as i64,
+                start_s: idx as f64,
+                end_s: idx as f64 + 0.5,
+                text: format!("highfrequency bounded marker {idx}"),
+                speaker: Some("others".into()),
+                confidence: None,
+            })
+            .collect::<Vec<_>>();
+        db.insert_segments("m-many-hits", &segments).unwrap();
+
+        let (db_hits, meetings_truncated, rows_truncated) = db
+            .search_transcript_segments_visible(
+                "highfrequency",
+                Some("m-many-hits"),
+                TranscriptChannel::Merged.render_channel(),
+                20,
+                7,
+                &HashSet::new(),
+            )
+            .unwrap();
+        assert_eq!(db_hits.len(), 7, "the DB result honors its hard row cap");
+        assert!(
+            rows_truncated,
+            "the extra probe row must report undisclosed candidates"
+        );
+        assert!(
+            !meetings_truncated,
+            "one scoped meeting cannot truncate the meeting set"
+        );
+
+        let out = execute_tool(
+            &ToolCall::SearchTranscript {
+                query: "highfrequency".into(),
+                meeting_id: Some("m-many-hits".into()),
+                limit: 100,
+                max_per_meeting: 20,
+                channel: TranscriptChannel::Merged,
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            out.contains("shown=20, counted=500")
+                && out.contains("rawCandidatesScanned=500")
+                && out.contains("scanTruncated=true")
+                && out.contains("exactTotal=false"),
+            "a bounded scan must never masquerade as an exact corpus total: {out}"
+        );
+        assert_eq!(
+            out.lines()
+                .filter(|line| line.starts_with("- offset "))
+                .count(),
+            20,
+            "per-meeting disclosure remains independently bounded"
+        );
+    }
+
+    #[test]
+    fn transcript_search_applies_channel_before_meeting_cap_and_discloses_meeting_truncation() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+
+        // All meetings share a timestamp, so their ids define recency order. These 20 mic-only
+        // meetings sort ahead of the one selected-channel system meeting. A pre-projection
+        // meeting cap would therefore lose the valid system hit.
+        for idx in 0..20 {
+            let meeting_id = format!("z-mic-{idx:02}");
+            seed_meeting(&db, &meeting_id, &format!("Mic-only {idx}"), "note", None);
+            db.insert_segments(
+                &meeting_id,
+                &[Segment {
+                    idx: 0,
+                    start_s: 1.0,
+                    end_s: 2.0,
+                    text: "selected channel sentinel".into(),
+                    speaker: Some("me".into()),
+                    confidence: None,
+                }],
+            )
+            .unwrap();
+        }
+        seed_meeting(&db, "a-system-channel", "System target", "note", None);
+        db.insert_segments(
+            "a-system-channel",
+            &[Segment {
+                idx: 0,
+                start_s: 1.0,
+                end_s: 2.0,
+                text: "selected channel sentinel".into(),
+                speaker: Some("others".into()),
+                confidence: None,
+            }],
+        )
+        .unwrap();
+
+        let selected = execute_tool(
+            &ToolCall::SearchTranscript {
+                query: "selected channel sentinel".into(),
+                meeting_id: None,
+                limit: 100,
+                max_per_meeting: 5,
+                channel: TranscriptChannel::System,
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            selected.contains("[meeting:a-system-channel]"),
+            "the selected-channel hit below the unfiltered meeting cap must survive: {selected}"
+        );
+        assert!(
+            !selected.contains("[meeting:z-mic-"),
+            "mic-only candidates must not consume system-channel capacity: {selected}"
+        );
+        assert!(
+            selected.contains("candidateMeetingsTruncated=false")
+                && selected.contains("exactTotal=true"),
+            "one selected-channel meeting has an exact count: {selected}"
+        );
+
+        for idx in 0..21 {
+            let meeting_id = format!("overflow-system-{idx:02}");
+            seed_meeting(
+                &db,
+                &meeting_id,
+                &format!("Overflow system {idx}"),
+                "note",
+                None,
+            );
+            db.insert_segments(
+                &meeting_id,
+                &[Segment {
+                    idx: 0,
+                    start_s: 3.0,
+                    end_s: 4.0,
+                    text: "selected overflow sentinel".into(),
+                    speaker: Some("others".into()),
+                    confidence: None,
+                }],
+            )
+            .unwrap();
+        }
+
+        let truncated = execute_tool(
+            &ToolCall::SearchTranscript {
+                query: "selected overflow sentinel".into(),
+                meeting_id: None,
+                limit: 100,
+                max_per_meeting: 5,
+                channel: TranscriptChannel::System,
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            truncated.contains("counted=20")
+                && truncated.contains("candidateMeetingsTruncated=true")
+                && truncated.contains("scanTruncated=false")
+                && truncated.contains("exactTotal=false"),
+            "meeting-set truncation must be explicit and make the total inexact: {truncated}"
+        );
+    }
+
+    #[test]
+    fn transcript_search_empty_queries_are_successful_zero_hits_even_when_scoped() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        seed_meeting(&db, "m-empty-query", "Must stay hidden", "note", None);
+        db.insert_segments(
+            "m-empty-query",
+            &[Segment {
+                idx: 0,
+                start_s: 1.0,
+                end_s: 2.0,
+                text: "must stay hidden too".into(),
+                speaker: Some("others".into()),
+                confidence: None,
+            }],
+        )
+        .unwrap();
+
+        for query in ["", " \t\n "] {
+            let out = execute_tool(
+                &ToolCall::SearchTranscript {
+                    query: query.into(),
+                    meeting_id: Some("m-empty-query".into()),
+                    limit: 20,
+                    max_per_meeting: 5,
+                    channel: TranscriptChannel::Merged,
+                },
+                &db,
+                &HashSet::new(),
+                &cfg,
+            )
+            .expect("empty transcript query is a successful zero-hit search");
+            assert_eq!(out, "No transcript passages match \"\".");
+            assert!(
+                !out.contains("m-empty-query") && !out.contains("Must stay hidden"),
+                "the scoped zero-hit response must not disclose meeting existence: {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn transcript_search_excerpt_centers_the_lexical_hit_without_moving_offsets() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        seed_meeting(&db, "m-late-hit", "Late hit", "note", None);
+        let long_text = format!("{}needle-at-the-end", "unrelated prefix ".repeat(40));
+        let segments = vec![Segment {
+            idx: 11,
+            start_s: 8.0,
+            end_s: 10.0,
+            text: long_text,
+            speaker: Some("others".into()),
+            confidence: None,
+        }];
+        db.insert_segments("m-late-hit", &segments).unwrap();
+        let projection =
+            TranscriptProjection::new(&segments, TranscriptChannel::Merged, &HashSet::new());
+        let expected_range = format!(
+            "offset {}..{}",
+            projection.lines[0].start_char, projection.lines[0].end_char
+        );
+
+        let out = execute_tool(
+            &ToolCall::SearchTranscript {
+                query: "needle".into(),
+                meeting_id: Some("m-late-hit".into()),
+                limit: 20,
+                max_per_meeting: 5,
+                channel: TranscriptChannel::Merged,
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        let hit_line = out
+            .lines()
+            .find(|line| line.starts_with("- offset "))
+            .expect("search result line");
+        let excerpt = hit_line
+            .split_once(" — ")
+            .map(|(_, excerpt)| excerpt)
+            .expect("bounded excerpt");
+        assert!(
+            excerpt.starts_with('…') && excerpt.contains("needle-at-the-end"),
+            "the excerpt must retain a late lexical hit and mark leading truncation: {excerpt}"
+        );
+        assert!(
+            excerpt.chars().count() <= 240,
+            "the centered excerpt exceeded its scalar bound: {}",
+            excerpt.chars().count()
+        );
+        assert!(
+            hit_line.contains(&expected_range),
+            "excerpt centering must not change the canonical transcript coordinate: {hit_line}"
+        );
+    }
+
+    #[test]
+    fn transcript_navigation_remains_mcp_only_and_outside_cloud_agent_catalogs() {
+        let specs = tool_specs();
+        let get_meeting = specs
+            .iter()
+            .find(|spec| spec.name == "get_meeting")
+            .expect("in-app get_meeting spec");
+        assert!(
+            get_meeting.parameters["properties"]
+                .get("channel")
+                .is_none(),
+            "raw capture lanes must not be advertised to the cloud-capable assistant"
+        );
+        let names = specs
+            .into_iter()
+            .map(|spec| spec.name)
+            .collect::<HashSet<_>>();
+        assert!(
+            !names.contains("search_transcript") && !names.contains("get_meeting_chapters"),
+            "transcript navigation is a loopback MCP surface, not agent/cloud prompt input"
+        );
+    }
+
+    #[test]
+    fn in_app_get_meeting_forces_merged_even_for_an_injected_channel_argument() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        seed_meeting(&db, "m-agent-channel", "Agent channel", "note", None);
+        db.insert_segments(
+            "m-agent-channel",
+            &[
+                Segment {
+                    idx: 0,
+                    start_s: 1.0,
+                    end_s: 2.0,
+                    text: "system lane remains in merged".into(),
+                    speaker: Some("others-0".into()),
+                    confidence: None,
+                },
+                Segment {
+                    idx: 1,
+                    start_s: 3.0,
+                    end_s: 4.0,
+                    text: "mic lane remains in merged".into(),
+                    speaker: Some("me".into()),
+                    confidence: None,
+                },
+            ],
+        )
+        .unwrap();
+        db.insert_voiceprint(
+            "vp-agent-boundary",
+            "m-agent-channel",
+            0,
+            Some("NER_MODEL_UNAVAILABLE_NAME"),
+            &[0.1, 0.2],
+            "2026-07-28T00:00:00Z",
+        )
+        .unwrap();
+        let unlocked = Mutex::new(HashSet::new());
+        let exec = exec_at(&db, &unlocked, &cfg, AssistantScope::Vault);
+
+        for injected in ["system", "mic", "invented"] {
+            let out = exec
+                .run(
+                    "get_meeting",
+                    &serde_json::json!({
+                        "meetingId": "m-agent-channel",
+                        "channel": injected,
+                        "includeNote": false
+                    }),
+                )
+                .expect("unadvertised channel input is clamped to merged");
+            assert!(
+                out.contains("channel=merged")
+                    && out.contains("system lane remains in merged")
+                    && out.contains("mic lane remains in merged")
+                    && !out.contains("channel=system")
+                    && !out.contains("channel=mic")
+                    && !out.contains("NER_MODEL_UNAVAILABLE_NAME")
+                    && !out.contains("SPEAKERS ("),
+                "in-app get_meeting escaped the merged/no-enrolled-label boundary for {injected}: {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn transcript_search_discloses_only_during_session_unlock() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        seed_folder(&db, "f-search", "Private search");
+        seed_meeting(
+            &db,
+            "m-secret-search",
+            "Secret launch",
+            "private note",
+            Some("f-search"),
+        );
+        db.insert_segments(
+            "m-secret-search",
+            &[Segment {
+                idx: 42,
+                start_s: 12.0,
+                end_s: 14.0,
+                text: "ultraviolet launch phrase".into(),
+                speaker: Some("others-0".into()),
+                confidence: None,
+            }],
+        )
+        .unwrap();
+        db.set_folder_locked("f-search", true, None).unwrap();
+        let call = ToolCall::SearchTranscript {
+            query: "ultraviolet launch".into(),
+            meeting_id: None,
+            limit: 20,
+            max_per_meeting: 5,
+            channel: TranscriptChannel::Merged,
+        };
+
+        let assert_masked = |out: &str| {
+            assert_eq!(
+                out, "No transcript passages match \"ultraviolet launch\".",
+                "locked and absent results must be indistinguishable"
+            );
+            for secret in [
+                "m-secret-search",
+                "Secret launch",
+                "ultraviolet launch phrase",
+                "Speaker",
+                "offset",
+                "total=",
+                "seg 42",
+                "@00:12",
+            ] {
+                assert!(
+                    !out.contains(secret),
+                    "locked search leaked {secret:?}: {out}"
+                );
+            }
+        };
+
+        let locked =
+            execute_tool(&call, &db, &HashSet::new(), &cfg).expect("locked search is masked");
+        assert_masked(&locked);
+
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f-search".to_string());
+        let open = execute_tool(&call, &db, &unlocked, &cfg).unwrap();
+        assert!(
+            open.contains("[meeting:m-secret-search]")
+                && open.contains("[[Secret launch]]")
+                && open.contains("ultraviolet launch phrase")
+                && open.contains("offset")
+                && open.contains("total=1"),
+            "session unlock alone admits the matching content: {open}"
+        );
+
+        unlocked.remove("f-search");
+        let relocked = execute_tool(&call, &db, &unlocked, &cfg).unwrap();
+        assert_masked(&relocked);
+    }
+
+    #[test]
+    fn chapters_use_the_structured_channel_coordinate_and_mask_locked_timelines() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        seed_folder(&db, "f-nav", "Private");
+        seed_meeting(&db, "m-chapters", "Secret planning", "note", Some("f-nav"));
+        let segments = vec![
+            Segment {
+                idx: 0,
+                start_s: 0.0,
+                end_s: 1.0,
+                text: "opening".into(),
+                speaker: Some("others".into()),
+                confidence: None,
+            },
+            Segment {
+                idx: 1,
+                start_s: 3.0,
+                end_s: 5.0,
+                text: "launch plan details".into(),
+                speaker: Some("others-0".into()),
+                confidence: None,
+            },
+        ];
+        db.insert_segments("m-chapters", &segments).unwrap();
+        db.set_timeline_data(
+            "m-chapters",
+            &serde_json::to_string(&crate::storage::models::MeetingTimeline {
+                speakers: Vec::new(),
+                topics: vec![
+                    crate::storage::models::TopicSpan {
+                        label: "Launch plan".into(),
+                        start_s: 2.5,
+                        end_s: 5.5,
+                    },
+                    crate::storage::models::TopicSpan {
+                        label: "No lane overlap".into(),
+                        start_s: 20.0,
+                        end_s: 21.0,
+                    },
+                ],
+            })
+            .unwrap(),
+        )
+        .unwrap();
+
+        let projection =
+            TranscriptProjection::new(&segments, TranscriptChannel::Merged, &HashSet::new());
+        let target = &projection.lines[1];
+        let expected_range = format!("offset {}..{}", target.start_char, target.end_char);
+        let open = execute_tool(
+            &ToolCall::GetMeetingChapters {
+                meeting_id: "m-chapters".into(),
+                channel: TranscriptChannel::Merged,
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            open.contains("format=structured, channel=merged")
+                && open.contains("Launch plan")
+                && open.contains(&expected_range),
+            "chapter range must point into the same projection: {open}"
+        );
+        let non_overlap = open
+            .lines()
+            .find(|line| line.contains("No lane overlap"))
+            .expect("non-overlapping topic remains listed");
+        assert!(
+            !non_overlap.contains("offset"),
+            "a topic with no rendered line must omit the offset field: {non_overlap}"
+        );
+
+        db.set_folder_locked("f-nav", true, None).unwrap();
+        let locked = execute_tool(
+            &ToolCall::GetMeetingChapters {
+                meeting_id: "m-chapters".into(),
+                channel: TranscriptChannel::Merged,
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert_eq!(locked, "No chapter map for meeting m-chapters.");
+        assert!(
+            !locked.contains("Launch plan") && !locked.contains("Secret planning"),
+            "locked derived content and title stay masked: {locked}"
+        );
+    }
+
+    #[test]
+    fn speaker_map_reads_only_visible_present_labels_and_never_ghosts() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        seed_folder(&db, "f-speaker", "Speakers");
+        seed_meeting(&db, "m-speaker", "Call", "note", Some("f-speaker"));
+        db.insert_segments(
+            "m-speaker",
+            &[
+                Segment {
+                    idx: 0,
+                    start_s: 1.0,
+                    end_s: 2.0,
+                    text: "hello there".into(),
+                    speaker: Some("others-1".into()),
+                    confidence: None,
+                },
+                Segment {
+                    idx: 1,
+                    start_s: 2.0,
+                    end_s: 3.0,
+                    text: "   ".into(),
+                    speaker: Some("others-2".into()),
+                    confidence: None,
+                },
+            ],
+        )
+        .unwrap();
+        db.insert_voiceprint(
+            "vp-visible",
+            "m-speaker",
+            1,
+            Some("Anna\nNowak"),
+            &[0.1, 0.2],
+            "2026-07-01T00:00:00Z",
+        )
+        .unwrap();
+        db.insert_voiceprint(
+            "vp-ghost",
+            "m-speaker",
+            7,
+            Some("Ghost"),
+            &[0.3, 0.4],
+            "2026-07-01T00:00:00Z",
+        )
+        .unwrap();
+        db.insert_voiceprint(
+            "vp-empty",
+            "m-speaker",
+            2,
+            Some("EmptyGhost"),
+            &[0.5, 0.6],
+            "2026-07-01T00:00:00Z",
+        )
+        .unwrap();
+
+        let open = execute_tool(
+            &ToolCall::GetMeeting {
+                meeting_id: "m-speaker".into(),
+                transcript_format: "structured".into(),
+                channel: TranscriptChannel::Merged,
+                include_speaker_map: true,
+                offset: 0,
+                max_chars: 0,
+                include_note: false,
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert!(open.contains("- Speaker 2 = Anna Nowak"), "{open}");
+        assert!(
+            !open.contains("Ghost"),
+            "absent and empty-text speakers are omitted: {open}"
+        );
+
+        db.set_folder_locked("f-speaker", true, None).unwrap();
+        let locked = execute_tool(
+            &ToolCall::GetMeeting {
+                meeting_id: "m-speaker".into(),
+                transcript_format: "structured".into(),
+                channel: TranscriptChannel::Merged,
+                include_speaker_map: true,
+                offset: 0,
+                max_chars: 0,
+                include_note: false,
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert_eq!(locked, "No data for meeting m-speaker.");
+        assert!(!locked.contains("Anna"), "{locked}");
+    }
+
+    #[test]
+    fn speaker_map_is_deterministically_bounded_and_discloses_truncation() {
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        seed_meeting(&db, "m-speaker-bound", "Many speakers", "note", None);
+        let count = MAX_SPEAKER_MAP_ENTRIES + 5;
+        let segments = (0..count)
+            .map(|cluster| Segment {
+                idx: cluster as i64,
+                start_s: cluster as f64,
+                end_s: cluster as f64 + 0.5,
+                text: format!("speaker turn {cluster}"),
+                speaker: Some(format!("others-{cluster}")),
+                confidence: None,
+            })
+            .collect::<Vec<_>>();
+        db.insert_segments("m-speaker-bound", &segments).unwrap();
+        for cluster in 0..count {
+            db.insert_voiceprint(
+                &format!("vp-speaker-bound-{cluster}"),
+                "m-speaker-bound",
+                cluster as i64,
+                Some(&format!("ENROLLED_NAME_{cluster:02}")),
+                &[cluster as f32, 1.0],
+                "2026-07-28T00:00:00Z",
+            )
+            .unwrap();
+        }
+
+        let out = execute_tool(
+            &ToolCall::GetMeeting {
+                meeting_id: "m-speaker-bound".into(),
+                transcript_format: "structured".into(),
+                channel: TranscriptChannel::Merged,
+                include_speaker_map: true,
+                offset: 0,
+                max_chars: 0,
+                include_note: false,
+            },
+            &db,
+            &HashSet::new(),
+            &cfg,
+        )
+        .unwrap();
+        assert_eq!(
+            out.lines()
+                .filter(|line| line.starts_with("- Speaker "))
+                .count(),
+            MAX_SPEAKER_MAP_ENTRIES,
+            "speaker-map output must have a hard deterministic entry cap: {out}"
+        );
+        assert!(
+            out.contains("[speaker map truncated: showing 20 of 25 matching enrolled labels]"),
+            "the omitted labels must be disclosed honestly: {out}"
+        );
+        assert!(
+            !out.contains("ENROLLED_NAME_24"),
+            "a label beyond the response cap leaked: {out}"
+        );
+    }
+
+    #[test]
+    fn get_meeting_speaker_map_honors_page_budget_and_is_first_page_only() {
+        const MAP_BUDGET: usize = 40;
+        const ENROLLED_PREFIX: &str = "ENROLLED_BUDGET_PREFIX";
+        const ENROLLED_TAIL: &str = "ENROLLED_BUDGET_FORBIDDEN_TAIL";
+
+        let db = tmp_db();
+        let cfg = AppConfig::default();
+        seed_meeting(&db, "m-speaker-page", "Paged speaker", "note", None);
+        db.insert_segments(
+            "m-speaker-page",
+            &[Segment {
+                idx: 0,
+                start_s: 1.0,
+                end_s: 3.0,
+                text: "a transcript long enough for a later character page".into(),
+                speaker: Some("others-0".into()),
+                confidence: None,
+            }],
+        )
+        .unwrap();
+        let long_label = format!("{ENROLLED_PREFIX} {} {ENROLLED_TAIL}", "x".repeat(120));
+        db.insert_voiceprint(
+            "vp-speaker-page",
+            "m-speaker-page",
+            0,
+            Some(&long_label),
+            &[0.1, 0.2],
+            "2026-07-28T00:00:00Z",
+        )
+        .unwrap();
+
+        let call = |offset| {
+            execute_tool(
+                &ToolCall::GetMeeting {
+                    meeting_id: "m-speaker-page".into(),
+                    transcript_format: "structured".into(),
+                    channel: TranscriptChannel::Merged,
+                    include_speaker_map: true,
+                    offset,
+                    max_chars: MAP_BUDGET,
+                    include_note: false,
+                },
+                &db,
+                &HashSet::new(),
+                &cfg,
+            )
+            .unwrap()
+        };
+
+        let first = call(0);
+        assert!(
+            first.contains("SPEAKER MAP (TOTAL_CHARS:")
+                && first.contains("(showing 0..40)):")
+                && !first.contains(ENROLLED_TAIL),
+            "first-page label disclosure must be char-bounded and honest: {first}"
+        );
+        let map_body = first
+            .split_once("):\n")
+            .and_then(|(_, rest)| rest.split_once("\n\nTRANSCRIPT"))
+            .map(|(body, _)| body)
+            .unwrap_or_else(|| panic!("missing bounded speaker-map section: {first}"));
+        assert!(
+            map_body.chars().count() <= MAP_BUDGET,
+            "speaker-map body exceeded maxChars: {} > {MAP_BUDGET}",
+            map_body.chars().count()
+        );
+
+        let later = call(1);
+        assert!(
+            !later.contains("SPEAKER MAP")
+                && !later.contains("SPEAKERS (enrolled")
+                && !later.contains(ENROLLED_PREFIX)
+                && !later.contains(ENROLLED_TAIL),
+            "nonzero transcript pages must not repeat enrolled names: {later}"
+        );
+        assert!(
+            later.contains("TRANSCRIPT (format=structured, channel=merged"),
+            "later page still returns the requested transcript coordinate: {later}"
+        );
     }
 
     /// E1 (RED-before-GREEN) — `get_meeting` emits the NOTE section only on the FIRST window
@@ -5638,9 +7197,11 @@ mod tests {
             &ToolCall::GetMeeting {
                 meeting_id: "m-page".into(),
                 transcript_format: "structured".into(),
+                channel: TranscriptChannel::Merged,
+                include_speaker_map: false,
                 offset: 0,
                 max_chars: 20,
-                            include_note: true,
+                include_note: true,
             },
             &db,
             &HashSet::new(),
@@ -5662,9 +7223,11 @@ mod tests {
             &ToolCall::GetMeeting {
                 meeting_id: "m-page".into(),
                 transcript_format: "structured".into(),
+                channel: TranscriptChannel::Merged,
+                include_speaker_map: false,
                 offset: 10,
                 max_chars: 20,
-                            include_note: true,
+                include_note: true,
             },
             &db,
             &HashSet::new(),
@@ -5688,7 +7251,13 @@ mod tests {
     fn search_semantic_empty_query_matches_nothing() {
         let db = tmp_db();
         let cfg = AppConfig::default(); // semantic default ON — the guard must precede the model branch.
-        seed_meeting(&db, "m-hit", "Zephyr Kickoff", "zephyr launch planning", None);
+        seed_meeting(
+            &db,
+            "m-hit",
+            "Zephyr Kickoff",
+            "zephyr launch planning",
+            None,
+        );
         let out = execute_tool(
             &ToolCall::SearchSemantic { query: "".into() },
             &db,


### PR DESCRIPTION
Replaces #486, #489, #490, and #492 with one coherent implementation.\n\nWhat changed:\n- persists both raw capture lanes plus explicit ingest-time acoustic echo provenance; merged rendering and summarization filter only that provenance\n- adds channel-aware get_meeting, bounded located transcript search, canonical structured offsets, chapters, and visibility-gated enrolled speaker labels\n- keeps raw selectors and navigation tools local-MCP-only; cloud-capable orchestration remains merged-only without enrolled labels\n- preserves the #518 response revocation barrier and adds deterministic relock-before-write regressions\n- bounds segment/meeting scans and speaker-map disclosure with truthful truncation metadata\n\nVerification:\n- Harness v2 exact-diff PASS: combined + lock-security + egress-security, zero MAJOR/BLOCKER and zero proof gaps\n- cargo test --lib: 2548 passed, 0 failed, 15 ignored\n- cargo clippy --lib -- -D warnings: PASS\n- real Tauri runtime smoke: Angular served and Rust MCP listener stayed alive\n\nThe failed intermediate reviews remain recorded in the harness task history; no implementation work was discarded and no Claude invocation was used.