### PR TITLE
feat(mcp): add visibility-safe historical note context

### DIFF
--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -1650,7 +1650,7 @@ fn tools_spec() -> Value {
         },
         {
             "name": "knowledge_diff",
-            "description": "The DECISION LEDGER for one person or project: what you knew about it changed over time (bitemporal facts). Pass an entity name (e.g. 'Anna' or 'Project Atlas') or id, plus two ISO-8601 instants 'from' and 'to' (e.g. '2026-06-01T00:00:00Z'). Returns what CHANGED between those two moments (added / removed / changed facts, e.g. status in-progress → shipped) PLUS the full chronological supersession ledger — each decision carries the old value, the new value, when it took effect, and the source meeting id. Answers 'what changed since', 'when did X flip', 'the history of Y's status'. Sealed-and-locked meetings' facts are excluded.",
+            "description": "The DECISION LEDGER for one person or project: what you knew about it changed over time (bitemporal facts). Pass an entity name (e.g. 'Anna' or 'Project Atlas') or id, plus two ISO-8601 instants 'from' and 'to' (e.g. '2026-06-01T00:00:00Z'). Returns what CHANGED between those two moments (added / removed / changed facts) PLUS the chronological supersession ledger. A separate bounded section may quote Decisions and Risks/Open Questions from currently visible mentioning-meeting notes; those items are explicitly historical source material, not bitemporal facts, current truth, or an open-risk ledger. Sealed-and-locked meetings are excluded.",
             "inputSchema": { "type": "object", "properties": { "entity": { "type": "string" }, "from": { "type": "string", "description": "ISO-8601 instant to snapshot the earlier state at." }, "to": { "type": "string", "description": "ISO-8601 instant to snapshot the later state at." } }, "required": ["entity", "from", "to"] }
         },
         {
@@ -1933,10 +1933,11 @@ fn dispatch_tool(
                 max_chars: mcp_usize_arg(args, "maxChars").min(MAX_TOOL_WINDOW_CHARS),
             }
         }
-        // Brain v3 PR-6 — the KNOWLEDGE DIFF / decision ledger for one entity. Routes through the
-        // SAME gated reader (`resolve_entity_id` + `build_knowledge_diff` → `list_facts_visible`) as
-        // the dossier, so a sealed-and-not-unlocked meeting's fact is invisible here too. `entity`,
-        // `from`, `to` are all required.
+        // LOCAL_LOOPBACK ONLY: KnowledgeDiff is absent from model-facing `tool_specs` and every
+        // GatedToolExecutor scope. This mapper is reachable only through this module's fixed
+        // 127.0.0.1 listener, exact Host/Origin/token gates, visibility snapshot, and response
+        // revalidation/cancellation. The gated reader covers both fact rows and read-time note
+        // context. `entity`, `from`, and `to` are all required.
         "knowledge_diff" => {
             let entity = args.get("entity").and_then(Value::as_str).unwrap_or("");
             if entity.trim().is_empty() {
@@ -3289,6 +3290,133 @@ mod tests {
             response["error"]["message"],
             Value::String(VISIBILITY_RETRY_MESSAGE.into())
         );
+        let _ = std::fs::remove_file(&p);
+    }
+
+    /// KnowledgeDiff note context is reachable only through the fixed loopback MCP catalog, and a
+    /// relock after materialization but before response production discards content AND bounded
+    /// source-count metadata. The model-facing/GatedToolExecutor boundary is asserted separately in
+    /// `tools::tests::local_mcp_only_tools_remain_outside_cloud_agent_catalogs`.
+    #[test]
+    fn knowledge_diff_note_context_is_loopback_only_and_revoked_after_relock() {
+        use crate::storage::models::{EntityKind, Folder};
+
+        assert!(mcp_listener_addr().ip().is_loopback());
+        assert_eq!(*mcp_listener_addr().ip(), Ipv4Addr::LOCALHOST);
+        assert!(
+            tools_spec()
+                .as_array()
+                .is_some_and(|tools| tools.iter().any(|tool| tool["name"] == "knowledge_diff")),
+            "knowledge_diff must stay in the fixed local MCP catalog"
+        );
+        assert!(
+            crate::tools::tool_specs()
+                .iter()
+                .all(|tool| tool.name != "knowledge_diff"),
+            "knowledge_diff note context must not enter a model-facing tool catalog"
+        );
+
+        let (db, p) = temp_db();
+        db.insert_folder(&Folder {
+            id: "f-kd-race".into(),
+            name: "Private knowledge diff".into(),
+            path: "Private knowledge diff".into(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-07-29T00:00:00Z".into(),
+        })
+        .unwrap();
+        let entity_id = db.upsert_entity("Atlas Race", EntityKind::Project).unwrap();
+        for index in 0..=100 {
+            let meeting_id = format!("m-kd-race-{index:03}");
+            seed(
+                &db,
+                &meeting_id,
+                &format!("PRIVATE_KD_TITLE_{index:03}"),
+                &format!("## Decisions\n- PRIVATE_KD_CONTENT_{index:03}.\n"),
+                Some("f-kd-race"),
+            );
+            db.add_mention(&entity_id, &meeting_id).unwrap();
+        }
+        db.set_folder_locked("f-kd-race", true, None).unwrap();
+
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f-kd-race".to_string());
+        let lifecycle = Mutex::new(());
+        let epoch = AtomicU64::new(0);
+        let unlocked = Mutex::new(unlocked);
+        let context = RpcContext {
+            db: Some(&db),
+            lifecycle: &lifecycle,
+            seal_epoch: &epoch,
+            unlocked_folders: &unlocked,
+        };
+        let params = json!({
+            "name": "knowledge_diff",
+            "arguments": {
+                "entity": "Atlas Race",
+                "from": "2026-01-01T00:00:00Z",
+                "to": "2026-12-31T23:59:59Z"
+            }
+        });
+        let pending = match handle_tool_call(
+            &context,
+            json!(71),
+            Some(&params),
+            Instant::now() + REQUEST_DEADLINE,
+        ) {
+            RpcReply::Content(pending) => pending,
+            RpcReply::Immediate(response) => {
+                panic!("knowledge_diff unexpectedly finalized early: {response}")
+            }
+        };
+        let materialized = pending
+            .outcome
+            .as_ref()
+            .unwrap_or_else(|error| panic!("knowledge_diff failed before relock: {error:?}"));
+        for expected in [
+            "PRIVATE_KD_TITLE_100",
+            "PRIVATE_KD_CONTENT_100",
+            "source:m-kd-race-100",
+            "HISTORICAL NOTE CONTEXT TRUNCATED",
+            "newest 100 visible mentioning meetings scanned",
+        ] {
+            assert!(
+                materialized.contains(expected),
+                "race fixture did not materialize {expected:?}: {materialized}"
+            );
+        }
+
+        {
+            let _lifecycle = lifecycle.lock().unwrap();
+            epoch.fetch_add(1, Ordering::SeqCst);
+            unlocked.lock().unwrap().clear();
+        }
+        let response = {
+            let _lifecycle = lifecycle.lock().unwrap();
+            finalize_content_reply(pending, &epoch, &unlocked)
+        };
+        assert_eq!(response["error"]["code"], VISIBILITY_RETRY_CODE);
+        assert_eq!(
+            response["error"]["message"],
+            Value::String(VISIBILITY_RETRY_MESSAGE.into())
+        );
+        let serialized = response.to_string();
+        for forbidden in [
+            "PRIVATE_KD_TITLE",
+            "PRIVATE_KD_CONTENT",
+            "m-kd-race",
+            "Atlas Race",
+            "HISTORICAL NOTE CONTEXT",
+            "meeting",
+            "scanned",
+            "TRUNCATED",
+        ] {
+            assert!(
+                !serialized.contains(forbidden),
+                "knowledge_diff leaked materialized content/count metadata after relock: {serialized}"
+            );
+        }
         let _ = std::fs::remove_file(&p);
     }
 

--- a/src-tauri/src/storage/graph_store.rs
+++ b/src-tauri/src/storage/graph_store.rs
@@ -196,8 +196,24 @@ impl Db {
         entity_id: &str,
         unlocked: &HashSet<String>,
     ) -> Result<Vec<VaultSource>> {
+        self.entity_mentions_visible_limited(entity_id, unlocked, usize::MAX)
+    }
+
+    /// The newest bounded window of VISIBLE meetings mentioning `entity_id`.
+    ///
+    /// The limit is applied by SQLite after the visibility predicate and stable
+    /// newest-first ordering. Callers that need an honest truncation bit should
+    /// request `display_limit + 1`; this avoids materialising an unbounded
+    /// mention set merely to learn that more rows exist.
+    pub fn entity_mentions_visible_limited(
+        &self,
+        entity_id: &str,
+        unlocked: &HashSet<String>,
+        limit: usize,
+    ) -> Result<Vec<VaultSource>> {
         let conn = self.lock();
         let visible = visibility_clause("n", unlocked);
+        let row_limit = i64::try_from(limit).unwrap_or(i64::MAX);
         let sql = format!(
             "SELECT m.id, m.title, m.started_at
                FROM entity_mentions em
@@ -211,11 +227,12 @@ impl Db {
                          WHERE n.meeting_id = m.id AND {visible}
                       )
                     )
-              ORDER BY m.started_at DESC, m.id DESC"
+              ORDER BY m.started_at DESC, m.id DESC
+              LIMIT ?2"
         );
         let mut stmt = conn.prepare(&sql).map_err(map_err)?;
         let rows = stmt
-            .query_map(rusqlite::params![entity_id], |r| {
+            .query_map(rusqlite::params![entity_id, row_limit], |r| {
                 let meeting_id: String = r.get(0)?;
                 let title: Option<String> = r.get(1)?;
                 let started_at: String = r.get(2)?;

--- a/src-tauri/src/summarize/mod.rs
+++ b/src-tauri/src/summarize/mod.rs
@@ -25,6 +25,7 @@ pub mod meta;
 /// at runtime by `redact::active_name_redactor` when the NER model dir is present, else the
 /// byte-identical `NoopNameRedactor` (so a no-model build's name egress is unchanged).
 pub mod ner_deberta;
+pub(crate) mod note_sections;
 pub mod ollama;
 pub mod organize;
 pub mod provider;

--- a/src-tauri/src/summarize/note_sections.rs
+++ b/src-tauri/src/summarize/note_sections.rs
@@ -1,0 +1,468 @@
+//! Deterministic, read-time extraction of historical decision/risk context from visible meeting
+//! notes. This module owns no persistence and performs no inference: it only recognizes explicit
+//! Markdown sections and preserves their list-item text verbatim.
+
+use std::collections::HashSet;
+
+use crate::error::Result;
+use crate::storage::Db;
+
+pub(crate) const NOTE_CONTEXT_MEETING_LIMIT: usize = 100;
+pub(crate) const NOTE_CONTEXT_ENTRY_LIMIT: usize = 100;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NoteSectionKind {
+    Decision,
+    RiskOrOpenQuestion,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NoteSectionEntry {
+    pub kind: NoteSectionKind,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HistoricalNoteEntry {
+    pub kind: NoteSectionKind,
+    pub text: String,
+    pub meeting_id: String,
+    pub meeting_title: String,
+    pub started_at: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct HistoricalNoteContext {
+    pub entries: Vec<HistoricalNoteEntry>,
+    pub meetings_scanned: usize,
+    pub meetings_truncated: bool,
+    pub entries_truncated: bool,
+}
+
+/// Extract recognized list items from explicit decision/risk sections. This is intentionally a
+/// small Markdown recognizer rather than a prose classifier: only ATX headings open a section, any
+/// later ATX heading closes it, and fenced code is opaque. That keeps arbitrary note prose from
+/// being promoted into decision-like historical context.
+#[cfg(test)]
+pub(crate) fn extract_note_sections(markdown: &str) -> Vec<NoteSectionEntry> {
+    extract_note_sections_limited(markdown, usize::MAX)
+}
+
+/// Read the newest bounded set of VISIBLE meetings mentioning an already-resolved entity and parse
+/// their CURRENT visible note Markdown. Both readers are existing lock gates. There is no cache or
+/// write path, so edits/resummarization are reflected on the next call and relock immediately hides
+/// the note again.
+pub(crate) fn visible_entity_note_context(
+    db: &Db,
+    entity_id: &str,
+    unlocked: &HashSet<String>,
+) -> Result<HistoricalNoteContext> {
+    // GATE 1: sealed-and-not-session-unlocked meetings are absent, including id/title/count.
+    let meetings = db.entity_mentions_visible_limited(
+        entity_id,
+        unlocked,
+        NOTE_CONTEXT_MEETING_LIMIT.saturating_add(1),
+    )?;
+    let meetings_scanned = meetings.len().min(NOTE_CONTEXT_MEETING_LIMIT);
+    let meetings_truncated = meetings.len() > NOTE_CONTEXT_MEETING_LIMIT;
+    let mut entries = Vec::new();
+    let mut entries_truncated = false;
+
+    for meeting in meetings.into_iter().take(NOTE_CONTEXT_MEETING_LIMIT) {
+        if entries_truncated {
+            // The bounded source row still belongs to the scanned window, but once the output cap
+            // is proven exceeded there is no reason to read more note bodies.
+            continue;
+        }
+        // GATE 2: re-read the current note only while it remains visible. A relocked/stale mention
+        // therefore contributes nothing, even if it passed the first query.
+        let Some(note) = db.get_note_if_visible(&meeting.meeting_id, unlocked)? else {
+            continue;
+        };
+        let remaining = NOTE_CONTEXT_ENTRY_LIMIT.saturating_sub(entries.len());
+        // Read one beyond the remaining output budget so truncation is explicit, never silent.
+        let extracted = extract_note_sections_limited(&note.markdown, remaining.saturating_add(1));
+        if extracted.len() > remaining {
+            entries_truncated = true;
+        }
+        let title = if meeting.title.trim().is_empty() {
+            "(untitled)".to_string()
+        } else {
+            meeting.title
+        };
+        entries.extend(
+            extracted
+                .into_iter()
+                .take(remaining)
+                .map(|entry| HistoricalNoteEntry {
+                    kind: entry.kind,
+                    text: entry.text,
+                    meeting_id: meeting.meeting_id.clone(),
+                    meeting_title: title.clone(),
+                    started_at: meeting.started_at.clone(),
+                }),
+        );
+    }
+
+    Ok(HistoricalNoteContext {
+        entries,
+        meetings_scanned,
+        meetings_truncated,
+        entries_truncated,
+    })
+}
+
+fn extract_note_sections_limited(markdown: &str, limit: usize) -> Vec<NoteSectionEntry> {
+    let mut entries = Vec::new();
+    let mut section = None;
+    let mut fence: Option<(char, usize)> = None;
+
+    for line in markdown.lines() {
+        if let Some((marker, run_len)) = fence_marker(line) {
+            match fence {
+                Some((open_marker, open_len))
+                    if marker == open_marker
+                        && run_len >= open_len
+                        && fence_tail(line, run_len).trim().is_empty() =>
+                {
+                    fence = None;
+                }
+                None => fence = Some((marker, run_len)),
+                Some(_) => {}
+            }
+            continue;
+        }
+        if fence.is_some() {
+            continue;
+        }
+        if let Some(heading) = atx_heading(line) {
+            section = section_kind(heading);
+            continue;
+        }
+        let Some(kind) = section else {
+            continue;
+        };
+        let Some(item) = list_item(line) else {
+            continue;
+        };
+        if is_checklist(item) || is_placeholder(item) {
+            continue;
+        }
+        entries.push(NoteSectionEntry {
+            kind,
+            text: item.trim().to_string(),
+        });
+        if entries.len() >= limit {
+            break;
+        }
+    }
+    entries
+}
+
+/// A CommonMark-style fenced block marker (up to three leading spaces, 3+ backticks or tildes).
+fn fence_marker(line: &str) -> Option<(char, usize)> {
+    let bytes = line.as_bytes();
+    let indent = bytes.iter().take_while(|byte| **byte == b' ').count();
+    if indent > 3 || indent >= bytes.len() {
+        return None;
+    }
+    let marker = bytes[indent] as char;
+    if marker != '`' && marker != '~' {
+        return None;
+    }
+    let run_len = bytes[indent..]
+        .iter()
+        .take_while(|byte| **byte == marker as u8)
+        .count();
+    (run_len >= 3).then_some((marker, run_len))
+}
+
+fn fence_tail(line: &str, run_len: usize) -> &str {
+    let indent = line.as_bytes().iter().take_while(|b| **b == b' ').count();
+    &line[indent + run_len..]
+}
+
+/// Parse an ATX heading and strip an optional closing `#` run. Setext headings are deliberately not
+/// accepted: requiring an explicit ATX boundary keeps the recognizer deterministic and local.
+fn atx_heading(line: &str) -> Option<&str> {
+    let bytes = line.as_bytes();
+    let indent = bytes.iter().take_while(|byte| **byte == b' ').count();
+    if indent > 3 || indent >= bytes.len() {
+        return None;
+    }
+    let hashes = bytes[indent..]
+        .iter()
+        .take_while(|byte| **byte == b'#')
+        .count();
+    if !(1..=6).contains(&hashes) {
+        return None;
+    }
+    let after = indent + hashes;
+    if after < bytes.len() && !bytes[after].is_ascii_whitespace() {
+        return None;
+    }
+    let heading = line[after..].trim();
+    let without_hashes = heading.trim_end_matches('#');
+    if without_hashes.len() != heading.len()
+        && without_hashes
+            .chars()
+            .last()
+            .map(char::is_whitespace)
+            .unwrap_or(false)
+    {
+        Some(without_hashes.trim_end())
+    } else {
+        Some(heading)
+    }
+}
+
+fn section_kind(heading: &str) -> Option<NoteSectionKind> {
+    let normalized = normalize_heading(heading);
+    match normalized.as_str() {
+        "decision" | "decisions" | "decyzja" | "decyzje" => Some(NoteSectionKind::Decision),
+        "risk"
+        | "risks"
+        | "ryzyko"
+        | "ryzyka"
+        | "open question"
+        | "open questions"
+        | "otwarte pytanie"
+        | "otwarte pytania"
+        | "risks and open questions"
+        | "risks or open questions"
+        | "risks and or open questions"
+        | "ryzyka i otwarte pytania"
+        | "ryzyka oraz otwarte pytania"
+        | "ryzyka lub otwarte pytania"
+        | "ryzyka i lub otwarte pytania"
+        | "ryzyka i or otwarte pytania"
+        | "ryzyka i or lub otwarte pytania"
+        | "ryzyka and otwarte pytania"
+        | "ryzyka or otwarte pytania" => Some(NoteSectionKind::RiskOrOpenQuestion),
+        _ => None,
+    }
+}
+
+/// Drop optional emoji/punctuation while preserving Unicode letters. `/` and `&` are normalized to
+/// connector words so `Risks/Open Questions`, `Risks & Open Questions`, and `and/or` forms match.
+fn normalize_heading(heading: &str) -> String {
+    let mut normalized = String::new();
+    for character in heading.chars() {
+        if character.is_alphanumeric() {
+            normalized.extend(character.to_lowercase());
+        } else if character == '&' {
+            normalized.push_str(" and ");
+        } else if character == '/' {
+            normalized.push_str(" or ");
+        } else {
+            normalized.push(' ');
+        }
+    }
+    let mut words = Vec::new();
+    for word in normalized.split_whitespace() {
+        if words.last().copied() != Some(word) {
+            words.push(word);
+        }
+    }
+    words.join(" ")
+}
+
+fn list_item(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    let mut chars = trimmed.char_indices();
+    let (_, first) = chars.next()?;
+    if matches!(first, '-' | '*' | '+' | '•') {
+        let after = &trimmed[first.len_utf8()..];
+        return (after.is_empty()
+            || after
+                .chars()
+                .next()
+                .map(char::is_whitespace)
+                .unwrap_or(false))
+        .then(|| after.trim_start());
+    }
+
+    let digit_bytes = trimmed
+        .as_bytes()
+        .iter()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    if digit_bytes == 0 || digit_bytes >= trimmed.len() {
+        return None;
+    }
+    let marker = trimmed.as_bytes()[digit_bytes];
+    if marker != b'.' && marker != b')' {
+        return None;
+    }
+    let after = &trimmed[digit_bytes + 1..];
+    (after
+        .chars()
+        .next()
+        .map(char::is_whitespace)
+        .unwrap_or(false))
+    .then(|| after.trim_start())
+}
+
+fn is_checklist(item: &str) -> bool {
+    let item = item.trim_start();
+    let Some(after_open) = item.strip_prefix('[') else {
+        return false;
+    };
+    let Some((marker, _)) = after_open.split_once(']') else {
+        return false;
+    };
+    matches!(marker.trim(), "" | "x" | "X" | "-" | "~" | "✓" | "✔")
+}
+
+fn is_placeholder(item: &str) -> bool {
+    let mut normalized = item.trim();
+    if normalized.is_empty()
+        || normalized.starts_with("<!--")
+        || (normalized.starts_with("{{") && normalized.ends_with("}}"))
+    {
+        return true;
+    }
+    normalized = normalized.trim_matches(|c: char| {
+        matches!(
+            c,
+            '*' | '_' | '~' | '`' | '"' | '\'' | '(' | ')' | '[' | ']'
+        )
+    });
+    normalized = normalized.trim();
+    normalized = normalized.trim_end_matches(['.', ',', ';', ':', '!', '?']);
+    let normalized = normalized.trim().to_lowercase();
+    matches!(
+        normalized.as_str(),
+        "" | "-"
+            | "—"
+            | "–"
+            | "…"
+            | "none"
+            | "none recorded"
+            | "nothing recorded"
+            | "not recorded"
+            | "not discussed"
+            | "not mentioned"
+            | "no decisions"
+            | "no decisions recorded"
+            | "no decisions were made"
+            | "no risks"
+            | "no risks recorded"
+            | "no open questions"
+            | "n/a"
+            | "na"
+            | "tbd"
+            | "todo"
+            | "brak"
+            | "brak decyzji"
+            | "brak ryzyk"
+            | "brak otwartych pytań"
+            | "nie odnotowano"
+            | "nie zapisano"
+            | "nie omówiono"
+            | "nie wspomniano"
+            | "nie dotyczy"
+            | "do ustalenia"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn texts(entries: &[NoteSectionEntry]) -> Vec<(NoteSectionKind, &str)> {
+        entries
+            .iter()
+            .map(|entry| (entry.kind, entry.text.as_str()))
+            .collect()
+    }
+
+    #[test]
+    fn parses_english_polish_emoji_and_connector_heading_variants() {
+        let markdown = "\
+## ✅ Decisions
+- Ship the Łódź rollout.
+## ⚠️ Risks & Open Questions
+- Will Zürich approve?
+## Decyzje 🎯
+- Wdrożyć żółty wariant.
+## Ryzyka i/lub otwarte pytania
+- Czy zespół ma budżet?
+## Risks and/or Open Questions
+- Supply-chain fallback?
+";
+        assert_eq!(
+            texts(&extract_note_sections(markdown)),
+            vec![
+                (NoteSectionKind::Decision, "Ship the Łódź rollout."),
+                (NoteSectionKind::RiskOrOpenQuestion, "Will Zürich approve?"),
+                (NoteSectionKind::Decision, "Wdrożyć żółty wariant."),
+                (NoteSectionKind::RiskOrOpenQuestion, "Czy zespół ma budżet?"),
+                (
+                    NoteSectionKind::RiskOrOpenQuestion,
+                    "Supply-chain fallback?"
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn respects_atx_boundaries_and_ignores_backtick_and_tilde_fences() {
+        let markdown = "\
+```markdown
+## Decisions
+- fenced backtick leak
+```
+## Decisions
+- Keep this decision.
+### Rationale
+- outside the decision section
+~~~md
+## Ryzyka
+- fenced tilde leak
+~~~
+## Risks / Open Questions
+- Keep this risk.
+## Summary
+- outside the risk section
+";
+        assert_eq!(
+            texts(&extract_note_sections(markdown)),
+            vec![
+                (NoteSectionKind::Decision, "Keep this decision."),
+                (NoteSectionKind::RiskOrOpenQuestion, "Keep this risk."),
+            ]
+        );
+    }
+
+    #[test]
+    fn omits_empty_placeholders_and_checklists_but_preserves_unicode_items() {
+        let markdown = "\
+## Decisions
+-
+- None recorded.
+- Brak decyzji.
+- N/A
+- [ ] This is an action, not a decision.
+- [x] Completed task is still a checklist.
+- Zażółć gęślą jaźń — decyzja pozostaje.
+## Otwarte pytania
+- TBD
+- Nie odnotowano.
+1. Czy właścicielką jest Łucja?
+";
+        assert_eq!(
+            texts(&extract_note_sections(markdown)),
+            vec![
+                (
+                    NoteSectionKind::Decision,
+                    "Zażółć gęślą jaźń — decyzja pozostaje."
+                ),
+                (
+                    NoteSectionKind::RiskOrOpenQuestion,
+                    "Czy właścicielką jest Łucja?"
+                ),
+            ]
+        );
+    }
+}

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -104,10 +104,13 @@ impl AssistantScope {
     fn allows(self, tool: &str) -> bool {
         // Local-MCP discovery helpers are intentionally absent from every cloud-capable assistant
         // scope. They can be dispatched only by the loopback MCP mapper into `execute_tool`.
-        if matches!(tool, "list_entities" | "list_note_folders") {
+        if matches!(
+            tool,
+            "list_entities" | "list_note_folders" | "knowledge_diff"
+        ) {
             return false;
         }
-        const VAULT_READS: [&str; 10] = [
+        const VAULT_READS: [&str; 9] = [
             "search_meetings",
             "search_semantic",
             "get_meeting",
@@ -118,9 +121,6 @@ impl AssistantScope {
             "list_recent_meetings",
             "get_open_commitments",
             "get_entity_dossier",
-            // Brain v3 PR-6 — the knowledge diff / decision ledger (an owned-vault fact read,
-            // egress-free; gated by `list_facts_visible` like `get_entity_dossier`).
-            "knowledge_diff",
             // Feature C — the typed note-folder database query (an owned-vault read, egress-free).
             "query_database",
         ];
@@ -259,11 +259,13 @@ pub enum ToolCall {
     /// Local-MCP-only discovery of visible note folders, visible row counts, and typed columns.
     /// Intentionally absent from [`tool_specs`] and [`GatedToolExecutor`].
     ListNoteFolders,
-    /// Brain v3 PR-6 — the KNOWLEDGE DIFF / decision ledger for one entity: what changed between two
-    /// instants (`from`/`to` ISO-8601) plus the full chronological supersession ledger. EGRESS-FREE:
-    /// reads the entity's facts through the visibility-gated [`Db::list_facts_visible`] inside
-    /// [`crate::facts::build_knowledge_diff`], so a sealed-and-not-session-unlocked meeting's fact is
-    /// invisible here too. Caller passes a non-empty entity name/id; `from`/`to` are required.
+    /// LOCAL-MCP-ONLY knowledge diff / decision ledger for one entity: what changed between two
+    /// instants (`from`/`to` ISO-8601), the chronological supersession ledger, and a separate,
+    /// explicitly-HISTORICAL read-time context from Decisions / Risks / Open Questions sections in
+    /// visible mentioning-meeting notes. Intentionally absent from [`tool_specs`] and every
+    /// [`GatedToolExecutor`] scope, so note-derived content can leave this seam only through the
+    /// fixed loopback MCP transport and its visibility-revocation response gate. The note section is
+    /// never represented as current truth or an open-risk ledger.
     KnowledgeDiff {
         entity: String,
         from: String,
@@ -1108,18 +1110,24 @@ pub fn execute_tool(
         ToolCall::KnowledgeDiff { entity, from, to } => {
             // EGRESS-FREE + GATED: resolve the entity through the SAME gated resolver as the dossier
             // (a sealed-only entity never resolves), then build the diff/ledger through the
-            // visibility-gated `build_knowledge_diff` (`list_facts_visible`). No provider is ever
-            // constructed; nothing egresses.
+            // visibility-gated `build_knowledge_diff` (`list_facts_visible`). Separately parse the
+            // CURRENT visible note Markdown at read time through `entity_mentions_visible` +
+            // `get_note_if_visible`; this is historical source context, never fact-ledger state.
+            // No provider is ever constructed; nothing egresses.
             let entity = entity.as_str();
             let id = match crate::summarize::dossier::resolve_entity_id(db, entity, unlocked) {
                 Ok(Some(id)) => id,
                 Ok(None) => return entity_not_found(db, entity, unlocked),
                 Err(e) => return Err(AppError::Storage(format!("entity resolve failed: {e}"))),
             };
-            match crate::facts::build_knowledge_diff(db, &id, from, to, unlocked) {
-                Ok(kd) => Ok(format_knowledge_diff(entity, &kd)),
-                Err(e) => Err(AppError::Storage(format!("knowledge diff failed: {e}"))),
-            }
+            let kd = crate::facts::build_knowledge_diff(db, &id, from, to, unlocked)
+                .map_err(|e| AppError::Storage(format!("knowledge diff failed: {e}")))?;
+            let note_context =
+                crate::summarize::note_sections::visible_entity_note_context(db, &id, unlocked)
+                    .map_err(|e| {
+                        AppError::Storage(format!("knowledge diff note context failed: {e}"))
+                    })?;
+            Ok(format_knowledge_diff(entity, &kd, &note_context))
         }
         ToolCall::WebSearch { .. } => {
             // EGRESS GUARD: the synchronous, egress-free `execute_tool` is the MCP surface's only
@@ -1856,11 +1864,14 @@ fn edit_distance_at_most_two(left: &str, right: &str) -> bool {
 }
 
 /// Render the KNOWLEDGE DIFF into the tool text payload for the client to narrate: the between-two-
-/// instants set diff (added / removed / changed) then the chronological decision ledger. Each line is
-/// `<subject> · <predicate>: <old> → <new>` (or `+ <new>` / `- <old>`), with the effective date and
-/// the `source:<meetingId>` provenance so the client can cite. No entity/predicate/object is logged —
-/// this is the RETURNED payload, not a log line.
-fn format_knowledge_diff(entity: &str, kd: &crate::facts::EntityKnowledgeDiff) -> String {
+/// instants fact diff + chronological decision ledger, followed by a SEPARATE historical note
+/// context. Extracted note list items remain source-labelled historical material; they are never
+/// represented as bitemporal facts, current truth, or a live/open-risk ledger.
+fn format_knowledge_diff(
+    entity: &str,
+    kd: &crate::facts::EntityKnowledgeDiff,
+    note_context: &crate::summarize::note_sections::HistoricalNoteContext,
+) -> String {
     fn line(c: &crate::facts::FactStateChange) -> String {
         let val = match (&c.old_object, &c.new_object) {
             (Some(o), Some(n)) => format!("{o} → {n}"),
@@ -1904,6 +1915,53 @@ fn format_knowledge_diff(entity: &str, kd: &crate::facts::EntityKnowledgeDiff) -
     section("DECISION LEDGER (oldest → newest)", &kd.ledger);
     if d.changed.is_empty() && d.added.is_empty() && d.removed.is_empty() && kd.ledger.is_empty() {
         out.push_str("\nNo tracked facts in this window.\n");
+    }
+    if !note_context.entries.is_empty()
+        || note_context.meetings_truncated
+        || note_context.entries_truncated
+    {
+        out.push_str(
+            "\nHISTORICAL NOTE CONTEXT FROM CURRENTLY VISIBLE MEETINGS MENTIONING THIS ENTITY:\n\
+             Verbatim list items below are historical meeting-note material, not bitemporal facts, \
+             not necessarily current truth, and not an open-risk ledger.\n",
+        );
+        for entry in &note_context.entries {
+            let kind = match entry.kind {
+                crate::summarize::note_sections::NoteSectionKind::Decision => "historical decision",
+                crate::summarize::note_sections::NoteSectionKind::RiskOrOpenQuestion => {
+                    "historical risk/open question"
+                }
+            };
+            let date = entry.started_at.split(['T', ' ']).next().unwrap_or("");
+            out.push_str(&format!(
+                "- {kind} · [[{}]] · {} · source:{} — {}\n",
+                entry.meeting_title, date, entry.meeting_id, entry.text
+            ));
+        }
+        if note_context.meetings_truncated || note_context.entries_truncated {
+            let meeting_bound = if note_context.meetings_truncated {
+                format!(
+                    "newest {} visible mentioning meetings scanned",
+                    crate::summarize::note_sections::NOTE_CONTEXT_MEETING_LIMIT
+                )
+            } else {
+                format!(
+                    "{} visible mentioning meeting(s) scanned",
+                    note_context.meetings_scanned
+                )
+            };
+            let entry_bound = if note_context.entries_truncated {
+                format!(
+                    "first {} extracted entries shown",
+                    crate::summarize::note_sections::NOTE_CONTEXT_ENTRY_LIMIT
+                )
+            } else {
+                format!("all {} extracted entries shown", note_context.entries.len())
+            };
+            out.push_str(&format!(
+                "[HISTORICAL NOTE CONTEXT TRUNCATED — {meeting_bound}; {entry_bound}.]\n"
+            ));
+        }
     }
     out
 }
@@ -7166,10 +7224,11 @@ mod tests {
             !names.contains("search_transcript")
                 && !names.contains("get_meeting_chapters")
                 && !names.contains("list_entities")
-                && !names.contains("list_note_folders"),
+                && !names.contains("list_note_folders")
+                && !names.contains("knowledge_diff"),
             "local MCP helpers must never become agent/cloud prompt input"
         );
-        for tool in ["list_entities", "list_note_folders"] {
+        for tool in ["list_entities", "list_note_folders", "knowledge_diff"] {
             for scope in [
                 AssistantScope::CurrentMeeting,
                 AssistantScope::Vault,
@@ -7202,6 +7261,15 @@ mod tests {
                 "list_note_folders",
                 ToolCall::ListNoteFolders,
                 "No visible note folders.",
+            ),
+            (
+                "knowledge_diff",
+                ToolCall::KnowledgeDiff {
+                    entity: "nobody".into(),
+                    from: "2026-01-01T00:00:00Z".into(),
+                    to: "2026-12-31T23:59:59Z".into(),
+                },
+                "No visible entity matching \"nobody\".",
             ),
         ];
         for (_, call, expected) in &local_only_calls {
@@ -7265,6 +7333,228 @@ mod tests {
                 }
             }
         }
+    }
+
+    fn knowledge_diff_output(db: &Db, entity: &str, unlocked: &HashSet<String>) -> String {
+        execute_tool(
+            &ToolCall::KnowledgeDiff {
+                entity: entity.to_string(),
+                from: "2026-01-01T00:00:00Z".into(),
+                to: "2026-12-31T23:59:59Z".into(),
+            },
+            db,
+            unlocked,
+            &AppConfig::default(),
+        )
+        .unwrap()
+    }
+
+    /// R3 read-time note context: an entity with ZERO fact rows still gets explicitly-historical
+    /// Decisions/Risks from its visible mentioning note; an edit is reflected immediately; a hidden
+    /// meeting is byte-identical to absence, appears only during unlock, and disappears on relock.
+    /// The pre-existing bitemporal fact ledger continues to render independently.
+    #[test]
+    fn knowledge_diff_note_context_is_live_bounded_by_visibility_and_preserves_fact_ledger() {
+        use crate::facts::{FactOp, NewFact};
+        use crate::storage::models::EntityKind;
+
+        let db = tmp_db();
+        seed_meeting(
+            &db,
+            "m-open",
+            "Atlas Open Review",
+            "## Decisions\n- Use the blue launch plan.\n\
+             ## Risks & Open Questions\n- Will Łucja approve the rollout?\n",
+            None,
+        );
+        let atlas = db.upsert_entity("Atlas", EntityKind::Project).unwrap();
+        db.add_mention(&atlas, "m-open").unwrap();
+        let nothing = HashSet::new();
+
+        // No fact rows at all: note-derived context is still useful, but is explicitly NOT truth.
+        let no_facts = knowledge_diff_output(&db, &atlas, &nothing);
+        assert!(
+            no_facts.contains("No tracked facts in this window.")
+                && no_facts.contains(
+                    "HISTORICAL NOTE CONTEXT FROM CURRENTLY VISIBLE MEETINGS MENTIONING THIS ENTITY"
+                )
+                && no_facts.contains("Use the blue launch plan.")
+                && no_facts.contains("Will Łucja approve the rollout?")
+                && no_facts.contains("not necessarily current truth")
+                && no_facts.contains("not an open-risk ledger"),
+            "zero-fact entity must still return honestly-labelled visible note context: {no_facts}"
+        );
+
+        // Read-time, no stale rows: replace the note and the very next query sees only the new text.
+        db.upsert_note(&NoteRecord {
+            meeting_id: "m-open".into(),
+            provider_id: "claude_code".into(),
+            markdown: "## ✅ Decisions\n- Use the green launch plan.\n".into(),
+            created_at: "2026-07-29T01:00:00Z".into(),
+            exported_path: None,
+            model_requested: None,
+            model_served: None,
+            gateway_host: None,
+        })
+        .unwrap();
+        let edited = knowledge_diff_output(&db, &atlas, &nothing);
+        assert!(
+            edited.contains("Use the green launch plan.")
+                && !edited.contains("Use the blue launch plan.")
+                && !edited.contains("Will Łucja approve"),
+            "knowledge_diff must parse the current note, never stale extracted rows: {edited}"
+        );
+
+        // The original bitemporal ledger is unchanged and renders beside—not merged with—the note
+        // context.
+        db.apply_fact_ops(&[FactOp::Add(NewFact {
+            entity_id: atlas.clone(),
+            subject: "Atlas".into(),
+            predicate: "status".into(),
+            object: "active".into(),
+            valid_from: "2026-06-01T00:00:00Z".into(),
+            recorded_at: "2026-06-01T00:00:00Z".into(),
+            confidence: 1.0,
+            meeting_id: Some("m-open".into()),
+        })])
+        .unwrap();
+        let visible_baseline = knowledge_diff_output(&db, &atlas, &nothing);
+        assert!(
+            visible_baseline.contains("ADDED:")
+                && visible_baseline.contains("Atlas · status: + active")
+                && visible_baseline.contains("Use the green launch plan."),
+            "legacy fact diff and historical note context must both remain intact: {visible_baseline}"
+        );
+
+        seed_folder(&db, "f-secret-note-context", "Secret note context");
+        seed_meeting(
+            &db,
+            "m-secret-note-context",
+            "Secret Atlas Decision",
+            "## Decyzje\n- SECRET-ATLAS-DECISION.\n\
+             ## Ryzyka i otwarte pytania\n- SECRET-ATLAS-RISK?\n",
+            Some("f-secret-note-context"),
+        );
+        db.add_mention(&atlas, "m-secret-note-context").unwrap();
+        db.set_folder_locked("f-secret-note-context", true, Some(b"wrapped"))
+            .unwrap();
+
+        // Exact locked-vs-absent non-disclosure: adding a now-sealed source changes zero bytes.
+        let locked = knowledge_diff_output(&db, &atlas, &nothing);
+        assert_eq!(
+            locked, visible_baseline,
+            "a locked mentioning meeting must be byte-identical to the same vault without it"
+        );
+        for secret in [
+            "m-secret-note-context",
+            "Secret Atlas Decision",
+            "SECRET-ATLAS-DECISION",
+            "SECRET-ATLAS-RISK",
+        ] {
+            assert!(
+                !locked.contains(secret),
+                "sealed meeting id/title/content leaked through knowledge_diff: {locked}"
+            );
+        }
+
+        let mut unlocked = HashSet::new();
+        unlocked.insert("f-secret-note-context".to_string());
+        let open = knowledge_diff_output(&db, &atlas, &unlocked);
+        assert!(
+            open.contains("m-secret-note-context")
+                && open.contains("[[Secret Atlas Decision]]")
+                && open.contains("SECRET-ATLAS-DECISION")
+                && open.contains("SECRET-ATLAS-RISK"),
+            "session unlock must expose eligible historical note sections: {open}"
+        );
+
+        let relocked = knowledge_diff_output(&db, &atlas, &nothing);
+        assert_eq!(
+            relocked, visible_baseline,
+            "relock must immediately restore byte-identical non-disclosure without a purge"
+        );
+    }
+
+    /// Both independent bounds are honest: only the newest 100 visible mentioning meetings are in
+    /// the source window, and at most 100 extracted entries render with a truncation marker.
+    #[test]
+    fn knowledge_diff_note_context_enforces_meeting_and_entry_bounds() {
+        use crate::storage::models::EntityKind;
+
+        let db = tmp_db();
+        let atlas = db
+            .upsert_entity("Atlas Bounds", EntityKind::Project)
+            .unwrap();
+        // Same started_at is deliberate: the reader's stable id-desc tie-break makes m-101 newest.
+        // The SQL query fetches 101 rows (100 displayed + one truncation witness), so m-000 is not
+        // materialized and m-001 is the witness outside the displayed source window.
+        for index in 0..=101 {
+            let meeting_id = format!("m-{index:03}");
+            let markdown = if index == 0 {
+                "## Decisions\n- OUTSIDE-SQL-WINDOW.\n"
+            } else if index == 1 {
+                "## Decisions\n- OUTSIDE-DISPLAY-WINDOW.\n"
+            } else {
+                "## Summary\n- no eligible historical entry\n"
+            };
+            seed_meeting(
+                &db,
+                &meeting_id,
+                &format!("Bounds {index:03}"),
+                markdown,
+                None,
+            );
+            db.add_mention(&atlas, &meeting_id).unwrap();
+        }
+        let sql_window = db
+            .entity_mentions_visible_limited(&atlas, &HashSet::new(), 101)
+            .unwrap();
+        assert_eq!(sql_window.len(), 101);
+        assert_eq!(sql_window.first().unwrap().meeting_id, "m-101");
+        assert_eq!(sql_window.last().unwrap().meeting_id, "m-001");
+        assert!(
+            sql_window
+                .iter()
+                .all(|meeting| meeting.meeting_id != "m-000"),
+            "the oldest row must be outside the SQL source bound"
+        );
+        let meeting_bounded = knowledge_diff_output(&db, &atlas, &HashSet::new());
+        assert!(
+            !meeting_bounded.contains("OUTSIDE-SQL-WINDOW")
+                && !meeting_bounded.contains("OUTSIDE-DISPLAY-WINDOW")
+                && meeting_bounded.contains("newest 100 visible mentioning meetings scanned"),
+            "SQL and displayed source windows must be bounded with an honest marker: \
+             {meeting_bounded}"
+        );
+
+        let entries_entity = db
+            .upsert_entity("Entry Bounds", EntityKind::Project)
+            .unwrap();
+        let entry_markdown = format!(
+            "## Decisions\n{}",
+            (0..=100)
+                .map(|index| format!("- ENTRY-{index:03}."))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        seed_meeting(&db, "m-entry-bounds", "Entry Bounds", &entry_markdown, None);
+        db.add_mention(&entries_entity, "m-entry-bounds").unwrap();
+        let entry_bounded = knowledge_diff_output(&db, &entries_entity, &HashSet::new());
+        assert_eq!(
+            entry_bounded
+                .lines()
+                .filter(|line| line.starts_with("- historical decision"))
+                .count(),
+            100,
+            "at most 100 extracted entries may render"
+        );
+        assert!(
+            entry_bounded.contains("ENTRY-000")
+                && entry_bounded.contains("ENTRY-099")
+                && !entry_bounded.contains("ENTRY-100")
+                && entry_bounded.contains("first 100 extracted entries shown"),
+            "entry truncation must preserve order and disclose its bound: {entry_bounded}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- derive Decisions, Risks, and Open Questions at read time from the newest currently visible notes
- keep this context local to the fixed loopback MCP surface and out of model-facing tools
- bound the SQL candidate set to 101 and the rendered result to 100 entries
- revalidate visibility immediately before the MCP response, returning a content-free retry sentinel on relock

This safely replaces #491 without a new registry table, migration, or write-time cache.

## Verification
- Harness v2 PASS, Codex-only
- Rust: 2560 passed, 0 failed, 15 ignored
- combined adversarial review: PASS, 0 findings/proof gaps
- lock-security review: PASS, 0 findings/proof gaps
- egress review: PASS, 0 findings/proof gaps
- parser coverage includes English/Polish headings, emoji, fences, Unicode, placeholders, checklists, immediate edits, unlock/relock, bounds, and fact-ledger separation
