### PR TITLE
feat(reminders): add smart reminder inbox

### DIFF
--- a/e2e/reminders/reminders.spec.ts
+++ b/e2e/reminders/reminders.spec.ts
@@ -1,0 +1,2430 @@
+import { expect, test } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+const REMINDER_VISIBILITY_EVENT = "murmur://reminder-visibility-invalidated";
+const REMINDERS_UPDATED_EVENT = "murmur://reminders-updated";
+
+test("Reminders: a live count cannot be lost or overwritten by a stale startup summary", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    get_reminder_summary: () => {
+      const target = window as unknown as {
+        __summaryRequestStarted?: boolean;
+        __resolveReminderSummary?: (value: { dueInboxCount: number }) => void;
+      };
+      target.__summaryRequestStarted = true;
+      return new Promise<{ dueInboxCount: number }>((resolve) => {
+        target.__resolveReminderSummary = resolve;
+      });
+    },
+  });
+
+  await page.goto("/record");
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as unknown as { __summaryRequestStarted?: boolean })
+            .__summaryRequestStarted === true,
+      ),
+    )
+    .toBe(true);
+
+  await page.evaluate(() => {
+    const target = window as unknown as {
+      __demoEmit: (event: string, payload: unknown) => void;
+      __resolveReminderSummary?: (value: { dueInboxCount: number }) => void;
+    };
+    target.__demoEmit("murmur://reminders-updated", { dueInboxCount: 4 });
+    target.__resolveReminderSummary?.({ dueInboxCount: 2 });
+  });
+
+  const reminderNav = page.getByRole("link", { name: "Reminders" }).first();
+  await expect(reminderNav.locator(".nav-reminder-count")).toHaveText("4");
+});
+
+test("Reminders: a listener resolving after root teardown is immediately unregistered", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {},
+    {},
+    [],
+    [REMINDERS_UPDATED_EVENT],
+  );
+
+  await page.goto("/reminders");
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (event) =>
+          (
+            window as unknown as {
+              __demoEventListenerRegistrationCount: (
+                name: string,
+              ) => number;
+            }
+          ).__demoEventListenerRegistrationCount(event),
+        REMINDERS_UPDATED_EVENT,
+      ),
+    )
+    .toBe(1);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (event) =>
+          (
+            window as unknown as {
+              __demoEventListenerUnregisterCount: (name: string) => number;
+            }
+          ).__demoEventListenerUnregisterCount(event),
+        REMINDERS_UPDATED_EVENT,
+      ),
+    )
+    .toBe(0);
+
+  await page.evaluate(() => {
+    type AngularDebug = {
+      getInjector: (element: Element) => unknown;
+      ɵgetInjectorMetadata: (injector: unknown) => { type?: string } | null;
+      ɵgetInjectorResolutionPath: (injector: unknown) => unknown[];
+    };
+    const angular = (window as unknown as { ng?: AngularDebug }).ng;
+    const root = document.querySelector("app-root");
+    if (!angular || !root) {
+      throw new Error("Angular debug injector is unavailable");
+    }
+    const rootInjector = angular.getInjector(root);
+    const appEnvironment = angular
+      .ɵgetInjectorResolutionPath(rootInjector)
+      .find(
+        (injector) =>
+          angular.ɵgetInjectorMetadata(injector)?.type === "environment" &&
+          typeof (injector as { destroy?: unknown }).destroy === "function",
+      ) as { destroy: () => void } | undefined;
+    if (!appEnvironment) {
+      throw new Error("Angular application environment injector is unavailable");
+    }
+    appEnvironment.destroy();
+  });
+
+  await page.evaluate((event) => {
+    (
+      window as unknown as {
+        __demoReleaseEventListeners: (name: string) => void;
+      }
+    ).__demoReleaseEventListeners(event);
+  }, REMINDERS_UPDATED_EVENT);
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (event) =>
+          (
+            window as unknown as {
+              __demoEventListenerUnregisterCount: (name: string) => number;
+            }
+          ).__demoEventListenerUnregisterCount(event),
+        REMINDERS_UPDATED_EVENT,
+      ),
+    )
+    .toBe(1);
+});
+
+test("Reminders: an event supersedes the first in-flight list snapshot", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    get_reminder_summary: () => {
+      const target = window as unknown as Record<string, any>;
+      target.__firstListSummaryStarted = true;
+      return { dueInboxCount: 0 };
+    },
+    list_reminders: () => {
+      const target = window as unknown as Record<string, any>;
+      const makeSnapshot = (title: string, count: number) => {
+        const now = Date.now();
+        return {
+          inbox: Array.from({ length: count }, (_, index) => ({
+            occurrenceId: `${title}-occurrence-${index}`,
+            dueAt: now - (index + 1) * 60_000,
+            reminder: {
+              id: `${title}-reminder-${index}`,
+              title: `${title} ${index + 1}`,
+              details: null,
+              dueAt: now - (index + 1) * 60_000,
+              repeatEvery: null,
+              repeatUnit: null,
+              state: "active",
+              origin: "manual",
+              createdAt: now - 120_000,
+              updatedAt: now - 120_000,
+              completedAt: null,
+              sources: [],
+            },
+          })),
+          upcoming: [],
+          completed: [],
+          dueInboxCount: count,
+        };
+      };
+
+      target.__firstListCalls = (target.__firstListCalls ?? 0) + 1;
+      if (target.__firstListCalls === 1) {
+        target.__firstReminderListStarted = true;
+        const staleSnapshot = makeSnapshot("Stale first row", 1);
+        return new Promise((resolve) => {
+          target.__resolveFirstReminderList = () => resolve(staleSnapshot);
+        });
+      }
+      return makeSnapshot("Current event row", 4);
+    },
+  });
+
+  await page.goto("/reminders");
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const target = window as unknown as Record<string, any>;
+        return (
+          target.__firstListSummaryStarted === true &&
+          target.__firstReminderListStarted === true
+        );
+      }),
+    )
+    .toBe(true);
+
+  await page.evaluate(() => {
+    const target = window as unknown as {
+      __demoEmit: (event: string, payload: unknown) => void;
+    };
+    target.__demoEmit("murmur://reminders-updated", { dueInboxCount: 4 });
+  });
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (window as unknown as Record<string, any>).__firstListCalls ?? 0,
+      ),
+    )
+    .toBe(2);
+  await expect(page.getByText("Current event row 1")).toBeVisible();
+
+  await page.evaluate(async () => {
+    const target = window as unknown as Record<string, any>;
+    target.__resolveFirstReminderList?.();
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    });
+  });
+
+  await expect(page.getByText("Current event row 1")).toBeVisible();
+  await expect(page.getByText("Stale first row 1")).toHaveCount(0);
+  await expect(
+    page
+      .getByRole("link", { name: "Reminders" })
+      .first()
+      .locator(".nav-reminder-count"),
+  ).toHaveText("4");
+});
+
+test("Reminders: source invalidation masks a cached title before canonical refresh resolves", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    get_reminder_summary: () => ({ dueInboxCount: 1 }),
+    list_reminders: () => {
+      const target = window as unknown as {
+        __sourceMaskListCalls?: number;
+        __sourceMaskRefreshStarted?: boolean;
+        __resolveSourceMaskRefresh?: () => void;
+      };
+      const now = Date.now();
+      const reminder = {
+        id: "r-source-mask",
+        title: "Keep this reminder",
+        details: null,
+        dueAt: now - 60_000,
+        repeatEvery: null,
+        repeatUnit: null,
+        state: "active",
+        origin: "manual",
+        createdAt: now - 120_000,
+        updatedAt: now - 120_000,
+        completedAt: null,
+        sources: [
+          {
+            kind: "meeting",
+            id: "m-source-mask",
+            title: "Sealed source title",
+          },
+        ],
+      };
+      target.__sourceMaskListCalls = (target.__sourceMaskListCalls ?? 0) + 1;
+      if (target.__sourceMaskListCalls === 1) {
+        return {
+          inbox: [
+            {
+              occurrenceId: "o-source-mask",
+              dueAt: reminder.dueAt,
+              reminder,
+            },
+          ],
+          upcoming: [],
+          completed: [],
+          dueInboxCount: 1,
+        };
+      }
+      target.__sourceMaskRefreshStarted = true;
+      return new Promise((resolve) => {
+        target.__resolveSourceMaskRefresh = () =>
+          resolve({
+            inbox: [
+              {
+                occurrenceId: "o-source-mask",
+                dueAt: reminder.dueAt,
+                reminder: { ...reminder, sources: [] },
+              },
+            ],
+            upcoming: [],
+            completed: [],
+            dueInboxCount: 1,
+          });
+      });
+    },
+  });
+
+  await page.goto("/reminders");
+  const sourceChip = page
+    .locator(".source-chip")
+    .filter({ hasText: "Sealed source title" });
+  await expect(sourceChip).toBeVisible();
+
+  await page.evaluate(() => {
+    const target = window as unknown as {
+      __demoEmit: (event: string, payload: unknown) => void;
+    };
+    target.__demoEmit("murmur://reminder-source-updated", {
+      kind: "meeting",
+      id: "m-source-mask",
+    });
+  });
+
+  // The canonical read is deliberately still pending: masking must be a
+  // synchronous cache operation, not a successful-refetch side effect.
+  await expect(sourceChip).toHaveCount(0, { timeout: 700 });
+  await expect(page.getByText("Keep this reminder")).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as unknown as {
+              __sourceMaskRefreshStarted?: boolean;
+            }
+          ).__sourceMaskRefreshStarted === true,
+      ),
+    )
+    .toBe(true);
+
+  await page.evaluate(() => {
+    (
+      window as unknown as {
+        __resolveSourceMaskRefresh?: () => void;
+      }
+    ).__resolveSourceMaskRefresh?.();
+  });
+  await expect(page.getByText("Keep this reminder")).toBeVisible();
+  await expect(sourceChip).toHaveCount(0);
+});
+
+test("Reminders: source invalidation racing the first list cannot restore a stale title", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    get_reminder_summary: () => ({ dueInboxCount: 1 }),
+    list_reminders: () => {
+      const target = window as unknown as {
+        __sourceRaceListCalls?: number;
+        __sourceRaceFirstStarted?: boolean;
+        __resolveSourceRaceFirst?: () => void;
+      };
+      const now = Date.now();
+      target.__sourceRaceListCalls = (target.__sourceRaceListCalls ?? 0) + 1;
+      const makeSnapshot = (title: string, withSource: boolean) => {
+        const reminder = {
+          id: "r-source-race",
+          title,
+          details: null,
+          dueAt: now - 60_000,
+          repeatEvery: null,
+          repeatUnit: null,
+          state: "active",
+          origin: "manual",
+          createdAt: now - 120_000,
+          updatedAt: now - 120_000,
+          completedAt: null,
+          sources: withSource
+            ? [
+                {
+                  kind: "note",
+                  id: "n-source-race",
+                  title: "First snapshot sealed title",
+                },
+              ]
+            : [],
+        };
+        return {
+          inbox: [
+            {
+              occurrenceId: "o-source-race",
+              dueAt: reminder.dueAt,
+              reminder,
+            },
+          ],
+          upcoming: [],
+          completed: [],
+          dueInboxCount: 1,
+        };
+      };
+      if (target.__sourceRaceListCalls === 1) {
+        target.__sourceRaceFirstStarted = true;
+        const stale = makeSnapshot("Stale reminder snapshot", true);
+        return new Promise((resolve) => {
+          target.__resolveSourceRaceFirst = () => resolve(stale);
+        });
+      }
+      return makeSnapshot("Current reminder snapshot", false);
+    },
+  });
+
+  await page.goto("/reminders");
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as unknown as {
+              __sourceRaceFirstStarted?: boolean;
+            }
+          ).__sourceRaceFirstStarted === true,
+      ),
+    )
+    .toBe(true);
+
+  await page.evaluate(() => {
+    const target = window as unknown as {
+      __demoEmit: (event: string, payload: unknown) => void;
+    };
+    target.__demoEmit("murmur://reminder-source-updated", {
+      kind: "note",
+      id: "n-source-race",
+    });
+  });
+
+  await expect(page.getByText("Current reminder snapshot")).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as unknown as {
+              __sourceRaceListCalls?: number;
+            }
+          ).__sourceRaceListCalls ?? 0,
+      ),
+    )
+    .toBe(2);
+
+  await page.evaluate(async () => {
+    const target = window as unknown as {
+      __resolveSourceRaceFirst?: () => void;
+    };
+    target.__resolveSourceRaceFirst?.();
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    });
+  });
+
+  await expect(page.getByText("Current reminder snapshot")).toBeVisible();
+  await expect(page.getByText("Stale reminder snapshot")).toHaveCount(0);
+  await expect(
+    page.getByText("First snapshot sealed title", { exact: true }),
+  ).toHaveCount(0);
+});
+
+test("Reminder composer: source invalidation closes and purges an open edit", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    get_reminder_summary: () => ({ dueInboxCount: 1 }),
+    list_reminders: () => {
+      const target = window as unknown as {
+        __composerSourceListCalls?: number;
+      };
+      const now = Date.now();
+      target.__composerSourceListCalls =
+        (target.__composerSourceListCalls ?? 0) + 1;
+      const reminder = {
+        id: "r-composer-source",
+        title: "Composer reminder",
+        details: null,
+        dueAt: now - 60_000,
+        repeatEvery: null,
+        repeatUnit: null,
+        state: "active",
+        origin: "manual",
+        createdAt: now - 120_000,
+        updatedAt: now - 120_000,
+        completedAt: null,
+        sources:
+          target.__composerSourceListCalls === 1
+            ? [
+                {
+                  kind: "meeting",
+                  id: "m-composer-source",
+                  title: "Composer sealed title",
+                },
+              ]
+            : [],
+      };
+      return {
+        inbox: [
+          {
+            occurrenceId: "o-composer-source",
+            dueAt: reminder.dueAt,
+            reminder,
+          },
+        ],
+        upcoming: [],
+        completed: [],
+        dueInboxCount: 1,
+      };
+    },
+  });
+
+  await page.goto("/reminders");
+  await expect(page.getByText("Composer reminder")).toBeVisible();
+  await page
+    .locator(".reminder-card")
+    .filter({ hasText: "Composer reminder" })
+    .getByRole("button", { name: "Edit" })
+    .click();
+
+  const composer = page.locator("app-reminder-composer");
+  await expect(composer.getByRole("dialog")).toBeVisible();
+  await expect(
+    composer.getByText("Composer sealed title", { exact: true }),
+  ).toBeVisible();
+
+  await page.evaluate(() => {
+    const target = window as unknown as {
+      __demoEmit: (event: string, payload: unknown) => void;
+    };
+    target.__demoEmit("murmur://reminder-source-updated", {
+      kind: "meeting",
+      id: "m-composer-source",
+    });
+  });
+
+  await expect(composer.getByRole("dialog")).toHaveCount(0, { timeout: 700 });
+  await expect(
+    page.getByText("Composer sealed title", { exact: true }),
+  ).toHaveCount(0);
+});
+
+test("Reminders: global visibility invalidation purges every cached source and composer", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    get_reminder_summary: () => ({ dueInboxCount: 1 }),
+    list_reminders: () => {
+      const target = window as unknown as {
+        __globalVisibilityListCalls?: number;
+        __globalVisibilityRefreshStarted?: boolean;
+        __resolveGlobalVisibilityRefresh?: () => void;
+      };
+      const now = Date.now();
+      const reminder = (
+        id: string,
+        title: string,
+        sourceTitle: string,
+        dueAt: number,
+        state: "active" | "completed",
+      ) => ({
+        id,
+        title,
+        details: null,
+        dueAt,
+        repeatEvery: null,
+        repeatUnit: null,
+        state,
+        origin: "manual",
+        createdAt: now - 120_000,
+        updatedAt: now - 120_000,
+        completedAt: state === "completed" ? now - 30_000 : null,
+        sources: [
+          {
+            kind: "meeting",
+            id: `m-${id}`,
+            title: sourceTitle,
+          },
+        ],
+      });
+      const inboxReminder = reminder(
+        "global-inbox",
+        "Global inbox reminder",
+        "Global inbox source",
+        now - 60_000,
+        "active",
+      );
+      const snapshot = {
+        inbox: [
+          {
+            occurrenceId: "o-global-inbox",
+            dueAt: inboxReminder.dueAt,
+            reminder: inboxReminder,
+          },
+        ],
+        upcoming: [
+          reminder(
+            "global-upcoming",
+            "Global upcoming reminder",
+            "Global upcoming source",
+            now + 60_000,
+            "active",
+          ),
+        ],
+        completed: [
+          reminder(
+            "global-completed",
+            "Global completed reminder",
+            "Global completed source",
+            now - 120_000,
+            "completed",
+          ),
+        ],
+        dueInboxCount: 1,
+      };
+      target.__globalVisibilityListCalls =
+        (target.__globalVisibilityListCalls ?? 0) + 1;
+      if (target.__globalVisibilityListCalls === 1) {
+        return snapshot;
+      }
+      target.__globalVisibilityRefreshStarted = true;
+      return new Promise((resolve) => {
+        target.__resolveGlobalVisibilityRefresh = () =>
+          resolve({
+            ...snapshot,
+            inbox: snapshot.inbox.map((row) => ({
+              ...row,
+              reminder: { ...row.reminder, sources: [] },
+            })),
+            upcoming: snapshot.upcoming.map((row) => ({
+              ...row,
+              sources: [],
+            })),
+            completed: snapshot.completed.map((row) => ({
+              ...row,
+              sources: [],
+            })),
+          });
+      });
+    },
+  });
+
+  await page.goto("/reminders");
+  await expect(page.getByText("Global inbox source")).toBeVisible();
+  await page
+    .locator(".reminder-card")
+    .filter({ hasText: "Global inbox reminder" })
+    .getByRole("button", { name: "Edit" })
+    .click();
+  const composer = page.locator("app-reminder-composer");
+  await expect(composer.getByRole("dialog")).toBeVisible();
+  await expect(composer.getByText("Global inbox source")).toBeVisible();
+
+  await page.evaluate(() => {
+    const target = window as unknown as {
+      __demoEmit: (event: string, payload: unknown) => void;
+    };
+    target.__demoEmit("murmur://reminder-visibility-invalidated", null);
+  });
+
+  await expect(composer.getByRole("dialog")).toHaveCount(0, { timeout: 700 });
+  await expect(page.getByText("Global inbox source")).toHaveCount(0);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as unknown as {
+              __globalVisibilityRefreshStarted?: boolean;
+            }
+          ).__globalVisibilityRefreshStarted === true,
+      ),
+    )
+    .toBe(true);
+
+  await page.getByRole("button", { name: /Upcoming/ }).click();
+  await expect(page.getByText("Global upcoming reminder")).toBeVisible();
+  await expect(page.getByText("Global upcoming source")).toHaveCount(0);
+  await page.getByRole("button", { name: /Completed/ }).click();
+  await expect(page.getByText("Global completed reminder")).toBeVisible();
+  await expect(page.getByText("Global completed source")).toHaveCount(0);
+
+  await page.evaluate(() => {
+    (
+      window as unknown as {
+        __resolveGlobalVisibilityRefresh?: () => void;
+      }
+    ).__resolveGlobalVisibilityRefresh?.();
+  });
+  await expect(page.getByText("Global completed reminder")).toBeVisible();
+});
+
+test("Reminders: a newer list count beats a delayed startup summary", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    get_reminder_summary: () => {
+      const target = window as unknown as Record<string, any>;
+      target.__delayedSummaryStarted = true;
+      return new Promise<{ dueInboxCount: number }>((resolve) => {
+        target.__resolveDelayedSummary = resolve;
+      });
+    },
+    list_reminders: () => {
+      const target = window as unknown as Record<string, any>;
+      const now = Date.now();
+      const currentSnapshot = {
+        inbox: Array.from({ length: 3 }, (_, index) => ({
+          occurrenceId: `newest-occurrence-${index}`,
+          dueAt: now - (index + 1) * 60_000,
+          reminder: {
+            id: `newest-reminder-${index}`,
+            title: `Newest list row ${index + 1}`,
+            details: null,
+            dueAt: now - (index + 1) * 60_000,
+            repeatEvery: null,
+            repeatUnit: null,
+            state: "active",
+            origin: "manual",
+            createdAt: now - 120_000,
+            updatedAt: now - 120_000,
+            completedAt: null,
+            sources: [],
+          },
+        })),
+        upcoming: [],
+        completed: [],
+        dueInboxCount: 3,
+      };
+      return new Promise((resolve) => {
+        const resolveAfterSummaryStarted = () => {
+          if (target.__delayedSummaryStarted === true) {
+            resolve(currentSnapshot);
+            return;
+          }
+          window.setTimeout(resolveAfterSummaryStarted, 0);
+        };
+        resolveAfterSummaryStarted();
+      });
+    },
+  });
+
+  await page.goto("/reminders");
+  await expect(page.getByText("Newest list row 1")).toBeVisible();
+  const reminderCount = page
+    .getByRole("link", { name: "Reminders" })
+    .first()
+    .locator(".nav-reminder-count");
+  await expect(reminderCount).toHaveText("3");
+
+  await page.evaluate(async () => {
+    const target = window as unknown as Record<string, any>;
+    target.__resolveDelayedSummary?.({ dueInboxCount: 2 });
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    });
+  });
+
+  await expect(reminderCount).toHaveText("3");
+});
+
+test("Reminders: visibility-listener registration failure blocks source reads and composer hydration", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {
+      get_reminder_summary: () => ({ dueInboxCount: 1 }),
+      list_reminders: () => {
+        const target = window as unknown as {
+          __failedVisibilityListCalls?: number;
+        };
+        target.__failedVisibilityListCalls =
+          (target.__failedVisibilityListCalls ?? 0) + 1;
+        const now = Date.now();
+        return {
+          inbox: [
+            {
+              occurrenceId: "o-listener-failed",
+              dueAt: now - 60_000,
+              reminder: {
+                id: "r-listener-failed",
+                title: "Reminder survives",
+                details: null,
+                dueAt: now - 60_000,
+                repeatEvery: null,
+                repeatUnit: null,
+                state: "active",
+                origin: "manual",
+                createdAt: now - 120_000,
+                updatedAt: now - 120_000,
+                completedAt: null,
+                sources: [
+                  {
+                    kind: "meeting",
+                    id: "m-listener-failed",
+                    title: "Must never enter the renderer",
+                  },
+                ],
+              },
+            },
+          ],
+          upcoming: [],
+          completed: [],
+          dueInboxCount: 1,
+        };
+      },
+    },
+    {},
+    [REMINDER_VISIBILITY_EVENT],
+  );
+
+  await page.goto("/reminders");
+  await expect(
+    page.getByText("Couldn’t load reminders. Please try again."),
+  ).toBeVisible();
+  await expect(page.getByText("Inbox clear")).toHaveCount(0);
+  await expect(page.getByText("Must never enter the renderer")).toHaveCount(0);
+  expect(
+    await page.evaluate(
+      () =>
+        (
+          window as unknown as {
+            __failedVisibilityListCalls?: number;
+          }
+        ).__failedVisibilityListCalls ?? 0,
+    ),
+  ).toBe(0);
+
+  await page.getByRole("button", { name: "New reminder" }).first().click();
+  await expect(
+    page.locator("app-reminder-composer").getByRole("dialog"),
+  ).toHaveCount(0);
+});
+
+test("Reminders: Retry reconnects a transient privacy-listener failure without duplicates", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {
+      get_reminder_summary: () => ({ dueInboxCount: 1 }),
+      list_reminders: () => {
+        const target = window as unknown as {
+          __privacyRetryListCalls?: number;
+          __privacyRetryLocked?: boolean;
+        };
+        target.__privacyRetryListCalls =
+          (target.__privacyRetryListCalls ?? 0) + 1;
+        const now = Date.now();
+        const reminder = {
+          id: "r-privacy-retry",
+          title: "Retry-safe reminder",
+          details: null,
+          dueAt: now - 60_000,
+          repeatEvery: null,
+          repeatUnit: null,
+          state: "active",
+          origin: "manual",
+          createdAt: now - 120_000,
+          updatedAt: now - 120_000,
+          completedAt: null,
+          sources: target.__privacyRetryLocked
+            ? []
+            : [
+                {
+                  kind: "meeting",
+                  id: "m-privacy-retry",
+                  title: "Retry private title",
+                },
+              ],
+        };
+        return {
+          inbox: [
+            {
+              occurrenceId: "o-privacy-retry",
+              dueAt: reminder.dueAt,
+              reminder,
+            },
+          ],
+          upcoming: [],
+          completed: [],
+          dueInboxCount: 1,
+        };
+      },
+    },
+    {},
+    [],
+    [],
+    {},
+    {},
+    {
+      [REMINDER_VISIBILITY_EVENT]: Array.from(
+        { length: 20 },
+        (_, index) => index + 1,
+      ),
+    },
+  );
+
+  await page.goto("/reminders");
+  await expect(
+    page.getByText("Couldn’t load reminders. Please try again."),
+  ).toBeVisible();
+  await expect(page.getByText("Inbox clear")).toHaveCount(0);
+  expect(
+    await page.evaluate(
+      () =>
+        (
+          window as unknown as {
+            __privacyRetryListCalls?: number;
+          }
+        ).__privacyRetryListCalls ?? 0,
+    ),
+  ).toBe(0);
+
+  await page.evaluate((event) => {
+    (
+      window as unknown as {
+        __demoReleaseRejectedEventListeners: (name: string) => void;
+      }
+    ).__demoReleaseRejectedEventListeners(event);
+  }, REMINDER_VISIBILITY_EVENT);
+  await page.getByRole("button", { name: "Retry" }).click();
+  await expect(page.getByText("Retry private title")).toBeVisible();
+  await expect(
+    page.getByText("Couldn’t load reminders. Please try again."),
+  ).toHaveCount(0);
+
+  await page.evaluate((event) => {
+    const target = window as unknown as {
+      __privacyRetryLocked?: boolean;
+      __demoEmit: (name: string, payload: unknown) => void;
+    };
+    target.__privacyRetryLocked = true;
+    target.__demoEmit(event, null);
+  }, REMINDER_VISIBILITY_EVENT);
+  await expect(page.getByText("Retry private title")).toHaveCount(0);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as unknown as {
+              __privacyRetryListCalls?: number;
+            }
+          ).__privacyRetryListCalls ?? 0,
+      ),
+    )
+    .toBe(2);
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
+  expect(
+    await page.evaluate(
+      () =>
+        (
+          window as unknown as {
+            __privacyRetryListCalls?: number;
+          }
+        ).__privacyRetryListCalls ?? 0,
+    ),
+  ).toBe(2);
+});
+
+test("Reminders: Retry restores transient live updates without duplicating privacy listeners", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {
+      get_reminder_summary: () => ({ dueInboxCount: 1 }),
+      list_reminders: () => {
+        const target = window as unknown as {
+          __updatesRetryListCalls?: number;
+        };
+        target.__updatesRetryListCalls =
+          (target.__updatesRetryListCalls ?? 0) + 1;
+        const now = Date.now();
+        return {
+          inbox: [
+            {
+              occurrenceId: "o-updates-retry",
+              dueAt: now - 60_000,
+              reminder: {
+                id: "r-updates-retry",
+                title: "Live updates reconnect",
+                details: null,
+                dueAt: now - 60_000,
+                repeatEvery: null,
+                repeatUnit: null,
+                state: "active",
+                origin: "manual",
+                createdAt: now - 120_000,
+                updatedAt: now - 120_000,
+                completedAt: null,
+                sources: [],
+              },
+            },
+          ],
+          upcoming: [],
+          completed: [],
+          dueInboxCount: 1,
+        };
+      },
+    },
+    {},
+    [],
+    [],
+    {},
+    {},
+    {
+      [REMINDERS_UPDATED_EVENT]: Array.from(
+        { length: 20 },
+        (_, index) => index + 1,
+      ),
+    },
+  );
+
+  await page.goto("/reminders");
+  await expect(page.getByText("Live updates reconnect")).toBeVisible();
+  await expect(
+    page.getByText(
+      "Live reminder updates are unavailable. Retry to reconnect.",
+    ),
+  ).toBeVisible();
+  await page.evaluate((event) => {
+    (
+      window as unknown as {
+        __demoReleaseRejectedEventListeners: (name: string) => void;
+      }
+    ).__demoReleaseRejectedEventListeners(event);
+  }, REMINDERS_UPDATED_EVENT);
+  await page.getByRole("button", { name: "Retry" }).click();
+  await expect(
+    page.getByText(
+      "Live reminder updates are unavailable. Retry to reconnect.",
+    ),
+  ).toHaveCount(0);
+
+  await page.evaluate((event) => {
+    (
+      window as unknown as {
+        __demoEmit: (name: string, payload: unknown) => void;
+      }
+    ).__demoEmit(event, { dueInboxCount: 2 });
+  }, REMINDERS_UPDATED_EVENT);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as unknown as {
+              __updatesRetryListCalls?: number;
+            }
+          ).__updatesRetryListCalls ?? 0,
+      ),
+    )
+    .toBe(3);
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
+  expect(
+    await page.evaluate(
+      () =>
+        (
+          window as unknown as {
+            __updatesRetryListCalls?: number;
+          }
+        ).__updatesRetryListCalls ?? 0,
+    ),
+  ).toBe(3);
+});
+
+test("Smart Reminder: visibility-listener registration failure prevents audit and context hydration", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {
+      get_reminder_summary: () => ({ dueInboxCount: 0 }),
+      audit_reminder_suggestions: () => {
+        const target = window as unknown as {
+          __failedVisibilityAuditCalls?: number;
+        };
+        target.__failedVisibilityAuditCalls =
+          (target.__failedVisibilityAuditCalls ?? 0) + 1;
+        return [
+          {
+            id: "sg-listener-failed",
+            title: "Must never be audited or rendered",
+            suggestedDueAt: null,
+            source: {
+              kind: "meeting",
+              id: "m-atlas-roadmap",
+              title: "Must never hydrate context",
+            },
+          },
+        ];
+      },
+    },
+    {},
+    [REMINDER_VISIBILITY_EVENT],
+  );
+
+  await page.goto("/meeting/m-atlas-roadmap");
+  const card = page.locator("app-smart-reminder-card");
+  await expect(
+    card.getByText(
+      "Smart reminder suggestions aren’t available securely right now.",
+    ),
+  ).toBeVisible();
+  await expect(card.getByText("Must never be audited or rendered")).toHaveCount(
+    0,
+  );
+  await expect(
+    card.getByRole("button", { name: "New reminder" }),
+  ).toBeDisabled();
+  expect(
+    await page.evaluate(
+      () =>
+        (
+          window as unknown as {
+            __failedVisibilityAuditCalls?: number;
+          }
+        ).__failedVisibilityAuditCalls ?? 0,
+    ),
+  ).toBe(0);
+});
+
+test("Reminder composer: a request created before the listener barrier is discarded", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {
+      get_reminder_summary: () => ({ dueInboxCount: 1 }),
+      list_reminders: () => {
+        const target = window as unknown as {
+          __composerBarrierLocked?: boolean;
+        };
+        const now = Date.now();
+        const reminder = {
+          id: "r-composer-barrier",
+          title: "Source-bearing edit request",
+          details: null,
+          dueAt: now - 60_000,
+          repeatEvery: null,
+          repeatUnit: null,
+          state: "active",
+          origin: "manual",
+          createdAt: now - 120_000,
+          updatedAt: now - 120_000,
+          completedAt: null,
+          sources: target.__composerBarrierLocked
+            ? []
+            : [
+                {
+                  kind: "meeting",
+                  id: "m-composer-barrier",
+                  title: "Composer private source title",
+                },
+              ],
+        };
+        return {
+          inbox: [
+            {
+              occurrenceId: "o-composer-barrier",
+              dueAt: reminder.dueAt,
+              reminder,
+            },
+          ],
+          upcoming: [],
+          completed: [],
+          dueInboxCount: 1,
+        };
+      },
+    },
+    {},
+    [],
+    [],
+    { [REMINDER_VISIBILITY_EVENT]: [2] },
+  );
+
+  await page.goto("/reminders");
+  const reminder = page
+    .locator(".reminder-card")
+    .filter({ hasText: "Source-bearing edit request" });
+  await expect(
+    reminder.getByText("Composer private source title"),
+  ).toBeVisible();
+  const composer = page.locator("app-reminder-composer");
+
+  // The lock event is deliberately emitted before Tauri acknowledges the
+  // visibility listener. It is therefore not replayed when registration later
+  // succeeds; the pre-barrier request itself must be treated as stale. Native
+  // click + event + release run in ONE browser task, so Angular's scheduled
+  // effect cannot manufacture a false-green gap between those operations.
+  await reminder
+    .getByRole("button", { name: "Edit" })
+    .evaluate((button, event) => {
+      const target = window as unknown as {
+        __composerBarrierLocked?: boolean;
+        __demoEmit: (name: string, payload: unknown) => void;
+        __demoReleaseEventListeners: (name: string) => void;
+      };
+      (button as HTMLButtonElement).click();
+      target.__composerBarrierLocked = true;
+      target.__demoEmit(event, null);
+      target.__demoReleaseEventListeners(event);
+    }, REMINDER_VISIBILITY_EVENT);
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
+
+  await expect(page.getByText("Composer private source title")).toHaveCount(0);
+  await expect(composer.getByRole("dialog")).toHaveCount(0);
+
+  // A request born after the barrier remains usable.
+  await page.getByRole("button", { name: "New reminder" }).first().click();
+  await expect(composer.getByRole("dialog")).toBeVisible();
+  await composer.getByRole("button", { name: "Cancel" }).click();
+});
+
+test("Reminder composer: a stale submit cannot close or contaminate a newer request", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    get_reminder_summary: () => ({ dueInboxCount: 0 }),
+    list_reminders: () => ({
+      inbox: [],
+      upcoming: [],
+      completed: [],
+      dueInboxCount: 0,
+    }),
+    create_reminder: () => {
+      const target = window as unknown as {
+        __staleSubmitAttempt?: number;
+        __resolveStaleSubmit?: (value: unknown) => void;
+        __rejectStaleSubmit?: (error: unknown) => void;
+      };
+      target.__staleSubmitAttempt = (target.__staleSubmitAttempt ?? 0) + 1;
+      return new Promise((resolve, reject) => {
+        target.__resolveStaleSubmit = resolve;
+        target.__rejectStaleSubmit = reject;
+      });
+    },
+  });
+
+  await page.goto("/reminders");
+  const composer = page.locator("app-reminder-composer");
+  const openFresh = async (title: string): Promise<void> => {
+    await page.getByRole("button", { name: "New reminder" }).first().click();
+    await expect(composer.getByRole("dialog")).toBeVisible();
+    await composer.locator('input[type="text"]').first().fill(title);
+  };
+  const emitVisibilityInvalidation = async (): Promise<void> => {
+    await page.evaluate((event) => {
+      (
+        window as unknown as {
+          __demoEmit: (name: string, payload: unknown) => void;
+        }
+      ).__demoEmit(event, null);
+    }, REMINDER_VISIBILITY_EVENT);
+    await expect(composer.getByRole("dialog")).toHaveCount(0);
+  };
+  const settleFrames = async (): Promise<void> => {
+    await page.evaluate(
+      () =>
+        new Promise<void>((resolve) => {
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+        }),
+    );
+  };
+
+  await openFresh("Request A");
+  await composer.getByRole("button", { name: "Create reminder" }).click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as unknown as {
+              __staleSubmitAttempt?: number;
+            }
+          ).__staleSubmitAttempt ?? 0,
+      ),
+    )
+    .toBe(1);
+  await emitVisibilityInvalidation();
+  await openFresh("Request B survives A");
+
+  await page.evaluate(() => {
+    (
+      window as unknown as {
+        __resolveStaleSubmit?: (value: unknown) => void;
+      }
+    ).__resolveStaleSubmit?.({
+      id: "r-stale-a",
+      title: "Request A",
+      details: null,
+      dueAt: Date.now() + 60_000,
+      repeatEvery: null,
+      repeatUnit: null,
+      state: "active",
+      origin: "manual",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      completedAt: null,
+      sources: [],
+    });
+  });
+  await settleFrames();
+  await expect(composer.getByRole("dialog")).toBeVisible();
+  await expect(composer.locator('input[type="text"]').first()).toHaveValue(
+    "Request B survives A",
+  );
+  await expect(
+    composer.getByText("Couldn’t save this reminder. Please try again."),
+  ).toHaveCount(0);
+
+  await composer.getByRole("button", { name: "Create reminder" }).click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (
+            window as unknown as {
+              __staleSubmitAttempt?: number;
+            }
+          ).__staleSubmitAttempt ?? 0,
+      ),
+    )
+    .toBe(2);
+  await emitVisibilityInvalidation();
+  await openFresh("Request C survives B");
+  await page.evaluate(() => {
+    (
+      window as unknown as {
+        __rejectStaleSubmit?: (error: unknown) => void;
+      }
+    ).__rejectStaleSubmit?.(new Error("old request failed"));
+  });
+  await settleFrames();
+
+  await expect(composer.getByRole("dialog")).toBeVisible();
+  await expect(composer.locator('input[type="text"]').first()).toHaveValue(
+    "Request C survives B",
+  );
+  await expect(
+    composer.getByText("Couldn’t save this reminder. Please try again."),
+  ).toHaveCount(0);
+  await expect(
+    composer.getByRole("button", { name: "Create reminder" }),
+  ).toBeEnabled();
+  await composer.getByRole("button", { name: "Cancel" }).click();
+});
+
+test("Reminder composer: focus, source limit, and busy source locking stay coherent", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    get_reminder_summary: () => ({ dueInboxCount: 1 }),
+    list_link_candidates: () => [
+      {
+        kind: "note",
+        id: "n20",
+        title: "Source 20",
+        snippet: "",
+        createdAt: "",
+      },
+    ],
+    list_reminders: () => {
+      const now = Date.now();
+      const reminder = {
+        id: "r-source-limit",
+        title: "Twenty-source reminder",
+        details: null,
+        dueAt: now - 60_000,
+        repeatEvery: null,
+        repeatUnit: null,
+        state: "active",
+        origin: "manual",
+        createdAt: now - 120_000,
+        updatedAt: now - 120_000,
+        completedAt: null,
+        sources: Array.from({ length: 20 }, (_, index) => ({
+          kind: "note",
+          id: `n${index}`,
+          title: `Source ${index}`,
+        })),
+      };
+      return {
+        inbox: [
+          {
+            occurrenceId: "o-source-limit",
+            dueAt: reminder.dueAt,
+            reminder,
+          },
+        ],
+        upcoming: [],
+        completed: [],
+        dueInboxCount: 1,
+      };
+    },
+    update_reminder: () =>
+      new Promise((resolve) => {
+        (
+          window as unknown as {
+            __resolveBusyUpdate?: (value: unknown) => void;
+          }
+        ).__resolveBusyUpdate = resolve;
+      }),
+  });
+
+  await page.goto("/reminders");
+  const row = page
+    .locator(".reminder-card")
+    .filter({ hasText: "Twenty-source reminder" });
+  const edit = row.getByRole("button", { name: "Edit" });
+  const composer = page.locator("app-reminder-composer");
+
+  await edit.click();
+  const dialog = composer.getByRole("dialog");
+  const titleInput = composer.locator('input[type="text"]').first();
+  await expect(titleInput).toBeFocused();
+  const close = dialog.getByRole("button", {
+    name: "Close reminder composer",
+  });
+  const save = dialog.getByRole("button", { name: "Save changes" });
+  await close.focus();
+  await page.keyboard.press("Shift+Tab");
+  await expect(save).toBeFocused();
+  await page.keyboard.press("Escape");
+  await expect(dialog).toHaveCount(0);
+  await expect(edit).toBeFocused();
+
+  await edit.click();
+  const addSource = dialog.getByRole("button", { name: "+ Add source" });
+  await expect(addSource).toBeDisabled();
+  const removeSource0 = dialog.getByRole("button", {
+    name: "Remove Source 0",
+    exact: true,
+  });
+  await expect(removeSource0).toBeEnabled();
+  await removeSource0.click();
+  await expect(addSource).toBeEnabled();
+  await addSource.click();
+  await page.getByRole("option", { name: /Source 20/ }).click();
+  await expect(addSource).toBeDisabled();
+  await expect(dialog.getByText("20 / 20")).toBeVisible();
+  await dialog.getByRole("button", { name: "+17 more" }).click();
+  await expect(
+    dialog.getByRole("button", { name: "Remove Source 20", exact: true }),
+  ).toBeEnabled();
+
+  await dialog
+    .getByRole("button", { name: "Remove Source 1", exact: true })
+    .click();
+  await expect(addSource).toBeEnabled();
+  await save.click();
+  await expect(addSource).toBeDisabled();
+  await expect(
+    dialog.getByRole("button", { name: "Remove Source 2", exact: true }),
+  ).toBeDisabled();
+
+  await page.evaluate(() => {
+    (
+      window as unknown as {
+        __resolveBusyUpdate?: (value: unknown) => void;
+      }
+    ).__resolveBusyUpdate?.({
+      id: "r-source-limit",
+      title: "Twenty-source reminder",
+      details: null,
+      dueAt: Date.now() + 60_000,
+      repeatEvery: null,
+      repeatUnit: null,
+      state: "active",
+      origin: "manual",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      completedAt: null,
+      sources: [],
+    });
+  });
+  await expect(dialog).toHaveCount(0);
+});
+
+test("Smart Reminder: a lock before listener readiness cannot rehydrate the parent title", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {
+      get_reminder_summary: () => ({ dueInboxCount: 0 }),
+      audit_reminder_suggestions: () => {
+        const target = window as unknown as {
+          __listenerBarrierLocked?: boolean;
+          __listenerBarrierAuditCalls?: number;
+        };
+        target.__listenerBarrierAuditCalls =
+          (target.__listenerBarrierAuditCalls ?? 0) + 1;
+        if (target.__listenerBarrierLocked) {
+          return Promise.reject(new Error("locked: source is sealed"));
+        }
+        return [
+          {
+            id: "sg-listener-barrier",
+            title: "Unsafe pre-lock suggestion",
+            suggestedDueAt: null,
+            source: {
+              kind: "meeting",
+              id: "m-atlas-roadmap",
+              title: "Q2 Roadmap Planning",
+            },
+          },
+        ];
+      },
+    },
+    {},
+    [],
+    [REMINDER_VISIBILITY_EVENT],
+  );
+
+  await page.goto("/meeting/m-atlas-roadmap");
+  const card = page.locator("app-smart-reminder-card");
+  const newReminder = card.getByRole("button", { name: "New reminder" });
+  await expect(newReminder).toBeDisabled();
+  expect(
+    await page.evaluate(
+      () =>
+        (
+          window as unknown as {
+            __listenerBarrierAuditCalls?: number;
+          }
+        ).__listenerBarrierAuditCalls ?? 0,
+    ),
+  ).toBe(0);
+
+  await page.evaluate((event) => {
+    const target = window as unknown as {
+      __listenerBarrierLocked?: boolean;
+      __demoEmit: (name: string, payload: unknown) => void;
+      __demoReleaseEventListeners: (name: string) => void;
+    };
+    target.__listenerBarrierLocked = true;
+    target.__demoEmit(event, null);
+    target.__demoReleaseEventListeners(event);
+  }, REMINDER_VISIBILITY_EVENT);
+
+  await expect(newReminder).toBeEnabled();
+  await expect(
+    card.getByText("Smart reminder suggestions aren’t available right now."),
+  ).toBeVisible();
+  await expect(card.getByText("Unsafe pre-lock suggestion")).toHaveCount(0);
+
+  await newReminder.click();
+  const composer = page.locator("app-reminder-composer");
+  await expect(composer.getByRole("dialog")).toBeVisible();
+  await expect(
+    composer.getByText("Q2 Roadmap Planning", { exact: true }),
+  ).toHaveCount(0);
+  await composer.getByRole("button", { name: "Cancel" }).click();
+});
+
+test("Smart Reminder: a mounted meeting card drops stale rows after every canonical source edit", async ({
+  page,
+}) => {
+  test.setTimeout(30_000);
+  const errors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      errors.push(message.text());
+    }
+  });
+  page.on("pageerror", (error) => errors.push(String(error)));
+
+  await mockTauri(page, {
+    get_reminder_summary: () => ({ dueInboxCount: 0 }),
+    audit_reminder_suggestions: (args: {
+      sourceKind: "meeting" | "note";
+      sourceId: string;
+    }) => {
+      const target = window as unknown as {
+        __smartSourceState?: {
+          phase: "before" | "title" | "transcript" | "locked";
+          auditCalls: number;
+          events: Array<Record<string, unknown>>;
+        };
+      };
+      target.__smartSourceState ??= {
+        phase: "before",
+        auditCalls: 0,
+        events: [],
+      };
+      target.__smartSourceState.auditCalls += 1;
+      if (target.__smartSourceState.phase === "locked") {
+        return Promise.reject(new Error("locked: source is sealed"));
+      }
+      const titles = {
+        before: "Before source edit",
+        title: "After title edit",
+        transcript: "After transcript or manual-note edit",
+      };
+      return [
+        {
+          id: `sg-${target.__smartSourceState.phase}`,
+          title: titles[target.__smartSourceState.phase],
+          suggestedDueAt: null,
+          source: {
+            kind: args.sourceKind,
+            id: args.sourceId,
+            title: "Q2 Roadmap Planning",
+          },
+        },
+      ];
+    },
+    rename_meeting: () => {
+      const target = window as unknown as {
+        __smartSourceState: {
+          phase: "before" | "title" | "transcript" | "locked";
+          auditCalls: number;
+          events: Array<Record<string, unknown>>;
+        };
+        __demoEmit: (event: string, payload: unknown) => void;
+      };
+      target.__smartSourceState.phase = "title";
+      const payload = { kind: "meeting", id: "m-atlas-roadmap" };
+      target.__smartSourceState.events.push(payload);
+      target.__demoEmit("murmur://reminder-source-updated", payload);
+      return null;
+    },
+  });
+
+  await page.goto("/meeting/m-atlas-roadmap");
+  const card = page.locator("app-smart-reminder-card");
+  await expect(card.getByText("Before source edit")).toBeVisible();
+  const initialAudits = await page.evaluate(
+    () =>
+      (
+        window as unknown as {
+          __smartSourceState: { auditCalls: number };
+        }
+      ).__smartSourceState.auditCalls,
+  );
+
+  // The real title-edit UI and the opaque backend event can race; both paths
+  // synchronously clear and coalesce into one debounced re-audit.
+  const notePanel = page.locator("app-note-panel");
+  await notePanel.getByRole("button", { name: /More/ }).click();
+  await notePanel.getByRole("menuitem", { name: "Rename" }).click();
+  await page.getByLabel("Meeting title").fill("Renamed roadmap");
+  await page.locator(".rename").getByRole("button", { name: "Save" }).click();
+  await expect(card.getByText("Before source edit")).toHaveCount(0, {
+    timeout: 700,
+  });
+  await expect(card.getByText("After title edit")).toBeVisible();
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          () =>
+            (
+              window as unknown as {
+                __smartSourceState: { auditCalls: number };
+              }
+            ).__smartSourceState.auditCalls,
+        ),
+      { timeout: 5_000 },
+    )
+    .toBe(initialAudits + 1);
+
+  // A source-specific event must not cross-bleed into another mounted card.
+  await page.evaluate(() => {
+    const target = window as unknown as {
+      __smartSourceState: {
+        events: Array<Record<string, unknown>>;
+      };
+      __demoEmit: (event: string, payload: unknown) => void;
+    };
+    const payload = { kind: "meeting", id: "m-other" };
+    target.__smartSourceState.events.push(payload);
+    target.__demoEmit("murmur://reminder-source-updated", payload);
+  });
+  await page.waitForTimeout(1_000);
+  await expect(card.getByText("After title edit")).toBeVisible();
+  expect(
+    await page.evaluate(
+      () =>
+        (
+          window as unknown as {
+            __smartSourceState: { auditCalls: number };
+          }
+        ).__smartSourceState.auditCalls,
+    ),
+  ).toBe(initialAudits + 1);
+
+  // Simulate a canonical transcript/manual-notes write that changes no current
+  // Angular input. Only the content-free source event can invalidate this row.
+  await page.evaluate(() => {
+    const target = window as unknown as {
+      __smartSourceState: {
+        phase: "before" | "title" | "transcript" | "locked";
+        events: Array<Record<string, unknown>>;
+      };
+      __demoEmit: (event: string, payload: unknown) => void;
+    };
+    target.__smartSourceState.phase = "transcript";
+    const payload = { kind: "meeting", id: "m-atlas-roadmap" };
+    target.__smartSourceState.events.push(payload);
+    target.__demoEmit("murmur://reminder-source-updated", payload);
+  });
+  await expect(card.getByText("After title edit")).toHaveCount(0, {
+    timeout: 700,
+  });
+  await expect(
+    card.getByText("After transcript or manual-note edit"),
+  ).toBeVisible();
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          () =>
+            (
+              window as unknown as {
+                __smartSourceState: { auditCalls: number };
+              }
+            ).__smartSourceState.auditCalls,
+        ),
+      { timeout: 5_000 },
+    )
+    .toBe(initialAudits + 2);
+
+  // Global lock-authority revocation carries no source identity. Every mounted
+  // card must drop derived text immediately, then let the gated audit fail
+  // closed while the source remains sealed.
+  await page.evaluate(() => {
+    const target = window as unknown as {
+      __smartSourceState: {
+        phase: "before" | "title" | "transcript" | "locked";
+      };
+      __demoEmit: (event: string, payload: unknown) => void;
+    };
+    target.__smartSourceState.phase = "locked";
+    target.__demoEmit("murmur://reminder-visibility-invalidated", null);
+  });
+  await expect(
+    card.getByText("After transcript or manual-note edit"),
+  ).toHaveCount(0, { timeout: 700 });
+  await card.getByRole("button", { name: "New reminder" }).click();
+  const composer = page.locator("app-reminder-composer");
+  await expect(composer.getByRole("dialog")).toBeVisible();
+  await expect(
+    composer.getByText("Q2 Roadmap Planning", { exact: true }),
+  ).toHaveCount(0);
+  await composer.getByRole("button", { name: "Cancel" }).click();
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          () =>
+            (
+              window as unknown as {
+                __smartSourceState: { auditCalls: number };
+              }
+            ).__smartSourceState.auditCalls,
+        ),
+      { timeout: 5_000 },
+    )
+    .toBe(initialAudits + 3);
+  await expect(
+    card.getByText("Smart reminder suggestions aren’t available right now."),
+  ).toBeVisible();
+
+  // A later count-only event changes the root store revision. The still-mounted
+  // card must not copy its stale parent title back after the visibility barrier.
+  await page.evaluate(() => {
+    const target = window as unknown as {
+      __demoEmit: (event: string, payload: unknown) => void;
+    };
+    target.__demoEmit("murmur://reminders-updated", { dueInboxCount: 0 });
+  });
+  await card.getByRole("button", { name: "New reminder" }).click();
+  await expect(composer.getByRole("dialog")).toBeVisible();
+  await expect(
+    composer.getByText("Q2 Roadmap Planning", { exact: true }),
+  ).toHaveCount(0);
+  await composer.getByRole("button", { name: "Cancel" }).click();
+
+  const eventPayloads = await page.evaluate(
+    () =>
+      (
+        window as unknown as {
+          __smartSourceState: {
+            events: Array<Record<string, unknown>>;
+          };
+        }
+      ).__smartSourceState.events,
+  );
+  expect(eventPayloads).toHaveLength(3);
+  for (const payload of eventPayloads) {
+    expect(Object.keys(payload).sort()).toEqual(["id", "kind"]);
+  }
+  expect(errors).toEqual([]);
+});
+
+test("Reminders: route, composer, inbox, Smart review, context, and event refresh", async ({
+  page,
+}) => {
+  test.setTimeout(90_000);
+  const errors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      errors.push(message.text());
+    }
+  });
+  page.on("pageerror", (error) => errors.push(String(error)));
+
+  // One Tauri setup before any navigation. Every override is page-side and
+  // self-contained because mockTauri serializes functions with toString().
+  await mockTauri(page, {
+    get_reminder_summary: () => ({ dueInboxCount: 2 }),
+    list_folders: () => {
+      const target = window as unknown as {
+        __reminderLockState?: { locked: boolean };
+      };
+      target.__reminderLockState ??= { locked: false };
+      return [
+        {
+          id: "nf-product",
+          name: "Product Notes",
+          path: "Notes/Product",
+          parentId: null,
+          noteCount: 1,
+          locked: true,
+          unlocked: !target.__reminderLockState.locked,
+          kind: "note",
+          children: [],
+        },
+      ];
+    },
+    relock_all: () => {
+      const target = window as unknown as {
+        __reminderLockState?: { locked: boolean };
+      };
+      target.__reminderLockState ??= { locked: false };
+      target.__reminderLockState.locked = true;
+      return null;
+    },
+    get_note: (args: { id: string }) => {
+      const target = window as unknown as {
+        __reminderLockState?: { locked: boolean };
+      };
+      target.__reminderLockState ??= { locked: false };
+      if (target.__reminderLockState.locked) {
+        return {
+          id: args.id,
+          title: "🔒 Locked",
+          folderId: "nf-product",
+          markdown: "",
+          tags: [],
+          properties: {},
+          updatedAt: Date.now(),
+          createdAt: Date.now() - 86400000,
+          exportedPath: null,
+          locked: true,
+          shared: false,
+        };
+      }
+      return {
+        id: args.id,
+        title: "Atlas — PRD v3",
+        folderId: "nf-product",
+        markdown:
+          "# Atlas — PRD v3\n\n## Open questions\n- Confirm the launch owner.",
+        tags: ["atlas", "prd"],
+        properties: { status: "in-review" },
+        updatedAt: Date.now() - 3600000,
+        createdAt: Date.now() - 86400000,
+        exportedPath: "/Vault/Notes/Product/Atlas-PRD-v3.md",
+        locked: false,
+        shared: false,
+      };
+    },
+    list_reminders: () => {
+      const target = window as unknown as {
+        __reminderState?: Record<string, any>;
+      };
+      target.__reminderState ??= {
+        listCalls: 0,
+        inbox: [
+          {
+            occurrenceId: "o-1",
+            dueAt: Date.now() - 7200000,
+            reminder: {
+              id: "r-due-1",
+              title: "Send the roadmap follow-up",
+              details: "Include the final rollout date.",
+              dueAt: Date.now() - 7200000,
+              repeatEvery: null,
+              repeatUnit: null,
+              state: "active",
+              origin: "manual",
+              createdAt: Date.now() - 9000000,
+              updatedAt: Date.now() - 9000000,
+              completedAt: null,
+              sources: [],
+            },
+          },
+          {
+            occurrenceId: "o-2",
+            dueAt: Date.now() - 3600000,
+            reminder: {
+              id: "r-due-2",
+              title: "Book the pilot review",
+              details: null,
+              dueAt: Date.now() - 3600000,
+              repeatEvery: 1,
+              repeatUnit: "weeks",
+              state: "active",
+              origin: "manual",
+              createdAt: Date.now() - 8000000,
+              updatedAt: Date.now() - 8000000,
+              completedAt: null,
+              sources: [],
+            },
+          },
+        ],
+        upcoming: [
+          {
+            id: "r-smart",
+            title: "Confirm the Atlas launch owner",
+            details: null,
+            dueAt: Date.now() + 86400000,
+            repeatEvery: null,
+            repeatUnit: null,
+            state: "active",
+            origin: "smart",
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+            completedAt: null,
+            sources: [
+              {
+                kind: "meeting",
+                id: "m-atlas-roadmap",
+                title: "Q2 Roadmap Planning",
+              },
+            ],
+          },
+        ],
+        completed: [],
+        suggestions: {
+          meeting: [
+            {
+              id: "sg-meeting-1",
+              title: "Send the reviewed roadmap",
+              suggestedDueAt: Date.now() + 10800000,
+              source: {
+                kind: "meeting",
+                id: "m-atlas-roadmap",
+                title: "Q2 Roadmap Planning",
+              },
+            },
+            {
+              id: "sg-meeting-2",
+              title: "Schedule the pilot follow-up",
+              suggestedDueAt: null,
+              source: {
+                kind: "meeting",
+                id: "m-atlas-roadmap",
+                title: "Q2 Roadmap Planning",
+              },
+            },
+          ],
+          note: [
+            {
+              id: "sg-note-1",
+              title: "Resolve the PRD open question",
+              suggestedDueAt: null,
+              source: {
+                kind: "note",
+                id: "n-atlas-prd",
+                title: "Atlas — PRD v3",
+              },
+            },
+          ],
+        },
+        calls: [],
+      };
+      target.__reminderState.listCalls += 1;
+      return {
+        inbox: target.__reminderState.inbox,
+        upcoming: target.__reminderState.upcoming,
+        completed: target.__reminderState.completed,
+        dueInboxCount: target.__reminderState.inbox.length,
+      };
+    },
+    create_reminder: (args: { draft: Record<string, unknown> }) => {
+      const target = window as unknown as {
+        __reminderState: Record<string, any>;
+      };
+      target.__reminderState.calls.push({ command: "create", args });
+      const reminder = {
+        id: "r-created",
+        ...args.draft,
+        state: "active",
+        origin: "manual",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        completedAt: null,
+        sources: (
+          args.draft.sources as Array<{ kind: string; id: string }>
+        ).map((source) => ({
+          ...source,
+          title:
+            source.kind === "meeting" ? "Atlas meeting" : "Atlas project note",
+        })),
+      };
+      target.__reminderState.upcoming.push(reminder);
+      return reminder;
+    },
+    complete_reminder: (args: {
+      reminderId: string;
+      expectedDueAt: number;
+    }) => {
+      const target = window as unknown as {
+        __reminderState: Record<string, any>;
+      };
+      target.__reminderState.calls.push({ command: "complete", args });
+      const item = target.__reminderState.inbox.find(
+        (row: any) => row.reminder.id === args.reminderId,
+      );
+      target.__reminderState.inbox = target.__reminderState.inbox.filter(
+        (row: any) => row.reminder.id !== args.reminderId,
+      );
+      if (item) {
+        if (
+          item.reminder.repeatEvery === 1 &&
+          item.reminder.repeatUnit === "weeks"
+        ) {
+          target.__reminderState.upcoming.push({
+            ...item.reminder,
+            dueAt: args.expectedDueAt + 7 * 24 * 60 * 60 * 1000,
+            updatedAt: Date.now(),
+          });
+        } else {
+          target.__reminderState.completed.push({
+            ...item.reminder,
+            state: "completed",
+            completedAt: Date.now(),
+          });
+        }
+      }
+      return null;
+    },
+    dismiss_reminder_occurrence: (args: { occurrenceId: string }) => {
+      const target = window as unknown as {
+        __reminderState: Record<string, any>;
+      };
+      target.__reminderState.calls.push({ command: "dismissOccurrence", args });
+      const item = target.__reminderState.inbox.find(
+        (row: any) => row.occurrenceId === args.occurrenceId,
+      );
+      target.__reminderState.inbox = target.__reminderState.inbox.filter(
+        (row: any) => row.occurrenceId !== args.occurrenceId,
+      );
+      if (item) {
+        target.__reminderState.upcoming.push({
+          ...item.reminder,
+          dueAt:
+            item.reminder.repeatEvery === 1 &&
+            item.reminder.repeatUnit === "weeks"
+              ? item.dueAt + 7 * 24 * 60 * 60 * 1000
+              : item.reminder.dueAt,
+          updatedAt: Date.now(),
+        });
+      }
+      return null;
+    },
+    audit_reminder_suggestions: (args: {
+      sourceKind: "meeting" | "note";
+      sourceId: string;
+    }) => {
+      const target = window as unknown as {
+        __reminderState: Record<string, any>;
+      };
+      target.__reminderState.calls.push({ command: "audit", args });
+      return target.__reminderState.suggestions[args.sourceKind] ?? [];
+    },
+    dismiss_reminder_suggestion: (args: { suggestionId: string }) => {
+      const target = window as unknown as {
+        __reminderState: Record<string, any>;
+      };
+      target.__reminderState.calls.push({ command: "dismissSuggestion", args });
+      for (const kind of ["meeting", "note"]) {
+        target.__reminderState.suggestions[kind] =
+          target.__reminderState.suggestions[kind].filter(
+            (row: any) => row.id !== args.suggestionId,
+          );
+      }
+      return null;
+    },
+    accept_reminder_suggestion: (args: {
+      suggestionId: string;
+      draft: Record<string, unknown>;
+    }) => {
+      const target = window as unknown as {
+        __reminderState: Record<string, any>;
+      };
+      target.__reminderState.calls.push({ command: "acceptSuggestion", args });
+      for (const kind of ["meeting", "note"]) {
+        target.__reminderState.suggestions[kind] =
+          target.__reminderState.suggestions[kind].filter(
+            (row: any) => row.id !== args.suggestionId,
+          );
+      }
+      const reminder = {
+        id: "r-accepted",
+        ...args.draft,
+        state: "active",
+        origin: "smart",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        completedAt: null,
+        sources: [],
+      };
+      target.__reminderState.upcoming.push(reminder);
+      return reminder;
+    },
+    list_link_candidates: () => [
+      {
+        kind: "meeting",
+        id: "m-source",
+        title: "Atlas meeting",
+        snippet: "",
+      },
+      {
+        kind: "note",
+        id: "n-source",
+        title: "Atlas project note",
+        snippet: "",
+      },
+      {
+        kind: "document",
+        id: "d-hidden",
+        title: "Generic imported PDF",
+        snippet: "",
+      },
+    ],
+  });
+
+  await page.goto("/reminders");
+
+  const reminderNav = page.getByRole("link", { name: "Reminders" }).first();
+  await expect(reminderNav).toBeVisible();
+  await expect(reminderNav.locator(".count")).toHaveText("2");
+  await expect(page.getByRole("heading", { name: "Reminders" })).toBeVisible();
+  await expect(page.getByText("Send the roadmap follow-up")).toBeVisible();
+
+  // Composer: recurrence + two visible sources, never the generic document.
+  await page.getByRole("button", { name: "New reminder" }).first().click();
+  const composer = page.locator("app-reminder-composer");
+  await composer.getByLabel("Title").fill("Prepare launch review");
+  await composer.getByLabel("Details optional").fill("Bring the owner matrix.");
+  await composer.getByLabel("Date").fill("2026-08-15");
+  await composer.getByLabel("Time").fill("09:30");
+  await composer.getByLabel("Repeat").check();
+  await composer.getByLabel("Repeat every").fill("2");
+  await composer.getByLabel("Repeat unit").selectOption("weeks");
+  await composer.getByRole("button", { name: "+ Add source" }).click();
+  await expect(page.getByText("Generic imported PDF")).toHaveCount(0);
+  await page.getByRole("option", { name: /Atlas meeting/ }).click();
+  await page.getByRole("option", { name: /Atlas project note/ }).click();
+  await page.locator(".sp-search").press("Escape");
+  await composer.getByRole("button", { name: "Create reminder" }).click();
+  await expect(composer.getByRole("dialog")).toHaveCount(0);
+
+  const createCall = await page.evaluate(() => {
+    const state = (
+      window as unknown as { __reminderState: Record<string, any> }
+    ).__reminderState;
+    return state.calls.find((call: any) => call.command === "create");
+  });
+  expect(createCall.args.draft).toMatchObject({
+    title: "Prepare launch review",
+    details: "Bring the owner matrix.",
+    repeatEvery: 2,
+    repeatUnit: "weeks",
+    sources: [
+      { kind: "meeting", id: "m-source" },
+      { kind: "note", id: "n-source" },
+    ],
+  });
+  expect(createCall.args.draft.sources[0]).not.toHaveProperty("title");
+
+  // Inbox confirm-then-refresh actions.
+  await page
+    .locator(".reminder-card")
+    .filter({ hasText: "Book the pilot review" })
+    .getByRole("button", { name: "Complete" })
+    .click();
+  await expect(page.getByText("Book the pilot review")).toHaveCount(0);
+  await page
+    .locator(".reminder-card")
+    .filter({ hasText: "Send the roadmap follow-up" })
+    .getByRole("button", { name: "Dismiss" })
+    .click();
+  await expect(page.getByText("Send the roadmap follow-up")).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Upcoming" }).click();
+  const recurringUpcoming = page
+    .locator(".reminder-card")
+    .filter({ hasText: "Book the pilot review" });
+  const dismissedOneOff = page
+    .locator(".reminder-card")
+    .filter({ hasText: "Send the roadmap follow-up" });
+  await expect(recurringUpcoming).toBeVisible();
+  await expect(dismissedOneOff).toBeVisible();
+  await expect(recurringUpcoming.getByText("↻ Every week")).toBeVisible();
+  const nextRecurringLabel = await page.evaluate(() => {
+    const reminder = (
+      window as unknown as { __reminderState: Record<string, any> }
+    ).__reminderState.upcoming.find((row: any) => row.id === "r-due-2");
+    return new Intl.DateTimeFormat(undefined, {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    }).format(new Date(reminder.dueAt));
+  });
+  await expect(
+    recurringUpcoming.locator(".reminder-meta span").first(),
+  ).toHaveText(nextRecurringLabel);
+  expect(
+    await page.evaluate(() => {
+      const reminder = (
+        window as unknown as { __reminderState: Record<string, any> }
+      ).__reminderState.upcoming.find((row: any) => row.id === "r-due-1");
+      return {
+        state: reminder.state,
+        remainsPastDue: reminder.dueAt < Date.now(),
+      };
+    }),
+  ).toEqual({ state: "active", remainsPastDue: true });
+  await expect(page.getByText("✦ Smart").first()).toBeVisible();
+  await page.getByRole("button", { name: "Completed" }).click();
+  await expect(page.getByText("Book the pilot review")).toHaveCount(0);
+  await expect(page.getByText("Send the roadmap follow-up")).toHaveCount(0);
+  await expect(page.getByText("No completed reminders")).toBeVisible();
+  await page.getByRole("button", { name: "Upcoming" }).click();
+
+  // Count-only event updates both nav badge and canonical rows by refetch.
+  const callsBeforeEvent = await page.evaluate(
+    () =>
+      (window as unknown as { __reminderState: Record<string, any> })
+        .__reminderState.listCalls,
+  );
+  await page.evaluate(() => {
+    const target = window as unknown as {
+      __reminderState: Record<string, any>;
+      __demoEmit: (event: string, payload: unknown) => void;
+    };
+    target.__reminderState.inbox = [0, 1, 2, 3].map((index) => ({
+      occurrenceId: `o-event-${index}`,
+      dueAt: Date.now() - index * 60000,
+      reminder: {
+        id: `r-event-${index}`,
+        title: `Event reminder ${index + 1}`,
+        details: null,
+        dueAt: Date.now() - index * 60000,
+        repeatEvery: null,
+        repeatUnit: null,
+        state: "active",
+        origin: "manual",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        completedAt: null,
+        sources: [],
+      },
+    }));
+    target.__demoEmit("murmur://reminders-updated", { dueInboxCount: 4 });
+  });
+  await expect(reminderNav.locator(".count")).toHaveText("4");
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as unknown as { __reminderState: Record<string, any> })
+            .__reminderState.listCalls,
+      ),
+    )
+    .toBeGreaterThan(callsBeforeEvent);
+
+  // Meeting context: manual source prefill, Escape in-dialog, explicit
+  // suggestion dismiss, then edit-before-accept with Smart provenance.
+  await page
+    .locator(".reminder-card")
+    .filter({ hasText: "Confirm the Atlas launch owner" })
+    .getByRole("button", { name: /Meeting · Q2 Roadmap Planning/ })
+    .click();
+  const meetingCard = page.locator("app-smart-reminder-card");
+  await expect(meetingCard).toBeVisible();
+  await meetingCard.getByRole("button", { name: "New reminder" }).click();
+  await expect(composer.getByText("Q2 Roadmap Planning")).toBeVisible();
+  await composer.getByLabel("Title").press("Escape");
+  await expect(composer.getByRole("dialog")).toHaveCount(0);
+
+  await meetingCard
+    .locator(".suggestion-row")
+    .filter({ hasText: "Send the reviewed roadmap" })
+    .getByRole("button", { name: "Dismiss" })
+    .click();
+  await expect(meetingCard.getByText("Send the reviewed roadmap")).toHaveCount(
+    0,
+  );
+
+  await meetingCard
+    .locator(".suggestion-row")
+    .filter({ hasText: "Schedule the pilot follow-up" })
+    .getByRole("button", { name: "Edit & create" })
+    .click();
+  await expect(composer.getByLabel("Date")).toHaveValue("");
+  await expect(composer.getByLabel("Time")).toHaveValue("");
+  await composer.getByLabel("Date").fill("2026-08-20");
+  await composer.getByLabel("Time").fill("14:00");
+  await composer.getByRole("button", { name: "Create reminder" }).click();
+  await expect(meetingCard.locator(".suggestion-row")).toHaveCount(0);
+
+  const smartCalls = await page.evaluate(
+    () =>
+      (window as unknown as { __reminderState: Record<string, any> })
+        .__reminderState.calls,
+  );
+  expect(
+    smartCalls.some(
+      (call: any) =>
+        call.command === "dismissSuggestion" &&
+        call.args.suggestionId === "sg-meeting-1",
+    ),
+  ).toBe(true);
+  expect(
+    smartCalls.some(
+      (call: any) =>
+        call.command === "acceptSuggestion" &&
+        call.args.suggestionId === "sg-meeting-2",
+    ),
+  ).toBe(true);
+
+  // Routed authored-note context carries the note source into the same composer.
+  await page.getByRole("link", { name: "Notes" }).first().click();
+  await page
+    .getByRole("button", { name: /Atlas — PRD v3/ })
+    .first()
+    .click();
+  const noteCard = page.locator("app-smart-reminder-card");
+  await expect(noteCard).toBeVisible();
+  await noteCard.getByRole("button", { name: "New reminder" }).click();
+  await expect(composer.getByText("Atlas — PRD v3")).toBeVisible();
+  await composer.getByRole("button", { name: "Cancel" }).click();
+
+  // A committed authored-note edit updates sourceRevision and re-audits once
+  // after the debounce, instead of once per keystroke/autosave frame.
+  const noteAuditsBeforeEdit = await page.evaluate(
+    () =>
+      (
+        window as unknown as { __reminderState: Record<string, any> }
+      ).__reminderState.calls.filter(
+        (call: any) =>
+          call.command === "audit" && call.args.sourceKind === "note",
+      ).length,
+  );
+  const noteBody = page.locator(".body-area");
+  await noteBody.evaluate((element) => {
+    const textarea = element as HTMLTextAreaElement;
+    for (const value of [
+      "## Open questions\n\nConfirm the launch owner.",
+      "## Open questions\n\nConfirm the launch owner and legal review draft.",
+      "## Open questions\n\nConfirm the launch owner and legal review.",
+    ]) {
+      textarea.value = value;
+      textarea.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    }
+  });
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          () =>
+            (
+              window as unknown as { __reminderState: Record<string, any> }
+            ).__reminderState.calls.filter(
+              (call: any) =>
+                call.command === "audit" && call.args.sourceKind === "note",
+            ).length,
+        ),
+      { timeout: 5_000 },
+    )
+    .toBe(noteAuditsBeforeEdit + 1);
+  await page.waitForTimeout(1_200);
+  expect(
+    await page.evaluate(
+      () =>
+        (
+          window as unknown as { __reminderState: Record<string, any> }
+        ).__reminderState.calls.filter(
+          (call: any) =>
+            call.command === "audit" && call.args.sourceKind === "note",
+        ).length,
+    ),
+  ).toBe(noteAuditsBeforeEdit + 1);
+
+  // Relock publishes the folder tree first; the editor synchronously masks the
+  // note and destroys the Smart card, so staged suggestion plaintext cannot
+  // survive the lock transition.
+  await expect(
+    noteCard.getByText("Resolve the PRD open question"),
+  ).toBeVisible();
+  await page
+    .getByRole("button", { name: /Re-seal all 1 unlocked folder now/ })
+    .click();
+  await expect(page.getByText("Resolve the PRD open question")).toHaveCount(0);
+  await expect(noteCard).toHaveCount(0);
+
+  expect(errors).toEqual([]);
+});

--- a/e2e/settings-ai/mock-invoke.ts
+++ b/e2e/settings-ai/mock-invoke.ts
@@ -24,11 +24,21 @@ const BASE_MOCK = path.resolve(
  * @example
  *   await mockTauri(page, { brain_posture: () => "hybrid" });
  *   await mockTauri(page, {}, { list_brain_models: REGISTRY });
+ *   await mockTauri(page, {}, {}, ["murmur://privacy-event"]);
+ *   await mockTauri(page, {}, {}, [], ["murmur://delayed-event"]);
+ *   await mockTauri(page, {}, {}, [], [], { "murmur://event": [2] });
+ *   await mockTauri(page, {}, {}, [], [], {}, { "murmur://event": [1] });
+ *   await mockTauri(page, {}, {}, [], [], {}, {}, { "murmur://event": [1, 2] });
  */
 export async function mockTauri(
   page: Page,
   overrides: Record<string, (args: any) => unknown> = {},
   constants: Record<string, unknown> = {},
+  rejectedEventListeners: string[] = [],
+  delayedEventListeners: string[] = [],
+  delayedEventListenerOrdinals: Record<string, number[]> = {},
+  rejectedEventListenerOrdinals: Record<string, number[]> = {},
+  heldRejectedEventListenerOrdinals: Record<string, number[]> = {},
 ): Promise<void> {
   await page.addInitScript({ path: BASE_MOCK });
   const serialized = {
@@ -42,16 +52,175 @@ export async function mockTauri(
       Object.entries(overrides).map(([k, v]) => [k, v.toString()]),
     ),
   };
-  await page.addInitScript((ov: Record<string, string>) => {
-    const internals = (window as unknown as { __TAURI_INTERNALS__: { invoke: (c: string, a: unknown) => Promise<unknown> } }).__TAURI_INTERNALS__;
-    const orig = internals.invoke.bind(internals);
-    const names = Object.keys(ov);
-    internals.invoke = (cmd: string, args: unknown) => {
-      if (names.includes(cmd)) {
-        const fn = new Function("args", `return (${ov[cmd]})(args);`);
-        return Promise.resolve(fn(args ?? {}));
-      }
-      return orig(cmd, args);
-    };
-  }, serialized);
+  await page.addInitScript(
+    (config: {
+      overrides: Record<string, string>;
+      rejectedEventListeners: string[];
+      delayedEventListeners: string[];
+      delayedEventListenerOrdinals: Record<string, number[]>;
+      rejectedEventListenerOrdinals: Record<string, number[]>;
+      heldRejectedEventListenerOrdinals: Record<string, number[]>;
+    }) => {
+      const internals = (
+        window as unknown as {
+          __TAURI_INTERNALS__: {
+            invoke: (c: string, a: unknown) => Promise<unknown>;
+          };
+        }
+      ).__TAURI_INTERNALS__;
+      const orig = internals.invoke.bind(internals);
+      const names = Object.keys(config.overrides);
+      const pendingEventListeners = new Map<string, Array<() => void>>();
+      const releasedEventListeners = new Set<string>();
+      const releasedHeldRejections = new Set<string>();
+      const eventListenerCounts = new Map<string, number>();
+      const eventUnregisterCounts = new Map<string, number>();
+      const eventPluginInternals = (
+        window as unknown as {
+          __TAURI_EVENT_PLUGIN_INTERNALS__: {
+            unregisterListener: (event: string, eventId: number) => void;
+          };
+        }
+      ).__TAURI_EVENT_PLUGIN_INTERNALS__;
+      const unregisterListener =
+        eventPluginInternals.unregisterListener.bind(eventPluginInternals);
+      const currentLocalDate = (daysAgo: number): string => {
+        const date = new Date();
+        date.setHours(12, 0, 0, 0);
+        date.setDate(date.getDate() - daysAgo);
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, "0");
+        const day = String(date.getDate()).padStart(2, "0");
+        return `${year}-${month}-${day}`;
+      };
+      const refreshDemoAnalyticsWindow = (value: unknown): unknown => {
+        if (
+          typeof value !== "object" ||
+          value === null ||
+          !("perDay" in value) ||
+          !Array.isArray(value.perDay)
+        ) {
+          return value;
+        }
+        const perDay = value.perDay;
+        return {
+          ...value,
+          perDay: perDay.map((entry, index) =>
+            typeof entry === "object" && entry !== null
+              ? {
+                  ...entry,
+                  date: currentLocalDate(perDay.length - index - 1),
+                }
+              : entry,
+          ),
+        };
+      };
+      eventPluginInternals.unregisterListener = (
+        event: string,
+        eventId: number,
+      ) => {
+        eventUnregisterCounts.set(
+          event,
+          (eventUnregisterCounts.get(event) ?? 0) + 1,
+        );
+        unregisterListener(event, eventId);
+      };
+      (
+        window as unknown as {
+          __demoEventListenerRegistrationCount: (event: string) => number;
+          __demoEventListenerUnregisterCount: (event: string) => number;
+        }
+      ).__demoEventListenerRegistrationCount = (event: string) =>
+        eventListenerCounts.get(event) ?? 0;
+      (
+        window as unknown as {
+          __demoEventListenerUnregisterCount: (event: string) => number;
+        }
+      ).__demoEventListenerUnregisterCount = (event: string) =>
+        eventUnregisterCounts.get(event) ?? 0;
+      (
+        window as unknown as {
+          __demoReleaseEventListeners: (event: string) => void;
+        }
+      ).__demoReleaseEventListeners = (event: string) => {
+        releasedEventListeners.add(event);
+        const pending = pendingEventListeners.get(event) ?? [];
+        pendingEventListeners.delete(event);
+        for (const release of pending) {
+          release();
+        }
+      };
+      (
+        window as unknown as {
+          __demoReleaseRejectedEventListeners: (event: string) => void;
+        }
+      ).__demoReleaseRejectedEventListeners = (event: string) => {
+        releasedHeldRejections.add(event);
+      };
+      internals.invoke = (cmd: string, args: unknown) => {
+        const event =
+          typeof args === "object" && args !== null && "event" in args
+            ? String((args as { event: unknown }).event)
+            : "";
+        const listenerOrdinal =
+          cmd === "plugin:event|listen"
+            ? (eventListenerCounts.get(event) ?? 0) + 1
+            : 0;
+        if (listenerOrdinal > 0) {
+          eventListenerCounts.set(event, listenerOrdinal);
+        }
+        if (
+          cmd === "plugin:event|listen" &&
+          (config.rejectedEventListeners.includes(event) ||
+            (config.rejectedEventListenerOrdinals[event] ?? []).includes(
+              listenerOrdinal,
+            ) ||
+            ((config.heldRejectedEventListenerOrdinals[event] ?? []).includes(
+              listenerOrdinal,
+            ) &&
+              !releasedHeldRejections.has(event)))
+        ) {
+          return Promise.reject(new Error(`mock listen rejected for ${event}`));
+        }
+        if (
+          cmd === "plugin:event|listen" &&
+          (config.delayedEventListeners.includes(event) ||
+            (config.delayedEventListenerOrdinals[event] ?? []).includes(
+              listenerOrdinal,
+            )) &&
+          !releasedEventListeners.has(event)
+        ) {
+          return new Promise((resolve, reject) => {
+            const pending = pendingEventListeners.get(event) ?? [];
+            pending.push(() => {
+              orig(cmd, args).then(resolve, reject);
+            });
+            pendingEventListeners.set(event, pending);
+          });
+        }
+        if (names.includes(cmd)) {
+          const fn = new Function(
+            "args",
+            `return (${config.overrides[cmd]})(args);`,
+          );
+          return Promise.resolve(fn(args ?? {}));
+        }
+        if (cmd === "get_analytics") {
+          // The screenshot fixture has a fixed historical anchor. Keep only the
+          // shared test helper's fallback window relative to today so the 30-day
+          // chart remains non-uniform when the calendar advances.
+          return orig(cmd, args).then(refreshDemoAnalyticsWindow);
+        }
+        return orig(cmd, args);
+      };
+    },
+    {
+      overrides: serialized,
+      rejectedEventListeners,
+      delayedEventListeners,
+      delayedEventListenerOrdinals,
+      rejectedEventListenerOrdinals,
+      heldRejectedEventListenerOrdinals,
+    },
+  );
 }

--- a/scripts/harness-runtime-smoke.py
+++ b/scripts/harness-runtime-smoke.py
@@ -382,8 +382,13 @@ def read_json_object(path: Path, label: str) -> dict[str, Any]:
     return value
 
 
-def enhanced_task_dir(root: Path) -> Path:
+def harness_task_dir(root: Path, task_id: str) -> Path:
     """Resolve the exact task evidence directory in canonical and verify snapshots."""
+
+    if not task_id or len(task_id) > 160 or not all(
+        char.isalnum() or char in "-_" for char in task_id
+    ):
+        raise RuntimeProofError("Harness task id is invalid")
 
     harness_runtime = os.environ.get("MURMUR_HARNESS_RUNTIME_DIR")
     if harness_runtime:
@@ -395,7 +400,7 @@ def enhanced_task_dir(root: Path) -> Path:
         expected_runtime = task_dir / "runtime" / "checks" / "runtime-smoke"
         if (
             runtime_root != expected_runtime
-            or task_dir.name != ENHANCED_RUNTIME_TASK_ID
+            or task_dir.name != task_id
         ):
             raise RuntimeProofError(
                 "Harness runtime evidence directory is outside the exact task"
@@ -406,12 +411,12 @@ def enhanced_task_dir(root: Path) -> Path:
         / "agent-harness"
         / "v2"
         / "tasks"
-        / ENHANCED_RUNTIME_TASK_ID
+        / task_id
     )
 
 
-def validate_task_provenance(root: Path) -> dict[str, Any]:
-    task_dir = enhanced_task_dir(root)
+def validate_task_provenance(root: Path, expected_task_id: str) -> dict[str, Any]:
+    task_dir = harness_task_dir(root, expected_task_id)
     task_path = task_dir / "task.json"
     task_fingerprint = fingerprint_file(task_path, label="Harness task contract")
     task = read_json_object(task_path, "Harness task contract")
@@ -422,13 +427,13 @@ def validate_task_provenance(root: Path) -> dict[str, Any]:
     driver = Path(str(task.get("repo_realpath", ""))).resolve()
     if (
         task.get("schema_version") != 2
-        or task.get("task_id") != ENHANCED_RUNTIME_TASK_ID
+        or task.get("task_id") != expected_task_id
         or task_dir
         != git_common
         / "agent-harness"
         / "v2"
         / "tasks"
-        / ENHANCED_RUNTIME_TASK_ID
+        / expected_task_id
         or not driver.is_dir()
         or (driver / ".git").resolve() != git_common
         or not isinstance(branch, str)
@@ -441,6 +446,8 @@ def validate_task_provenance(root: Path) -> dict[str, Any]:
         raise RuntimeProofError("Harness task contract is not bound to this exact worktree")
 
     proof_mode = "canonical"
+    attempt_id: str | None = None
+    attempt_plan_sha256: str | None = None
     if root == canonical_worktree:
         if common_dir(root) != git_common or git_branch(root) != branch:
             raise RuntimeProofError(
@@ -449,9 +456,19 @@ def validate_task_provenance(root: Path) -> dict[str, Any]:
     else:
         state_path = task_dir / "state.json"
         state = read_json_object(state_path, "Harness task state")
-        attempt_id = state.get("attempt_id")
-        if not valid_lowercase_hex(attempt_id, 64):
+        snapshot_prefix = "verify-"
+        snapshot_attempt_id = (
+            root.name.removeprefix(snapshot_prefix)
+            if root.name.startswith(snapshot_prefix)
+            else ""
+        )
+        state_attempt_id = state.get("attempt_id")
+        if (
+            not valid_lowercase_hex(snapshot_attempt_id, 64)
+            or state_attempt_id != snapshot_attempt_id
+        ):
             raise RuntimeProofError("Harness verify snapshot has no valid attempt id")
+        attempt_id = snapshot_attempt_id
         attempt_dir = task_dir / "attempts" / attempt_id
         plan_path = attempt_dir / "plan.json"
         plan = read_json_object(plan_path, "Harness attempt plan")
@@ -465,13 +482,13 @@ def validate_task_provenance(root: Path) -> dict[str, Any]:
             or state.get("schema_version") != 2
             or state.get("status") != "VERIFYING"
             or state.get("phase") != "checks"
-            or state.get("task_id") != ENHANCED_RUNTIME_TASK_ID
+            or state.get("task_id") != expected_task_id
             or Path(str(state.get("plan_path", ""))).resolve() != plan_path
             or state.get("diff_sha256") != plan.get("diff_sha256")
             or state.get("plan_sha256") != plan.get("plan_sha256")
             or state.get("protocol_sha256") != plan.get("protocol_sha256")
             or plan.get("schema_version") != 2
-            or plan.get("task_id") != ENHANCED_RUNTIME_TASK_ID
+            or plan.get("task_id") != expected_task_id
             or plan.get("base_sha") != task.get("base_sha")
             or plan.get("contract_sha256") != task.get("contract_sha256")
             or not valid_lowercase_hex(plan.get("tree_sha"), 40)
@@ -482,6 +499,7 @@ def validate_task_provenance(root: Path) -> dict[str, Any]:
                 "Harness verify snapshot is not bound to its exact attempt plan"
             )
         proof_mode = "verified-snapshot"
+        attempt_plan_sha256 = str(plan["plan_sha256"])
     return {
         "path": str(task_path),
         "sha256": task_fingerprint["sha256"],
@@ -489,7 +507,69 @@ def validate_task_provenance(root: Path) -> dict[str, Any]:
         "baseSha": task["base_sha"],
         "contractSha256": task["contract_sha256"],
         "mode": proof_mode,
+        "attemptId": attempt_id,
+        "attemptPlanSha256": attempt_plan_sha256,
     }
+
+
+def active_harness_task(marker: str | None, task_id: str) -> str | None:
+    """Resolve a complete Harness marker/task pair, rejecting either half fail-closed."""
+
+    if marker is None and not task_id:
+        return None
+    if marker != "1" or not task_id:
+        raise RuntimeProofError(
+            "Harness runtime requires both MURMUR_HARNESS=1 and MURMUR_HARNESS_TASK"
+        )
+    return task_id
+
+
+def unchanged_harness_provenance(
+    expected: dict[str, Any], current: dict[str, Any]
+) -> bool:
+    """Bind snapshot work to the exact attempt as well as the task and plan."""
+
+    if expected != current:
+        return False
+    if expected.get("mode") == "verified-snapshot":
+        return valid_lowercase_hex(expected.get("attemptId"), 64) and valid_lowercase_hex(
+            expected.get("attemptPlanSha256"), 64
+        )
+    return expected.get("attemptId") is None and expected.get("attemptPlanSha256") is None
+
+
+def assert_fail_closed_harness_regressions() -> None:
+    """Keep both marker mismatch directions and attempt substitution permanently RED."""
+
+    for marker, task_id in (("1", ""), (None, "some-task")):
+        try:
+            active_harness_task(marker, task_id)
+        except RuntimeProofError:
+            pass
+        else:
+            raise RuntimeProofError("Harness marker/task mismatch regression")
+    if active_harness_task("1", "some-task") != "some-task":
+        raise RuntimeProofError("Harness marker/task binding regression")
+    first = {
+        "mode": "verified-snapshot",
+        "attemptId": "a" * 64,
+        "attemptPlanSha256": "b" * 64,
+    }
+    substituted = {**first, "attemptId": "c" * 64}
+    if unchanged_harness_provenance(first, substituted):
+        raise RuntimeProofError("Harness attempt-substitution regression")
+
+
+def verified_snapshot_owns_cargo_lane(
+    provenance: dict[str, Any] | None, inherited_seatbelt: bool
+) -> bool:
+    """Never bypass resource arbitration without both exact provenance and kernel confinement."""
+
+    return bool(
+        provenance is not None
+        and provenance.get("mode") == "verified-snapshot"
+        and inherited_seatbelt
+    )
 
 
 def validate_restart_intent(
@@ -1229,15 +1309,16 @@ def main() -> int:
     started_at = utc_now()
 
     root = repo_root()
-    harness_task = os.environ.get("MURMUR_HARNESS_TASK", "")
-    enhanced_required = harness_task == ENHANCED_RUNTIME_TASK_ID
-    if enhanced_required and os.environ.get("MURMUR_HARNESS") != "1":
-        return emit(
-            "FAIL",
-            "the enhanced runtime proof requires an exact Harness-owned task environment",
-            None,
-            started_at,
+    harness_task_value = os.environ.get("MURMUR_HARNESS_TASK", "")
+    try:
+        assert_fail_closed_harness_regressions()
+        harness_task = active_harness_task(
+            os.environ.get("MURMUR_HARNESS"), harness_task_value
         )
+    except RuntimeProofError as exc:
+        return emit("FAIL", str(exc), None, started_at)
+    harness_owned_runtime = harness_task is not None
+    enhanced_required = harness_task == ENHANCED_RUNTIME_TASK_ID
     try:
         mode, timeout = selected_timeout(
             root,
@@ -1250,13 +1331,13 @@ def main() -> int:
 
     runtime_root = runtime_dir(root)
     preflight_task: dict[str, Any] | None = None
-    if enhanced_required:
+    if harness_owned_runtime:
         try:
-            preflight_task = validate_task_provenance(root)
+            preflight_task = validate_task_provenance(root, harness_task)
             task_directory = Path(preflight_task["path"]).parent.resolve()
             if not path_is_within(runtime_root.resolve(), task_directory):
                 raise RuntimeProofError(
-                    "enhanced runtime evidence directory is outside its exact Harness task"
+                    "runtime evidence directory is outside the exact Harness task"
                 )
         except (OSError, ValueError, RuntimeError) as exc:
             return emit("FAIL", str(exc), None, started_at)
@@ -1372,20 +1453,29 @@ def main() -> int:
     staged_binary = temp_root / "Murmur-runtime-bin"
     runner_source = Path(__file__).resolve()
     wrapper_source = root / "scripts" / "harness-runtime-smoke"
-    outer_harness_owns_cargo_lane = (
-        enhanced_required
+    verified_snapshot = bool(
+        harness_owned_runtime
         and preflight_task is not None
         and preflight_task.get("mode") == "verified-snapshot"
     )
-    if outer_harness_owns_cargo_lane:
+    # Executed negative regression: a verified snapshot with no inherited Seatbelt can never
+    # select the outer-owned lane, even if every provenance field is otherwise valid.
+    if verified_snapshot_owns_cargo_lane(preflight_task, False):
+        return emit("FAIL", "resource-lane selector failed closed", log_path, started_at)
+    inherited_seatbelt = False
+    if verified_snapshot:
         try:
-            if not inherited_network_sandbox_is_active():
+            inherited_seatbelt = inherited_network_sandbox_is_active()
+            if not inherited_seatbelt:
                 raise RuntimeProofError(
                     "verified snapshot lacks a kernel-enforced outbound network restriction"
                 )
             network_enforcement = "inherited-harness-seatbelt"
         except RuntimeProofError as exc:
             return emit("FAIL", str(exc), log_path, started_at)
+    outer_harness_owns_cargo_lane = verified_snapshot_owns_cargo_lane(
+        preflight_task, inherited_seatbelt
+    )
 
     try:
         isolated_home = temp_root / "home"
@@ -1476,10 +1566,17 @@ def main() -> int:
 
             app_env = env.copy()
             app_command = [str(app_binary.resolve())]
+            if harness_owned_runtime:
+                task_provenance = validate_task_provenance(root, harness_task)
+                if preflight_task is None or not unchanged_harness_provenance(
+                    preflight_task, task_provenance
+                ):
+                    raise RuntimeProofError(
+                        "Harness task or attempt provenance changed during build"
+                    )
             if enhanced_required:
                 if sqlcipher_binary is None:
                     raise RuntimeProofError("SQLCipher disappeared after preflight")
-                task_provenance = validate_task_provenance(root)
                 runner_fingerprint = fingerprint_file(
                     runner_source, label="runtime runner source"
                 )
@@ -1762,9 +1859,6 @@ def main() -> int:
                 current_stage = fingerprint_file(staged_binary, label="staged app binary")
                 if not same_fingerprint(current_stage, staged_identity):
                     raise RuntimeProofError("staged app binary changed after execution")
-                current_task = validate_task_provenance(root)
-                if current_task["sha256"] != task_provenance["sha256"]:
-                    raise RuntimeProofError("Harness task contract changed during execution")
                 if (
                     fingerprint_file(runner_source, label="runtime runner source")["sha256"]
                     != challenge["runnerSourceSha256"]
@@ -1782,6 +1876,15 @@ def main() -> int:
                 pass_reason = (
                     "Angular served and the directly supervised real Rust MCP listener stayed alive"
                 )
+
+            if harness_owned_runtime:
+                current_task = validate_task_provenance(root, harness_task)
+                if task_provenance is None or not unchanged_harness_provenance(
+                    task_provenance, current_task
+                ):
+                    raise RuntimeProofError(
+                        "Harness task or attempt provenance changed during execution"
+                    )
 
         text = log_path.read_text(errors="replace")
         fatal_markers = ("thread 'main' panicked", "fatal runtime error", "Abort trap", "SIGABRT")

--- a/scripts/harness-runtime-smoke.py
+++ b/scripts/harness-runtime-smoke.py
@@ -1,32 +1,80 @@
 #!/usr/bin/env python3
 """Exclusive, task-owned Tauri boot smoke for the development harness.
 
-It never frees a port or kills an unknown process. The installed Murmur app therefore
-wins over this smoke: if :1420 or :8765 is owned, the result is BLOCKED with evidence.
+The generic path proves that Angular and the directly supervised Rust app boot without
+reusing or killing foreign listeners. The exact reminders Harness task additionally
+proves its lock/egress/restart claims with a runner-authenticated, content-free receipt.
 """
 
 from __future__ import annotations
 
 import argparse
+import base64
+import ctypes
+import ctypes.util
+import hashlib
 import json
 import os
+import secrets
+import select
 import shutil
 import signal
 import socket
+import sqlite3
+import stat
 import subprocess
 import sys
 import tempfile
+import threading
 import time
+import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, BinaryIO, Iterable
 
 
 DEV_DEK = "0123456789abcdef" * 4
+ENHANCED_RUNTIME_TASK_ID = "reminders-smart-inbox-v2-merge-20260731"
+RUNTIME_CHALLENGE_FILE = "reminder-runtime-challenge.json"
+RESTART_INTENT_FILE = "reminder-runtime-restart-intent.json"
+RESTART_GENERATION_FILE = "reminder-runtime-restart-generation.json"
+RUNTIME_WITNESS_FILE = "reminder-runtime-witness.json"
+RUNNER_PASS_FILE = "runner-pass.json"
+MAX_RECEIPT_BYTES = 64 * 1024
+NETWORK_PROFILE = b"""(version 1)
+(allow default)
+(deny network-outbound (require-not (remote ip "localhost:*")))
+"""
+EXPECTED_RUNTIME_CHECKS: dict[str, Any] = {
+    "actualTauriIpc": True,
+    "sqlcipherIntegrity": True,
+    "plainSqliteRejected": True,
+    "lockUnlockRelock": True,
+    "inFlightLocalInference": True,
+    "maskedReads": True,
+    "restartPurge": True,
+    "noEgress": True,
+    "providerCases": 4,
+    "localGenerateCount": 5,
+    "stubCase": True,
+}
+
+
+class RuntimeProofError(RuntimeError):
+    """A proof assertion failed; cleanup still has to run before emitting FAIL."""
 
 
 def utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def valid_lowercase_hex(value: Any, length: int) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == length
+        and all(character in "0123456789abcdef" for character in value)
+    )
 
 
 def repo_root() -> Path:
@@ -42,7 +90,47 @@ def common_dir(root: Path) -> Path:
         cwd=str(root),
         text=True,
     ).strip()
-    return Path(value).resolve()
+    path = Path(value)
+    if not path.is_absolute():
+        path = root / path
+    return path.resolve()
+
+
+def git_head(root: Path) -> str:
+    value = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=str(root), text=True
+    ).strip()
+    if not valid_lowercase_hex(value, 40):
+        raise RuntimeProofError("Git HEAD is not a full lowercase object id")
+    return value
+
+
+def git_branch(root: Path) -> str:
+    return subprocess.check_output(
+        ["git", "branch", "--show-current"], cwd=str(root), text=True
+    ).strip()
+
+
+def git_index_tree(root: Path) -> str:
+    value = subprocess.check_output(
+        ["git", "write-tree"], cwd=str(root), text=True
+    ).strip()
+    if not valid_lowercase_hex(value, 40):
+        raise RuntimeProofError("Git index tree is not a full lowercase object id")
+    return value
+
+
+def tracked_worktree_matches_index(root: Path) -> bool:
+    result = subprocess.run(
+        ["git", "diff", "--quiet", "--no-ext-diff"],
+        cwd=str(root),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if result.returncode not in (0, 1):
+        raise RuntimeProofError("Git could not compare the runtime worktree with its index")
+    return result.returncode == 0
 
 
 def runtime_dir(root: Path) -> Path:
@@ -57,30 +145,40 @@ def runtime_dir(root: Path) -> Path:
     return common_dir(root) / "agent-harness" / "runtime"
 
 
-def listener(port: int) -> str | None:
-    listening = False
-    for family, host in ((socket.AF_INET, "127.0.0.1"), (socket.AF_INET6, "::1")):
-        try:
-            with socket.socket(family, socket.SOCK_STREAM) as sock:
-                sock.settimeout(0.25)
-                if sock.connect_ex((host, port)) == 0:
-                    listening = True
-                    break
-        except OSError:
-            continue
-    if not listening:
-        return None
+def path_is_within(path: Path, parent: Path) -> bool:
     try:
-        result = subprocess.run(
-            ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN"],
-            text=True,
-            capture_output=True,
-            timeout=3,
-            check=False,
-        )
-        return result.stdout.strip() or f"listener on 127.0.0.1:{port}"
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        return f"listener on 127.0.0.1:{port}"
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def listener_pids(port: int) -> set[int]:
+    result = subprocess.run(
+        ["lsof", "-nP", "-a", "-t", f"-iTCP:{port}", "-sTCP:LISTEN"],
+        text=True,
+        capture_output=True,
+        timeout=3,
+        check=False,
+    )
+    if result.returncode not in (0, 1):
+        raise RuntimeError(f"lsof could not inspect listener ownership on port {port}")
+    pids: set[int] = set()
+    for value in result.stdout.splitlines():
+        value = value.strip()
+        if value:
+            try:
+                pids.add(int(value))
+            except ValueError as exc:
+                raise RuntimeError(f"lsof returned an invalid PID for port {port}") from exc
+    return pids
+
+
+def listener(port: int) -> str | None:
+    pids = listener_pids(port)
+    if not pids:
+        return None
+    return f"listener PID(s) {','.join(str(pid) for pid in sorted(pids))} on 127.0.0.1:{port}"
 
 
 def angular_ready() -> bool:
@@ -95,11 +193,983 @@ def angular_ready() -> bool:
 
 
 def runtime_mode(root: Path) -> str:
-    candidates = (
+    candidates = [
         root / "src-tauri" / "target" / "debug" / "Murmur",
         root / "target" / "debug" / "Murmur",
-    )
+    ]
+    target_dir = os.environ.get("CARGO_TARGET_DIR")
+    if target_dir and path_is_within(Path(__file__).resolve(), root.resolve()):
+        target_path = Path(target_dir)
+        if not target_path.is_absolute():
+            target_path = root / target_path
+        candidates.insert(0, target_path.resolve() / "debug" / "Murmur")
     return "warm" if any(path.is_file() for path in candidates) else "cold"
+
+
+def cargo_target_dir(root: Path, env: dict[str, str]) -> Path:
+    raw = env.get("CARGO_TARGET_DIR")
+    target = Path(raw) if raw else root / "target"
+    if not target.is_absolute():
+        target = root / target
+    return target.resolve()
+
+
+def fingerprint_file(
+    path: Path,
+    *,
+    label: str,
+    require_single_link: bool = True,
+) -> dict[str, Any]:
+    """Hash one exact, non-symlink inode and reject replacement during the read."""
+
+    metadata = path.lstat()
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or (require_single_link and metadata.st_nlink != 1)
+    ):
+        raise RuntimeProofError(f"{label} is not a safe regular file")
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    try:
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_dev != metadata.st_dev
+            or opened.st_ino != metadata.st_ino
+            or opened.st_size != metadata.st_size
+            or (require_single_link and opened.st_nlink != 1)
+        ):
+            raise RuntimeProofError(f"{label} changed while being opened")
+        digest = hashlib.sha256()
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+        finished = os.fstat(descriptor)
+        if (
+            finished.st_dev != opened.st_dev
+            or finished.st_ino != opened.st_ino
+            or finished.st_size != opened.st_size
+            or finished.st_mtime_ns != opened.st_mtime_ns
+        ):
+            raise RuntimeProofError(f"{label} changed while being hashed")
+    finally:
+        os.close(descriptor)
+    return {
+        "path": str(path.resolve()),
+        "device": opened.st_dev,
+        "inode": opened.st_ino,
+        "size": opened.st_size,
+        "sha256": digest.hexdigest(),
+    }
+
+
+def same_fingerprint(actual: dict[str, Any], expected: dict[str, Any]) -> bool:
+    return all(
+        actual.get(key) == expected.get(key)
+        for key in ("path", "device", "inode", "size", "sha256")
+    )
+
+
+def write_bytes_create_only(path: Path, encoded: bytes, mode: int = 0o600) -> None:
+    temp = path.parent / f".{path.name}.{os.getpid()}.{secrets.token_hex(8)}.tmp"
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(temp, flags, mode)
+    try:
+        offset = 0
+        while offset < len(encoded):
+            written = os.write(descriptor, encoded[offset:])
+            if written <= 0:
+                raise OSError("short create-only write")
+            offset += written
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    try:
+        os.link(temp, path, follow_symlinks=False)
+    finally:
+        temp.unlink(missing_ok=True)
+    directory_fd = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def write_json_create_only(path: Path, value: dict[str, Any]) -> None:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    if len(encoded) > MAX_RECEIPT_BYTES:
+        raise ValueError("runtime receipt exceeds its size bound")
+    write_bytes_create_only(path, encoded)
+
+
+def copy_file_create_only(source: Path, destination: Path) -> dict[str, Any]:
+    source_before = fingerprint_file(source, label="built app binary")
+    source_fd = os.open(source, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    destination_fd = os.open(
+        destination,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+        0o500,
+    )
+    try:
+        opened = os.fstat(source_fd)
+        if (
+            opened.st_dev != source_before["device"]
+            or opened.st_ino != source_before["inode"]
+            or opened.st_size != source_before["size"]
+        ):
+            raise RuntimeProofError("built app binary changed before staging began")
+        while True:
+            chunk = os.read(source_fd, 1024 * 1024)
+            if not chunk:
+                break
+            offset = 0
+            while offset < len(chunk):
+                written = os.write(destination_fd, chunk[offset:])
+                if written <= 0:
+                    raise OSError("short staged binary write")
+                offset += written
+        os.fsync(destination_fd)
+    finally:
+        os.close(destination_fd)
+        os.close(source_fd)
+    source_after = fingerprint_file(source, label="built app binary")
+    if not same_fingerprint(source_after, source_before):
+        raise RuntimeProofError("built app binary changed while it was staged")
+    directory_fd = os.open(destination.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+    staged = fingerprint_file(destination, label="staged app binary")
+    if (
+        staged["size"] != source_before["size"]
+        or staged["sha256"] != source_before["sha256"]
+    ):
+        raise RuntimeProofError("staged app binary is not byte-identical to Cargo output")
+    return staged
+
+
+def read_json_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        metadata = path.lstat()
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+            or metadata.st_size > MAX_RECEIPT_BYTES
+        ):
+            raise ValueError(f"{label} is not a bounded regular file")
+        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        try:
+            opened = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(opened.st_mode)
+                or opened.st_ino != metadata.st_ino
+                or opened.st_dev != metadata.st_dev
+                or opened.st_size > MAX_RECEIPT_BYTES
+            ):
+                raise ValueError(f"{label} changed while being opened")
+            encoded = os.read(descriptor, MAX_RECEIPT_BYTES + 1)
+        finally:
+            os.close(descriptor)
+        if len(encoded) > MAX_RECEIPT_BYTES:
+            raise ValueError(f"{label} exceeds its size bound")
+        value = json.loads(encoded.decode("utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{label} is unreadable or invalid") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return value
+
+
+def enhanced_task_dir(root: Path) -> Path:
+    """Resolve the exact task evidence directory in canonical and verify snapshots."""
+
+    harness_runtime = os.environ.get("MURMUR_HARNESS_RUNTIME_DIR")
+    if harness_runtime:
+        runtime_root = Path(harness_runtime)
+        if not runtime_root.is_absolute():
+            raise RuntimeProofError("Harness runtime evidence directory must be absolute")
+        runtime_root = runtime_root.resolve()
+        task_dir = runtime_root.parent.parent.parent
+        expected_runtime = task_dir / "runtime" / "checks" / "runtime-smoke"
+        if (
+            runtime_root != expected_runtime
+            or task_dir.name != ENHANCED_RUNTIME_TASK_ID
+        ):
+            raise RuntimeProofError(
+                "Harness runtime evidence directory is outside the exact task"
+            )
+        return task_dir
+    return (
+        common_dir(root)
+        / "agent-harness"
+        / "v2"
+        / "tasks"
+        / ENHANCED_RUNTIME_TASK_ID
+    )
+
+
+def validate_task_provenance(root: Path) -> dict[str, Any]:
+    task_dir = enhanced_task_dir(root)
+    task_path = task_dir / "task.json"
+    task_fingerprint = fingerprint_file(task_path, label="Harness task contract")
+    task = read_json_object(task_path, "Harness task contract")
+    head = git_head(root)
+    branch = task.get("branch")
+    canonical_worktree = Path(str(task.get("worktree_path", ""))).resolve()
+    git_common = Path(str(task.get("git_common_dir", ""))).resolve()
+    driver = Path(str(task.get("repo_realpath", ""))).resolve()
+    if (
+        task.get("schema_version") != 2
+        or task.get("task_id") != ENHANCED_RUNTIME_TASK_ID
+        or task_dir
+        != git_common
+        / "agent-harness"
+        / "v2"
+        / "tasks"
+        / ENHANCED_RUNTIME_TASK_ID
+        or not driver.is_dir()
+        or (driver / ".git").resolve() != git_common
+        or not isinstance(branch, str)
+        or not branch.startswith("agent/v2/")
+        or not valid_lowercase_hex(task.get("base_sha"), 40)
+        or not valid_lowercase_hex(task.get("contract_sha256"), 64)
+        or task.get("base_sha") != head
+        or "runtime" not in task.get("claims", [])
+    ):
+        raise RuntimeProofError("Harness task contract is not bound to this exact worktree")
+
+    proof_mode = "canonical"
+    if root == canonical_worktree:
+        if common_dir(root) != git_common or git_branch(root) != branch:
+            raise RuntimeProofError(
+                "Harness task contract is not bound to this exact worktree"
+            )
+    else:
+        state_path = task_dir / "state.json"
+        state = read_json_object(state_path, "Harness task state")
+        attempt_id = state.get("attempt_id")
+        if not valid_lowercase_hex(attempt_id, 64):
+            raise RuntimeProofError("Harness verify snapshot has no valid attempt id")
+        attempt_dir = task_dir / "attempts" / attempt_id
+        plan_path = attempt_dir / "plan.json"
+        plan = read_json_object(plan_path, "Harness attempt plan")
+        expected_snapshot = canonical_worktree.parent / f"verify-{attempt_id}"
+        if (
+            root != expected_snapshot
+            or root.parent != canonical_worktree.parent
+            or not (root / ".git").is_dir()
+            or common_dir(root) != (root / ".git").resolve()
+            or git_branch(root)
+            or state.get("schema_version") != 2
+            or state.get("status") != "VERIFYING"
+            or state.get("phase") != "checks"
+            or state.get("task_id") != ENHANCED_RUNTIME_TASK_ID
+            or Path(str(state.get("plan_path", ""))).resolve() != plan_path
+            or state.get("diff_sha256") != plan.get("diff_sha256")
+            or state.get("plan_sha256") != plan.get("plan_sha256")
+            or state.get("protocol_sha256") != plan.get("protocol_sha256")
+            or plan.get("schema_version") != 2
+            or plan.get("task_id") != ENHANCED_RUNTIME_TASK_ID
+            or plan.get("base_sha") != task.get("base_sha")
+            or plan.get("contract_sha256") != task.get("contract_sha256")
+            or not valid_lowercase_hex(plan.get("tree_sha"), 40)
+            or git_index_tree(root) != plan.get("tree_sha")
+            or not tracked_worktree_matches_index(root)
+        ):
+            raise RuntimeProofError(
+                "Harness verify snapshot is not bound to its exact attempt plan"
+            )
+        proof_mode = "verified-snapshot"
+    return {
+        "path": str(task_path),
+        "sha256": task_fingerprint["sha256"],
+        "gitHead": head,
+        "baseSha": task["base_sha"],
+        "contractSha256": task["contract_sha256"],
+        "mode": proof_mode,
+    }
+
+
+def validate_restart_intent(
+    path: Path, first_pid: int, challenge: dict[str, Any]
+) -> str:
+    intent = read_json_object(path, "restart intent")
+    run_id = intent.get("runId")
+    if (
+        set(intent)
+        != {
+            "schemaVersion",
+            "runId",
+            "firstPid",
+            "phaseOnePassed",
+            "runnerNonce",
+            "binarySha256",
+            "selectorSuccesses",
+            "lockedAuditOutcomes",
+            "restartCanaryRows",
+        }
+        or intent.get("schemaVersion") != 1
+        or intent.get("firstPid") != first_pid
+        or intent.get("phaseOnePassed") is not True
+        or run_id != challenge["runId"]
+        or intent.get("runnerNonce") != challenge["runnerNonce"]
+        or intent.get("binarySha256") != challenge["binarySha256"]
+        or intent.get("selectorSuccesses") != 5
+        or intent.get("lockedAuditOutcomes") != 2
+        or intent.get("restartCanaryRows") != 2
+    ):
+        raise ValueError("restart intent failed its runner binding")
+    if not isinstance(run_id, str):
+        raise ValueError("restart intent run id is invalid")
+    return run_id
+
+
+def validate_runtime_witness(
+    witness: dict[str, Any],
+    *,
+    challenge: dict[str, Any],
+    phase_two_nonce: str,
+    first_pid: int,
+    second_pid: int,
+    proxy_connections: int,
+) -> dict[str, Any]:
+    if (
+        set(witness)
+        != {
+            "schemaVersion",
+            "verdict",
+            "runId",
+            "runnerNonce",
+            "phaseTwoNonce",
+            "binarySha256",
+            "networkProfileSha256",
+            "runnerSourceSha256",
+            "taskContractSha256",
+            "gitHead",
+            "firstPid",
+            "secondPid",
+            "checks",
+        }
+        or witness.get("schemaVersion") != 1
+        or witness.get("verdict") != "PASS"
+        or witness.get("runId") != challenge["runId"]
+        or witness.get("runnerNonce") != challenge["runnerNonce"]
+        or witness.get("phaseTwoNonce") != phase_two_nonce
+        or witness.get("binarySha256") != challenge["binarySha256"]
+        or witness.get("networkProfileSha256") != challenge["networkProfileSha256"]
+        or witness.get("runnerSourceSha256") != challenge["runnerSourceSha256"]
+        or witness.get("taskContractSha256") != challenge["taskContractSha256"]
+        or witness.get("gitHead") != challenge["gitHead"]
+        or witness.get("firstPid") != first_pid
+        or witness.get("secondPid") != second_pid
+        or first_pid == second_pid
+        or witness.get("checks") != EXPECTED_RUNTIME_CHECKS
+        or proxy_connections != 0
+    ):
+        raise ValueError("runtime witness failed its runner binding")
+    return {
+        "schema_version": 1,
+        "first_pid": first_pid,
+        "second_pid": second_pid,
+        "pid_changed": True,
+        "binary_sha256": challenge["binarySha256"],
+        "external_provider_egress_connections": proxy_connections,
+        "checks": EXPECTED_RUNTIME_CHECKS,
+    }
+
+
+def poll_json_pipe(
+    descriptor: int,
+    buffer: bytearray,
+    parsed: dict[str, Any] | None,
+) -> tuple[dict[str, Any] | None, bool]:
+    eof = False
+    while True:
+        readable, _, _ = select.select([descriptor], [], [], 0)
+        if not readable:
+            break
+        try:
+            chunk = os.read(descriptor, 4096)
+        except BlockingIOError:
+            break
+        if not chunk:
+            eof = True
+            break
+        buffer.extend(chunk)
+        if len(buffer) > MAX_RECEIPT_BYTES:
+            raise ValueError("runtime witness pipe exceeds its size bound")
+    if parsed is None and b"\n" in buffer:
+        line, remainder = bytes(buffer).split(b"\n", 1)
+        if remainder:
+            raise ValueError("runtime witness pipe contains multiple messages")
+        try:
+            value = json.loads(line.decode("utf-8"))
+        except (UnicodeError, json.JSONDecodeError) as exc:
+            raise ValueError("runtime witness pipe is invalid") from exc
+        if not isinstance(value, dict):
+            raise ValueError("runtime witness pipe must contain one JSON object")
+        parsed = value
+        buffer.clear()
+        buffer.extend(remainder)
+    elif parsed is not None and buffer:
+        raise ValueError("runtime witness pipe contains trailing data")
+    return parsed, eof
+
+
+def drain_json_pipe_to_eof(
+    descriptor: int,
+    buffer: bytearray,
+    parsed: dict[str, Any] | None,
+    deadline: float,
+) -> dict[str, Any]:
+    eof = False
+    while time.monotonic() < deadline:
+        parsed, eof = poll_json_pipe(descriptor, buffer, parsed)
+        if eof:
+            break
+        time.sleep(0.02)
+    if not eof or parsed is None or buffer:
+        raise ValueError("runtime witness pipe did not close after one bounded message")
+    return parsed
+
+
+def process_group_exists(pgid: int) -> bool:
+    try:
+        os.killpg(pgid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+def direct_child_pids(parent_pid: int) -> list[int]:
+    result = subprocess.run(
+        ["pgrep", "-P", str(parent_pid)],
+        text=True,
+        capture_output=True,
+        timeout=3,
+        check=False,
+    )
+    if result.returncode == 1:
+        return []
+    if result.returncode != 0:
+        raise RuntimeError("pgrep could not audit the guardian's direct children")
+    return sorted(
+        {
+            int(field)
+            for field in result.stdout.split()
+            if field.isascii() and field.isdigit()
+        }
+    )
+
+
+def inherited_network_sandbox_is_active() -> bool:
+    """Ask the macOS kernel whether outbound networking is restricted."""
+
+    if sys.platform != "darwin":
+        return False
+    library_path = ctypes.util.find_library("sandbox")
+    if not library_path:
+        raise RuntimeProofError("cannot resolve the macOS sandbox library")
+    try:
+        library = ctypes.CDLL(library_path)
+        sandbox_check = library.sandbox_check
+        sandbox_check.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_uint]
+        sandbox_check.restype = ctypes.c_int
+        denied = sandbox_check(os.getpid(), b"network-outbound", 0)
+    except (AttributeError, OSError) as exc:
+        raise RuntimeProofError("cannot inspect the inherited macOS sandbox") from exc
+    return denied == 1
+
+
+class GuardedProcess:
+    def __init__(
+        self,
+        *,
+        label: str,
+        guardian: subprocess.Popen[bytes],
+        child_pid: int,
+        liveness_fd: int,
+        result_path: Path,
+    ) -> None:
+        self.label = label
+        self.guardian = guardian
+        self.child_pid = child_pid
+        self.liveness_fd = liveness_fd
+        self.result_path = result_path
+
+    def result_if_exited(self) -> dict[str, Any] | None:
+        if self.guardian.poll() is None:
+            return None
+        if self.guardian.returncode != 0:
+            raise RuntimeError(f"{self.label} guardian exited with {self.guardian.returncode}")
+        result = read_json_object(self.result_path, f"{self.label} guardian result")
+        if result.get("schema_version") != 1 or result.get("child_pid") != self.child_pid:
+            raise RuntimeError(f"{self.label} guardian result is not bound to its child")
+        return result
+
+
+def launch_guarded(
+    *,
+    label: str,
+    command: list[str],
+    root: Path,
+    env: dict[str, str],
+    log: BinaryIO,
+    result_path: Path,
+    timeout_seconds: float,
+    child_start_deadline: float,
+    inherited_fds: Iterable[int] = (),
+) -> GuardedProcess:
+    guardian_path = root / ".agents" / "harness" / "process_guardian.py"
+    if not guardian_path.is_file():
+        raise RuntimeError("the pinned process guardian is missing")
+    inherited = tuple(inherited_fds)
+    pass_arguments: list[str] = []
+    for descriptor in inherited:
+        pass_arguments.extend(["--pass-fd", str(descriptor)])
+    parent_fd, guardian_fd = os.pipe()
+    guardian = subprocess.Popen(
+        [
+            sys.executable,
+            str(guardian_path),
+            "--parent-fd",
+            str(parent_fd),
+            "--result",
+            str(result_path),
+            "--cwd",
+            str(root),
+            "--timeout-seconds",
+            str(max(1.0, timeout_seconds)),
+            "--term-grace-seconds",
+            "5",
+            *pass_arguments,
+            "--",
+            *command,
+        ],
+        cwd=str(root),
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        pass_fds=(parent_fd, *inherited),
+        start_new_session=True,
+    )
+    os.close(parent_fd)
+    try:
+        while time.monotonic() < child_start_deadline:
+            children = direct_child_pids(guardian.pid)
+            if len(children) == 1:
+                return GuardedProcess(
+                    label=label,
+                    guardian=guardian,
+                    child_pid=children[0],
+                    liveness_fd=guardian_fd,
+                    result_path=result_path,
+                )
+            if len(children) > 1:
+                raise RuntimeError(f"{label} guardian created multiple direct children")
+            if guardian.poll() is not None:
+                raise RuntimeError(f"{label} guardian exited before starting its child")
+            time.sleep(0.05)
+        raise RuntimeError(f"{label} guardian did not start its child")
+    except BaseException:
+        os.close(guardian_fd)
+        try:
+            os.killpg(guardian.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        guardian.wait(timeout=10)
+        raise
+
+
+def close_liveness(process: GuardedProcess) -> None:
+    if process.liveness_fd >= 0:
+        os.close(process.liveness_fd)
+        process.liveness_fd = -1
+
+
+def validate_natural_guardian(
+    process: GuardedProcess,
+    result: dict[str, Any],
+    *,
+    expected_exit: int,
+) -> None:
+    close_liveness(process)
+    if (
+        result.get("exit_code") != expected_exit
+        or result.get("timed_out") is not False
+        or result.get("parent_lost") is not False
+        or result.get("guardian_signal") is not None
+        or result.get("leader_exited_with_live_group") is not False
+        or result.get("termination_reason") is not None
+        or process_group_exists(process.child_pid)
+    ):
+        raise RuntimeProofError(f"{process.label} did not exit as a quiescent owned process")
+
+
+def wait_guarded_natural(
+    process: GuardedProcess,
+    *,
+    deadline: float,
+    expected_exit: int,
+) -> dict[str, Any]:
+    while time.monotonic() < deadline:
+        result = process.result_if_exited()
+        if result is not None:
+            validate_natural_guardian(process, result, expected_exit=expected_exit)
+            return result
+        time.sleep(0.05)
+    raise RuntimeProofError(f"{process.label} did not finish before its deadline")
+
+
+def request_guarded_shutdown(process: GuardedProcess) -> dict[str, Any]:
+    if process.guardian.poll() is not None:
+        raise RuntimeProofError(f"{process.label} exited before controlled shutdown")
+    try:
+        os.killpg(process.child_pid, signal.SIGTERM)
+    except ProcessLookupError as exc:
+        raise RuntimeProofError(f"{process.label} vanished before controlled shutdown") from exc
+    deadline = time.monotonic() + 20
+    while time.monotonic() < deadline:
+        result = process.result_if_exited()
+        if result is not None:
+            close_liveness(process)
+            if (
+                result.get("exit_code") not in (0, -signal.SIGTERM, 128 + signal.SIGTERM)
+                or result.get("timed_out") is not False
+                or result.get("parent_lost") is not False
+                or result.get("guardian_signal") is not None
+                or result.get("leader_exited_with_live_group") is not False
+                or result.get("termination_reason") is not None
+                or process_group_exists(process.child_pid)
+            ):
+                raise RuntimeProofError(
+                    f"{process.label} did not honor runner-controlled shutdown cleanly"
+                )
+            return result
+        time.sleep(0.05)
+    raise RuntimeProofError(f"{process.label} did not stop under live-parent supervision")
+
+
+def fallback_terminate_guarded(process: GuardedProcess | None) -> None:
+    if process is None:
+        return
+    close_liveness(process)
+    try:
+        process.guardian.wait(timeout=20)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.guardian.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            process.guardian.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(process.guardian.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.guardian.wait(timeout=5)
+    deadline = time.monotonic() + 5
+    while process_group_exists(process.child_pid) and time.monotonic() < deadline:
+        time.sleep(0.05)
+    if process_group_exists(process.child_pid):
+        raise RuntimeError(f"owned {process.label} process group survived guardian cleanup")
+
+
+def owned_process_group_survivors(
+    processes: Iterable[GuardedProcess | None],
+) -> list[int]:
+    """Audit the exact PGIDs published by the parent-death guardians."""
+
+    return sorted(
+        {
+            process.child_pid
+            for process in processes
+            if process is not None and process_group_exists(process.child_pid)
+        }
+    )
+
+
+def lsof_text_records(pid: int) -> list[dict[str, str]]:
+    result = subprocess.run(
+        ["lsof", "-nP", "-a", "-p", str(pid), "-d", "txt", "-F", "pDint"],
+        text=True,
+        capture_output=True,
+        timeout=3,
+        check=False,
+    )
+    if result.returncode != 0:
+        return []
+    records: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    for line in result.stdout.splitlines():
+        if not line:
+            continue
+        field, value = line[0], line[1:]
+        if field == "f":
+            if current is not None:
+                records.append(current)
+            current = {"f": value}
+        elif current is not None and field in {"D", "i", "n", "t"}:
+            current[field] = value
+    if current is not None:
+        records.append(current)
+    return records
+
+
+def prove_mapped_executable(
+    pid: int,
+    expected: dict[str, Any],
+    *,
+    deadline: float,
+) -> dict[str, Any]:
+    while time.monotonic() < deadline:
+        for record in lsof_text_records(pid):
+            try:
+                device = int(record.get("D", ""), 0)
+                inode = int(record.get("i", ""), 10)
+                mapped_path = str(Path(record.get("n", "")).resolve())
+            except (OSError, TypeError, ValueError):
+                continue
+            if (
+                record.get("f") == "txt"
+                and record.get("t") == "REG"
+                and mapped_path == expected["path"]
+                and device == expected["device"]
+                and inode == expected["inode"]
+            ):
+                current = fingerprint_file(Path(expected["path"]), label="staged app binary")
+                if not same_fingerprint(current, expected):
+                    raise RuntimeProofError("staged app binary changed after process launch")
+                return {
+                    "pid": pid,
+                    "path": mapped_path,
+                    "device": device,
+                    "inode": inode,
+                    "sha256": current["sha256"],
+                }
+        time.sleep(0.05)
+    raise RuntimeProofError("the launched PID never mapped the staged app binary")
+
+
+class ExternalEgressObserver:
+    def __init__(self) -> None:
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._socket.bind(("127.0.0.1", 0))
+        self._socket.listen()
+        self._socket.settimeout(0.2)
+        self._stop = threading.Event()
+        self._lock = threading.Lock()
+        self._connections = 0
+        self._health_connections = 0
+        self._unauthorized_connections = 0
+        self._failed = False
+        self._health_path = f"/runner-health-{secrets.token_hex(16)}"
+        self._authorization_token = secrets.token_hex(32)
+        credentials = f"murmur-harness:{self._authorization_token}".encode("ascii")
+        self._authorization_value = b"Basic " + base64.b64encode(credentials)
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    @property
+    def endpoint(self) -> str:
+        host, port = self._socket.getsockname()
+        return f"http://murmur-harness:{self._authorization_token}@{host}:{port}"
+
+    @property
+    def address(self) -> tuple[str, int]:
+        host, port = self._socket.getsockname()
+        return str(host), int(port)
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                connection, _ = self._socket.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                if not self._stop.is_set():
+                    self._failed = True
+                return
+            with connection:
+                try:
+                    connection.settimeout(0.5)
+                    prefix = bytearray()
+                    while len(prefix) < 4096 and not prefix.endswith(b"\r\n\r\n"):
+                        chunk = connection.recv(1)
+                        if not chunk:
+                            break
+                        prefix.extend(chunk)
+                except OSError:
+                    prefix = bytearray()
+            header_lines = bytes(prefix).splitlines()
+            first_line = header_lines[0] if header_lines else b""
+            authorization = next(
+                (
+                    line.split(b":", 1)[1].strip()
+                    for line in header_lines[1:]
+                    if line.lower().startswith(b"proxy-authorization:")
+                ),
+                b"",
+            )
+            if not secrets.compare_digest(authorization, self._authorization_value):
+                with self._lock:
+                    self._unauthorized_connections += 1
+                continue
+            expected_health = (
+                f"GET http://murmur-harness.invalid{self._health_path} HTTP/1.1"
+            ).encode("ascii")
+            is_health = first_line == expected_health
+            with self._lock:
+                if is_health:
+                    self._health_connections += 1
+                else:
+                    # No hostname is exempt. A GitHub update check is egress just like a
+                    # provider connection and must have been disabled by the exact renderer.
+                    self._connections += 1
+
+    def connections(self) -> int:
+        with self._lock:
+            return self._connections
+
+    def unauthorized_connections(self) -> int:
+        with self._lock:
+            return self._unauthorized_connections
+
+    def assert_healthy(self) -> None:
+        if self._failed or not self._thread.is_alive():
+            raise RuntimeError("external egress observer failed")
+
+    def prove_liveness(self) -> None:
+        self.assert_healthy()
+        with socket.create_connection(self.address, timeout=1) as connection:
+            request_line = (
+                f"GET http://murmur-harness.invalid{self._health_path} HTTP/1.1\r\n"
+            ).encode("ascii")
+            request = (
+                request_line
+                + b"Host: murmur-harness.invalid\r\n"
+                + b"Proxy-Authorization: "
+                + self._authorization_value
+                + b"\r\nConnection: close\r\n\r\n"
+            )
+            connection.sendall(request)
+        deadline = time.monotonic() + 1
+        while time.monotonic() < deadline:
+            with self._lock:
+                if self._health_connections == 1:
+                    return
+            time.sleep(0.01)
+        raise RuntimeError("external egress observer liveness was not witnessed")
+
+    def prove_unauthorized_rejected(self) -> None:
+        self.assert_healthy()
+        with socket.create_connection(self.address, timeout=1) as connection:
+            connection.sendall(
+                b"GET http://unauthorized.invalid/ HTTP/1.1\r\n"
+                b"Host: unauthorized.invalid\r\nConnection: close\r\n\r\n"
+            )
+        deadline = time.monotonic() + 1
+        while time.monotonic() < deadline:
+            with self._lock:
+                if (
+                    self._unauthorized_connections == 1
+                    and self._health_connections == 0
+                    and self._connections == 0
+                ):
+                    return
+            time.sleep(0.01)
+        raise RuntimeError("external egress observer accepted an unauthorized local client")
+
+    def settle_and_close(self) -> int:
+        time.sleep(0.5)
+        self.assert_healthy()
+        self._stop.set()
+        self._socket.close()
+        self._thread.join(timeout=2)
+        if self._thread.is_alive() or self._failed:
+            raise RuntimeError("external egress observer did not close cleanly")
+        return self.connections()
+
+    def force_close(self) -> None:
+        self._stop.set()
+        self._socket.close()
+        self._thread.join(timeout=2)
+
+
+def verify_external_encrypted_database(
+    isolated_home: Path,
+    sqlcipher_binary: str,
+) -> dict[str, Any]:
+    data_root = isolated_home / "Library" / "Application Support"
+    candidates = list(data_root.rglob("meetnotes.sqlite")) if data_root.is_dir() else []
+    if len(candidates) != 1:
+        raise RuntimeProofError("the isolated runtime did not produce exactly one database")
+    database = candidates[0]
+    before = fingerprint_file(database, label="isolated SQLCipher database")
+    with database.open("rb") as handle:
+        encrypted_header = handle.read(16) != b"SQLite format 3\0"
+    uri = f"file:{urllib.parse.quote(str(database))}?mode=ro&immutable=1"
+    plain_query_rejected = False
+    try:
+        connection = sqlite3.connect(uri, uri=True)
+        try:
+            connection.execute("SELECT COUNT(*) FROM sqlite_master").fetchone()
+        except sqlite3.DatabaseError:
+            plain_query_rejected = True
+        finally:
+            connection.close()
+    except sqlite3.DatabaseError:
+        plain_query_rejected = True
+
+    script = f""".bail on
+PRAGMA key = "x'{DEV_DEK}'";
+PRAGMA query_only = ON;
+PRAGMA cipher_integrity_check;
+PRAGMA integrity_check;
+SELECT CASE WHEN
+  (SELECT COUNT(*) FROM sqlite_master
+    WHERE type='table' AND name IN (
+      'reminders','reminder_sources','reminder_due_occurrences',
+      'reminder_audit_cache','reminder_pending_suggestions'
+    )) = 5
+  AND (SELECT COUNT(*) FROM reminders WHERE title='Runtime reminder probe') = 1
+THEN 'schema-ok' ELSE 'schema-fail' END;
+"""
+    result = subprocess.run(
+        [sqlcipher_binary, "-batch", "-noheader", "-readonly", str(database)],
+        input=script,
+        text=True,
+        capture_output=True,
+        timeout=15,
+        check=False,
+    )
+    output = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    cipher_ok = (
+        result.returncode == 0
+        and output.count("ok") >= 2
+        and output[-1:] == ["schema-ok"]
+        and not result.stderr.strip()
+    )
+    after = fingerprint_file(database, label="isolated SQLCipher database")
+    unchanged = same_fingerprint(after, before)
+    if not encrypted_header or not plain_query_rejected or not cipher_ok or not unchanged:
+        raise RuntimeProofError("external keyed SQLCipher/plain-SQLite proof failed")
+    return {
+        "encryptedHeader": True,
+        "plainSqliteRejected": True,
+        "cipherIntegrityCheck": "ok",
+        "sqliteIntegrityCheck": "ok",
+        "schemaAndReminder": "schema-ok",
+        "databaseSha256": before["sha256"],
+        "databaseInodeStable": True,
+    }
 
 
 def selected_timeout(
@@ -118,7 +1188,13 @@ def selected_timeout(
     return mode, timeout
 
 
-def emit(verdict: str, reason: str, log_path: Path | None, started_at: str) -> int:
+def emit(
+    verdict: str,
+    reason: str,
+    log_path: Path | None,
+    started_at: str,
+    runtime_evidence: dict[str, Any] | None = None,
+) -> int:
     payload = {
         "schema_version": 1,
         "verdict": verdict,
@@ -127,10 +1203,9 @@ def emit(verdict: str, reason: str, log_path: Path | None, started_at: str) -> i
         "finished_at": utc_now(),
         "log_path": str(log_path) if log_path else None,
     }
+    if runtime_evidence is not None:
+        payload["runtime_evidence"] = runtime_evidence
     print(json.dumps(payload, sort_keys=True))
-    # Dedicated exit codes so the harness distinguishes an ENVIRONMENTAL block (a stray dev
-    # server owning an exclusive port — not this change's fault) from a genuine boot FAILURE.
-    # The harness honors code 3 as BLOCKED only for this runner-owned canonical probe.
     if verdict == "PASS":
         return 0
     if verdict == "BLOCKED":
@@ -154,6 +1229,15 @@ def main() -> int:
     started_at = utc_now()
 
     root = repo_root()
+    harness_task = os.environ.get("MURMUR_HARNESS_TASK", "")
+    enhanced_required = harness_task == ENHANCED_RUNTIME_TASK_ID
+    if enhanced_required and os.environ.get("MURMUR_HARNESS") != "1":
+        return emit(
+            "FAIL",
+            "the enhanced runtime proof requires an exact Harness-owned task environment",
+            None,
+            started_at,
+        )
     try:
         mode, timeout = selected_timeout(
             root,
@@ -163,27 +1247,80 @@ def main() -> int:
         )
     except ValueError as exc:
         return emit("FAIL", str(exc), None, started_at)
-    runtime_root = runtime_dir(root)
-    runtime_root.mkdir(parents=True, exist_ok=True)
-    run_id = f"boot-{int(time.time())}-{os.getpid()}"
-    log_path = runtime_root / f"{run_id}.log"
-    if args.runtime_write_probe:
-        log_path.write_text("task-private runtime write probe\n", encoding="utf-8")
-        return emit("PASS", "task-private runtime log is writable", log_path, started_at)
 
-    for port in (1420, 8765):
-        owner = listener(port)
-        if owner:
+    runtime_root = runtime_dir(root)
+    preflight_task: dict[str, Any] | None = None
+    if enhanced_required:
+        try:
+            preflight_task = validate_task_provenance(root)
+            task_directory = Path(preflight_task["path"]).parent.resolve()
+            if not path_is_within(runtime_root.resolve(), task_directory):
+                raise RuntimeProofError(
+                    "enhanced runtime evidence directory is outside its exact Harness task"
+                )
+        except (OSError, ValueError, RuntimeError) as exc:
+            return emit("FAIL", str(exc), None, started_at)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    run_id = f"boot-{int(time.time())}-{os.getpid()}-{secrets.token_hex(8)}"
+    if args.runtime_write_probe:
+        probe_path = runtime_root / f"{run_id}-write-probe.json"
+        write_json_create_only(probe_path, {"schemaVersion": 1, "writable": True})
+        return emit("PASS", "task-private runtime log is writable", probe_path, started_at)
+
+    required_tools = ("lsof", "pgrep", "npm", "cargo")
+    for tool in required_tools:
+        if shutil.which(tool) is None:
+            return emit("BLOCKED", f"{tool} is unavailable; runtime probe cannot start", None, started_at)
+    sqlcipher_binary = shutil.which("sqlcipher")
+    sandbox_binary = "/usr/bin/sandbox-exec"
+    if enhanced_required:
+        try:
+            if preflight_task is None:
+                raise RuntimeProofError("enhanced task provenance disappeared")
+            runtime_metadata = runtime_root.lstat()
+            if (
+                not stat.S_ISDIR(runtime_metadata.st_mode)
+                or runtime_root.is_symlink()
+            ):
+                raise RuntimeProofError("enhanced runtime evidence directory is unsafe")
+        except (OSError, ValueError, RuntimeError) as exc:
+            return emit("FAIL", str(exc), None, started_at)
+        if sys.platform != "darwin" or not Path(sandbox_binary).is_file():
             return emit(
                 "BLOCKED",
-                f"exclusive runtime port {port} is already owned; refusing to kill or reuse it: {owner}",
+                "macOS sandbox-exec is required for the enhanced no-egress proof",
                 None,
                 started_at,
             )
-    if shutil.which("npm") is None:
-        return emit("BLOCKED", "npm is unavailable; runtime probe cannot start", None, started_at)
+        if sqlcipher_binary is None:
+            return emit(
+                "BLOCKED",
+                "the SQLCipher CLI is required for external keyed integrity proof",
+                None,
+                started_at,
+            )
+    try:
+        for port in (1420, 8765):
+            owner = listener(port)
+            if owner:
+                return emit(
+                    "BLOCKED",
+                    f"exclusive runtime port {port} is already owned; refusing to kill or reuse it: {owner}",
+                    None,
+                    started_at,
+                )
+    except (RuntimeError, subprocess.TimeoutExpired) as exc:
+        return emit("BLOCKED", str(exc), None, started_at)
     if not (root / "package.json").is_file():
         return emit("FAIL", "package.json is missing from the Git root", None, started_at)
+    angular_bin = root / "node_modules" / ".bin" / "ng"
+    if not angular_bin.is_file():
+        return emit(
+            "BLOCKED",
+            "the local Angular CLI is unavailable; run npm ci before the runtime probe",
+            None,
+            started_at,
+        )
     if args.preflight:
         return emit(
             "PASS",
@@ -192,9 +1329,64 @@ def main() -> int:
             started_at,
         )
 
+    run_dir = runtime_root / run_id
+    try:
+        run_dir.mkdir(mode=0o700, exist_ok=False)
+    except OSError:
+        return emit("FAIL", "could not create a unique runtime evidence directory", None, started_at)
+    log_path = run_dir / "boot.log"
     original_home = Path.home()
     temp_root = Path(tempfile.mkdtemp(prefix=f"murmur-{run_id}-"))
-    proc: subprocess.Popen[bytes] | None = None
+    cargo_proc: GuardedProcess | None = None
+    frontend_proc: GuardedProcess | None = None
+    first_app_proc: GuardedProcess | None = None
+    second_app_proc: GuardedProcess | None = None
+    observer: ExternalEgressObserver | None = None
+    observer_closed = False
+    witness_read_fd = -1
+    witness_write_fd = -1
+    witness_buffer = bytearray()
+    pipe_witness: dict[str, Any] | None = None
+    failure_reason: str | None = None
+    cleanup_errors: list[str] = []
+    pass_reason: str | None = None
+    runtime_evidence: dict[str, Any] | None = None
+    challenge: dict[str, Any] | None = None
+    task_provenance: dict[str, Any] | None = None
+    staged_identity: dict[str, Any] | None = None
+    app_identities: list[dict[str, Any]] = []
+    sqlcipher_evidence: dict[str, Any] | None = None
+    provider_connections: int | None = None
+    unauthorized_connections_rejected: int | None = None
+    guardian_results: dict[str, dict[str, Any]] = {}
+    phase_two_nonce: str | None = None
+    temp_removed = False
+    network_enforcement: str | None = None
+
+    challenge_path = run_dir / RUNTIME_CHALLENGE_FILE
+    intent_path = run_dir / RESTART_INTENT_FILE
+    generation_path = run_dir / RESTART_GENERATION_FILE
+    witness_path = run_dir / RUNTIME_WITNESS_FILE
+    runner_pass_path = run_dir / RUNNER_PASS_FILE
+    profile_path = run_dir / "app-loopback.sb"
+    staged_binary = temp_root / "Murmur-runtime-bin"
+    runner_source = Path(__file__).resolve()
+    wrapper_source = root / "scripts" / "harness-runtime-smoke"
+    outer_harness_owns_cargo_lane = (
+        enhanced_required
+        and preflight_task is not None
+        and preflight_task.get("mode") == "verified-snapshot"
+    )
+    if outer_harness_owns_cargo_lane:
+        try:
+            if not inherited_network_sandbox_is_active():
+                raise RuntimeProofError(
+                    "verified snapshot lacks a kernel-enforced outbound network restriction"
+                )
+            network_enforcement = "inherited-harness-seatbelt"
+        except RuntimeProofError as exc:
+            return emit("FAIL", str(exc), log_path, started_at)
+
     try:
         isolated_home = temp_root / "home"
         isolated_home.mkdir(parents=True)
@@ -202,65 +1394,588 @@ def main() -> int:
         env.update(
             {
                 "HOME": str(isolated_home),
+                "CFFIXED_USER_HOME": str(isolated_home),
                 "CARGO_HOME": env.get("CARGO_HOME", str(original_home / ".cargo")),
                 "RUSTUP_HOME": env.get("RUSTUP_HOME", str(original_home / ".rustup")),
                 "TMPDIR": str(temp_root / "tmp"),
                 "npm_config_cache": str(temp_root / "npm-cache"),
                 "MURMUR_DEV_DEK": DEV_DEK,
+                "MURMUR_DEV_KEK": DEV_DEK,
+                "MURMUR_HARNESS_RUNTIME_DIR": str(run_dir),
                 "MISTRALRS_METAL_PRECOMPILE": "0",
             }
         )
+        env["CARGO_TARGET_DIR"] = str(cargo_target_dir(root, env))
         Path(env["TMPDIR"]).mkdir(parents=True)
 
         with log_path.open("wb") as log:
-            proc = subprocess.Popen(
-                ["npm", "run", "dev"],
-                cwd=str(root),
-                env=env,
-                stdout=log,
-                stderr=subprocess.STDOUT,
-                start_new_session=True,
-            )
             deadline = time.monotonic() + timeout
+            cargo_command = [
+                "cargo",
+                "build",
+                "--manifest-path",
+                "src-tauri/Cargo.toml",
+                "--bin",
+                "Murmur",
+            ]
+            if not outer_harness_owns_cargo_lane:
+                cargo_command = [
+                    str(root / "scripts" / "agent-resource-run"),
+                    "--deadline-seconds",
+                    str(max(1, int(deadline - time.monotonic()))),
+                    "--",
+                    *cargo_command,
+                ]
+            frontend_proc = launch_guarded(
+                label="Angular",
+                command=[str(angular_bin), "serve", "--port", "1420"],
+                root=root,
+                env=env,
+                log=log,
+                result_path=run_dir / "angular-guardian.json",
+                timeout_seconds=timeout + args.settle_seconds + 60,
+                child_start_deadline=min(deadline, time.monotonic() + 15),
+            )
+            cargo_proc = launch_guarded(
+                label="Cargo build",
+                command=cargo_command,
+                root=root,
+                env=env,
+                log=log,
+                result_path=run_dir / "cargo-guardian.json",
+                timeout_seconds=max(1, deadline - time.monotonic()),
+                child_start_deadline=min(deadline, time.monotonic() + 15),
+            )
+            guardian_results["cargo"] = wait_guarded_natural(
+                cargo_proc,
+                deadline=deadline + 10,
+                expected_exit=0,
+            )
+            app_binary = cargo_target_dir(root, env) / "debug" / "Murmur"
+            if not app_binary.is_file() or app_binary.is_symlink():
+                raise RuntimeProofError(
+                    "Cargo succeeded but its exact real Rust app binary is missing or unsafe"
+                )
+
             while time.monotonic() < deadline:
-                if proc.poll() is not None:
-                    return emit("FAIL", f"dev process exited early with {proc.returncode}", log_path, started_at)
-                if angular_ready() and listener(8765):
+                frontend_result = frontend_proc.result_if_exited()
+                if frontend_result is not None:
+                    raise RuntimeProofError(
+                        f"Angular process exited early with {frontend_result.get('exit_code')}"
+                    )
+                angular_pids = listener_pids(1420)
+                if angular_pids and angular_pids != {frontend_proc.child_pid}:
+                    raise RuntimeProofError("Angular port ownership changed to a foreign process")
+                if angular_ready() and angular_pids == {frontend_proc.child_pid}:
                     break
-                time.sleep(1)
+                time.sleep(0.25)
             else:
-                return emit(
-                    "FAIL",
-                    f"timed out after {timeout}s waiting for Angular and the real Rust MCP listener ({mode} start)",
-                    log_path,
-                    started_at,
+                raise RuntimeProofError(
+                    f"timed out after {timeout}s waiting for Angular ({mode} start)"
+                )
+
+            app_env = env.copy()
+            app_command = [str(app_binary.resolve())]
+            if enhanced_required:
+                if sqlcipher_binary is None:
+                    raise RuntimeProofError("SQLCipher disappeared after preflight")
+                task_provenance = validate_task_provenance(root)
+                runner_fingerprint = fingerprint_file(
+                    runner_source, label="runtime runner source"
+                )
+                wrapper_fingerprint = fingerprint_file(
+                    wrapper_source, label="runtime runner wrapper"
+                )
+                write_bytes_create_only(profile_path, NETWORK_PROFILE)
+                profile_fingerprint = fingerprint_file(
+                    profile_path, label="runtime network sandbox profile"
+                )
+                staged_identity = copy_file_create_only(app_binary, staged_binary)
+                observer = ExternalEgressObserver()
+                observer.prove_unauthorized_rejected()
+                unauthorized_connections_rejected = observer.unauthorized_connections()
+                observer.prove_liveness()
+                for key in (
+                    "ANTHROPIC_API_KEY",
+                    "OPENAI_API_KEY",
+                    "CLAUDE_API_KEY",
+                    "OLLAMA_HOST",
+                ):
+                    app_env.pop(key, None)
+                for key in (
+                    "HTTP_PROXY",
+                    "HTTPS_PROXY",
+                    "ALL_PROXY",
+                    "http_proxy",
+                    "https_proxy",
+                    "all_proxy",
+                ):
+                    app_env[key] = observer.endpoint
+                app_env["NO_PROXY"] = ""
+                app_env["no_proxy"] = ""
+                runner_nonce = secrets.token_hex(32)
+                challenge = {
+                    "schemaVersion": 1,
+                    "taskId": ENHANCED_RUNTIME_TASK_ID,
+                    "runId": run_id,
+                    "runnerPid": os.getpid(),
+                    "runnerNonce": runner_nonce,
+                    "binarySha256": staged_identity["sha256"],
+                    "networkProfileSha256": profile_fingerprint["sha256"],
+                    "runnerSourceSha256": runner_fingerprint["sha256"],
+                    "taskContractSha256": task_provenance["sha256"],
+                    "gitHead": task_provenance["gitHead"],
+                    "startedAt": started_at,
+                }
+                write_json_create_only(challenge_path, challenge)
+                app_env.update(
+                    {
+                        "MURMUR_HARNESS_RUN_ID": run_id,
+                        "MURMUR_HARNESS_RUNNER_NONCE": runner_nonce,
+                        "MURMUR_HARNESS_BINARY_SHA256": staged_identity["sha256"],
+                        "MURMUR_HARNESS_EGRESS_PROXY": observer.endpoint,
+                    }
+                )
+                current_stage = fingerprint_file(staged_binary, label="staged app binary")
+                if not same_fingerprint(current_stage, staged_identity):
+                    raise RuntimeProofError("staged app binary changed before first launch")
+                if outer_harness_owns_cargo_lane:
+                    app_command = [str(staged_binary)]
+                else:
+                    network_enforcement = "nested-runtime-seatbelt"
+                    app_command = [
+                        sandbox_binary,
+                        "-f",
+                        str(profile_path),
+                        str(staged_binary),
+                    ]
+
+            first_app_proc = launch_guarded(
+                label="first Rust app",
+                command=app_command,
+                root=root,
+                env=app_env,
+                log=log,
+                result_path=run_dir / "first-app-guardian.json",
+                timeout_seconds=max(1, deadline - time.monotonic()) + 30,
+                child_start_deadline=min(deadline, time.monotonic() + 15),
+            )
+            if enhanced_required:
+                if staged_identity is None:
+                    raise RuntimeProofError("staged binary identity is absent")
+                app_identities.append(
+                    prove_mapped_executable(
+                        first_app_proc.child_pid,
+                        staged_identity,
+                        deadline=min(deadline, time.monotonic() + 10),
+                    )
+                )
+
+            restart_run_id: str | None = None
+            while time.monotonic() < deadline:
+                frontend_result = frontend_proc.result_if_exited()
+                if frontend_result is not None:
+                    raise RuntimeProofError(
+                        f"Angular process exited early with {frontend_result.get('exit_code')}"
+                    )
+                if listener_pids(1420) != {frontend_proc.child_pid}:
+                    raise RuntimeProofError(
+                        "Angular readiness is no longer owned by its supervised child"
+                    )
+
+                if restart_run_id is None and intent_path.is_file():
+                    if not enhanced_required or challenge is None:
+                        raise RuntimeProofError(
+                            "an enhanced restart intent appeared in an ordinary runtime task"
+                        )
+                    restart_run_id = validate_restart_intent(
+                        intent_path, first_app_proc.child_pid, challenge
+                    )
+
+                if restart_run_id is not None and second_app_proc is None:
+                    first_result = first_app_proc.result_if_exited()
+                    if first_result is None:
+                        time.sleep(0.1)
+                        continue
+                    validate_natural_guardian(first_app_proc, first_result, expected_exit=0)
+                    guardian_results["firstApp"] = first_result
+                    if listener_pids(8765):
+                        raise RuntimeProofError("the MCP port was not closed between app generations")
+                    if staged_identity is None or challenge is None:
+                        raise RuntimeProofError("enhanced generation state is incomplete")
+                    current_stage = fingerprint_file(staged_binary, label="staged app binary")
+                    if not same_fingerprint(current_stage, staged_identity):
+                        raise RuntimeProofError("staged app binary changed before second launch")
+                    phase_two_nonce = secrets.token_hex(32)
+                    witness_read_fd, witness_write_fd = os.pipe()
+                    os.set_blocking(witness_read_fd, False)
+                    second_env = app_env.copy()
+                    second_env["MURMUR_HARNESS_PHASE_TWO_NONCE"] = phase_two_nonce
+                    second_env["MURMUR_HARNESS_WITNESS_FD"] = str(witness_write_fd)
+                    second_app_proc = launch_guarded(
+                        label="second Rust app",
+                        command=app_command,
+                        root=root,
+                        env=second_env,
+                        log=log,
+                        result_path=run_dir / "second-app-guardian.json",
+                        timeout_seconds=max(1, deadline - time.monotonic()) + 30,
+                        child_start_deadline=min(deadline, time.monotonic() + 15),
+                        inherited_fds=(witness_write_fd,),
+                    )
+                    os.close(witness_write_fd)
+                    witness_write_fd = -1
+                    app_identities.append(
+                        prove_mapped_executable(
+                            second_app_proc.child_pid,
+                            staged_identity,
+                            deadline=min(deadline, time.monotonic() + 10),
+                        )
+                    )
+                    write_json_create_only(
+                        generation_path,
+                        {
+                            "schemaVersion": 1,
+                            "runId": restart_run_id,
+                            "runnerNonce": challenge["runnerNonce"],
+                            "binarySha256": staged_identity["sha256"],
+                            "firstPid": first_app_proc.child_pid,
+                            "secondPid": second_app_proc.child_pid,
+                            "runnerOwned": True,
+                        },
+                    )
+
+                if second_app_proc is not None and witness_read_fd >= 0:
+                    pipe_witness, _ = poll_json_pipe(
+                        witness_read_fd, witness_buffer, pipe_witness
+                    )
+
+                active_app = second_app_proc or first_app_proc
+                active_result = active_app.result_if_exited()
+                if active_result is not None:
+                    generation = "restarted" if restart_run_id is not None else "real"
+                    raise RuntimeProofError(
+                        f"{generation} Rust app process exited early with "
+                        f"{active_result.get('exit_code')}"
+                    )
+
+                mcp_pids = listener_pids(8765)
+                if mcp_pids and mcp_pids != {active_app.child_pid}:
+                    raise RuntimeProofError(
+                        "the MCP listener is not owned by the active supervised Rust process"
+                    )
+                if angular_ready() and mcp_pids == {active_app.child_pid}:
+                    if enhanced_required:
+                        if (
+                            restart_run_id is None
+                            or second_app_proc is None
+                            or phase_two_nonce is None
+                            or pipe_witness is None
+                            or witness_path.exists()
+                        ):
+                            raise RuntimeProofError(
+                                "enhanced MCP appeared without one private-pipe restart witness"
+                            )
+                    elif any(
+                        path.exists()
+                        for path in (
+                            intent_path,
+                            generation_path,
+                            witness_path,
+                            challenge_path,
+                        )
+                    ):
+                        raise RuntimeProofError(
+                            "enhanced runtime artifacts appeared in an ordinary task"
+                        )
+                    break
+                time.sleep(0.25)
+            else:
+                raise RuntimeProofError(
+                    f"timed out after {timeout}s waiting for Angular, the real Rust MCP "
+                    f"listener, and any private-pipe witness ({mode} start)"
                 )
 
             time.sleep(max(0, args.settle_seconds))
-            if proc.poll() is not None:
-                return emit("FAIL", f"dev process exited during settle with {proc.returncode}", log_path, started_at)
+            active_app = second_app_proc or first_app_proc
+            if frontend_proc.result_if_exited() is not None:
+                raise RuntimeProofError("Angular process exited during settle")
+            if active_app.result_if_exited() is not None:
+                raise RuntimeProofError("real Rust app process exited during settle")
+            if listener_pids(1420) != {frontend_proc.child_pid}:
+                raise RuntimeProofError("Angular listener ownership changed during settle")
+            if listener_pids(8765) != {active_app.child_pid}:
+                raise RuntimeProofError("MCP listener ownership changed during settle")
+
+            if enhanced_required:
+                if (
+                    challenge is None
+                    or observer is None
+                    or first_app_proc is None
+                    or second_app_proc is None
+                    or phase_two_nonce is None
+                    or pipe_witness is None
+                    or staged_identity is None
+                    or task_provenance is None
+                    or sqlcipher_binary is None
+                ):
+                    raise RuntimeProofError(
+                        "enhanced runtime proof did not establish both generations"
+                    )
+                observer.assert_healthy()
+                guardian_results["secondApp"] = request_guarded_shutdown(second_app_proc)
+                pipe_witness = drain_json_pipe_to_eof(
+                    witness_read_fd,
+                    witness_buffer,
+                    pipe_witness,
+                    time.monotonic() + 5,
+                )
+                os.close(witness_read_fd)
+                witness_read_fd = -1
+                if listener_pids(8765):
+                    raise RuntimeProofError("MCP remained open after second app shutdown")
+                sqlcipher_evidence = verify_external_encrypted_database(
+                    isolated_home, sqlcipher_binary
+                )
+                guardian_results["angular"] = request_guarded_shutdown(frontend_proc)
+                provider_connections = observer.settle_and_close()
+                observer_closed = True
+                if provider_connections != 0:
+                    raise RuntimeProofError(
+                        "the external proxy observed a non-health egress connection"
+                    )
+                if observer.unauthorized_connections() != 1:
+                    raise RuntimeProofError(
+                        "the external proxy did not reject exactly one unauthorized local client"
+                    )
+                runtime_evidence = validate_runtime_witness(
+                    pipe_witness,
+                    challenge=challenge,
+                    phase_two_nonce=phase_two_nonce,
+                    first_pid=first_app_proc.child_pid,
+                    second_pid=second_app_proc.child_pid,
+                    proxy_connections=provider_connections,
+                )
+                runtime_evidence["unauthorized_loopback_connections_rejected"] = (
+                    unauthorized_connections_rejected
+                )
+                current_stage = fingerprint_file(staged_binary, label="staged app binary")
+                if not same_fingerprint(current_stage, staged_identity):
+                    raise RuntimeProofError("staged app binary changed after execution")
+                current_task = validate_task_provenance(root)
+                if current_task["sha256"] != task_provenance["sha256"]:
+                    raise RuntimeProofError("Harness task contract changed during execution")
+                if (
+                    fingerprint_file(runner_source, label="runtime runner source")["sha256"]
+                    != challenge["runnerSourceSha256"]
+                    or fingerprint_file(profile_path, label="network sandbox profile")["sha256"]
+                    != challenge["networkProfileSha256"]
+                ):
+                    raise RuntimeProofError("runtime proof source or network profile changed")
+                pass_reason = (
+                    "Angular served; two mapped copies of the exact Rust binary completed "
+                    "a private-pipe restart proof with zero observed or permitted remote egress"
+                )
+            else:
+                guardian_results["firstApp"] = request_guarded_shutdown(first_app_proc)
+                guardian_results["angular"] = request_guarded_shutdown(frontend_proc)
+                pass_reason = (
+                    "Angular served and the directly supervised real Rust MCP listener stayed alive"
+                )
 
         text = log_path.read_text(errors="replace")
         fatal_markers = ("thread 'main' panicked", "fatal runtime error", "Abort trap", "SIGABRT")
         hits = [marker for marker in fatal_markers if marker.lower() in text.lower()]
         if hits:
-            return emit("FAIL", f"fatal marker(s) in boot log: {', '.join(hits)}", log_path, started_at)
-        return emit("PASS", "Angular served and the real Rust MCP listener stayed alive", log_path, started_at)
+            raise RuntimeProofError(f"fatal marker(s) in boot log: {', '.join(hits)}")
+        if listener_pids(1420) or listener_pids(8765):
+            raise RuntimeProofError("runtime listeners survived controlled shutdown")
+        survivors = owned_process_group_survivors(
+            (second_app_proc, first_app_proc, frontend_proc, cargo_proc)
+        )
+        if survivors:
+            raise RuntimeProofError("an owned runtime process group survived supervision")
+    except (OSError, ValueError, RuntimeError, subprocess.SubprocessError) as exc:
+        failure_reason = str(exc)
     finally:
-        if proc is not None and proc.poll() is None:
+        if witness_write_fd >= 0:
             try:
-                os.killpg(proc.pid, signal.SIGTERM)
-                proc.wait(timeout=12)
-            except (ProcessLookupError, subprocess.TimeoutExpired):
-                try:
-                    os.killpg(proc.pid, signal.SIGKILL)
-                except ProcessLookupError:
-                    pass
-                try:
-                    proc.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    pass
-        shutil.rmtree(temp_root, ignore_errors=True)
+                os.close(witness_write_fd)
+            except OSError as exc:
+                cleanup_errors.append(f"witness writer: {exc}")
+        if witness_read_fd >= 0:
+            try:
+                os.close(witness_read_fd)
+            except OSError as exc:
+                cleanup_errors.append(f"witness reader: {exc}")
+        for process in (second_app_proc, first_app_proc, frontend_proc, cargo_proc):
+            if process is None or process.guardian.poll() is not None:
+                continue
+            try:
+                fallback_terminate_guarded(process)
+            except Exception as exc:
+                cleanup_errors.append(f"{process.label}: {exc}")
+        if observer is not None and not observer_closed:
+            try:
+                observer.force_close()
+            except Exception as exc:
+                cleanup_errors.append(f"egress observer: {exc}")
+        try:
+            shutil.rmtree(temp_root)
+            temp_removed = not temp_root.exists()
+            if not temp_removed:
+                cleanup_errors.append("temporary HOME still exists after cleanup")
+        except Exception as exc:
+            cleanup_errors.append(f"temporary HOME: {exc}")
+
+    try:
+        if listener_pids(1420) or listener_pids(8765):
+            cleanup_errors.append("runtime listener remained after final cleanup")
+    except Exception as exc:
+        cleanup_errors.append(f"listener audit: {exc}")
+    try:
+        survivors = owned_process_group_survivors(
+            (second_app_proc, first_app_proc, frontend_proc, cargo_proc)
+        )
+        if survivors:
+            cleanup_errors.append("owned process group remained after final cleanup")
+    except Exception as exc:
+        cleanup_errors.append(f"process-group audit: {exc}")
+
+    if cleanup_errors:
+        return emit(
+            "FAIL",
+            f"owned runtime cleanup was incomplete: {'; '.join(cleanup_errors)}",
+            log_path,
+            started_at,
+        )
+    if failure_reason is not None:
+        return emit("FAIL", failure_reason, log_path, started_at)
+    if pass_reason is None:
+        return emit("FAIL", "runtime proof ended without a verdict", log_path, started_at)
+
+    if enhanced_required:
+        if (
+            challenge is None
+            or task_provenance is None
+            or staged_identity is None
+            or pipe_witness is None
+            or runtime_evidence is None
+            or sqlcipher_evidence is None
+            or provider_connections is None
+            or unauthorized_connections_rejected != 1
+            or phase_two_nonce is None
+            or len(app_identities) != 2
+            or not temp_removed
+        ):
+            return emit(
+                "FAIL",
+                "enhanced runtime proof lacks final runner-owned evidence",
+                log_path,
+                started_at,
+            )
+        try:
+            # The app never writes a shared witness file. Only the runner publishes the
+            # already-validated pipe message after both app generations and cleanup finish.
+            write_json_create_only(witness_path, pipe_witness)
+            artifact_hashes = {
+                "challenge": fingerprint_file(
+                    challenge_path, label="runtime challenge"
+                )["sha256"],
+                "restartIntent": fingerprint_file(
+                    intent_path, label="restart intent"
+                )["sha256"],
+                "restartGeneration": fingerprint_file(
+                    generation_path, label="restart generation"
+                )["sha256"],
+                "runtimeWitness": fingerprint_file(
+                    witness_path, label="runtime witness"
+                )["sha256"],
+                "cargoGuardian": fingerprint_file(
+                    run_dir / "cargo-guardian.json", label="Cargo guardian result"
+                )["sha256"],
+                "angularGuardian": fingerprint_file(
+                    run_dir / "angular-guardian.json", label="Angular guardian result"
+                )["sha256"],
+                "firstAppGuardian": fingerprint_file(
+                    run_dir / "first-app-guardian.json", label="first app guardian result"
+                )["sha256"],
+                "secondAppGuardian": fingerprint_file(
+                    run_dir / "second-app-guardian.json", label="second app guardian result"
+                )["sha256"],
+            }
+            wrapper_fingerprint = fingerprint_file(
+                wrapper_source, label="runtime runner wrapper"
+            )
+            runner_pass = {
+                "schemaVersion": 1,
+                "verdict": "PASS",
+                "taskId": ENHANCED_RUNTIME_TASK_ID,
+                "runId": run_id,
+                "startedAt": started_at,
+                "finishedAt": utc_now(),
+                "gitHead": challenge["gitHead"],
+                "binarySha256": challenge["binarySha256"],
+                "stagedBinary": staged_identity,
+                "appGenerations": app_identities,
+                "provenance": {
+                    "taskContractSha256": challenge["taskContractSha256"],
+                    "runnerSourceSha256": challenge["runnerSourceSha256"],
+                    "runnerWrapperSha256": wrapper_fingerprint["sha256"],
+                    "networkProfileSha256": challenge["networkProfileSha256"],
+                },
+                "restart": {
+                    "firstPid": first_app_proc.child_pid if first_app_proc else None,
+                    "secondPid": second_app_proc.child_pid if second_app_proc else None,
+                    "phaseTwoNonceSha256": hashlib.sha256(
+                        phase_two_nonce.encode("ascii")
+                    ).hexdigest(),
+                    "restartCanaryRows": 2,
+                    "witnessSha256": artifact_hashes["runtimeWitness"],
+                },
+                "network": {
+                    "sandbox": "loopback-only",
+                    "enforcement": network_enforcement,
+                    "kernelRestrictedOutbound": True,
+                    "externalProxyConnections": provider_connections,
+                    "unauthorizedLocalConnectionsRejected": unauthorized_connections_rejected,
+                    "observerClosedAfterApps": True,
+                },
+                "sqlcipher": sqlcipher_evidence,
+                "cleanup": {
+                    "portsClosed": True,
+                    "ownedProcessGroupSurvivors": 0,
+                    "temporaryHomeRemoved": True,
+                    "guardiansParentLost": any(
+                        result.get("parent_lost") is not False
+                        for result in guardian_results.values()
+                    ),
+                },
+                "artifactSha256": artifact_hashes,
+                "checks": EXPECTED_RUNTIME_CHECKS,
+            }
+            if runner_pass["cleanup"]["guardiansParentLost"]:
+                raise RuntimeProofError("a PASS guardian reported parent_lost")
+            write_json_create_only(runner_pass_path, runner_pass)
+            runner_pass_hash = fingerprint_file(
+                runner_pass_path, label="final runner PASS"
+            )["sha256"]
+            runtime_evidence.update(
+                {
+                    "runner_pass_path": str(runner_pass_path),
+                    "runner_pass_sha256": runner_pass_hash,
+                    "runtime_witness_path": str(witness_path),
+                    "runtime_witness_sha256": artifact_hashes["runtimeWitness"],
+                    "network_sandbox": "loopback-only",
+                    "external_sqlcipher_cli": True,
+                    "temporary_home_removed": True,
+                    "ports_closed": True,
+                }
+            )
+        except (OSError, ValueError, RuntimeError) as exc:
+            return emit("FAIL", str(exc), log_path, started_at)
+
+    return emit("PASS", pass_reason, log_path, started_at, runtime_evidence)
 
 
 if __name__ == "__main__":

--- a/src-tauri/src/commands/lock.rs
+++ b/src-tauri/src/commands/lock.rs
@@ -50,10 +50,45 @@ pub fn lock_folder(
         &app,
         crate::mcp::VisibilityRevokingEntrypoint::LockFolder,
     );
-    lock_folder_with_visibility_revocation(state.inner(), &folder_id, mcp_revocation)?;
+    let result = lock_folder_with_visibility_revocation_and_notice(
+        state.inner(),
+        &folder_id,
+        mcp_revocation,
+        || emit_reminder_visibility_invalidated_fail_closed(&app),
+    );
+    result?;
     // The seal purged ALL pending audit findings — ping the FE inbox (count-only).
     emit_audit_updated_after_purge(&app, state.inner());
     Ok(())
+}
+
+/// A lock authority transition must synchronously revoke every FE reminder-title cache. If the
+/// content-free Tauri event bus itself fails, tear down the renderer and terminate the app instead
+/// of leaving a stale source title that could reappear when a merely hidden window is shown again.
+fn emit_reminder_visibility_invalidated_fail_closed(app: &AppHandle) {
+    if crate::events::emit_reminder_visibility_invalidated(app) {
+        return;
+    }
+    if let Some(window) = app.get_webview_window("main") {
+        if let Err(error) = window.hide() {
+            tracing::error!(
+                target: "reminders",
+                error = %error,
+                "failed to hide Murmur after reminder visibility invalidation failure"
+            );
+        }
+        if let Err(error) = window.destroy() {
+            tracing::error!(
+                target: "reminders",
+                error = %error,
+                "failed to destroy Murmur renderer after reminder visibility invalidation failure"
+            );
+        }
+    }
+    // `exit` remains the terminal fallback even if the window manager rejected both operations.
+    // The database is already fail-closed; exiting prevents any surviving renderer cache from
+    // being presented after the visibility authority changed.
+    app.exit(1);
 }
 
 /// Run the initial seal under an already-closed MCP response gate. Reopen admission only once the
@@ -64,7 +99,17 @@ pub(crate) fn lock_folder_with_visibility_revocation(
     folder_id: &str,
     mcp_revocation: crate::mcp::VisibilityRevocation,
 ) -> Result<(), AppError> {
-    let result = lock_folder_inner(state, folder_id.to_string());
+    lock_folder_with_visibility_revocation_and_notice(state, folder_id, mcp_revocation, || {})
+}
+
+fn lock_folder_with_visibility_revocation_and_notice(
+    state: &AppState,
+    folder_id: &str,
+    mcp_revocation: crate::mcp::VisibilityRevocation,
+    visibility_revoked: impl FnOnce(),
+) -> Result<(), AppError> {
+    let result =
+        lock_folder_inner_with_visibility_notice(state, folder_id.to_string(), visibility_revoked);
     let logically_revoked = state
         .db
         .folder_by_id(folder_id)
@@ -85,6 +130,14 @@ pub(crate) fn lock_folder_with_visibility_revocation(
 /// Inner of [`lock_folder`] taking `&AppState` (so the lifecycle stress test can drive it without a
 /// `tauri::State`). Holds the [`AppState::lifecycle`] guard for the whole seal.
 pub(crate) fn lock_folder_inner(state: &AppState, folder_id: String) -> Result<(), AppError> {
+    lock_folder_inner_with_visibility_notice(state, folder_id, || {})
+}
+
+pub(crate) fn lock_folder_inner_with_visibility_notice(
+    state: &AppState,
+    folder_id: String,
+    visibility_revoked: impl FnOnce(),
+) -> Result<(), AppError> {
     let _lifecycle = lifecycle_guard(state);
     let folder = state
         .db
@@ -103,6 +156,10 @@ pub(crate) fn lock_folder_inner(state: &AppState, folder_id: String) -> Result<(
         // Always replay that idempotent tail. Only release the CK when primary plaintext/audio residue
         // proves the keyed portion itself was interrupted.
         bump_seal_epoch(state);
+        // The durable gate is already closed. Blank every renderer cache before attempting the
+        // fallible session-authority cleanup below; its canonical refresh waits on this lifecycle
+        // guard and therefore cannot observe the intermediate state.
+        visibility_revoked();
         {
             let mut unlocked = state
                 .unlocked_folders
@@ -310,7 +367,11 @@ pub(crate) fn lock_folder_inner(state: &AppState, folder_id: String) -> Result<(
     // with intact plaintext — never lost content.
     state
         .db
-        .set_folder_locked(&folder_id, true, Some(&wrapped))?;
+        .publish_fresh_folder_lock_and_purge_reminder_derived(&folder_id, &wrapped)?;
+    // `locked=1` is now a durable visibility gate. Notify before any subsequent fallible step,
+    // including the session-set mutex: a poisoned mutex must return an error with renderer caches
+    // already blanked (or the main window hidden if the event bus failed).
+    visibility_revoked();
     {
         let mut unlocked = state
             .unlocked_folders
@@ -663,6 +724,10 @@ pub fn relock_folder(
             "folder visibility changed before relock preparation".into(),
         ));
     }
+    // Verify EVERY non-empty plaintext family before deleting an export or blanking the first DB
+    // column. Retained blobs must match byte-identically; missing blobs are encrypt+verified into an
+    // immutable repair plan. The lifecycle guard prevents either side changing afterward.
+    let verified = verify_relock_retained_blobs(state.inner(), &folder_id)?;
     // Remove every managed plaintext export before revoking visibility. A user-modified export or
     // collision sibling fails here while the folder is still open, never after `locked` is visible.
     prepare_folder_exports_before_relock(state.inner(), &folder_id)?;
@@ -681,9 +746,16 @@ pub fn relock_folder(
     // Epoch + session membership now authoritatively hide this folder. New MCP responses may be
     // admitted against that post-revocation snapshot while physical cleanup continues.
     crate::mcp::finish_visibility_revocation(mcp_revocation);
+    // Emit while the lifecycle guard is still held. The FE discards cached titles synchronously;
+    // its canonical refresh cannot pass the same guard until physical reblank has completed.
+    emit_reminder_visibility_invalidated_fail_closed(&app);
     if let Ok(mut cache) = state.verify_cache.lock() {
         cache.clear();
     }
+    // Any interrupted-fresh-seal rows now receive only ciphertexts that the preflight already
+    // decrypt-verified against their exact plaintext. This is after export cleanup and logical
+    // revocation, but before the first broad reblank.
+    verified.apply_repairs(&state.db)?;
     let mut one = std::collections::HashSet::new();
     one.insert(folder_id.clone());
     // Brain-v3 audit Fix 4: strip the just-re-sealed items' `[[Title]]` markers from VISIBLE sources
@@ -697,7 +769,7 @@ pub fn relock_folder(
     remove_rollup_export_files(&rollup_exports);
     // Phase 0.5 — re-blank the transcript + timeline plaintext and drop the decrypted session WAV
     // (the .enc + the *_blob columns stay; the folder is still locked=1 on disk).
-    reblank_folder_extras(state.inner(), &folder_id)?;
+    reblank_folder_extras_after_verification(state.inner(), &folder_id, verified.ck())?;
     drain_lock_marker_export_cleanup(&state.db)?;
     // The folder has remained logically hidden throughout. A failure above retains the cached KEK
     // for a repair retry; success leaves it available for other still-unlocked folders.
@@ -731,7 +803,9 @@ pub(crate) fn relock_all_with_visibility_gate(
         crate::mcp::VisibilityRevokingEntrypoint::RelockAll,
     );
     let prior_epoch = state.seal_epoch.load(std::sync::atomic::Ordering::SeqCst);
-    let result = relock_all_inner(state);
+    let result = relock_all_inner_with_visibility_notice(state, || {
+        emit_reminder_visibility_invalidated_fail_closed(app);
+    });
     // `relock_all_inner` deliberately keeps logical revocation even when a later vault/DB cleanup
     // fails. Reopen only if the epoch advanced and the unlock authority is observably empty.
     let logically_revoked = state.seal_epoch.load(std::sync::atomic::Ordering::SeqCst)
@@ -754,6 +828,13 @@ pub(crate) fn relock_all_with_visibility_gate(
 /// the `relock_all` command funnel through here, so the guard lives HERE (the `relock_all` command
 /// must NOT take it separately — a std `Mutex` is non-reentrant and would self-deadlock).
 pub(crate) fn relock_all_inner(state: &AppState) -> Result<(), AppError> {
+    relock_all_inner_with_visibility_notice(state, || {})
+}
+
+fn relock_all_inner_with_visibility_notice(
+    state: &AppState,
+    visibility_revoked: impl FnOnce(),
+) -> Result<(), AppError> {
     let _lifecycle = lifecycle_guard(state);
     // Snapshot the session set, then revoke every gated read BEFORE any fallible filesystem work.
     // This ordering is load-bearing for screen-share: an external edit or unlink failure may retain
@@ -779,16 +860,45 @@ pub(crate) fn relock_all_inner(state: &AppState) -> Result<(), AppError> {
             .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?;
         g.clear();
     }
+    // This callback is deliberately inside the lifecycle interval and immediately after the
+    // in-memory visibility authority is cleared. A FE re-fetch therefore blocks until every
+    // fallible reblank step has either completed or failed closed, while cached titles disappear
+    // at the exact logical transition.
+    visibility_revoked();
     if let Ok(mut cache) = state.verify_cache.lock() {
         cache.clear();
     }
-    for folder_id in &session_unlocked {
+    // Resolve every target and preflight ALL non-empty plaintext before the first export removal or
+    // DB blank. Retained blobs are authenticated; missing blobs are encrypt+verified into immutable
+    // repair plans. Visibility is already revoked fail-closed, while the cached KEK remains held for
+    // an authenticated retry if any retained blob is corrupt or stale.
+    let locked: std::collections::HashSet<String> =
+        state.db.locked_folder_ids()?.into_iter().collect();
+    let mut verified_relocks = Vec::with_capacity(locked.len());
+    for folder_id in &locked {
+        verified_relocks.push((
+            folder_id.clone(),
+            verify_relock_retained_blobs(state, folder_id)?,
+        ));
+    }
+    let mut export_cleanup: std::collections::HashSet<String> =
+        session_unlocked.iter().cloned().collect();
+    for (folder_id, verified) in &verified_relocks {
+        if verified.ck().is_some() {
+            export_cleanup.insert(folder_id.clone());
+        }
+    }
+    for folder_id in &export_cleanup {
         prepare_folder_exports_before_relock(state, folder_id)?;
+    }
+    // Every folder plan was fully built before this first plaintext blank. Applying a repair stores
+    // only ciphertext already decrypt-verified byte-identical; any later failure retains the cached
+    // KEK and leaves completed rows recoverable for an idempotent retry.
+    for (_, verified) in &verified_relocks {
+        verified.apply_repairs(&state.db)?;
     }
     // Re-blank every sealed note across all locked folders. The tx also purges ALL memory rollups
     // (may paraphrase the re-sealed facts) — their exported vault `.md`s are removed here.
-    let locked: std::collections::HashSet<String> =
-        state.db.locked_folder_ids()?.into_iter().collect();
     // Brain-v3 audit Fix 4: BEFORE the relock purge drops the naming edges, strip the just-re-sealed
     // items' `[[Title]]` markers from every VISIBLE source note (a source in a DIFFERENT still-open
     // folder that was materialized while this folder was session-unlocked) + re-export those sources'
@@ -799,8 +909,8 @@ pub(crate) fn relock_all_inner(state: &AppState) -> Result<(), AppError> {
     remove_rollup_export_files(&rollup_exports);
     // Phase 0.5 — re-blank the transcript + timeline + drop the decrypted session WAVs for every
     // locked folder too (the .enc + *_blob columns stay).
-    for fid in &locked {
-        reblank_folder_extras(state, fid)?;
+    for (folder_id, verified) in &verified_relocks {
+        reblank_folder_extras_after_verification(state, folder_id, verified.ck())?;
     }
     // Zeroize the cached KEK copy only after all seal/reblank work succeeded. If an earlier step
     // returned an error, visibility is still revoked but the KEK remains available for repair.
@@ -977,21 +1087,22 @@ pub(crate) fn remove_lock_inner(state: &AppState, folder_id: String) -> Result<(
         } else {
             Some(folder.path.as_str())
         };
-        let exported_markdown = match render_markdown_with_attachments_for_export_under_lifecycle_authorized(
-            state,
-            &crate::storage::AttachmentOwner::Meeting {
-                meeting_id: latest.meeting_id.clone(),
-                provider_id: latest.provider_id.clone(),
-            },
-            &latest.markdown,
-            std::path::Path::new(vault),
-        ) {
-            Ok(markdown) => markdown,
-            Err(e) => {
-                tracing::warn!(target: "export", error = %e, "meeting image re-export after unlock failed");
-                continue;
-            }
-        };
+        let exported_markdown =
+            match render_markdown_with_attachments_for_export_under_lifecycle_authorized(
+                state,
+                &crate::storage::AttachmentOwner::Meeting {
+                    meeting_id: latest.meeting_id.clone(),
+                    provider_id: latest.provider_id.clone(),
+                },
+                &latest.markdown,
+                std::path::Path::new(vault),
+            ) {
+                Ok(markdown) => markdown,
+                Err(e) => {
+                    tracing::warn!(target: "export", error = %e, "meeting image re-export after unlock failed");
+                    continue;
+                }
+            };
         if let Ok(path) = crate::export::write_note(
             std::path::Path::new(vault),
             sub,
@@ -1109,12 +1220,7 @@ pub(crate) async fn discard_unrecoverable_folder_lock_with_candidates_for_test(
     folder_id: String,
     candidates: Zeroizing<Vec<[u8; 32]>>,
 ) -> Result<FolderNode, AppError> {
-    discard_unrecoverable_folder_lock_with_enumeration(
-        state,
-        folder_id,
-        Some(Ok(candidates)),
-    )
-    .await
+    discard_unrecoverable_folder_lock_with_enumeration(state, folder_id, Some(Ok(candidates))).await
 }
 
 /// Execute the destructive-discard state machine with either the production

--- a/src-tauri/src/commands/lock.rs
+++ b/src-tauri/src/commands/lock.rs
@@ -94,6 +94,7 @@ fn emit_reminder_visibility_invalidated_fail_closed(app: &AppHandle) {
 /// Run the initial seal under an already-closed MCP response gate. Reopen admission only once the
 /// folder is durably marked locked and absent from the session unlock set. If sealing fails before
 /// that logical transition, dropping the incomplete revocation deliberately leaves the gate closed.
+#[cfg(test)]
 pub(crate) fn lock_folder_with_visibility_revocation(
     state: &AppState,
     folder_id: &str,
@@ -129,6 +130,7 @@ fn lock_folder_with_visibility_revocation_and_notice(
 
 /// Inner of [`lock_folder`] taking `&AppState` (so the lifecycle stress test can drive it without a
 /// `tauri::State`). Holds the [`AppState::lifecycle`] guard for the whole seal.
+#[cfg(test)]
 pub(crate) fn lock_folder_inner(state: &AppState, folder_id: String) -> Result<(), AppError> {
     lock_folder_inner_with_visibility_notice(state, folder_id, || {})
 }
@@ -827,6 +829,7 @@ pub(crate) fn relock_all_with_visibility_gate(
 /// restore-plaintext (Step 1) and clear-`content_blob` (Step 2). All three off-thread callers and
 /// the `relock_all` command funnel through here, so the guard lives HERE (the `relock_all` command
 /// must NOT take it separately — a std `Mutex` is non-reentrant and would self-deadlock).
+#[cfg(test)]
 pub(crate) fn relock_all_inner(state: &AppState) -> Result<(), AppError> {
     relock_all_inner_with_visibility_notice(state, || {})
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -460,6 +460,14 @@ pub(crate) fn require_current_document_content_snapshot(
     snapshot: &DocumentContentSnapshot,
 ) -> Result<(), AppError> {
     let _lifecycle = lifecycle_guard(state);
+    require_current_document_content_snapshot_under_lifecycle(state, note_id, snapshot)
+}
+
+pub(crate) fn require_current_document_content_snapshot_under_lifecycle(
+    state: &AppState,
+    note_id: &str,
+    snapshot: &DocumentContentSnapshot,
+) -> Result<(), AppError> {
     require_current_content_visibility_snapshot_under_lifecycle(state, snapshot.visibility)?;
     let Some((folder_id, _created_at, _updated_at)) = state.db.note_gate_anchor(note_id)? else {
         return Err(AppError::InvalidArg(format!("no note {note_id}")));
@@ -7490,6 +7498,26 @@ pub(crate) fn repair_locked_folder_at_rest(
     folder_id: &str,
     ck: &[u8; 32],
 ) -> Result<(), AppError> {
+    // Attachments can carry both a session plaintext BLOB and a tracked plaintext vault export.
+    // Authenticate every governed row before the first note export is deleted or any plaintext
+    // column is blanked below. Missing ciphertext is repairable only when the exact canonical bytes
+    // still exist in SQLCipher; a blob-less/blank row fails closed so an exported image is never
+    // mistaken for a disposable duplicate.
+    let attachments = db.attachments_in_folder(folder_id)?;
+    let mut attachment_seals = Vec::new();
+    for attachment in &attachments {
+        if let Some(blob) =
+            verify_or_prepare_attachment_relock_blob(ck, folder_id, attachment, true)?
+        {
+            attachment_seals.push((attachment.id.clone(), blob));
+        }
+    }
+    if !attachment_seals.is_empty() {
+        // Store only replacements already decrypt-verified against the exact SQLCipher plaintext.
+        // `store_attachment_seals` does not blank `data`; later failures remain retryable.
+        db.store_attachment_seals(&attachment_seals)?;
+    }
+
     // Meeting-note exports must be removed while their recorded path still exists. `seal_note`
     // clears that cleanup authority, so delete/prove absent first on both initial seal and repair.
     for note in db.notes_in_folder(folder_id)? {
@@ -7567,6 +7595,11 @@ pub(crate) fn repair_locked_folder_at_rest(
             db.set_meeting_sys_master_path(&meeting_id, Some(&path))?;
         }
     }
+    // Startup reconciliation checks the repair predicate before its global cleanup pass. Complete
+    // the attachment half here now that every row was authenticated above: blank only rows with a
+    // recoverable blob, then delete tracked exports with retry metadata preserved on failure.
+    let attachment_exports = db.blank_attachments_in_folder(folder_id)?;
+    delete_attachment_exports_with_retry(db, attachment_exports)?;
     Ok(())
 }
 
@@ -7585,6 +7618,17 @@ pub(crate) fn locked_folder_requires_authenticated_repair(
         }
     }
     if !db.note_exported_path_rows_in_folder(folder_id)?.is_empty() {
+        return Ok(true);
+    }
+    if db
+        .attachments_in_folder(folder_id)?
+        .iter()
+        .any(|attachment| {
+            !attachment.data.is_empty()
+                || attachment.data_blob.is_none()
+                || attachment.exported_path.is_some()
+        })
+    {
         return Ok(true);
     }
     for document in db.raw_documents_in_folder(folder_id)? {
@@ -8195,20 +8239,329 @@ pub(crate) fn enqueue_marker_cleanup_for_folders(
 /// remove the decrypted session WAV, re-pointing audio_path back at the `.enc`. The `*_blob`
 /// columns + the `.enc` stay (the folder is still `locked=1`). Idempotent.
 pub(crate) fn reblank_folder_extras(state: &AppState, folder_id: &str) -> Result<(), AppError> {
+    let verified = verify_relock_retained_blobs(state, folder_id)?;
+    if verified.has_repairs() {
+        prepare_folder_exports_before_relock(state, folder_id)?;
+        verified.apply_repairs(&state.db)?;
+    }
+    reblank_folder_extras_after_verification(state, folder_id, verified.ck())
+}
+
+/// Authenticate every retained ciphertext whose current session plaintext is about to be
+/// destroyed by relock, and prove that it decrypts byte-identical to that plaintext. A non-empty
+/// plaintext with no blob is an interrupted-fresh-seal repair: build and decrypt-verify its
+/// replacement ciphertext in memory, but do not blank anything yet. Relock-all constructs one plan
+/// per folder before applying the FIRST repair/blank, so one corrupt/stale blob leaves every good
+/// plaintext column untouched.
+pub(crate) struct VerifiedRelockPlan {
+    ck: Option<Zeroizing<[u8; 32]>>,
+    attachment_seals: Vec<(String, Vec<u8>)>,
+    note_seals: Vec<(String, String, Vec<u8>)>,
+    segment_seals: Vec<(String, i64, Vec<u8>)>,
+    timeline_seals: Vec<(String, Vec<u8>)>,
+    manual_note_seals: Vec<(String, Vec<u8>)>,
+    document_seals: Vec<(String, Vec<u8>)>,
+}
+
+impl VerifiedRelockPlan {
+    pub(crate) fn ck(&self) -> Option<&[u8; 32]> {
+        self.ck.as_deref()
+    }
+
+    pub(crate) fn has_repairs(&self) -> bool {
+        !self.attachment_seals.is_empty()
+            || !self.note_seals.is_empty()
+            || !self.segment_seals.is_empty()
+            || !self.timeline_seals.is_empty()
+            || !self.manual_note_seals.is_empty()
+            || !self.document_seals.is_empty()
+    }
+
+    /// Persist only ciphertexts already decrypt-verified against their exact captured plaintext.
+    /// Each low-level `seal_*` call stores that recoverable blob and blanks the matching plaintext;
+    /// a later DB failure therefore leaves completed rows recoverable and the cached KEK available
+    /// for an idempotent retry.
+    pub(crate) fn apply_repairs(&self, db: &Db) -> Result<(), AppError> {
+        // Persist attachment replacements before any of the existing `seal_*` calls below can
+        // blank a plaintext column. The batch itself retains `data`, so a later failure remains
+        // recoverable and an idempotent retry can authenticate the newly retained blobs.
+        if !self.attachment_seals.is_empty() {
+            db.store_attachment_seals(&self.attachment_seals)?;
+        }
+        for (meeting_id, provider_id, blob) in &self.note_seals {
+            db.seal_note(meeting_id, provider_id, blob)?;
+        }
+        for (meeting_id, idx, blob) in &self.segment_seals {
+            db.seal_segment(meeting_id, *idx, blob)?;
+        }
+        for (meeting_id, blob) in &self.timeline_seals {
+            db.seal_timeline(meeting_id, blob)?;
+        }
+        for (meeting_id, blob) in &self.manual_note_seals {
+            db.seal_manual_notes(meeting_id, blob)?;
+        }
+        for (document_id, blob) in &self.document_seals {
+            db.seal_document(document_id, blob)?;
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn verify_relock_retained_blobs(
+    state: &AppState,
+    folder_id: &str,
+) -> Result<VerifiedRelockPlan, AppError> {
+    let notes = state.db.notes_in_folder(folder_id)?;
+    let meeting_ids = state.db.meeting_ids_in_folder(folder_id)?;
+    let documents = state.db.raw_documents_in_folder(folder_id)?;
+    let attachments = state.db.attachments_in_folder(folder_id)?;
+    let mut meeting_content = Vec::with_capacity(meeting_ids.len());
+    for meeting_id in &meeting_ids {
+        meeting_content.push((
+            meeting_id.clone(),
+            state.db.raw_segments(meeting_id)?,
+            state.db.raw_timeline(meeting_id)?,
+            state.db.raw_manual_notes(meeting_id)?,
+        ));
+    }
+    let mut needs_verification = notes.iter().any(|note| !note.markdown.is_empty())
+        || documents.iter().any(|document| !document.text.is_empty())
+        || attachments.iter().any(|attachment| {
+            !attachment.data.is_empty()
+                || attachment.data_blob.is_none()
+                || attachment.exported_path.is_some()
+        });
+    if !needs_verification {
+        needs_verification = meeting_content
+            .iter()
+            .any(|(_, segments, timeline, manual)| {
+                segments.iter().any(|segment| !segment.text.is_empty())
+                    || timeline
+                        .as_ref()
+                        .is_some_and(|timeline| !timeline.data.is_empty())
+                    || manual
+                        .as_ref()
+                        .is_some_and(|manual| !manual.text.is_empty())
+            });
+    }
+    if !needs_verification {
+        return Ok(VerifiedRelockPlan {
+            ck: None,
+            attachment_seals: Vec::new(),
+            note_seals: Vec::new(),
+            segment_seals: Vec::new(),
+            timeline_seals: Vec::new(),
+            manual_note_seals: Vec::new(),
+            document_seals: Vec::new(),
+        });
+    }
+
+    if state.db.folder_wrapped_key(folder_id)?.is_none() {
+        return Err(AppError::Locked(
+            "relock found plaintext without a wrapped folder key; content retained for authenticated repair"
+                .into(),
+        ));
+    }
+    let ck = session_folder_ck(state, folder_id)?;
+    let mut attachment_seals = Vec::new();
+    let mut note_seals = Vec::new();
+    let mut segment_seals = Vec::new();
+    let mut timeline_seals = Vec::new();
+    let mut manual_note_seals = Vec::new();
+    let mut document_seals = Vec::new();
+    for attachment in &attachments {
+        if attachment.data.is_empty()
+            && attachment.data_blob.is_some()
+            && attachment.exported_path.is_none()
+        {
+            continue;
+        }
+        if let Some(blob) =
+            verify_or_prepare_attachment_relock_blob(&ck, folder_id, attachment, true)?
+        {
+            attachment_seals.push((attachment.id.clone(), blob));
+        }
+    }
+    for note in &notes {
+        if !note.markdown.is_empty() {
+            if let Some(blob) = verify_or_prepare_relock_blob(
+                &ck,
+                note.content_blob.as_deref(),
+                &aad_content(folder_id, &note.meeting_id, &note.provider_id, "note"),
+                note.markdown.as_bytes(),
+                "note",
+            )? {
+                note_seals.push((note.meeting_id.clone(), note.provider_id.clone(), blob));
+            }
+        }
+    }
+    for (meeting_id, segments, timeline, manual) in &meeting_content {
+        for segment in segments {
+            if !segment.text.is_empty() {
+                if let Some(blob) = verify_or_prepare_relock_blob(
+                    &ck,
+                    segment.text_blob.as_deref(),
+                    &aad_content(folder_id, meeting_id, AAD_NO_PROVIDER, "segment"),
+                    segment.text.as_bytes(),
+                    "segment",
+                )? {
+                    segment_seals.push((meeting_id.clone(), segment.idx, blob));
+                }
+            }
+        }
+        if let Some(timeline) = timeline {
+            if !timeline.data.is_empty() {
+                if let Some(blob) = verify_or_prepare_relock_blob(
+                    &ck,
+                    timeline.data_blob.as_deref(),
+                    &aad_content(folder_id, meeting_id, AAD_NO_PROVIDER, "timeline"),
+                    timeline.data.as_bytes(),
+                    "timeline",
+                )? {
+                    timeline_seals.push((meeting_id.clone(), blob));
+                }
+            }
+        }
+        if let Some(manual) = manual {
+            if !manual.text.is_empty() {
+                if let Some(blob) = verify_or_prepare_relock_blob(
+                    &ck,
+                    manual.blob.as_deref(),
+                    &aad_content(folder_id, meeting_id, AAD_NO_PROVIDER, "manual_notes"),
+                    manual.text.as_bytes(),
+                    "manual notes",
+                )? {
+                    manual_note_seals.push((meeting_id.clone(), blob));
+                }
+            }
+        }
+    }
+    for document in &documents {
+        if !document.text.is_empty() {
+            if let Some(blob) = verify_or_prepare_relock_blob(
+                &ck,
+                document.blob.as_deref(),
+                &aad_document(folder_id, &document.id),
+                document.text.as_bytes(),
+                "document",
+            )? {
+                document_seals.push((document.id.clone(), blob));
+            }
+        }
+    }
+    Ok(VerifiedRelockPlan {
+        ck: Some(ck),
+        attachment_seals,
+        note_seals,
+        segment_seals,
+        timeline_seals,
+        manual_note_seals,
+        document_seals,
+    })
+}
+
+/// Verify the attachment recovery copy for relock/startup without consulting an unlocked-content
+/// reader. SQLCipher protects the canonical metadata; `byte_len + sha256` binds the decrypted bytes
+/// to that metadata, while the attachment AAD binds the seal to its exact folder/owner/id.
+fn verify_or_prepare_attachment_relock_blob(
+    ck: &[u8; 32],
+    folder_id: &str,
+    attachment: &crate::storage::AttachmentRecord,
+    require_recoverable_empty: bool,
+) -> Result<Option<Vec<u8>>, AppError> {
+    use sha2::{Digest, Sha256};
+
+    let verify_metadata = |plaintext: &[u8]| -> Result<(), AppError> {
+        let digest: [u8; 32] = Sha256::digest(plaintext).into();
+        if plaintext.len() as u64 != attachment.byte_len || digest != attachment.sha256 {
+            return Err(AppError::Storage(
+                "attachment bytes do not match their authenticated metadata during relock".into(),
+            ));
+        }
+        Ok(())
+    };
+    let aad = attachment_aad(folder_id, &attachment.owner, &attachment.id);
+
+    if !attachment.data.is_empty() {
+        verify_metadata(&attachment.data)?;
+        return verify_or_prepare_relock_blob(
+            ck,
+            attachment.data_blob.as_deref(),
+            &aad,
+            &attachment.data,
+            "attachment",
+        );
+    }
+
+    let Some(blob) = attachment.data_blob.as_deref() else {
+        if require_recoverable_empty {
+            return Err(AppError::Storage(
+                "attachment has neither plaintext nor a recoverable seal during relock".into(),
+            ));
+        }
+        return Ok(None);
+    };
+    let restored = crate::crypto::decrypt(ck, blob, &aad)?;
+    verify_metadata(&restored)?;
+    Ok(None)
+}
+
+fn verify_or_prepare_relock_blob(
+    ck: &[u8; 32],
+    retained_blob: Option<&[u8]>,
+    aad: &[u8],
+    plaintext: &[u8],
+    family: &'static str,
+) -> Result<Option<Vec<u8>>, AppError> {
+    if let Some(blob) = retained_blob {
+        verify_relock_plaintext_copy(ck, blob, aad, plaintext, family)?;
+        return Ok(None);
+    }
+    let blob = crate::crypto::encrypt(ck, plaintext, aad)?;
+    verify_relock_plaintext_copy(ck, &blob, aad, plaintext, family)?;
+    Ok(Some(blob))
+}
+
+fn verify_relock_plaintext_copy(
+    ck: &[u8; 32],
+    blob: &[u8],
+    aad: &[u8],
+    plaintext: &[u8],
+    family: &'static str,
+) -> Result<(), AppError> {
+    let restored = crate::crypto::decrypt(ck, blob, aad)?;
+    if restored != plaintext {
+        return Err(AppError::Storage(format!(
+            "{family} retained seal does not match session plaintext"
+        )));
+    }
+    Ok(())
+}
+
+fn reblank_folder_extras_after_verification(
+    state: &AppState,
+    folder_id: &str,
+    verified_ck: Option<&[u8; 32]>,
+) -> Result<(), AppError> {
     // SEAL-NET KEY (2026-07-16 lock review of #356): resolve the folder CK from the SESSION-CACHED
     // KEK only — never a keychain/biometric prompt (this runs on relock / app-close / screen-share).
     // Both relock paths retain the KEK until every filesystem reblank succeeds, then zeroize it as
     // the final session-state commit. A failed reblank therefore remains retryable and never claims
     // a locked state while a known plaintext audio path survives.
-    let seal_ck: Option<Zeroizing<[u8; 32]>> = (|| {
-        let kek = state.master_kek.lock().ok()?.clone()?;
-        let wrapped = state.db.folder_wrapped_key(folder_id).ok().flatten()?;
-        let bytes = Zeroizing::new(
-            crate::crypto::decrypt(&kek, &wrapped, &aad_wrapped_ck(folder_id)).ok()?,
-        );
-        let arr: [u8; 32] = bytes.as_slice().try_into().ok()?;
-        Some(Zeroizing::new(arr))
-    })();
+    let resolved_ck: Option<Zeroizing<[u8; 32]>> = if verified_ck.is_none() {
+        (|| {
+            let kek = state.master_kek.lock().ok()?.clone()?;
+            let wrapped = state.db.folder_wrapped_key(folder_id).ok().flatten()?;
+            let bytes = Zeroizing::new(
+                crate::crypto::decrypt(&kek, &wrapped, &aad_wrapped_ck(folder_id)).ok()?,
+            );
+            let arr: [u8; 32] = bytes.as_slice().try_into().ok()?;
+            Some(Zeroizing::new(arr))
+        })()
+    } else {
+        None
+    };
+    let seal_ck = verified_ck.or(resolved_ck.as_deref());
     for mid in state.db.meeting_ids_in_folder(folder_id)? {
         for s in state.db.raw_segments(&mid)? {
             if s.text_blob.is_some() && !s.text.is_empty() {
@@ -8229,7 +8582,7 @@ pub(crate) fn reblank_folder_extras(state: &AppState, folder_id: &str) -> Result
         }
         let playback_aad = aad_audio_role(&mid, folder_id, StreamRole::Playback);
         if let Some(enc) = reblank_audio(
-            seal_ck.as_deref(),
+            seal_ck,
             state.db.get_meeting(&mid)?.and_then(|m| m.audio_path),
             &playback_aad,
         )? {
@@ -8237,11 +8590,11 @@ pub(crate) fn reblank_folder_extras(state: &AppState, folder_id: &str) -> Result
         }
         let (mic, sys) = state.db.get_meeting_master_paths(&mid)?;
         let mic_aad = aad_audio_role(&mid, folder_id, StreamRole::Mic);
-        if let Some(enc) = reblank_audio(seal_ck.as_deref(), mic, &mic_aad)? {
+        if let Some(enc) = reblank_audio(seal_ck, mic, &mic_aad)? {
             state.db.set_meeting_mic_master_path(&mid, Some(&enc))?;
         }
         let sys_aad = aad_audio_role(&mid, folder_id, StreamRole::Sys);
-        if let Some(enc) = reblank_audio(seal_ck.as_deref(), sys, &sys_aad)? {
+        if let Some(enc) = reblank_audio(seal_ck, sys, &sys_aad)? {
             state.db.set_meeting_sys_master_path(&mid, Some(&enc))?;
         }
         // FAIL-CLOSED sweep (2026-07-16 reviews: #352 adversarial MEDIUM, then the #356 lock-review
@@ -8257,7 +8610,7 @@ pub(crate) fn reblank_folder_extras(state: &AppState, folder_id: &str) -> Result
             .iter()
             .any(|s| s.text_blob.is_none());
         if has_unsealed {
-            if let Some(ck) = seal_ck.as_ref() {
+            if let Some(ck) = seal_ck {
                 seal_meeting_extras(&state.db, folder_id, &mid, ck)?;
                 tracing::warn!(target: "lock", meeting_id = %mid, "relock authenticated and sealed exact crash-window transcript rows in place under the folder CK");
             } else {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -8238,6 +8238,7 @@ pub(crate) fn enqueue_marker_cleanup_for_folders(
 /// RE-BLANK (relock): re-blank the plaintext transcript + timeline of every governed meeting and
 /// remove the decrypted session WAV, re-pointing audio_path back at the `.enc`. The `*_blob`
 /// columns + the `.enc` stay (the folder is still `locked=1`). Idempotent.
+#[cfg(test)]
 pub(crate) fn reblank_folder_extras(state: &AppState, folder_id: &str) -> Result<(), AppError> {
     let verified = verify_relock_retained_blobs(state, folder_id)?;
     if verified.has_repairs() {
@@ -8268,6 +8269,7 @@ impl VerifiedRelockPlan {
         self.ck.as_deref()
     }
 
+    #[cfg(test)]
     pub(crate) fn has_repairs(&self) -> bool {
         !self.attachment_seals.is_empty()
             || !self.note_seals.is_empty()

--- a/src-tauri/src/commands/reminders.rs
+++ b/src-tauri/src/commands/reminders.rs
@@ -1,14 +1,26 @@
-//! macOS Reminders commands — extracted verbatim from `commands` (God-file split, a PURE MOVE —
-//! no behavior change). This is a small, self-contained, NON-content-gated domain: it shells out to
-//! `osascript` to create a macOS Reminder from an action-item text + optional ISO due date. It reads
-//! NO meeting content and touches no seal/unlock surface, so there is nothing to gate. Every symbol
-//! keeps its EXACT prior body/signature and is re-exported at `crate::commands` via `pub use
-//! reminders::*;` in `commands/mod.rs`, so `generate_handler![commands::add_reminder]` in `lib.rs`
-//! and every `crate::commands::…` caller resolve UNCHANGED. `build_reminder_script` /
-//! `add_reminder_blocking` stay `pub(crate)` so the voice-action dispatch in `commands/mod.rs`
-//! still reaches them through the re-export.
+//! Reminder commands. The original Apple Reminders integration below remains a content-free
+//! `osascript` adapter. The first-class Murmur reminder store is independent user data, while its
+//! disposable Smart-audit suggestions ARE source-derived plaintext: every list/accept/dismiss path
+//! must therefore gate and re-hash the canonical meeting or authored note under the lock lifecycle.
+//! All symbols are re-exported at `crate::commands` via `pub use reminders::*;`.
+
+use std::collections::{BTreeSet, HashMap};
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::Serialize;
+use tauri::{ipc::Response, AppHandle, Manager, State};
 
 use crate::error::AppError;
+use crate::reason::{GenOptions, LocalReasoner};
+use crate::reminder_audit::ReminderAuditCandidate;
+use crate::state::AppState;
+use crate::storage::models::{
+    ReminderDraft, ReminderInboxItem, ReminderOrigin, ReminderSourceAnchor, ReminderSourceView,
+    ReminderState, ReminderSuggestionView, ReminderSummary, ReminderView, RemindersSnapshot,
+    StoredReminder, StoredReminderSuggestion,
+};
+use crate::transcribe::types::Segment;
 
 /// Escape a string for embedding inside an AppleScript `"…"` literal: backslash + double-quote are
 /// escaped, and raw CR/LF are flattened to spaces (an AppleScript string literal cannot span lines).
@@ -121,6 +133,5178 @@ pub(crate) fn add_reminder_blocking(text: &str, due_date: Option<&str>) -> Resul
                 String::from_utf8_lossy(&out.stderr).trim()
             ),
         )))
+    }
+}
+
+// ── First-class Murmur reminders (independent from the Apple integration above) ─────────────────
+
+const MAX_REMINDER_SOURCES: usize = 20;
+const MAX_REMINDER_AUDIT_ROWS: usize = 32;
+const MAX_AUDIT_MARKDOWN_BYTES: usize = 256 * 1024;
+const MAX_AUDIT_SEGMENT_BYTES: usize = 64 * 1024;
+const MAX_AUDIT_SEGMENTS: usize = 128;
+pub(crate) const REMINDER_SCHEDULER_TICK_SECS: u64 = 15;
+const REMINDER_SOURCE_INVALIDATION_TICK_MS: u64 = 250;
+const REMINDER_SOURCE_INVALIDATION_BATCH: usize = 128;
+const REMINDER_RUNTIME_PROBE_TASK_ID: &str = "reminders-smart-inbox-v2-merge-20260731";
+const REMINDER_RUNTIME_GATEWAY_URL: &str = "https://runtime-gateway.invalid";
+
+/// The native Harness runtime smoke uses an isolated temporary HOME and exposes its task-private
+/// runtime directory. The exact task id is part of the authorization so this feature-specific
+/// regression never changes another Harness task, an ordinary `tauri dev`, or a release build.
+pub(crate) fn reminder_runtime_probe_requested() -> bool {
+    cfg!(debug_assertions)
+        && std::env::var("MURMUR_HARNESS").as_deref() == Ok("1")
+        && std::env::var("MURMUR_HARNESS_TASK").as_deref() == Ok(REMINDER_RUNTIME_PROBE_TASK_ID)
+        && std::env::var_os("MURMUR_HARNESS_RUNTIME_DIR").is_some()
+        && std::env::var_os("MURMUR_DEV_DEK").is_some()
+}
+
+/// Install the debug KEK and fake local Brain sidecar before Tauri starts any worker. The smoke
+/// supplies an isolated HOME + SQLCipher DEK and an externally-owned loopback egress observer, so
+/// none of this can read the operator's Keychain, models, database, or configuration.
+pub(crate) fn prepare_reminder_runtime_probe_environment() {
+    #[cfg(debug_assertions)]
+    if reminder_runtime_probe_requested() {
+        if std::env::var_os("MURMUR_DEV_KEK").is_none() {
+            // SAFETY: `lib::run` calls this at process entry, before Tauri or any app worker starts.
+            std::env::set_var(
+                "MURMUR_DEV_KEK",
+                "1111111111111111111111111111111111111111111111111111111111111111",
+            );
+        }
+        runtime_probe::prepare_process_environment();
+    }
+}
+
+#[cfg(debug_assertions)]
+pub(crate) fn record_reminder_runtime_startup_reconcile(
+    derived_before: usize,
+    derived_after: usize,
+) -> Result<(), AppError> {
+    runtime_probe::record_startup_reconcile(derived_before, derived_after)
+}
+
+/// Fixed renderer orchestration for the exact Harness task. Product commands perform every
+/// lifecycle transition; this script only sequences real `invoke` calls and reduces their
+/// content-bearing responses to booleans before handing them to the native control probe.
+pub(crate) fn reminder_runtime_probe_initialization_script() -> &'static str {
+    r#"
+void (async () => {
+  const SOURCE_ID = "runtime-probe-meeting-5-20260729";
+  const DUE_AT = 4102444800000;
+  const TITLE = "Runtime reminder probe";
+  const errorIsLocked = (error) => String(error ?? "").startsWith("locked: ");
+  const detailIsMasked = (detail) =>
+    detail?.locked === true &&
+    detail?.note === null &&
+    Array.isArray(detail?.segments) && detail.segments.length === 0 &&
+    Array.isArray(detail?.assistantInteractions) && detail.assistantInteractions.length === 0 &&
+    detail?.meeting?.title === "🔒 Locked" &&
+    detail?.meeting?.audioPath == null &&
+    detail?.aiProvider == null &&
+    detail?.aiModel == null &&
+    detail?.modelServed == null;
+  const reminderSourcesAreMasked = (snapshot) => {
+    const all = [
+      ...(snapshot?.upcoming ?? []),
+      ...(snapshot?.completed ?? []),
+      ...(snapshot?.inbox ?? []).map((row) => row.reminder),
+    ];
+    const reminder = all.find((row) => row?.title === TITLE && row?.dueAt === DUE_AT);
+    return !!reminder && Array.isArray(reminder.sources) && reminder.sources.length === 0;
+  };
+  let invoke = null;
+  let control = null;
+  let stage = "ipc-bridge";
+  try {
+    // Tauri injects the invoke protocol before this appended script, but installs the public
+    // `invoke` helper in the following core script. Yield until that fixed bootstrap finishes.
+    for (let attempt = 0; attempt < 1000; attempt += 1) {
+      const candidate = window.__TAURI_INTERNALS__?.invoke;
+      if (typeof candidate === "function") {
+        const nativeInvoke = candidate;
+        invoke = (command, args, options) => {
+          if (command === "check_for_update") {
+            return Promise.reject(new Error("runtime update check disabled"));
+          }
+          return nativeInvoke(command, args, options);
+        };
+        window.__TAURI_INTERNALS__.invoke = invoke;
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    if (!invoke) throw new Error("Tauri IPC bridge did not initialize");
+    control = (action, extra = {}) =>
+      invoke("reminder_runtime_probe_control", { input: { action, ...extra } });
+    stage = "claim";
+    const claim = await control("claim");
+    if (!claim.owner) return;
+    let phase = claim.phase;
+    for (let attempt = 0; phase === "waiting" && attempt < 1000; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      phase = (await control("phase")).phase;
+    }
+    if (phase === "initial") {
+      stage = "prepare";
+      const fixture = await control("prepare");
+      stage = "lock-unlock";
+      await invoke("lock_folder", { folderId: fixture.folderId });
+      await invoke("unlock_folder", { folderId: fixture.folderId });
+      stage = "create-reminder";
+      await invoke("create_reminder", {
+        draft: {
+          title: TITLE,
+          details: "Synthetic runtime proof",
+          dueAt: DUE_AT,
+          repeatEvery: null,
+          repeatUnit: null,
+          sources: [{ kind: "meeting", id: SOURCE_ID }],
+        },
+      });
+
+      stage = "provider-preflight";
+      await invoke("set_anthropic_key", { key: "runtime-probe-anthropic-key" });
+      await invoke("set_gateway_key", { key: "runtime-probe-gateway-key" });
+      await invoke("consent_to_cloud_egress");
+      await invoke("select_brain_model", { modelId: "qwen3-1.7b" });
+      const providers = ["claude_code", "anthropic", "gateway", "ollama"];
+      for (let index = 0; index < providers.length; index += 1) {
+        const provider = providers[index];
+        stage = `provider-${index}-config`;
+        const config = await invoke("get_config");
+        config.providerId = provider;
+        config.providerModel = "runtime-probe-model";
+        config.anthropicModel = "runtime-probe-model";
+        config.gatewayModel = "runtime-probe-model";
+        config.ollamaModel = "runtime-probe-model";
+        config.gatewayBaseUrl = fixture.gatewayEndpoint;
+        config.ollamaBaseUrl = "https://remote-ollama.invalid";
+        config.claudeBinary = fixture.claudeBinary;
+        config.roleNotesConnection = provider;
+        config.roleAskConnection = provider;
+        config.roleLiveConnection = provider;
+        await invoke("save_config", { config });
+        const readback = await invoke("get_config");
+        if (
+          readback.providerId !== provider ||
+          readback.roleNotesConnection !== provider ||
+          readback.roleAskConnection !== provider ||
+          readback.roleLiveConnection !== provider
+        ) throw new Error("provider config readback mismatch");
+        stage = `provider-${index}-audit`;
+        await control("begin-provider-case", { providerIndex: index });
+        const rows = await invoke("audit_reminder_suggestions", {
+          sourceKind: "meeting",
+          sourceId: fixture.sourceIds[index],
+        });
+        if (!Array.isArray(rows) || rows.length === 0) {
+          throw new Error("provider audit produced no deterministic candidate");
+        }
+        await control("finish-provider-case", { providerIndex: index });
+      }
+
+      stage = "stub-audit";
+      await control("begin-stub-case");
+      const stubRows = await invoke("audit_reminder_suggestions", {
+        sourceKind: "meeting",
+        sourceId: fixture.sourceIds[4],
+      });
+      if (!Array.isArray(stubRows) || stubRows.length === 0) {
+        throw new Error("stub audit produced no deterministic candidate");
+      }
+      await control("finish-stub-case");
+
+      stage = "race-arm";
+      await control("arm-race");
+      const inflight = invoke("audit_reminder_suggestions", {
+        sourceKind: "meeting",
+        sourceId: SOURCE_ID,
+      }).then(
+        () => ({ locked: false }),
+        (error) => ({ locked: errorIsLocked(error) }),
+      );
+      let entered = false;
+      for (let attempt = 0; attempt < 1000; attempt += 1) {
+        if ((await control("race-entered")).entered) {
+          entered = true;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      if (!entered) throw new Error("local inference did not enter");
+      stage = "race-relock";
+      await invoke("relock_all");
+      await control("release-race");
+      const raceResult = await inflight;
+
+      stage = "phase-one-reads";
+      const snapshot = await invoke("list_reminders");
+      const detail = await invoke("get_meeting_detail", { meetingId: SOURCE_ID });
+      let postLockAuditLocked = false;
+      try {
+        await invoke("audit_reminder_suggestions", {
+          sourceKind: "meeting",
+          sourceId: SOURCE_ID,
+        });
+      } catch (error) {
+        postLockAuditLocked = errorIsLocked(error);
+      }
+      stage = "phase-one-finish";
+      await control("finish-phase-one", {
+        auditLocked: raceResult.locked,
+        sourcesMasked: reminderSourcesAreMasked(snapshot),
+        detailMasked: detailIsMasked(detail),
+        postLockAuditLocked,
+      });
+      return;
+    }
+
+    if (phase !== "restart") throw new Error("restart phase was not established");
+    stage = "restart-reads";
+    const snapshot = await invoke("list_reminders");
+    const detail = await invoke("get_meeting_detail", { meetingId: SOURCE_ID });
+    let postLockAuditLocked = false;
+    try {
+      await invoke("audit_reminder_suggestions", {
+        sourceKind: "meeting",
+        sourceId: SOURCE_ID,
+      });
+    } catch (error) {
+      postLockAuditLocked = errorIsLocked(error);
+    }
+    stage = "restart-finish";
+    await control("finish-restart", {
+      auditLocked: postLockAuditLocked,
+      sourcesMasked: reminderSourcesAreMasked(snapshot),
+      detailMasked: detailIsMasked(detail),
+      postLockAuditLocked,
+    });
+  } catch (_) {
+    if (control) await control("fail", { stage }).catch(() => {});
+  }
+})();"#
+}
+
+/// Product update command with one debug-only guard for the exact Harness runtime probe.
+///
+/// The renderer also suppresses its best-effort startup check, but Angular and the appended
+/// initialization script can race during a real WebView boot. Blocking at the IPC boundary keeps
+/// the no-egress proof deterministic without changing release behavior.
+#[tauri::command(rename = "check_for_update")]
+pub async fn check_for_update_guarded() -> Result<crate::update::UpdateInfo, AppError> {
+    #[cfg(debug_assertions)]
+    if reminder_runtime_probe_requested() {
+        return Err(AppError::Unavailable(
+            "Update checks are disabled during the isolated runtime probe.".into(),
+        ));
+    }
+
+    crate::update::check_for_update().await
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReminderRuntimeProbeInput {
+    action: String,
+    #[serde(default)]
+    provider_index: Option<usize>,
+    #[serde(default)]
+    audit_locked: bool,
+    #[serde(default)]
+    sources_masked: bool,
+    #[serde(default)]
+    detail_masked: bool,
+    #[serde(default)]
+    post_lock_audit_locked: bool,
+    #[serde(default)]
+    stage: Option<String>,
+}
+
+/// Test-control command for the exact debug Harness task. All content-bearing operations remain
+/// ordinary product IPC commands; this endpoint exposes only fixture ids, counters, booleans, and
+/// the final task-private witness.
+#[tauri::command]
+pub fn reminder_runtime_probe_control(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    input: ReminderRuntimeProbeInput,
+) -> Result<serde_json::Value, AppError> {
+    #[cfg(debug_assertions)]
+    {
+        runtime_probe::control(&app, state.inner(), input)
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        let _ = (app, state, input);
+        Err(AppError::InvalidArg(
+            "runtime reminder probe is unavailable".into(),
+        ))
+    }
+}
+
+#[cfg(debug_assertions)]
+mod runtime_probe {
+    use std::collections::BTreeSet;
+    use std::fs::{File, OpenOptions};
+    use std::io::{ErrorKind, Read, Write};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Mutex, OnceLock};
+    use std::time::Duration;
+
+    use serde::{Deserialize, Serialize};
+    use serde_json::{json, Value};
+    use sha2::{Digest, Sha256};
+    use tauri::Manager;
+    use zeroize::Zeroizing;
+
+    use super::*;
+    use crate::settings::AppConfig;
+    use crate::storage::models::{Folder, Meeting, MeetingStatus, NoteRecord};
+
+    const FOLDER_ID: &str = "runtime-probe-folder-20260729";
+    const SOURCE_PREFIX: &str = "runtime-probe-meeting";
+    const SOURCE_COUNT: usize = 6;
+    const PROVIDER_COUNT: usize = 4;
+    const LOCAL_MODEL_ID: &str = "qwen3-1.7b";
+    const REMINDER_DUE_AT: i64 = 4_102_444_800_000;
+    const REMINDER_TITLE: &str = "Runtime reminder probe";
+    const CHALLENGE_FILE: &str = "reminder-runtime-challenge.json";
+    const INTENT_FILE: &str = "reminder-runtime-restart-intent.json";
+    const GENERATION_FILE: &str = "reminder-runtime-restart-generation.json";
+    const WITNESS_FILE: &str = "reminder-runtime-witness.json";
+    const MAX_RECEIPT_BYTES: u64 = 64 * 1024;
+
+    static PROCESS_CLAIMED: AtomicBool = AtomicBool::new(false);
+    static SETUP_FAILED: AtomicBool = AtomicBool::new(false);
+    static SELECTOR_SUCCESSES: AtomicUsize = AtomicUsize::new(0);
+    static LOCKED_AUDIT_OUTCOMES: AtomicUsize = AtomicUsize::new(0);
+    static STARTUP_DERIVED_BEFORE: AtomicUsize = AtomicUsize::new(usize::MAX);
+    static STARTUP_DERIVED_AFTER: AtomicUsize = AtomicUsize::new(usize::MAX);
+    static RUNTIME: OnceLock<Mutex<RuntimeState>> = OnceLock::new();
+
+    struct RuntimeState {
+        proxy_endpoint: String,
+        original_config: Option<AppConfig>,
+        provider_cases: BTreeSet<usize>,
+        stub_passed: bool,
+        active_case: Option<(usize, ObservationWindow)>,
+        race_window: Option<ObservationWindow>,
+    }
+
+    #[derive(Clone)]
+    struct ObservationWindow {
+        egress_before: i64,
+        brain_before: usize,
+        selector_before: usize,
+        seal_epoch_before: u64,
+        race_nonce: Option<String>,
+    }
+
+    #[derive(Debug, Clone)]
+    struct ProbePaths {
+        runtime_dir: PathBuf,
+        challenge: PathBuf,
+        intent: PathBuf,
+        generation: PathBuf,
+        witness: PathBuf,
+        sidecar_script: PathBuf,
+        claude_script: PathBuf,
+        dummy_model: PathBuf,
+        brain_count: PathBuf,
+        race_armed: PathBuf,
+        race_started: PathBuf,
+        race_release: PathBuf,
+        race_done: PathBuf,
+        claude_called: PathBuf,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    struct RuntimeChallenge {
+        schema_version: u8,
+        task_id: String,
+        run_id: String,
+        runner_pid: u32,
+        runner_nonce: String,
+        binary_sha256: String,
+        network_profile_sha256: String,
+        runner_source_sha256: String,
+        task_contract_sha256: String,
+        git_head: String,
+        started_at: String,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    struct RestartIntent {
+        schema_version: u8,
+        run_id: String,
+        first_pid: u32,
+        phase_one_passed: bool,
+        runner_nonce: String,
+        binary_sha256: String,
+        selector_successes: usize,
+        locked_audit_outcomes: usize,
+        restart_canary_rows: usize,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    struct RestartGeneration {
+        schema_version: u8,
+        run_id: String,
+        runner_nonce: String,
+        binary_sha256: String,
+        first_pid: u32,
+        second_pid: u32,
+        runner_owned: bool,
+    }
+
+    #[derive(Debug, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct RuntimeWitness {
+        schema_version: u8,
+        verdict: &'static str,
+        run_id: String,
+        runner_nonce: String,
+        phase_two_nonce: String,
+        binary_sha256: String,
+        network_profile_sha256: String,
+        runner_source_sha256: String,
+        task_contract_sha256: String,
+        git_head: String,
+        first_pid: u32,
+        second_pid: u32,
+        checks: RuntimeWitnessChecks,
+    }
+
+    #[derive(Debug, Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct RuntimeWitnessChecks {
+        actual_tauri_ipc: bool,
+        sqlcipher_integrity: bool,
+        plain_sqlite_rejected: bool,
+        lock_unlock_relock: bool,
+        in_flight_local_inference: bool,
+        masked_reads: bool,
+        restart_purge: bool,
+        no_egress: bool,
+        provider_cases: usize,
+        local_generate_count: usize,
+        stub_case: bool,
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase", deny_unknown_fields)]
+    struct SidecarRaceEvent {
+        runner_nonce: String,
+        race_nonce: String,
+        request_id: u64,
+    }
+
+    enum ProbePhase {
+        Initial,
+        Waiting,
+        Restart(RestartGeneration),
+    }
+
+    pub(super) fn prepare_process_environment() {
+        if let Err(_error) = prepare_process_environment_inner() {
+            SETUP_FAILED.store(true, Ordering::Release);
+        }
+    }
+
+    fn prepare_process_environment_inner() -> Result<(), AppError> {
+        verify_isolated_runtime()?;
+        let paths = ProbePaths::new()?;
+        let challenge = probe_challenge(&paths)?;
+        if current_executable_sha256()? != challenge.binary_sha256 {
+            return Err(AppError::Unavailable(
+                "running executable does not match the runner challenge".into(),
+            ));
+        }
+        configure_witness_fd()?;
+        write_probe_executables(&paths)?;
+        ensure_dummy_model(&paths)?;
+        let endpoint = std::env::var("MURMUR_HARNESS_EGRESS_PROXY")
+            .map_err(|_| AppError::Unavailable("runner egress observer is absent".into()))?;
+        validate_proxy_endpoint(&endpoint)?;
+        if std::env::var("MURMUR_HARNESS_RUN_ID").as_deref() != Ok(challenge.run_id.as_str())
+            || std::env::var("MURMUR_HARNESS_RUNNER_NONCE").as_deref()
+                != Ok(challenge.runner_nonce.as_str())
+            || std::env::var("MURMUR_HARNESS_BINARY_SHA256").as_deref()
+                != Ok(challenge.binary_sha256.as_str())
+        {
+            return Err(AppError::Unavailable(
+                "runner challenge environment is not bound".into(),
+            ));
+        }
+        // SAFETY: called at process entry before Tauri starts any worker.
+        for key in [
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "ALL_PROXY",
+            "http_proxy",
+            "https_proxy",
+            "all_proxy",
+        ] {
+            std::env::set_var(key, &endpoint);
+        }
+        std::env::set_var("NO_PROXY", "");
+        std::env::set_var("no_proxy", "");
+        std::env::set_var("MURMUR_BRAIN_SIDECAR", &paths.sidecar_script);
+        RUNTIME
+            .set(Mutex::new(RuntimeState {
+                proxy_endpoint: endpoint,
+                original_config: None,
+                provider_cases: BTreeSet::new(),
+                stub_passed: false,
+                active_case: None,
+                race_window: None,
+            }))
+            .map_err(|_| AppError::Unavailable("runtime probe initialized twice".into()))?;
+        Ok(())
+    }
+
+    fn validate_proxy_endpoint(endpoint: &str) -> Result<(), AppError> {
+        let parsed = reqwest::Url::parse(endpoint).map_err(|_| {
+            AppError::Unavailable("runner egress observer endpoint is invalid".into())
+        })?;
+        let valid = endpoint.len() <= 160
+            && parsed.scheme() == "http"
+            && parsed.host_str() == Some("127.0.0.1")
+            && parsed.port().is_some()
+            && parsed.username() == "murmur-harness"
+            && parsed
+                .password()
+                .is_some_and(|password| valid_lowercase_hex(password, 64))
+            && parsed.path() == "/"
+            && parsed.query().is_none()
+            && parsed.fragment().is_none();
+        if valid {
+            Ok(())
+        } else {
+            Err(AppError::Unavailable(
+                "runner egress observer endpoint is invalid".into(),
+            ))
+        }
+    }
+
+    pub(super) fn control(
+        app: &AppHandle,
+        state: &AppState,
+        input: ReminderRuntimeProbeInput,
+    ) -> Result<Value, AppError> {
+        if !super::reminder_runtime_probe_requested() {
+            return Err(AppError::InvalidArg(
+                "runtime reminder probe is not authorized".into(),
+            ));
+        }
+        if SETUP_FAILED.load(Ordering::Acquire) {
+            return Err(AppError::Unavailable(
+                "runtime reminder probe setup failed".into(),
+            ));
+        }
+        let paths = ProbePaths::new()?;
+        match input.action.as_str() {
+            "claim" => claim(&paths),
+            "phase" => Ok(json!({"phase": phase_name(&probe_phase(&paths)?)})),
+            "prepare" => prepare_fixture(state, &paths),
+            "begin-provider-case" => begin_provider_case(
+                state,
+                &paths,
+                required_provider_index(input.provider_index)?,
+            ),
+            "finish-provider-case" => finish_provider_case(
+                state,
+                &paths,
+                required_provider_index(input.provider_index)?,
+            ),
+            "begin-stub-case" => begin_stub_case(state, &paths),
+            "finish-stub-case" => finish_stub_case(state, &paths),
+            "arm-race" => arm_race(state, &paths),
+            "race-entered" => race_entered(&paths),
+            "release-race" => release_race(state, &paths),
+            "finish-phase-one" => finish_phase_one(app, state, &paths, &input),
+            "finish-restart" => finish_restart(app, state, &paths, &input),
+            "fail" => fail_probe(app, input.stage.as_deref()),
+            _ => Err(AppError::InvalidArg(
+                "unknown runtime reminder probe action".into(),
+            )),
+        }
+    }
+
+    fn claim(paths: &ProbePaths) -> Result<Value, AppError> {
+        if PROCESS_CLAIMED.swap(true, Ordering::AcqRel) {
+            return Ok(json!({"owner": false, "phase": "duplicate"}));
+        }
+        let phase = probe_phase(paths)?;
+        Ok(json!({"owner": true, "phase": phase_name(&phase)}))
+    }
+
+    fn phase_name(phase: &ProbePhase) -> &'static str {
+        match phase {
+            ProbePhase::Initial => "initial",
+            ProbePhase::Waiting => "waiting",
+            ProbePhase::Restart(_) => "restart",
+        }
+    }
+
+    fn probe_phase(paths: &ProbePaths) -> Result<ProbePhase, AppError> {
+        let challenge = probe_challenge(paths)?;
+        if !paths.intent.is_file() {
+            return Ok(ProbePhase::Initial);
+        }
+        let intent: RestartIntent = read_json(&paths.intent)?;
+        if intent.schema_version != 1
+            || intent.run_id != challenge.run_id
+            || intent.runner_nonce != challenge.runner_nonce
+            || intent.binary_sha256 != challenge.binary_sha256
+            || !intent.phase_one_passed
+            || intent.first_pid == 0
+            || intent.selector_successes != PROVIDER_COUNT + 1
+            || intent.locked_audit_outcomes != 2
+            || intent.restart_canary_rows != 2
+        {
+            return Err(AppError::Unavailable(
+                "runtime restart intent is stale or invalid".into(),
+            ));
+        }
+        if !paths.generation.is_file() {
+            return Ok(ProbePhase::Waiting);
+        }
+        let generation: RestartGeneration = read_json(&paths.generation)?;
+        if generation.schema_version != 1
+            || generation.run_id != intent.run_id
+            || generation.runner_nonce != challenge.runner_nonce
+            || generation.binary_sha256 != challenge.binary_sha256
+            || !std::env::var("MURMUR_HARNESS_PHASE_TWO_NONCE")
+                .is_ok_and(|value| valid_lowercase_hex(&value, 64))
+            || generation.first_pid != intent.first_pid
+            || generation.second_pid == generation.first_pid
+            || generation.second_pid != std::process::id()
+            || !generation.runner_owned
+        {
+            return Err(AppError::Unavailable(
+                "runtime restart generation is invalid".into(),
+            ));
+        }
+        Ok(ProbePhase::Restart(generation))
+    }
+
+    fn prepare_fixture(state: &AppState, paths: &ProbePaths) -> Result<Value, AppError> {
+        if !matches!(probe_phase(paths)?, ProbePhase::Initial) {
+            return Err(AppError::Unavailable(
+                "runtime fixture can only be prepared before restart".into(),
+            ));
+        }
+        for path in [
+            &paths.witness,
+            &paths.brain_count,
+            &paths.race_armed,
+            &paths.race_started,
+            &paths.race_release,
+            &paths.race_done,
+            &paths.claude_called,
+        ] {
+            if path.exists() {
+                return Err(AppError::Unavailable(
+                    "runtime fixture contains stale proof artifacts".into(),
+                ));
+            }
+        }
+        ensure_dummy_model(paths)?;
+        seed_sources(state)?;
+
+        let mut runtime = runtime()?;
+        if runtime.original_config.is_some() {
+            return Err(AppError::Unavailable(
+                "runtime fixture was prepared twice".into(),
+            ));
+        }
+        runtime.original_config = Some(
+            state
+                .config
+                .lock()
+                .map_err(|_| AppError::Unavailable("runtime config is unavailable".into()))?
+                .clone(),
+        );
+        if derived_count(state)? != 0 || egress_count(state)? != 0 {
+            return Err(AppError::Unavailable(
+                "runtime fixture did not start from an empty proof domain".into(),
+            ));
+        }
+        let source_ids = (0..SOURCE_COUNT).map(source_id).collect::<Vec<_>>();
+        Ok(json!({
+            "folderId": FOLDER_ID,
+            "sourceIds": source_ids,
+            "dueAt": REMINDER_DUE_AT,
+            "providerCount": PROVIDER_COUNT,
+            "proxyEndpoint": runtime.proxy_endpoint.clone(),
+            "gatewayEndpoint": REMINDER_RUNTIME_GATEWAY_URL,
+            "claudeBinary": paths.claude_script,
+        }))
+    }
+
+    fn begin_provider_case(
+        state: &AppState,
+        paths: &ProbePaths,
+        index: usize,
+    ) -> Result<Value, AppError> {
+        let expected = provider_name(index)?;
+        let mut runtime = runtime()?;
+        if runtime.provider_cases.len() != index
+            || runtime.provider_cases.contains(&index)
+            || runtime.active_case.is_some()
+        {
+            return Err(AppError::Unavailable(
+                "runtime provider case order is invalid".into(),
+            ));
+        }
+        let config = state
+            .config
+            .lock()
+            .map_err(|_| AppError::Unavailable("runtime config is unavailable".into()))?
+            .clone();
+        if config.provider_id != expected
+            || config.role_notes_connection != expected
+            || config.role_ask_connection != expected
+            || config.role_live_connection != expected
+            || !config.cloud_egress_consented
+            || config.claude_binary != paths.claude_script.to_string_lossy()
+            || config.gateway_base_url.as_str() != REMINDER_RUNTIME_GATEWAY_URL
+            || config.ollama_base_url != "https://remote-ollama.invalid"
+            || config.brain_light_model_id.as_deref() != Some(LOCAL_MODEL_ID)
+        {
+            return Err(AppError::Unavailable(
+                "runtime provider configuration is not dispatch-capable".into(),
+            ));
+        }
+        if crate::secrets::get_secret(crate::summarize::ANTHROPIC_KEY_ACCOUNT)?.is_none()
+            || crate::secrets::get_secret(crate::summarize::GATEWAY_KEY_ACCOUNT)?.is_none()
+        {
+            return Err(AppError::Unavailable(
+                "runtime provider credentials are absent".into(),
+            ));
+        }
+        let engine = state.reasoner.light();
+        if !engine.id().starts_with("sidecar:") || source_derived_count(state, index)? != 0 {
+            return Err(AppError::Unavailable(
+                "runtime local provider audit is not an uncached sidecar call".into(),
+            ));
+        }
+        runtime.active_case = Some((index, begin_window(state, paths)?));
+        Ok(json!({"ready": true}))
+    }
+
+    fn finish_provider_case(
+        state: &AppState,
+        paths: &ProbePaths,
+        index: usize,
+    ) -> Result<Value, AppError> {
+        let mut runtime = runtime()?;
+        let Some((active_index, window)) = runtime.active_case.take() else {
+            return Err(AppError::Unavailable(
+                "runtime provider case was not started".into(),
+            ));
+        };
+        if active_index != index {
+            return Err(AppError::Unavailable(
+                "runtime provider case changed identity".into(),
+            ));
+        }
+        finish_window(state, paths, &window, 1)?;
+        assert_source_engine(state, index, |engine| engine.starts_with("sidecar:"))?;
+        runtime.provider_cases.insert(index);
+        Ok(json!({"passed": true}))
+    }
+
+    fn begin_stub_case(state: &AppState, paths: &ProbePaths) -> Result<Value, AppError> {
+        let mut runtime = runtime()?;
+        if runtime.provider_cases.len() != PROVIDER_COUNT
+            || runtime.stub_passed
+            || runtime.active_case.is_some()
+        {
+            return Err(AppError::Unavailable(
+                "runtime stub case precondition failed".into(),
+            ));
+        }
+        remove_file_if_present(&paths.dummy_model)?;
+        if state.reasoner.light().id() != "stub"
+            || source_derived_count(state, PROVIDER_COUNT)? != 0
+        {
+            return Err(AppError::Unavailable(
+                "runtime missing local model did not select the stub".into(),
+            ));
+        }
+        runtime.active_case = Some((PROVIDER_COUNT, begin_window(state, paths)?));
+        Ok(json!({"ready": true}))
+    }
+
+    fn finish_stub_case(state: &AppState, paths: &ProbePaths) -> Result<Value, AppError> {
+        let mut runtime = runtime()?;
+        let Some((index, window)) = runtime.active_case.take() else {
+            return Err(AppError::Unavailable(
+                "runtime stub case was not started".into(),
+            ));
+        };
+        if index != PROVIDER_COUNT {
+            return Err(AppError::Unavailable(
+                "runtime stub case changed identity".into(),
+            ));
+        }
+        finish_window(state, paths, &window, 0)?;
+        assert_source_engine(state, PROVIDER_COUNT, |engine| engine == "stub")?;
+        ensure_dummy_model(paths)?;
+        runtime.stub_passed = true;
+        Ok(json!({"passed": true}))
+    }
+
+    fn arm_race(state: &AppState, paths: &ProbePaths) -> Result<Value, AppError> {
+        let mut runtime = runtime()?;
+        if runtime.provider_cases.len() != PROVIDER_COUNT
+            || !runtime.stub_passed
+            || runtime.race_window.is_some()
+            || source_derived_count(state, SOURCE_COUNT - 1)? != 0
+            || derived_count(state)? == 0
+        {
+            return Err(AppError::Unavailable(
+                "runtime inference race precondition failed".into(),
+            ));
+        }
+        ensure_dummy_model(paths)?;
+        if !state.reasoner.light().id().starts_with("sidecar:") {
+            return Err(AppError::Unavailable(
+                "runtime inference race is not using the local sidecar".into(),
+            ));
+        }
+        for path in [
+            &paths.race_armed,
+            &paths.race_started,
+            &paths.race_release,
+            &paths.race_done,
+        ] {
+            if path.exists() {
+                return Err(AppError::Unavailable(
+                    "runtime inference race contains stale markers".into(),
+                ));
+            }
+        }
+        let challenge = probe_challenge(paths)?;
+        let race_nonce = uuid::Uuid::new_v4().simple().to_string();
+        let mut window = begin_window(state, paths)?;
+        window.race_nonce = Some(race_nonce.clone());
+        write_json_atomic(
+            &paths.race_armed,
+            &SidecarRaceEvent {
+                runner_nonce: challenge.runner_nonce,
+                race_nonce,
+                request_id: 0,
+            },
+        )?;
+        runtime.race_window = Some(window);
+        Ok(json!({"armed": true}))
+    }
+
+    fn race_entered(paths: &ProbePaths) -> Result<Value, AppError> {
+        let runtime = runtime()?;
+        let Some(window) = runtime.race_window.as_ref() else {
+            return Err(AppError::Unavailable(
+                "runtime inference race was not armed".into(),
+            ));
+        };
+        let expected_nonce = window
+            .race_nonce
+            .as_deref()
+            .ok_or_else(|| AppError::Unavailable("runtime race nonce is absent".into()))?;
+        let entered = if paths.race_started.is_file() {
+            let event: SidecarRaceEvent = read_json(&paths.race_started)?;
+            let challenge = probe_challenge(paths)?;
+            event.runner_nonce == challenge.runner_nonce
+                && event.race_nonce == expected_nonce
+                && event.request_id > 0
+                && brain_generate_count(paths)? == window.brain_before.saturating_add(1)
+        } else {
+            false
+        };
+        Ok(json!({"entered": entered}))
+    }
+
+    fn release_race(state: &AppState, paths: &ProbePaths) -> Result<Value, AppError> {
+        if !paths.race_started.is_file() {
+            return Err(AppError::Unavailable(
+                "runtime local inference has not started".into(),
+            ));
+        }
+        let runtime = runtime()?;
+        let window = runtime
+            .race_window
+            .as_ref()
+            .ok_or_else(|| AppError::Unavailable("runtime inference race was not armed".into()))?;
+        let expected_nonce = window
+            .race_nonce
+            .as_deref()
+            .ok_or_else(|| AppError::Unavailable("runtime race nonce is absent".into()))?;
+        let event: SidecarRaceEvent = read_json(&paths.race_started)?;
+        let challenge = probe_challenge(paths)?;
+        if event.runner_nonce != challenge.runner_nonce
+            || event.race_nonce != expected_nonce
+            || event.request_id == 0
+            || state.seal_epoch.load(Ordering::SeqCst) <= window.seal_epoch_before
+            || !folder_is_relocked(state)?
+            || crate::commands::locked_folder_requires_authenticated_repair(&state.db, FOLDER_ID)?
+            || !relocked_content_is_recoverable(state)?
+        {
+            return Err(AppError::Unavailable(
+                "runtime relock did not land between local Generate start and release".into(),
+            ));
+        }
+        write_json_atomic(&paths.race_release, &event)?;
+        Ok(json!({"released": true}))
+    }
+
+    fn finish_phase_one(
+        _app: &AppHandle,
+        state: &AppState,
+        paths: &ProbePaths,
+        input: &ReminderRuntimeProbeInput,
+    ) -> Result<Value, AppError> {
+        require_ipc_assertions(input)?;
+        let mut runtime = runtime()?;
+        let window = runtime.race_window.take().ok_or_else(|| {
+            AppError::Unavailable(
+                "runtime inference race did not have an observation window".into(),
+            )
+        })?;
+        finish_window(state, paths, &window, 1)?;
+        let race_started: SidecarRaceEvent = read_json(&paths.race_started)?;
+        let race_done: SidecarRaceEvent = read_json(&paths.race_done)?;
+        let challenge = probe_challenge(paths)?;
+        if derived_count(state)? != 0
+            || source_derived_count(state, SOURCE_COUNT - 1)? != 0
+            || brain_generate_count(paths)? != PROVIDER_COUNT + 1
+            || SELECTOR_SUCCESSES.load(Ordering::Acquire) != PROVIDER_COUNT + 1
+            || LOCKED_AUDIT_OUTCOMES.load(Ordering::Acquire) != 2
+            || race_done.runner_nonce != challenge.runner_nonce
+            || Some(race_done.race_nonce.as_str()) != window.race_nonce.as_deref()
+            || race_done.request_id == 0
+            || race_done.runner_nonce != race_started.runner_nonce
+            || race_done.race_nonce != race_started.race_nonce
+            || race_done.request_id != race_started.request_id
+            || !folder_is_relocked(state)?
+            || crate::commands::locked_folder_requires_authenticated_repair(&state.db, FOLDER_ID)?
+            || !relocked_content_is_recoverable(state)?
+            || !reminder_is_persisted_and_masked(state)?
+        {
+            return Err(AppError::Unavailable(
+                "runtime phase-one privacy invariant failed".into(),
+            ));
+        }
+        let (cipher_integrity, plain_rejected) = prove_sqlcipher(state)?;
+        if !cipher_integrity || !plain_rejected {
+            return Err(AppError::Unavailable(
+                "runtime SQLCipher proof failed".into(),
+            ));
+        }
+
+        let original = runtime.original_config.take().ok_or_else(|| {
+            AppError::Unavailable("runtime original configuration is unavailable".into())
+        })?;
+        original.save(&state.db)?;
+        *state
+            .config
+            .lock()
+            .map_err(|_| AppError::Unavailable("runtime config is unavailable".into()))? = original;
+        crate::secrets::delete_secret(crate::summarize::ANTHROPIC_KEY_ACCOUNT)?;
+        crate::secrets::delete_secret(crate::summarize::GATEWAY_KEY_ACCOUNT)?;
+        drop(runtime);
+
+        // Simulate the exact crash window startup reconciliation protects: the folder remains
+        // sealed and session-hidden, but two synthetic source-derived rows reach disk after the
+        // clean relock transaction. Process two must observe both rows before startup reblank and
+        // observe zero afterwards. No user content is copied into this isolated debug-only canary.
+        seed_restart_purge_canary(state)?;
+        if derived_count(state)? != 2 {
+            return Err(AppError::Unavailable(
+                "runtime restart purge canary was not persisted".into(),
+            ));
+        }
+        let intent = RestartIntent {
+            schema_version: 1,
+            run_id: challenge.run_id,
+            first_pid: std::process::id(),
+            phase_one_passed: true,
+            runner_nonce: challenge.runner_nonce,
+            binary_sha256: challenge.binary_sha256,
+            selector_successes: SELECTOR_SUCCESSES.load(Ordering::Acquire),
+            locked_audit_outcomes: LOCKED_AUDIT_OUTCOMES.load(Ordering::Acquire),
+            restart_canary_rows: 2,
+        };
+        write_json_atomic(&paths.intent, &intent)?;
+        tracing::info!(
+            target: "reminders",
+            provider_cases = PROVIDER_COUNT,
+            local_generates = PROVIDER_COUNT + 1,
+            "native reminder runtime probe phase one passed; requesting runner restart"
+        );
+        // Deliberately bypass Tauri's normal ExitRequested lifecycle hook: that hook calls
+        // `relock_all` and would purge this canary in process one, turning the claimed startup
+        // crash-recovery proof into a false positive. This debug-only, exact-task probe owns a
+        // synthetic isolated HOME; the runner observes this exact PID exit, drains its process
+        // group, then starts the same binary so process two must perform the 2 -> 0 startup purge.
+        std::process::exit(0)
+    }
+
+    fn finish_restart(
+        app: &AppHandle,
+        state: &AppState,
+        paths: &ProbePaths,
+        input: &ReminderRuntimeProbeInput,
+    ) -> Result<Value, AppError> {
+        require_ipc_assertions(input)?;
+        let challenge = probe_challenge(paths)?;
+        let generation = match probe_phase(paths)? {
+            ProbePhase::Restart(generation) => generation,
+            _ => {
+                return Err(AppError::Unavailable(
+                    "runtime second process lacks a runner generation".into(),
+                ));
+            }
+        };
+        let intent: RestartIntent = read_json(&paths.intent)?;
+        if derived_count(state)? != 0
+            || source_derived_count(state, SOURCE_COUNT - 1)? != 0
+            || !folder_is_relocked(state)?
+            || crate::commands::locked_folder_requires_authenticated_repair(&state.db, FOLDER_ID)?
+            || !relocked_content_is_recoverable(state)?
+            || !reminder_is_persisted_and_masked(state)?
+            || brain_generate_count(paths)? != PROVIDER_COUNT + 1
+            || intent.selector_successes != PROVIDER_COUNT + 1
+            || intent.locked_audit_outcomes != 2
+            || intent.restart_canary_rows != 2
+            || SELECTOR_SUCCESSES.load(Ordering::Acquire) != 0
+            || LOCKED_AUDIT_OUTCOMES.load(Ordering::Acquire) != 1
+            || STARTUP_DERIVED_BEFORE.load(Ordering::Acquire) != 2
+            || STARTUP_DERIVED_AFTER.load(Ordering::Acquire) != 0
+            || egress_count(state)? != 0
+            || paths.claude_called.exists()
+        {
+            return Err(AppError::Unavailable(
+                "runtime post-restart privacy invariant failed".into(),
+            ));
+        }
+        let (cipher_integrity, plain_rejected) = prove_sqlcipher(state)?;
+        if !cipher_integrity || !plain_rejected {
+            return Err(AppError::Unavailable(
+                "runtime post-restart SQLCipher proof failed".into(),
+            ));
+        }
+        let phase_two_nonce = std::env::var("MURMUR_HARNESS_PHASE_TWO_NONCE")
+            .map_err(|_| AppError::Unavailable("runtime phase-two nonce is absent".into()))?;
+        if !valid_lowercase_hex(&phase_two_nonce, 64) {
+            return Err(AppError::Unavailable(
+                "runtime phase-two nonce is invalid".into(),
+            ));
+        }
+        let witness = RuntimeWitness {
+            schema_version: 1,
+            verdict: "PASS",
+            run_id: generation.run_id,
+            runner_nonce: generation.runner_nonce,
+            phase_two_nonce,
+            binary_sha256: generation.binary_sha256,
+            network_profile_sha256: challenge.network_profile_sha256,
+            runner_source_sha256: challenge.runner_source_sha256,
+            task_contract_sha256: challenge.task_contract_sha256,
+            git_head: challenge.git_head,
+            first_pid: generation.first_pid,
+            second_pid: generation.second_pid,
+            checks: RuntimeWitnessChecks {
+                actual_tauri_ipc: true,
+                sqlcipher_integrity: true,
+                plain_sqlite_rejected: true,
+                lock_unlock_relock: true,
+                in_flight_local_inference: true,
+                masked_reads: true,
+                restart_purge: true,
+                no_egress: true,
+                provider_cases: PROVIDER_COUNT,
+                local_generate_count: PROVIDER_COUNT + 1,
+                stub_case: true,
+            },
+        };
+        write_witness_pipe(&witness)?;
+        start_mcp_after_probe(app);
+        tracing::info!(
+            target: "reminders",
+            provider_cases = PROVIDER_COUNT,
+            local_generates = PROVIDER_COUNT + 1,
+            "native reminder runtime privacy probe passed after runner-owned restart"
+        );
+        Ok(json!({"passed": true}))
+    }
+
+    fn fail_probe(app: &AppHandle, stage: Option<&str>) -> Result<Value, AppError> {
+        let stage = stage.filter(|candidate| allowed_failure_stage(candidate));
+        tracing::error!(
+            target: "reminders",
+            stage = stage.unwrap_or("unknown"),
+            "native reminder runtime privacy probe failed"
+        );
+        app.exit(70);
+        Err(AppError::Unavailable(
+            "runtime reminder probe failed".into(),
+        ))
+    }
+
+    fn allowed_failure_stage(stage: &str) -> bool {
+        matches!(
+            stage,
+            "claim"
+                | "prepare"
+                | "lock-unlock"
+                | "create-reminder"
+                | "provider-preflight"
+                | "stub-audit"
+                | "race-arm"
+                | "race-relock"
+                | "phase-one-reads"
+                | "phase-one-finish"
+                | "restart-reads"
+                | "restart-finish"
+        ) || (stage.starts_with("provider-")
+            && (stage.ends_with("-config") || stage.ends_with("-audit"))
+            && stage.len() <= 32)
+    }
+
+    fn require_ipc_assertions(input: &ReminderRuntimeProbeInput) -> Result<(), AppError> {
+        if input.audit_locked
+            && input.sources_masked
+            && input.detail_masked
+            && input.post_lock_audit_locked
+        {
+            Ok(())
+        } else {
+            Err(AppError::Unavailable(
+                "runtime renderer IPC assertion failed".into(),
+            ))
+        }
+    }
+
+    fn required_provider_index(index: Option<usize>) -> Result<usize, AppError> {
+        index.ok_or_else(|| AppError::InvalidArg("runtime provider index is required".into()))
+    }
+
+    fn provider_name(index: usize) -> Result<&'static str, AppError> {
+        ["claude_code", "anthropic", "gateway", "ollama"]
+            .get(index)
+            .copied()
+            .ok_or_else(|| AppError::InvalidArg("runtime provider index is invalid".into()))
+    }
+
+    fn begin_window(state: &AppState, paths: &ProbePaths) -> Result<ObservationWindow, AppError> {
+        remove_file_if_present(&paths.claude_called)?;
+        Ok(ObservationWindow {
+            egress_before: egress_count(state)?,
+            brain_before: brain_generate_count(paths)?,
+            selector_before: SELECTOR_SUCCESSES.load(Ordering::Acquire),
+            seal_epoch_before: state.seal_epoch.load(Ordering::SeqCst),
+            race_nonce: None,
+        })
+    }
+
+    fn finish_window(
+        state: &AppState,
+        paths: &ProbePaths,
+        window: &ObservationWindow,
+        expected_brain_increment: usize,
+    ) -> Result<(), AppError> {
+        std::thread::sleep(Duration::from_millis(50));
+        if paths.claude_called.exists()
+            || egress_count(state)? != window.egress_before
+            || brain_generate_count(paths)?
+                != window.brain_before.saturating_add(expected_brain_increment)
+            || SELECTOR_SUCCESSES.load(Ordering::Acquire)
+                != window
+                    .selector_before
+                    .saturating_add(expected_brain_increment)
+        {
+            return Err(AppError::Unavailable(
+                "runtime audit attempted a non-local transport".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn assert_source_engine(
+        state: &AppState,
+        source_index: usize,
+        expected: impl FnOnce(&str) -> bool,
+    ) -> Result<(), AppError> {
+        let id = source_id(source_index);
+        let conn = state.db.lock();
+        let engine: String = conn
+            .query_row(
+                "SELECT engine_id FROM reminder_audit_cache
+                  WHERE source_kind='meeting' AND source_id=?1",
+                rusqlite::params![id],
+                |row| row.get(0),
+            )
+            .map_err(crate::storage::db::map_err)?;
+        let pending: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM reminder_pending_suggestions
+                  WHERE source_kind='meeting' AND source_id=?1",
+                rusqlite::params![source_id(source_index)],
+                |row| row.get(0),
+            )
+            .map_err(crate::storage::db::map_err)?;
+        if expected(&engine) && pending > 0 {
+            Ok(())
+        } else {
+            Err(AppError::Unavailable(
+                "runtime audit engine evidence is invalid".into(),
+            ))
+        }
+    }
+
+    fn source_derived_count(state: &AppState, source_index: usize) -> Result<i64, AppError> {
+        let id = source_id(source_index);
+        state
+            .db
+            .lock()
+            .query_row(
+                "SELECT
+                   (SELECT COUNT(*) FROM reminder_audit_cache
+                     WHERE source_kind='meeting' AND source_id=?1) +
+                   (SELECT COUNT(*) FROM reminder_pending_suggestions
+                     WHERE source_kind='meeting' AND source_id=?1)",
+                rusqlite::params![id],
+                |row| row.get(0),
+            )
+            .map_err(crate::storage::db::map_err)
+    }
+
+    fn derived_count(state: &AppState) -> Result<i64, AppError> {
+        state
+            .db
+            .lock()
+            .query_row(
+                "SELECT
+                   (SELECT COUNT(*) FROM reminder_audit_cache) +
+                   (SELECT COUNT(*) FROM reminder_pending_suggestions)",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(crate::storage::db::map_err)
+    }
+
+    fn seed_restart_purge_canary(state: &AppState) -> Result<(), AppError> {
+        const HASH: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        const KEY: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let mut connection = state.db.lock();
+        let transaction = connection
+            .transaction()
+            .map_err(crate::storage::db::map_err)?;
+        transaction
+            .execute(
+                "INSERT INTO reminder_audit_cache
+                   (source_kind,source_id,content_hash,engine_id,audited_at)
+                 VALUES ('meeting',?1,?2,'runtime-restart-canary',1)",
+                rusqlite::params![source_id(SOURCE_COUNT - 1), HASH],
+            )
+            .map_err(crate::storage::db::map_err)?;
+        transaction
+            .execute(
+                "INSERT INTO reminder_pending_suggestions
+                   (id,source_kind,source_id,content_hash,engine_id,candidate_key,title,
+                    suggested_due_at,created_at)
+                 VALUES ('runtime-restart-canary','meeting',?1,?2,
+                         'runtime-restart-canary',?3,'Synthetic restart canary',NULL,1)",
+                rusqlite::params![source_id(SOURCE_COUNT - 1), HASH, KEY],
+            )
+            .map_err(crate::storage::db::map_err)?;
+        transaction.commit().map_err(crate::storage::db::map_err)
+    }
+
+    fn egress_count(state: &AppState) -> Result<i64, AppError> {
+        state
+            .db
+            .lock()
+            .query_row("SELECT COUNT(*) FROM egress_log", [], |row| row.get(0))
+            .map_err(crate::storage::db::map_err)
+    }
+
+    fn folder_is_relocked(state: &AppState) -> Result<bool, AppError> {
+        let locked = state
+            .db
+            .folder_by_id(FOLDER_ID)?
+            .is_some_and(|folder| folder.locked);
+        let session_visible = state
+            .unlocked_folders
+            .lock()
+            .map_err(|_| AppError::Unavailable("runtime unlock set is unavailable".into()))?
+            .contains(FOLDER_ID);
+        Ok(locked && !session_visible)
+    }
+
+    /// Read-only native recovery proof for the exact synthetic rows. The folder remains locked and
+    /// absent from the session unlock set: we unwrap its CK through the debug KEK hatch, decrypt
+    /// every at-rest note/segment blob with its production AAD, and compare byte-for-byte with the
+    /// seeded fixture without restoring plaintext into SQLite.
+    fn relocked_content_is_recoverable(state: &AppState) -> Result<bool, AppError> {
+        let kek = Zeroizing::new(crate::secrets::master_kek_with_policy(
+            "Verify Harness relock",
+            false,
+        )?);
+        let wrapped = state.db.folder_wrapped_key(FOLDER_ID)?.ok_or_else(|| {
+            AppError::Unavailable("runtime folder has no wrapped content key".into())
+        })?;
+        let ck_bytes =
+            crate::crypto::decrypt(&kek, &wrapped, &crate::commands::aad_wrapped_ck(FOLDER_ID))?;
+        let ck_array: [u8; 32] = ck_bytes.try_into().map_err(|_| {
+            AppError::Unavailable("runtime folder content key has an invalid length".into())
+        })?;
+        let ck = Zeroizing::new(ck_array);
+
+        let notes = state.db.notes_in_folder(FOLDER_ID)?;
+        if notes.len() != SOURCE_COUNT {
+            return Ok(false);
+        }
+        let mut observed = BTreeSet::new();
+        for note in notes {
+            let Some(blob) = note.content_blob.as_deref() else {
+                return Ok(false);
+            };
+            if !note.markdown.is_empty() || note.exported_path.is_some() {
+                return Ok(false);
+            }
+            let index = (0..SOURCE_COUNT)
+                .find(|index| note.meeting_id == source_id(*index))
+                .ok_or_else(|| {
+                    AppError::Unavailable("runtime relock contains an unknown note".into())
+                })?;
+            if !observed.insert(index) {
+                return Ok(false);
+            }
+            let plaintext = crate::crypto::decrypt(
+                &ck,
+                blob,
+                &crate::commands::aad_content(
+                    FOLDER_ID,
+                    &note.meeting_id,
+                    &note.provider_id,
+                    "note",
+                ),
+            )?;
+            if plaintext
+                != format!("## Action items\n- [ ] Runtime provider probe {index}").as_bytes()
+            {
+                return Ok(false);
+            }
+            let segments = state.db.raw_segments(&note.meeting_id)?;
+            if segments.len() != 1
+                || segments[0].idx != 0
+                || !segments[0].text.is_empty()
+                || segments[0].text_blob.is_none()
+            {
+                return Ok(false);
+            }
+            let segment_plaintext = crate::crypto::decrypt(
+                &ck,
+                segments[0].text_blob.as_deref().unwrap_or_default(),
+                &crate::commands::aad_content(FOLDER_ID, &note.meeting_id, "-", "segment"),
+            )?;
+            if segment_plaintext != format!("Runtime provider probe {index}").as_bytes() {
+                return Ok(false);
+            }
+        }
+        Ok(observed.len() == SOURCE_COUNT)
+    }
+
+    fn reminder_is_persisted_and_masked(state: &AppState) -> Result<bool, AppError> {
+        let snapshot = reminders_snapshot_at(state, chrono::Utc::now().timestamp_millis())?;
+        Ok(snapshot
+            .upcoming
+            .iter()
+            .chain(snapshot.completed.iter())
+            .find(|reminder| reminder.title == REMINDER_TITLE && reminder.due_at == REMINDER_DUE_AT)
+            .is_some_and(|reminder| reminder.sources.is_empty()))
+    }
+
+    fn prove_sqlcipher(state: &AppState) -> Result<(bool, bool), AppError> {
+        let integrity = {
+            let conn = state.db.lock();
+            let mut statement = conn
+                .prepare("PRAGMA cipher_integrity_check")
+                .map_err(crate::storage::db::map_err)?;
+            let mut rows = statement.query([]).map_err(crate::storage::db::map_err)?;
+            rows.next().map_err(crate::storage::db::map_err)?.is_none()
+        };
+        let path = database_path()?;
+        let mut header = [0u8; 16];
+        let encrypted_header = File::open(&path)
+            .and_then(|mut file| std::io::Read::read_exact(&mut file, &mut header))
+            .map(|_| header != *b"SQLite format 3\0")
+            .unwrap_or(false);
+        let plain_query_rejected = rusqlite::Connection::open_with_flags(
+            &path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+        )
+        .and_then(|connection| {
+            connection.query_row("SELECT COUNT(*) FROM sqlite_master", [], |row| {
+                row.get::<_, i64>(0)
+            })
+        })
+        .is_err();
+        Ok((integrity, encrypted_header && plain_query_rejected))
+    }
+
+    fn database_path() -> Result<PathBuf, AppError> {
+        dirs::data_dir()
+            .map(|base| {
+                base.join(crate::state::app_dir_name())
+                    .join("meetnotes.sqlite")
+            })
+            .ok_or_else(|| AppError::Unavailable("runtime database path is unavailable".into()))
+    }
+
+    fn seed_sources(state: &AppState) -> Result<(), AppError> {
+        if state.db.folder_by_id(FOLDER_ID)?.is_some() {
+            return Err(AppError::Unavailable(
+                "runtime fixture folder already exists".into(),
+            ));
+        }
+        state.db.insert_folder(&Folder {
+            id: FOLDER_ID.into(),
+            name: "Runtime probe".into(),
+            path: "Runtime probe".into(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-07-29T09:00:00Z".into(),
+        })?;
+        for index in 0..SOURCE_COUNT {
+            let id = source_id(index);
+            state.db.insert_meeting(&Meeting {
+                id: id.clone(),
+                started_at: format!("2026-07-29T10:{index:02}:00Z"),
+                ended_at: None,
+                title: Some(format!("Runtime probe {index}")),
+                duration_s: 0,
+                audio_path: None,
+                status: MeetingStatus::Summarized,
+                folder_id: None,
+            })?;
+            state.db.upsert_note(&NoteRecord {
+                meeting_id: id.clone(),
+                provider_id: "runtime-probe-local".into(),
+                markdown: format!("## Action items\n- [ ] Runtime provider probe {index}"),
+                created_at: format!("2026-07-29T11:{index:02}:00Z"),
+                exported_path: None,
+                model_requested: None,
+                model_served: None,
+                gateway_host: None,
+            })?;
+            state.db.set_note_folder(&id, Some(FOLDER_ID))?;
+            state.db.replace_segments(
+                &id,
+                &[Segment {
+                    idx: 0,
+                    start_s: 0.0,
+                    end_s: 1.0,
+                    text: format!("Runtime provider probe {index}"),
+                    speaker: Some("me".into()),
+                    confidence: Some(1.0),
+                }],
+            )?;
+        }
+        Ok(())
+    }
+
+    fn source_id(index: usize) -> String {
+        format!("{SOURCE_PREFIX}-{index}-20260729")
+    }
+
+    fn runtime() -> Result<std::sync::MutexGuard<'static, RuntimeState>, AppError> {
+        RUNTIME
+            .get()
+            .ok_or_else(|| AppError::Unavailable("runtime probe was not initialized".into()))?
+            .lock()
+            .map_err(|_| AppError::Unavailable("runtime probe state is unavailable".into()))
+    }
+
+    pub(super) fn record_selector_success() -> Result<(), AppError> {
+        if !super::reminder_runtime_probe_requested() || RUNTIME.get().is_none() {
+            return Ok(());
+        }
+        SELECTOR_SUCCESSES
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |value| {
+                value.checked_add(1)
+            })
+            .map(|_| ())
+            .map_err(|_| AppError::Unavailable("runtime selector counter overflowed".into()))
+    }
+
+    pub(super) fn record_locked_audit_outcome() -> Result<(), AppError> {
+        if !super::reminder_runtime_probe_requested() || RUNTIME.get().is_none() {
+            return Ok(());
+        }
+        LOCKED_AUDIT_OUTCOMES
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |value| {
+                value.checked_add(1)
+            })
+            .map(|_| ())
+            .map_err(|_| AppError::Unavailable("runtime lock counter overflowed".into()))
+    }
+
+    pub(super) fn record_startup_reconcile(
+        derived_before: usize,
+        derived_after: usize,
+    ) -> Result<(), AppError> {
+        if !super::reminder_runtime_probe_requested()
+            || std::env::var_os("MURMUR_HARNESS_PHASE_TWO_NONCE").is_none()
+        {
+            return Ok(());
+        }
+        let paths = ProbePaths::new()?;
+        let intent: RestartIntent = read_json(&paths.intent)?;
+        if intent.restart_canary_rows != 2 || derived_before != 2 || derived_after != 0 {
+            return Err(AppError::Unavailable(
+                "startup reminder purge did not consume the persisted canary".into(),
+            ));
+        }
+        STARTUP_DERIVED_BEFORE
+            .compare_exchange(
+                usize::MAX,
+                derived_before,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .map_err(|_| {
+                AppError::Unavailable("startup reminder purge was observed twice".into())
+            })?;
+        STARTUP_DERIVED_AFTER
+            .compare_exchange(
+                usize::MAX,
+                derived_after,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .map_err(|_| {
+                AppError::Unavailable("startup reminder purge was observed twice".into())
+            })?;
+        Ok(())
+    }
+
+    impl ProbePaths {
+        fn new() -> Result<Self, AppError> {
+            let home = verified_home()?;
+            let runtime_dir = std::env::var_os("MURMUR_HARNESS_RUNTIME_DIR")
+                .map(PathBuf::from)
+                .filter(|path| path.is_absolute())
+                .ok_or_else(|| {
+                    AppError::Unavailable("runtime probe directory is unavailable".into())
+                })?;
+            if !runtime_dir.is_dir() {
+                return Err(AppError::Unavailable(
+                    "runner-owned runtime probe directory is absent".into(),
+                ));
+            }
+            let model = crate::reason::brain_model_by_id(LOCAL_MODEL_ID).ok_or_else(|| {
+                AppError::Unavailable("runtime local model fixture is unavailable".into())
+            })?;
+            let dummy_model = crate::transcribe::models_dir()?.join(model.filename);
+            Ok(Self {
+                challenge: runtime_dir.join(CHALLENGE_FILE),
+                intent: runtime_dir.join(INTENT_FILE),
+                generation: runtime_dir.join(GENERATION_FILE),
+                witness: runtime_dir.join(WITNESS_FILE),
+                sidecar_script: runtime_dir.join("reminder-runtime-brain-sidecar.py"),
+                claude_script: runtime_dir.join("reminder-runtime-claude-marker.sh"),
+                dummy_model,
+                brain_count: home.join(".murmur-reminder-brain-count"),
+                race_armed: home.join(".murmur-reminder-race-armed"),
+                race_started: home.join(".murmur-reminder-race-started"),
+                race_release: home.join(".murmur-reminder-race-release"),
+                race_done: home.join(".murmur-reminder-race-done"),
+                claude_called: home.join(".murmur-reminder-claude-called"),
+                runtime_dir,
+            })
+        }
+    }
+
+    fn verify_isolated_runtime() -> Result<(), AppError> {
+        let _ = verified_home()?;
+        let runtime = std::env::var_os("MURMUR_HARNESS_RUNTIME_DIR")
+            .map(PathBuf::from)
+            .ok_or_else(|| AppError::Unavailable("runtime probe directory is absent".into()))?;
+        if !runtime.is_absolute() || !runtime.is_dir() {
+            return Err(AppError::Unavailable(
+                "runtime probe directory is not an absolute runner directory".into(),
+            ));
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let metadata = std::fs::symlink_metadata(&runtime).map_err(|_| {
+                AppError::Unavailable("runtime probe directory metadata is unavailable".into())
+            })?;
+            if metadata.file_type().is_symlink() || metadata.permissions().mode() & 0o077 != 0 {
+                return Err(AppError::Unavailable(
+                    "runtime probe directory is not private".into(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn verified_home() -> Result<PathBuf, AppError> {
+        let home = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .ok_or_else(|| AppError::Unavailable("runtime probe HOME is unavailable".into()))?;
+        let parent_name = home
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str())
+            .unwrap_or_default();
+        if home.file_name().and_then(|name| name.to_str()) != Some("home")
+            || !parent_name.starts_with("murmur-boot-")
+        {
+            return Err(AppError::Unavailable(
+                "runtime probe is outside its isolated HOME".into(),
+            ));
+        }
+        Ok(home)
+    }
+
+    fn probe_challenge(paths: &ProbePaths) -> Result<RuntimeChallenge, AppError> {
+        let challenge: RuntimeChallenge = read_json(&paths.challenge)?;
+        let valid_run_id = challenge.run_id.starts_with("boot-")
+            && challenge.run_id.len() <= 128
+            && challenge
+                .run_id
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-');
+        if challenge.schema_version != 1
+            || challenge.task_id != REMINDER_RUNTIME_PROBE_TASK_ID
+            || !valid_run_id
+            || paths.runtime_dir.file_name().and_then(|name| name.to_str())
+                != Some(challenge.run_id.as_str())
+            || challenge.runner_pid == 0
+            || !valid_lowercase_hex(&challenge.runner_nonce, 64)
+            || !valid_lowercase_hex(&challenge.binary_sha256, 64)
+            || !valid_lowercase_hex(&challenge.network_profile_sha256, 64)
+            || !valid_lowercase_hex(&challenge.runner_source_sha256, 64)
+            || !valid_lowercase_hex(&challenge.task_contract_sha256, 64)
+            || !valid_lowercase_hex(&challenge.git_head, 40)
+            || challenge.started_at.len() < 20
+            || challenge.started_at.len() > 40
+            || !challenge.started_at.ends_with('Z')
+            || !challenge.started_at.is_ascii()
+        {
+            return Err(AppError::Unavailable(
+                "runner challenge is stale or invalid".into(),
+            ));
+        }
+        Ok(challenge)
+    }
+
+    fn valid_lowercase_hex(value: &str, len: usize) -> bool {
+        value.len() == len
+            && value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    }
+
+    fn current_executable_sha256() -> Result<String, AppError> {
+        let path = std::env::current_exe()
+            .map_err(|_| AppError::Unavailable("running executable path is unavailable".into()))?;
+        let before = std::fs::symlink_metadata(&path).map_err(|_| {
+            AppError::Unavailable("running executable metadata is unavailable".into())
+        })?;
+        if before.file_type().is_symlink() || !before.file_type().is_file() || before.len() == 0 {
+            return Err(AppError::Unavailable(
+                "running executable is not a regular file".into(),
+            ));
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            if before.nlink() != 1 {
+                return Err(AppError::Unavailable(
+                    "running executable has an unexpected link count".into(),
+                ));
+            }
+        }
+        let mut file = File::open(&path)
+            .map_err(|_| AppError::Unavailable("running executable open failed".into()))?;
+        let opened = file
+            .metadata()
+            .map_err(|_| AppError::Unavailable("running executable metadata changed".into()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            if opened.dev() != before.dev()
+                || opened.ino() != before.ino()
+                || opened.len() != before.len()
+            {
+                return Err(AppError::Unavailable(
+                    "running executable changed while opening".into(),
+                ));
+            }
+        }
+        #[cfg(not(unix))]
+        if opened.len() != before.len() {
+            return Err(AppError::Unavailable(
+                "running executable changed while opening".into(),
+            ));
+        }
+        let mut hasher = Sha256::new();
+        let mut buffer = [0_u8; 64 * 1024];
+        loop {
+            let read = file
+                .read(&mut buffer)
+                .map_err(|_| AppError::Unavailable("running executable read failed".into()))?;
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+        }
+        let after = std::fs::symlink_metadata(&path)
+            .map_err(|_| AppError::Unavailable("running executable metadata disappeared".into()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            if after.file_type().is_symlink()
+                || !after.file_type().is_file()
+                || after.dev() != before.dev()
+                || after.ino() != before.ino()
+                || after.len() != before.len()
+            {
+                return Err(AppError::Unavailable(
+                    "running executable changed while hashing".into(),
+                ));
+            }
+        }
+        #[cfg(not(unix))]
+        if !after.file_type().is_file() || after.len() != before.len() {
+            return Err(AppError::Unavailable(
+                "running executable changed while hashing".into(),
+            ));
+        }
+        Ok(format!("{:x}", hasher.finalize()))
+    }
+
+    #[cfg(unix)]
+    fn configure_witness_fd() -> Result<(), AppError> {
+        use std::os::fd::RawFd;
+
+        unsafe extern "C" {
+            fn fcntl(fd: RawFd, command: i32, ...) -> i32;
+        }
+        const F_GETFD: i32 = 1;
+        const F_SETFD: i32 = 2;
+        const FD_CLOEXEC: i32 = 1;
+
+        let phase_nonce = std::env::var("MURMUR_HARNESS_PHASE_TWO_NONCE").ok();
+        let descriptor = std::env::var("MURMUR_HARNESS_WITNESS_FD").ok();
+        match (phase_nonce, descriptor) {
+            (None, None) => Ok(()),
+            (Some(nonce), Some(raw)) if valid_lowercase_hex(&nonce, 64) => {
+                let fd = raw.parse::<RawFd>().map_err(|_| {
+                    AppError::Unavailable("runtime witness descriptor is invalid".into())
+                })?;
+                if fd <= 2 {
+                    return Err(AppError::Unavailable(
+                        "runtime witness descriptor is unsafe".into(),
+                    ));
+                }
+                // SAFETY: the runner deliberately passes this open descriptor to process two.
+                let flags = unsafe { fcntl(fd, F_GETFD) };
+                if flags < 0 || unsafe { fcntl(fd, F_SETFD, flags | FD_CLOEXEC) } < 0 {
+                    return Err(AppError::Unavailable(
+                        "runtime witness descriptor cannot be protected".into(),
+                    ));
+                }
+                Ok(())
+            }
+            _ => Err(AppError::Unavailable(
+                "runtime witness descriptor is not phase-bound".into(),
+            )),
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn configure_witness_fd() -> Result<(), AppError> {
+        if std::env::var_os("MURMUR_HARNESS_PHASE_TWO_NONCE").is_some()
+            || std::env::var_os("MURMUR_HARNESS_WITNESS_FD").is_some()
+        {
+            return Err(AppError::Unavailable(
+                "runtime witness descriptor requires Unix".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn write_witness_pipe(witness: &RuntimeWitness) -> Result<(), AppError> {
+        use std::os::fd::{FromRawFd, RawFd};
+
+        let fd = std::env::var("MURMUR_HARNESS_WITNESS_FD")
+            .map_err(|_| AppError::Unavailable("runtime witness descriptor is absent".into()))?
+            .parse::<RawFd>()
+            .map_err(|_| AppError::Unavailable("runtime witness descriptor is invalid".into()))?;
+        if fd <= 2 {
+            return Err(AppError::Unavailable(
+                "runtime witness descriptor is unsafe".into(),
+            ));
+        }
+        let mut bytes = serde_json::to_vec(witness)
+            .map_err(|_| AppError::Unavailable("runtime witness encoding failed".into()))?;
+        bytes.push(b'\n');
+        if bytes.len() as u64 > MAX_RECEIPT_BYTES {
+            return Err(AppError::Unavailable(
+                "runtime witness exceeds its size bound".into(),
+            ));
+        }
+        // Consume the descriptor exactly once. Removing the environment binding first makes a
+        // duplicate IPC call fail closed even if the OS later reuses the descriptor number.
+        std::env::remove_var("MURMUR_HARNESS_WITNESS_FD");
+        // SAFETY: process two exclusively owns the inherited write end supplied by the runner.
+        let mut pipe = unsafe { File::from_raw_fd(fd) };
+        pipe.write_all(&bytes)
+            .and_then(|_| pipe.flush())
+            .map_err(|_| AppError::Unavailable("runtime witness pipe write failed".into()))
+    }
+
+    #[cfg(not(unix))]
+    fn write_witness_pipe(_witness: &RuntimeWitness) -> Result<(), AppError> {
+        Err(AppError::Unavailable(
+            "runtime witness pipe requires Unix".into(),
+        ))
+    }
+
+    fn write_probe_executables(paths: &ProbePaths) -> Result<(), AppError> {
+        let sidecar = r#"#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import sys
+import time
+
+home = pathlib.Path(os.environ["HOME"])
+count = home / ".murmur-reminder-brain-count"
+armed = home / ".murmur-reminder-race-armed"
+started = home / ".murmur-reminder-race-started"
+release = home / ".murmur-reminder-race-release"
+done = home / ".murmur-reminder-race-done"
+
+def read_object(path):
+    with path.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise ValueError("race receipt is not an object")
+    return value
+
+def create_object(path, value):
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        if os.write(descriptor, encoded) != len(encoded):
+            raise OSError("short race receipt write")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+print(json.dumps({"type": "ready", "model_id": "runtime-probe-local"}), flush=True)
+for line in sys.stdin:
+    try:
+        request = json.loads(line)
+    except json.JSONDecodeError:
+        sys.exit(72)
+    request_id = request.get("id") if isinstance(request, dict) else None
+    if (
+        not isinstance(request, dict)
+        or request.get("type") != "generate"
+        or not isinstance(request_id, int)
+        or isinstance(request_id, bool)
+        or request_id <= 0
+    ):
+        sys.exit(73)
+    with count.open("a", encoding="ascii") as handle:
+        handle.write("x\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    race_event = None
+    if armed.exists():
+        arm = read_object(armed)
+        if (
+            set(arm) != {"runnerNonce", "raceNonce", "requestId"}
+            or not isinstance(arm.get("runnerNonce"), str)
+            or not isinstance(arm.get("raceNonce"), str)
+            or arm.get("requestId") != 0
+        ):
+            sys.exit(74)
+        race_event = {
+            "runnerNonce": arm["runnerNonce"],
+            "raceNonce": arm["raceNonce"],
+            "requestId": request_id,
+        }
+        create_object(started, race_event)
+        while True:
+            if release.exists():
+                if read_object(release) != race_event:
+                    sys.exit(75)
+                break
+            time.sleep(0.01)
+    response = json.dumps(
+        {
+            "type": "done",
+            "id": request_id,
+            "text": json.dumps({"keepIds": ["c1"]}, separators=(",", ":")),
+        },
+        separators=(",", ":"),
+    )
+    if race_event is not None:
+        create_object(done, race_event)
+    print(
+        response,
+        flush=True,
+    )
+"#;
+        let claude = r#"#!/bin/sh
+: > "$HOME/.murmur-reminder-claude-called"
+exit 71
+"#;
+        write_executable(&paths.sidecar_script, sidecar.as_bytes())?;
+        write_executable(&paths.claude_script, claude.as_bytes())
+    }
+
+    #[cfg(unix)]
+    fn write_executable(path: &Path, bytes: &[u8]) -> Result<(), AppError> {
+        use std::os::unix::fs::PermissionsExt;
+        if path.exists() {
+            let existing = read_bounded_regular(path)?;
+            let metadata = std::fs::symlink_metadata(path)
+                .map_err(|_| AppError::Unavailable("runtime executable metadata failed".into()))?;
+            if existing != bytes || metadata.permissions().mode() & 0o777 != 0o700 {
+                return Err(AppError::Unavailable(
+                    "runtime executable changed between generations".into(),
+                ));
+            }
+            return Ok(());
+        }
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(path)
+            .map_err(|_| AppError::Unavailable("runtime executable create failed".into()))?;
+        file.write_all(bytes)
+            .and_then(|_| file.sync_all())
+            .map_err(|_| AppError::Unavailable("runtime executable write failed".into()))?;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+            .map_err(|_| AppError::Unavailable("runtime executable chmod failed".into()))
+    }
+
+    #[cfg(not(unix))]
+    fn write_executable(_path: &Path, _bytes: &[u8]) -> Result<(), AppError> {
+        Err(AppError::Unavailable(
+            "runtime executable probe requires Unix".into(),
+        ))
+    }
+
+    fn ensure_dummy_model(paths: &ProbePaths) -> Result<(), AppError> {
+        if paths.dummy_model.is_file() {
+            return Ok(());
+        }
+        if let Some(parent) = paths.dummy_model.parent() {
+            std::fs::create_dir_all(parent).map_err(|_| {
+                AppError::Unavailable("runtime model directory could not be created".into())
+            })?;
+        }
+        std::fs::write(&paths.dummy_model, b"GGUF").map_err(|_| {
+            AppError::Unavailable("runtime local model fixture could not be written".into())
+        })
+    }
+
+    fn brain_generate_count(paths: &ProbePaths) -> Result<usize, AppError> {
+        match std::fs::read_to_string(&paths.brain_count) {
+            Ok(value) => Ok(value.lines().filter(|line| *line == "x").count()),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(0),
+            Err(_) => Err(AppError::Unavailable(
+                "runtime local generation counter is unreadable".into(),
+            )),
+        }
+    }
+
+    fn remove_file_if_present(path: &Path) -> Result<(), AppError> {
+        match std::fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+            Err(_) => Err(AppError::Unavailable(
+                "runtime marker cleanup failed".into(),
+            )),
+        }
+    }
+
+    fn read_bounded_regular(path: &Path) -> Result<Vec<u8>, AppError> {
+        let before = std::fs::symlink_metadata(path)
+            .map_err(|_| AppError::Unavailable("runtime receipt metadata failed".into()))?;
+        if !before.file_type().is_file() || before.len() > MAX_RECEIPT_BYTES {
+            return Err(AppError::Unavailable(
+                "runtime receipt is not a bounded regular file".into(),
+            ));
+        }
+        #[cfg(unix)]
+        let file = {
+            use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+            #[cfg(target_os = "macos")]
+            const O_NOFOLLOW: i32 = 0x0000_0100;
+            #[cfg(target_os = "linux")]
+            const O_NOFOLLOW: i32 = 0x0002_0000;
+            #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+            const O_NOFOLLOW: i32 = 0;
+            if before.nlink() != 1 {
+                return Err(AppError::Unavailable(
+                    "runtime receipt has an unsafe link count".into(),
+                ));
+            }
+            OpenOptions::new()
+                .read(true)
+                .custom_flags(O_NOFOLLOW)
+                .open(path)
+                .map_err(|_| AppError::Unavailable("runtime receipt open failed".into()))?
+        };
+        #[cfg(not(unix))]
+        let file = File::open(path)
+            .map_err(|_| AppError::Unavailable("runtime receipt open failed".into()))?;
+        let after = file
+            .metadata()
+            .map_err(|_| AppError::Unavailable("runtime receipt metadata changed".into()))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            if !after.file_type().is_file()
+                || after.nlink() != 1
+                || after.dev() != before.dev()
+                || after.ino() != before.ino()
+                || after.len() > MAX_RECEIPT_BYTES
+            {
+                return Err(AppError::Unavailable(
+                    "runtime receipt changed while opening".into(),
+                ));
+            }
+        }
+        #[cfg(not(unix))]
+        if !after.file_type().is_file() || after.len() > MAX_RECEIPT_BYTES {
+            return Err(AppError::Unavailable(
+                "runtime receipt changed while opening".into(),
+            ));
+        }
+        let mut bytes = Vec::with_capacity(after.len() as usize);
+        file.take(MAX_RECEIPT_BYTES + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|_| AppError::Unavailable("runtime receipt read failed".into()))?;
+        if bytes.len() as u64 > MAX_RECEIPT_BYTES {
+            return Err(AppError::Unavailable(
+                "runtime receipt exceeds its size bound".into(),
+            ));
+        }
+        Ok(bytes)
+    }
+
+    fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T, AppError> {
+        let bytes = read_bounded_regular(path)?;
+        serde_json::from_slice(&bytes)
+            .map_err(|_| AppError::Unavailable("runtime receipt is invalid".into()))
+    }
+
+    fn write_json_atomic(path: &Path, value: &impl Serialize) -> Result<(), AppError> {
+        let parent = path
+            .parent()
+            .ok_or_else(|| AppError::Unavailable("runtime receipt has no parent".into()))?;
+        if !parent.is_dir() || path.exists() {
+            return Err(AppError::Unavailable(
+                "runtime receipt target is absent or already claimed".into(),
+            ));
+        }
+        let bytes = serde_json::to_vec(value)
+            .map_err(|_| AppError::Unavailable("runtime receipt encoding failed".into()))?;
+        if bytes.len() as u64 > MAX_RECEIPT_BYTES {
+            return Err(AppError::Unavailable(
+                "runtime receipt exceeds its size bound".into(),
+            ));
+        }
+        let temp = parent.join(format!(
+            ".{}.{}.{}.tmp",
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("receipt"),
+            std::process::id(),
+            uuid::Uuid::new_v4().simple()
+        ));
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temp)
+            .map_err(|_| AppError::Unavailable("runtime receipt create failed".into()))?;
+        file.write_all(&bytes)
+            .and_then(|_| file.sync_all())
+            .map_err(|_| AppError::Unavailable("runtime receipt sync failed".into()))?;
+        drop(file);
+        let promoted = std::fs::hard_link(&temp, path);
+        let cleanup = std::fs::remove_file(&temp);
+        promoted.map_err(|_| AppError::Unavailable("runtime receipt promote failed".into()))?;
+        cleanup.map_err(|_| AppError::Unavailable("runtime receipt cleanup failed".into()))?;
+        File::open(parent)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|_| AppError::Unavailable("runtime receipt directory sync failed".into()))
+    }
+
+    fn start_mcp_after_probe(app: &AppHandle) {
+        let state = app.state::<AppState>();
+        let require_token = state
+            .config
+            .lock()
+            .map(|config| config.mcp_require_token)
+            .unwrap_or(true);
+        crate::mcp::spawn(app.clone(), require_token);
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::validate_proxy_endpoint;
+
+        #[test]
+        fn runtime_proxy_requires_loopback_and_per_run_basic_auth() {
+            let token = "a".repeat(64);
+            assert!(validate_proxy_endpoint(&format!(
+                "http://murmur-harness:{token}@127.0.0.1:49152"
+            ))
+            .is_ok());
+
+            for invalid in [
+                "http://127.0.0.1:49152",
+                "http://murmur-harness:aaaaaaaa@127.0.0.1:49152",
+                "http://murmur-harness:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@localhost:49152",
+                "https://murmur-harness:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@127.0.0.1:49152",
+                "http://murmur-harness:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa@127.0.0.1:49152/path",
+            ] {
+                assert!(validate_proxy_endpoint(invalid).is_err(), "{invalid}");
+            }
+        }
+    }
+}
+
+/// Serialize a source-content-bearing command result while the same coarse lock lifecycle guard
+/// still protects the reads that built it. Tauri's blanket `IpcResponse` implementation normally
+/// calls `serde_json::to_string` only *after* the command returns; returning an already encoded
+/// `Response::Json` closes that post-return relock window without changing the JS payload shape.
+fn lifecycle_reminder_response<T: Serialize>(
+    state: &AppState,
+    build: impl FnOnce() -> Result<T, AppError>,
+) -> Result<Response, AppError> {
+    let lifecycle = super::lifecycle_guard(state);
+    let payload = build()?;
+    serialize_reminder_response_under_lifecycle(&lifecycle, &payload)
+}
+
+fn serialize_reminder_response_under_lifecycle<T: Serialize>(
+    _lifecycle: &std::sync::MutexGuard<'_, ()>,
+    payload: &T,
+) -> Result<Response, AppError> {
+    serde_json::to_string(payload)
+        .map(Response::new)
+        .map_err(|_| AppError::Unavailable("reminder response encoding failed".into()))
+}
+
+#[tauri::command]
+pub fn list_reminders(app: AppHandle, state: State<'_, AppState>) -> Result<Response, AppError> {
+    lifecycle_reminder_response(state.inner(), || {
+        let now = chrono::Utc::now().timestamp_millis();
+        let inserted = state.db.materialize_due_reminders(now)?;
+        let snapshot = reminders_snapshot_at(state.inner(), now)?;
+        if inserted > 0 {
+            crate::events::emit_reminders_updated(&app, snapshot.due_inbox_count);
+        }
+        Ok(snapshot)
+    })
+}
+
+#[tauri::command]
+pub fn get_reminder_summary(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> Result<ReminderSummary, AppError> {
+    let _lifecycle = super::lifecycle_guard(state.inner());
+    let inserted = state
+        .db
+        .materialize_due_reminders(chrono::Utc::now().timestamp_millis())?;
+    let summary = ReminderSummary {
+        due_inbox_count: state.db.due_reminder_count()?,
+    };
+    if inserted > 0 {
+        crate::events::emit_reminders_updated(&app, summary.due_inbox_count);
+    }
+    Ok(summary)
+}
+
+#[tauri::command]
+pub fn create_reminder(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    draft: ReminderDraft,
+) -> Result<Response, AppError> {
+    lifecycle_reminder_response(state.inner(), || {
+        let draft = validate_draft(draft)?;
+        require_sources_visible(state.inner(), &draft.sources)?;
+        let id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now().timestamp_millis();
+        state
+            .db
+            .create_reminder(&id, &draft, ReminderOrigin::Manual, now)?;
+        let stored = state
+            .db
+            .get_stored_reminder(&id)?
+            .ok_or_else(|| AppError::Storage("new reminder row disappeared".into()))?;
+        let view = reminder_view(state.inner(), stored)?;
+        state.db.materialize_due_reminders(now)?;
+        emit_reminder_count(&app, state.inner());
+        Ok(view)
+    })
+}
+
+#[tauri::command]
+pub fn update_reminder(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    reminder_id: String,
+    draft: ReminderDraft,
+) -> Result<Response, AppError> {
+    lifecycle_reminder_response(state.inner(), || {
+        validate_opaque_id(&reminder_id, "reminder")?;
+        let mut draft = validate_draft(draft)?;
+        require_sources_visible(state.inner(), &draft.sources)?;
+        let existing = state
+            .db
+            .get_stored_reminder(&reminder_id)?
+            .ok_or_else(|| AppError::InvalidArg("unknown reminder id".into()))?;
+        preserve_hidden_sources_on_update(state.inner(), &existing.sources, &mut draft.sources)?;
+        let now = chrono::Utc::now().timestamp_millis();
+        if !state.db.update_reminder(&reminder_id, &draft, now)? {
+            return Err(AppError::InvalidArg("unknown reminder id".into()));
+        }
+        let stored = state
+            .db
+            .get_stored_reminder(&reminder_id)?
+            .ok_or_else(|| AppError::Storage("updated reminder row disappeared".into()))?;
+        let view = reminder_view(state.inner(), stored)?;
+        state.db.materialize_due_reminders(now)?;
+        emit_reminder_count(&app, state.inner());
+        Ok(view)
+    })
+}
+
+#[tauri::command]
+pub fn delete_reminder(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    reminder_id: String,
+) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state.inner());
+    validate_opaque_id(&reminder_id, "reminder")?;
+    if !state.db.delete_reminder(&reminder_id)? {
+        return Err(AppError::InvalidArg("unknown reminder id".into()));
+    }
+    emit_reminder_count(&app, state.inner());
+    Ok(())
+}
+
+#[tauri::command]
+pub fn complete_reminder(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    reminder_id: String,
+    expected_due_at: i64,
+) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state.inner());
+    validate_opaque_id(&reminder_id, "reminder")?;
+    validate_due_at(expected_due_at)?;
+    let now = chrono::Utc::now().timestamp_millis();
+    // False is an idempotent replay (or a stale UI schedule generation), never a second advance.
+    let _ = state
+        .db
+        .complete_reminder(&reminder_id, expected_due_at, now)?;
+    // A very short recurrence can already be due after advancement; materialize it in the same
+    // user action rather than waiting for the next scheduler tick.
+    state.db.materialize_due_reminders(now)?;
+    emit_reminder_count(&app, state.inner());
+    Ok(())
+}
+
+#[tauri::command]
+pub fn dismiss_reminder_occurrence(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    occurrence_id: String,
+) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state.inner());
+    validate_opaque_id(&occurrence_id, "occurrence")?;
+    let _ = state
+        .db
+        .dismiss_reminder_occurrence(&occurrence_id, chrono::Utc::now().timestamp_millis())?;
+    emit_reminder_count(&app, state.inner());
+    Ok(())
+}
+
+/// Audit one currently visible canonical source for possible reminders. Deterministic candidates
+/// are prepared locally; the optional light-model call may only select their ids and never creates
+/// a reminder. The source is re-gated and re-hashed under lifecycle immediately before any cache
+/// rows cross IPC or any derived rows are replaced.
+#[tauri::command]
+pub async fn audit_reminder_suggestions(
+    state: State<'_, AppState>,
+    source_kind: String,
+    source_id: String,
+) -> Result<Response, AppError> {
+    #[cfg(debug_assertions)]
+    let record_locked_outcome = reminder_runtime_probe_requested()
+        && source_kind == "meeting"
+        && source_id == "runtime-probe-meeting-5-20260729";
+    let reasoner = state.reasoner.light();
+    let result = audit_reminder_suggestions_with_response(
+        state.inner(),
+        source_kind,
+        source_id,
+        reasoner,
+        |lifecycle, views| serialize_reminder_response_under_lifecycle(lifecycle, &views),
+    )
+    .await;
+    #[cfg(debug_assertions)]
+    if record_locked_outcome && matches!(&result, Err(AppError::Locked(_))) {
+        runtime_probe::record_locked_audit_outcome()?;
+    }
+    result
+}
+
+#[cfg(test)]
+async fn audit_reminder_suggestions_inner(
+    state: &AppState,
+    source_kind: String,
+    source_id: String,
+    reasoner: Arc<dyn LocalReasoner>,
+) -> Result<Vec<ReminderSuggestionView>, AppError> {
+    audit_reminder_suggestions_with_response(state, source_kind, source_id, reasoner, |_, views| {
+        Ok(views)
+    })
+    .await
+}
+
+async fn audit_reminder_suggestions_with_response<R>(
+    state: &AppState,
+    source_kind: String,
+    source_id: String,
+    reasoner: Arc<dyn LocalReasoner>,
+    finish: impl FnOnce(
+        &std::sync::MutexGuard<'_, ()>,
+        Vec<ReminderSuggestionView>,
+    ) -> Result<R, AppError>,
+) -> Result<R, AppError> {
+    validate_reminder_audit_source(&source_kind, &source_id)?;
+    let (snapshot, source_content) =
+        capture_reminder_audit_source(state, &source_kind, &source_id)?;
+    let expected_hash = reminder_audit_source_hash(&source_content);
+    let engine_id = reasoner.id().to_string();
+
+    // Cache reads return source-derived rows, so they stay inside the same lifecycle interval as
+    // snapshot revalidation, exact canonical re-read/hash, and live source-metadata resolution.
+    {
+        let lifecycle = super::lifecycle_guard(state);
+        let current = current_reminder_audit_source_under_lifecycle(
+            state,
+            &source_kind,
+            &source_id,
+            &snapshot,
+        )?;
+        require_reminder_audit_hash(&current, &expected_hash)?;
+        if state.db.reminder_audit_cache_matches(
+            &source_kind,
+            &source_id,
+            &expected_hash,
+            &engine_id,
+        )? {
+            let rows = state.db.list_pending_reminder_suggestions(
+                &source_kind,
+                &source_id,
+                &expected_hash,
+                &engine_id,
+                MAX_REMINDER_AUDIT_ROWS,
+            )?;
+            return finish(&lifecycle, reminder_suggestion_views(rows, &current.source));
+        }
+    }
+
+    // The hash above covers ALL exact canonical parts. Candidate extraction gets a separately
+    // bounded, complete-line note prefix and ordered segment prefix so neither local tokenization
+    // nor the tiny selector prompt scales with an arbitrarily long meeting.
+    let candidate_markdown = reminder_candidate_markdown(&source_content);
+    let candidate_segments = bounded_audit_segments(&source_content.segments);
+    drop(source_content);
+    let transcript_candidates = crate::summarize::recall_net::possible_missed_item_candidates(
+        &candidate_markdown,
+        &candidate_segments,
+    );
+    let candidates =
+        crate::reminder_audit::build_candidates(&candidate_markdown, &transcript_candidates);
+    let candidates = select_reminder_audit_candidates(reasoner, candidates).await?;
+
+    let lifecycle = super::lifecycle_guard(state);
+    let current =
+        current_reminder_audit_source_under_lifecycle(state, &source_kind, &source_id, &snapshot)?;
+    require_reminder_audit_hash(&current, &expected_hash)?;
+    if !state.db.replace_reminder_audit_results(
+        &source_kind,
+        &source_id,
+        &expected_hash,
+        &engine_id,
+        &candidates,
+        chrono::Utc::now().timestamp_millis(),
+    )? {
+        return Err(AppError::InvalidArg(
+            "reminder audit source changed — retry the audit".into(),
+        ));
+    }
+    let rows = state.db.list_pending_reminder_suggestions(
+        &source_kind,
+        &source_id,
+        &expected_hash,
+        &engine_id,
+        MAX_REMINDER_AUDIT_ROWS,
+    )?;
+    finish(&lifecycle, reminder_suggestion_views(rows, &current.source))
+}
+
+/// Promote one still-current suggestion into a canonical Smart reminder. The derived row is the
+/// one-shot capability: replay cannot insert a second reminder, while sibling suggestions from the
+/// same audit remain independently promotable.
+#[tauri::command]
+pub fn accept_reminder_suggestion(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    suggestion_id: String,
+    draft: ReminderDraft,
+) -> Result<Response, AppError> {
+    accept_reminder_suggestion_with_postwork(
+        state.inner(),
+        suggestion_id,
+        draft,
+        |state| {
+            state
+                .db
+                .materialize_due_reminders(chrono::Utc::now().timestamp_millis())?;
+            emit_reminder_count(&app, state);
+            Ok(())
+        },
+        |lifecycle, view| serialize_reminder_response_under_lifecycle(lifecycle, &view),
+    )
+}
+
+#[cfg(test)]
+fn accept_reminder_suggestion_inner(
+    state: &AppState,
+    suggestion_id: String,
+    draft: ReminderDraft,
+) -> Result<ReminderView, AppError> {
+    accept_reminder_suggestion_with_postwork(
+        state,
+        suggestion_id,
+        draft,
+        |_| Ok(()),
+        |_, view| Ok(view),
+    )
+}
+
+/// Keep the source-title-bearing response and every fallible command post-step inside one
+/// visibility lifecycle interval. A concurrent relock must not blank/revoke the source after the
+/// view is built but before the command has finished materializing, publishing its new count, and
+/// serializing the final IPC body.
+fn accept_reminder_suggestion_with_postwork<R>(
+    state: &AppState,
+    suggestion_id: String,
+    draft: ReminderDraft,
+    postwork: impl FnOnce(&AppState) -> Result<(), AppError>,
+    finish: impl FnOnce(&std::sync::MutexGuard<'_, ()>, ReminderView) -> Result<R, AppError>,
+) -> Result<R, AppError> {
+    let lifecycle = super::lifecycle_guard(state);
+    let view = accept_reminder_suggestion_under_lifecycle(state, suggestion_id, draft)?;
+    postwork(state)?;
+    finish(&lifecycle, view)
+}
+
+fn accept_reminder_suggestion_under_lifecycle(
+    state: &AppState,
+    suggestion_id: String,
+    draft: ReminderDraft,
+) -> Result<ReminderView, AppError> {
+    validate_opaque_id(&suggestion_id, "reminder suggestion")?;
+    let suggestion = state
+        .db
+        .get_pending_reminder_suggestion_gate_anchor(&suggestion_id)?
+        .ok_or_else(|| AppError::InvalidArg("unknown reminder suggestion".into()))?;
+
+    let current = read_reminder_audit_source_under_lifecycle(
+        state,
+        &suggestion.source_kind,
+        &suggestion.source_id,
+    )?;
+    let current_hash = reminder_audit_source_hash(&current);
+    let draft = validate_draft(draft)?;
+    require_smart_source_capacity(
+        &draft.sources,
+        &suggestion.source_kind,
+        &suggestion.source_id,
+    )?;
+    require_sources_visible(state, &draft.sources)?;
+
+    let reminder_id = uuid::Uuid::new_v4().to_string();
+    let now = chrono::Utc::now().timestamp_millis();
+    if !state.db.promote_pending_reminder_suggestion(
+        &suggestion.id,
+        &suggestion.source_kind,
+        &suggestion.source_id,
+        &current_hash,
+        &reminder_id,
+        &draft,
+        now,
+    )? {
+        return Err(AppError::InvalidArg(
+            "reminder suggestion is stale or was already accepted".into(),
+        ));
+    }
+    let stored = state
+        .db
+        .get_stored_reminder(&reminder_id)?
+        .ok_or_else(|| AppError::Storage("promoted reminder row disappeared".into()))?;
+    reminder_view(state, stored)
+}
+
+/// Dismiss one still-current derived row. Editing, moving, sealing, or relocking the source before
+/// this point rejects the request; the command never acts on a stale suggestion capability.
+#[tauri::command]
+pub fn dismiss_reminder_suggestion(
+    state: State<'_, AppState>,
+    suggestion_id: String,
+) -> Result<(), AppError> {
+    validate_opaque_id(&suggestion_id, "reminder suggestion")?;
+    let suggestion = state
+        .db
+        .get_pending_reminder_suggestion_gate_anchor(&suggestion_id)?
+        .ok_or_else(|| AppError::InvalidArg("unknown reminder suggestion".into()))?;
+
+    let _lifecycle = super::lifecycle_guard(state.inner());
+    let current = read_reminder_audit_source_under_lifecycle(
+        state.inner(),
+        &suggestion.source_kind,
+        &suggestion.source_id,
+    )?;
+    let current_hash = reminder_audit_source_hash(&current);
+    if !state.db.dismiss_pending_reminder_suggestion(
+        &suggestion.id,
+        &suggestion.source_kind,
+        &suggestion.source_id,
+        &current_hash,
+    )? {
+        return Err(AppError::InvalidArg(
+            "reminder suggestion is stale or already dismissed".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Start the app-process reminder workers. The durable due scheduler retains its 15-second cadence;
+/// a separate short worker drains content-free canonical-source invalidations for Smart cards.
+/// Neither worker makes a delivery claim while the process is fully quit.
+pub(crate) fn spawn_reminder_scheduler(app: AppHandle) {
+    let invalidation_app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        loop {
+            if let Some(state) = invalidation_app.try_state::<AppState>() {
+                match state
+                    .db
+                    .peek_reminder_source_invalidations(REMINDER_SOURCE_INVALIDATION_BATCH)
+                {
+                    Ok(invalidations) => {
+                        for invalidation in invalidations {
+                            if crate::events::emit_reminder_source_updated(
+                                &invalidation_app,
+                                &invalidation.kind,
+                                &invalidation.id,
+                            ) {
+                                if let Err(error) =
+                                    state.db.ack_reminder_source_invalidation(&invalidation)
+                                {
+                                    tracing::warn!(
+                                        target: "reminders",
+                                        error = %error,
+                                        "reminder source invalidation acknowledgement failed"
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            target: "reminders",
+                            error = %error,
+                            "reminder source invalidation drain failed"
+                        );
+                    }
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(
+                REMINDER_SOURCE_INVALIDATION_TICK_MS,
+            ))
+            .await;
+        }
+    });
+
+    tauri::async_runtime::spawn(async move {
+        loop {
+            if let Some(state) = app.try_state::<AppState>() {
+                let now = chrono::Utc::now().timestamp_millis();
+                match state.db.materialize_due_reminders(now) {
+                    Ok(inserted) if inserted > 0 => emit_reminder_count(&app, state.inner()),
+                    Ok(_) => {}
+                    Err(error) => {
+                        tracing::warn!(
+                            target: "reminders",
+                            error = %error,
+                            "due reminder materialization failed"
+                        );
+                    }
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(REMINDER_SCHEDULER_TICK_SECS)).await;
+        }
+    });
+}
+
+fn reminders_snapshot_at(state: &AppState, _now: i64) -> Result<RemindersSnapshot, AppError> {
+    let stored = state.db.list_stored_reminders()?;
+    let occurrences = state.db.unread_reminder_occurrences()?;
+    let inbox_reminder_ids = occurrences
+        .iter()
+        .map(|occurrence| occurrence.reminder_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut views = HashMap::<String, ReminderView>::new();
+    let mut upcoming = Vec::new();
+    let mut completed = Vec::new();
+    for row in stored {
+        let view = reminder_view(state, row)?;
+        match view.state {
+            ReminderState::Active if !inbox_reminder_ids.contains(view.id.as_str()) => {
+                upcoming.push(view.clone());
+            }
+            ReminderState::Active => {}
+            ReminderState::Completed => completed.push(view.clone()),
+        }
+        views.insert(view.id.clone(), view);
+    }
+    completed.sort_by(|a, b| {
+        b.completed_at
+            .cmp(&a.completed_at)
+            .then_with(|| b.updated_at.cmp(&a.updated_at))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    let inbox = occurrences
+        .into_iter()
+        .filter_map(|occurrence| {
+            views
+                .get(&occurrence.reminder_id)
+                .cloned()
+                .map(|reminder| ReminderInboxItem {
+                    occurrence_id: occurrence.id,
+                    due_at: occurrence.due_at,
+                    reminder,
+                })
+        })
+        .collect::<Vec<_>>();
+    Ok(RemindersSnapshot {
+        due_inbox_count: inbox.len() as u64,
+        inbox,
+        upcoming,
+        completed,
+    })
+}
+
+fn reminder_view(state: &AppState, stored: StoredReminder) -> Result<ReminderView, AppError> {
+    let sources = visible_source_views(state, &stored.sources)?;
+    Ok(ReminderView {
+        id: stored.id,
+        title: stored.title,
+        details: stored.details,
+        due_at: stored.due_at,
+        repeat_every: stored.repeat_every,
+        repeat_unit: stored.repeat_unit,
+        state: stored.state,
+        origin: stored.origin,
+        created_at: stored.created_at,
+        updated_at: stored.updated_at,
+        completed_at: stored.completed_at,
+        sources,
+    })
+}
+
+enum ReminderAuditSourceSnapshot {
+    Meeting(super::MeetingContentSnapshot),
+    Note(super::DocumentContentSnapshot),
+}
+
+struct ReminderAuditSourceContent {
+    markdown: String,
+    manual_notes: String,
+    segments: Vec<Segment>,
+    source: ReminderSourceView,
+}
+
+/// Capture the source's visibility generation, then re-enter the same non-reentrant lifecycle
+/// interval for the exact canonical plaintext read. The second check closes the small gap between
+/// the existing snapshot helper releasing the mutex and this domain selecting content.
+fn capture_reminder_audit_source(
+    state: &AppState,
+    source_kind: &str,
+    source_id: &str,
+) -> Result<(ReminderAuditSourceSnapshot, ReminderAuditSourceContent), AppError> {
+    let snapshot = match source_kind {
+        "meeting" => ReminderAuditSourceSnapshot::Meeting(super::capture_meeting_content_snapshot(
+            state, source_id,
+        )?),
+        "note" => ReminderAuditSourceSnapshot::Note(super::capture_document_content_snapshot(
+            state, source_id,
+        )?),
+        _ => {
+            return Err(AppError::InvalidArg(
+                "reminder audit source must be a meeting or note".into(),
+            ));
+        }
+    };
+    let _lifecycle = super::lifecycle_guard(state);
+    let content =
+        current_reminder_audit_source_under_lifecycle(state, source_kind, source_id, &snapshot)?;
+    Ok((snapshot, content))
+}
+
+/// Revalidate a previously captured source authorization and re-read its exact canonical content.
+/// Callers hold the lifecycle mutex through the subsequent cache read or derived write.
+fn current_reminder_audit_source_under_lifecycle(
+    state: &AppState,
+    source_kind: &str,
+    source_id: &str,
+    snapshot: &ReminderAuditSourceSnapshot,
+) -> Result<ReminderAuditSourceContent, AppError> {
+    match (source_kind, snapshot) {
+        ("meeting", ReminderAuditSourceSnapshot::Meeting(snapshot)) => {
+            super::require_current_meeting_content_snapshot_under_lifecycle(
+                state, source_id, snapshot,
+            )?;
+        }
+        ("note", ReminderAuditSourceSnapshot::Note(snapshot)) => {
+            super::require_current_document_content_snapshot_under_lifecycle(
+                state, source_id, snapshot,
+            )?;
+        }
+        _ => {
+            return Err(AppError::InvalidArg(
+                "reminder audit source changed kind".into(),
+            ));
+        }
+    }
+    read_reminder_audit_source_under_lifecycle(state, source_kind, source_id)
+}
+
+/// Gate before every content/title read. Meeting hashes include the resolved source title, latest
+/// note (or an explicit empty part), typed manual notes, and every segment text in canonical `idx`
+/// order. Authored-note hashes include the resolved title plus exact `documents.text` body.
+fn read_reminder_audit_source_under_lifecycle(
+    state: &AppState,
+    source_kind: &str,
+    source_id: &str,
+) -> Result<ReminderAuditSourceContent, AppError> {
+    match source_kind {
+        "meeting" => {
+            if !super::meeting_is_unlocked(state, source_id)? {
+                return Err(AppError::Locked(
+                    "this meeting's folder is locked — unlock it and retry".into(),
+                ));
+            }
+            let meeting = state
+                .db
+                .get_meeting(source_id)?
+                .ok_or_else(|| AppError::InvalidArg("unknown reminder audit source".into()))?;
+            let markdown = state
+                .db
+                .latest_reminder_audit_markdown(source_id)?
+                .unwrap_or_default();
+            let manual_notes = state.db.get_manual_notes(source_id)?;
+            // Smart reminders follow the same canonical merged-transcript presentation as the
+            // meeting UI/export: measured capture echo is provenance, not user-visible speech.
+            let segments = state
+                .db
+                .get_segments_with_echo_provenance(source_id)?
+                .into_iter()
+                .filter(|stored| !stored.echo_suppressed)
+                .map(|stored| stored.segment)
+                .collect();
+            Ok(ReminderAuditSourceContent {
+                markdown,
+                manual_notes,
+                segments,
+                source: ReminderSourceView {
+                    kind: source_kind.to_string(),
+                    id: source_id.to_string(),
+                    title: meeting
+                        .title
+                        .filter(|title| !title.trim().is_empty())
+                        .unwrap_or_else(|| "Untitled meeting".into()),
+                },
+            })
+        }
+        "note" => {
+            let Some((folder_id, _created_at, _updated_at)) =
+                state.db.note_gate_anchor(source_id)?
+            else {
+                return Err(AppError::InvalidArg("unknown reminder audit source".into()));
+            };
+            if !super::folder_is_unlocked(state, &folder_id)? {
+                return Err(AppError::Locked(
+                    "this note's folder is locked — unlock it and retry".into(),
+                ));
+            }
+            let row = state
+                .db
+                .get_note_row(source_id)?
+                .ok_or_else(|| AppError::InvalidArg("unknown reminder audit source".into()))?;
+            Ok(ReminderAuditSourceContent {
+                markdown: row.text,
+                manual_notes: String::new(),
+                segments: Vec::new(),
+                source: ReminderSourceView {
+                    kind: source_kind.to_string(),
+                    id: source_id.to_string(),
+                    title: row
+                        .title
+                        .filter(|title| !title.trim().is_empty())
+                        .unwrap_or(row.name),
+                },
+            })
+        }
+        _ => Err(AppError::InvalidArg(
+            "reminder audit source must be a meeting or note".into(),
+        )),
+    }
+}
+
+fn reminder_audit_source_hash(content: &ReminderAuditSourceContent) -> String {
+    crate::storage::reminder_store::canonical_reminder_source_hash(
+        &content.source.title,
+        &content.markdown,
+        (content.source.kind == "meeting").then_some(content.manual_notes.as_str()),
+        &content.segments,
+    )
+}
+
+fn reminder_candidate_markdown(content: &ReminderAuditSourceContent) -> String {
+    // Candidate preparation is independently bounded from the full streaming hash. Reserve a
+    // quarter of the fixed budget for typed notes when present, then let a short generated note
+    // donate its unused bytes. Never concatenate the full canonical strings before truncation.
+    let markdown_budget = if content.manual_notes.is_empty() {
+        MAX_AUDIT_MARKDOWN_BYTES
+    } else {
+        MAX_AUDIT_MARKDOWN_BYTES * 3 / 4
+    };
+    let markdown = bounded_complete_lines(&content.markdown, markdown_budget);
+    let mut output = String::with_capacity(MAX_AUDIT_MARKDOWN_BYTES);
+    output.push_str(markdown);
+    if !content.manual_notes.is_empty() {
+        let separator_bytes = usize::from(!output.is_empty());
+        let remaining = MAX_AUDIT_MARKDOWN_BYTES
+            .saturating_sub(output.len())
+            .saturating_sub(separator_bytes);
+        let manual_notes = bounded_complete_lines(&content.manual_notes, remaining);
+        if !manual_notes.is_empty() {
+            if !output.is_empty() {
+                output.push('\n');
+            }
+            output.push_str(manual_notes);
+        }
+    }
+    output
+}
+
+fn reminder_suggestion_views(
+    rows: Vec<StoredReminderSuggestion>,
+    source: &ReminderSourceView,
+) -> Vec<ReminderSuggestionView> {
+    rows.into_iter()
+        .map(|row| ReminderSuggestionView {
+            id: row.id,
+            title: row.title,
+            suggested_due_at: row.suggested_due_at,
+            source: source.clone(),
+        })
+        .collect()
+}
+
+fn validate_reminder_audit_source(source_kind: &str, source_id: &str) -> Result<(), AppError> {
+    if !matches!(source_kind, "meeting" | "note") {
+        return Err(AppError::InvalidArg(
+            "reminder audit source must be a meeting or note".into(),
+        ));
+    }
+    validate_opaque_id(source_id, "reminder audit source")
+}
+
+fn require_reminder_audit_hash(
+    current: &ReminderAuditSourceContent,
+    expected_hash: &str,
+) -> Result<(), AppError> {
+    if reminder_audit_source_hash(current) != expected_hash {
+        return Err(AppError::InvalidArg(
+            "reminder audit source changed — retry the audit".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn bounded_complete_lines(value: &str, max_bytes: usize) -> &str {
+    let prefix = bounded_prefix(value, max_bytes);
+    if prefix.len() == value.len() {
+        return prefix;
+    }
+    prefix
+        .rfind('\n')
+        .map_or("", |last_newline| &prefix[..=last_newline])
+}
+
+fn bounded_prefix(value: &str, max_bytes: usize) -> &str {
+    if value.len() <= max_bytes {
+        return value;
+    }
+    let mut end = max_bytes;
+    while !value.is_char_boundary(end) {
+        end = end.saturating_sub(1);
+    }
+    &value[..end]
+}
+
+fn bounded_audit_segments(segments: &[Segment]) -> Vec<Segment> {
+    let mut remaining_bytes = MAX_AUDIT_SEGMENT_BYTES;
+    let mut bounded = Vec::new();
+    for segment in segments.iter().take(MAX_AUDIT_SEGMENTS) {
+        if segment.text.len() > remaining_bytes {
+            break;
+        }
+        remaining_bytes = remaining_bytes.saturating_sub(segment.text.len());
+        bounded.push(segment.clone());
+    }
+    bounded
+}
+
+async fn select_reminder_audit_candidates(
+    reasoner: Arc<dyn LocalReasoner>,
+    candidates: Vec<ReminderAuditCandidate>,
+) -> Result<Vec<ReminderAuditCandidate>, AppError> {
+    if candidates.is_empty() || reasoner.id() == "stub" {
+        return Ok(candidates);
+    }
+
+    let prompt_candidates = candidates
+        .iter()
+        .map(|candidate| {
+            serde_json::json!({
+                "id": candidate.id,
+                "title": candidate.title,
+            })
+        })
+        .collect::<Vec<_>>();
+    let user = format!(
+        "Select only clear, useful reminder candidates from this local list. \
+         Return candidate ids only.\n\nCandidates:\n{}",
+        serde_json::Value::Array(prompt_candidates)
+    );
+    let schema = serde_json::json!({
+        "type": "object",
+        "properties": {
+            "keepIds": {
+                "type": "array",
+                "items": { "type": "string" },
+                "maxItems": MAX_REMINDER_AUDIT_ROWS
+            }
+        },
+        "required": ["keepIds"],
+        "additionalProperties": false
+    });
+    let opts = GenOptions {
+        max_tokens: Some(128),
+        temperature: Some(0.0),
+        enable_thinking: false,
+        timeout: Some(Duration::from_secs(30)),
+        ..GenOptions::default()
+    };
+    let verdict = tokio::task::spawn_blocking(move || {
+        reasoner.structured_with(
+            "You are a conservative local reminder selector. Never invent, rewrite, or add \
+             candidates. Reply only with the requested JSON object.",
+            &user,
+            &schema,
+            opts,
+        )
+    })
+    .await;
+
+    let value = match verdict {
+        Ok(Ok(value)) => value,
+        Ok(Err(_)) | Err(_) => return Ok(candidates),
+    };
+    match crate::reminder_audit::validate_keep_ids(value, &candidates) {
+        Ok(selected) => {
+            #[cfg(debug_assertions)]
+            runtime_probe::record_selector_success()?;
+            Ok(selected)
+        }
+        Err(_) => Ok(candidates),
+    }
+}
+
+fn visible_source_views(
+    state: &AppState,
+    sources: &[ReminderSourceAnchor],
+) -> Result<Vec<ReminderSourceView>, AppError> {
+    let unlocked = super::unlocked_snapshot(state)?;
+    let mut visible = Vec::new();
+    for source in sources {
+        match source.kind.as_str() {
+            "meeting" if state.db.meeting_is_visible(&source.id, &unlocked)? => {
+                if let Some(meeting) = state.db.get_meeting(&source.id)? {
+                    visible.push(ReminderSourceView {
+                        kind: source.kind.clone(),
+                        id: source.id.clone(),
+                        title: meeting
+                            .title
+                            .filter(|title| !title.trim().is_empty())
+                            .unwrap_or_else(|| "Untitled meeting".into()),
+                    });
+                }
+            }
+            "note" if state.db.note_is_visible(&source.id, &unlocked)? => {
+                if let Some(note) = state.db.get_note_row(&source.id)? {
+                    visible.push(ReminderSourceView {
+                        kind: source.kind.clone(),
+                        id: source.id.clone(),
+                        title: note
+                            .title
+                            .filter(|title| !title.trim().is_empty())
+                            .unwrap_or(note.name),
+                    });
+                }
+            }
+            "meeting" | "note" => {} // currently sealed/deleted: omit metadata, keep reminder.
+            _ => {
+                return Err(AppError::Storage(
+                    "reminder source kind is invalid on disk".into(),
+                ));
+            }
+        }
+    }
+    Ok(visible)
+}
+
+fn validate_draft(mut draft: ReminderDraft) -> Result<ReminderDraft, AppError> {
+    draft.title = draft.title.trim().to_string();
+    if draft.title.is_empty() || draft.title.chars().count() > 240 {
+        return Err(AppError::InvalidArg(
+            "reminder title must be between 1 and 240 characters".into(),
+        ));
+    }
+    draft.details = draft.details.and_then(|details| {
+        let trimmed = details.trim().to_string();
+        (!trimmed.is_empty()).then_some(trimmed)
+    });
+    if draft
+        .details
+        .as_ref()
+        .is_some_and(|details| details.chars().count() > 4000)
+    {
+        return Err(AppError::InvalidArg("reminder details are too long".into()));
+    }
+    validate_due_at(draft.due_at)?;
+    match (draft.repeat_every, draft.repeat_unit) {
+        (None, None) => {}
+        (Some(1..=365), Some(_)) => {}
+        _ => {
+            return Err(AppError::InvalidArg(
+                "reminder recurrence requires an interval from 1 to 365 and a unit".into(),
+            ));
+        }
+    }
+    if draft.sources.len() > MAX_REMINDER_SOURCES {
+        return Err(AppError::InvalidArg("too many reminder sources".into()));
+    }
+    let mut dedup = BTreeSet::new();
+    for source in &draft.sources {
+        if !matches!(source.kind.as_str(), "meeting" | "note") {
+            return Err(AppError::InvalidArg(
+                "reminder source must be a meeting or note".into(),
+            ));
+        }
+        validate_opaque_id(&source.id, "source")?;
+        dedup.insert((source.kind.clone(), source.id.clone()));
+    }
+    draft.sources = dedup
+        .into_iter()
+        .map(|(kind, id)| ReminderSourceAnchor { kind, id })
+        .collect();
+    Ok(draft)
+}
+
+fn validate_due_at(due_at: i64) -> Result<(), AppError> {
+    if !(crate::storage::reminder_store::MIN_REMINDER_DUE_AT
+        ..crate::storage::reminder_store::MAX_REMINDER_DUE_AT)
+        .contains(&due_at)
+    {
+        return Err(AppError::InvalidArg(
+            "reminder due time is out of range".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn require_smart_source_capacity(
+    sources: &[ReminderSourceAnchor],
+    suggestion_source_kind: &str,
+    suggestion_source_id: &str,
+) -> Result<(), AppError> {
+    let already_attached = sources
+        .iter()
+        .any(|source| source.kind == suggestion_source_kind && source.id == suggestion_source_id);
+    if !already_attached && sources.len() >= MAX_REMINDER_SOURCES {
+        return Err(AppError::InvalidArg(
+            "too many reminder sources after attaching the Smart suggestion source".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn preserve_hidden_sources_on_update(
+    state: &AppState,
+    existing: &[ReminderSourceAnchor],
+    submitted: &mut Vec<ReminderSourceAnchor>,
+) -> Result<(), AppError> {
+    let unlocked = super::unlocked_snapshot(state)?;
+    let mut hidden = BTreeSet::new();
+    for source in existing {
+        let (exists, visible) = source_existence_and_visibility(state, source, &unlocked)?;
+        if exists && !visible {
+            hidden.insert((source.kind.clone(), source.id.clone()));
+        }
+    }
+    merge_hidden_source_anchors(submitted, hidden);
+    if submitted.len() > MAX_REMINDER_SOURCES {
+        return Err(AppError::InvalidArg("too many reminder sources".into()));
+    }
+    Ok(())
+}
+
+fn merge_hidden_source_anchors(
+    submitted: &mut Vec<ReminderSourceAnchor>,
+    hidden: BTreeSet<(String, String)>,
+) {
+    submitted.extend(
+        hidden
+            .into_iter()
+            .map(|(kind, id)| ReminderSourceAnchor { kind, id }),
+    );
+    submitted.sort_by(|left, right| {
+        left.kind
+            .cmp(&right.kind)
+            .then_with(|| left.id.cmp(&right.id))
+    });
+    submitted.dedup();
+}
+
+fn validate_opaque_id(id: &str, label: &str) -> Result<(), AppError> {
+    if id.is_empty() || id.len() > 160 || id.chars().any(char::is_whitespace) {
+        return Err(AppError::InvalidArg(format!("{label} id is invalid")));
+    }
+    Ok(())
+}
+
+fn require_sources_visible(
+    state: &AppState,
+    sources: &[ReminderSourceAnchor],
+) -> Result<(), AppError> {
+    let unlocked = super::unlocked_snapshot(state)?;
+    for source in sources {
+        let (_exists, visible) = source_existence_and_visibility(state, source, &unlocked)?;
+        if !visible {
+            return Err(AppError::Locked(
+                "unlock the source before attaching it to a reminder".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn source_existence_and_visibility(
+    state: &AppState,
+    source: &ReminderSourceAnchor,
+    unlocked: &std::collections::HashSet<String>,
+) -> Result<(bool, bool), AppError> {
+    match source.kind.as_str() {
+        "meeting" => {
+            let exists = state.db.get_meeting_gate_anchor(&source.id)?.is_some();
+            let visible = exists && state.db.meeting_is_visible(&source.id, unlocked)?;
+            Ok((exists, visible))
+        }
+        "note" => {
+            let exists = state.db.note_gate_anchor(&source.id)?.is_some();
+            let visible = exists && state.db.note_is_visible(&source.id, unlocked)?;
+            Ok((exists, visible))
+        }
+        _ => Err(AppError::Storage(
+            "reminder source kind is invalid on disk".into(),
+        )),
+    }
+}
+
+fn emit_reminder_count(app: &AppHandle, state: &AppState) {
+    match state.db.due_reminder_count() {
+        Ok(count) => crate::events::emit_reminders_updated(app, count),
+        Err(error) => {
+            tracing::warn!(
+                target: "reminders",
+                error = %error,
+                "could not count due reminders for update event"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod smart_audit_command_tests {
+    use std::collections::HashSet;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::mpsc;
+    use std::sync::{Condvar, Mutex, Once};
+    use std::time::Duration;
+
+    use serde_json::{json, Value};
+    use sha2::{Digest, Sha256};
+
+    use super::*;
+    use crate::settings::{AppConfig, BrainBackend};
+    use crate::storage::models::{Folder, Meeting, MeetingStatus, NoteRecord};
+    use crate::storage::{AttachmentOwner, Db, NewAttachment};
+
+    const TEST_DB_KEY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const TEST_DEV_KEK: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+    static TEST_KEK_ENV: Once = Once::new();
+
+    fn ensure_test_dev_kek() {
+        TEST_KEK_ENV.call_once(|| std::env::set_var("MURMUR_DEV_KEK", TEST_DEV_KEK));
+    }
+
+    fn test_state(tag: &str, reasoner: Arc<dyn LocalReasoner>) -> Arc<AppState> {
+        let path =
+            crate::storage::db::unique_temp_path(&format!("reminder-command-{tag}"), "sqlite");
+        let _ = std::fs::remove_file(&path);
+        let db = Arc::new(Db::open_with_key(&path, TEST_DB_KEY).unwrap());
+        Arc::new(AppState {
+            recorder: Mutex::new(None),
+            recording_stop: Mutex::new(None),
+            voice_listener: Mutex::new(None),
+            voice_listener_lifecycle: Mutex::new(()),
+            recording_starting: std::sync::atomic::AtomicBool::new(false),
+            voice_command_capture: Mutex::new(None),
+            pending_manual_command: Mutex::new(None),
+            live_running: std::sync::atomic::AtomicBool::new(false),
+            db,
+            config: Arc::new(Mutex::new(AppConfig::default())),
+            reasoner: crate::reason::ReasonerCell::fixed(reasoner),
+            current_meeting: Mutex::new(None),
+            focus_meeting: Mutex::new(None),
+            live_transcript: Mutex::new(String::new()),
+            live_bullets: Mutex::new(String::new()),
+            live_bullets_tracker: Mutex::new(crate::transcribe::bullets::BulletsTracker::default()),
+            capped_notified: std::sync::atomic::AtomicBool::new(false),
+            capture_fault_notified: std::sync::atomic::AtomicBool::new(false),
+            reactions_shadow_count: std::sync::atomic::AtomicU64::new(0),
+            reactions_emitted: Mutex::new(HashSet::new()),
+            in_flight_turns: Mutex::new(std::collections::HashMap::new()),
+            user_turn_in_progress: std::sync::atomic::AtomicBool::new(false),
+            verify_cache: Mutex::new(std::collections::HashMap::new()),
+            unlocked_folders: Arc::new(Mutex::new(HashSet::new())),
+            master_kek: Mutex::new(None),
+            org_ock_cache: Mutex::new(std::collections::HashMap::new()),
+            account_session: Mutex::new(None),
+            lifecycle: Mutex::new(()),
+            active_salvages: Mutex::new(HashSet::new()),
+            share_refresh_lock: tokio::sync::Mutex::new(()),
+            seal_epoch: std::sync::atomic::AtomicU64::new(0),
+            heavy_inference: Arc::new(tokio::sync::Semaphore::new(1)),
+        })
+    }
+
+    fn seed_meeting_source(state: &AppState) {
+        state
+            .db
+            .insert_folder(&Folder {
+                id: "f1".into(),
+                name: "Private".into(),
+                path: "Private".into(),
+                parent_id: None,
+                locked: false,
+                created_at: "2026-07-29T09:00:00Z".into(),
+            })
+            .unwrap();
+        state
+            .db
+            .insert_meeting(&Meeting {
+                id: "m1".into(),
+                started_at: "2026-07-29T10:00:00Z".into(),
+                ended_at: None,
+                title: Some("Planning".into()),
+                duration_s: 0,
+                audio_path: None,
+                status: MeetingStatus::Summarized,
+                folder_id: None,
+            })
+            .unwrap();
+        state
+            .db
+            .upsert_note(&NoteRecord {
+                meeting_id: "m1".into(),
+                provider_id: "local".into(),
+                markdown: "## Action items\n- [ ] Ship the plan".into(),
+                created_at: "2026-07-29T10:05:00Z".into(),
+                exported_path: None,
+                model_requested: None,
+                model_served: None,
+                gateway_host: None,
+            })
+            .unwrap();
+        state.db.set_note_folder("m1", Some("f1")).unwrap();
+        state
+            .db
+            .replace_segments(
+                "m1",
+                &[Segment {
+                    idx: 0,
+                    start_s: 0.0,
+                    end_s: 1.0,
+                    text: "We should ship the plan".into(),
+                    speaker: Some("me".into()),
+                    confidence: Some(0.9),
+                }],
+            )
+            .unwrap();
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct RelockPlaintext {
+        note: String,
+        segment: String,
+        timeline: String,
+        manual_notes: String,
+        document: String,
+        attachment: Vec<u8>,
+    }
+
+    const RELOCK_ATTACHMENT_ID: &str = "11111111-1111-4111-8111-111111111111";
+    const SECOND_RELOCK_ATTACHMENT_ID: &str = "22222222-2222-4222-8222-222222222222";
+
+    fn relock_attachment_bytes() -> Vec<u8> {
+        let width = 64u32;
+        let height = 40u32;
+        let mut bytes = Vec::with_capacity(30);
+        bytes.extend_from_slice(b"RIFF");
+        bytes.extend_from_slice(&22u32.to_le_bytes());
+        bytes.extend_from_slice(b"WEBPVP8X");
+        bytes.extend_from_slice(&10u32.to_le_bytes());
+        bytes.extend_from_slice(&[0, 0, 0, 0]);
+        let w = width - 1;
+        let h = height - 1;
+        bytes.extend_from_slice(&[w as u8, (w >> 8) as u8, (w >> 16) as u8]);
+        bytes.extend_from_slice(&[h as u8, (h >> 8) as u8, (h >> 16) as u8]);
+        bytes
+    }
+
+    fn seed_relock_all_families(state: &AppState) {
+        seed_meeting_source(state);
+        state
+            .db
+            .set_timeline_data("m1", r#"{"items":[{"text":"Ship it"}]}"#)
+            .unwrap();
+        state.db.set_manual_notes("m1", "Typed follow-up").unwrap();
+        state
+            .db
+            .insert_note(
+                "doc1",
+                "f1",
+                "Follow-up.md",
+                "Follow-up",
+                "Authored follow-up",
+                1_900_000_000,
+            )
+            .unwrap();
+        let attachment = relock_attachment_bytes();
+        let attachment_hash: [u8; 32] = Sha256::digest(&attachment).into();
+        let owner = AttachmentOwner::Meeting {
+            meeting_id: "m1".into(),
+            provider_id: "local".into(),
+        };
+        state
+            .db
+            .insert_attachment(&NewAttachment {
+                id: RELOCK_ATTACHMENT_ID,
+                owner: &owner,
+                mime_type: "image/webp",
+                extension: "webp",
+                width: 64,
+                height: 40,
+                sha256: &attachment_hash,
+                byte_len: attachment.len(),
+                data: &attachment,
+                data_blob: None,
+                created_at: 1_900_000_001,
+            })
+            .unwrap();
+    }
+
+    fn relock_plaintext(state: &AppState) -> RelockPlaintext {
+        RelockPlaintext {
+            note: state
+                .db
+                .notes_in_folder("f1")
+                .unwrap()
+                .into_iter()
+                .find(|note| note.meeting_id == "m1" && note.provider_id == "local")
+                .unwrap()
+                .markdown,
+            segment: state
+                .db
+                .raw_segments("m1")
+                .unwrap()
+                .into_iter()
+                .find(|segment| segment.idx == 0)
+                .unwrap()
+                .text,
+            timeline: state.db.raw_timeline("m1").unwrap().unwrap().data,
+            manual_notes: state.db.raw_manual_notes("m1").unwrap().unwrap().text,
+            document: state
+                .db
+                .raw_documents_in_folder("f1")
+                .unwrap()
+                .into_iter()
+                .find(|document| document.id == "doc1")
+                .unwrap()
+                .text,
+            attachment: state
+                .db
+                .attachments_in_folder("f1")
+                .unwrap()
+                .into_iter()
+                .find(|attachment| attachment.id == RELOCK_ATTACHMENT_ID)
+                .unwrap()
+                .data,
+        }
+    }
+
+    fn seed_session_unlocked_relock_state(tag: &str) -> (Arc<AppState>, [u8; 32]) {
+        ensure_test_dev_kek();
+        let state = test_state(tag, Arc::new(crate::reason::StubReasoner));
+        seed_relock_all_families(&state);
+        crate::commands::lock_folder_inner(&state, "f1".into()).unwrap();
+
+        let kek = crate::secrets::get_or_create_master_kek().unwrap();
+        let wrapped = state.db.folder_wrapped_key("f1").unwrap().unwrap();
+        let ck_bytes =
+            crate::crypto::decrypt(&kek, &wrapped, &crate::commands::aad_wrapped_ck("f1")).unwrap();
+        let ck: [u8; 32] = ck_bytes.try_into().unwrap();
+        *state.master_kek.lock().unwrap() = Some(zeroize::Zeroizing::new(kek));
+
+        for note in state.db.notes_in_folder("f1").unwrap() {
+            let blob = note.content_blob.as_ref().unwrap();
+            let markdown = String::from_utf8(
+                crate::crypto::decrypt(
+                    &ck,
+                    blob,
+                    &crate::commands::aad_content(
+                        "f1",
+                        &note.meeting_id,
+                        &note.provider_id,
+                        "note",
+                    ),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+            state
+                .db
+                .restore_note_markdown(&note.meeting_id, &note.provider_id, &markdown)
+                .unwrap();
+        }
+        crate::commands::unseal_folder_extras(&state, "f1", &ck, None).unwrap();
+        state.unlocked_folders.lock().unwrap().insert("f1".into());
+        (state, ck)
+    }
+
+    fn restore_relock_plaintext_from_blobs(state: &AppState, ck: &[u8; 32]) {
+        for note in state.db.notes_in_folder("f1").unwrap() {
+            let blob = note.content_blob.as_ref().unwrap();
+            let markdown = String::from_utf8(
+                crate::crypto::decrypt(
+                    ck,
+                    blob,
+                    &crate::commands::aad_content(
+                        "f1",
+                        &note.meeting_id,
+                        &note.provider_id,
+                        "note",
+                    ),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+            state
+                .db
+                .restore_note_markdown(&note.meeting_id, &note.provider_id, &markdown)
+                .unwrap();
+        }
+        crate::commands::unseal_folder_extras(state, "f1", ck, None).unwrap();
+    }
+
+    fn seed_second_session_unlocked_folder(state: &AppState) -> [u8; 32] {
+        state
+            .db
+            .insert_folder(&Folder {
+                id: "f2".into(),
+                name: "Second private".into(),
+                path: "Second private".into(),
+                parent_id: None,
+                locked: false,
+                created_at: "2026-07-29T11:00:00Z".into(),
+            })
+            .unwrap();
+        state
+            .db
+            .insert_meeting(&Meeting {
+                id: "m2".into(),
+                started_at: "2026-07-29T11:00:00Z".into(),
+                ended_at: Some("2026-07-29T11:30:00Z".into()),
+                title: Some("Second meeting".into()),
+                duration_s: 1_800,
+                audio_path: None,
+                status: MeetingStatus::Summarized,
+                folder_id: Some("f2".into()),
+            })
+            .unwrap();
+        state
+            .db
+            .upsert_note(&NoteRecord {
+                meeting_id: "m2".into(),
+                provider_id: "local".into(),
+                markdown: "Second folder plaintext".into(),
+                created_at: "2026-07-29T11:30:00Z".into(),
+                ..NoteRecord::default()
+            })
+            .unwrap();
+        state.db.set_note_folder("m2", Some("f2")).unwrap();
+        let attachment = relock_attachment_bytes();
+        let attachment_hash: [u8; 32] = Sha256::digest(&attachment).into();
+        let owner = AttachmentOwner::Meeting {
+            meeting_id: "m2".into(),
+            provider_id: "local".into(),
+        };
+        state
+            .db
+            .insert_attachment(&NewAttachment {
+                id: SECOND_RELOCK_ATTACHMENT_ID,
+                owner: &owner,
+                mime_type: "image/webp",
+                extension: "webp",
+                width: 64,
+                height: 40,
+                sha256: &attachment_hash,
+                byte_len: attachment.len(),
+                data: &attachment,
+                data_blob: None,
+                created_at: 1_900_000_002,
+            })
+            .unwrap();
+
+        crate::commands::lock_folder_inner(state, "f2".into()).unwrap();
+        let kek = crate::secrets::get_or_create_master_kek().unwrap();
+        let wrapped = state.db.folder_wrapped_key("f2").unwrap().unwrap();
+        let ck_bytes =
+            crate::crypto::decrypt(&kek, &wrapped, &crate::commands::aad_wrapped_ck("f2")).unwrap();
+        let ck: [u8; 32] = ck_bytes.try_into().unwrap();
+        *state.master_kek.lock().unwrap() = Some(zeroize::Zeroizing::new(kek));
+        let note = state.db.notes_in_folder("f2").unwrap().remove(0);
+        let markdown = String::from_utf8(
+            crate::crypto::decrypt(
+                &ck,
+                note.content_blob.as_ref().unwrap(),
+                &crate::commands::aad_content("f2", "m2", "local", "note"),
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        state
+            .db
+            .restore_note_markdown("m2", "local", &markdown)
+            .unwrap();
+        crate::commands::unseal_folder_extras(state, "f2", &ck, None).unwrap();
+        state.unlocked_folders.lock().unwrap().insert("f2".into());
+        ck
+    }
+
+    fn reminder_draft() -> ReminderDraft {
+        ReminderDraft {
+            title: "Ship the plan".into(),
+            details: None,
+            due_at: 2_000_000_000_000,
+            repeat_every: None,
+            repeat_unit: None,
+            sources: Vec::new(),
+        }
+    }
+
+    struct BarrierSelector {
+        calls: Arc<AtomicUsize>,
+        started: Mutex<Option<mpsc::Sender<()>>>,
+        release: Arc<(Mutex<bool>, Condvar)>,
+    }
+
+    impl LocalReasoner for BarrierSelector {
+        fn id(&self) -> &str {
+            "test-local-barrier"
+        }
+
+        fn reason(&self, _system: &str, _user: &str) -> crate::error::Result<String> {
+            panic!("Smart reminder runtime must not use free-form/provider reasoning")
+        }
+
+        fn structured(
+            &self,
+            _system: &str,
+            _user: &str,
+            _json_schema: &Value,
+        ) -> crate::error::Result<Value> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if let Some(sender) = self.started.lock().unwrap().take() {
+                sender.send(()).unwrap();
+            }
+            let (released, wake) = &*self.release;
+            let mut released = released.lock().unwrap();
+            while !*released {
+                released = wake.wait(released).unwrap();
+            }
+            Ok(json!({"keepIds": ["c1"]}))
+        }
+    }
+
+    enum SelectorReply {
+        Value(Value),
+        Error,
+    }
+
+    struct FixedSelector {
+        reply: SelectorReply,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl LocalReasoner for FixedSelector {
+        fn id(&self) -> &str {
+            "test-local"
+        }
+
+        fn reason(&self, _system: &str, _user: &str) -> crate::error::Result<String> {
+            Ok(String::new())
+        }
+
+        fn structured(
+            &self,
+            _system: &str,
+            _user: &str,
+            _json_schema: &Value,
+        ) -> crate::error::Result<Value> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            match &self.reply {
+                SelectorReply::Value(value) => Ok(value.clone()),
+                SelectorReply::Error => {
+                    Err(AppError::Unavailable("test selector unavailable".into()))
+                }
+            }
+        }
+    }
+
+    fn candidates() -> Vec<ReminderAuditCandidate> {
+        crate::reminder_audit::build_candidates("- [ ] First\n- [ ] Second\n", &[])
+    }
+
+    #[tokio::test]
+    async fn stub_selector_keeps_the_deterministic_candidates_without_a_model_call() {
+        let expected = candidates();
+        let selected = select_reminder_audit_candidates(
+            Arc::new(crate::reason::StubReasoner),
+            expected.clone(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(selected, expected);
+    }
+
+    #[tokio::test]
+    async fn malformed_unknown_and_error_selectors_each_fall_back_after_one_call() {
+        for reply in [
+            SelectorReply::Value(json!({"keepIds": "c1"})),
+            SelectorReply::Value(json!({"keepIds": ["invented"]})),
+            SelectorReply::Error,
+        ] {
+            let expected = candidates();
+            let calls = Arc::new(AtomicUsize::new(0));
+            let selected = select_reminder_audit_candidates(
+                Arc::new(FixedSelector {
+                    reply,
+                    calls: Arc::clone(&calls),
+                }),
+                expected.clone(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(selected, expected);
+            assert_eq!(calls.load(Ordering::SeqCst), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn valid_selector_can_only_keep_known_rows_in_source_order() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let selected = select_reminder_audit_candidates(
+            Arc::new(FixedSelector {
+                reply: SelectorReply::Value(json!({"keepIds": ["c2"]})),
+                calls: Arc::clone(&calls),
+            }),
+            candidates(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            selected
+                .iter()
+                .map(|candidate| candidate.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["c2"]
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn reminder_audit_runtime_uses_only_the_pinned_local_reasoner() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let selector: Arc<dyn LocalReasoner> = Arc::new(FixedSelector {
+            reply: SelectorReply::Value(json!({"keepIds": ["c1"]})),
+            calls: Arc::clone(&calls),
+        });
+        let state = test_state("local-only", Arc::clone(&selector));
+        seed_meeting_source(&state);
+
+        let rows =
+            audit_reminder_suggestions_inner(&state, "meeting".into(), "m1".into(), selector)
+                .await
+                .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn production_light_dispatch_never_falls_back_to_cloud_roles() {
+        let config = Arc::new(Mutex::new(AppConfig {
+            brain_backend: BrainBackend::Cloud,
+            provider_id: "anthropic".into(),
+            role_notes_connection: "anthropic".into(),
+            role_ask_connection: "gateway".into(),
+            role_live_connection: "claude_code".into(),
+            brain_light_model_id: Some("definitely-missing-test-model".into()),
+            ..AppConfig::default()
+        }));
+        let reasoners =
+            crate::reason::ReasonerCell::new(config, Arc::new(tokio::sync::Semaphore::new(1)));
+        assert_eq!(
+            reasoners.light().id(),
+            "stub",
+            "light class dispatch must degrade locally and never construct a cloud/provider path"
+        );
+    }
+
+    #[tokio::test]
+    async fn echo_suppressed_checklist_text_is_never_suggested() {
+        let state = test_state("echo-suppressed", Arc::new(crate::reason::StubReasoner));
+        seed_meeting_source(&state);
+        state
+            .db
+            .lock()
+            .execute_batch(
+                "UPDATE notes SET markdown='' WHERE meeting_id='m1';
+                 UPDATE segments
+                    SET text='- [ ] Do not repeat captured echo', echo_suppressed=1
+                  WHERE meeting_id='m1' AND idx=0;",
+            )
+            .unwrap();
+
+        let source = read_reminder_audit_source_under_lifecycle(&state, "meeting", "m1").unwrap();
+        assert!(
+            source.segments.is_empty(),
+            "Smart audit must consume the visible merged projection, not raw echo rows"
+        );
+        let rows = audit_reminder_suggestions_inner(
+            &state,
+            "meeting".into(),
+            "m1".into(),
+            Arc::new(crate::reason::StubReasoner),
+        )
+        .await
+        .unwrap();
+        assert!(
+            rows.is_empty(),
+            "suppressed capture echo must never become a Smart reminder"
+        );
+    }
+
+    #[test]
+    fn reminder_snapshot_partitions_future_due_and_dismissed_active_rows_without_duplicates() {
+        const NOW: i64 = 2_000_000_000_000;
+        let state = test_state("snapshot-partition", Arc::new(crate::reason::StubReasoner));
+        let mut future = reminder_draft();
+        future.title = "Future".into();
+        future.due_at = NOW + 1_000;
+        state
+            .db
+            .create_reminder("r-future", &future, ReminderOrigin::Manual, 1)
+            .unwrap();
+        let mut overdue = reminder_draft();
+        overdue.title = "Overdue".into();
+        overdue.due_at = NOW - 1_000;
+        state
+            .db
+            .create_reminder("r-overdue", &overdue, ReminderOrigin::Manual, 1)
+            .unwrap();
+        let mut completed = reminder_draft();
+        completed.title = "Completed".into();
+        completed.due_at = NOW - 2_000;
+        state
+            .db
+            .create_reminder("r-completed", &completed, ReminderOrigin::Manual, 1)
+            .unwrap();
+        assert!(state
+            .db
+            .complete_reminder("r-completed", completed.due_at, NOW - 1)
+            .unwrap());
+        assert_eq!(state.db.materialize_due_reminders(NOW).unwrap(), 1);
+
+        let due_snapshot = reminders_snapshot_at(&state, NOW).unwrap();
+        assert_eq!(
+            due_snapshot
+                .upcoming
+                .iter()
+                .map(|reminder| reminder.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["r-future"]
+        );
+        assert_eq!(due_snapshot.inbox.len(), 1);
+        assert_eq!(due_snapshot.inbox[0].reminder.id, "r-overdue");
+        assert_eq!(
+            due_snapshot
+                .completed
+                .iter()
+                .map(|reminder| reminder.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["r-completed"],
+            "completed projection must remain intact"
+        );
+        assert!(
+            due_snapshot
+                .upcoming
+                .iter()
+                .all(|reminder| reminder.id != "r-overdue"),
+            "a due active reminder must be represented only by its unread Inbox occurrence"
+        );
+
+        assert!(state
+            .db
+            .dismiss_reminder_occurrence(&due_snapshot.inbox[0].occurrence_id, NOW + 1)
+            .unwrap());
+        let dismissed_snapshot = reminders_snapshot_at(&state, NOW + 1).unwrap();
+        assert!(dismissed_snapshot.inbox.is_empty());
+        assert_eq!(
+            dismissed_snapshot
+                .upcoming
+                .iter()
+                .map(|reminder| reminder.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["r-overdue", "r-future"],
+            "a dismissed overdue one-off must remain accessible in Upcoming"
+        );
+        assert_eq!(dismissed_snapshot.completed.len(), 1);
+        assert!(matches!(
+            state
+                .db
+                .get_stored_reminder("r-overdue")
+                .unwrap()
+                .unwrap()
+                .state,
+            ReminderState::Active
+        ));
+    }
+
+    #[test]
+    fn reminder_snapshot_unread_occurrence_wins_materialize_after_captured_now_race() {
+        const SNAPSHOT_NOW: i64 = 2_000_000_000_000;
+        let state = test_state("snapshot-race", Arc::new(crate::reason::StubReasoner));
+        let mut racing_due = reminder_draft();
+        racing_due.title = "Racing due".into();
+        racing_due.due_at = SNAPSHOT_NOW + 1;
+        state
+            .db
+            .create_reminder("r-racing", &racing_due, ReminderOrigin::Manual, 1)
+            .unwrap();
+
+        assert_eq!(
+            state
+                .db
+                .materialize_due_reminders(SNAPSHOT_NOW + 1)
+                .unwrap(),
+            1,
+            "scheduler race precondition: unread occurrence was materialized after captured now"
+        );
+        let snapshot = reminders_snapshot_at(&state, SNAPSHOT_NOW).unwrap();
+        assert!(snapshot.upcoming.is_empty());
+        assert_eq!(snapshot.inbox.len(), 1);
+        assert_eq!(snapshot.inbox[0].reminder.id, "r-racing");
+    }
+
+    #[test]
+    fn smart_promotion_reserves_capacity_for_its_canonical_source() {
+        let twenty_other_sources = (0..MAX_REMINDER_SOURCES)
+            .map(|index| ReminderSourceAnchor {
+                kind: "note".into(),
+                id: format!("n{index}"),
+            })
+            .collect::<Vec<_>>();
+        assert!(matches!(
+            require_smart_source_capacity(&twenty_other_sources, "meeting", "m1"),
+            Err(AppError::InvalidArg(_))
+        ));
+
+        let mut including_origin = twenty_other_sources;
+        including_origin[MAX_REMINDER_SOURCES - 1] = ReminderSourceAnchor {
+            kind: "meeting".into(),
+            id: "m1".into(),
+        };
+        require_smart_source_capacity(&including_origin, "meeting", "m1").unwrap();
+    }
+
+    #[test]
+    fn source_response_serialization_holds_lifecycle_until_json_is_complete() {
+        struct BlockingPayload {
+            entered: mpsc::Sender<()>,
+            release: mpsc::Receiver<()>,
+        }
+
+        impl serde::Serialize for BlockingPayload {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                self.entered.send(()).map_err(serde::ser::Error::custom)?;
+                self.release
+                    .recv_timeout(Duration::from_secs(5))
+                    .map_err(serde::ser::Error::custom)?;
+                "source title".serialize(serializer)
+            }
+        }
+
+        let state = test_state(
+            "response-serialization-lifecycle",
+            Arc::new(crate::reason::StubReasoner),
+        );
+        let (serialize_entered_tx, serialize_entered_rx) = mpsc::channel();
+        let (release_serialize_tx, release_serialize_rx) = mpsc::channel();
+        let (serialize_done_tx, serialize_done_rx) = mpsc::channel();
+        let serialize_state = Arc::clone(&state);
+        let serialize = std::thread::spawn(move || {
+            let result = lifecycle_reminder_response(&serialize_state, || {
+                Ok(BlockingPayload {
+                    entered: serialize_entered_tx,
+                    release: release_serialize_rx,
+                })
+            });
+            serialize_done_tx.send(result.is_ok()).unwrap();
+        });
+        serialize_entered_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("response never entered serde serialization");
+
+        let (competing_lock_tx, competing_lock_rx) = mpsc::channel();
+        let competing_state = Arc::clone(&state);
+        let competing = std::thread::spawn(move || {
+            let _lifecycle = super::super::lifecycle_guard(&competing_state);
+            competing_lock_tx.send(()).unwrap();
+        });
+        assert!(
+            matches!(
+                competing_lock_rx.recv_timeout(Duration::from_millis(150)),
+                Err(mpsc::RecvTimeoutError::Timeout)
+            ),
+            "a competing lock crossed the actual serde serialization boundary"
+        );
+
+        release_serialize_tx.send(()).unwrap();
+        assert!(
+            serialize_done_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("response serialization did not finish"),
+            "response serialization failed"
+        );
+        competing_lock_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("lifecycle remained blocked after serialization completed");
+        serialize.join().unwrap();
+        competing.join().unwrap();
+    }
+
+    #[tokio::test]
+    async fn accepted_view_holds_lifecycle_through_command_postwork() {
+        ensure_test_dev_kek();
+        let state = test_state(
+            "accept-postwork-lifecycle",
+            Arc::new(crate::reason::StubReasoner),
+        );
+        seed_meeting_source(&state);
+        let suggestions = audit_reminder_suggestions_inner(
+            &state,
+            "meeting".into(),
+            "m1".into(),
+            Arc::new(crate::reason::StubReasoner),
+        )
+        .await
+        .unwrap();
+        let suggestion_id = suggestions[0].id.clone();
+
+        let (postwork_entered_tx, postwork_entered_rx) = mpsc::channel();
+        let release_postwork = Arc::new((Mutex::new(false), Condvar::new()));
+        let accept_state = Arc::clone(&state);
+        let accept_release = Arc::clone(&release_postwork);
+        let accept = std::thread::spawn(move || {
+            accept_reminder_suggestion_with_postwork(
+                &accept_state,
+                suggestion_id,
+                reminder_draft(),
+                |_| {
+                    postwork_entered_tx.send(()).unwrap();
+                    let (released, wake) = &*accept_release;
+                    let mut released = released.lock().unwrap();
+                    while !*released {
+                        released = wake.wait(released).unwrap();
+                    }
+                    Ok(())
+                },
+                |_, view| Ok(view),
+            )
+        });
+        postwork_entered_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("acceptance never reached command postwork");
+
+        let lock_state = Arc::clone(&state);
+        let (lock_done_tx, lock_done_rx) = mpsc::channel();
+        let lock = std::thread::spawn(move || {
+            let result = crate::commands::lock_folder_inner(&lock_state, "f1".into());
+            lock_done_tx.send(result).unwrap();
+        });
+
+        // Give the competing lock a bounded opportunity to expose the old gap. It must remain
+        // blocked until the source-bearing response has crossed all command postwork.
+        let early_lock = lock_done_rx.recv_timeout(Duration::from_millis(150)).ok();
+        let lock_landed_early = early_lock.is_some();
+        {
+            let (released, wake) = &*release_postwork;
+            *released.lock().unwrap() = true;
+            wake.notify_all();
+        }
+
+        let accepted = accept.join().unwrap().unwrap();
+        let lock_result = match early_lock {
+            Some(result) => result,
+            None => lock_done_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("competing lock did not finish after acceptance released lifecycle"),
+        };
+        lock_result.unwrap();
+        lock.join().unwrap();
+
+        assert!(
+            !lock_landed_early,
+            "a concurrent lock crossed the acceptance command's postwork boundary"
+        );
+        assert_eq!(accepted.sources.len(), 1);
+        assert_eq!(accepted.sources[0].title, "Planning");
+    }
+
+    #[tokio::test]
+    async fn locked_reminder_list_masks_sources_and_audit_accept_fail_closed() {
+        let state = test_state("locked-paths", Arc::new(crate::reason::StubReasoner));
+        seed_meeting_source(&state);
+        let suggestions = audit_reminder_suggestions_inner(
+            &state,
+            "meeting".into(),
+            "m1".into(),
+            Arc::new(crate::reason::StubReasoner),
+        )
+        .await
+        .unwrap();
+        assert_eq!(suggestions.len(), 1);
+
+        let mut stored_draft = reminder_draft();
+        stored_draft.sources.push(ReminderSourceAnchor {
+            kind: "meeting".into(),
+            id: "m1".into(),
+        });
+        state
+            .db
+            .create_reminder("r1", &stored_draft, ReminderOrigin::Manual, 1)
+            .unwrap();
+
+        state
+            .db
+            .set_folder_locked("f1", true, Some(b"wrapped"))
+            .unwrap();
+        crate::commands::bump_seal_epoch(&state);
+
+        let snapshot = reminders_snapshot_at(&state, 1_900_000_000_000).unwrap();
+        assert_eq!(snapshot.upcoming.len(), 1);
+        assert!(
+            snapshot.upcoming[0].sources.is_empty(),
+            "locked source title/id metadata must not cross the list projection"
+        );
+        assert!(matches!(
+            audit_reminder_suggestions_inner(
+                &state,
+                "meeting".into(),
+                "m1".into(),
+                Arc::new(crate::reason::StubReasoner),
+            )
+            .await,
+            Err(AppError::Locked(_))
+        ));
+        assert!(matches!(
+            accept_reminder_suggestion_inner(&state, suggestions[0].id.clone(), reminder_draft()),
+            Err(AppError::Locked(_))
+        ));
+        assert_eq!(
+            state.db.list_stored_reminders().unwrap().len(),
+            1,
+            "locked acceptance must not promote a second reminder"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn inflight_non_text_segment_edit_cannot_persist_suggestions() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let (started_tx, started_rx) = mpsc::channel();
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let selector: Arc<dyn LocalReasoner> = Arc::new(BarrierSelector {
+            calls: Arc::clone(&calls),
+            started: Mutex::new(Some(started_tx)),
+            release: Arc::clone(&release),
+        });
+        let state = test_state("inflight-edit", Arc::clone(&selector));
+        seed_meeting_source(&state);
+
+        let worker_state = Arc::clone(&state);
+        let audit = tokio::spawn(async move {
+            audit_reminder_suggestions_inner(&worker_state, "meeting".into(), "m1".into(), selector)
+                .await
+        });
+        started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        state
+            .db
+            .lock()
+            .execute(
+                "UPDATE segments SET start_s=start_s+0.5
+                  WHERE meeting_id='m1' AND idx=0",
+                [],
+            )
+            .unwrap();
+        {
+            let (released, wake) = &*release;
+            *released.lock().unwrap() = true;
+            wake.notify_all();
+        }
+
+        assert!(matches!(audit.await.unwrap(), Err(AppError::InvalidArg(_))));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        let derived: i64 = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT
+                   (SELECT COUNT(*) FROM reminder_audit_cache) +
+                   (SELECT COUNT(*) FROM reminder_pending_suggestions)",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(derived, 0);
+    }
+
+    #[test]
+    fn fresh_lock_atomically_purges_all_reminder_audit_rows_and_keeps_accepted_reminder() {
+        ensure_test_dev_kek();
+        let state = test_state(
+            "fresh-lock-reminder-purge",
+            Arc::new(crate::reason::StubReasoner),
+        );
+        seed_meeting_source(&state);
+        let content = read_reminder_audit_source_under_lifecycle(&state, "meeting", "m1").unwrap();
+        let content_hash = reminder_audit_source_hash(&content);
+        let seeded_candidates = crate::reminder_audit::build_candidates(
+            "- [ ] First\n- [ ] Second\n- [ ] Third\n",
+            &[],
+        );
+        state
+            .db
+            .replace_reminder_audit_results_unchecked(
+                "meeting",
+                "m1",
+                &content_hash,
+                "test-local",
+                &seeded_candidates,
+                10,
+            )
+            .unwrap();
+        let rows = state
+            .db
+            .list_pending_reminder_suggestions(
+                "meeting",
+                "m1",
+                &content_hash,
+                "test-local",
+                MAX_REMINDER_AUDIT_ROWS,
+            )
+            .unwrap();
+        assert_eq!(rows.len(), 3);
+        assert!(state
+            .db
+            .promote_pending_reminder_suggestion(
+                &rows[0].id,
+                "meeting",
+                "m1",
+                &content_hash,
+                "accepted-before-fresh-lock",
+                &reminder_draft(),
+                11,
+            )
+            .unwrap());
+        assert!(state
+            .db
+            .dismiss_pending_reminder_suggestion(&rows[1].id, "meeting", "m1", &content_hash)
+            .unwrap());
+        let before: (i64, i64, i64) = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT
+                   (SELECT COUNT(*) FROM reminder_pending_suggestions),
+                   (SELECT COUNT(*) FROM reminder_audit_cache),
+                   (SELECT COUNT(*) FROM reminder_suggestion_decisions)",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            before,
+            (1, 1, 2),
+            "precondition requires pending plaintext plus accepted and dismissed fingerprints"
+        );
+
+        crate::commands::lock_folder_inner(&state, "f1".into()).unwrap();
+
+        let after: (i64, i64, i64) = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT
+                   (SELECT COUNT(*) FROM reminder_pending_suggestions),
+                   (SELECT COUNT(*) FROM reminder_audit_cache),
+                   (SELECT COUNT(*) FROM reminder_suggestion_decisions)",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            after,
+            (0, 0, 0),
+            "the transaction publishing fresh locked=1 must withdraw every reminder audit row"
+        );
+        let accepted = state
+            .db
+            .get_stored_reminder("accepted-before-fresh-lock")
+            .unwrap()
+            .expect("accepted canonical reminder must survive fresh lock");
+        assert!(matches!(accepted.origin, ReminderOrigin::Smart));
+        assert!(accepted.sources.contains(&ReminderSourceAnchor {
+            kind: "meeting".into(),
+            id: "m1".into(),
+        }));
+    }
+
+    #[test]
+    fn initial_lock_notifies_after_gate_closes_but_before_plaintext_cleanup() {
+        ensure_test_dev_kek();
+        let state = test_state(
+            "initial-lock-visibility-notice",
+            Arc::new(crate::reason::StubReasoner),
+        );
+        seed_meeting_source(&state);
+        let notified = AtomicBool::new(false);
+
+        crate::commands::lock_folder_inner_with_visibility_notice(&state, "f1".into(), || {
+            assert!(
+                state.db.folder_by_id("f1").unwrap().unwrap().locked,
+                "the durable visibility gate must close before renderer invalidation"
+            );
+            assert!(
+                !state
+                    .db
+                    .latest_reminder_audit_markdown("m1")
+                    .unwrap()
+                    .unwrap()
+                    .is_empty(),
+                "the notice must precede the remaining fallible plaintext cleanup"
+            );
+            notified.store(true, Ordering::SeqCst);
+        })
+        .unwrap();
+
+        assert!(notified.load(Ordering::SeqCst));
+        assert_eq!(
+            state
+                .db
+                .latest_reminder_audit_markdown("m1")
+                .unwrap()
+                .as_deref(),
+            Some(""),
+            "the verified seal still completes after the early invalidation"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn inflight_relock_boundary_cannot_persist_or_expose_suggestions() {
+        ensure_test_dev_kek();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let (started_tx, started_rx) = mpsc::channel();
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let selector: Arc<dyn LocalReasoner> = Arc::new(BarrierSelector {
+            calls,
+            started: Mutex::new(Some(started_tx)),
+            release: Arc::clone(&release),
+        });
+        let state = test_state("inflight-relock", Arc::clone(&selector));
+        seed_meeting_source(&state);
+        crate::commands::lock_folder_inner(&state, "f1".into()).unwrap();
+        let kek = crate::secrets::get_or_create_master_kek().unwrap();
+        let wrapped = state.db.folder_wrapped_key("f1").unwrap().unwrap();
+        let ck_bytes =
+            crate::crypto::decrypt(&kek, &wrapped, &crate::commands::aad_wrapped_ck("f1")).unwrap();
+        let ck: [u8; 32] = ck_bytes.try_into().unwrap();
+        *state.master_kek.lock().unwrap() = Some(zeroize::Zeroizing::new(kek));
+        for note in state.db.notes_in_folder("f1").unwrap() {
+            let blob = note.content_blob.as_ref().unwrap();
+            let markdown = String::from_utf8(
+                crate::crypto::decrypt(
+                    &ck,
+                    blob,
+                    &crate::commands::aad_content(
+                        "f1",
+                        &note.meeting_id,
+                        &note.provider_id,
+                        "note",
+                    ),
+                )
+                .unwrap(),
+            )
+            .unwrap();
+            state
+                .db
+                .restore_note_markdown(&note.meeting_id, &note.provider_id, &markdown)
+                .unwrap();
+        }
+        crate::commands::unseal_folder_extras(&state, "f1", &ck, None).unwrap();
+        state.unlocked_folders.lock().unwrap().insert("f1".into());
+        let content = read_reminder_audit_source_under_lifecycle(&state, "meeting", "m1").unwrap();
+        assert!(
+            state
+                .db
+                .replace_reminder_audit_results(
+                    "meeting",
+                    "m1",
+                    &reminder_audit_source_hash(&content),
+                    "old-local-engine",
+                    &candidates(),
+                    1,
+                )
+                .unwrap(),
+            "precondition: relock has source-derived plaintext to purge"
+        );
+
+        let worker_state = Arc::clone(&state);
+        let audit = tokio::spawn(async move {
+            audit_reminder_suggestions_inner(&worker_state, "meeting".into(), "m1".into(), selector)
+                .await
+        });
+        started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        crate::commands::relock_all_inner(&state).unwrap();
+        assert_eq!(
+            state
+                .db
+                .latest_reminder_audit_markdown("m1")
+                .unwrap()
+                .as_deref(),
+            Some(""),
+            "production relock must reblank meeting-note plaintext"
+        );
+        assert!(
+            state
+                .db
+                .get_segments("m1")
+                .unwrap()
+                .iter()
+                .all(|segment| segment.text.is_empty()),
+            "production relock must reblank transcript plaintext"
+        );
+        {
+            let (released, wake) = &*release;
+            *released.lock().unwrap() = true;
+            wake.notify_all();
+        }
+
+        assert!(matches!(audit.await.unwrap(), Err(AppError::Locked(_))));
+        let derived: i64 = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT
+                   (SELECT COUNT(*) FROM reminder_audit_cache) +
+                   (SELECT COUNT(*) FROM reminder_pending_suggestions)",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(derived, 0);
+    }
+
+    #[test]
+    fn relock_corrupt_retained_blob_preserves_every_plaintext_family() {
+        let corruptions = [
+            (
+                "note",
+                "UPDATE notes SET content_blob = x'00'
+                  WHERE meeting_id = 'm1' AND provider_id = 'local'",
+            ),
+            (
+                "segment",
+                "UPDATE segments SET text_blob = x'00'
+                  WHERE meeting_id = 'm1' AND idx = 0",
+            ),
+            (
+                "timeline",
+                "UPDATE timelines SET data_blob = x'00'
+                  WHERE meeting_id = 'm1'",
+            ),
+            (
+                "manual-notes",
+                "UPDATE meetings SET manual_notes_blob = x'00'
+                  WHERE id = 'm1'",
+            ),
+            (
+                "document",
+                "UPDATE documents SET text_blob = x'00'
+                  WHERE id = 'doc1'",
+            ),
+            (
+                "attachment",
+                "UPDATE note_attachments SET data_blob = x'00'
+                  WHERE id = '11111111-1111-4111-8111-111111111111'",
+            ),
+        ];
+
+        for (family, corruption) in corruptions {
+            let (state, _ck) =
+                seed_session_unlocked_relock_state(&format!("relock-corrupt-{family}"));
+            let expected = relock_plaintext(&state);
+            state.db.lock().execute(corruption, []).unwrap();
+
+            let error = crate::commands::relock_all_inner(&state)
+                .expect_err("a corrupt retained blob must abort before the first blank");
+            assert!(
+                matches!(error, AppError::Other(_) | AppError::Storage(_)),
+                "{family}: unexpected relock error: {error}"
+            );
+            assert_eq!(
+                relock_plaintext(&state),
+                expected,
+                "{family}: relock failure must preserve every session plaintext family"
+            );
+        }
+    }
+
+    #[test]
+    fn relock_valid_retained_blobs_round_trip_every_plaintext_family_byte_identically() {
+        let (state, ck) = seed_session_unlocked_relock_state("relock-valid-round-trip");
+        let expected = relock_plaintext(&state);
+
+        crate::commands::relock_all_inner(&state).unwrap();
+        assert_eq!(
+            relock_plaintext(&state),
+            RelockPlaintext {
+                note: String::new(),
+                segment: String::new(),
+                timeline: String::new(),
+                manual_notes: String::new(),
+                document: String::new(),
+                attachment: Vec::new(),
+            },
+            "a verified relock must blank every session plaintext family, including attachments"
+        );
+        restore_relock_plaintext_from_blobs(&state, &ck);
+
+        assert_eq!(
+            relock_plaintext(&state),
+            expected,
+            "all five retained ciphertext families must restore byte-identically"
+        );
+    }
+
+    #[test]
+    fn relock_audio_failure_retry_round_trips_playback_and_masters_byte_identically() {
+        ensure_test_dev_kek();
+        let state = test_state(
+            "relock-audio-failure-retry",
+            Arc::new(crate::reason::StubReasoner),
+        );
+        seed_meeting_source(&state);
+
+        let directory = std::env::temp_dir().join(format!(
+            "murmur-relock-audio-roundtrip-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&directory).unwrap();
+        let playback = directory.join("playback.wav");
+        let mic = directory.join("mic-master.wav");
+        let system = directory.join("system-master.wav");
+        let expected_playback = b"RIFF-playback-byte-identical".to_vec();
+        let expected_mic = b"RIFF-mic-master-byte-identical".to_vec();
+        let expected_system = b"RIFF-system-master-byte-identical".to_vec();
+        std::fs::write(&playback, &expected_playback).unwrap();
+        std::fs::write(&mic, &expected_mic).unwrap();
+        std::fs::write(&system, &expected_system).unwrap();
+        state
+            .db
+            .set_meeting_audio_path("m1", Some(playback.to_string_lossy().as_ref()))
+            .unwrap();
+        state
+            .db
+            .set_meeting_mic_master_path("m1", Some(mic.to_string_lossy().as_ref()))
+            .unwrap();
+        state
+            .db
+            .set_meeting_sys_master_path("m1", Some(system.to_string_lossy().as_ref()))
+            .unwrap();
+
+        crate::commands::lock_folder_inner(&state, "f1".into()).unwrap();
+        let kek = crate::secrets::get_or_create_master_kek().unwrap();
+        let wrapped = state.db.folder_wrapped_key("f1").unwrap().unwrap();
+        let ck_bytes =
+            crate::crypto::decrypt(&kek, &wrapped, &crate::commands::aad_wrapped_ck("f1"))
+                .unwrap();
+        let ck: [u8; 32] = ck_bytes.try_into().unwrap();
+        let retry_kek = kek;
+        *state.master_kek.lock().unwrap() = Some(zeroize::Zeroizing::new(kek));
+
+        let playback_enc = std::path::PathBuf::from(format!(
+            "{}{}",
+            playback.to_string_lossy(),
+            crate::commands::ENC_SUFFIX
+        ));
+        crate::commands::unseal_folder_extras(&state, "f1", &ck, None).unwrap();
+        state.unlocked_folders.lock().unwrap().insert("f1".into());
+
+        assert_eq!(std::fs::read(&playback).unwrap(), expected_playback);
+        assert_eq!(std::fs::read(&mic).unwrap(), expected_mic);
+        assert_eq!(std::fs::read(&system).unwrap(), expected_system);
+
+        std::fs::write(&playback_enc, b"corrupt retained playback ciphertext").unwrap();
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o500)).unwrap();
+        let failed_relock = crate::commands::relock_all_inner(&state);
+        std::fs::set_permissions(&directory, std::fs::Permissions::from_mode(0o700)).unwrap();
+        failed_relock
+            .expect_err("corrupt retained audio must abort before deleting session plaintext");
+        assert_eq!(std::fs::read(&playback).unwrap(), expected_playback);
+        assert_eq!(std::fs::read(&mic).unwrap(), expected_mic);
+        assert_eq!(std::fs::read(&system).unwrap(), expected_system);
+
+        *state.master_kek.lock().unwrap() = Some(zeroize::Zeroizing::new(retry_kek));
+        state.unlocked_folders.lock().unwrap().insert("f1".into());
+        crate::commands::relock_all_inner(&state).unwrap();
+        assert!(!playback.exists());
+        assert!(!mic.exists());
+        assert!(!system.exists());
+
+        crate::commands::unseal_folder_extras(&state, "f1", &ck, None).unwrap();
+        assert_eq!(std::fs::read(&playback).unwrap(), expected_playback);
+        assert_eq!(std::fs::read(&mic).unwrap(), expected_mic);
+        assert_eq!(std::fs::read(&system).unwrap(), expected_system);
+
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn relock_repairs_blobless_partial_fresh_seals_before_success() {
+        let partial_seals = [
+            (
+                "note",
+                "UPDATE notes SET content_blob = NULL
+                  WHERE meeting_id = 'm1' AND provider_id = 'local'",
+                "SELECT content_blob IS NOT NULL FROM notes
+                  WHERE meeting_id = 'm1' AND provider_id = 'local'",
+            ),
+            (
+                "timeline",
+                "UPDATE timelines SET data_blob = NULL WHERE meeting_id = 'm1'",
+                "SELECT data_blob IS NOT NULL FROM timelines WHERE meeting_id = 'm1'",
+            ),
+            (
+                "manual-notes",
+                "UPDATE meetings SET manual_notes_blob = NULL WHERE id = 'm1'",
+                "SELECT manual_notes_blob IS NOT NULL FROM meetings WHERE id = 'm1'",
+            ),
+            (
+                "document",
+                "UPDATE documents SET text_blob = NULL WHERE id = 'doc1'",
+                "SELECT text_blob IS NOT NULL FROM documents WHERE id = 'doc1'",
+            ),
+            (
+                "attachment",
+                "UPDATE note_attachments SET data_blob = NULL
+                  WHERE id = '11111111-1111-4111-8111-111111111111'",
+                "SELECT data_blob IS NOT NULL FROM note_attachments
+                  WHERE id = '11111111-1111-4111-8111-111111111111'",
+            ),
+        ];
+
+        for (family, make_partial, blob_present) in partial_seals {
+            let (state, ck) =
+                seed_session_unlocked_relock_state(&format!("relock-partial-{family}"));
+            let expected = relock_plaintext(&state);
+            state.db.lock().execute(make_partial, []).unwrap();
+
+            crate::commands::relock_all_inner(&state).unwrap();
+            assert_eq!(
+                relock_plaintext(&state),
+                RelockPlaintext {
+                    note: String::new(),
+                    segment: String::new(),
+                    timeline: String::new(),
+                    manual_notes: String::new(),
+                    document: String::new(),
+                    attachment: Vec::new(),
+                },
+                "{family}: successful relock must leave no plaintext family readable at rest"
+            );
+            let repaired: bool = state
+                .db
+                .lock()
+                .query_row(blob_present, [], |row| row.get(0))
+                .unwrap();
+            assert!(
+                repaired,
+                "{family}: relock must persist the decrypt-verified replacement blob"
+            );
+
+            restore_relock_plaintext_from_blobs(&state, &ck);
+            assert_eq!(
+                relock_plaintext(&state),
+                expected,
+                "{family}: repaired seal must restore every family byte-identically"
+            );
+        }
+    }
+
+    #[test]
+    fn single_folder_reblank_helper_rejects_corrupt_attachment_before_any_plaintext_blank() {
+        let (state, _ck) = seed_session_unlocked_relock_state("single-folder-attachment-corrupt");
+        let expected = relock_plaintext(&state);
+        state
+            .db
+            .lock()
+            .execute(
+                "UPDATE note_attachments SET data_blob=x'00' WHERE id=?1",
+                rusqlite::params![RELOCK_ATTACHMENT_ID],
+            )
+            .unwrap();
+
+        crate::commands::reblank_folder_extras(&state, "f1")
+            .expect_err("single-folder relock must reject corrupt attachment ciphertext");
+        assert_eq!(
+            relock_plaintext(&state),
+            expected,
+            "single-folder verification failure must precede every plaintext blank"
+        );
+    }
+
+    #[test]
+    fn relock_rejects_attachment_with_neither_plaintext_nor_blob_and_preserves_other_plaintext() {
+        let (state, _ck) = seed_session_unlocked_relock_state("attachment-no-recovery-copy");
+        let expected = relock_plaintext(&state);
+        state
+            .db
+            .lock()
+            .execute(
+                "UPDATE note_attachments
+                    SET data=X'', data_blob=NULL, exported_path=NULL
+                  WHERE id=?1",
+                rusqlite::params![RELOCK_ATTACHMENT_ID],
+            )
+            .unwrap();
+
+        crate::commands::relock_all_inner(&state)
+            .expect_err("a governed attachment with no recovery copy must fail closed");
+        let actual = relock_plaintext(&state);
+        assert_eq!(actual.note, expected.note);
+        assert_eq!(actual.segment, expected.segment);
+        assert_eq!(actual.timeline, expected.timeline);
+        assert_eq!(actual.manual_notes, expected.manual_notes);
+        assert_eq!(actual.document, expected.document);
+        assert!(actual.attachment.is_empty());
+        let row = state
+            .db
+            .attachments_in_folder("f1")
+            .unwrap()
+            .into_iter()
+            .find(|attachment| attachment.id == RELOCK_ATTACHMENT_ID)
+            .unwrap();
+        assert!(row.data_blob.is_none());
+        assert!(row.exported_path.is_none());
+    }
+
+    #[test]
+    fn relock_all_preflights_every_folder_before_corrupt_attachment_can_blank_a_sibling() {
+        let (state, _first_ck) =
+            seed_session_unlocked_relock_state("multi-folder-attachment-corrupt");
+        let first_expected = relock_plaintext(&state);
+        let _second_ck = seed_second_session_unlocked_folder(&state);
+        let second_note_expected = state.db.notes_in_folder("f2").unwrap().remove(0).markdown;
+        let second_attachment_expected =
+            state.db.attachments_in_folder("f2").unwrap().remove(0).data;
+        state
+            .db
+            .lock()
+            .execute(
+                "UPDATE note_attachments SET data_blob=x'00' WHERE id=?1",
+                rusqlite::params![SECOND_RELOCK_ATTACHMENT_ID],
+            )
+            .unwrap();
+
+        crate::commands::relock_all_inner(&state)
+            .expect_err("one corrupt attachment must abort the all-folder preflight");
+        assert_eq!(
+            relock_plaintext(&state),
+            first_expected,
+            "a sibling folder encountered earlier must retain all of its plaintext"
+        );
+        assert_eq!(
+            state.db.notes_in_folder("f2").unwrap().remove(0).markdown,
+            second_note_expected
+        );
+        assert_eq!(
+            state.db.attachments_in_folder("f2").unwrap().remove(0).data,
+            second_attachment_expected
+        );
+    }
+
+    #[test]
+    fn startup_repairs_blobless_attachment_before_blanking_and_restores_exact_bytes() {
+        let (state, ck) = seed_session_unlocked_relock_state("startup-attachment-blobless");
+        let expected = relock_attachment_bytes();
+        state
+            .db
+            .lock()
+            .execute(
+                "UPDATE note_attachments SET data_blob=NULL WHERE id=?1",
+                rusqlite::params![RELOCK_ATTACHMENT_ID],
+            )
+            .unwrap();
+        state.unlocked_folders.lock().unwrap().clear();
+
+        assert!(
+            crate::commands::locked_folder_requires_authenticated_repair(&state.db, "f1").unwrap()
+        );
+        crate::commands::repair_locked_folder_at_rest(&state.db, "f1", &ck).unwrap();
+        assert!(
+            !crate::commands::locked_folder_requires_authenticated_repair(&state.db, "f1").unwrap(),
+            "startup repair must reach a fully sealed attachment shape before reporting success"
+        );
+        let sealed = state
+            .db
+            .attachments_in_folder("f1")
+            .unwrap()
+            .into_iter()
+            .find(|attachment| attachment.id == RELOCK_ATTACHMENT_ID)
+            .unwrap();
+        assert!(sealed.data.is_empty());
+        assert!(sealed.data_blob.is_some());
+
+        crate::commands::unseal_attachments_in_folder(&state, "f1", &ck, false).unwrap();
+        let restored = state
+            .db
+            .attachments_in_folder("f1")
+            .unwrap()
+            .into_iter()
+            .find(|attachment| attachment.id == RELOCK_ATTACHMENT_ID)
+            .unwrap();
+        assert_eq!(restored.data, expected);
+    }
+
+    #[test]
+    fn startup_authenticates_retained_attachment_before_cleaning_export_residue() {
+        let (state, ck) = seed_session_unlocked_relock_state("startup-attachment-export-valid");
+        let expected = relock_attachment_bytes();
+        let export = std::env::temp_dir().join(format!(
+            "murmur-reminder-relock-valid-{}.webp",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::write(&export, &expected).unwrap();
+        state
+            .db
+            .lock()
+            .execute(
+                "UPDATE note_attachments SET data=X'', exported_path=?2 WHERE id=?1",
+                rusqlite::params![RELOCK_ATTACHMENT_ID, export.to_string_lossy().as_ref()],
+            )
+            .unwrap();
+        state.unlocked_folders.lock().unwrap().clear();
+
+        assert!(
+            crate::commands::locked_folder_requires_authenticated_repair(&state.db, "f1").unwrap(),
+            "an export path alone must force authenticated startup repair"
+        );
+        crate::commands::repair_locked_folder_at_rest(&state.db, "f1", &ck).unwrap();
+        assert!(!export.exists());
+        let sealed = state
+            .db
+            .attachments_in_folder("f1")
+            .unwrap()
+            .into_iter()
+            .find(|attachment| attachment.id == RELOCK_ATTACHMENT_ID)
+            .unwrap();
+        assert!(sealed.data.is_empty());
+        assert!(sealed.data_blob.is_some());
+        assert!(sealed.exported_path.is_none());
+        assert!(
+            !crate::commands::locked_folder_requires_authenticated_repair(&state.db, "f1").unwrap()
+        );
+
+        crate::commands::unseal_attachments_in_folder(&state, "f1", &ck, false).unwrap();
+        assert_eq!(
+            state
+                .db
+                .attachments_in_folder("f1")
+                .unwrap()
+                .into_iter()
+                .find(|attachment| attachment.id == RELOCK_ATTACHMENT_ID)
+                .unwrap()
+                .data,
+            expected
+        );
+    }
+
+    #[test]
+    fn startup_corrupt_or_blobless_attachment_export_aborts_without_deleting_residue() {
+        for (case, blob_sql) in [("corrupt", "x'00'"), ("missing", "NULL")] {
+            let (state, ck) =
+                seed_session_unlocked_relock_state(&format!("startup-attachment-export-{case}"));
+            let expected = relock_plaintext(&state);
+            let export = std::env::temp_dir().join(format!(
+                "murmur-reminder-relock-{case}-{}.webp",
+                uuid::Uuid::new_v4()
+            ));
+            std::fs::write(&export, relock_attachment_bytes()).unwrap();
+            let sql = format!(
+                "UPDATE note_attachments
+                    SET data=X'', data_blob={blob_sql}, exported_path=?2
+                  WHERE id=?1"
+            );
+            state
+                .db
+                .lock()
+                .execute(
+                    &sql,
+                    rusqlite::params![RELOCK_ATTACHMENT_ID, export.to_string_lossy().as_ref()],
+                )
+                .unwrap();
+            state.unlocked_folders.lock().unwrap().clear();
+
+            assert!(
+                crate::commands::locked_folder_requires_authenticated_repair(&state.db, "f1")
+                    .unwrap(),
+                "{case}: tracked export residue must force authenticated startup repair"
+            );
+            crate::commands::repair_locked_folder_at_rest(&state.db, "f1", &ck)
+                .expect_err("unrecoverable attachment export must fail before cleanup");
+            assert!(export.exists(), "{case}: export residue must be preserved");
+            let row = state
+                .db
+                .attachments_in_folder("f1")
+                .unwrap()
+                .into_iter()
+                .find(|attachment| attachment.id == RELOCK_ATTACHMENT_ID)
+                .unwrap();
+            assert!(row.data.is_empty());
+            assert!(row.exported_path.is_some());
+            assert_eq!(
+                RelockPlaintext {
+                    attachment: expected.attachment.clone(),
+                    ..relock_plaintext(&state)
+                },
+                expected,
+                "{case}: attachment preflight must preserve every other plaintext family"
+            );
+            std::fs::remove_file(export).unwrap();
+        }
+    }
+
+    #[test]
+    fn full_hash_rejects_edits_beyond_the_bounded_candidate_prefix() {
+        let mut segments = (0..=MAX_AUDIT_SEGMENTS)
+            .map(|idx| Segment {
+                idx: idx as i64,
+                start_s: idx as f64,
+                end_s: idx as f64 + 0.5,
+                text: format!("segment {idx}"),
+                speaker: None,
+                confidence: None,
+            })
+            .collect::<Vec<_>>();
+        let before = ReminderAuditSourceContent {
+            markdown: "- [ ] Keep the bounded candidate\n".into(),
+            manual_notes: String::new(),
+            segments: segments.clone(),
+            source: ReminderSourceView {
+                kind: "meeting".into(),
+                id: "m1".into(),
+                title: "Meeting".into(),
+            },
+        };
+        let expected_hash = reminder_audit_source_hash(&before);
+        segments[MAX_AUDIT_SEGMENTS].text = "edited outside candidate prefix".into();
+        let after = ReminderAuditSourceContent {
+            markdown: before.markdown.clone(),
+            manual_notes: before.manual_notes.clone(),
+            segments,
+            source: before.source.clone(),
+        };
+
+        let bounded_before = bounded_audit_segments(&before.segments);
+        let bounded_after = bounded_audit_segments(&after.segments);
+        assert_eq!(
+            bounded_before
+                .iter()
+                .map(|segment| segment.text.as_str())
+                .collect::<Vec<_>>(),
+            bounded_after
+                .iter()
+                .map(|segment| segment.text.as_str())
+                .collect::<Vec<_>>(),
+            "candidate extraction must stay bounded before the edited tail"
+        );
+        assert!(
+            require_reminder_audit_hash(&after, &expected_hash).is_err(),
+            "the full canonical hash must still reject the source edit"
+        );
+    }
+
+    #[test]
+    fn audit_hash_covers_source_title_and_manual_notes() {
+        let content = ReminderAuditSourceContent {
+            markdown: "Summary".into(),
+            manual_notes: "- [ ] Follow up".into(),
+            segments: Vec::new(),
+            source: ReminderSourceView {
+                kind: "meeting".into(),
+                id: "m1".into(),
+                title: "Planning".into(),
+            },
+        };
+        let hash = reminder_audit_source_hash(&content);
+
+        let mut title_edit = ReminderAuditSourceContent {
+            markdown: content.markdown.clone(),
+            manual_notes: content.manual_notes.clone(),
+            segments: content.segments.clone(),
+            source: content.source.clone(),
+        };
+        title_edit.source.title = "Renamed planning".into();
+        assert_ne!(reminder_audit_source_hash(&title_edit), hash);
+
+        let mut manual_edit = title_edit;
+        manual_edit.source.title = content.source.title.clone();
+        manual_edit.manual_notes = "- [ ] Follow up today".into();
+        assert_ne!(reminder_audit_source_hash(&manual_edit), hash);
+
+        let note = ReminderAuditSourceContent {
+            markdown: "Body".into(),
+            manual_notes: String::new(),
+            segments: Vec::new(),
+            source: ReminderSourceView {
+                kind: "note".into(),
+                id: "n1".into(),
+                title: "Authored title".into(),
+            },
+        };
+        let note_hash = reminder_audit_source_hash(&note);
+        let mut renamed_note = ReminderAuditSourceContent {
+            markdown: note.markdown.clone(),
+            manual_notes: String::new(),
+            segments: Vec::new(),
+            source: note.source,
+        };
+        renamed_note.source.title = "Renamed authored title".into();
+        assert_ne!(reminder_audit_source_hash(&renamed_note), note_hash);
+    }
+
+    #[test]
+    fn audit_hash_covers_every_canonical_segment_field() {
+        let content = ReminderAuditSourceContent {
+            markdown: "Summary".into(),
+            manual_notes: String::new(),
+            segments: vec![Segment {
+                idx: 7,
+                start_s: 1.25,
+                end_s: 2.5,
+                text: "Follow up".into(),
+                speaker: Some("me".into()),
+                confidence: Some(0.75),
+            }],
+            source: ReminderSourceView {
+                kind: "meeting".into(),
+                id: "m1".into(),
+                title: "Planning".into(),
+            },
+        };
+        let original = reminder_audit_source_hash(&content);
+        let mutations: [fn(&mut Segment); 6] = [
+            |segment: &mut Segment| segment.idx += 1,
+            |segment: &mut Segment| segment.start_s += 0.25,
+            |segment: &mut Segment| segment.end_s += 0.25,
+            |segment: &mut Segment| segment.text.push('!'),
+            |segment: &mut Segment| segment.speaker = Some("others".into()),
+            |segment: &mut Segment| segment.confidence = Some(0.5),
+        ];
+        for mutate in mutations {
+            let mut edited = ReminderAuditSourceContent {
+                markdown: content.markdown.clone(),
+                manual_notes: content.manual_notes.clone(),
+                segments: content.segments.clone(),
+                source: content.source.clone(),
+            };
+            mutate(&mut edited.segments[0]);
+            assert_ne!(reminder_audit_source_hash(&edited), original);
+        }
+    }
+
+    #[test]
+    fn meeting_manual_notes_feed_deterministic_candidates() {
+        let content = ReminderAuditSourceContent {
+            markdown: "No checklist in the generated note.".into(),
+            manual_notes: "## Action items\n- [ ] Call the customer".into(),
+            segments: Vec::new(),
+            source: ReminderSourceView {
+                kind: "meeting".into(),
+                id: "m1".into(),
+                title: "Planning".into(),
+            },
+        };
+        let candidates =
+            crate::reminder_audit::build_candidates(&reminder_candidate_markdown(&content), &[]);
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].title, "Call the customer");
+    }
+
+    #[test]
+    fn candidate_markdown_is_bounded_and_reserves_manual_note_space() {
+        let content = ReminderAuditSourceContent {
+            markdown: "generated line\n".repeat(MAX_AUDIT_MARKDOWN_BYTES),
+            manual_notes: "- [ ] Manual follow up\n".repeat(10_000),
+            segments: Vec::new(),
+            source: ReminderSourceView {
+                kind: "meeting".into(),
+                id: "m1".into(),
+                title: "Planning".into(),
+            },
+        };
+        let bounded = reminder_candidate_markdown(&content);
+        assert!(bounded.len() <= MAX_AUDIT_MARKDOWN_BYTES);
+        assert!(bounded.contains("Manual follow up"));
+    }
+
+    #[test]
+    fn hidden_source_merge_preserves_locked_anchor_and_allows_visible_removal() {
+        let mut submitted = vec![ReminderSourceAnchor {
+            kind: "meeting".into(),
+            id: "visible-kept".into(),
+        }];
+        merge_hidden_source_anchors(
+            &mut submitted,
+            BTreeSet::from([("note".to_string(), "locked-note".to_string())]),
+        );
+        assert_eq!(
+            submitted,
+            vec![
+                ReminderSourceAnchor {
+                    kind: "meeting".into(),
+                    id: "visible-kept".into(),
+                },
+                ReminderSourceAnchor {
+                    kind: "note".into(),
+                    id: "locked-note".into(),
+                }
+            ]
+        );
+        assert!(
+            !submitted
+                .iter()
+                .any(|source| source.id == "visible-removed"),
+            "an omitted visible source must remain explicitly removable"
+        );
     }
 }
 

--- a/src-tauri/src/commands/reminders.rs
+++ b/src-tauri/src/commands/reminders.rs
@@ -20,6 +20,7 @@ use crate::storage::models::{
     ReminderState, ReminderSuggestionView, ReminderSummary, ReminderView, RemindersSnapshot,
     StoredReminder, StoredReminderSuggestion,
 };
+use crate::storage::reminder_store::ReminderSuggestionPromotion;
 use crate::transcribe::types::Segment;
 
 /// Escape a string for embedding inside an AppleScript `"…"` literal: backslash + double-quote are
@@ -2674,15 +2675,18 @@ fn accept_reminder_suggestion_under_lifecycle(
 
     let reminder_id = uuid::Uuid::new_v4().to_string();
     let now = chrono::Utc::now().timestamp_millis();
-    if !state.db.promote_pending_reminder_suggestion(
-        &suggestion.id,
-        &suggestion.source_kind,
-        &suggestion.source_id,
-        &current_hash,
-        &reminder_id,
-        &draft,
-        now,
-    )? {
+    if !state
+        .db
+        .promote_pending_reminder_suggestion(ReminderSuggestionPromotion {
+            suggestion_id: &suggestion.id,
+            expected_source_kind: &suggestion.source_kind,
+            expected_source_id: &suggestion.source_id,
+            expected_content_hash: &current_hash,
+            reminder_id: &reminder_id,
+            draft: &draft,
+            now,
+        })?
+    {
         return Err(AppError::InvalidArg(
             "reminder suggestion is stale or was already accepted".into(),
         ));
@@ -4413,15 +4417,15 @@ mod smart_audit_command_tests {
         assert_eq!(rows.len(), 3);
         assert!(state
             .db
-            .promote_pending_reminder_suggestion(
-                &rows[0].id,
-                "meeting",
-                "m1",
-                &content_hash,
-                "accepted-before-fresh-lock",
-                &reminder_draft(),
-                11,
-            )
+            .promote_pending_reminder_suggestion(ReminderSuggestionPromotion {
+                suggestion_id: &rows[0].id,
+                expected_source_kind: "meeting",
+                expected_source_id: "m1",
+                expected_content_hash: &content_hash,
+                reminder_id: "accepted-before-fresh-lock",
+                draft: &reminder_draft(),
+                now: 11,
+            })
             .unwrap());
         assert!(state
             .db

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -5918,6 +5918,7 @@
         let wrapped = state.db.folder_wrapped_key(&fid).unwrap().unwrap();
         let ck_vec = crate::crypto::decrypt(&kek, &wrapped, &aad_wrapped_ck(&fid)).unwrap();
         let ck: [u8; 32] = ck_vec.try_into().expect("CK is 32 bytes");
+        *state.master_kek.lock().unwrap() = Some(Zeroizing::new(kek));
         unseal_folder_extras(&state, &fid, &ck, None).unwrap();
         state.unlocked_folders.lock().unwrap().insert(fid.clone());
 
@@ -7602,6 +7603,7 @@
         let wrapped = state.db.folder_wrapped_key(folder_id).unwrap().unwrap();
         let ck_vec = crate::crypto::decrypt(&kek, &wrapped, &aad_wrapped_ck(folder_id)).unwrap();
         let ck: [u8; 32] = ck_vec.try_into().expect("CK is 32 bytes");
+        *state.master_kek.lock().unwrap() = Some(Zeroizing::new(kek));
         for n in state.db.notes_in_folder(folder_id).unwrap() {
             if let Some(blob) = &n.content_blob {
                 let aad = aad_content(folder_id, &n.meeting_id, &n.provider_id, "note");

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -542,6 +542,83 @@ pub fn emit_audit_updated(app: &AppHandle, pending: u32) {
     }
 }
 
+/// Content-free reminder invalidation ping. The app-process scheduler and every reminder mutation
+/// emit only the unread due count; reminder titles/details never enter the event bus or logs.
+pub const EVENT_REMINDERS_UPDATED: &str = "murmur://reminders-updated";
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemindersUpdatedPayload {
+    pub due_inbox_count: u64,
+}
+
+pub fn emit_reminders_updated(app: &AppHandle, due_inbox_count: u64) {
+    if let Err(e) = app.emit(
+        EVENT_REMINDERS_UPDATED,
+        RemindersUpdatedPayload { due_inbox_count },
+    ) {
+        tracing::warn!(
+            target: "reminders",
+            error = %e,
+            "failed to emit reminders-updated notice"
+        );
+    }
+}
+
+/// Content-free invalidation for one meeting/note Smart-reminder card. Canonical mutations enqueue
+/// this durable ping in SQLCipher; the background drain emits only the source kind + opaque id so
+/// the FE can re-fetch through the normal gated command.
+pub const EVENT_REMINDER_SOURCE_UPDATED: &str = "murmur://reminder-source-updated";
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReminderSourceUpdatedPayload {
+    pub kind: String,
+    pub id: String,
+}
+
+/// Best-effort emit. The boolean is the durable outbox acknowledgement decision: `true` means the
+/// worker may CAS-delete that exact queue revision; `false` leaves it for replay.
+pub fn emit_reminder_source_updated(app: &AppHandle, kind: &str, id: &str) -> bool {
+    match app.emit(
+        EVENT_REMINDER_SOURCE_UPDATED,
+        ReminderSourceUpdatedPayload {
+            kind: kind.to_string(),
+            id: id.to_string(),
+        },
+    ) {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::warn!(
+                target: "reminders",
+                error = %e,
+                "failed to emit reminder-source-updated notice"
+            );
+            false
+        }
+    }
+}
+
+/// Global, content-free privacy invalidation emitted while the lock lifecycle guard is held,
+/// immediately after visibility authority is revoked. Unlike source-edit invalidations this has no
+/// source id: consumers must synchronously discard every cached reminder source title before
+/// re-fetching through the canonical gated commands.
+pub const EVENT_REMINDER_VISIBILITY_INVALIDATED: &str = "murmur://reminder-visibility-invalidated";
+
+pub fn emit_reminder_visibility_invalidated(app: &AppHandle) -> bool {
+    match app.emit(EVENT_REMINDER_VISIBILITY_INVALIDATED, ()) {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::error!(
+                target: "reminders",
+                error = %e,
+                "failed to emit reminder visibility invalidation"
+            );
+            false
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -558,6 +635,36 @@ mod tests {
         assert_eq!(EVENT_AUDIT_UPDATED, "murmur://audit-updated");
         let json = serde_json::to_string(&AuditUpdatedPayload { pending: 4 }).unwrap();
         assert_eq!(json, r#"{"pending":4}"#);
+    }
+
+    #[test]
+    fn reminders_updated_event_is_count_only() {
+        assert_eq!(EVENT_REMINDERS_UPDATED, "murmur://reminders-updated");
+        let json = serde_json::to_string(&RemindersUpdatedPayload { due_inbox_count: 2 }).unwrap();
+        assert_eq!(json, r#"{"dueInboxCount":2}"#);
+    }
+
+    #[test]
+    fn reminder_source_updated_event_is_opaque_id_and_kind_only() {
+        assert_eq!(
+            EVENT_REMINDER_SOURCE_UPDATED,
+            "murmur://reminder-source-updated"
+        );
+        let json = serde_json::to_string(&ReminderSourceUpdatedPayload {
+            kind: "meeting".into(),
+            id: "m1".into(),
+        })
+        .unwrap();
+        assert_eq!(json, r#"{"kind":"meeting","id":"m1"}"#);
+    }
+
+    #[test]
+    fn reminder_visibility_invalidated_event_is_content_free() {
+        assert_eq!(
+            EVENT_REMINDER_VISIBILITY_INVALIDATED,
+            "murmur://reminder-visibility-invalidated"
+        );
+        assert_eq!(serde_json::to_string(&()).unwrap(), "null");
     }
 
     /// The FE listens on this exact event name; a rename silently drops the tab-strip fan-out.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,6 +28,7 @@ pub mod pipeline;
 pub mod proactive;
 pub mod prompts;
 pub mod reason;
+pub(crate) mod reminder_audit;
 pub mod rerank;
 pub mod router;
 pub mod screenshare;
@@ -72,6 +73,7 @@ pub fn run() {
     // strictly before any ggml-Metal device can be initialized. SAFETY: single-threaded at
     // startup, before any thread that could read the env. (Mirror guard in `Transcriber::load`.)
     std::env::set_var("GGML_METAL_NO_RESIDENCY", "1");
+    commands::prepare_reminder_runtime_probe_environment();
 
     // Acquire global process ownership BEFORE touching even the shared log, encrypted library, or
     // recovery ledger. Lease expiry alone cannot prove a mic-only recorder died: a stalled spool
@@ -160,7 +162,7 @@ pub fn run() {
         previous_panic_hook(info);
     }));
 
-    tauri::Builder::default()
+    let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(
             tauri_plugin_global_shortcut::Builder::new()
@@ -171,7 +173,16 @@ pub fn run() {
                     }
                 })
                 .build(),
-        )
+        );
+    if commands::reminder_runtime_probe_requested() {
+        // The exact Harness task drives real product commands through the normal Tauri IPC bridge.
+        // The fixed script claims one webview per process; its content-free control endpoint only
+        // sequences the runner-owned restart and validates counters/receipts.
+        builder = builder.append_invoke_initialization_script(
+            commands::reminder_runtime_probe_initialization_script(),
+        );
+    }
+    builder
         .invoke_handler(tauri::generate_handler![
             commands::set_focus_meeting,
             commands::start_recording,
@@ -354,6 +365,19 @@ pub fn run() {
             commands::get_action_items,
             commands::list_open_commitments,
             commands::patch_note_tasks,
+            // First-class Murmur reminder store. `add_reminder` immediately below remains the
+            // separate Apple Reminders osascript integration.
+            commands::list_reminders,
+            commands::get_reminder_summary,
+            commands::create_reminder,
+            commands::update_reminder,
+            commands::delete_reminder,
+            commands::complete_reminder,
+            commands::dismiss_reminder_occurrence,
+            commands::audit_reminder_suggestions,
+            commands::accept_reminder_suggestion,
+            commands::dismiss_reminder_suggestion,
+            commands::reminder_runtime_probe_control,
             commands::add_reminder,
             commands::pin_moment,
             commands::link_meeting_entities,
@@ -460,7 +484,7 @@ pub fn run() {
             commands::remove_lock,
             commands::discard_unrecoverable_folder_lock,
             commands::discard_unrecoverable_meeting_lock,
-            update::check_for_update,
+            commands::check_for_update_guarded,
             update::app_info,
             update::open_release_page,
         ])
@@ -575,6 +599,10 @@ pub fn run() {
                         return Ok(());
                     }
                 };
+                // Start background reminder work only after every synchronous fatal startup
+                // preflight has accepted this process. A rejected DB/recovery launch must not
+                // materialize occurrences or emit events while its fatal dialog is exiting.
+                commands::spawn_reminder_scheduler(app.handle().clone());
                 let app_handle = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
                     // This affine owner is deliberately retained across BOTH detection/claim and the
@@ -739,7 +767,7 @@ pub fn run() {
             // Pass the AppHandle so the server resolves the ONE managed AppState for every request:
             // DB, live session unlock set, seal epoch, and lifecycle guard cannot drift into an
             // independently-opened/snapshotted authority.
-            {
+            if !commands::reminder_runtime_probe_requested() {
                 let state = app.state::<AppState>();
                 let require_token = state
                     .config
@@ -749,6 +777,14 @@ pub fn run() {
                     // reasoner-dispatch poison posture (unreadable config never relaxes auth).
                     .unwrap_or(true);
                 crate::mcp::spawn(app.handle().clone(), require_token);
+            } else {
+                // The canonical runtime smoke treats the real MCP listener as its readiness
+                // witness. In this isolated debug process only, the IPC privacy probe starts MCP
+                // after it has proved relock/restart masking and the no-egress configuration matrix.
+                tracing::info!(
+                    target: "reminders",
+                    "native reminder runtime privacy probe is pending"
+                );
             }
             // Brain v2 L1.1 — TOPIC-CHUNK startup backfill: index topic segments for every VISIBLE
             // meeting that has a transcript, content-hash idempotent (an already-indexed vault is a

--- a/src-tauri/src/reminder_audit.rs
+++ b/src-tauri/src/reminder_audit.rs
@@ -1,0 +1,398 @@
+//! Pure, bounded candidate preparation for the local Smart-reminder audit.
+//!
+//! This module never reads storage and never creates a reminder. Model output can only select
+//! candidate ids that were produced deterministically from already-gated caller input.
+
+use std::collections::HashSet;
+use std::fmt::Write;
+
+use chrono::{Local, NaiveDate, TimeZone};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::error::{AppError, Result};
+use crate::summarize::action_items::parse_action_items;
+
+const MAX_MARKDOWN_BYTES: usize = 256 * 1024;
+const MAX_TRANSCRIPT_CANDIDATE_BYTES: usize = 64 * 1024;
+const MAX_TRANSCRIPT_CANDIDATE_INPUTS: usize = 128;
+const MAX_CANDIDATES: usize = 32;
+const MAX_TITLE_CHARS: usize = 240;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ReminderAuditCandidate {
+    pub id: String,
+    pub title: String,
+    pub suggested_due_at: Option<i64>,
+    pub candidate_key: String,
+}
+
+/// Hash all canonical source parts without separator ambiguity.
+///
+/// Each UTF-8 part is framed by its big-endian byte length, so `["ab", "c"]` and `["a", "bc"]`
+/// cannot collide merely because their concatenation is the same. Hashing streams over the input
+/// and does not copy or log source content.
+pub(crate) fn content_hash(parts: &[&str]) -> String {
+    let mut hasher = Sha256::new();
+    for part in parts {
+        let bytes = part.as_bytes();
+        let byte_len = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+        hasher.update(byte_len.to_be_bytes());
+        hasher.update(bytes);
+    }
+    hex_digest(hasher.finalize())
+}
+
+/// Build deterministic Smart-reminder candidates from already-gated caller content.
+///
+/// Open note checkboxes are considered before caller-vetted transcript cues. This gives an
+/// explicit action item precedence when both sources normalize to the same title. The caller owns
+/// transcript cue extraction; accepting arbitrary transcript lines here would turn this bounded
+/// audit into a second, less conservative classifier.
+pub(crate) fn build_candidates(
+    markdown: &str,
+    transcript_candidates: &[String],
+) -> Vec<ReminderAuditCandidate> {
+    let mut candidates = Vec::new();
+    let mut seen_keys = HashSet::new();
+
+    for item in parse_action_items(bounded_complete_lines(markdown, MAX_MARKDOWN_BYTES))
+        .into_iter()
+        .filter(|item| !item.done)
+    {
+        push_candidate(
+            &mut candidates,
+            &mut seen_keys,
+            bounded_prefix(&item.text, MAX_TRANSCRIPT_CANDIDATE_BYTES),
+        );
+        if candidates.len() == MAX_CANDIDATES {
+            return candidates;
+        }
+    }
+
+    let mut remaining_bytes = MAX_TRANSCRIPT_CANDIDATE_BYTES;
+    for raw in transcript_candidates
+        .iter()
+        .take(MAX_TRANSCRIPT_CANDIDATE_INPUTS)
+    {
+        if candidates.len() == MAX_CANDIDATES || remaining_bytes == 0 {
+            break;
+        }
+        let bounded = bounded_prefix(raw, remaining_bytes);
+        remaining_bytes = remaining_bytes.saturating_sub(bounded.len());
+        push_candidate(&mut candidates, &mut seen_keys, bounded);
+    }
+
+    candidates
+}
+
+/// Validate the one allowed local-model decision: selecting ids from the supplied candidate set.
+///
+/// The returned rows are clones of the deterministic candidates in their original order. Unknown
+/// or duplicate ids, an oversized selection, and any additional JSON field reject the entire
+/// response, so model text can never become a title or date.
+pub(crate) fn validate_keep_ids(
+    value: Value,
+    candidates: &[ReminderAuditCandidate],
+) -> Result<Vec<ReminderAuditCandidate>> {
+    if candidates.len() > MAX_CANDIDATES {
+        return Err(invalid_model_selection());
+    }
+    let object = value.as_object().ok_or_else(invalid_model_selection)?;
+    if object.len() != 1 {
+        return Err(invalid_model_selection());
+    }
+    let keep_ids = object
+        .get("keepIds")
+        .and_then(Value::as_array)
+        .ok_or_else(invalid_model_selection)?;
+    if keep_ids.len() > candidates.len() {
+        return Err(invalid_model_selection());
+    }
+
+    let mut candidate_ids = HashSet::with_capacity(candidates.len());
+    for candidate in candidates {
+        if !candidate_ids.insert(candidate.id.as_str()) {
+            return Err(invalid_model_selection());
+        }
+    }
+
+    let mut kept_ids = HashSet::with_capacity(keep_ids.len());
+    for id in keep_ids {
+        let id = id.as_str().ok_or_else(invalid_model_selection)?;
+        if !candidate_ids.contains(id) || !kept_ids.insert(id) {
+            return Err(invalid_model_selection());
+        }
+    }
+
+    Ok(candidates
+        .iter()
+        .filter(|candidate| kept_ids.contains(candidate.id.as_str()))
+        .cloned()
+        .collect())
+}
+
+fn push_candidate(
+    candidates: &mut Vec<ReminderAuditCandidate>,
+    seen_keys: &mut HashSet<String>,
+    raw_title: &str,
+) {
+    if candidates.len() == MAX_CANDIDATES {
+        return;
+    }
+    let title = bounded_title(raw_title);
+    if title.is_empty() {
+        return;
+    }
+    let normalized = normalize_title(&title);
+    let candidate_key = hex_digest(Sha256::digest(normalized.as_bytes()));
+    if !seen_keys.insert(candidate_key.clone()) {
+        return;
+    }
+    candidates.push(ReminderAuditCandidate {
+        id: format!("c{}", candidates.len() + 1),
+        suggested_due_at: first_valid_due_at(&title),
+        title,
+        candidate_key,
+    });
+}
+
+fn bounded_title(raw: &str) -> String {
+    let mut out = String::new();
+    for word in raw.split_whitespace() {
+        let separator_chars = usize::from(!out.is_empty());
+        let remaining = MAX_TITLE_CHARS.saturating_sub(out.chars().count() + separator_chars);
+        if remaining == 0 {
+            break;
+        }
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.extend(word.chars().take(remaining));
+        if word.chars().count() > remaining {
+            break;
+        }
+    }
+    out
+}
+
+fn normalize_title(title: &str) -> String {
+    title.to_lowercase()
+}
+
+fn first_valid_due_at(title: &str) -> Option<i64> {
+    let len = title.len();
+    if len < 10 {
+        return None;
+    }
+    for start in 0..=len - 10 {
+        let Some(raw_date) = title.get(start..start + 10) else {
+            continue;
+        };
+        if !has_iso_shape(raw_date) || !has_date_boundaries(title, start) {
+            continue;
+        }
+        let Ok(date) = NaiveDate::parse_from_str(raw_date, "%Y-%m-%d") else {
+            continue;
+        };
+        if date.format("%Y-%m-%d").to_string() != raw_date {
+            continue;
+        }
+        let local_nine = date.and_hms_opt(9, 0, 0)?;
+        if let Some(timestamp) = Local.from_local_datetime(&local_nine).single() {
+            let timestamp = timestamp.timestamp_millis();
+            if (crate::storage::reminder_store::MIN_REMINDER_DUE_AT
+                ..crate::storage::reminder_store::MAX_REMINDER_DUE_AT)
+                .contains(&timestamp)
+            {
+                return Some(timestamp);
+            }
+        }
+    }
+    None
+}
+
+fn has_date_boundaries(value: &str, start: usize) -> bool {
+    let before_is_digit = value
+        .get(..start)
+        .and_then(|prefix| prefix.chars().next_back())
+        .is_some_and(|character| character.is_ascii_digit());
+    let after_is_digit = value
+        .get(start + 10..)
+        .and_then(|suffix| suffix.chars().next())
+        .is_some_and(|character| character.is_ascii_digit());
+    !before_is_digit && !after_is_digit
+}
+
+fn has_iso_shape(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() == 10
+        && bytes[4] == b'-'
+        && bytes[7] == b'-'
+        && bytes[..4].iter().all(u8::is_ascii_digit)
+        && bytes[5..7].iter().all(u8::is_ascii_digit)
+        && bytes[8..].iter().all(u8::is_ascii_digit)
+}
+
+fn bounded_complete_lines(value: &str, max_bytes: usize) -> &str {
+    let prefix = bounded_prefix(value, max_bytes);
+    if prefix.len() == value.len() {
+        return prefix;
+    }
+    prefix
+        .rfind('\n')
+        .map_or("", |last_newline| &prefix[..=last_newline])
+}
+
+fn bounded_prefix(value: &str, max_bytes: usize) -> &str {
+    if value.len() <= max_bytes {
+        return value;
+    }
+    let mut end = max_bytes;
+    while !value.is_char_boundary(end) {
+        end = end.saturating_sub(1);
+    }
+    &value[..end]
+}
+
+fn hex_digest(bytes: impl AsRef<[u8]>) -> String {
+    let bytes = bytes.as_ref();
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        let _ = write!(&mut out, "{byte:02x}");
+    }
+    out
+}
+
+fn invalid_model_selection() -> AppError {
+    AppError::InvalidArg("invalid local reminder-audit selection".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{Local, TimeZone};
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn candidates_include_open_but_not_completed_checkboxes() {
+        let markdown =
+            "## Action items\n- [ ] Ship the plan\n- [x] Already shipped\n- [X] Also done\n";
+        let transcript = vec!["Call the customer".to_string()];
+
+        let candidates = build_candidates(markdown, &transcript);
+
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|candidate| candidate.title.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Ship the plan", "Call the customer"]
+        );
+    }
+
+    #[test]
+    fn only_calendar_valid_exact_iso_dates_become_local_nine_am() {
+        let transcript = vec![
+            "Impossible deadline 2026-02-30".to_string(),
+            "Leap-day deadline 2028-02-29".to_string(),
+            "Not exact 2028-2-29".to_string(),
+            "Embedded in a longer number 12028-02-29".to_string(),
+        ];
+
+        let candidates = build_candidates("", &transcript);
+
+        assert_eq!(candidates[0].suggested_due_at, None);
+        assert_eq!(
+            candidates[1].suggested_due_at,
+            Local
+                .with_ymd_and_hms(2028, 2, 29, 9, 0, 0)
+                .single()
+                .map(|value| value.timestamp_millis())
+        );
+        assert_eq!(candidates[2].suggested_due_at, None);
+        assert_eq!(candidates[3].suggested_due_at, None);
+    }
+
+    #[test]
+    fn suggested_dates_obey_the_canonical_reminder_horizon() {
+        assert_eq!(first_valid_due_at("Legacy deadline 1999-12-31"), None);
+        assert_eq!(first_valid_due_at("Far deadline 2200-01-01"), None);
+        assert!(first_valid_due_at("Supported deadline 2199-12-30").is_some());
+    }
+
+    #[test]
+    fn content_hash_is_stable_and_length_framed() {
+        assert_eq!(
+            content_hash(&["ab", "c"]),
+            "601d5476e2ccfe2c87a2bba7a322659734a05749d5b5aa781f513e4912db0d5f"
+        );
+        assert_ne!(content_hash(&["ab", "c"]), content_hash(&["a", "bc"]));
+        assert_ne!(content_hash(&[""]), content_hash(&[]));
+    }
+
+    #[test]
+    fn candidate_count_title_size_and_normalized_dedupe_are_bounded() {
+        let mut transcript = vec![
+            "  Review   the PLAN  ".to_string(),
+            "review the plan".to_string(),
+            "Ż".repeat(MAX_TITLE_CHARS + 20),
+        ];
+        transcript.extend((0..MAX_CANDIDATES + 10).map(|idx| format!("Unique task {idx}")));
+
+        let candidates = build_candidates("", &transcript);
+
+        assert_eq!(candidates.len(), MAX_CANDIDATES);
+        assert_eq!(
+            candidates
+                .iter()
+                .filter(|candidate| candidate.title.eq_ignore_ascii_case("review the plan"))
+                .count(),
+            1
+        );
+        assert!(candidates
+            .iter()
+            .all(|candidate| candidate.title.chars().count() <= MAX_TITLE_CHARS));
+        assert_eq!(
+            candidates
+                .iter()
+                .find(|candidate| candidate.title.starts_with('Ż'))
+                .map(|candidate| candidate.title.chars().count()),
+            Some(MAX_TITLE_CHARS)
+        );
+
+        let mut empty_prefix = vec![String::new(); MAX_TRANSCRIPT_CANDIDATE_INPUTS];
+        empty_prefix.push("Must stay beyond the bounded scan".into());
+        assert!(
+            build_candidates("", &empty_prefix).is_empty(),
+            "the transcript candidate-list scan itself must be bounded"
+        );
+    }
+
+    #[test]
+    fn model_selection_rejects_unknown_ids_and_returns_only_known_rows() {
+        let candidates = build_candidates(
+            "- [ ] First\n- [ ] Second\n- [ ] Third\n",
+            &Vec::<String>::new(),
+        );
+
+        let kept = validate_keep_ids(json!({"keepIds": ["c3", "c1"]}), &candidates).unwrap();
+        assert_eq!(
+            kept.iter()
+                .map(|candidate| candidate.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["c1", "c3"],
+            "candidate source order stays authoritative"
+        );
+        assert!(validate_keep_ids(json!({"keepIds": ["invented"]}), &candidates).is_err());
+        assert!(validate_keep_ids(json!({"keepIds": "c1"}), &candidates).is_err());
+        assert!(validate_keep_ids(
+            json!({"keepIds": ["c1"], "inventedTitle": "poison"}),
+            &candidates
+        )
+        .is_err());
+    }
+}

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -1010,6 +1010,12 @@ impl Db {
             .map_err(map_err)?;
         }
 
+        // First-class Murmur Reminders. This runs after the meetings/notes/segments/documents
+        // substrates exist because its derived-suggestion invalidation triggers attach to all four.
+        // The durable reminder rows are an independent SQLCipher domain; only the future Smart
+        // audit cache/pending-suggestion tables are source-derived and trigger-purged.
+        Self::migrate_reminders(&conn)?;
+
         // Note image attachments — canonical bytes live inside SQLCipher. Folder-locked owners
         // additionally use the per-folder `data_blob` seal managed by the lock lifecycle.
         // Runs after documents + org_items exist so every FK target is available.
@@ -7963,3 +7969,7 @@ mod lock_tests;
 #[cfg(test)]
 #[path = "db_tests/graph_tests.rs"]
 mod graph_tests;
+
+#[cfg(test)]
+#[path = "db_tests/reminder_tests.rs"]
+mod reminder_tests;

--- a/src-tauri/src/storage/db_tests/reminder_tests.rs
+++ b/src-tauri/src/storage/db_tests/reminder_tests.rs
@@ -1,0 +1,1552 @@
+use super::*;
+use chrono::{Datelike, Local, TimeZone, Timelike};
+
+use crate::reminder_audit::{build_candidates, ReminderAuditCandidate};
+use crate::storage::models::{
+    Folder, Meeting, MeetingStatus, NoteRecord, ReminderDraft, ReminderOrigin, ReminderRepeatUnit,
+    ReminderSourceAnchor, ReminderState,
+};
+
+fn reminder_db() -> Db {
+    register_vec_extension();
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
+    let db = Db {
+        conn: Mutex::new(conn),
+    };
+    db.migrate().unwrap();
+    db
+}
+
+fn draft(due_at: i64) -> ReminderDraft {
+    ReminderDraft {
+        title: "Review the launch plan".into(),
+        details: Some("Bring the final checklist".into()),
+        due_at,
+        repeat_every: None,
+        repeat_unit: None,
+        sources: vec![],
+    }
+}
+
+fn audit_hash(fill: char) -> String {
+    fill.to_string().repeat(64)
+}
+
+fn audit_candidates(titles: &[&str]) -> Vec<ReminderAuditCandidate> {
+    build_candidates(
+        "",
+        &titles
+            .iter()
+            .map(|title| (*title).to_string())
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn derived_reminder_audit_count(db: &Db) -> i64 {
+    db.lock()
+        .query_row(
+            "SELECT
+               (SELECT COUNT(*) FROM reminder_audit_cache) +
+               (SELECT COUNT(*) FROM reminder_pending_suggestions)",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap()
+}
+
+fn expect_source_invalidations(db: &Db, expected: &[(&str, &str)]) {
+    let invalidations = db.peek_reminder_source_invalidations(64).unwrap();
+    let actual = invalidations
+        .iter()
+        .map(|item| (item.kind.clone(), item.id.clone()))
+        .collect::<Vec<_>>();
+    let expected = expected
+        .iter()
+        .map(|(kind, id)| ((*kind).to_string(), (*id).to_string()))
+        .collect::<Vec<_>>();
+    assert_eq!(actual, expected);
+    for invalidation in invalidations {
+        assert!(
+            db.ack_reminder_source_invalidation(&invalidation).unwrap(),
+            "unchanged peeked revision must acknowledge"
+        );
+    }
+}
+
+fn seed_reminder_audit_source(db: &Db, folder_id: &str, meeting_id: &str) {
+    db.insert_folder(&Folder {
+        id: folder_id.into(),
+        name: "Private".into(),
+        path: "Private".into(),
+        parent_id: None,
+        locked: false,
+        created_at: "2026-07-29T09:00:00Z".into(),
+    })
+    .unwrap();
+    db.insert_meeting(&Meeting {
+        id: meeting_id.into(),
+        started_at: "2026-07-29T10:00:00Z".into(),
+        ended_at: None,
+        title: Some("Planning".into()),
+        duration_s: 0,
+        audio_path: None,
+        status: MeetingStatus::Summarized,
+        folder_id: None,
+    })
+    .unwrap();
+    db.upsert_note(&NoteRecord {
+        meeting_id: meeting_id.into(),
+        provider_id: "local".into(),
+        markdown: "- [ ] Ship the plan".into(),
+        created_at: "2026-07-29T10:05:00Z".into(),
+        exported_path: None,
+        model_requested: None,
+        model_served: None,
+        gateway_host: None,
+    })
+    .unwrap();
+    db.set_note_folder(meeting_id, Some(folder_id)).unwrap();
+}
+
+#[test]
+fn reminder_migration_is_additive_and_idempotent() {
+    let db = reminder_db();
+    db.migrate().unwrap();
+    db.migrate().unwrap();
+    let conn = db.lock();
+    for table in [
+        "reminders",
+        "reminder_sources",
+        "reminder_due_occurrences",
+        "reminder_audit_cache",
+        "reminder_pending_suggestions",
+        "reminder_suggestion_decisions",
+        "reminder_source_invalidation_queue",
+    ] {
+        let exists: bool = conn
+            .query_row(
+                "SELECT EXISTS(
+                   SELECT 1 FROM sqlite_master WHERE type='table' AND name=?1
+                 )",
+                rusqlite::params![table],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(exists, "{table} missing after repeated migrate");
+    }
+    for trigger in [
+        "reminder_derived_notes_projection_au",
+        "reminder_derived_segments_projection_au",
+        "reminder_derived_segments_echo_au",
+        "reminder_derived_documents_anchor_au",
+        "reminder_source_queue_notes_ai",
+        "reminder_source_queue_notes_au",
+        "reminder_source_queue_notes_ad",
+        "reminder_source_queue_segments_ai",
+        "reminder_source_queue_segments_au",
+        "reminder_source_queue_segments_ad",
+        "reminder_source_queue_meetings_au",
+        "reminder_source_queue_meetings_ad",
+        "reminder_source_queue_documents_ai",
+        "reminder_source_queue_documents_au",
+        "reminder_source_queue_documents_ad",
+    ] {
+        let exists: bool = conn
+            .query_row(
+                "SELECT EXISTS(
+                   SELECT 1 FROM sqlite_master WHERE type='trigger' AND name=?1
+                 )",
+                rusqlite::params![trigger],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(
+            exists,
+            "{trigger} missing after repeated additive migration"
+        );
+    }
+    let mut columns = conn
+        .prepare("PRAGMA table_info(reminder_source_invalidation_queue)")
+        .unwrap();
+    let column_names = columns
+        .query_map([], |row| row.get::<_, String>(1))
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap();
+    assert_eq!(
+        column_names,
+        vec!["source_kind", "source_id", "revision"],
+        "durable outbox must persist no title, hash, or source content"
+    );
+}
+
+#[test]
+fn reminder_migration_upgrades_pre_encrypt_v7_source_shape_before_full_triggers() {
+    register_vec_extension();
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "PRAGMA foreign_keys = ON;
+         CREATE TABLE meetings(
+           id TEXT PRIMARY KEY,
+           started_at TEXT,
+           title TEXT,
+           audio_path TEXT
+         );
+         CREATE TABLE segments(meeting_id TEXT, idx INTEGER, text TEXT);
+         CREATE TABLE notes(meeting_id TEXT, markdown TEXT);
+         INSERT INTO meetings VALUES('m1','2026-07-01','Sync',NULL);
+         INSERT INTO segments VALUES('m1',0,'legacy transcript');
+         INSERT INTO notes VALUES('m1','# Legacy note');
+         PRAGMA user_version=7;",
+    )
+    .unwrap();
+    let db = Db {
+        conn: Mutex::new(conn),
+    };
+
+    db.migrate()
+        .expect("legacy pre-encrypt shape must accept the full reminder triggers");
+    db.migrate()
+        .expect("legacy compatibility migration must be idempotent");
+    let note_projection: (String, String, String) = db
+        .lock()
+        .query_row(
+            "SELECT markdown,provider_id,created_at FROM notes WHERE meeting_id='m1'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        note_projection,
+        ("# Legacy note".into(), "legacy".into(), String::new()),
+        "guarded ALTERs must preserve content and backfill deterministic projection defaults"
+    );
+    let segment_projection: (String, f64, f64) = db
+        .lock()
+        .query_row(
+            "SELECT text,start_s,end_s FROM segments WHERE meeting_id='m1' AND idx=0",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(segment_projection, ("legacy transcript".into(), 0.0, 0.0));
+
+    db.lock()
+        .execute(
+            "UPDATE notes SET markdown='# Edited legacy note' WHERE meeting_id='m1'",
+            [],
+        )
+        .unwrap();
+    db.lock()
+        .execute(
+            "UPDATE segments SET text='edited legacy transcript'
+              WHERE meeting_id='m1' AND idx=0",
+            [],
+        )
+        .unwrap();
+    expect_source_invalidations(&db, &[("meeting", "m1")]);
+}
+
+#[test]
+fn reminder_source_outbox_is_bounded_replayable_and_cas_preserves_racing_edits() {
+    let db = reminder_db();
+    {
+        let mut conn = db.lock();
+        let tx = conn.transaction().unwrap();
+        for idx in 0..300 {
+            tx.execute(
+                "INSERT OR IGNORE INTO reminder_source_invalidation_queue(source_kind,source_id)
+                 VALUES ('meeting',?1)",
+                rusqlite::params![format!("m-{idx:03}")],
+            )
+            .unwrap();
+        }
+        tx.execute(
+            "INSERT INTO reminder_source_invalidation_queue(source_kind,source_id,revision)
+             VALUES ('meeting','m-000',1)
+             ON CONFLICT(source_kind,source_id) DO UPDATE SET revision=revision+1",
+            [],
+        )
+        .unwrap();
+        tx.commit().unwrap();
+    }
+    let count: i64 = db
+        .lock()
+        .query_row(
+            "SELECT COUNT(*) FROM reminder_source_invalidation_queue",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(count, 300, "duplicate source edits must coalesce");
+
+    let first = db.peek_reminder_source_invalidations(usize::MAX).unwrap();
+    assert_eq!(first.len(), 256, "peek must enforce its internal bound");
+    assert_eq!(first[0].id, "m-000");
+    assert_eq!(first[0].revision, 2);
+    assert_eq!(
+        db.peek_reminder_source_invalidations(usize::MAX).unwrap(),
+        first,
+        "a crash or failed emit before acknowledgement must replay the same batch"
+    );
+
+    db.lock()
+        .execute(
+            "INSERT INTO reminder_source_invalidation_queue(source_kind,source_id,revision)
+             VALUES ('meeting','m-000',1)
+             ON CONFLICT(source_kind,source_id) DO UPDATE SET revision=revision+1",
+            [],
+        )
+        .unwrap();
+    assert!(
+        !db.ack_reminder_source_invalidation(&first[0]).unwrap(),
+        "a stale acknowledgement must not delete a newer edit"
+    );
+    for item in &first[1..] {
+        assert!(db.ack_reminder_source_invalidation(item).unwrap());
+    }
+
+    let second = db.peek_reminder_source_invalidations(256).unwrap();
+    assert_eq!(second.len(), 45);
+    assert!(
+        second
+            .iter()
+            .any(|item| item.id == "m-000" && item.revision == 3),
+        "a mutation racing the emit must remain queued at its newer revision"
+    );
+    for item in &second {
+        assert!(db.ack_reminder_source_invalidation(item).unwrap());
+    }
+    assert!(db.peek_reminder_source_invalidations(1).unwrap().is_empty());
+}
+
+#[test]
+fn reminder_source_outbox_covers_every_canonical_smart_source_mutation() {
+    let db = reminder_db();
+    seed_reminder_audit_source(&db, "f1", "m1");
+    db.insert_folder(&Folder {
+        id: "f2".into(),
+        name: "Moved".into(),
+        path: "Moved".into(),
+        parent_id: None,
+        locked: false,
+        created_at: "2026-07-29T09:01:00Z".into(),
+    })
+    .unwrap();
+    db.insert_meeting(&Meeting {
+        id: "m2".into(),
+        started_at: "2026-07-29T11:00:00Z".into(),
+        ended_at: None,
+        title: Some("Second".into()),
+        duration_s: 0,
+        audio_path: None,
+        status: MeetingStatus::Summarized,
+        folder_id: None,
+    })
+    .unwrap();
+    expect_source_invalidations(&db, &[("meeting", "m1")]);
+
+    db.upsert_note(&NoteRecord {
+        meeting_id: "m1".into(),
+        provider_id: "provider-b".into(),
+        markdown: "provider note".into(),
+        created_at: "2026-07-29T10:06:00Z".into(),
+        exported_path: None,
+        model_requested: None,
+        model_served: None,
+        gateway_host: None,
+    })
+    .unwrap();
+    expect_source_invalidations(&db, &[("meeting", "m1")]);
+    for update in [
+        "UPDATE notes SET provider_id='provider-c'
+          WHERE meeting_id='m1' AND provider_id='provider-b'",
+        "UPDATE notes SET markdown='changed'
+          WHERE meeting_id='m1' AND provider_id='provider-c'",
+        "UPDATE notes SET created_at='2026-07-29T10:07:00Z'
+          WHERE meeting_id='m1' AND provider_id='provider-c'",
+        "UPDATE notes SET folder_id='f2'
+          WHERE meeting_id='m1' AND provider_id='provider-c'",
+    ] {
+        db.lock().execute(update, []).unwrap();
+        expect_source_invalidations(&db, &[("meeting", "m1")]);
+    }
+    db.lock()
+        .execute(
+            "UPDATE notes SET meeting_id='m2'
+              WHERE meeting_id='m1' AND provider_id='provider-c'",
+            [],
+        )
+        .unwrap();
+    expect_source_invalidations(&db, &[("meeting", "m1"), ("meeting", "m2")]);
+    db.lock()
+        .execute(
+            "DELETE FROM notes WHERE meeting_id='m2' AND provider_id='provider-c'",
+            [],
+        )
+        .unwrap();
+    expect_source_invalidations(&db, &[("meeting", "m2")]);
+
+    db.replace_segments(
+        "m1",
+        &[crate::transcribe::types::Segment {
+            idx: 0,
+            start_s: 0.0,
+            end_s: 1.0,
+            text: "follow up".into(),
+            speaker: None,
+            confidence: None,
+        }],
+    )
+    .unwrap();
+    expect_source_invalidations(&db, &[("meeting", "m1")]);
+    let segment_rowid: i64 = db
+        .lock()
+        .query_row(
+            "SELECT rowid FROM segments WHERE meeting_id='m1'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    for update in [
+        "UPDATE segments SET idx=idx+1 WHERE rowid=?1",
+        "UPDATE segments SET start_s=start_s+0.25 WHERE rowid=?1",
+        "UPDATE segments SET end_s=end_s+0.25 WHERE rowid=?1",
+        "UPDATE segments SET text='changed text' WHERE rowid=?1",
+        "UPDATE segments SET speaker='me' WHERE rowid=?1",
+        "UPDATE segments SET confidence=0.5 WHERE rowid=?1",
+        "UPDATE segments SET echo_suppressed=1 WHERE rowid=?1",
+    ] {
+        db.lock()
+            .execute(update, rusqlite::params![segment_rowid])
+            .unwrap();
+        expect_source_invalidations(&db, &[("meeting", "m1")]);
+    }
+    db.lock()
+        .execute(
+            "UPDATE segments SET meeting_id='m2' WHERE rowid=?1",
+            rusqlite::params![segment_rowid],
+        )
+        .unwrap();
+    expect_source_invalidations(&db, &[("meeting", "m1"), ("meeting", "m2")]);
+    db.lock()
+        .execute(
+            "DELETE FROM segments WHERE rowid=?1",
+            rusqlite::params![segment_rowid],
+        )
+        .unwrap();
+    expect_source_invalidations(&db, &[("meeting", "m2")]);
+
+    db.lock()
+        .execute("UPDATE meetings SET title='Renamed' WHERE id='m1'", [])
+        .unwrap();
+    expect_source_invalidations(&db, &[("meeting", "m1")]);
+    db.lock()
+        .execute("UPDATE meetings SET manual_notes='typed' WHERE id='m1'", [])
+        .unwrap();
+    expect_source_invalidations(&db, &[("meeting", "m1")]);
+
+    db.insert_note("n1", "f1", "Fallback", "Title", "Text", 1)
+        .unwrap();
+    expect_source_invalidations(&db, &[("note", "n1")]);
+    for update in [
+        "UPDATE documents SET text='changed' WHERE id='n1'",
+        "UPDATE documents SET title='Renamed' WHERE id='n1'",
+        "UPDATE documents SET name='renamed.md' WHERE id='n1'",
+        "UPDATE documents SET folder_id='f2' WHERE id='n1'",
+        "UPDATE documents SET kind='document' WHERE id='n1'",
+        "UPDATE documents SET kind='note' WHERE id='n1'",
+    ] {
+        db.lock().execute(update, []).unwrap();
+        expect_source_invalidations(&db, &[("note", "n1")]);
+    }
+    db.lock()
+        .execute("DELETE FROM documents WHERE id='n1'", [])
+        .unwrap();
+    expect_source_invalidations(&db, &[("note", "n1")]);
+
+    db.lock()
+        .execute("DELETE FROM meetings WHERE id='m2'", [])
+        .unwrap();
+    expect_source_invalidations(&db, &[("meeting", "m2")]);
+}
+
+#[test]
+fn reminder_crud_round_trips_sources_and_delete_cascades() {
+    let db = reminder_db();
+    let mut input = draft(2_000_000_000_000);
+    input.sources = vec![
+        ReminderSourceAnchor {
+            kind: "meeting".into(),
+            id: "m1".into(),
+        },
+        ReminderSourceAnchor {
+            kind: "note".into(),
+            id: "n1".into(),
+        },
+    ];
+    db.create_reminder("r1", &input, ReminderOrigin::Manual, 10)
+        .unwrap();
+    let stored = db.get_stored_reminder("r1").unwrap().unwrap();
+    assert_eq!(stored.title, input.title);
+    assert_eq!(stored.sources.len(), 2);
+    assert_eq!(stored.state, ReminderState::Active);
+
+    let mut edited = input.clone();
+    edited.title = "Review the final plan".into();
+    edited.details = None;
+    edited.sources.truncate(1);
+    assert!(db.update_reminder("r1", &edited, 11).unwrap());
+    let stored = db.get_stored_reminder("r1").unwrap().unwrap();
+    assert_eq!(stored.title, "Review the final plan");
+    assert_eq!(stored.details, None);
+    assert_eq!(stored.sources.len(), 1);
+    assert_eq!(stored.updated_at, 11);
+
+    assert!(db.delete_reminder("r1").unwrap());
+    assert!(db.get_stored_reminder("r1").unwrap().is_none());
+    let source_count: i64 = db
+        .lock()
+        .query_row(
+            "SELECT COUNT(*) FROM reminder_sources WHERE reminder_id='r1'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(source_count, 0);
+}
+
+#[test]
+fn due_materialization_is_idempotent_across_repeated_ticks() {
+    let db = reminder_db();
+    db.create_reminder("r1", &draft(1_000_000_000_000), ReminderOrigin::Manual, 1)
+        .unwrap();
+    assert_eq!(db.materialize_due_reminders(999_999_999_999).unwrap(), 0);
+    assert_eq!(db.materialize_due_reminders(1_000_000_000_000).unwrap(), 1);
+    assert_eq!(db.materialize_due_reminders(1_000_000_000_001).unwrap(), 0);
+    assert_eq!(db.due_reminder_count().unwrap(), 1);
+    let occurrences = db.unread_reminder_occurrences().unwrap();
+    assert_eq!(occurrences.len(), 1);
+    assert_eq!(occurrences[0].reminder_id, "r1");
+    assert!(
+        uuid::Uuid::parse_str(&occurrences[0].id).is_ok(),
+        "occurrence identity must be an opaque UUID, not a reminder/due composite"
+    );
+    assert!(!occurrences[0].id.contains("r1"));
+}
+
+#[test]
+fn dismiss_is_idempotent_and_keeps_the_reminder_active() {
+    let db = reminder_db();
+    db.create_reminder("r1", &draft(10), ReminderOrigin::Manual, 1)
+        .unwrap();
+    db.materialize_due_reminders(10).unwrap();
+    let occurrence = db.unread_reminder_occurrences().unwrap().remove(0);
+    assert!(db.dismiss_reminder_occurrence(&occurrence.id, 20).unwrap());
+    assert!(!db.dismiss_reminder_occurrence(&occurrence.id, 21).unwrap());
+    assert_eq!(db.due_reminder_count().unwrap(), 0);
+    assert_eq!(
+        db.get_stored_reminder("r1").unwrap().unwrap().state,
+        ReminderState::Active
+    );
+}
+
+#[test]
+fn recurring_dismiss_advances_exactly_once_and_next_due_materializes_later() {
+    let db = reminder_db();
+    let due = Local
+        .with_ymd_and_hms(2028, 1, 31, 9, 45, 0)
+        .earliest()
+        .unwrap()
+        .timestamp_millis();
+    let mut recurring = draft(due);
+    recurring.repeat_every = Some(1);
+    recurring.repeat_unit = Some(ReminderRepeatUnit::Months);
+    db.create_reminder("r1", &recurring, ReminderOrigin::Manual, 1)
+        .unwrap();
+    db.materialize_due_reminders(due).unwrap();
+    let occurrence = db.unread_reminder_occurrences().unwrap().remove(0);
+
+    assert!(db
+        .dismiss_reminder_occurrence(&occurrence.id, due + 1)
+        .unwrap());
+    let advanced_due = db.get_stored_reminder("r1").unwrap().unwrap().due_at;
+    let advanced = Local.timestamp_millis_opt(advanced_due).earliest().unwrap();
+    assert_eq!(
+        (advanced.year(), advanced.month(), advanced.day()),
+        (2028, 2, 29)
+    );
+    assert!(
+        !db.dismiss_reminder_occurrence(&occurrence.id, due + 2)
+            .unwrap(),
+        "replaying the dismissed occurrence must not advance the series twice"
+    );
+    assert_eq!(
+        db.get_stored_reminder("r1").unwrap().unwrap().due_at,
+        advanced_due
+    );
+    assert_eq!(db.materialize_due_reminders(advanced_due - 1).unwrap(), 0);
+    assert_eq!(db.materialize_due_reminders(advanced_due).unwrap(), 1);
+    let next_occurrence = db.unread_reminder_occurrences().unwrap().remove(0);
+    assert_eq!(next_occurrence.reminder_id, "r1");
+    assert_eq!(next_occurrence.due_at, advanced_due);
+}
+
+#[test]
+fn one_off_completion_is_idempotent_and_terminal() {
+    let db = reminder_db();
+    db.create_reminder("r1", &draft(10), ReminderOrigin::Manual, 1)
+        .unwrap();
+    assert!(db.complete_reminder("r1", 10, 20).unwrap());
+    assert!(!db.complete_reminder("r1", 10, 21).unwrap());
+    let stored = db.get_stored_reminder("r1").unwrap().unwrap();
+    assert_eq!(stored.state, ReminderState::Completed);
+    assert_eq!(stored.completed_at, Some(20));
+    assert_eq!(db.due_reminder_count().unwrap(), 0);
+}
+
+#[test]
+fn recurring_completion_advances_once_and_months_clamp_to_valid_dates() {
+    let db = reminder_db();
+    let due = Local
+        .with_ymd_and_hms(2028, 1, 31, 9, 45, 0)
+        .earliest()
+        .unwrap()
+        .timestamp_millis();
+    let mut recurring = draft(due);
+    recurring.repeat_every = Some(1);
+    recurring.repeat_unit = Some(ReminderRepeatUnit::Months);
+    db.create_reminder("r1", &recurring, ReminderOrigin::Manual, 1)
+        .unwrap();
+
+    assert!(db.complete_reminder("r1", due, due + 1).unwrap());
+    assert!(
+        !db.complete_reminder("r1", due, due + 2).unwrap(),
+        "replaying the old schedule generation must not advance twice"
+    );
+    let stored = db.get_stored_reminder("r1").unwrap().unwrap();
+    assert_eq!(stored.state, ReminderState::Active);
+    let next = Local
+        .timestamp_millis_opt(stored.due_at)
+        .earliest()
+        .unwrap();
+    assert_eq!((next.year(), next.month(), next.day()), (2028, 2, 29));
+    assert_eq!((next.hour(), next.minute()), (9, 45));
+    assert_eq!(
+        db.lock()
+            .query_row(
+                "SELECT COUNT(*) FROM reminder_due_occurrences
+                  WHERE reminder_id='r1' AND status='completed'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+        1
+    );
+}
+
+#[test]
+fn smart_audit_cache_replace_is_idempotent_revision_scoped_and_bounded() {
+    let db = reminder_db();
+    let hash_a = audit_hash('a');
+    let hash_b = audit_hash('b');
+    let candidates = audit_candidates(&["Ship the plan", "Call the customer"]);
+
+    db.replace_reminder_audit_results_unchecked(
+        "meeting",
+        "m1",
+        &hash_a,
+        "stub-local",
+        &candidates,
+        10,
+    )
+    .unwrap();
+    assert!(db
+        .reminder_audit_cache_matches("meeting", "m1", &hash_a, "stub-local")
+        .unwrap());
+    assert!(!db
+        .reminder_audit_cache_matches("meeting", "m1", &hash_a, "other-engine")
+        .unwrap());
+    let first = db
+        .list_pending_reminder_suggestions("meeting", "m1", &hash_a, "stub-local", usize::MAX)
+        .unwrap();
+    assert_eq!(first.len(), 2);
+
+    db.replace_reminder_audit_results_unchecked(
+        "meeting",
+        "m1",
+        &hash_a,
+        "stub-local",
+        &candidates,
+        11,
+    )
+    .unwrap();
+    let repeated = db
+        .list_pending_reminder_suggestions("meeting", "m1", &hash_a, "stub-local", usize::MAX)
+        .unwrap();
+    assert_eq!(
+        repeated
+            .iter()
+            .map(|row| row.id.as_str())
+            .collect::<Vec<_>>(),
+        first.iter().map(|row| row.id.as_str()).collect::<Vec<_>>(),
+        "same revision produces stable rows rather than duplicates"
+    );
+    assert!(repeated.iter().all(|row| row.created_at == 11));
+
+    db.replace_reminder_audit_results_unchecked(
+        "meeting",
+        "m1",
+        &hash_b,
+        "stub-local",
+        &audit_candidates(&["Revised task"]),
+        12,
+    )
+    .unwrap();
+    assert!(!db
+        .reminder_audit_cache_matches("meeting", "m1", &hash_a, "stub-local")
+        .unwrap());
+    assert!(db
+        .list_pending_reminder_suggestions("meeting", "m1", &hash_a, "stub-local", 32)
+        .unwrap()
+        .is_empty());
+    assert_eq!(
+        db.list_pending_reminder_suggestions("meeting", "m1", &hash_b, "stub-local", 32)
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn dismissing_one_smart_suggestion_keeps_the_cache_and_sibling() {
+    let db = reminder_db();
+    let hash = audit_hash('a');
+    db.replace_reminder_audit_results_unchecked(
+        "meeting",
+        "m1",
+        &hash,
+        "stub-local",
+        &audit_candidates(&["First task", "Second task"]),
+        10,
+    )
+    .unwrap();
+    let rows = db
+        .list_pending_reminder_suggestions("meeting", "m1", &hash, "stub-local", 32)
+        .unwrap();
+    let gate_anchor = db
+        .get_pending_reminder_suggestion_gate_anchor(&rows[0].id)
+        .unwrap()
+        .expect("content-free accept/dismiss anchor");
+    assert_eq!(gate_anchor.id, rows[0].id);
+    assert_eq!(gate_anchor.source_kind, "meeting");
+    assert_eq!(gate_anchor.source_id, "m1");
+
+    assert!(db
+        .dismiss_pending_reminder_suggestion(
+            &gate_anchor.id,
+            &gate_anchor.source_kind,
+            &gate_anchor.source_id,
+            &hash,
+        )
+        .unwrap());
+    assert!(!db
+        .dismiss_pending_reminder_suggestion(&rows[0].id, "meeting", "m1", &hash)
+        .unwrap());
+    assert!(db
+        .reminder_audit_cache_matches("meeting", "m1", &hash, "stub-local")
+        .unwrap());
+    let remaining = db
+        .list_pending_reminder_suggestions("meeting", "m1", &hash, "stub-local", 32)
+        .unwrap();
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].id, rows[1].id);
+}
+
+#[test]
+fn smart_suggestions_promote_once_and_siblings_can_promote_sequentially() {
+    let db = reminder_db();
+    let hash = audit_hash('a');
+    db.replace_reminder_audit_results_unchecked(
+        "meeting",
+        "m1",
+        &hash,
+        "stub-local",
+        &audit_candidates(&["First task", "Second task"]),
+        10,
+    )
+    .unwrap();
+    let rows = db
+        .list_pending_reminder_suggestions("meeting", "m1", &hash, "stub-local", 32)
+        .unwrap();
+    let mut first_draft = draft(2_000_000_000_000);
+    first_draft.title = "Edited before accepting".into();
+    first_draft.sources.push(ReminderSourceAnchor {
+        kind: "note".into(),
+        id: "n-extra".into(),
+    });
+
+    assert!(db
+        .promote_pending_reminder_suggestion(
+            &rows[0].id,
+            "meeting",
+            "m1",
+            &hash,
+            "r-smart-1",
+            &first_draft,
+            20,
+        )
+        .unwrap());
+    assert!(!db
+        .promote_pending_reminder_suggestion(
+            &rows[0].id,
+            "meeting",
+            "m1",
+            &hash,
+            "r-replay",
+            &first_draft,
+            21,
+        )
+        .unwrap());
+    assert!(db
+        .reminder_audit_cache_matches("meeting", "m1", &hash, "stub-local")
+        .unwrap());
+    let after_first = db
+        .list_pending_reminder_suggestions("meeting", "m1", &hash, "stub-local", 32)
+        .unwrap();
+    assert_eq!(after_first.len(), 1, "the sibling remains reviewable");
+
+    let mut second_draft = draft(2_000_000_100_000);
+    second_draft.title = "Second accepted task".into();
+    assert!(db
+        .promote_pending_reminder_suggestion(
+            &after_first[0].id,
+            "meeting",
+            "m1",
+            &hash,
+            "r-smart-2",
+            &second_draft,
+            22,
+        )
+        .unwrap());
+    assert!(db
+        .list_pending_reminder_suggestions("meeting", "m1", &hash, "stub-local", 32)
+        .unwrap()
+        .is_empty());
+
+    let first = db.get_stored_reminder("r-smart-1").unwrap().unwrap();
+    assert_eq!(first.origin, ReminderOrigin::Smart);
+    assert_eq!(first.title, "Edited before accepting");
+    assert!(first.sources.contains(&ReminderSourceAnchor {
+        kind: "meeting".into(),
+        id: "m1".into(),
+    }));
+    assert!(first.sources.contains(&ReminderSourceAnchor {
+        kind: "note".into(),
+        id: "n-extra".into(),
+    }));
+    assert_eq!(
+        db.lock()
+            .query_row("SELECT COUNT(*) FROM reminders", [], |row| row
+                .get::<_, i64>(0))
+            .unwrap(),
+        2,
+        "replay must not create a third reminder"
+    );
+}
+
+#[test]
+fn canonical_source_edits_purge_only_derived_suggestions_not_user_reminders() {
+    let db = reminder_db();
+    db.insert_meeting(&Meeting {
+        id: "m1".into(),
+        started_at: "2026-07-29T10:00:00Z".into(),
+        ended_at: None,
+        title: Some("Planning".into()),
+        duration_s: 0,
+        audio_path: None,
+        status: MeetingStatus::Summarized,
+        folder_id: None,
+    })
+    .unwrap();
+    db.upsert_note(&NoteRecord {
+        meeting_id: "m1".into(),
+        provider_id: "local".into(),
+        markdown: "- [ ] Ship the plan".into(),
+        created_at: "2026-07-29T10:05:00Z".into(),
+        exported_path: None,
+        model_requested: None,
+        model_served: None,
+        gateway_host: None,
+    })
+    .unwrap();
+    let mut reminder = draft(2_000_000_000_000);
+    reminder.sources.push(ReminderSourceAnchor {
+        kind: "meeting".into(),
+        id: "m1".into(),
+    });
+    db.create_reminder("r1", &reminder, ReminderOrigin::Smart, 1)
+        .unwrap();
+    db.replace_reminder_audit_results_unchecked(
+        "meeting",
+        "m1",
+        &audit_hash('a'),
+        "stub-local",
+        &audit_candidates(&["Ship the plan"]),
+        1,
+    )
+    .unwrap();
+
+    db.upsert_note(&NoteRecord {
+        meeting_id: "m1".into(),
+        provider_id: "local".into(),
+        markdown: "- [ ] Ship the revised plan".into(),
+        created_at: "2026-07-29T10:06:00Z".into(),
+        exported_path: None,
+        model_requested: None,
+        model_served: None,
+        gateway_host: None,
+    })
+    .unwrap();
+
+    let derived = derived_reminder_audit_count(&db);
+    assert_eq!(
+        derived, 0,
+        "source edit must transactionally purge derived plaintext"
+    );
+    let reminders: i64 = db
+        .lock()
+        .query_row("SELECT COUNT(*) FROM reminders WHERE id='r1'", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(
+        reminders, 1,
+        "an accepted/user-owned reminder is an independent domain"
+    );
+}
+
+#[test]
+fn relock_enqueues_empty_meeting_and_authored_note_sources_without_content_updates() {
+    let db = reminder_db();
+    db.insert_folder(&Folder {
+        id: "f-private".into(),
+        name: "Private".into(),
+        path: "Private".into(),
+        parent_id: None,
+        locked: false,
+        created_at: "2026-07-29T09:00:00Z".into(),
+    })
+    .unwrap();
+    db.insert_meeting(&Meeting {
+        id: "m-title-only".into(),
+        started_at: "2026-07-29T10:00:00Z".into(),
+        ended_at: None,
+        title: Some("Title only".into()),
+        duration_s: 0,
+        audio_path: None,
+        status: MeetingStatus::Summarized,
+        folder_id: None,
+    })
+    .unwrap();
+    db.upsert_note(&NoteRecord {
+        meeting_id: "m-title-only".into(),
+        provider_id: "local".into(),
+        markdown: String::new(),
+        created_at: "2026-07-29T10:05:00Z".into(),
+        exported_path: None,
+        model_requested: None,
+        model_served: None,
+        gateway_host: None,
+    })
+    .unwrap();
+    db.set_note_folder("m-title-only", Some("f-private"))
+        .unwrap();
+    db.insert_note("n-empty", "f-private", "Empty.md", "Empty", "", 1)
+        .unwrap();
+    expect_source_invalidations(&db, &[("meeting", "m-title-only"), ("note", "n-empty")]);
+
+    db.set_folder_locked("f-private", true, Some(b"wrapped"))
+        .unwrap();
+    let mut folders = std::collections::HashSet::new();
+    folders.insert("f-private".to_string());
+    db.blank_sealed_notes_in_folders(&folders).unwrap();
+
+    expect_source_invalidations(&db, &[("meeting", "m-title-only"), ("note", "n-empty")]);
+}
+
+#[test]
+fn relock_and_startup_reconcile_purge_derived_audits_but_keep_reminders() {
+    let db = reminder_db();
+    seed_reminder_audit_source(&db, "f-private", "m1");
+    let mut accepted = draft(2_000_000_000_000);
+    accepted.sources.push(ReminderSourceAnchor {
+        kind: "meeting".into(),
+        id: "m1".into(),
+    });
+    db.create_reminder("r-accepted", &accepted, ReminderOrigin::Smart, 1)
+        .unwrap();
+    db.replace_reminder_audit_results_unchecked(
+        "meeting",
+        "m1",
+        &audit_hash('a'),
+        "stub-local",
+        &audit_candidates(&["Pending before relock"]),
+        10,
+    )
+    .unwrap();
+    assert_eq!(derived_reminder_audit_count(&db), 2);
+    db.lock()
+        .execute(
+            "INSERT INTO reminder_suggestion_decisions
+               (source_kind,source_id,content_hash,candidate_key,decision,reminder_id,decided_at)
+             VALUES ('meeting','m1',?1,?2,'dismissed',NULL,10)",
+            rusqlite::params![audit_hash('a'), audit_hash('d')],
+        )
+        .unwrap();
+
+    db.set_folder_locked("f-private", true, Some(b"wrapped"))
+        .unwrap();
+    let mut folders = std::collections::HashSet::new();
+    folders.insert("f-private".to_string());
+    db.blank_sealed_notes_in_folders(&folders).unwrap();
+    assert_eq!(
+        derived_reminder_audit_count(&db),
+        0,
+        "relock transaction must purge cache and suggestion"
+    );
+    assert_eq!(
+        db.lock()
+            .query_row(
+                "SELECT COUNT(*) FROM reminder_suggestion_decisions",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+        0,
+        "relock transaction must purge unkeyed decision fingerprints"
+    );
+    assert!(db.get_stored_reminder("r-accepted").unwrap().is_some());
+
+    // Simulate candidates derived while the folder was session-unlocked immediately before a
+    // process crash. The on-disk folder remains locked, so startup reconciliation must purge them.
+    db.replace_reminder_audit_results_unchecked(
+        "meeting",
+        "m1",
+        &audit_hash('b'),
+        "stub-local",
+        &audit_candidates(&["Pending at crash"]),
+        11,
+    )
+    .unwrap();
+    assert_eq!(derived_reminder_audit_count(&db), 2);
+    db.lock()
+        .execute(
+            "INSERT INTO reminder_suggestion_decisions
+               (source_kind,source_id,content_hash,candidate_key,decision,reminder_id,decided_at)
+             VALUES ('meeting','m1',?1,?2,'dismissed',NULL,11)",
+            rusqlite::params![audit_hash('b'), audit_hash('e')],
+        )
+        .unwrap();
+    db.reblank_locked_folders_at_rest().unwrap();
+    assert_eq!(
+        derived_reminder_audit_count(&db),
+        0,
+        "startup reconcile must purge crash-window audit plaintext"
+    );
+    assert_eq!(
+        db.lock()
+            .query_row(
+                "SELECT COUNT(*) FROM reminder_suggestion_decisions",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+        0,
+        "startup reconcile must purge crash-window decision fingerprints"
+    );
+    assert!(db.get_stored_reminder("r-accepted").unwrap().is_some());
+}
+
+#[test]
+fn reminder_audit_cas_rejects_a_stale_canonical_revision() {
+    let db = reminder_db();
+    seed_reminder_audit_source(&db, "f1", "m1");
+    let before_hash = crate::storage::reminder_store::canonical_reminder_source_hash(
+        "Planning",
+        "- [ ] Ship the plan",
+        Some(""),
+        &[],
+    );
+    assert!(db
+        .replace_reminder_audit_results(
+            "meeting",
+            "m1",
+            &before_hash,
+            "stub-local",
+            &audit_candidates(&["Ship the plan"]),
+            10,
+        )
+        .unwrap());
+
+    db.upsert_note(&NoteRecord {
+        meeting_id: "m1".into(),
+        provider_id: "local".into(),
+        markdown: "- [ ] Ship the revised plan".into(),
+        created_at: "2026-07-29T10:06:00Z".into(),
+        exported_path: None,
+        model_requested: None,
+        model_served: None,
+        gateway_host: None,
+    })
+    .unwrap();
+    assert!(!db
+        .replace_reminder_audit_results(
+            "meeting",
+            "m1",
+            &before_hash,
+            "stub-local",
+            &audit_candidates(&["Ship the plan"]),
+            11,
+        )
+        .unwrap());
+    assert_eq!(
+        derived_reminder_audit_count(&db),
+        0,
+        "a stale post-inference revision must not be reinserted after its edit trigger purged it"
+    );
+}
+
+#[test]
+fn smart_decision_fingerprints_are_purged_while_accepted_reminders_survive() {
+    let db = reminder_db();
+    let hash = audit_hash('a');
+    let candidates = audit_candidates(&["Accepted task", "Dismissed task"]);
+    db.replace_reminder_audit_results_unchecked(
+        "meeting",
+        "m1",
+        &hash,
+        "engine-a",
+        &candidates,
+        10,
+    )
+    .unwrap();
+    let rows = db
+        .list_pending_reminder_suggestions("meeting", "m1", &hash, "engine-a", 32)
+        .unwrap();
+    let accepted = rows
+        .iter()
+        .find(|row| row.title == "Accepted task")
+        .unwrap();
+    let dismissed = rows
+        .iter()
+        .find(|row| row.title == "Dismissed task")
+        .unwrap();
+    assert!(db
+        .promote_pending_reminder_suggestion(
+            &accepted.id,
+            "meeting",
+            "m1",
+            &hash,
+            "r-accepted",
+            &draft(2_000_000_000_000),
+            20,
+        )
+        .unwrap());
+    assert!(db
+        .dismiss_pending_reminder_suggestion(&dismissed.id, "meeting", "m1", &hash)
+        .unwrap());
+
+    {
+        let mut conn = db.lock();
+        let tx = conn.transaction().unwrap();
+        Db::purge_all_reminder_derived_tx(&tx).unwrap();
+        tx.commit().unwrap();
+    }
+    assert_eq!(
+        db.list_stored_reminders().unwrap().len(),
+        1,
+        "purging derived fingerprints must preserve the accepted canonical reminder"
+    );
+    let decisions: i64 = db
+        .lock()
+        .query_row(
+            "SELECT COUNT(*) FROM reminder_suggestion_decisions",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        decisions, 0,
+        "unkeyed content-hash and candidate-key fingerprints must not survive a seal/relock purge"
+    );
+    db.replace_reminder_audit_results_unchecked(
+        "meeting",
+        "m1",
+        &hash,
+        "engine-b",
+        &candidates,
+        30,
+    )
+    .unwrap();
+    let regenerated = db
+        .list_pending_reminder_suggestions("meeting", "m1", &hash, "engine-b", 32)
+        .unwrap();
+    assert_eq!(
+        regenerated.len(),
+        2,
+        "purged decision fingerprints must not survive to suppress a later unlocked audit"
+    );
+
+    assert!(db.delete_reminder("r-accepted").unwrap());
+    {
+        let mut conn = db.lock();
+        let tx = conn.transaction().unwrap();
+        Db::purge_all_reminder_derived_tx(&tx).unwrap();
+        tx.commit().unwrap();
+    }
+    db.replace_reminder_audit_results_unchecked(
+        "meeting",
+        "m1",
+        &hash,
+        "engine-c",
+        &candidates,
+        40,
+    )
+    .unwrap();
+    let regenerated = db
+        .list_pending_reminder_suggestions("meeting", "m1", &hash, "engine-c", 32)
+        .unwrap();
+    assert_eq!(regenerated.len(), 2);
+}
+
+#[test]
+fn identical_source_updates_keep_audit_but_real_edits_purge_it() {
+    let db = reminder_db();
+    seed_reminder_audit_source(&db, "f1", "m1");
+    db.replace_segments(
+        "m1",
+        &[crate::transcribe::types::Segment {
+            idx: 0,
+            start_s: 0.0,
+            end_s: 1.0,
+            text: "We should follow up".into(),
+            speaker: None,
+            confidence: None,
+        }],
+    )
+    .unwrap();
+    let hash = audit_hash('a');
+    let candidates = audit_candidates(&["Ship the plan"]);
+
+    for identical_update in [
+        "UPDATE notes SET markdown=markdown WHERE meeting_id='m1'",
+        "UPDATE segments SET text=text WHERE meeting_id='m1'",
+        "UPDATE meetings SET manual_notes=manual_notes,title=title WHERE id='m1'",
+    ] {
+        db.replace_reminder_audit_results_unchecked(
+            "meeting",
+            "m1",
+            &hash,
+            "engine",
+            &candidates,
+            10,
+        )
+        .unwrap();
+        db.lock().execute(identical_update, []).unwrap();
+        assert_eq!(
+            derived_reminder_audit_count(&db),
+            2,
+            "identical update unexpectedly invalidated: {identical_update}"
+        );
+    }
+    db.lock()
+        .execute(
+            "UPDATE segments SET start_s=start_s+0.25 WHERE meeting_id='m1' AND idx=0",
+            [],
+        )
+        .unwrap();
+    assert_eq!(
+        derived_reminder_audit_count(&db),
+        0,
+        "a non-text canonical segment edit must invalidate derived suggestions"
+    );
+
+    db.replace_reminder_audit_results_unchecked("meeting", "m1", &hash, "engine", &candidates, 11)
+        .unwrap();
+    db.lock()
+        .execute(
+            "UPDATE segments SET echo_suppressed=1 WHERE meeting_id='m1' AND idx=0",
+            [],
+        )
+        .unwrap();
+    assert_eq!(
+        derived_reminder_audit_count(&db),
+        0,
+        "a suppression-only presentation edit must invalidate derived suggestions"
+    );
+
+    db.replace_reminder_audit_results_unchecked("meeting", "m1", &hash, "engine", &candidates, 11)
+        .unwrap();
+    db.lock()
+        .execute(
+            "UPDATE meetings SET manual_notes='changed' WHERE id='m1'",
+            [],
+        )
+        .unwrap();
+    assert_eq!(derived_reminder_audit_count(&db), 0);
+
+    db.insert_note("n1", "f1", "Note", "Note", "- [ ] Call", 1)
+        .unwrap();
+    db.replace_reminder_audit_results_unchecked("note", "n1", &hash, "engine", &candidates, 10)
+        .unwrap();
+    db.lock()
+        .execute(
+            "UPDATE documents SET text=text,title=title,kind=kind WHERE id='n1'",
+            [],
+        )
+        .unwrap();
+    assert_eq!(derived_reminder_audit_count(&db), 2);
+    db.lock()
+        .execute("UPDATE documents SET title='Renamed' WHERE id='n1'", [])
+        .unwrap();
+    assert_eq!(derived_reminder_audit_count(&db), 0);
+}
+
+#[test]
+fn latest_note_winner_changes_and_authored_note_fallback_renames_invalidate() {
+    let db = reminder_db();
+    seed_reminder_audit_source(&db, "f1", "m1");
+    db.upsert_note(&NoteRecord {
+        meeting_id: "m1".into(),
+        provider_id: "z-provider".into(),
+        markdown: "- [ ] Follow the newer provider".into(),
+        created_at: "2026-07-29T10:06:00Z".into(),
+        exported_path: None,
+        model_requested: None,
+        model_served: None,
+        gateway_host: None,
+    })
+    .unwrap();
+    assert_eq!(
+        db.latest_reminder_audit_markdown("m1").unwrap().as_deref(),
+        Some("- [ ] Follow the newer provider")
+    );
+    let winner_hash = crate::storage::reminder_store::canonical_reminder_source_hash(
+        "Planning",
+        "- [ ] Follow the newer provider",
+        Some(""),
+        &[],
+    );
+    assert!(db
+        .replace_reminder_audit_results(
+            "meeting",
+            "m1",
+            &winner_hash,
+            "engine",
+            &audit_candidates(&["Follow the newer provider"]),
+            10,
+        )
+        .unwrap());
+
+    db.lock()
+        .execute(
+            "UPDATE notes SET created_at='2026-07-29T10:07:00Z'
+              WHERE meeting_id='m1' AND provider_id='local'",
+            [],
+        )
+        .unwrap();
+    assert_eq!(
+        db.latest_reminder_audit_markdown("m1").unwrap().as_deref(),
+        Some("- [ ] Ship the plan"),
+        "timestamp-only edit must deterministically switch the canonical provider winner"
+    );
+    assert_eq!(
+        derived_reminder_audit_count(&db),
+        0,
+        "winner-switch update must purge the old provider's derived plaintext"
+    );
+    assert!(!db
+        .replace_reminder_audit_results(
+            "meeting",
+            "m1",
+            &winner_hash,
+            "engine",
+            &audit_candidates(&["Follow the newer provider"]),
+            11,
+        )
+        .unwrap());
+
+    db.insert_note("n1", "f1", "Fallback name", "", "- [ ] Call", 1)
+        .unwrap();
+    let note_hash = crate::storage::reminder_store::canonical_reminder_source_hash(
+        "Fallback name",
+        "- [ ] Call",
+        None,
+        &[],
+    );
+    assert!(db
+        .replace_reminder_audit_results(
+            "note",
+            "n1",
+            &note_hash,
+            "engine",
+            &audit_candidates(&["Call"]),
+            12,
+        )
+        .unwrap());
+    db.lock()
+        .execute(
+            "UPDATE documents SET name='Renamed fallback' WHERE id='n1'",
+            [],
+        )
+        .unwrap();
+    assert_eq!(
+        derived_reminder_audit_count(&db),
+        0,
+        "fallback-name-only edit must invalidate authored-note suggestions"
+    );
+    assert!(!db
+        .replace_reminder_audit_results(
+            "note",
+            "n1",
+            &note_hash,
+            "engine",
+            &audit_candidates(&["Call"]),
+            13,
+        )
+        .unwrap());
+}
+
+#[test]
+fn meeting_and_authored_note_folder_moves_purge_pending_plaintext() {
+    let db = reminder_db();
+    seed_reminder_audit_source(&db, "f1", "m1");
+    db.insert_folder(&Folder {
+        id: "f2".into(),
+        name: "Moved".into(),
+        path: "Moved".into(),
+        parent_id: None,
+        locked: false,
+        created_at: "2026-07-29T09:01:00Z".into(),
+    })
+    .unwrap();
+    let hash = audit_hash('f');
+    let candidates = audit_candidates(&["Move-safe"]);
+    db.replace_reminder_audit_results_unchecked("meeting", "m1", &hash, "engine", &candidates, 10)
+        .unwrap();
+    db.lock()
+        .execute("UPDATE notes SET folder_id='f2' WHERE meeting_id='m1'", [])
+        .unwrap();
+    assert_eq!(derived_reminder_audit_count(&db), 0);
+
+    db.insert_note("n1", "f1", "Note", "Note", "- [ ] Move-safe", 1)
+        .unwrap();
+    db.replace_reminder_audit_results_unchecked("note", "n1", &hash, "engine", &candidates, 11)
+        .unwrap();
+    db.lock()
+        .execute("UPDATE documents SET folder_id='f2' WHERE id='n1'", [])
+        .unwrap();
+    assert_eq!(
+        derived_reminder_audit_count(&db),
+        0,
+        "folder ownership changes must purge source-derived reminder plaintext"
+    );
+}
+
+#[test]
+fn non_schedule_edits_preserve_dismissed_occurrences() {
+    let db = reminder_db();
+    let mut original = draft(10);
+    original.sources.push(ReminderSourceAnchor {
+        kind: "meeting".into(),
+        id: "m1".into(),
+    });
+    db.create_reminder("r1", &original, ReminderOrigin::Manual, 1)
+        .unwrap();
+    db.materialize_due_reminders(10).unwrap();
+    let occurrence = db.unread_reminder_occurrences().unwrap().remove(0);
+    db.dismiss_reminder_occurrence(&occurrence.id, 11).unwrap();
+
+    let mut edited = original;
+    edited.title = "New title".into();
+    edited.sources.push(ReminderSourceAnchor {
+        kind: "note".into(),
+        id: "n1".into(),
+    });
+    assert!(db.update_reminder("r1", &edited, 12).unwrap());
+    assert_eq!(db.materialize_due_reminders(20).unwrap(), 0);
+    let status: String = db
+        .lock()
+        .query_row(
+            "SELECT status FROM reminder_due_occurrences WHERE reminder_id='r1'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(status, "dismissed");
+}
+
+#[test]
+fn schedule_change_clears_history_and_reused_due_materializes_once() {
+    let db = reminder_db();
+    let original = draft(10);
+    db.create_reminder("r1", &original, ReminderOrigin::Manual, 1)
+        .unwrap();
+    db.materialize_due_reminders(10).unwrap();
+    let occurrence = db.unread_reminder_occurrences().unwrap().remove(0);
+    db.dismiss_reminder_occurrence(&occurrence.id, 11).unwrap();
+
+    let mut changed = original.clone();
+    changed.due_at = 20;
+    db.update_reminder("r1", &changed, 12).unwrap();
+    db.update_reminder("r1", &original, 13).unwrap();
+    assert_eq!(db.materialize_due_reminders(13).unwrap(), 1);
+    assert_eq!(db.materialize_due_reminders(14).unwrap(), 0);
+    assert_eq!(db.due_reminder_count().unwrap(), 1);
+}
+
+#[test]
+fn overdue_recurrence_skips_missed_cycles_to_first_future_due() {
+    let db = reminder_db();
+    let due = Local
+        .with_ymd_and_hms(2026, 1, 1, 9, 0, 0)
+        .earliest()
+        .unwrap()
+        .timestamp_millis();
+    let now = Local
+        .with_ymd_and_hms(2026, 2, 1, 12, 0, 0)
+        .earliest()
+        .unwrap()
+        .timestamp_millis();
+    let mut recurring = draft(due);
+    recurring.repeat_every = Some(1);
+    recurring.repeat_unit = Some(ReminderRepeatUnit::Days);
+    db.create_reminder("r1", &recurring, ReminderOrigin::Manual, 1)
+        .unwrap();
+    assert!(db.complete_reminder("r1", due, now).unwrap());
+    let next = db.get_stored_reminder("r1").unwrap().unwrap().due_at;
+    assert!(next > now);
+    let local = Local.timestamp_millis_opt(next).earliest().unwrap();
+    assert_eq!((local.year(), local.month(), local.day()), (2026, 2, 2));
+}
+
+#[test]
+fn recurrence_terminates_cleanly_at_supported_horizon() {
+    let db = reminder_db();
+    let due = Local
+        .with_ymd_and_hms(2199, 12, 31, 9, 0, 0)
+        .earliest()
+        .unwrap()
+        .timestamp_millis();
+    let mut recurring = draft(due);
+    recurring.repeat_every = Some(1);
+    recurring.repeat_unit = Some(ReminderRepeatUnit::Years);
+    db.create_reminder("r1", &recurring, ReminderOrigin::Manual, 1)
+        .unwrap();
+    assert!(db.complete_reminder("r1", due, due + 1).unwrap());
+    let stored = db.get_stored_reminder("r1").unwrap().unwrap();
+    assert_eq!(stored.state, ReminderState::Completed);
+    assert_eq!(stored.completed_at, Some(due + 1));
+}

--- a/src-tauri/src/storage/db_tests/reminder_tests.rs
+++ b/src-tauri/src/storage/db_tests/reminder_tests.rs
@@ -6,6 +6,7 @@ use crate::storage::models::{
     Folder, Meeting, MeetingStatus, NoteRecord, ReminderDraft, ReminderOrigin, ReminderRepeatUnit,
     ReminderSourceAnchor, ReminderState,
 };
+use crate::storage::reminder_store::ReminderSuggestionPromotion;
 
 fn reminder_db() -> Db {
     register_vec_extension();
@@ -788,26 +789,26 @@ fn smart_suggestions_promote_once_and_siblings_can_promote_sequentially() {
     });
 
     assert!(db
-        .promote_pending_reminder_suggestion(
-            &rows[0].id,
-            "meeting",
-            "m1",
-            &hash,
-            "r-smart-1",
-            &first_draft,
-            20,
-        )
+        .promote_pending_reminder_suggestion(ReminderSuggestionPromotion {
+            suggestion_id: &rows[0].id,
+            expected_source_kind: "meeting",
+            expected_source_id: "m1",
+            expected_content_hash: &hash,
+            reminder_id: "r-smart-1",
+            draft: &first_draft,
+            now: 20,
+        })
         .unwrap());
     assert!(!db
-        .promote_pending_reminder_suggestion(
-            &rows[0].id,
-            "meeting",
-            "m1",
-            &hash,
-            "r-replay",
-            &first_draft,
-            21,
-        )
+        .promote_pending_reminder_suggestion(ReminderSuggestionPromotion {
+            suggestion_id: &rows[0].id,
+            expected_source_kind: "meeting",
+            expected_source_id: "m1",
+            expected_content_hash: &hash,
+            reminder_id: "r-replay",
+            draft: &first_draft,
+            now: 21,
+        })
         .unwrap());
     assert!(db
         .reminder_audit_cache_matches("meeting", "m1", &hash, "stub-local")
@@ -820,15 +821,15 @@ fn smart_suggestions_promote_once_and_siblings_can_promote_sequentially() {
     let mut second_draft = draft(2_000_000_100_000);
     second_draft.title = "Second accepted task".into();
     assert!(db
-        .promote_pending_reminder_suggestion(
-            &after_first[0].id,
-            "meeting",
-            "m1",
-            &hash,
-            "r-smart-2",
-            &second_draft,
-            22,
-        )
+        .promote_pending_reminder_suggestion(ReminderSuggestionPromotion {
+            suggestion_id: &after_first[0].id,
+            expected_source_kind: "meeting",
+            expected_source_id: "m1",
+            expected_content_hash: &hash,
+            reminder_id: "r-smart-2",
+            draft: &second_draft,
+            now: 22,
+        })
         .unwrap());
     assert!(db
         .list_pending_reminder_suggestions("meeting", "m1", &hash, "stub-local", 32)
@@ -1144,15 +1145,15 @@ fn smart_decision_fingerprints_are_purged_while_accepted_reminders_survive() {
         .find(|row| row.title == "Dismissed task")
         .unwrap();
     assert!(db
-        .promote_pending_reminder_suggestion(
-            &accepted.id,
-            "meeting",
-            "m1",
-            &hash,
-            "r-accepted",
-            &draft(2_000_000_000_000),
-            20,
-        )
+        .promote_pending_reminder_suggestion(ReminderSuggestionPromotion {
+            suggestion_id: &accepted.id,
+            expected_source_kind: "meeting",
+            expected_source_id: "m1",
+            expected_content_hash: &hash,
+            reminder_id: "r-accepted",
+            draft: &draft(2_000_000_000_000),
+            now: 20,
+        })
         .unwrap());
     assert!(db
         .dismiss_pending_reminder_suggestion(&dismissed.id, "meeting", "m1", &hash)

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -15,6 +15,7 @@ pub mod models;
 pub(crate) mod notes_store;
 pub(crate) mod org_store;
 pub(crate) mod recording_store;
+pub(crate) mod reminder_store;
 pub(crate) mod seal_store;
 pub(crate) mod settings_store;
 pub mod usage;

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -1219,6 +1219,225 @@ pub struct ActionItem {
     pub due_date: Option<String>,
 }
 
+// ── Murmur Reminders ────────────────────────────────────────────────────────────────────────────
+
+/// A reminder's recurrence cadence. Stored as a stable lowercase string and surfaced unchanged
+/// over IPC.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ReminderRepeatUnit {
+    Days,
+    Weeks,
+    Months,
+    Years,
+}
+
+impl ReminderRepeatUnit {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Days => "days",
+            Self::Weeks => "weeks",
+            Self::Months => "months",
+            Self::Years => "years",
+        }
+    }
+
+    pub(crate) fn parse(value: &str) -> crate::error::Result<Self> {
+        match value {
+            "days" => Ok(Self::Days),
+            "weeks" => Ok(Self::Weeks),
+            "months" => Ok(Self::Months),
+            "years" => Ok(Self::Years),
+            other => Err(crate::error::AppError::Storage(format!(
+                "unknown reminder repeat unit: {other}"
+            ))),
+        }
+    }
+}
+
+/// Reminder provenance. `Smart` means the user explicitly promoted a reviewed local suggestion;
+/// it never means that an audit created a reminder automatically.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ReminderOrigin {
+    Manual,
+    Smart,
+}
+
+impl ReminderOrigin {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Manual => "manual",
+            Self::Smart => "smart",
+        }
+    }
+
+    pub(crate) fn parse(value: &str) -> crate::error::Result<Self> {
+        match value {
+            "manual" => Ok(Self::Manual),
+            "smart" => Ok(Self::Smart),
+            other => Err(crate::error::AppError::Storage(format!(
+                "unknown reminder origin: {other}"
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ReminderState {
+    Active,
+    Completed,
+}
+
+impl ReminderState {
+    pub(crate) fn parse(value: &str) -> crate::error::Result<Self> {
+        match value {
+            "active" => Ok(Self::Active),
+            "completed" => Ok(Self::Completed),
+            other => Err(crate::error::AppError::Storage(format!(
+                "unknown reminder state: {other}"
+            ))),
+        }
+    }
+}
+
+/// An opaque anchor to a Murmur-authored note or meeting. Titles are deliberately NOT stored here:
+/// the command layer resolves them only through the source's current visibility gate.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ReminderSourceAnchor {
+    pub kind: String,
+    pub id: String,
+}
+
+/// User-editable input shared by create/update and Smart-suggestion promotion.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ReminderDraft {
+    pub title: String,
+    pub details: Option<String>,
+    /// UTC epoch milliseconds. The composer derives this from a calendar-valid local date/time.
+    pub due_at: i64,
+    pub repeat_every: Option<u32>,
+    pub repeat_unit: Option<ReminderRepeatUnit>,
+    #[serde(default)]
+    pub sources: Vec<ReminderSourceAnchor>,
+}
+
+/// Canonical SQLCipher-backed reminder row plus its opaque source anchors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredReminder {
+    pub id: String,
+    pub title: String,
+    pub details: Option<String>,
+    pub due_at: i64,
+    pub repeat_every: Option<u32>,
+    pub repeat_unit: Option<ReminderRepeatUnit>,
+    pub state: ReminderState,
+    pub origin: ReminderOrigin,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub completed_at: Option<i64>,
+    pub sources: Vec<ReminderSourceAnchor>,
+}
+
+/// Live-gated source metadata. A sealed/deleted source contributes no entry; the reminder itself is
+/// independent user data and remains usable.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ReminderSourceView {
+    pub kind: String,
+    pub id: String,
+    pub title: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ReminderView {
+    pub id: String,
+    pub title: String,
+    pub details: Option<String>,
+    pub due_at: i64,
+    pub repeat_every: Option<u32>,
+    pub repeat_unit: Option<ReminderRepeatUnit>,
+    pub state: ReminderState,
+    pub origin: ReminderOrigin,
+    pub created_at: i64,
+    pub updated_at: i64,
+    pub completed_at: Option<i64>,
+    pub sources: Vec<ReminderSourceView>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ReminderInboxItem {
+    pub occurrence_id: String,
+    pub due_at: i64,
+    pub reminder: ReminderView,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RemindersSnapshot {
+    pub inbox: Vec<ReminderInboxItem>,
+    pub upcoming: Vec<ReminderView>,
+    pub completed: Vec<ReminderView>,
+    pub due_inbox_count: u64,
+}
+
+/// Content-free shell badge projection. Fetching it never resolves reminder/source titles.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ReminderSummary {
+    pub due_inbox_count: u64,
+}
+
+/// Storage projection for one unread due occurrence. The command layer joins the referenced
+/// reminder to its live-gated source metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredReminderOccurrence {
+    pub id: String,
+    pub reminder_id: String,
+    pub due_at: i64,
+}
+
+/// One disposable Smart-audit suggestion row. The title is source-derived plaintext, so storage
+/// purges this domain on every source edit/seal/relock; it is never treated as user-owned reminder
+/// data until an explicit atomic promotion succeeds.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredReminderSuggestion {
+    pub id: String,
+    pub source_kind: String,
+    pub source_id: String,
+    pub content_hash: String,
+    pub engine_id: String,
+    pub candidate_key: String,
+    pub title: String,
+    pub suggested_due_at: Option<i64>,
+    pub created_at: i64,
+}
+
+/// Content-free lookup anchor for accept/dismiss authorization. Command code may read this before
+/// taking the lifecycle mutex because it contains no suggestion title, due time, or source title.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReminderSuggestionGateAnchor {
+    pub id: String,
+    pub source_kind: String,
+    pub source_id: String,
+}
+
+/// IPC-safe Smart suggestion. Source metadata is resolved through the current visibility gate by
+/// the command layer; storage never persists a source title in the derived audit tables.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ReminderSuggestionView {
+    pub id: String,
+    pub title: String,
+    pub suggested_due_at: Option<i64>,
+    pub source: ReminderSourceView,
+}
+
 /// One OPEN action item ("commitment") rolled up across the whole library, carrying its meeting
 /// context. Produced by the deterministic `Db::list_open_commitments` aggregation: only OPEN
 /// (`- [ ]`, not `- [x]`) items from VISIBLE meetings contribute — a sealed-and-not-unlocked

--- a/src-tauri/src/storage/reminder_store.rs
+++ b/src-tauri/src/storage/reminder_store.rs
@@ -38,6 +38,20 @@ pub(crate) struct ReminderSourceInvalidation {
     pub revision: i64,
 }
 
+/// Exact one-shot capability and user-edited draft promoted by the Smart Reminder accept flow.
+/// Grouping the CAS anchors keeps callers from swapping or omitting one of the source bindings.
+pub(crate) struct ReminderSuggestionPromotion<'a> {
+    pub suggestion_id: &'a str,
+    pub expected_source_kind: &'a str,
+    pub expected_source_id: &'a str,
+    pub expected_content_hash: &'a str,
+    pub reminder_id: &'a str,
+    pub draft: &'a ReminderDraft,
+    pub now: i64,
+}
+
+type ReminderOccurrenceScheduleRow = (String, i64, i64, Option<i64>, Option<String>, String);
+
 /// Exact canonical Smart-audit fingerprint shared by the gated command read and the transactional
 /// storage CAS. Every meaning-bearing segment field is framed explicitly; floating-point values
 /// use their stored IEEE bit pattern, preserving `None` vs zero and avoiding formatter drift.
@@ -813,16 +827,19 @@ impl Db {
     /// domain. The candidate row is the one-shot capability: it is consumed in the same transaction
     /// as the `origin='smart'` insert, so replay cannot create another row. The cache and sibling
     /// candidates remain authoritative so the user can accept several suggestions from one audit.
-    pub fn promote_pending_reminder_suggestion(
+    pub(crate) fn promote_pending_reminder_suggestion(
         &self,
-        suggestion_id: &str,
-        expected_source_kind: &str,
-        expected_source_id: &str,
-        expected_content_hash: &str,
-        reminder_id: &str,
-        draft: &ReminderDraft,
-        now: i64,
+        promotion: ReminderSuggestionPromotion<'_>,
     ) -> Result<bool> {
+        let ReminderSuggestionPromotion {
+            suggestion_id,
+            expected_source_kind,
+            expected_source_id,
+            expected_content_hash,
+            reminder_id,
+            draft,
+            now,
+        } = promotion;
         validate_source(expected_source_kind, expected_source_id)?;
         validate_hash(expected_content_hash)?;
         if reminder_id.is_empty() || reminder_id.chars().count() > MAX_SOURCE_ID_CHARS {
@@ -1255,7 +1272,7 @@ impl Db {
     pub fn dismiss_reminder_occurrence(&self, occurrence_id: &str, now: i64) -> Result<bool> {
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
-        let row: Option<(String, i64, i64, Option<i64>, Option<String>, String)> = tx
+        let row: Option<ReminderOccurrenceScheduleRow> = tx
             .query_row(
                 "SELECT o.reminder_id, o.due_at, r.due_at, r.repeat_every, r.repeat_unit, r.state
                    FROM reminder_due_occurrences o

--- a/src-tauri/src/storage/reminder_store.rs
+++ b/src-tauri/src/storage/reminder_store.rs
@@ -1,0 +1,1830 @@
+//! Canonical SQLCipher-backed Murmur reminder store.
+//!
+//! Durable reminders are user-owned data and deliberately survive source lock/relock. Their source
+//! anchors contain opaque ids only; command-layer title resolution is live-gated. The audit cache
+//! and pending Smart suggestions are a separate DERIVED plaintext domain; unkeyed decision hashes
+//! are purged with it on seal/relock/startup. Additive SQL triggers invalidate the plaintext rows
+//! in the same transaction as every canonical meeting/note content insert, edit, seal-blank, or
+//! delete.
+
+use chrono::{Datelike, Local, NaiveDate, NaiveDateTime, TimeZone, Timelike};
+use rusqlite::{Connection, OptionalExtension, Row, Transaction};
+use std::borrow::Cow;
+
+use crate::error::{AppError, Result};
+use crate::reminder_audit::ReminderAuditCandidate;
+use crate::storage::db::{map_err, Db};
+use crate::storage::models::{
+    ReminderDraft, ReminderOrigin, ReminderRepeatUnit, ReminderSourceAnchor, ReminderState,
+    ReminderSuggestionGateAnchor, StoredReminder, StoredReminderOccurrence,
+    StoredReminderSuggestion,
+};
+use crate::transcribe::types::Segment;
+
+const MAX_PENDING_SUGGESTIONS: usize = 32;
+const MAX_REMINDER_TITLE_CHARS: usize = 240;
+const MAX_SOURCE_ID_CHARS: usize = 160;
+const MAX_ENGINE_ID_CHARS: usize = 160;
+const MAX_SOURCE_INVALIDATION_DRAIN: usize = 256;
+const MAX_LOCAL_DATETIME_GAP_MINUTES: usize = 48 * 60;
+pub(crate) const MIN_REMINDER_DUE_AT: i64 = 946_684_800_000; // 2000-01-01T00:00:00Z
+pub(crate) const MAX_REMINDER_DUE_AT: i64 = 7_258_118_400_000; // 2200-01-01T00:00:00Z
+
+/// Content-free Smart-card invalidation claimed from the durable SQLCipher queue.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReminderSourceInvalidation {
+    pub kind: String,
+    pub id: String,
+    pub revision: i64,
+}
+
+/// Exact canonical Smart-audit fingerprint shared by the gated command read and the transactional
+/// storage CAS. Every meaning-bearing segment field is framed explicitly; floating-point values
+/// use their stored IEEE bit pattern, preserving `None` vs zero and avoiding formatter drift.
+pub(crate) fn canonical_reminder_source_hash(
+    title: &str,
+    markdown: &str,
+    manual_notes: Option<&str>,
+    segments: &[Segment],
+) -> String {
+    let mut parts = Vec::<Cow<'_, str>>::with_capacity(6 + segments.len() * 13);
+    parts.extend([
+        Cow::Borrowed("source-title"),
+        Cow::Borrowed(title),
+        Cow::Borrowed("markdown"),
+        Cow::Borrowed(markdown),
+        Cow::Borrowed("manual-notes"),
+        Cow::Borrowed(manual_notes.unwrap_or("")),
+    ]);
+    for segment in segments {
+        parts.extend([
+            Cow::Borrowed("segment-idx"),
+            Cow::Owned(segment.idx.to_string()),
+            Cow::Borrowed("segment-start-bits"),
+            Cow::Owned(format!("{:016x}", segment.start_s.to_bits())),
+            Cow::Borrowed("segment-end-bits"),
+            Cow::Owned(format!("{:016x}", segment.end_s.to_bits())),
+            Cow::Borrowed("segment-text"),
+            Cow::Borrowed(segment.text.as_str()),
+            Cow::Borrowed("segment-speaker"),
+            Cow::Borrowed(segment.speaker.as_deref().unwrap_or("")),
+            Cow::Borrowed(if segment.speaker.is_some() {
+                "speaker-present"
+            } else {
+                "speaker-absent"
+            }),
+            Cow::Borrowed("segment-confidence"),
+            Cow::Owned(
+                segment
+                    .confidence
+                    .map(|value| format!("present:{:08x}", value.to_bits()))
+                    .unwrap_or_else(|| "absent".into()),
+            ),
+        ]);
+    }
+    crate::reminder_audit::content_hash(&parts.iter().map(|part| part.as_ref()).collect::<Vec<_>>())
+}
+
+impl Db {
+    /// Additive, idempotent schema for durable reminders, source anchors, due occurrences, and the
+    /// derived Smart-audit cache/pending domain.
+    pub(crate) fn migrate_reminders(conn: &Connection) -> Result<()> {
+        // Keep the outbox table/column migration ahead of trigger creation. A development database
+        // may already have the first two-column draft; adding the revision is additive and lets the
+        // companion triggers below compile against both fresh and previously-opened databases.
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS reminder_source_invalidation_queue (
+               source_kind TEXT NOT NULL,
+               source_id   TEXT NOT NULL,
+               revision    INTEGER NOT NULL DEFAULT 1,
+               PRIMARY KEY (source_kind, source_id),
+               CHECK (source_kind IN ('meeting','note'))
+             );",
+        )
+        .map_err(map_err)?;
+        Self::add_column_if_missing(
+            conn,
+            "reminder_source_invalidation_queue",
+            "revision",
+            "INTEGER NOT NULL DEFAULT 1",
+        )?;
+        // Pre-SQLCipher-v7 databases used the original one-note/three-column transcript shape:
+        // `notes(meeting_id,markdown)` and `segments(meeting_id,idx,text)`. Core migration already
+        // adds every other field referenced by the reminder triggers, but these four canonical
+        // projection columns predate its guarded-ALTER list. Add deterministic legacy defaults
+        // BEFORE creating any trigger so both NEW/OLD aliases are valid on first open and every
+        // database receives the same full invalidation trigger set (never a reduced compatibility
+        // trigger that could persist after a later upgrade).
+        Self::add_column_if_missing(
+            conn,
+            "notes",
+            "provider_id",
+            "TEXT NOT NULL DEFAULT 'legacy'",
+        )?;
+        Self::add_column_if_missing(conn, "notes", "created_at", "TEXT NOT NULL DEFAULT ''")?;
+        Self::add_column_if_missing(conn, "segments", "start_s", "REAL NOT NULL DEFAULT 0")?;
+        Self::add_column_if_missing(conn, "segments", "end_s", "REAL NOT NULL DEFAULT 0")?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS reminders (
+               id            TEXT PRIMARY KEY,
+               title         TEXT NOT NULL,
+               details       TEXT,
+               due_at        INTEGER NOT NULL,
+               repeat_every  INTEGER,
+               repeat_unit   TEXT,
+               state         TEXT NOT NULL DEFAULT 'active',
+               origin        TEXT NOT NULL DEFAULT 'manual',
+               created_at    INTEGER NOT NULL,
+               updated_at    INTEGER NOT NULL,
+               completed_at  INTEGER,
+               CHECK (length(title) BETWEEN 1 AND 240),
+               CHECK (details IS NULL OR length(details) <= 4000),
+               CHECK (repeat_every IS NULL OR repeat_every BETWEEN 1 AND 365),
+               CHECK ((repeat_every IS NULL) = (repeat_unit IS NULL)),
+               CHECK (repeat_unit IS NULL OR repeat_unit IN ('days','weeks','months','years')),
+               CHECK (state IN ('active','completed')),
+               CHECK (origin IN ('manual','smart'))
+             );
+             CREATE INDEX IF NOT EXISTS idx_reminders_state_due
+               ON reminders(state, due_at, id);
+
+             CREATE TABLE IF NOT EXISTS reminder_sources (
+               reminder_id TEXT NOT NULL,
+               source_kind TEXT NOT NULL,
+               source_id   TEXT NOT NULL,
+               PRIMARY KEY (reminder_id, source_kind, source_id),
+               FOREIGN KEY (reminder_id) REFERENCES reminders(id) ON DELETE CASCADE,
+               CHECK (source_kind IN ('meeting','note'))
+             );
+             CREATE INDEX IF NOT EXISTS idx_reminder_sources_source
+               ON reminder_sources(source_kind, source_id);
+
+             CREATE TABLE IF NOT EXISTS reminder_due_occurrences (
+               id           TEXT PRIMARY KEY,
+               reminder_id  TEXT NOT NULL,
+               due_at       INTEGER NOT NULL,
+               status       TEXT NOT NULL DEFAULT 'unread',
+               created_at   INTEGER NOT NULL,
+               resolved_at  INTEGER,
+               UNIQUE (reminder_id, due_at),
+               FOREIGN KEY (reminder_id) REFERENCES reminders(id) ON DELETE CASCADE,
+               CHECK (status IN ('unread','dismissed','completed'))
+             );
+             CREATE INDEX IF NOT EXISTS idx_reminder_occurrences_status_due
+               ON reminder_due_occurrences(status, due_at, id);
+
+             -- Derived Smart-audit state. These tables are populated only after the audit's
+             -- post-inference re-gate/hash check. Their plaintext is disposable source-derived
+             -- content, unlike the independent durable reminder domain above.
+             CREATE TABLE IF NOT EXISTS reminder_audit_cache (
+               source_kind  TEXT NOT NULL,
+               source_id    TEXT NOT NULL,
+               content_hash TEXT NOT NULL,
+               engine_id    TEXT NOT NULL,
+               audited_at   INTEGER NOT NULL,
+               PRIMARY KEY (source_kind, source_id),
+               CHECK (source_kind IN ('meeting','note'))
+             );
+             CREATE TABLE IF NOT EXISTS reminder_pending_suggestions (
+               id               TEXT PRIMARY KEY,
+               source_kind      TEXT NOT NULL,
+               source_id        TEXT NOT NULL,
+               content_hash     TEXT NOT NULL,
+               engine_id        TEXT NOT NULL,
+               candidate_key    TEXT NOT NULL,
+               title            TEXT NOT NULL,
+               suggested_due_at INTEGER,
+               created_at       INTEGER NOT NULL,
+               UNIQUE (source_kind, source_id, content_hash, candidate_key),
+               CHECK (source_kind IN ('meeting','note')),
+               CHECK (length(title) BETWEEN 1 AND 240)
+             );
+             CREATE INDEX IF NOT EXISTS idx_reminder_suggestions_source
+               ON reminder_pending_suggestions(source_kind, source_id);
+
+             -- Session-durable, plaintext-free user decisions. Engine identity is deliberately
+             -- absent, but the unkeyed source/candidate hashes are purged on seal/relock/startup
+             -- with the derived audit domain.
+             CREATE TABLE IF NOT EXISTS reminder_suggestion_decisions (
+               source_kind  TEXT NOT NULL,
+               source_id    TEXT NOT NULL,
+               content_hash TEXT NOT NULL,
+               candidate_key TEXT NOT NULL,
+               decision     TEXT NOT NULL,
+               reminder_id  TEXT,
+               decided_at   INTEGER NOT NULL,
+               PRIMARY KEY (source_kind, source_id, content_hash, candidate_key),
+               FOREIGN KEY (reminder_id) REFERENCES reminders(id) ON DELETE CASCADE,
+               CHECK (source_kind IN ('meeting','note')),
+               CHECK (decision IN ('accepted','dismissed')),
+               CHECK ((decision = 'accepted') = (reminder_id IS NOT NULL))
+             );
+             CREATE INDEX IF NOT EXISTS idx_reminder_decisions_reminder
+               ON reminder_suggestion_decisions(reminder_id);
+
+             -- Durable content-free bridge from canonical DB mutations to the FE. Triggers enqueue
+             -- only the source discriminator + opaque id; repeated edits coalesce until claimed.
+             CREATE TABLE IF NOT EXISTS reminder_source_invalidation_queue (
+               source_kind TEXT NOT NULL,
+               source_id   TEXT NOT NULL,
+               revision    INTEGER NOT NULL DEFAULT 1,
+               PRIMARY KEY (source_kind, source_id),
+               CHECK (source_kind IN ('meeting','note'))
+             );
+
+             -- MEETING NOTE changes (including seal/relock blanking).
+             CREATE TRIGGER IF NOT EXISTS reminder_derived_notes_ai
+             AFTER INSERT ON notes BEGIN
+               DELETE FROM reminder_pending_suggestions
+                WHERE source_kind = 'meeting' AND source_id = new.meeting_id;
+               DELETE FROM reminder_audit_cache
+                WHERE source_kind = 'meeting' AND source_id = new.meeting_id;
+             END;
+             CREATE TRIGGER IF NOT EXISTS reminder_derived_notes_au
+             AFTER UPDATE OF meeting_id, provider_id, markdown, created_at, folder_id ON notes
+             WHEN old.meeting_id IS NOT new.meeting_id
+               OR old.provider_id IS NOT new.provider_id
+               OR old.markdown IS NOT new.markdown
+               OR old.created_at IS NOT new.created_at
+               OR old.folder_id IS NOT new.folder_id BEGIN
+               DELETE FROM reminder_pending_suggestions
+                WHERE source_kind = 'meeting' AND source_id = new.meeting_id;
+               DELETE FROM reminder_audit_cache
+                WHERE source_kind = 'meeting' AND source_id = new.meeting_id;
+               DELETE FROM reminder_pending_suggestions
+                WHERE source_kind = 'meeting' AND source_id = old.meeting_id;
+               DELETE FROM reminder_audit_cache
+                WHERE source_kind = 'meeting' AND source_id = old.meeting_id;
+             END;
+             -- Additive companion for databases that already created the earlier markdown-only
+             -- trigger: latest-note selection and lock ownership also change on these fields.
+             CREATE TRIGGER IF NOT EXISTS reminder_derived_notes_projection_au
+             AFTER UPDATE OF meeting_id, provider_id, created_at, folder_id ON notes
+             WHEN old.meeting_id IS NOT new.meeting_id
+               OR old.provider_id IS NOT new.provider_id
+               OR old.created_at IS NOT new.created_at
+               OR old.folder_id IS NOT new.folder_id BEGIN
+               DELETE FROM reminder_pending_suggestions
+                WHERE source_kind = 'meeting' AND source_id = new.meeting_id;
+               DELETE FROM reminder_audit_cache
+                WHERE source_kind = 'meeting' AND source_id = new.meeting_id;
+               DELETE FROM reminder_pending_suggestions
+                WHERE source_kind = 'meeting' AND source_id = old.meeting_id;
+               DELETE FROM reminder_audit_cache
+                WHERE source_kind = 'meeting' AND source_id = old.meeting_id;
+             END;
+             CREATE TRIGGER IF NOT EXISTS reminder_derived_notes_ad
+             AFTER DELETE ON notes BEGIN
+               DELETE FROM reminder_pending_suggestions
+                WHERE source_kind = 'meeting' AND source_id = old.meeting_id;
+               DELETE FROM reminder_audit_cache
+                WHERE source_kind = 'meeting' AND source_id = old.meeting_id;
+             END;
+
+             -- Transcript changes are canonical meeting-content changes too. The triggers are
+             -- cheap no-ops unless this source currently has a pending audit.
+             CREATE TRIGGER IF NOT EXISTS reminder_derived_segments_ai
+             AFTER INSERT ON segments BEGIN
+               DELETE FROM reminder_pending_suggestions
+                WHERE source_kind = 'meeting' AND source_id = new.meeting_id;
+               DELETE FROM reminder_audit_cache
+                WHERE source_kind = 'meeting' AND source_id = new.meeting_id;
+             END;
+             CREATE TRIGGER IF NOT EXISTS reminder_derived_segments_au
+             AFTER UPDATE OF meeting_id, idx, start_s, end_s, text, speaker, confidence ON segments
+             WHEN old.meeting_id IS NOT new.meeting_id
+               OR old.idx IS NOT new.idx
+               OR old.start_s IS NOT new.start_s
+               OR old.end_s IS NOT new.end_s
+               OR old.text IS NOT new.text
+               OR old.speaker IS NOT new.speaker
+               OR old.confidence IS NOT new.confidence BEGIN
+               DELETE FROM reminder_pending_suggestions
+                WHERE source_kind = 'meeting' AND source_id = new.meeting_id;
+               DELETE FROM reminder_audit_cache
+                WHERE source_kind = 'meeting' AND source_id = new.meeting_id;
+               DELETE FROM reminder_pending_suggestions
+                WHERE source_kind = 'meeting' AND source_id = old.meeting_id;
+               DELETE FROM reminder_audit_cache
+                WHERE source_kind = 'meeting' AND source_id = old.meeting_id;
+             END;
+             -- Additive companion for databases that already created the earlier text-only
+             -- trigger: every other visible segment field is part of the canonical fingerprint.
+             CREATE TRIGGER IF NOT EXISTS reminder_derived_segments_projection_au
+             AFTER UPDATE OF meeting_id, idx, start_s, end_s, speaker, confidence ON segments
+             WHEN old.meeting_id IS NOT new.meeting_id
+               OR old.idx IS NOT new.idx
+               OR old.start_s IS NOT new.start_s
+               OR old.end_s IS NOT new.end_s
+               OR old.speaker IS NOT new.speaker
+               OR old.confidence IS NOT new.confidence BEGIN
+               DELETE FROM reminder_pending_suggestions
+                WHERE source_kind = 'meeting' AND source_id = new.meeting_id;
+               DELETE FROM reminder_audit_cache
+                WHERE source_kind = 'meeting' AND source_id = new.meeting_id;
+               DELETE FROM reminder_pending_suggestions
+                WHERE source_kind = 'meeting' AND source_id = old.meeting_id;
+               DELETE FROM reminder_audit_cache
+                WHERE source_kind = 'meeting' AND source_id = old.meeting_id;
+             END;
+             -- Presentation-only echo provenance changes membership in the canonical merged
+             -- transcript used by Smart audit. Keep this as a dedicated additive trigger so a
+             -- database first opened by an earlier build also gains the invalidation rule.
+             CREATE TRIGGER IF NOT EXISTS reminder_derived_segments_echo_au
+             AFTER UPDATE OF echo_suppressed ON segments
+             WHEN old.echo_suppressed IS NOT new.echo_suppressed BEGIN
+               DELETE FROM reminder_pending_suggestions
+                WHERE source_kind = 'meeting' AND source_id = new.meeting_id;
+               DELETE FROM reminder_audit_cache
+                WHERE source_kind = 'meeting' AND source_id = new.meeting_id;
+             END;
+             CREATE TRIGGER IF NOT EXISTS reminder_derived_segments_ad
+             AFTER DELETE ON segments BEGIN
+               DELETE FROM reminder_pending_suggestions
+                WHERE source_kind = 'meeting' AND source_id = old.meeting_id;
+               DELETE FROM reminder_audit_cache
+                WHERE source_kind = 'meeting' AND source_id = old.meeting_id;
+             END;
+
+             -- Manual meeting notes/title changes and meeting deletion.
+             CREATE TRIGGER IF NOT EXISTS reminder_derived_meetings_au
+             AFTER UPDATE OF manual_notes, title ON meetings
+             WHEN old.manual_notes IS NOT new.manual_notes
+               OR old.title IS NOT new.title BEGIN
+               DELETE FROM reminder_pending_suggestions
+                WHERE source_kind = 'meeting' AND source_id = new.id;
+               DELETE FROM reminder_audit_cache
+                WHERE source_kind = 'meeting' AND source_id = new.id;
+             END;
+             CREATE TRIGGER IF NOT EXISTS reminder_derived_meetings_ad
+             AFTER DELETE ON meetings BEGIN
+               DELETE FROM reminder_pending_suggestions
+                WHERE source_kind = 'meeting' AND source_id = old.id;
+               DELETE FROM reminder_audit_cache
+                WHERE source_kind = 'meeting' AND source_id = old.id;
+               DELETE FROM reminder_sources
+                WHERE source_kind = 'meeting' AND source_id = old.id;
+               DELETE FROM reminder_suggestion_decisions
+                WHERE source_kind = 'meeting' AND source_id = old.id;
+             END;
+
+             -- Authored-note edits, seal/relock blanking, and deletion.
+             CREATE TRIGGER IF NOT EXISTS reminder_derived_documents_ai
+             AFTER INSERT ON documents WHEN new.kind = 'note' BEGIN
+               DELETE FROM reminder_pending_suggestions
+                WHERE source_kind = 'note' AND source_id = new.id;
+               DELETE FROM reminder_audit_cache
+                WHERE source_kind = 'note' AND source_id = new.id;
+             END;
+             CREATE TRIGGER IF NOT EXISTS reminder_derived_documents_au
+             AFTER UPDATE OF text, title, name, kind, folder_id ON documents
+             WHEN (old.kind = 'note' OR new.kind = 'note')
+               AND (old.text IS NOT new.text
+                    OR old.title IS NOT new.title
+                    OR old.name IS NOT new.name
+                    OR old.folder_id IS NOT new.folder_id
+                    OR old.kind IS NOT new.kind) BEGIN
+               DELETE FROM reminder_pending_suggestions
+                WHERE source_kind = 'note' AND source_id = new.id;
+               DELETE FROM reminder_audit_cache
+                WHERE source_kind = 'note' AND source_id = new.id;
+               DELETE FROM reminder_sources
+                WHERE source_kind = 'note' AND source_id = new.id
+                  AND new.kind != 'note';
+               DELETE FROM reminder_suggestion_decisions
+                WHERE source_kind = 'note' AND source_id = new.id
+                  AND new.kind != 'note';
+             END;
+             -- Additive companion for databases that already created the earlier trigger:
+             -- fallback display names are hashed, and folder moves change lock visibility.
+             CREATE TRIGGER IF NOT EXISTS reminder_derived_documents_anchor_au
+             AFTER UPDATE OF name, folder_id ON documents
+             WHEN (old.kind = 'note' OR new.kind = 'note')
+               AND (old.name IS NOT new.name OR old.folder_id IS NOT new.folder_id) BEGIN
+               DELETE FROM reminder_pending_suggestions
+                WHERE source_kind = 'note' AND source_id = new.id;
+               DELETE FROM reminder_audit_cache
+                WHERE source_kind = 'note' AND source_id = new.id;
+             END;
+             CREATE TRIGGER IF NOT EXISTS reminder_derived_documents_ad
+             AFTER DELETE ON documents WHEN old.kind = 'note' BEGIN
+               DELETE FROM reminder_pending_suggestions
+                WHERE source_kind = 'note' AND source_id = old.id;
+               DELETE FROM reminder_audit_cache
+                WHERE source_kind = 'note' AND source_id = old.id;
+               DELETE FROM reminder_sources
+                WHERE source_kind = 'note' AND source_id = old.id;
+               DELETE FROM reminder_suggestion_decisions
+                WHERE source_kind = 'note' AND source_id = old.id;
+             END;
+
+             -- Content-free Smart-card refresh queue. These are NEW companion triggers, so an
+             -- existing database gains live invalidation without replacing any prior purge trigger.
+             CREATE TRIGGER IF NOT EXISTS reminder_source_queue_notes_ai
+             AFTER INSERT ON notes BEGIN
+               INSERT INTO reminder_source_invalidation_queue(source_kind,source_id,revision)
+               VALUES ('meeting',new.meeting_id,1)
+               ON CONFLICT(source_kind,source_id) DO UPDATE SET revision=revision+1;
+             END;
+             CREATE TRIGGER IF NOT EXISTS reminder_source_queue_notes_au
+             AFTER UPDATE OF meeting_id, provider_id, markdown, created_at, folder_id ON notes
+             WHEN old.meeting_id IS NOT new.meeting_id
+               OR old.provider_id IS NOT new.provider_id
+               OR old.markdown IS NOT new.markdown
+               OR old.created_at IS NOT new.created_at
+               OR old.folder_id IS NOT new.folder_id BEGIN
+               INSERT INTO reminder_source_invalidation_queue(source_kind,source_id,revision)
+               VALUES ('meeting',old.meeting_id,1)
+               ON CONFLICT(source_kind,source_id) DO UPDATE SET revision=revision+1;
+               INSERT INTO reminder_source_invalidation_queue(source_kind,source_id,revision)
+               VALUES ('meeting',new.meeting_id,1)
+               ON CONFLICT(source_kind,source_id) DO UPDATE SET revision=revision+1;
+             END;
+             CREATE TRIGGER IF NOT EXISTS reminder_source_queue_notes_ad
+             AFTER DELETE ON notes BEGIN
+               INSERT INTO reminder_source_invalidation_queue(source_kind,source_id,revision)
+               VALUES ('meeting',old.meeting_id,1)
+               ON CONFLICT(source_kind,source_id) DO UPDATE SET revision=revision+1;
+             END;
+
+             CREATE TRIGGER IF NOT EXISTS reminder_source_queue_segments_ai
+             AFTER INSERT ON segments BEGIN
+               INSERT INTO reminder_source_invalidation_queue(source_kind,source_id,revision)
+               VALUES ('meeting',new.meeting_id,1)
+               ON CONFLICT(source_kind,source_id) DO UPDATE SET revision=revision+1;
+             END;
+             CREATE TRIGGER IF NOT EXISTS reminder_source_queue_segments_au
+             AFTER UPDATE OF meeting_id, idx, start_s, end_s, text, speaker, confidence,
+                             echo_suppressed ON segments
+             WHEN old.meeting_id IS NOT new.meeting_id
+               OR old.idx IS NOT new.idx
+               OR old.start_s IS NOT new.start_s
+               OR old.end_s IS NOT new.end_s
+               OR old.text IS NOT new.text
+               OR old.speaker IS NOT new.speaker
+               OR old.confidence IS NOT new.confidence
+               OR old.echo_suppressed IS NOT new.echo_suppressed BEGIN
+               INSERT INTO reminder_source_invalidation_queue(source_kind,source_id,revision)
+               VALUES ('meeting',old.meeting_id,1)
+               ON CONFLICT(source_kind,source_id) DO UPDATE SET revision=revision+1;
+               INSERT INTO reminder_source_invalidation_queue(source_kind,source_id,revision)
+               VALUES ('meeting',new.meeting_id,1)
+               ON CONFLICT(source_kind,source_id) DO UPDATE SET revision=revision+1;
+             END;
+             CREATE TRIGGER IF NOT EXISTS reminder_source_queue_segments_ad
+             AFTER DELETE ON segments BEGIN
+               INSERT INTO reminder_source_invalidation_queue(source_kind,source_id,revision)
+               VALUES ('meeting',old.meeting_id,1)
+               ON CONFLICT(source_kind,source_id) DO UPDATE SET revision=revision+1;
+             END;
+
+             CREATE TRIGGER IF NOT EXISTS reminder_source_queue_meetings_au
+             AFTER UPDATE OF manual_notes, title ON meetings
+             WHEN old.manual_notes IS NOT new.manual_notes
+               OR old.title IS NOT new.title BEGIN
+               INSERT INTO reminder_source_invalidation_queue(source_kind,source_id,revision)
+               VALUES ('meeting',new.id,1)
+               ON CONFLICT(source_kind,source_id) DO UPDATE SET revision=revision+1;
+             END;
+             CREATE TRIGGER IF NOT EXISTS reminder_source_queue_meetings_ad
+             AFTER DELETE ON meetings BEGIN
+               INSERT INTO reminder_source_invalidation_queue(source_kind,source_id,revision)
+               VALUES ('meeting',old.id,1)
+               ON CONFLICT(source_kind,source_id) DO UPDATE SET revision=revision+1;
+             END;
+
+             CREATE TRIGGER IF NOT EXISTS reminder_source_queue_documents_ai
+             AFTER INSERT ON documents WHEN new.kind = 'note' BEGIN
+               INSERT INTO reminder_source_invalidation_queue(source_kind,source_id,revision)
+               VALUES ('note',new.id,1)
+               ON CONFLICT(source_kind,source_id) DO UPDATE SET revision=revision+1;
+             END;
+             CREATE TRIGGER IF NOT EXISTS reminder_source_queue_documents_au
+             AFTER UPDATE OF text, title, name, kind, folder_id ON documents
+             WHEN (old.kind = 'note' OR new.kind = 'note')
+               AND (old.text IS NOT new.text
+                    OR old.title IS NOT new.title
+                    OR old.name IS NOT new.name
+                    OR old.kind IS NOT new.kind
+                    OR old.folder_id IS NOT new.folder_id) BEGIN
+               INSERT INTO reminder_source_invalidation_queue(source_kind,source_id,revision)
+               VALUES ('note',new.id,1)
+               ON CONFLICT(source_kind,source_id) DO UPDATE SET revision=revision+1;
+             END;
+             CREATE TRIGGER IF NOT EXISTS reminder_source_queue_documents_ad
+             AFTER DELETE ON documents WHEN old.kind = 'note' BEGIN
+               INSERT INTO reminder_source_invalidation_queue(source_kind,source_id,revision)
+               VALUES ('note',old.id,1)
+               ON CONFLICT(source_kind,source_id) DO UPDATE SET revision=revision+1;
+             END;",
+        )
+        .map_err(map_err)
+    }
+
+    /// Peek a bounded batch of content-free Smart-card invalidations without deleting it. Rows stay
+    /// durable across process crashes and emit failures; the worker CAS-acknowledges only after a
+    /// successful event delivery.
+    pub(crate) fn peek_reminder_source_invalidations(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<ReminderSourceInvalidation>> {
+        let limit = limit.min(MAX_SOURCE_INVALIDATION_DRAIN);
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT source_kind,source_id,revision
+                   FROM reminder_source_invalidation_queue
+                  ORDER BY source_kind,source_id
+                  LIMIT ?1",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![limit as i64], |row| {
+                Ok(ReminderSourceInvalidation {
+                    kind: row.get(0)?,
+                    id: row.get(1)?,
+                    revision: row.get(2)?,
+                })
+            })
+            .map_err(map_err)?;
+        rows.collect::<rusqlite::Result<Vec<_>>>().map_err(map_err)
+    }
+
+    /// Delete exactly the revision that was successfully emitted. If a canonical mutation raced
+    /// the emit and incremented the row, the CAS fails and the newer invalidation remains queued.
+    pub(crate) fn ack_reminder_source_invalidation(
+        &self,
+        invalidation: &ReminderSourceInvalidation,
+    ) -> Result<bool> {
+        let conn = self.lock();
+        conn.execute(
+            "DELETE FROM reminder_source_invalidation_queue
+              WHERE source_kind=?1 AND source_id=?2 AND revision=?3",
+            rusqlite::params![&invalidation.kind, &invalidation.id, invalidation.revision],
+        )
+        .map(|changed| changed != 0)
+        .map_err(map_err)
+    }
+
+    pub fn reminder_audit_cache_matches(
+        &self,
+        source_kind: &str,
+        source_id: &str,
+        content_hash: &str,
+        engine_id: &str,
+    ) -> Result<bool> {
+        validate_audit_identity(source_kind, source_id, content_hash, engine_id)?;
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT EXISTS(
+               SELECT 1 FROM reminder_audit_cache
+                WHERE source_kind=?1 AND source_id=?2 AND content_hash=?3 AND engine_id=?4
+             )",
+            rusqlite::params![source_kind, source_id, content_hash, engine_id],
+            |row| row.get(0),
+        )
+        .map_err(map_err)
+    }
+
+    /// Deterministic canonical note projection for Smart meeting audits. This intentionally lives
+    /// beside the transactional CAS query: both order by provider as a stable tie-break after the
+    /// persisted timestamp. Callers must pass the meeting visibility gate before using the text.
+    pub(crate) fn latest_reminder_audit_markdown(
+        &self,
+        meeting_id: &str,
+    ) -> Result<Option<String>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT markdown FROM notes
+              WHERE meeting_id=?1
+              ORDER BY created_at DESC, provider_id DESC
+              LIMIT 1",
+            rusqlite::params![meeting_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
+    /// Return only rows from the caller's current source revision and engine, capped independently
+    /// of caller input. Requiring the matching cache row makes orphaned/stale candidate plaintext
+    /// fail closed.
+    pub fn list_pending_reminder_suggestions(
+        &self,
+        source_kind: &str,
+        source_id: &str,
+        content_hash: &str,
+        engine_id: &str,
+        limit: usize,
+    ) -> Result<Vec<StoredReminderSuggestion>> {
+        validate_audit_identity(source_kind, source_id, content_hash, engine_id)?;
+        let limit = limit.min(MAX_PENDING_SUGGESTIONS);
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT s.id,s.source_kind,s.source_id,s.content_hash,s.engine_id,
+                        s.candidate_key,s.title,s.suggested_due_at,s.created_at
+                   FROM reminder_pending_suggestions s
+                  WHERE s.source_kind=?1 AND s.source_id=?2
+                    AND s.content_hash=?3 AND s.engine_id=?4
+                    AND EXISTS (
+                      SELECT 1 FROM reminder_audit_cache c
+                       WHERE c.source_kind=s.source_kind AND c.source_id=s.source_id
+                         AND c.content_hash=s.content_hash AND c.engine_id=s.engine_id
+                    )
+                  ORDER BY s.created_at ASC, s.id ASC
+                  LIMIT ?5",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(
+                rusqlite::params![
+                    source_kind,
+                    source_id,
+                    content_hash,
+                    engine_id,
+                    limit as i64
+                ],
+                stored_suggestion_from_row,
+            )
+            .map_err(map_err)?;
+        rows.collect::<rusqlite::Result<Vec<_>>>().map_err(map_err)
+    }
+
+    /// Content-free pre-gate lookup for accept/dismiss. The suggestion title and due time are
+    /// deliberately absent, so a locked source cannot cause derived plaintext to enter the command
+    /// process merely to discover which lifecycle gate governs it.
+    pub fn get_pending_reminder_suggestion_gate_anchor(
+        &self,
+        id: &str,
+    ) -> Result<Option<ReminderSuggestionGateAnchor>> {
+        if id.is_empty() || id.chars().count() > 96 {
+            return Err(AppError::InvalidArg(
+                "reminder suggestion id is invalid".into(),
+            ));
+        }
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT id,source_kind,source_id
+               FROM reminder_pending_suggestions WHERE id=?1",
+            rusqlite::params![id],
+            |row| {
+                Ok(ReminderSuggestionGateAnchor {
+                    id: row.get(0)?,
+                    source_kind: row.get(1)?,
+                    source_id: row.get(2)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
+    /// Atomically replace one source's successful audit cache and pending candidate rows. An empty
+    /// candidate slice is still cached, preventing repeated audits of unchanged content. The
+    /// authoritative canonical hash is recomputed while this transaction owns the DB mutex; a
+    /// transcript/note writer racing the command's post-inference read therefore makes this CAS
+    /// return `false` rather than allowing stale derived plaintext to be inserted after its purge
+    /// trigger already fired.
+    pub(crate) fn replace_reminder_audit_results(
+        &self,
+        source_kind: &str,
+        source_id: &str,
+        content_hash: &str,
+        engine_id: &str,
+        candidates: &[ReminderAuditCandidate],
+        now: i64,
+    ) -> Result<bool> {
+        validate_audit_identity(source_kind, source_id, content_hash, engine_id)?;
+        validate_audit_candidates(candidates)?;
+
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        if canonical_reminder_audit_hash_tx(&tx, source_kind, source_id)?.as_deref()
+            != Some(content_hash)
+        {
+            return Ok(false);
+        }
+        replace_reminder_audit_results_tx(
+            &tx,
+            source_kind,
+            source_id,
+            content_hash,
+            engine_id,
+            candidates,
+            now,
+        )?;
+        tx.commit().map_err(map_err).map(|_| true)
+    }
+
+    /// Storage-domain fixture hook. Production callers must use the CAS method above.
+    #[cfg(test)]
+    pub(crate) fn replace_reminder_audit_results_unchecked(
+        &self,
+        source_kind: &str,
+        source_id: &str,
+        content_hash: &str,
+        engine_id: &str,
+        candidates: &[ReminderAuditCandidate],
+        now: i64,
+    ) -> Result<()> {
+        validate_audit_identity(source_kind, source_id, content_hash, engine_id)?;
+        validate_audit_candidates(candidates)?;
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        replace_reminder_audit_results_tx(
+            &tx,
+            source_kind,
+            source_id,
+            content_hash,
+            engine_id,
+            candidates,
+            now,
+        )?;
+        tx.commit().map_err(map_err)
+    }
+
+    /// Dismiss exactly the source revision the caller re-gated and remember that plaintext-free
+    /// candidate identity until the source is sealed/relocked or startup reconciliation withdraws
+    /// the unlocked visibility snapshot.
+    pub fn dismiss_pending_reminder_suggestion(
+        &self,
+        id: &str,
+        source_kind: &str,
+        source_id: &str,
+        content_hash: &str,
+    ) -> Result<bool> {
+        validate_source(source_kind, source_id)?;
+        validate_hash(content_hash)?;
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let candidate_key: Option<String> = tx
+            .query_row(
+                "SELECT s.candidate_key
+                   FROM reminder_pending_suggestions s
+                   JOIN reminder_audit_cache c
+                     ON c.source_kind=s.source_kind AND c.source_id=s.source_id
+                    AND c.content_hash=s.content_hash AND c.engine_id=s.engine_id
+                  WHERE s.id=?1 AND s.source_kind=?2 AND s.source_id=?3
+                    AND s.content_hash=?4",
+                rusqlite::params![id, source_kind, source_id, content_hash],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(map_err)?;
+        let Some(candidate_key) = candidate_key else {
+            return Ok(false);
+        };
+        let decided = tx
+            .execute(
+                "INSERT OR IGNORE INTO reminder_suggestion_decisions
+                   (source_kind,source_id,content_hash,candidate_key,decision,reminder_id,decided_at)
+                 VALUES (?1,?2,?3,?4,'dismissed',NULL,?5)",
+                rusqlite::params![source_kind, source_id, content_hash, candidate_key, chrono::Utc::now().timestamp_millis()],
+            )
+            .map_err(map_err)?;
+        if decided != 1 {
+            return Ok(false);
+        }
+        let consumed = tx
+            .execute(
+                "DELETE FROM reminder_pending_suggestions
+                  WHERE id=?1 AND source_kind=?2 AND source_id=?3 AND content_hash=?4
+                    AND candidate_key=?5",
+                rusqlite::params![id, source_kind, source_id, content_hash, candidate_key],
+            )
+            .map_err(map_err)?;
+        if consumed != 1 {
+            return Err(AppError::Storage(
+                "reminder suggestion changed during dismissal".into(),
+            ));
+        }
+        tx.commit().map_err(map_err)?;
+        Ok(true)
+    }
+
+    /// Explicitly promote one still-current pending suggestion into the independent reminder
+    /// domain. The candidate row is the one-shot capability: it is consumed in the same transaction
+    /// as the `origin='smart'` insert, so replay cannot create another row. The cache and sibling
+    /// candidates remain authoritative so the user can accept several suggestions from one audit.
+    pub fn promote_pending_reminder_suggestion(
+        &self,
+        suggestion_id: &str,
+        expected_source_kind: &str,
+        expected_source_id: &str,
+        expected_content_hash: &str,
+        reminder_id: &str,
+        draft: &ReminderDraft,
+        now: i64,
+    ) -> Result<bool> {
+        validate_source(expected_source_kind, expected_source_id)?;
+        validate_hash(expected_content_hash)?;
+        if reminder_id.is_empty() || reminder_id.chars().count() > MAX_SOURCE_ID_CHARS {
+            return Err(AppError::InvalidArg("reminder id is invalid".into()));
+        }
+
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let candidate_key: Option<String> = tx
+            .query_row(
+                "SELECT s.candidate_key
+                   FROM reminder_pending_suggestions s
+                   JOIN reminder_audit_cache c
+                     ON c.source_kind=s.source_kind AND c.source_id=s.source_id
+                    AND c.content_hash=s.content_hash AND c.engine_id=s.engine_id
+                  WHERE s.id=?1 AND s.source_kind=?2 AND s.source_id=?3
+                    AND s.content_hash=?4",
+                rusqlite::params![
+                    suggestion_id,
+                    expected_source_kind,
+                    expected_source_id,
+                    expected_content_hash
+                ],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(map_err)?;
+        let Some(candidate_key) = candidate_key else {
+            return Ok(false);
+        };
+
+        tx.execute(
+            "INSERT INTO reminders
+               (id,title,details,due_at,repeat_every,repeat_unit,state,origin,created_at,updated_at)
+             VALUES (?1,?2,?3,?4,?5,?6,'active','smart',?7,?7)",
+            rusqlite::params![
+                reminder_id,
+                draft.title,
+                draft.details,
+                draft.due_at,
+                draft.repeat_every,
+                draft.repeat_unit.map(ReminderRepeatUnit::as_str),
+                now,
+            ],
+        )
+        .map_err(map_err)?;
+        insert_sources_tx(&tx, reminder_id, &draft.sources)?;
+        tx.execute(
+            "INSERT OR IGNORE INTO reminder_sources(reminder_id,source_kind,source_id)
+             VALUES (?1,?2,?3)",
+            rusqlite::params![reminder_id, expected_source_kind, expected_source_id],
+        )
+        .map_err(map_err)?;
+
+        let decided = tx
+            .execute(
+                "INSERT OR IGNORE INTO reminder_suggestion_decisions
+                   (source_kind,source_id,content_hash,candidate_key,decision,reminder_id,decided_at)
+                 VALUES (?1,?2,?3,?4,'accepted',?5,?6)",
+                rusqlite::params![
+                    expected_source_kind,
+                    expected_source_id,
+                    expected_content_hash,
+                    candidate_key,
+                    reminder_id,
+                    now
+                ],
+            )
+            .map_err(map_err)?;
+        if decided != 1 {
+            return Ok(false);
+        }
+        let consumed = tx
+            .execute(
+                "DELETE FROM reminder_pending_suggestions
+                  WHERE id=?1 AND source_kind=?2 AND source_id=?3 AND content_hash=?4
+                    AND candidate_key=?5",
+                rusqlite::params![
+                    suggestion_id,
+                    expected_source_kind,
+                    expected_source_id,
+                    expected_content_hash,
+                    candidate_key
+                ],
+            )
+            .map_err(map_err)?;
+        if consumed != 1 {
+            return Err(AppError::Storage(
+                "reminder suggestion changed during promotion".into(),
+            ));
+        }
+        tx.commit().map_err(map_err)?;
+        Ok(true)
+    }
+
+    /// Purge all disposable source-derived reminder audit plaintext and unkeyed decision
+    /// fingerprints inside an existing lock/seal transaction. Canonical accepted reminders and
+    /// their opaque source anchors are untouched.
+    pub(crate) fn purge_all_reminder_derived_tx(tx: &Transaction<'_>) -> Result<()> {
+        tx.execute("DELETE FROM reminder_pending_suggestions", [])
+            .map_err(map_err)?;
+        tx.execute("DELETE FROM reminder_audit_cache", [])
+            .map_err(map_err)?;
+        tx.execute("DELETE FROM reminder_suggestion_decisions", [])
+            .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Publish the durable visibility gate for a fresh folder seal and withdraw every reminder
+    /// audit capability/fingerprint authorized by the formerly-open snapshot in the SAME
+    /// transaction. The caller has already verified all note ciphertext round-trips; this method
+    /// deliberately does not touch sealed blobs or plaintext.
+    pub(crate) fn publish_fresh_folder_lock_and_purge_reminder_derived(
+        &self,
+        folder_id: &str,
+        wrapped_key: &[u8],
+    ) -> Result<()> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let updated = tx
+            .execute(
+                "UPDATE folders SET locked = 1, wrapped_key = ?2
+                  WHERE id = ?1 AND locked = 0",
+                rusqlite::params![folder_id, wrapped_key],
+            )
+            .map_err(map_err)?;
+        if updated != 1 {
+            return Err(AppError::Storage(
+                "folder disappeared or was no longer open while publishing fresh lock".into(),
+            ));
+        }
+        Self::purge_all_reminder_derived_tx(&tx)?;
+        tx.commit().map_err(map_err)
+    }
+
+    pub fn create_reminder(
+        &self,
+        id: &str,
+        draft: &ReminderDraft,
+        origin: ReminderOrigin,
+        now: i64,
+    ) -> Result<()> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        tx.execute(
+            "INSERT INTO reminders
+               (id,title,details,due_at,repeat_every,repeat_unit,state,origin,created_at,updated_at)
+             VALUES (?1,?2,?3,?4,?5,?6,'active',?7,?8,?8)",
+            rusqlite::params![
+                id,
+                draft.title,
+                draft.details,
+                draft.due_at,
+                draft.repeat_every,
+                draft.repeat_unit.map(ReminderRepeatUnit::as_str),
+                origin.as_str(),
+                now
+            ],
+        )
+        .map_err(map_err)?;
+        insert_sources_tx(&tx, id, &draft.sources)?;
+        tx.commit().map_err(map_err)
+    }
+
+    pub fn update_reminder(&self, id: &str, draft: &ReminderDraft, now: i64) -> Result<bool> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let existing_schedule: Option<(i64, Option<i64>, Option<String>)> = tx
+            .query_row(
+                "SELECT due_at,repeat_every,repeat_unit FROM reminders WHERE id=?1",
+                rusqlite::params![id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .optional()
+            .map_err(map_err)?;
+        let Some((old_due_at, old_repeat_every, old_repeat_unit)) = existing_schedule else {
+            return Ok(false);
+        };
+        let new_repeat_every = draft.repeat_every.map(i64::from);
+        let new_repeat_unit = draft
+            .repeat_unit
+            .map(ReminderRepeatUnit::as_str)
+            .map(str::to_owned);
+        let schedule_changed = old_due_at != draft.due_at
+            || old_repeat_every != new_repeat_every
+            || old_repeat_unit != new_repeat_unit;
+        let changed = tx
+            .execute(
+                "UPDATE reminders
+                    SET title=?2, details=?3, due_at=?4, repeat_every=?5, repeat_unit=?6,
+                        updated_at=?7
+                  WHERE id=?1",
+                rusqlite::params![
+                    id,
+                    draft.title,
+                    draft.details,
+                    draft.due_at,
+                    draft.repeat_every,
+                    draft.repeat_unit.map(ReminderRepeatUnit::as_str),
+                    now
+                ],
+            )
+            .map_err(map_err)?;
+        debug_assert_eq!(changed, 1);
+        tx.execute(
+            "DELETE FROM reminder_sources WHERE reminder_id=?1",
+            rusqlite::params![id],
+        )
+        .map_err(map_err)?;
+        insert_sources_tx(&tx, id, &draft.sources)?;
+        if schedule_changed {
+            // The `(reminder_id,due_at)` unique key is the generation authority. Clear ALL old
+            // generations only when the schedule changes so a deliberately reused timestamp can
+            // materialize once, while title/details/source-only edits preserve unread/dismissed
+            // inbox state exactly.
+            tx.execute(
+                "DELETE FROM reminder_due_occurrences WHERE reminder_id=?1",
+                rusqlite::params![id],
+            )
+            .map_err(map_err)?;
+        }
+        tx.commit().map_err(map_err)?;
+        Ok(true)
+    }
+
+    pub fn delete_reminder(&self, id: &str) -> Result<bool> {
+        let conn = self.lock();
+        conn.execute("DELETE FROM reminders WHERE id=?1", rusqlite::params![id])
+            .map(|n| n != 0)
+            .map_err(map_err)
+    }
+
+    /// Idempotently materialize every active reminder whose due time has arrived. The unique
+    /// `(reminder_id,due_at)` key is the dedupe authority across scheduler ticks and restarts.
+    pub fn materialize_due_reminders(&self, now: i64) -> Result<u64> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let due = {
+            let mut stmt = tx
+                .prepare(
+                    "SELECT id,due_at FROM reminders
+                      WHERE state='active' AND due_at <= ?1
+                      ORDER BY due_at,id",
+                )
+                .map_err(map_err)?;
+            let rows = stmt
+                .query_map(rusqlite::params![now], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+                })
+                .map_err(map_err)?;
+            rows.collect::<rusqlite::Result<Vec<_>>>()
+                .map_err(map_err)?
+        };
+        let mut inserted = 0_u64;
+        for (reminder_id, due_at) in due {
+            inserted += tx
+                .execute(
+                    "INSERT OR IGNORE INTO reminder_due_occurrences
+                       (id,reminder_id,due_at,status,created_at)
+                     VALUES (?1,?2,?3,'unread',?4)",
+                    rusqlite::params![uuid::Uuid::new_v4().to_string(), reminder_id, due_at, now],
+                )
+                .map_err(map_err)? as u64;
+        }
+        tx.commit().map_err(map_err)?;
+        Ok(inserted)
+    }
+
+    pub fn due_reminder_count(&self) -> Result<u64> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT COUNT(*) FROM reminder_due_occurrences WHERE status='unread'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .map(|n| n.max(0) as u64)
+        .map_err(map_err)
+    }
+
+    pub fn unread_reminder_occurrences(&self) -> Result<Vec<StoredReminderOccurrence>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, reminder_id, due_at
+                   FROM reminder_due_occurrences
+                  WHERE status='unread'
+                  ORDER BY due_at ASC, id ASC",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(StoredReminderOccurrence {
+                    id: row.get(0)?,
+                    reminder_id: row.get(1)?,
+                    due_at: row.get(2)?,
+                })
+            })
+            .map_err(map_err)?;
+        rows.collect::<rusqlite::Result<Vec<_>>>().map_err(map_err)
+    }
+
+    pub fn list_stored_reminders(&self) -> Result<Vec<StoredReminder>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT id,title,details,due_at,repeat_every,repeat_unit,state,origin,
+                        created_at,updated_at,completed_at
+                   FROM reminders
+                  ORDER BY CASE state WHEN 'active' THEN 0 ELSE 1 END,
+                           CASE state WHEN 'active' THEN due_at ELSE completed_at END ASC,
+                           id ASC",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map([], stored_reminder_from_row)
+            .map_err(map_err)?;
+        let mut reminders = Vec::new();
+        for row in rows {
+            reminders.push(row.map_err(map_err)??);
+        }
+        drop(stmt);
+        for reminder in &mut reminders {
+            reminder.sources = list_sources(&conn, &reminder.id)?;
+        }
+        Ok(reminders)
+    }
+
+    pub fn get_stored_reminder(&self, id: &str) -> Result<Option<StoredReminder>> {
+        let conn = self.lock();
+        let mut reminder = conn
+            .query_row(
+                "SELECT id,title,details,due_at,repeat_every,repeat_unit,state,origin,
+                        created_at,updated_at,completed_at
+                   FROM reminders WHERE id=?1",
+                rusqlite::params![id],
+                stored_reminder_from_row,
+            )
+            .optional()
+            .map_err(map_err)?
+            .transpose()?;
+        if let Some(row) = &mut reminder {
+            row.sources = list_sources(&conn, id)?;
+        }
+        Ok(reminder)
+    }
+
+    /// Complete exactly the schedule generation represented by `expected_due_at`. Replaying the
+    /// same UI action after a recurring reminder advanced is a no-op, not a second advancement.
+    pub fn complete_reminder(&self, id: &str, expected_due_at: i64, now: i64) -> Result<bool> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let row: Option<(i64, Option<i64>, Option<String>, String)> = tx
+            .query_row(
+                "SELECT due_at, repeat_every, repeat_unit, state
+                   FROM reminders WHERE id=?1",
+                rusqlite::params![id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .optional()
+            .map_err(map_err)?;
+        let Some((due_at, repeat_every, repeat_unit, state)) = row else {
+            return Ok(false);
+        };
+        if due_at != expected_due_at || state != "active" {
+            return Ok(false);
+        }
+
+        let occurrence_id = uuid::Uuid::new_v4().to_string();
+        tx.execute(
+            "INSERT INTO reminder_due_occurrences
+               (id,reminder_id,due_at,status,created_at,resolved_at)
+             VALUES (?1,?2,?3,'completed',?4,?4)
+             ON CONFLICT(reminder_id,due_at) DO UPDATE SET
+               status='completed', resolved_at=excluded.resolved_at",
+            rusqlite::params![occurrence_id, id, due_at, now],
+        )
+        .map_err(map_err)?;
+
+        match (repeat_every, repeat_unit) {
+            (Some(every), Some(unit)) => {
+                let unit = ReminderRepeatUnit::parse(&unit)?;
+                match next_recurrence_after(due_at, every as u32, unit, now)? {
+                    Some(next_due) => {
+                        tx.execute(
+                            "UPDATE reminders
+                                SET due_at=?2, state='active', completed_at=NULL, updated_at=?3
+                              WHERE id=?1 AND due_at=?4 AND state='active'",
+                            rusqlite::params![id, next_due, now, due_at],
+                        )
+                        .map_err(map_err)?;
+                    }
+                    None => {
+                        // No representable future occurrence remains before the exclusive 2200
+                        // horizon. End the series cleanly rather than persisting an unsupported
+                        // date or making every subsequent read fail validation.
+                        tx.execute(
+                            "UPDATE reminders
+                                SET state='completed', completed_at=?2, updated_at=?2
+                              WHERE id=?1 AND due_at=?3 AND state='active'",
+                            rusqlite::params![id, now, due_at],
+                        )
+                        .map_err(map_err)?;
+                    }
+                }
+            }
+            (None, None) => {
+                tx.execute(
+                    "UPDATE reminders
+                        SET state='completed', completed_at=?2, updated_at=?2
+                      WHERE id=?1 AND due_at=?3 AND state='active'",
+                    rusqlite::params![id, now, due_at],
+                )
+                .map_err(map_err)?;
+            }
+            _ => {
+                return Err(AppError::Storage(
+                    "reminder recurrence columns are inconsistent".into(),
+                ));
+            }
+        }
+        tx.commit().map_err(map_err)?;
+        Ok(true)
+    }
+
+    /// Dismiss one exact unread occurrence. For a recurring series, dismissal acknowledges the
+    /// current schedule generation and advances it exactly once to the first future recurrence.
+    /// The occurrence status and schedule CAS share one transaction, so replaying the same UI
+    /// action cannot advance the series twice. A one-off reminder remains active and visible as
+    /// overdue after its Inbox occurrence is dismissed.
+    pub fn dismiss_reminder_occurrence(&self, occurrence_id: &str, now: i64) -> Result<bool> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let row: Option<(String, i64, i64, Option<i64>, Option<String>, String)> = tx
+            .query_row(
+                "SELECT o.reminder_id, o.due_at, r.due_at, r.repeat_every, r.repeat_unit, r.state
+                   FROM reminder_due_occurrences o
+                   JOIN reminders r ON r.id=o.reminder_id
+                  WHERE o.id=?1 AND o.status='unread'",
+                rusqlite::params![occurrence_id],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                    ))
+                },
+            )
+            .optional()
+            .map_err(map_err)?;
+        let Some((
+            reminder_id,
+            occurrence_due_at,
+            reminder_due_at,
+            repeat_every,
+            repeat_unit,
+            state,
+        )) = row
+        else {
+            return Ok(false);
+        };
+
+        let dismissed = tx
+            .execute(
+                "UPDATE reminder_due_occurrences
+                SET status='dismissed', resolved_at=?2
+              WHERE id=?1 AND status='unread'",
+                rusqlite::params![occurrence_id, now],
+            )
+            .map_err(map_err)?;
+        if dismissed != 1 {
+            return Err(AppError::Storage(
+                "reminder occurrence changed during dismissal".into(),
+            ));
+        }
+
+        // A stale occurrence cannot mutate a newer schedule generation. It is still safe to
+        // dismiss the exact Inbox row the user acted on.
+        if state == "active" && reminder_due_at == occurrence_due_at {
+            match (repeat_every, repeat_unit) {
+                (Some(every), Some(unit)) => {
+                    let unit = ReminderRepeatUnit::parse(&unit)?;
+                    match next_recurrence_after(reminder_due_at, every as u32, unit, now)? {
+                        Some(next_due) => {
+                            let advanced = tx
+                                .execute(
+                                    "UPDATE reminders
+                                        SET due_at=?2, state='active', completed_at=NULL,
+                                            updated_at=?3
+                                      WHERE id=?1 AND due_at=?4 AND state='active'",
+                                    rusqlite::params![reminder_id, next_due, now, reminder_due_at],
+                                )
+                                .map_err(map_err)?;
+                            if advanced != 1 {
+                                return Err(AppError::Storage(
+                                    "reminder changed during occurrence dismissal".into(),
+                                ));
+                            }
+                        }
+                        None => {
+                            let terminalized = tx
+                                .execute(
+                                    "UPDATE reminders
+                                        SET state='completed', completed_at=?2, updated_at=?2
+                                      WHERE id=?1 AND due_at=?3 AND state='active'",
+                                    rusqlite::params![reminder_id, now, reminder_due_at],
+                                )
+                                .map_err(map_err)?;
+                            if terminalized != 1 {
+                                return Err(AppError::Storage(
+                                    "reminder changed during occurrence dismissal".into(),
+                                ));
+                            }
+                        }
+                    }
+                }
+                (None, None) => {}
+                _ => {
+                    return Err(AppError::Storage(
+                        "reminder recurrence columns are inconsistent".into(),
+                    ));
+                }
+            }
+        }
+
+        tx.commit().map_err(map_err)?;
+        Ok(true)
+    }
+}
+
+fn validate_source(source_kind: &str, source_id: &str) -> Result<()> {
+    if !matches!(source_kind, "meeting" | "note")
+        || source_id.is_empty()
+        || source_id.chars().count() > MAX_SOURCE_ID_CHARS
+    {
+        return Err(AppError::InvalidArg(
+            "reminder audit source is invalid".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_hash(value: &str) -> Result<()> {
+    let valid = value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte));
+    if !valid {
+        return Err(AppError::InvalidArg(
+            "reminder audit content hash is invalid".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_audit_identity(
+    source_kind: &str,
+    source_id: &str,
+    content_hash: &str,
+    engine_id: &str,
+) -> Result<()> {
+    validate_source(source_kind, source_id)?;
+    validate_hash(content_hash)?;
+    if engine_id.is_empty() || engine_id.chars().count() > MAX_ENGINE_ID_CHARS {
+        return Err(AppError::InvalidArg(
+            "reminder audit engine id is invalid".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_audit_candidates(candidates: &[ReminderAuditCandidate]) -> Result<()> {
+    if candidates.len() > MAX_PENDING_SUGGESTIONS {
+        return Err(AppError::InvalidArg(
+            "too many reminder audit candidates".into(),
+        ));
+    }
+    let mut ids = std::collections::HashSet::with_capacity(candidates.len());
+    let mut keys = std::collections::HashSet::with_capacity(candidates.len());
+    for candidate in candidates {
+        if candidate.id.is_empty()
+            || candidate.id.chars().count() > 32
+            || !ids.insert(candidate.id.as_str())
+            || candidate.title.trim().is_empty()
+            || candidate.title.chars().count() > MAX_REMINDER_TITLE_CHARS
+            || validate_hash(&candidate.candidate_key).is_err()
+            || !keys.insert(candidate.candidate_key.as_str())
+        {
+            return Err(AppError::InvalidArg(
+                "reminder audit candidate is invalid".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn reminder_suggestion_id(
+    source_kind: &str,
+    source_id: &str,
+    content_hash: &str,
+    candidate_key: &str,
+) -> String {
+    format!(
+        "rs:{}",
+        crate::reminder_audit::content_hash(&[source_kind, source_id, content_hash, candidate_key])
+    )
+}
+
+fn delete_reminder_audit_source_tx(
+    tx: &Transaction<'_>,
+    source_kind: &str,
+    source_id: &str,
+) -> Result<()> {
+    tx.execute(
+        "DELETE FROM reminder_pending_suggestions
+          WHERE source_kind=?1 AND source_id=?2",
+        rusqlite::params![source_kind, source_id],
+    )
+    .map_err(map_err)?;
+    tx.execute(
+        "DELETE FROM reminder_audit_cache WHERE source_kind=?1 AND source_id=?2",
+        rusqlite::params![source_kind, source_id],
+    )
+    .map_err(map_err)?;
+    Ok(())
+}
+
+fn replace_reminder_audit_results_tx(
+    tx: &Transaction<'_>,
+    source_kind: &str,
+    source_id: &str,
+    content_hash: &str,
+    engine_id: &str,
+    candidates: &[ReminderAuditCandidate],
+    now: i64,
+) -> Result<()> {
+    delete_reminder_audit_source_tx(tx, source_kind, source_id)?;
+    {
+        let mut stmt = tx
+            .prepare(
+                "INSERT INTO reminder_pending_suggestions
+                   (id,source_kind,source_id,content_hash,engine_id,candidate_key,title,
+                    suggested_due_at,created_at)
+                 SELECT ?1,?2,?3,?4,?5,?6,?7,?8,?9
+                  WHERE NOT EXISTS (
+                    SELECT 1 FROM reminder_suggestion_decisions d
+                     WHERE d.source_kind=?2 AND d.source_id=?3
+                       AND d.content_hash=?4 AND d.candidate_key=?6
+                  )",
+            )
+            .map_err(map_err)?;
+        for candidate in candidates {
+            let id = reminder_suggestion_id(
+                source_kind,
+                source_id,
+                content_hash,
+                &candidate.candidate_key,
+            );
+            stmt.execute(rusqlite::params![
+                id,
+                source_kind,
+                source_id,
+                content_hash,
+                engine_id,
+                candidate.candidate_key,
+                candidate.title,
+                candidate.suggested_due_at,
+                now,
+            ])
+            .map_err(map_err)?;
+        }
+    }
+    tx.execute(
+        "INSERT INTO reminder_audit_cache
+           (source_kind,source_id,content_hash,engine_id,audited_at)
+         VALUES (?1,?2,?3,?4,?5)",
+        rusqlite::params![source_kind, source_id, content_hash, engine_id, now],
+    )
+    .map_err(map_err)?;
+    Ok(())
+}
+
+/// Raw canonical hash used only inside the command-authorized audit CAS transaction. This helper
+/// must never back an IPC reader: it intentionally bypasses visibility because the command already
+/// holds the lifecycle gate, and keeping these reads on the same DB transaction is what closes the
+/// transcript-writer race between post-inference verification and derived insertion.
+fn canonical_reminder_audit_hash_tx(
+    tx: &Transaction<'_>,
+    source_kind: &str,
+    source_id: &str,
+) -> Result<Option<String>> {
+    match source_kind {
+        "meeting" => {
+            let row: Option<(Option<String>, String)> = tx
+                .query_row(
+                    "SELECT title, COALESCE(manual_notes, '') FROM meetings WHERE id=?1",
+                    rusqlite::params![source_id],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .optional()
+                .map_err(map_err)?;
+            let Some((title, manual_notes)) = row else {
+                return Ok(None);
+            };
+            let title = title
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| "Untitled meeting".into());
+            let markdown = tx
+                .query_row(
+                    "SELECT markdown FROM notes
+                      WHERE meeting_id=?1
+                      ORDER BY created_at DESC, provider_id DESC
+                      LIMIT 1",
+                    rusqlite::params![source_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()
+                .map_err(map_err)?
+                .unwrap_or_default();
+            let mut segments = Vec::new();
+            let mut stmt = tx
+                .prepare(
+                    "SELECT idx,start_s,end_s,text,speaker,confidence,echo_suppressed
+                       FROM segments WHERE meeting_id=?1 ORDER BY idx",
+                )
+                .map_err(map_err)?;
+            let rows = stmt
+                .query_map(rusqlite::params![source_id], |row| {
+                    Ok((
+                        Segment {
+                            idx: row.get(0)?,
+                            start_s: row.get(1)?,
+                            end_s: row.get(2)?,
+                            text: row.get(3)?,
+                            speaker: row.get(4)?,
+                            confidence: row.get(5)?,
+                        },
+                        row.get::<_, i64>(6)? != 0,
+                    ))
+                })
+                .map_err(map_err)?;
+            for row in rows {
+                let (segment, echo_suppressed) = row.map_err(map_err)?;
+                if !echo_suppressed {
+                    segments.push(segment);
+                }
+            }
+            Ok(Some(canonical_reminder_source_hash(
+                &title,
+                &markdown,
+                Some(&manual_notes),
+                &segments,
+            )))
+        }
+        "note" => {
+            let row: Option<(String, Option<String>, String)> = tx
+                .query_row(
+                    "SELECT name,title,COALESCE(text,'') FROM documents
+                      WHERE id=?1 AND kind='note'",
+                    rusqlite::params![source_id],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                )
+                .optional()
+                .map_err(map_err)?;
+            let Some((name, title, text)) = row else {
+                return Ok(None);
+            };
+            let title = title
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or(name);
+            Ok(Some(canonical_reminder_source_hash(
+                &title,
+                &text,
+                None,
+                &[],
+            )))
+        }
+        _ => Err(AppError::InvalidArg(
+            "reminder audit source is invalid".into(),
+        )),
+    }
+}
+
+fn stored_suggestion_from_row(row: &Row<'_>) -> rusqlite::Result<StoredReminderSuggestion> {
+    Ok(StoredReminderSuggestion {
+        id: row.get(0)?,
+        source_kind: row.get(1)?,
+        source_id: row.get(2)?,
+        content_hash: row.get(3)?,
+        engine_id: row.get(4)?,
+        candidate_key: row.get(5)?,
+        title: row.get(6)?,
+        suggested_due_at: row.get(7)?,
+        created_at: row.get(8)?,
+    })
+}
+
+fn insert_sources_tx(
+    tx: &Transaction<'_>,
+    reminder_id: &str,
+    sources: &[ReminderSourceAnchor],
+) -> Result<()> {
+    let mut stmt = tx
+        .prepare(
+            "INSERT OR IGNORE INTO reminder_sources(reminder_id,source_kind,source_id)
+             VALUES (?1,?2,?3)",
+        )
+        .map_err(map_err)?;
+    for source in sources {
+        stmt.execute(rusqlite::params![reminder_id, source.kind, source.id])
+            .map_err(map_err)?;
+    }
+    Ok(())
+}
+
+fn list_sources(conn: &Connection, reminder_id: &str) -> Result<Vec<ReminderSourceAnchor>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT source_kind, source_id FROM reminder_sources
+              WHERE reminder_id=?1 ORDER BY source_kind, source_id",
+        )
+        .map_err(map_err)?;
+    let rows = stmt
+        .query_map(rusqlite::params![reminder_id], |row| {
+            Ok(ReminderSourceAnchor {
+                kind: row.get(0)?,
+                id: row.get(1)?,
+            })
+        })
+        .map_err(map_err)?;
+    rows.collect::<rusqlite::Result<Vec<_>>>().map_err(map_err)
+}
+
+fn stored_reminder_from_row(row: &Row<'_>) -> rusqlite::Result<Result<StoredReminder>> {
+    let repeat_unit: Option<String> = row.get(5)?;
+    let state: String = row.get(6)?;
+    let origin: String = row.get(7)?;
+    let repeat_unit = match repeat_unit
+        .as_deref()
+        .map(ReminderRepeatUnit::parse)
+        .transpose()
+    {
+        Ok(value) => value,
+        Err(error) => return Ok(Err(error)),
+    };
+    let state = match ReminderState::parse(&state) {
+        Ok(value) => value,
+        Err(error) => return Ok(Err(error)),
+    };
+    let origin = match ReminderOrigin::parse(&origin) {
+        Ok(value) => value,
+        Err(error) => return Ok(Err(error)),
+    };
+    Ok(Ok(StoredReminder {
+        id: row.get(0)?,
+        title: row.get(1)?,
+        details: row.get(2)?,
+        due_at: row.get(3)?,
+        repeat_every: row.get::<_, Option<i64>>(4)?.map(|n| n as u32),
+        repeat_unit,
+        state,
+        origin,
+        created_at: row.get(8)?,
+        updated_at: row.get(9)?,
+        completed_at: row.get(10)?,
+        sources: Vec::new(),
+    }))
+}
+
+/// Advance an overdue recurring series directly to its first future occurrence. A single user
+/// completion therefore acknowledges all missed cycles. The loop is bounded by the supported
+/// 200-year domain (daily cadence is < 74k steps); month/year transitions progressively clamp the
+/// day to the target month's last valid day (Jan 31 → Feb 28/29). DST gaps advance to the first
+/// valid local minute and ambiguous fall-back times choose the earlier occurrence.
+fn next_recurrence_after(
+    due_at: i64,
+    every: u32,
+    unit: ReminderRepeatUnit,
+    now: i64,
+) -> Result<Option<i64>> {
+    if !(MIN_REMINDER_DUE_AT..MAX_REMINDER_DUE_AT).contains(&due_at) {
+        return Err(AppError::InvalidArg(
+            "reminder due time is out of range".into(),
+        ));
+    }
+    let mut current = due_at;
+    for _ in 0..=74_000 {
+        let next = advance_calendar_due_raw(current, every, unit)?;
+        if next >= MAX_REMINDER_DUE_AT {
+            return Ok(None);
+        }
+        if next > now {
+            return Ok(Some(next));
+        }
+        current = next;
+    }
+    Err(AppError::Storage(
+        "recurring reminder did not advance within the supported horizon".into(),
+    ))
+}
+
+fn advance_calendar_due_raw(due_at: i64, every: u32, unit: ReminderRepeatUnit) -> Result<i64> {
+    if every == 0 || every > 365 {
+        return Err(AppError::InvalidArg(
+            "reminder repeat interval is out of range".into(),
+        ));
+    }
+    let local = Local
+        .timestamp_millis_opt(due_at)
+        .single()
+        .ok_or_else(|| AppError::InvalidArg("reminder due time is out of range".into()))?;
+    let date = local.date_naive();
+    let target_date = match unit {
+        ReminderRepeatUnit::Days => date.checked_add_signed(chrono::Duration::days(every as i64)),
+        ReminderRepeatUnit::Weeks => date.checked_add_signed(chrono::Duration::days(
+            (every as i64).checked_mul(7).ok_or_else(|| {
+                AppError::InvalidArg("reminder repeat interval is out of range".into())
+            })?,
+        )),
+        ReminderRepeatUnit::Months => add_months_clamped(date, every),
+        ReminderRepeatUnit::Years => add_months_clamped(
+            date,
+            every.checked_mul(12).ok_or_else(|| {
+                AppError::InvalidArg("reminder repeat interval is out of range".into())
+            })?,
+        ),
+    }
+    .ok_or_else(|| AppError::InvalidArg("recurring reminder date is out of range".into()))?;
+    let naive = NaiveDateTime::new(
+        target_date,
+        chrono::NaiveTime::from_hms_nano_opt(
+            local.hour(),
+            local.minute(),
+            local.second(),
+            local.nanosecond(),
+        )
+        .ok_or_else(|| AppError::InvalidArg("reminder time is invalid".into()))?,
+    );
+    resolve_local_datetime(naive)
+        .map(|dt| dt.timestamp_millis())
+        .ok_or_else(|| AppError::InvalidArg("recurring reminder time is invalid locally".into()))
+}
+
+fn add_months_clamped(date: NaiveDate, months: u32) -> Option<NaiveDate> {
+    let zero_based = date.year() as i64 * 12 + date.month0() as i64 + months as i64;
+    let year = i32::try_from(zero_based.div_euclid(12)).ok()?;
+    let month = u32::try_from(zero_based.rem_euclid(12)).ok()? + 1;
+    let last = last_day_of_month(year, month)?;
+    NaiveDate::from_ymd_opt(year, month, date.day().min(last))
+}
+
+fn last_day_of_month(year: i32, month: u32) -> Option<u32> {
+    let (next_year, next_month) = if month == 12 {
+        (year.checked_add(1)?, 1)
+    } else {
+        (year, month + 1)
+    };
+    NaiveDate::from_ymd_opt(next_year, next_month, 1)?
+        .pred_opt()
+        .map(|date| date.day())
+}
+
+fn resolve_local_datetime(naive: NaiveDateTime) -> Option<chrono::DateTime<Local>> {
+    resolve_local_datetime_with(naive, |candidate| {
+        Local.from_local_datetime(&candidate).earliest()
+    })
+}
+
+fn resolve_local_datetime_with<T>(
+    mut naive: NaiveDateTime,
+    mut resolve: impl FnMut(NaiveDateTime) -> Option<T>,
+) -> Option<T> {
+    for _ in 0..=MAX_LOCAL_DATETIME_GAP_MINUTES {
+        if let Some(value) = resolve(naive) {
+            return Some(value);
+        }
+        naive = naive.checked_add_signed(chrono::Duration::minutes(1))?;
+    }
+    None
+}
+
+#[cfg(test)]
+mod recurrence_resolution_tests {
+    use super::*;
+
+    #[test]
+    fn resolver_crosses_a_skipped_civil_day() {
+        let skipped_start = NaiveDate::from_ymd_opt(2011, 12, 30)
+            .unwrap()
+            .and_hms_opt(9, 0, 0)
+            .unwrap();
+        let first_valid = NaiveDate::from_ymd_opt(2011, 12, 31)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+
+        let resolved = resolve_local_datetime_with(skipped_start, |candidate| {
+            (candidate >= first_valid).then_some(candidate)
+        });
+
+        assert_eq!(resolved, Some(first_valid));
+    }
+}

--- a/src-tauri/src/storage/seal_store.rs
+++ b/src-tauri/src/storage/seal_store.rs
@@ -325,6 +325,9 @@ impl Db {
         // folder's titles in its evidence with no matching id, so a scoped purge cannot cover it.
         // Cheap re-derivable rows; the next pass re-stages anything still true.
         Self::purge_all_pending_audit_findings_tx(&tx)?;
+        // Smart-reminder audit candidates/cache are disposable source-derived plaintext too.
+        // Accepted reminders live in separate tables and deliberately survive this purge.
+        Self::purge_all_reminder_derived_tx(&tx)?;
 
         // Documents anchored on this folder: drop sealed ciphertext + plaintext + their chunks/vectors.
         tx.execute(
@@ -478,6 +481,10 @@ impl Db {
 
     /// Re-blank the plaintext `markdown` of every note in `folder_ids` that still has a sealed
     /// `content_blob` (relock / relock-all). Idempotent; leaves the blob intact.
+    /// The caller MUST first authenticate every retained blob-backed non-empty plaintext and
+    /// encrypt+decrypt-verify every blob-less non-empty plaintext in every target folder under the
+    /// cached folder CK, while holding the lock lifecycle guard. Any prepared missing seal must be
+    /// persisted before this low-level transaction, which deliberately has no key access of its own.
     ///
     /// Returns the `exported_path`s of the memory rollups purged in the same transaction
     /// (`purge_memory_rollups_tx` — a relock re-asserts the sealed shape, so sealed-derived rollup
@@ -528,7 +535,11 @@ impl Db {
             let mut dids = tx
                 .prepare("SELECT id FROM documents WHERE folder_id = ?1")
                 .map_err(map_err)?;
+            let mut note_ids_stmt = tx
+                .prepare("SELECT id FROM documents WHERE folder_id = ?1 AND kind = 'note'")
+                .map_err(map_err)?;
             let mut document_ids: Vec<String> = Vec::new();
+            let mut authored_note_ids: Vec<String> = Vec::new();
             for id in folder_ids {
                 let rows = dids
                     .query_map(rusqlite::params![id], |r| r.get::<_, String>(0))
@@ -536,8 +547,40 @@ impl Db {
                 for r in rows {
                     document_ids.push(r.map_err(map_err)?);
                 }
+                let note_rows = note_ids_stmt
+                    .query_map(rusqlite::params![id], |r| r.get::<_, String>(0))
+                    .map_err(map_err)?;
+                for row in note_rows {
+                    authored_note_ids.push(row.map_err(map_err)?);
+                }
             }
             drop(dids);
+            drop(note_ids_stmt);
+            // A relock changes visibility authority even for a title-only source whose canonical
+            // text was already empty, so content-column UPDATE triggers may legitimately stay
+            // silent. Queue every governed reminder source explicitly in this same reblank
+            // transaction; the event contains only kind + opaque id.
+            {
+                let mut queue = tx
+                    .prepare(
+                        "INSERT INTO reminder_source_invalidation_queue
+                           (source_kind,source_id,revision)
+                         VALUES (?1,?2,1)
+                         ON CONFLICT(source_kind,source_id)
+                         DO UPDATE SET revision=revision+1",
+                    )
+                    .map_err(map_err)?;
+                for meeting_id in &meeting_ids {
+                    queue
+                        .execute(rusqlite::params!["meeting", meeting_id])
+                        .map_err(map_err)?;
+                }
+                for note_id in &authored_note_ids {
+                    queue
+                        .execute(rusqlite::params!["note", note_id])
+                        .map_err(map_err)?;
+                }
+            }
             Self::purge_doc_chunks_tx(&tx, &document_ids)?;
             // Phase F0 LOCK-SAFETY: purge the correction-log rows of every meeting in these (now
             // re-blanked / sealed) folders in the SAME transaction — a sealed meeting contributes
@@ -578,6 +621,9 @@ impl Db {
             // meeting/document id can match; a relock invalidates the pass's visibility
             // snapshot). Resolved rows were blanked on resolve and survive.
             Self::purge_all_pending_audit_findings_tx(&tx)?;
+            // A relock withdraws the visibility snapshot that authorized every pending Smart
+            // candidate. Purge the whole derived audit domain in this same re-blank transaction.
+            Self::purge_all_reminder_derived_tx(&tx)?;
 
             // Brain v3 PR-3 LINK-ENGINE LOCK-SAFETY: purge every DERIVED `links` row whose SRC OR DST is
             // a meeting OR document/note in these (re-blanked / sealed) folders in this SAME relock tx —
@@ -626,6 +672,25 @@ impl Db {
              WHERE folder_id IN (SELECT id FROM folders WHERE locked = 1)";
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
+        #[cfg(debug_assertions)]
+        let runtime_derived_before = if crate::commands::reminder_runtime_probe_requested()
+            && std::env::var_os("MURMUR_HARNESS_PHASE_TWO_NONCE").is_some()
+        {
+            let count: i64 = tx
+                .query_row(
+                    "SELECT
+                       (SELECT COUNT(*) FROM reminder_audit_cache) +
+                       (SELECT COUNT(*) FROM reminder_pending_suggestions)",
+                    [],
+                    |row| row.get(0),
+                )
+                .map_err(map_err)?;
+            Some(usize::try_from(count).map_err(|_| {
+                crate::error::AppError::Storage("runtime reminder count is negative".into())
+            })?)
+        } else {
+            None
+        };
         tx.execute(
             "UPDATE notes SET markdown = '' \
                WHERE content_blob IS NOT NULL \
@@ -777,6 +842,9 @@ impl Db {
             .map_err(map_err)?;
         if any_locked {
             Self::purge_all_pending_audit_findings_tx(&tx)?;
+            // Startup reconciliation must not leave candidates derived during a crashed unlocked
+            // session at rest. Canonical promoted reminders remain untouched.
+            Self::purge_all_reminder_derived_tx(&tx)?;
         }
         // brain2 realtime notes LOCK-SAFETY: re-blank the typed-notes plaintext of every meeting in a
         // locked folder ONLY WHERE its `manual_notes_blob` exists (the sealed copy is present) — so a
@@ -946,7 +1014,28 @@ impl Db {
             }
             out
         };
+        #[cfg(debug_assertions)]
+        let runtime_derived_after = if runtime_derived_before.is_some() {
+            let count: i64 = tx
+                .query_row(
+                    "SELECT
+                       (SELECT COUNT(*) FROM reminder_audit_cache) +
+                       (SELECT COUNT(*) FROM reminder_pending_suggestions)",
+                    [],
+                    |row| row.get(0),
+                )
+                .map_err(map_err)?;
+            Some(usize::try_from(count).map_err(|_| {
+                crate::error::AppError::Storage("runtime reminder count is negative".into())
+            })?)
+        } else {
+            None
+        };
         tx.commit().map_err(map_err)?;
+        #[cfg(debug_assertions)]
+        if let (Some(before), Some(after)) = (runtime_derived_before, runtime_derived_after) {
+            crate::commands::record_reminder_runtime_startup_reconcile(before, after)?;
+        }
         Ok((audio, rollup_exports, note_md_exports))
     }
 

--- a/src-tauri/src/summarize/recall_net.rs
+++ b/src-tauri/src/summarize/recall_net.rs
@@ -218,6 +218,47 @@ pub fn append_possible_missed_items(note_markdown: &str, segments: &[Segment]) -
         return note_markdown.to_string();
     }
 
+    let MissedItemScan { picked, overflow } = scan_possible_missed_items(note_markdown, segments);
+    if picked.is_empty() {
+        return note_markdown.to_string();
+    }
+
+    let mut out = note_markdown.trim_end().to_string();
+    out.push_str("\n\n");
+    out.push_str(MISSED_HEADING);
+    out.push_str("\n\n");
+    out.push_str(MISSED_PREAMBLE);
+    out.push_str("\n\n");
+    for quote in &picked {
+        out.push_str("- \"");
+        out.push_str(quote);
+        out.push_str("\"\n");
+    }
+    // NO SILENT CAP: say how many cue-bearing lines the cap hid.
+    if overflow > 0 {
+        let cap = MAX_MISSED;
+        out.push_str(&format!(
+            "- _(+{overflow} more cue-bearing line(s) not shown — this scan shows at most {cap}.)_\n"
+        ));
+    }
+    out
+}
+
+/// Return the same conservative EN/PL transcript commitments the recall-net renderer may surface.
+///
+/// This is a bounded, deterministic, zero-egress helper for callers that need the candidates
+/// without mutating or rendering the note. An already-rendered [`MISSED_HEADING`] does not suppress
+/// extraction here; idempotency remains a renderer concern.
+pub fn possible_missed_item_candidates(note_markdown: &str, segments: &[Segment]) -> Vec<String> {
+    scan_possible_missed_items(note_markdown, segments).picked
+}
+
+struct MissedItemScan {
+    picked: Vec<String>,
+    overflow: usize,
+}
+
+fn scan_possible_missed_items(note_markdown: &str, segments: &[Segment]) -> MissedItemScan {
     // What the note ALREADY captured: one content-token set per parsed checklist item. Note that
     // `parse_action_items` drops assistant-directed lines ("Klaudku, …") — the candidate side below
     // filters the identical class out of the transcript, so the two sides stay consistent.
@@ -265,29 +306,10 @@ pub fn append_possible_missed_items(note_markdown: &str, segments: &[Segment]) -
         picked.push((quote_of(text), toks));
     }
 
-    if picked.is_empty() {
-        return note_markdown.to_string();
+    MissedItemScan {
+        picked: picked.into_iter().map(|(quote, _)| quote).collect(),
+        overflow,
     }
-
-    let mut out = note_markdown.trim_end().to_string();
-    out.push_str("\n\n");
-    out.push_str(MISSED_HEADING);
-    out.push_str("\n\n");
-    out.push_str(MISSED_PREAMBLE);
-    out.push_str("\n\n");
-    for (quote, _) in &picked {
-        out.push_str("- \"");
-        out.push_str(quote);
-        out.push_str("\"\n");
-    }
-    // NO SILENT CAP: say how many cue-bearing lines the cap hid.
-    if overflow > 0 {
-        let cap = MAX_MISSED;
-        out.push_str(&format!(
-            "- _(+{overflow} more cue-bearing line(s) not shown — this scan shows at most {cap}.)_\n"
-        ));
-    }
-    out
 }
 
 /// Whether `note_markdown` already carries the appended section (line-exact heading match, so a

--- a/src/app/app-shell/app-shell.component.html
+++ b/src/app/app-shell/app-shell.component.html
@@ -121,6 +121,9 @@
                 >
                   <mur-icon [icon]="item.icon" />
                   <span class="nav-label">{{ item.label }}</span>
+                  @if (item.path === "/reminders" && reminderCount() > 0) {
+                    <span class="count nav-reminder-count">{{ reminderCount() }}</span>
+                  }
                 </a>
               }
             }
@@ -231,6 +234,9 @@
         >
           <mur-icon [icon]="item.icon" />
           <span class="nav-label">{{ item.label }}</span>
+          @if (item.path === "/reminders" && reminderCount() > 0) {
+            <span class="count nav-reminder-count">{{ reminderCount() }}</span>
+          }
         </a>
       }
 
@@ -373,3 +379,5 @@
   (dismiss)="docPreview.close()"
 />
 
+<!-- The one opaque app-wide Murmur reminder composer host. -->
+<app-reminder-composer />

--- a/src/app/app-shell/app-shell.component.ts
+++ b/src/app/app-shell/app-shell.component.ts
@@ -33,6 +33,8 @@ import { DocumentPreviewComponent } from "../features/brain/document-preview/doc
 import { LockSharesDialogComponent } from "../features/folders/lock-shares-dialog/lock-shares-dialog.component";
 import { MeetingsSidebarTreeComponent } from "../features/folders/meetings-sidebar-tree/meetings-sidebar-tree.component";
 import { NotesSidebarTreeComponent } from "../features/notes/notes-sidebar-tree/notes-sidebar-tree.component";
+import { ReminderComposerComponent } from "../features/reminders/reminder-composer/reminder-composer.component";
+import { RemindersStore } from "../features/reminders/reminders.store";
 import { ChromeService } from "../services/chrome.service";
 import { DocumentPreviewService } from "../services/document-preview.service";
 import { FolderLockFlowService } from "../services/folder-lock-flow.service";
@@ -89,6 +91,7 @@ const NAV_GROUPS: readonly NavGroup[] = [
     items: [
       { path: "/library", label: "Meetings", icon: "meetings" },
       { path: "/notes", label: "Notes", icon: "notes" },
+      { path: "/reminders", label: "Reminders", icon: "reminders" },
     ],
   },
   {
@@ -118,6 +121,7 @@ const NAV_ITEMS: readonly NavItem[] = [
   { path: "/record", label: "Record", icon: "record" },
   { path: "/library", label: "Meetings", icon: "meetings" },
   { path: "/notes", label: "Notes", icon: "notes" },
+  { path: "/reminders", label: "Reminders", icon: "reminders" },
   { path: "/analytics", label: "Analytics", icon: "analytics" },
   { path: "/graph", label: "Graph", icon: "graph" },
   { path: "/people", label: "People", icon: "people" },
@@ -165,6 +169,7 @@ const INSIGHT_PATHS = NAV_GROUPS.filter((g) => g.collapsible).flatMap((g) =>
     MurSidebarSectionComponent,
     LockSharesDialogComponent,
     DocumentPreviewComponent,
+    ReminderComposerComponent,
   ],
   host: {
     // Scoped to !inDrilldown so the pill-clearance padding never leaks onto
@@ -204,6 +209,8 @@ export class AppShellComponent {
   private readonly chrome = inject(ChromeService);
   private readonly tabs = inject(TabsService);
   private readonly injector = inject(Injector);
+  private readonly reminders = inject(RemindersStore);
+  readonly reminderCount = this.reminders.dueInboxCount;
 
   /**
    * Shared lock×shares flow (probe → warn/revoke dialog → lock) — rendered
@@ -225,6 +232,10 @@ export class AppShellComponent {
    * "open a document" surface calls {@link DocumentPreviewService.open}.
    */
   readonly docPreview = inject(DocumentPreviewService);
+
+  constructor() {
+    void this.reminders.initSummary();
+  }
 
   /**
    * The current URL, updated on every completed navigation. Seeded from

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -57,6 +57,13 @@ export const routes: Routes = [
           ),
       },
       {
+        path: "reminders",
+        loadComponent: () =>
+          import("./features/reminders/reminders/reminders.component").then(
+            (m) => m.RemindersComponent,
+          ),
+      },
+      {
         // New-note gateway: creates a note then replaces the URL with /notes/:id.
         path: "notes/new",
         loadComponent: () =>

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -130,6 +130,14 @@ import type {
   OrgFeedUpdatedPayload,
   ActiveSharesReport,
   ContentDeletedPayload,
+  ReminderDraft,
+  ReminderSourceAnchor,
+  ReminderSourceUpdatedPayload,
+  ReminderSuggestionView,
+  ReminderSummary,
+  RemindersSnapshot,
+  RemindersUpdatedPayload,
+  ReminderView,
 } from "./models";
 
 export const EVENT_STATUS = "meetnotes://status";
@@ -180,6 +188,14 @@ export const EVENT_ORG_FEED_UPDATED = "murmur://org-feed-updated";
 // Delete fan-out fix — a note/meeting delete FULLY succeeded (local rows gone + any org shares
 // revoked); lets OTHER open surfaces (the tab-strip) prune themselves. Content-free (id + kind only).
 export const EVENT_CONTENT_DELETED = "murmur://content-deleted";
+/** Count-only invalidation for the first-class Murmur reminder inbox. */
+export const EVENT_REMINDERS_UPDATED = "murmur://reminders-updated";
+/** Kind + opaque source id only; Smart cards re-audit through the gated command. */
+export const EVENT_REMINDER_SOURCE_UPDATED =
+  "murmur://reminder-source-updated";
+/** No-payload privacy barrier: every cached reminder source title must be discarded immediately. */
+export const EVENT_REMINDER_VISIBILITY_INVALIDATED =
+  "murmur://reminder-visibility-invalidated";
 
 /**
  * Thin wrapper over @tauri-apps/api invoke/listen. One method per Tauri command
@@ -1208,6 +1224,65 @@ export class IpcService {
   /** Add a macOS Reminder for an action item (best-effort, TCC-gated). */
   addReminder(text: string, dueDate: string | null): Promise<void> {
     return invoke<void>("add_reminder", { text, dueDate });
+  }
+
+  /** Content-free startup/sidebar count; does not read reminder titles or details. */
+  getReminderSummary(): Promise<ReminderSummary> {
+    return invoke<ReminderSummary>("get_reminder_summary");
+  }
+
+  /** Canonical Inbox / Upcoming / Completed snapshot. */
+  listReminders(): Promise<RemindersSnapshot> {
+    return invoke<RemindersSnapshot>("list_reminders");
+  }
+
+  createMurmurReminder(draft: ReminderDraft): Promise<ReminderView> {
+    return invoke<ReminderView>("create_reminder", { draft });
+  }
+
+  updateMurmurReminder(
+    reminderId: string,
+    draft: ReminderDraft,
+  ): Promise<ReminderView> {
+    return invoke<ReminderView>("update_reminder", { reminderId, draft });
+  }
+
+  deleteMurmurReminder(reminderId: string): Promise<void> {
+    return invoke<void>("delete_reminder", { reminderId });
+  }
+
+  completeMurmurReminder(
+    reminderId: string,
+    expectedDueAt: number,
+  ): Promise<void> {
+    return invoke<void>("complete_reminder", { reminderId, expectedDueAt });
+  }
+
+  dismissMurmurReminderOccurrence(occurrenceId: string): Promise<void> {
+    return invoke<void>("dismiss_reminder_occurrence", { occurrenceId });
+  }
+
+  auditReminderSuggestions(
+    source: ReminderSourceAnchor,
+  ): Promise<ReminderSuggestionView[]> {
+    return invoke<ReminderSuggestionView[]>("audit_reminder_suggestions", {
+      sourceKind: source.kind,
+      sourceId: source.id,
+    });
+  }
+
+  acceptReminderSuggestion(
+    suggestionId: string,
+    draft: ReminderDraft,
+  ): Promise<ReminderView> {
+    return invoke<ReminderView>("accept_reminder_suggestion", {
+      suggestionId,
+      draft,
+    });
+  }
+
+  dismissReminderSuggestion(suggestionId: string): Promise<void> {
+    return invoke<void>("dismiss_reminder_suggestion", { suggestionId });
   }
 
   /** Pin a meeting moment → ^block-ref in the note + an obsidian:// deep link. */
@@ -2938,5 +3013,37 @@ export class IpcService {
     return listen<ContentDeletedPayload>(EVENT_CONTENT_DELETED, (e) =>
       cb(e.payload),
     );
+  }
+
+  /** Count-only reminder invalidation. Canonical rows are always refetched. */
+  onRemindersUpdated(
+    cb: (p: RemindersUpdatedPayload) => void,
+  ): Promise<UnlistenFn> {
+    return listen<RemindersUpdatedPayload>(EVENT_REMINDERS_UPDATED, (e) =>
+      cb(e.payload),
+    );
+  }
+
+  /**
+   * One canonical Smart-audit source changed. The event carries no title,
+   * content, hash, or revision; the mounted card filters by opaque identity and
+   * re-enters `auditReminderSuggestions`, whose lock gate remains authoritative.
+   */
+  onReminderSourceUpdated(
+    cb: (p: ReminderSourceUpdatedPayload) => void,
+  ): Promise<UnlistenFn> {
+    return listen<ReminderSourceUpdatedPayload>(
+      EVENT_REMINDER_SOURCE_UPDATED,
+      (e) => cb(e.payload),
+    );
+  }
+
+  /**
+   * Lock authority changed. The event intentionally carries no ids or content:
+   * consumers synchronously purge all cached source metadata, then re-fetch
+   * through the ordinary lock-gated commands.
+   */
+  onReminderVisibilityInvalidated(cb: () => void): Promise<UnlistenFn> {
+    return listen<void>(EVENT_REMINDER_VISIBILITY_INVALIDATED, () => cb());
   }
 }

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -1547,6 +1547,87 @@ export interface ActionItem {
   dueDate: string | null;
 }
 
+// ── First-class Murmur reminders ──────────────────────────────────────────
+
+/** Calendar recurrence units accepted by the reminder composer/backend. */
+export type ReminderRepeatUnit = "days" | "weeks" | "months" | "years";
+
+export type ReminderState = "active" | "completed";
+export type ReminderOrigin = "manual" | "smart";
+
+/** The only identity persisted for a reminder source. */
+export interface ReminderSourceAnchor {
+  kind: SourceKind;
+  id: string;
+}
+
+/** Live-gated metadata for a currently visible reminder source. */
+export interface ReminderSourceView extends ReminderSourceAnchor {
+  title: string;
+}
+
+/** Create/update payload. Source titles are deliberately never sent. */
+export interface ReminderDraft {
+  title: string;
+  details: string | null;
+  /** UTC epoch milliseconds derived from a calendar-valid local date/time. */
+  dueAt: number;
+  repeatEvery: number | null;
+  repeatUnit: ReminderRepeatUnit | null;
+  sources: ReminderSourceAnchor[];
+}
+
+export interface ReminderView {
+  id: string;
+  title: string;
+  details: string | null;
+  dueAt: number;
+  repeatEvery: number | null;
+  repeatUnit: ReminderRepeatUnit | null;
+  state: ReminderState;
+  origin: ReminderOrigin;
+  createdAt: number;
+  updatedAt: number;
+  completedAt: number | null;
+  sources: ReminderSourceView[];
+}
+
+export interface ReminderInboxItem {
+  occurrenceId: string;
+  dueAt: number;
+  reminder: ReminderView;
+}
+
+export interface RemindersSnapshot {
+  inbox: ReminderInboxItem[];
+  upcoming: ReminderView[];
+  completed: ReminderView[];
+  dueInboxCount: number;
+}
+
+/** Content-free startup/nav projection. */
+export interface ReminderSummary {
+  dueInboxCount: number;
+}
+
+/** Count-only invalidation event; consumers refetch canonical rows. */
+export type RemindersUpdatedPayload = ReminderSummary;
+
+/**
+ * Content-free invalidation for one mounted Smart-reminder source. Canonical
+ * writes publish only the kind + opaque id; consumers re-enter the gated audit
+ * command for any source-derived content.
+ */
+export type ReminderSourceUpdatedPayload = ReminderSourceAnchor;
+
+/** Review-only Smart candidate; it is not a reminder until explicitly accepted. */
+export interface ReminderSuggestionView {
+  id: string;
+  title: string;
+  suggestedDueAt: number | null;
+  source: ReminderSourceView;
+}
+
 export interface PinResult {
   url: string;
   blockId: string;

--- a/src/app/design-system/icon/icon.component.html
+++ b/src/app/design-system/icon/icon.component.html
@@ -19,6 +19,12 @@
         <path d="M6.9 10.2h6.2M6.9 12.7h6.2M6.9 15.1h4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
       </svg>
     }
+    @case ("reminders") {
+      <svg viewBox="0 0 20 20" fill="none">
+        <path d="M6 4.2h8M6 9.9h8M6 15.6h8" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" />
+        <path d="m2.8 4.2.9.9 1.7-2M2.8 9.9l.9.9 1.7-2M2.8 15.6l.9.9 1.7-2" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    }
     @case ("analytics") {
       <svg viewBox="0 0 20 20" fill="none">
         <path d="M4 16V9M8 16V5m4 11v-7m4 7V7" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" />

--- a/src/app/design-system/icon/icon.component.ts
+++ b/src/app/design-system/icon/icon.component.ts
@@ -5,6 +5,7 @@ export type ShellIcon =
   | "record"
   | "meetings"
   | "notes"
+  | "reminders"
   | "analytics"
   | "graph"
   | "people"

--- a/src/app/design-system/source-picker/source-picker.component.html
+++ b/src/app/design-system/source-picker/source-picker.component.html
@@ -54,9 +54,16 @@
             type="button"
             class="sp-chip-remove"
             [attr.aria-label]="'Remove ' + (c.title || c.id)"
+            [disabled]="disabled()"
             (click)="remove(c)"
           >
-            <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 16 16"
+              fill="none"
+              aria-hidden="true"
+            >
               <path
                 d="M4 4l8 8M12 4l-8 8"
                 stroke="currentColor"
@@ -75,7 +82,9 @@
             [attr.aria-expanded]="chipsExpanded()"
             (click)="toggleChips()"
           >
-            {{ chipsExpanded() ? "Show less" : "+" + hiddenChipCount() + " more" }}
+            {{
+              chipsExpanded() ? "Show less" : "+" + hiddenChipCount() + " more"
+            }}
           </button>
         </li>
       }
@@ -88,6 +97,7 @@
     class="btn btn-ghost sp-trigger"
     [attr.aria-expanded]="open()"
     aria-haspopup="listbox"
+    [disabled]="disabled() || selectionLimitReached()"
     (click)="toggle()"
   >
     {{ triggerLabel() }}
@@ -100,91 +110,97 @@
        ancestor (the `.card` backdrop-filter / drawer transform containing-block
        trap that made the picker "look dead"). display:contents → no extra box. -->
   <div class="sp-overlay" appTeleportToBody>
-  <!-- Scrim: a click OUTSIDE the popover closes it. Transparent (only the panel
+    <!-- Scrim: a click OUTSIDE the popover closes it. Transparent (only the panel
        carries the opaque overlay — T3). role=button + Enter/Space/Esc satisfy the
        a11y lints (mirrors the quick-search scrim). -->
-  <div
-    class="sp-scrim"
-    role="button"
-    tabindex="0"
-    aria-label="Close source picker"
-    (click)="close()"
-    (keydown.enter)="close()"
-    (keydown.space)="close(); $event.preventDefault()"
-    (keydown.escape)="close()"
-  ></div>
+    <div
+      class="sp-scrim"
+      role="button"
+      tabindex="0"
+      aria-label="Close source picker"
+      (click)="close()"
+      (keydown.enter)="close()"
+      (keydown.space)="close(); $event.preventDefault()"
+      (keydown.escape)="close()"
+    ></div>
 
-  <!-- OPAQUE floating popover (T3): --surface-overlay + backdrop-filter:none via
+    <!-- OPAQUE floating popover (T3): --surface-overlay + backdrop-filter:none via
        the global .menu primitive. Positioned in JS (afterNextRender) under the
        trigger; re-positioned on scroll/resize via the shared directive. -->
-  <div
-    #popover
-    class="sp-pop menu"
-    appRepositionOnScroll
-    (reposition)="reposition()"
-  >
-    <input
-      #search
-      type="text"
-      class="sp-search"
-      role="combobox"
-      aria-autocomplete="list"
-      aria-controls="sp-listbox"
-      [attr.aria-expanded]="candidates().length > 0"
-      [placeholder]="placeholder()"
-      [value]="query()"
-      (input)="onQuery($any($event.target).value)"
-      (keydown)="onKeydown($event)"
-    />
-
     <div
-      #list
-      id="sp-listbox"
-      class="sp-list"
-      role="listbox"
-      aria-label="Source candidates"
-      (scroll)="onScroll()"
+      #popover
+      class="sp-pop menu"
+      appRepositionOnScroll
+      (reposition)="reposition()"
     >
-      @for (r of rows(); track r.candidate.kind + r.candidate.id; let i = $index) {
-        <button
-          type="button"
-          class="sp-row menu-item"
-          role="option"
-          [class.is-active]="i === activeIndex()"
-          [class.is-picked]="r.picked"
-          [attr.aria-selected]="i === activeIndex()"
-          (click)="pick(r.candidate)"
-        >
-          <span class="sp-title">{{ r.candidate.title }}</span>
-          @if (r.picked) {
-            <svg
-              class="sp-check"
-              width="14"
-              height="14"
-              viewBox="0 0 16 16"
-              fill="none"
-              aria-hidden="true"
-            >
-              <path
-                d="M3.5 8.5l3 3 6-6.5"
-                stroke="currentColor"
-                stroke-width="1.6"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-            </svg>
+      <input
+        #search
+        type="text"
+        class="sp-search"
+        role="combobox"
+        aria-autocomplete="list"
+        aria-controls="sp-listbox"
+        [attr.aria-expanded]="candidates().length > 0"
+        [placeholder]="placeholder()"
+        [value]="query()"
+        [disabled]="disabled()"
+        (input)="onQuery($any($event.target).value)"
+        (keydown)="onKeydown($event)"
+      />
+
+      <div
+        #list
+        id="sp-listbox"
+        class="sp-list"
+        role="listbox"
+        aria-label="Source candidates"
+        (scroll)="onScroll()"
+      >
+        @for (
+          r of rows();
+          track r.candidate.kind + r.candidate.id;
+          let i = $index
+        ) {
+          <button
+            type="button"
+            class="sp-row menu-item"
+            role="option"
+            [class.is-active]="i === activeIndex()"
+            [class.is-picked]="r.picked"
+            [attr.aria-selected]="i === activeIndex()"
+            [disabled]="disabled() || (!r.picked && selectionLimitReached())"
+            (click)="pick(r.candidate)"
+          >
+            <span class="sp-title">{{ r.candidate.title }}</span>
+            @if (r.picked) {
+              <svg
+                class="sp-check"
+                width="14"
+                height="14"
+                viewBox="0 0 16 16"
+                fill="none"
+                aria-hidden="true"
+              >
+                <path
+                  d="M3.5 8.5l3 3 6-6.5"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            } @else {
+              <span class="sp-kind">{{ r.candidate.kind }}</span>
+            }
+          </button>
+        } @empty {
+          @if (loading()) {
+            <p class="sp-empty">Searching…</p>
           } @else {
-            <span class="sp-kind">{{ r.candidate.kind }}</span>
+            <p class="sp-empty">No matching notes or meetings.</p>
           }
-        </button>
-      } @empty {
-        @if (loading()) {
-          <p class="sp-empty">Searching…</p>
-        } @else {
-          <p class="sp-empty">No matching notes or meetings.</p>
         }
-      }
+      </div>
     </div>
-  </div>
   </div>
 }

--- a/src/app/design-system/source-picker/source-picker.component.ts
+++ b/src/app/design-system/source-picker/source-picker.component.ts
@@ -34,12 +34,12 @@ const SCROLL_LOAD_THRESHOLD_PX = 56;
 /** Keyboard ↑/↓: pull the next page once the active row is within this many rows of the end. */
 const KEYBOARD_LOAD_AHEAD_ROWS = 3;
 
-/** The `NoteCitation.kind`s the picker offers — the Brain scopes to these only. */
-const ALLOWED_KINDS: ReadonlySet<string> = new Set<LinkKind>([
+/** Backward-compatible default: the Brain may scope to all local document kinds. */
+const DEFAULT_ALLOWED_KINDS: readonly LinkKind[] = [
   "meeting",
   "note",
   "document",
-]);
+];
 
 /**
  * Design System — `<mur-source-picker>`: the "scope the Brain to these sources"
@@ -82,6 +82,18 @@ export class SourcePickerComponent {
   readonly placeholder = input("Add a note or meeting…");
   /** Label on the trigger button. */
   readonly triggerLabel = input("+ Source");
+  /** Disable every source mutation while a parent operation owns the draft. */
+  readonly disabled = input(false);
+  /** Optional hard cap. Removal remains available at the cap unless disabled. */
+  readonly selectionLimit = input<number | null>(null);
+  /**
+   * Candidate kinds this instance may expose. Defaults to the historical Brain
+   * picker set; callers such as Reminders can narrow it to note + meeting.
+   */
+  readonly allowedKinds = input<readonly LinkKind[]>(DEFAULT_ALLOWED_KINDS);
+  private readonly allowedKindSet = computed<ReadonlySet<LinkKind>>(
+    () => new Set(this.allowedKinds()),
+  );
 
   /** Whether the popover is open. */
   readonly open = signal(false);
@@ -99,6 +111,15 @@ export class SourcePickerComponent {
   private readonly selectedKeys = computed(
     () => new Set(this.selected().map((s) => s.kind + s.id)),
   );
+  readonly selectionLimitReached = computed(() => {
+    const limit = this.selectionLimit();
+    return (
+      limit !== null &&
+      Number.isInteger(limit) &&
+      limit >= 0 &&
+      this.selected().length >= limit
+    );
+  });
 
   /** Rows annotated with whether they are already picked (no template method). */
   readonly rows = computed(() =>
@@ -137,7 +158,8 @@ export class SourcePickerComponent {
     this._chipsExpanded.update((v) => !v);
   }
 
-  private readonly triggerEl = viewChild<ElementRef<HTMLButtonElement>>("trigger");
+  private readonly triggerEl =
+    viewChild<ElementRef<HTMLButtonElement>>("trigger");
   private readonly popoverEl = viewChild<ElementRef<HTMLDivElement>>("popover");
   private readonly searchEl = viewChild<ElementRef<HTMLInputElement>>("search");
   private readonly listEl = viewChild<ElementRef<HTMLDivElement>>("list");
@@ -155,7 +177,7 @@ export class SourcePickerComponent {
     // with a `requestSeq` stale guard. Gated on `open()` so a closed picker
     // isn't querying.
     effect(() => {
-      if (!this.open()) {
+      if (!this.open() || this.disabled()) {
         return;
       }
       const q = this.query();
@@ -184,12 +206,20 @@ export class SourcePickerComponent {
         { injector: this.injector },
       );
     });
+    effect(() => {
+      if (this.open() && (this.disabled() || this.selectionLimitReached())) {
+        this.close();
+      }
+    });
     this.destroyRef.onDestroy(() => this.debounce.cancel(DEBOUNCE_KEY));
   }
 
   // --- Popover open/close ---------------------------------------------------
 
   toggle(): void {
+    if (this.disabled() || this.selectionLimitReached()) {
+      return;
+    }
     if (this.open()) {
       this.close();
     } else {
@@ -230,11 +260,17 @@ export class SourcePickerComponent {
   // --- Search input + keyboard nav -----------------------------------------
 
   onQuery(value: string): void {
+    if (this.disabled()) {
+      return;
+    }
     this.query.set(value);
     this.activeIndex.set(0);
   }
 
   onKeydown(event: KeyboardEvent): void {
+    if (this.disabled()) {
+      return;
+    }
     switch (event.key) {
       case "ArrowDown":
         event.preventDefault();
@@ -280,7 +316,9 @@ export class SourcePickerComponent {
       if (seq !== this.requestSeq) {
         return; // superseded by a newer query.
       }
-      const kept = rows.filter((c) => ALLOWED_KINDS.has(c.kind));
+      const kept = rows.filter((c) =>
+        this.allowedKindSet().has(c.kind as LinkKind),
+      );
       // `hasMore` tracks the RAW backend page (unfiltered) — a full page means
       // more rows exist upstream even if this page's kept rows are few.
       this.hasMore = rows.length === PAGE_SIZE;
@@ -323,7 +361,9 @@ export class SourcePickerComponent {
       }
       this.rawOffset += page.length;
       this.hasMore = page.length === PAGE_SIZE;
-      const kept = page.filter((c) => ALLOWED_KINDS.has(c.kind));
+      const kept = page.filter((c) =>
+        this.allowedKindSet().has(c.kind as LinkKind),
+      );
       // Dedupe on append: a row that shifted pages mid-scroll must not repeat —
       // the template's `track c.kind + c.id` requires unique keys.
       const seen = new Set(this.candidates().map((c) => c.kind + c.id));
@@ -357,7 +397,8 @@ export class SourcePickerComponent {
       return;
     }
     const nearBottom =
-      el.scrollTop + el.clientHeight >= el.scrollHeight - SCROLL_LOAD_THRESHOLD_PX;
+      el.scrollTop + el.clientHeight >=
+      el.scrollHeight - SCROLL_LOAD_THRESHOLD_PX;
     if (nearBottom) {
       void this.loadMore();
     }
@@ -366,8 +407,11 @@ export class SourcePickerComponent {
   // --- Selection ------------------------------------------------------------
 
   pick(candidate: NoteCitation): void {
+    if (this.disabled() || this.selectionLimitReached()) {
+      return;
+    }
     const kind = candidate.kind as LinkKind;
-    if (!ALLOWED_KINDS.has(kind)) {
+    if (!this.allowedKindSet().has(kind)) {
       return;
     }
     const key = candidate.kind + candidate.id;
@@ -386,6 +430,9 @@ export class SourcePickerComponent {
   }
 
   remove(ref: SourceRef): void {
+    if (this.disabled()) {
+      return;
+    }
     this.selected.update((list) =>
       list.filter((s) => !(s.kind === ref.kind && s.id === ref.id)),
     );

--- a/src/app/features/detail/meeting-actions/meeting-actions.component.html
+++ b/src/app/features/detail/meeting-actions/meeting-actions.component.html
@@ -4,7 +4,7 @@
       <div class="act-head-text">
         <h3 class="act-title">Action items</h3>
         <span class="act-sub"
-          >Send them to Reminders, or write them into your note</span
+          >Send them to Apple Reminders, or write them into your note</span
         >
       </div>
       <button
@@ -63,11 +63,11 @@
                   type="button"
                   class="btn btn-ghost act-add"
                   [disabled]="busyIdx().has(it.idx)"
-                  [attr.aria-label]="'Add to Reminders: ' + it.text"
+                  [attr.aria-label]="'Add to Apple Reminders: ' + it.text"
                   (click)="addToReminders(it)"
                 >
                   {{
-                    busyIdx().has(it.idx) ? "Adding…" : "Add to Reminders"
+                    busyIdx().has(it.idx) ? "Adding…" : "Add to Apple Reminders"
                   }}
                 </button>
               }
@@ -82,4 +82,11 @@
     </ul>
   </div>
 }
+
+<app-smart-reminder-card
+  sourceKind="meeting"
+  [sourceId]="meetingId()"
+  [sourceTitle]="meetingTitle() ?? 'Meeting'"
+  [sourceRevision]="sourceRevision()"
+/>
   

--- a/src/app/features/detail/meeting-actions/meeting-actions.component.ts
+++ b/src/app/features/detail/meeting-actions/meeting-actions.component.ts
@@ -11,6 +11,7 @@ import {
 import { IpcService } from "../../../core/ipc.service";
 import type { ActionItem } from "../../../core/models";
 import { ErrorCopyService } from "../../../core/copy/error-copy.service";
+import { SmartReminderCardComponent } from "../../reminders/smart-reminder-card/smart-reminder-card.component";
 
 /**
  * "Action items" — a glass panel listing the action-item checklist parsed from a
@@ -31,8 +32,7 @@ import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 @Component({
   selector: "app-meeting-actions",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  // Hide the host entirely when there are no items (no empty panel).
-  host: { "[hidden]": "items().length === 0" },
+  imports: [SmartReminderCardComponent],
   templateUrl: "./meeting-actions.component.html",
   styleUrl: "./meeting-actions.component.scss",
 })
@@ -43,6 +43,8 @@ export class MeetingActionsComponent implements OnInit {
 
   /** The meeting whose note's action items are listed + patched. */
   readonly meetingId = input.required<string>();
+  readonly meetingTitle = input<string | null>(null);
+  readonly sourceRevision = input<string | null>(null);
 
   /** The parsed action items; empty before load (and while none exist). */
   readonly items = signal<ActionItem[]>([]);

--- a/src/app/features/detail/note-panel/note-panel.component.html
+++ b/src/app/features/detail/note-panel/note-panel.component.html
@@ -452,7 +452,11 @@
   }
 
   <!-- ACTION ITEMS (Reminders + Obsidian Tasks; hidden when none). -->
-  <app-meeting-actions [meetingId]="meetingId()" />
+  <app-meeting-actions
+    [meetingId]="meetingId()"
+    [meetingTitle]="meetingTitle()"
+    [sourceRevision]="noteRaw()"
+  />
 
   <!-- "Ask about this meeting" moved OUT of this in-flow Note panel into the
        detail shell's summoned right-side drawer (2026-07 slideout), so the

--- a/src/app/features/notes/note-editor/note-editor.component.html
+++ b/src/app/features/notes/note-editor/note-editor.component.html
@@ -654,6 +654,15 @@
             </div>
           }
 
+          @if (!embedded() && !doc.locked) {
+            <app-smart-reminder-card
+              sourceKind="note"
+              [sourceId]="doc.id"
+              [sourceTitle]="title() || doc.title"
+              [sourceRevision]="doc.updatedAt"
+            />
+          }
+
         </article>
       }
     }

--- a/src/app/features/notes/note-editor/note-editor.component.ts
+++ b/src/app/features/notes/note-editor/note-editor.component.ts
@@ -67,6 +67,7 @@ import {
   type PropertySchemaField,
 } from "./property-field-types";
 import { ErrorCopyService } from "../../../core/copy/error-copy.service";
+import { SmartReminderCardComponent } from "../../reminders/smart-reminder-card/smart-reminder-card.component";
 
 /** The autosave indicator state. */
 type SaveState = "idle" | "saving" | "saved" | "error";
@@ -183,6 +184,7 @@ const NOTE_CHAT_OPEN_KEY = "murmur-note-chat-open";
     NoteSharePanelComponent,
     NoteChatComponent,
     MurToggleComponent,
+    SmartReminderCardComponent,
     FormsModule,
   ],
   templateUrl: "./note-editor.component.html",

--- a/src/app/features/reminders/reminder-composer/reminder-composer.component.html
+++ b/src/app/features/reminders/reminder-composer/reminder-composer.component.html
@@ -1,0 +1,163 @@
+@if (service.request() && listenerState() === "ready") {
+  <div class="composer-backdrop">
+    <button
+      type="button"
+      class="composer-scrim"
+      aria-label="Close reminder composer"
+      [disabled]="busy()"
+      (click)="close()"
+    ></button>
+    <section
+      #panel
+      class="composer-panel"
+      role="dialog"
+      aria-modal="true"
+      tabindex="-1"
+      [attr.aria-labelledby]="'reminder-composer-title'"
+    >
+      <header class="composer-head">
+        <div>
+          <p class="composer-eyebrow">Murmur reminders</p>
+          <h2 id="reminder-composer-title">{{ heading() }}</h2>
+        </div>
+        <button
+          type="button"
+          class="composer-close"
+          aria-label="Close reminder composer"
+          [disabled]="busy()"
+          (click)="close()"
+        >
+          ×
+        </button>
+      </header>
+
+      <form class="composer-form" (submit)="submit($event)">
+        <label class="field">
+          <span>Title</span>
+          <input
+            #titleInput
+            type="text"
+            maxlength="240"
+            required
+            autocomplete="off"
+            [value]="title()"
+            [disabled]="busy()"
+            (input)="setTitle($any($event.target).value)"
+          />
+        </label>
+
+        <label class="field">
+          <span>Details <small>optional</small></span>
+          <textarea
+            maxlength="4000"
+            rows="3"
+            [value]="details()"
+            [disabled]="busy()"
+            (input)="setDetails($any($event.target).value)"
+          ></textarea>
+        </label>
+
+        <div class="due-grid">
+          <label class="field">
+            <span>Date</span>
+            <input
+              type="date"
+              required
+              [value]="date()"
+              [disabled]="busy()"
+              (input)="setDate($any($event.target).value)"
+            />
+          </label>
+          <label class="field">
+            <span>Time</span>
+            <input
+              type="time"
+              required
+              [value]="time()"
+              [disabled]="busy()"
+              (input)="setTime($any($event.target).value)"
+            />
+          </label>
+        </div>
+
+        <div class="repeat-row">
+          <label class="repeat-toggle">
+            <input
+              type="checkbox"
+              [checked]="repeats()"
+              [disabled]="busy()"
+              (change)="setRepeats($any($event.target).checked)"
+            />
+            <span>Repeat</span>
+          </label>
+          @if (repeats()) {
+            <span>every</span>
+            <input
+              class="repeat-number"
+              type="number"
+              min="1"
+              max="365"
+              required
+              aria-label="Repeat every"
+              [value]="repeatEvery()"
+              [disabled]="busy()"
+              (input)="setRepeatEvery($any($event.target).value)"
+            />
+            <select
+              aria-label="Repeat unit"
+              [value]="repeatUnit()"
+              [disabled]="busy()"
+              (change)="setRepeatUnit($any($event.target).value)"
+            >
+              <option value="days">days</option>
+              <option value="weeks">weeks</option>
+              <option value="months">months</option>
+              <option value="years">years</option>
+            </select>
+          }
+        </div>
+
+        <div class="sources-field">
+          <div class="sources-label">
+            <span>Sources <small>optional</small></span>
+            <span>{{ sources().length }} / 20</span>
+          </div>
+          <mur-source-picker
+            [selected]="sources()"
+            (selectedChange)="setSources($event)"
+            [allowedKinds]="allowedKinds"
+            [disabled]="busy()"
+            [selectionLimit]="20"
+            triggerLabel="+ Add source"
+            placeholder="Find a note or meeting…"
+          />
+          @if (sourceLimitReached()) {
+            <p class="field-hint">Maximum 20 sources.</p>
+          }
+        </div>
+
+        @if (error(); as message) {
+          <p class="composer-error" role="alert">{{ message }}</p>
+        }
+
+        <footer class="composer-actions">
+          <button
+            type="button"
+            class="btn btn-ghost"
+            [disabled]="busy()"
+            (click)="close()"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            class="btn btn-primary"
+            [disabled]="!valid() || busy()"
+          >
+            {{ submitLabel() }}
+          </button>
+        </footer>
+      </form>
+    </section>
+  </div>
+}

--- a/src/app/features/reminders/reminder-composer/reminder-composer.component.scss
+++ b/src/app/features/reminders/reminder-composer/reminder-composer.component.scss
@@ -1,0 +1,175 @@
+:host {
+  display: contents;
+}
+
+.composer-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-overlay);
+  display: grid;
+  place-items: center;
+  padding: var(--space-5);
+}
+
+.composer-scrim {
+  position: fixed;
+  inset: 0;
+  border: 0;
+  margin: 0;
+  padding: 0;
+  background: var(--surface-hover);
+  cursor: default;
+}
+
+.composer-panel {
+  position: relative;
+  z-index: 1;
+  width: min(560px, 100%);
+  max-height: calc(100vh - var(--space-7));
+  overflow-y: auto;
+  padding: var(--space-5);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-xl);
+  background: var(--surface-overlay);
+  box-shadow: var(--shadow-lg);
+  backdrop-filter: none;
+}
+
+.composer-head,
+.composer-actions,
+.sources-label,
+.repeat-row {
+  display: flex;
+  align-items: center;
+}
+
+.composer-head {
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-5);
+}
+
+.composer-head h2,
+.composer-eyebrow,
+.composer-error,
+.field-hint {
+  margin: 0;
+}
+
+.composer-eyebrow {
+  color: var(--accent-hover);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.composer-close {
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.composer-form,
+.field,
+.sources-field {
+  display: flex;
+  flex-direction: column;
+}
+
+.composer-form {
+  gap: var(--space-4);
+}
+
+.field,
+.sources-field {
+  gap: var(--space-2);
+}
+
+.field > span,
+.sources-label {
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+  font-weight: 600;
+}
+
+small,
+.field-hint {
+  color: var(--text-muted);
+  font-weight: 400;
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+}
+
+textarea {
+  resize: vertical;
+}
+
+.due-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.repeat-row {
+  min-height: 36px;
+  gap: var(--space-2);
+  color: var(--text-secondary);
+}
+
+.repeat-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--text-primary);
+}
+
+.repeat-toggle input {
+  width: auto;
+}
+
+.repeat-number {
+  width: 72px;
+}
+
+.repeat-row select {
+  width: auto;
+  background: var(--surface-overlay);
+}
+
+.sources-label {
+  justify-content: space-between;
+}
+
+.composer-error {
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+.composer-actions {
+  justify-content: flex-end;
+  gap: var(--space-2);
+  padding-top: var(--space-2);
+}
+
+@media (max-width: 640px) {
+  .composer-backdrop {
+    padding: var(--space-3);
+  }
+
+  .due-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .repeat-row {
+    flex-wrap: wrap;
+  }
+}

--- a/src/app/features/reminders/reminder-composer/reminder-composer.component.ts
+++ b/src/app/features/reminders/reminder-composer/reminder-composer.component.ts
@@ -1,0 +1,497 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  ElementRef,
+  Injector,
+  afterNextRender,
+  computed,
+  effect,
+  inject,
+  signal,
+  viewChild,
+} from "@angular/core";
+import type { UnlistenFn } from "@tauri-apps/api/event";
+import { IpcService } from "../../../core/ipc.service";
+import type {
+  ReminderDraft,
+  ReminderSourceUpdatedPayload,
+  ReminderRepeatUnit,
+  SourceKind,
+  SourceRef,
+} from "../../../core/models";
+import { SourcePickerComponent } from "../../../design-system/source-picker/source-picker.component";
+import { RemindersStore } from "../reminders.store";
+import {
+  ReminderComposerService,
+  type ReminderComposerRequest,
+} from "./reminder-composer.service";
+
+const DEFAULT_DUE_OFFSET_MS = 60 * 60 * 1000;
+const MAX_SOURCES = 20;
+const REMINDER_SOURCE_KINDS = ["meeting", "note"] as const;
+const FOCUSABLE_SELECTOR = [
+  "button:not([disabled])",
+  "a[href]",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+const OVERLAY_FOCUSABLE_SELECTOR = FOCUSABLE_SELECTOR.split(",")
+  .map((selector) => `.sp-overlay ${selector}`)
+  .join(",");
+
+function localDateParts(epoch: number): { date: string; time: string } {
+  const value = new Date(epoch);
+  const year = String(value.getFullYear()).padStart(4, "0");
+  const month = String(value.getMonth() + 1).padStart(2, "0");
+  const day = String(value.getDate()).padStart(2, "0");
+  const hours = String(value.getHours()).padStart(2, "0");
+  const minutes = String(value.getMinutes()).padStart(2, "0");
+  return { date: `${year}-${month}-${day}`, time: `${hours}:${minutes}` };
+}
+
+function matchesInvalidation(
+  source: Pick<SourceRef, "kind" | "id">,
+  invalidation: ReminderSourceUpdatedPayload,
+): boolean {
+  return source.kind === invalidation.kind && source.id === invalidation.id;
+}
+
+@Component({
+  selector: "app-reminder-composer",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [SourcePickerComponent],
+  host: {
+    "(document:keydown)": "onDocumentKeydown($event)",
+    "(document:mousedown)": "rememberPointerTarget($event)",
+  },
+  templateUrl: "./reminder-composer.component.html",
+  styleUrl: "./reminder-composer.component.scss",
+})
+export class ReminderComposerComponent {
+  readonly service = inject(ReminderComposerService);
+  private readonly store = inject(RemindersStore);
+  private readonly ipc = inject(IpcService);
+  private readonly injector = inject(Injector);
+  private readonly destroyRef = inject(DestroyRef);
+
+  private readonly titleInput =
+    viewChild<ElementRef<HTMLInputElement>>("titleInput");
+  private readonly panel = viewChild<ElementRef<HTMLElement>>("panel");
+
+  readonly title = signal("");
+  readonly details = signal("");
+  readonly date = signal("");
+  readonly time = signal("");
+  readonly repeats = signal(false);
+  readonly repeatEvery = signal(1);
+  readonly repeatUnit = signal<ReminderRepeatUnit>("weeks");
+  readonly sources = signal<SourceRef[]>([]);
+  readonly busy = signal(false);
+  readonly error = signal<string | null>(null);
+  readonly allowedKinds = REMINDER_SOURCE_KINDS;
+  private destroyed = false;
+  private sourceUpdateUnlisten: UnlistenFn | null = null;
+  private visibilityInvalidatedUnlisten: UnlistenFn | null = null;
+  private hydratedRequestKey: number | null = null;
+  private restoreFocusTo: HTMLElement | null = null;
+  private lastPointerTarget: HTMLElement | null = null;
+  readonly listenerState = signal<"pending" | "ready" | "failed">("pending");
+
+  readonly heading = computed(() => {
+    const request = this.service.request();
+    if (request?.mode === "edit") {
+      return "Edit reminder";
+    }
+    if (request?.mode === "suggestion") {
+      return "Review Smart reminder";
+    }
+    return "New reminder";
+  });
+
+  readonly submitLabel = computed(() => {
+    const request = this.service.request();
+    if (this.busy()) {
+      return request?.mode === "edit" ? "Saving…" : "Creating…";
+    }
+    return request?.mode === "edit" ? "Save changes" : "Create reminder";
+  });
+
+  readonly sourceLimitReached = computed(
+    () => this.sources().length >= MAX_SOURCES,
+  );
+
+  readonly valid = computed(() => {
+    const title = this.title().trim();
+    const due = this.dueEpoch();
+    const recurrenceValid =
+      !this.repeats() ||
+      (Number.isInteger(this.repeatEvery()) &&
+        this.repeatEvery() >= 1 &&
+        this.repeatEvery() <= 365);
+    return (
+      title.length > 0 &&
+      title.length <= 240 &&
+      due !== null &&
+      recurrenceValid &&
+      this.sources().length <= MAX_SOURCES
+    );
+  });
+
+  constructor() {
+    void this.installUpdateListeners();
+    this.destroyRef.onDestroy(() => {
+      this.destroyed = true;
+      this.sourceUpdateUnlisten?.();
+      this.sourceUpdateUnlisten = null;
+      this.visibilityInvalidatedUnlisten?.();
+      this.visibilityInvalidatedUnlisten = null;
+    });
+
+    effect(() => {
+      const request = this.service.request();
+      if (!request) {
+        return;
+      }
+      const listenerState = this.listenerState();
+      if (listenerState === "pending") {
+        // Event registration has no replay. A request created in this interval
+        // cannot be proven newer than a lock event that might have been missed.
+        // Purge it immediately: a hung registration must not retain its title
+        // indefinitely in the root composer-service signal.
+        this.purgeInvalidatedRequest();
+        return;
+      }
+      if (listenerState === "failed") {
+        this.purgeInvalidatedRequest();
+        return;
+      }
+      this.hydrate(request);
+      afterNextRender(() => this.titleInput()?.nativeElement.focus(), {
+        injector: this.injector,
+      });
+    });
+  }
+
+  private async installUpdateListeners(): Promise<void> {
+    try {
+      await Promise.all([
+        this.installSourceUpdateListener(),
+        this.installVisibilityInvalidatedListener(),
+      ]);
+      if (!this.destroyed) {
+        // Listener registration has no replay. A request that already exists at
+        // this boundary may have been created before a lock event that landed
+        // while registration was pending. Purge synchronously before publishing
+        // `ready`; no request/event task can interleave between these two lines.
+        // The effect's pending-state purge remains a second line of defence, but
+        // cannot be the authority because Angular schedules effects.
+        this.purgeInvalidatedRequest();
+        this.listenerState.set("ready");
+      }
+    } catch {
+      if (!this.destroyed) {
+        // A composer request must not retain or hydrate source-derived text
+        // when this renderer cannot observe a later lock transition.
+        this.listenerState.set("failed");
+        this.purgeInvalidatedRequest();
+      }
+    }
+  }
+
+  private async installSourceUpdateListener(): Promise<void> {
+    const unlisten = await this.ipc.onReminderSourceUpdated((payload) => {
+      if (
+        this.destroyed ||
+        !payload ||
+        (payload.kind !== "meeting" && payload.kind !== "note") ||
+        typeof payload.id !== "string"
+      ) {
+        return;
+      }
+      const request = this.service.request();
+      const requestSources =
+        request?.mode === "edit"
+          ? request.reminder.sources
+          : request?.mode === "suggestion"
+            ? [request.suggestion.source]
+            : (request?.sources ?? []);
+      if (
+        !this.sources().some((source) =>
+          matchesInvalidation(source, payload),
+        ) &&
+        !requestSources.some((source) => matchesInvalidation(source, payload))
+      ) {
+        return;
+      }
+
+      // The event is content-free but authoritative: close and purge
+      // synchronously so neither an open modal nor retained component signals
+      // can keep a sealed source title alive.
+      this.purgeInvalidatedRequest();
+    });
+    if (this.destroyed) {
+      unlisten();
+      return;
+    }
+    this.sourceUpdateUnlisten = unlisten;
+  }
+
+  private purgeInvalidatedRequest(): void {
+    this.closeCurrentRequest();
+    this.title.set("");
+    this.details.set("");
+    this.date.set("");
+    this.time.set("");
+    this.repeats.set(false);
+    this.repeatEvery.set(1);
+    this.repeatUnit.set("weeks");
+    this.sources.set([]);
+    this.busy.set(false);
+    this.error.set(null);
+  }
+
+  private async installVisibilityInvalidatedListener(): Promise<void> {
+    const unlisten = await this.ipc.onReminderVisibilityInvalidated(() => {
+      if (!this.destroyed) {
+        this.purgeInvalidatedRequest();
+      }
+    });
+    if (this.destroyed) {
+      unlisten();
+      return;
+    }
+    this.visibilityInvalidatedUnlisten = unlisten;
+  }
+
+  close(): void {
+    if (!this.busy()) {
+      this.closeCurrentRequest();
+    }
+  }
+
+  rememberPointerTarget(event: MouseEvent): void {
+    if (!this.service.request() && event.target instanceof HTMLElement) {
+      this.lastPointerTarget = event.target;
+    }
+  }
+
+  onDocumentKeydown(event: KeyboardEvent): void {
+    if (!this.service.request() || this.listenerState() !== "ready") {
+      return;
+    }
+    if (event.key === "Escape" && !event.defaultPrevented) {
+      event.preventDefault();
+      this.close();
+      return;
+    }
+    if (event.key !== "Tab") {
+      return;
+    }
+
+    const panel = this.panel()?.nativeElement;
+    if (!panel) {
+      return;
+    }
+    const focusable = [
+      ...panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ...document.querySelectorAll<HTMLElement>(OVERLAY_FOCUSABLE_SELECTOR),
+    ].filter((element) => element.getClientRects().length > 0);
+    if (focusable.length === 0) {
+      event.preventDefault();
+      panel.focus();
+      return;
+    }
+
+    const active = document.activeElement;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (!focusable.includes(active as HTMLElement)) {
+      event.preventDefault();
+      first.focus();
+    } else if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  setTitle(value: string): void {
+    this.title.set(value);
+  }
+
+  setDetails(value: string): void {
+    this.details.set(value);
+  }
+
+  setDate(value: string): void {
+    this.date.set(value);
+  }
+
+  setTime(value: string): void {
+    this.time.set(value);
+  }
+
+  setRepeats(checked: boolean): void {
+    this.repeats.set(checked);
+  }
+
+  setRepeatEvery(value: string): void {
+    this.repeatEvery.set(Number(value));
+  }
+
+  setRepeatUnit(value: string): void {
+    this.repeatUnit.set(value as ReminderRepeatUnit);
+  }
+
+  setSources(sources: SourceRef[]): void {
+    this.sources.set(sources.slice(0, MAX_SOURCES));
+  }
+
+  async submit(event: Event): Promise<void> {
+    event.preventDefault();
+    const request = this.service.request();
+    const draft = this.toDraft();
+    if (!request || !draft || this.busy()) {
+      return;
+    }
+    const submittedKey = request.key;
+    this.busy.set(true);
+    this.error.set(null);
+    try {
+      if (request.mode === "edit") {
+        await this.store.update(request.reminder.id, draft);
+      } else if (request.mode === "suggestion") {
+        await this.store.acceptSuggestion(request.suggestion, draft);
+      } else {
+        await this.store.create(draft);
+      }
+      if (this.service.request()?.key !== submittedKey) {
+        return;
+      }
+      this.busy.set(false);
+      this.closeCurrentRequest();
+    } catch {
+      if (this.service.request()?.key === submittedKey) {
+        this.error.set("Couldn’t save this reminder. Please try again.");
+      }
+    } finally {
+      if (this.service.request()?.key === submittedKey) {
+        this.busy.set(false);
+      }
+    }
+  }
+
+  private hydrate(request: ReminderComposerRequest): void {
+    if (request.key !== this.hydratedRequestKey) {
+      const active = document.activeElement;
+      const candidate =
+        active instanceof HTMLElement && active !== document.body
+          ? active
+          : this.lastPointerTarget;
+      if (
+        candidate &&
+        candidate.isConnected &&
+        !this.panel()?.nativeElement.contains(candidate)
+      ) {
+        this.restoreFocusTo = candidate;
+      }
+      this.lastPointerTarget = null;
+      this.hydratedRequestKey = request.key;
+    }
+    const defaultDue = Date.now() + DEFAULT_DUE_OFFSET_MS;
+    if (request.mode === "edit") {
+      this.title.set(request.reminder.title);
+      this.details.set(request.reminder.details ?? "");
+      this.setDue(request.reminder.dueAt);
+      this.repeats.set(request.reminder.repeatEvery !== null);
+      this.repeatEvery.set(request.reminder.repeatEvery ?? 1);
+      this.repeatUnit.set(request.reminder.repeatUnit ?? "weeks");
+      this.sources.set(request.reminder.sources);
+    } else if (request.mode === "suggestion") {
+      this.title.set(request.suggestion.title);
+      this.details.set("");
+      if (request.suggestion.suggestedDueAt === null) {
+        this.date.set("");
+        this.time.set("");
+      } else {
+        this.setDue(request.suggestion.suggestedDueAt);
+      }
+      this.repeats.set(false);
+      this.repeatEvery.set(1);
+      this.repeatUnit.set("weeks");
+      this.sources.set([request.suggestion.source]);
+    } else {
+      this.title.set(request.title);
+      this.details.set("");
+      this.setDue(request.dueAt ?? defaultDue);
+      this.repeats.set(false);
+      this.repeatEvery.set(1);
+      this.repeatUnit.set("weeks");
+      this.sources.set(request.sources);
+    }
+    this.error.set(null);
+  }
+
+  private closeCurrentRequest(): void {
+    const restoreTarget = this.restoreFocusTo;
+    this.service.close();
+    this.hydratedRequestKey = null;
+    this.restoreFocusTo = null;
+    afterNextRender(
+      () => {
+        if (
+          !this.service.request() &&
+          restoreTarget?.isConnected &&
+          !restoreTarget.hasAttribute("disabled")
+        ) {
+          restoreTarget.focus();
+        }
+      },
+      { injector: this.injector },
+    );
+  }
+
+  private setDue(epoch: number): void {
+    const parts = localDateParts(epoch);
+    this.date.set(parts.date);
+    this.time.set(parts.time);
+  }
+
+  private dueEpoch(): number | null {
+    if (!this.date() || !this.time()) {
+      return null;
+    }
+    const value = new Date(`${this.date()}T${this.time()}`);
+    const epoch = value.getTime();
+    if (!Number.isFinite(epoch)) {
+      return null;
+    }
+    const parts = localDateParts(epoch);
+    return parts.date === this.date() && parts.time === this.time()
+      ? epoch
+      : null;
+  }
+
+  private toDraft(): ReminderDraft | null {
+    const dueAt = this.dueEpoch();
+    if (!this.valid() || dueAt === null) {
+      return null;
+    }
+    return {
+      title: this.title().trim(),
+      details: this.details().trim() || null,
+      dueAt,
+      repeatEvery: this.repeats() ? this.repeatEvery() : null,
+      repeatUnit: this.repeats() ? this.repeatUnit() : null,
+      sources: this.sources().map((source) => ({
+        kind: source.kind as SourceKind,
+        id: source.id,
+      })),
+    };
+  }
+}

--- a/src/app/features/reminders/reminder-composer/reminder-composer.service.ts
+++ b/src/app/features/reminders/reminder-composer/reminder-composer.service.ts
@@ -1,0 +1,69 @@
+import { Injectable, signal } from "@angular/core";
+import type {
+  ReminderSourceView,
+  ReminderSuggestionView,
+  ReminderView,
+  SourceRef,
+} from "../../../core/models";
+
+export type ReminderComposerRequest =
+  | {
+      key: number;
+      mode: "create";
+      title: string;
+      dueAt: number | null;
+      sources: SourceRef[];
+    }
+  | {
+      key: number;
+      mode: "edit";
+      reminder: ReminderView;
+    }
+  | {
+      key: number;
+      mode: "suggestion";
+      suggestion: ReminderSuggestionView;
+    };
+
+/** One root-provided request channel for the app-wide reminder composer. */
+@Injectable({ providedIn: "root" })
+export class ReminderComposerService {
+  private readonly _request = signal<ReminderComposerRequest | null>(null);
+  readonly request = this._request.asReadonly();
+  private nextKey = 0;
+
+  openCreate(options?: {
+    title?: string;
+    dueAt?: number | null;
+    source?: ReminderSourceView | SourceRef;
+  }): void {
+    const source = options?.source;
+    this._request.set({
+      key: ++this.nextKey,
+      mode: "create",
+      title: options?.title ?? "",
+      dueAt: options?.dueAt ?? null,
+      sources: source ? [source] : [],
+    });
+  }
+
+  openEdit(reminder: ReminderView): void {
+    this._request.set({
+      key: ++this.nextKey,
+      mode: "edit",
+      reminder,
+    });
+  }
+
+  openSuggestion(suggestion: ReminderSuggestionView): void {
+    this._request.set({
+      key: ++this.nextKey,
+      mode: "suggestion",
+      suggestion,
+    });
+  }
+
+  close(): void {
+    this._request.set(null);
+  }
+}

--- a/src/app/features/reminders/reminders.store.ts
+++ b/src/app/features/reminders/reminders.store.ts
@@ -1,0 +1,426 @@
+import {
+  DestroyRef,
+  Injectable,
+  computed,
+  inject,
+  signal,
+} from "@angular/core";
+import type { UnlistenFn } from "@tauri-apps/api/event";
+import { IpcService } from "../../core/ipc.service";
+import type {
+  ReminderDraft,
+  ReminderInboxItem,
+  ReminderSourceUpdatedPayload,
+  ReminderSuggestionView,
+  ReminderView,
+} from "../../core/models";
+
+interface ReminderListenerReadiness {
+  updatesReady: boolean;
+  privacyReady: boolean;
+}
+
+const LIVE_UPDATES_WARNING =
+  "Live reminder updates are unavailable. Retry to reconnect.";
+
+function validDueInboxCount(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isFinite(value) &&
+    Number.isInteger(value) &&
+    value >= 0
+  );
+}
+
+function validSourceInvalidation(
+  value: ReminderSourceUpdatedPayload | null | undefined,
+): value is ReminderSourceUpdatedPayload {
+  return (
+    (value?.kind === "meeting" || value?.kind === "note") &&
+    typeof value.id === "string" &&
+    value.id.length > 0
+  );
+}
+
+function withoutSourceMetadata(
+  reminder: ReminderView,
+  invalidation: ReminderSourceUpdatedPayload | null,
+): ReminderView {
+  const sources =
+    invalidation === null
+      ? []
+      : reminder.sources.filter(
+          (source) =>
+            source.kind !== invalidation.kind || source.id !== invalidation.id,
+        );
+  return sources.length === reminder.sources.length
+    ? reminder
+    : { ...reminder, sources };
+}
+
+/**
+ * Root-persisted reminder state. Cached rows survive route destruction and remain
+ * visible during every unconditional refresh (stale-while-revalidate).
+ */
+@Injectable({ providedIn: "root" })
+export class RemindersStore {
+  private readonly ipc = inject(IpcService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  private readonly _inbox = signal<ReminderInboxItem[]>([]);
+  readonly inbox = this._inbox.asReadonly();
+  private readonly _upcoming = signal<ReminderView[]>([]);
+  readonly upcoming = this._upcoming.asReadonly();
+  private readonly _completed = signal<ReminderView[]>([]);
+  readonly completed = this._completed.asReadonly();
+  private readonly _dueInboxCount = signal(0);
+  readonly dueInboxCount = this._dueInboxCount.asReadonly();
+  private readonly _loading = signal(false);
+  readonly loading = this._loading.asReadonly();
+  private readonly _error = signal<string | null>(null);
+  readonly error = this._error.asReadonly();
+  private readonly _busy = signal<ReadonlySet<string>>(new Set());
+  readonly busy = this._busy.asReadonly();
+  private readonly _revision = signal(0);
+  /** Content-free invalidation clock for contextual Smart suggestion cards. */
+  readonly revision = this._revision.asReadonly();
+
+  readonly hasCachedRows = computed(
+    () =>
+      this._inbox().length +
+        this._upcoming().length +
+        this._completed().length >
+      0,
+  );
+
+  private summaryStarted = false;
+  private rowsRequested = false;
+  private loadSequence = 0;
+  private countWriteEpoch = 0;
+  private destroyed = false;
+  private remindersUnlisten: UnlistenFn | null = null;
+  private reminderSourceUnlisten: UnlistenFn | null = null;
+  private reminderVisibilityUnlisten: UnlistenFn | null = null;
+  /** Coalesces only the current install attempt; failed slots remain retryable. */
+  private listenerAttempt: Promise<ReminderListenerReadiness> | null = null;
+
+  constructor() {
+    this.destroyRef.onDestroy(() => {
+      this.destroyed = true;
+      this.remindersUnlisten?.();
+      this.remindersUnlisten = null;
+      this.reminderSourceUnlisten?.();
+      this.reminderSourceUnlisten = null;
+      this.reminderVisibilityUnlisten?.();
+      this.reminderVisibilityUnlisten = null;
+    });
+  }
+
+  /**
+   * Starts the content-free shell projection exactly once. The count event may
+   * update navigation immediately; reminder rows are only fetched after the page
+   * has first loaded them.
+   */
+  async initSummary(): Promise<void> {
+    const takeSnapshot = !this.summaryStarted;
+    this.summaryStarted = true;
+    await this.ensureListeners();
+    if (this.destroyed || !takeSnapshot) {
+      return;
+    }
+
+    // Subscribe BEFORE taking the snapshot. If an event lands while the summary
+    // request is in flight, its newer count wins instead of being overwritten
+    // by the stale response.
+    const summaryEpoch = this.countWriteEpoch;
+    try {
+      const summary = await this.ipc.getReminderSummary();
+      if (!this.destroyed && this.countWriteEpoch === summaryEpoch) {
+        this.applyDueInboxCount(summary?.dueInboxCount);
+      }
+    } catch {
+      // Shell startup stays best-effort; the full route owns a visible error.
+    }
+  }
+
+  /** Unconditional refresh with a stale-result token; cached rows remain visible. */
+  async refresh(): Promise<void> {
+    const sequence = ++this.loadSequence;
+    // Set this before invoking IPC so an event racing the very first request
+    // launches a newer request whose sequence supersedes the stale response.
+    this.rowsRequested = true;
+    this._loading.set(true);
+    this._error.set(null);
+    try {
+      // The first canonical snapshot must not race ahead of either invalidation
+      // listener. An event arriving during that snapshot launches a newer
+      // sequence, so this response can no longer restore stale source metadata.
+      const readiness = await this.ensureListeners();
+      if (this.destroyed || sequence !== this.loadSequence) {
+        return;
+      }
+      if (!readiness.privacyReady) {
+        throw new Error("Reminder source visibility listeners are unavailable");
+      }
+      const snapshot = await this.ipc.listReminders();
+      if (this.destroyed || sequence !== this.loadSequence) {
+        return;
+      }
+      this._inbox.set(snapshot.inbox);
+      this._upcoming.set(snapshot.upcoming);
+      this._completed.set(snapshot.completed);
+      this.applyDueInboxCount(snapshot.dueInboxCount);
+      this._error.set(readiness.updatesReady ? null : LIVE_UPDATES_WARNING);
+    } catch {
+      if (sequence === this.loadSequence) {
+        this._error.set("Couldn’t load reminders. Please try again.");
+      }
+    } finally {
+      if (sequence === this.loadSequence) {
+        this._loading.set(false);
+      }
+    }
+  }
+
+  private ensureListeners(): Promise<ReminderListenerReadiness> {
+    const readiness = this.listenerReadiness();
+    if (this.destroyed || (readiness.updatesReady && readiness.privacyReady)) {
+      return Promise.resolve(readiness);
+    }
+    if (this.listenerAttempt) {
+      return this.listenerAttempt;
+    }
+
+    const attempt = Promise.all([
+      this.remindersUnlisten
+        ? Promise.resolve(true)
+        : this.installRemindersListener(),
+      this.reminderSourceUnlisten
+        ? Promise.resolve(true)
+        : this.installReminderSourceListener(),
+      this.reminderVisibilityUnlisten
+        ? Promise.resolve(true)
+        : this.installReminderVisibilityListener(),
+    ]).then(() => this.listenerReadiness());
+    this.listenerAttempt = attempt;
+    const clearAttempt = (): void => {
+      if (this.listenerAttempt === attempt) {
+        this.listenerAttempt = null;
+      }
+    };
+    void attempt.then(clearAttempt, clearAttempt);
+    return attempt;
+  }
+
+  private listenerReadiness(): ReminderListenerReadiness {
+    return {
+      updatesReady: this.remindersUnlisten !== null,
+      privacyReady:
+        this.reminderSourceUnlisten !== null &&
+        this.reminderVisibilityUnlisten !== null,
+    };
+  }
+
+  private async installRemindersListener(): Promise<boolean> {
+    if (this.remindersUnlisten) {
+      return true;
+    }
+    try {
+      const unlisten = await this.ipc.onRemindersUpdated((payload) => {
+        if (this.destroyed) {
+          return;
+        }
+        this.applyDueInboxCount(payload?.dueInboxCount);
+        this._revision.update((value) => value + 1);
+        if (this.rowsRequested) {
+          void this.refresh();
+        }
+      });
+      if (this.destroyed) {
+        unlisten();
+        return false;
+      }
+      if (this.remindersUnlisten) {
+        unlisten();
+        return true;
+      }
+      this.remindersUnlisten = unlisten;
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async installReminderSourceListener(): Promise<boolean> {
+    if (this.reminderSourceUnlisten) {
+      return true;
+    }
+    try {
+      const unlisten = await this.ipc.onReminderSourceUpdated((payload) => {
+        if (this.destroyed || !validSourceInvalidation(payload)) {
+          return;
+        }
+
+        // Fail closed before any awaited IPC: stale-while-revalidate must never
+        // keep a now-sealed title rendered if the refresh stalls or fails.
+        this.scrubCachedSourceMetadata(payload);
+        if (this.rowsRequested) {
+          void this.refresh();
+        }
+      });
+      if (this.destroyed) {
+        unlisten();
+        return false;
+      }
+      if (this.reminderSourceUnlisten) {
+        unlisten();
+        return true;
+      }
+      this.reminderSourceUnlisten = unlisten;
+      return true;
+    } catch {
+      // `emit()` only confirms dispatch into Tauri's event bus, not that this
+      // renderer subscribed. Without this listener a later source lifecycle
+      // change could leave cached metadata visible indefinitely.
+      this.scrubCachedSourceMetadata(null);
+      return false;
+    }
+  }
+
+  private async installReminderVisibilityListener(): Promise<boolean> {
+    if (this.reminderVisibilityUnlisten) {
+      return true;
+    }
+    try {
+      const unlisten = await this.ipc.onReminderVisibilityInvalidated(() => {
+        if (this.destroyed) {
+          return;
+        }
+
+        // Lock authority was revoked globally. Remove every live title before
+        // the gated canonical refresh is even allowed to begin.
+        this.scrubCachedSourceMetadata(null);
+        if (this.rowsRequested) {
+          void this.refresh();
+        }
+      });
+      if (this.destroyed) {
+        unlisten();
+        return false;
+      }
+      if (this.reminderVisibilityUnlisten) {
+        unlisten();
+        return true;
+      }
+      this.reminderVisibilityUnlisten = unlisten;
+      return true;
+    } catch {
+      // Never load or retain source titles when global lock revocation cannot
+      // be observed by this renderer.
+      this.scrubCachedSourceMetadata(null);
+      return false;
+    }
+  }
+
+  private scrubCachedSourceMetadata(
+    invalidation: ReminderSourceUpdatedPayload | null,
+  ): void {
+    this._inbox.update((rows) =>
+      rows.map((row) => {
+        const reminder = withoutSourceMetadata(row.reminder, invalidation);
+        return reminder === row.reminder ? row : { ...row, reminder };
+      }),
+    );
+    this._upcoming.update((rows) =>
+      rows.map((row) => withoutSourceMetadata(row, invalidation)),
+    );
+    this._completed.update((rows) =>
+      rows.map((row) => withoutSourceMetadata(row, invalidation)),
+    );
+  }
+
+  private applyDueInboxCount(value: unknown): boolean {
+    if (!validDueInboxCount(value)) {
+      return false;
+    }
+    this.countWriteEpoch += 1;
+    this._dueInboxCount.set(value);
+    return true;
+  }
+
+  async create(draft: ReminderDraft): Promise<ReminderView> {
+    return this.confirmThenRefresh("create", () =>
+      this.ipc.createMurmurReminder(draft),
+    );
+  }
+
+  async update(
+    reminderId: string,
+    draft: ReminderDraft,
+  ): Promise<ReminderView> {
+    return this.confirmThenRefresh(reminderId, () =>
+      this.ipc.updateMurmurReminder(reminderId, draft),
+    );
+  }
+
+  async delete(reminderId: string): Promise<void> {
+    await this.confirmThenRefresh(reminderId, () =>
+      this.ipc.deleteMurmurReminder(reminderId),
+    );
+  }
+
+  async complete(reminderId: string, expectedDueAt: number): Promise<void> {
+    await this.confirmThenRefresh(reminderId, () =>
+      this.ipc.completeMurmurReminder(reminderId, expectedDueAt),
+    );
+  }
+
+  async dismissOccurrence(occurrenceId: string): Promise<void> {
+    await this.confirmThenRefresh(occurrenceId, () =>
+      this.ipc.dismissMurmurReminderOccurrence(occurrenceId),
+    );
+  }
+
+  async acceptSuggestion(
+    suggestion: ReminderSuggestionView,
+    draft: ReminderDraft,
+  ): Promise<ReminderView> {
+    return this.confirmThenRefresh(suggestion.id, () =>
+      this.ipc.acceptReminderSuggestion(suggestion.id, draft),
+    );
+  }
+
+  private async confirmThenRefresh<T>(
+    key: string,
+    action: () => Promise<T>,
+  ): Promise<T> {
+    if (this._busy().has(key)) {
+      throw new Error("Reminder action already in progress");
+    }
+    this.setBusy(key, true);
+    this._error.set(null);
+    try {
+      const result = await action();
+      await this.refresh();
+      this._revision.update((value) => value + 1);
+      return result;
+    } catch (error) {
+      this._error.set("Couldn’t update reminders. Please try again.");
+      throw error;
+    } finally {
+      this.setBusy(key, false);
+    }
+  }
+
+  private setBusy(key: string, busy: boolean): void {
+    this._busy.update((current) => {
+      const next = new Set(current);
+      if (busy) {
+        next.add(key);
+      } else {
+        next.delete(key);
+      }
+      return next;
+    });
+  }
+}

--- a/src/app/features/reminders/reminders/reminders.component.html
+++ b/src/app/features/reminders/reminders/reminders.component.html
@@ -1,0 +1,206 @@
+<section class="reminders-page">
+  <header class="page-head">
+    <div>
+      <p class="page-eyebrow">Workspace</p>
+      <h1>Reminders</h1>
+      <p class="page-subtitle">
+        Follow-ups connected to the notes and meetings that shaped them.
+      </p>
+    </div>
+    <button type="button" class="btn btn-primary" (click)="newReminder()">
+      New reminder
+    </button>
+  </header>
+
+  <nav class="segments" aria-label="Reminder views">
+    <button
+      type="button"
+      [class.active]="segment() === 'inbox'"
+      [attr.aria-pressed]="segment() === 'inbox'"
+      (click)="selectSegment('inbox')"
+    >
+      Inbox
+      @if (counts().inbox > 0) {
+        <span class="count">{{ counts().inbox }}</span>
+      }
+    </button>
+    <button
+      type="button"
+      [class.active]="segment() === 'upcoming'"
+      [attr.aria-pressed]="segment() === 'upcoming'"
+      (click)="selectSegment('upcoming')"
+    >
+      Upcoming
+      @if (counts().upcoming > 0) {
+        <span class="count">{{ counts().upcoming }}</span>
+      }
+    </button>
+    <button
+      type="button"
+      [class.active]="segment() === 'completed'"
+      [attr.aria-pressed]="segment() === 'completed'"
+      (click)="selectSegment('completed')"
+    >
+      Completed
+      @if (counts().completed > 0) {
+        <span class="count">{{ counts().completed }}</span>
+      }
+    </button>
+  </nav>
+
+  @if (store.error(); as message) {
+    <div class="banner error-banner" role="alert">
+      <span>{{ message }}</span>
+      <button type="button" class="btn btn-ghost" (click)="store.refresh()">
+        Retry
+      </button>
+    </div>
+  }
+
+  @if (rows().length === 0 && store.loading()) {
+    <div class="empty-state">
+      <span class="loading-orb" aria-hidden="true"></span>
+      <p>Loading reminders…</p>
+    </div>
+  } @else if (rows().length === 0 && !store.error()) {
+    <div class="empty-state">
+      <div class="empty-icon" aria-hidden="true">✓</div>
+      <h2>{{ emptyCopy().title }}</h2>
+      <p>{{ emptyCopy().body }}</p>
+      @if (segment() !== "completed") {
+        <button type="button" class="btn btn-primary" (click)="newReminder()">
+          Create a reminder
+        </button>
+      }
+    </div>
+  } @else {
+    <div class="reminder-groups" [attr.aria-busy]="store.loading()">
+      @for (group of groups(); track group.id) {
+        <section
+          class="reminder-group"
+          [attr.aria-labelledby]="'group-' + group.id"
+        >
+          <h2 [id]="'group-' + group.id">{{ group.label }}</h2>
+          <ul class="reminder-list">
+            @for (row of group.rows; track row.key) {
+              <li class="card reminder-card">
+                <div class="reminder-main">
+                  <div class="reminder-title-row">
+                    <h3>{{ row.reminder.title }}</h3>
+                    @if (row.reminder.origin === "smart") {
+                      <span
+                        class="smart-badge"
+                        title="Created from a reviewed Smart suggestion"
+                      >
+                        ✦ Smart
+                      </span>
+                    }
+                  </div>
+                  <div class="reminder-meta">
+                    <span>{{ row.dueLabel }}</span>
+                    @if (row.recurrenceLabel; as recurrence) {
+                      <span>↻ {{ recurrence }}</span>
+                    }
+                  </div>
+                  @if (row.reminder.details; as details) {
+                    <p class="reminder-details">{{ details }}</p>
+                  }
+                  @if (row.reminder.sources.length > 0) {
+                    <div class="source-chips" aria-label="Reminder sources">
+                      @for (
+                        source of row.reminder.sources;
+                        track source.kind + source.id
+                      ) {
+                        <button
+                          type="button"
+                          class="source-chip"
+                          (click)="openSource(source)"
+                        >
+                          {{ source.kind === "meeting" ? "Meeting" : "Note" }} ·
+                          {{ source.title }}
+                        </button>
+                      }
+                    </div>
+                  }
+                </div>
+
+                <div class="reminder-actions">
+                  @if (segment() !== "completed") {
+                    <button
+                      type="button"
+                      class="btn btn-primary"
+                      [disabled]="
+                        store.busy().has(row.key) ||
+                        store.busy().has(row.reminder.id)
+                      "
+                      (click)="complete(row)"
+                    >
+                      Complete
+                    </button>
+                    @if (row.occurrenceId) {
+                      <button
+                        type="button"
+                        class="btn btn-ghost"
+                        [disabled]="
+                          store.busy().has(row.occurrenceId) ||
+                          store.busy().has(row.reminder.id)
+                        "
+                        (click)="dismiss(row)"
+                      >
+                        Dismiss
+                      </button>
+                    }
+                  }
+                  <button
+                    type="button"
+                    class="btn btn-ghost"
+                    [disabled]="store.busy().has(row.reminder.id)"
+                    (click)="edit(row.reminder)"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    class="btn btn-ghost danger-action"
+                    [disabled]="store.busy().has(row.reminder.id)"
+                    (click)="askDelete(row.reminder.id)"
+                  >
+                    Delete
+                  </button>
+                </div>
+
+                @if (confirmingDelete() === row.reminder.id) {
+                  <div
+                    class="delete-confirm"
+                    role="alertdialog"
+                    aria-label="Delete reminder"
+                  >
+                    <span>Delete this reminder permanently?</span>
+                    <div>
+                      <button
+                        type="button"
+                        class="btn btn-ghost"
+                        [disabled]="store.busy().has(row.reminder.id)"
+                        (click)="cancelDelete()"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        class="btn btn-danger"
+                        [disabled]="store.busy().has(row.reminder.id)"
+                        (click)="delete(row.reminder.id)"
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                }
+              </li>
+            }
+          </ul>
+        </section>
+      }
+    </div>
+  }
+</section>

--- a/src/app/features/reminders/reminders/reminders.component.scss
+++ b/src/app/features/reminders/reminders/reminders.component.scss
@@ -1,0 +1,248 @@
+:host {
+  display: block;
+  width: 100%;
+}
+
+.reminders-page {
+  width: min(var(--content-max), 100%);
+  margin: 0 auto;
+  padding: var(--space-6) var(--space-5) var(--space-8);
+}
+
+.page-head,
+.reminder-title-row,
+.reminder-meta,
+.reminder-actions,
+.source-chips,
+.delete-confirm,
+.delete-confirm > div {
+  display: flex;
+  align-items: center;
+}
+
+.page-head {
+  justify-content: space-between;
+  gap: var(--space-5);
+  margin-bottom: var(--space-5);
+}
+
+.page-head h1,
+.page-head p,
+.reminder-group h2,
+.reminder-card h3,
+.reminder-details,
+.delete-confirm span {
+  margin: 0;
+}
+
+.page-eyebrow {
+  color: var(--accent-hover);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.page-subtitle {
+  color: var(--text-secondary);
+}
+
+.segments {
+  display: inline-flex;
+  gap: var(--space-1);
+  margin-bottom: var(--space-5);
+  padding: var(--space-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: var(--surface-raised);
+  box-shadow: var(--glass-highlight);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+}
+
+.segments button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.segments button.active {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.error-banner {
+  justify-content: space-between;
+  margin-bottom: var(--space-4);
+}
+
+.reminder-groups,
+.reminder-group,
+.reminder-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.reminder-groups {
+  gap: var(--space-5);
+}
+
+.reminder-group {
+  gap: var(--space-3);
+}
+
+.reminder-group h2 {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.reminder-list {
+  gap: var(--space-3);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.reminder-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-4);
+  padding: var(--space-5);
+  overflow: hidden;
+}
+
+.reminder-main {
+  min-width: 0;
+}
+
+.reminder-title-row {
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.reminder-meta,
+.source-chips,
+.reminder-actions {
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.reminder-meta {
+  margin-top: var(--space-2);
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+}
+
+.reminder-details {
+  margin-top: var(--space-3);
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+}
+
+.smart-badge,
+.source-chip {
+  border-radius: var(--radius-pill);
+}
+
+.smart-badge {
+  padding: var(--space-1) var(--space-2);
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.source-chips {
+  margin-top: var(--space-3);
+}
+
+.source-chip {
+  max-width: 100%;
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--border);
+  background: var(--surface-input);
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.source-chip:hover {
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}
+
+.reminder-actions {
+  justify-content: flex-end;
+  align-self: start;
+}
+
+.danger-action {
+  color: var(--danger);
+}
+
+.delete-confirm {
+  grid-column: 1 / -1;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border);
+}
+
+.delete-confirm > div {
+  gap: var(--space-2);
+}
+
+.loading-orb {
+  width: var(--space-5);
+  height: var(--space-5);
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: var(--radius-pill);
+  animation: spin var(--transition) linear infinite;
+}
+
+.empty-icon {
+  display: grid;
+  place-items: center;
+  width: var(--space-7);
+  height: var(--space-7);
+  border-radius: var(--radius-lg);
+  background: var(--success-soft);
+  color: var(--success);
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@media (max-width: 760px) {
+  .reminders-page {
+    padding-inline: var(--space-3);
+  }
+
+  .page-head,
+  .delete-confirm {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .reminder-card {
+    grid-template-columns: 1fr;
+  }
+
+  .reminder-actions {
+    justify-content: flex-start;
+  }
+}

--- a/src/app/features/reminders/reminders/reminders.component.ts
+++ b/src/app/features/reminders/reminders/reminders.component.ts
@@ -1,0 +1,214 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from "@angular/core";
+import { TabsService } from "../../../core/tabs.service";
+import type {
+  ReminderInboxItem,
+  ReminderSourceView,
+  ReminderView,
+} from "../../../core/models";
+import { ReminderComposerService } from "../reminder-composer/reminder-composer.service";
+import { RemindersStore } from "../reminders.store";
+
+type ReminderSegment = "inbox" | "upcoming" | "completed";
+
+interface ReminderRowVm {
+  key: string;
+  occurrenceId: string | null;
+  expectedDueAt: number;
+  reminder: ReminderView;
+  dueLabel: string;
+  recurrenceLabel: string | null;
+}
+
+interface ReminderGroupVm {
+  id: string;
+  label: string;
+  rows: ReminderRowVm[];
+}
+
+const DATE_TIME = new Intl.DateTimeFormat(undefined, {
+  weekday: "short",
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+const MONTH_YEAR = new Intl.DateTimeFormat(undefined, {
+  month: "long",
+  year: "numeric",
+});
+
+function recurrenceLabel(reminder: ReminderView): string | null {
+  if (!reminder.repeatEvery || !reminder.repeatUnit) {
+    return null;
+  }
+  const singular = reminder.repeatUnit.slice(0, -1);
+  return reminder.repeatEvery === 1
+    ? `Every ${singular}`
+    : `Every ${reminder.repeatEvery} ${reminder.repeatUnit}`;
+}
+
+function reminderRow(
+  reminder: ReminderView,
+  occurrence?: ReminderInboxItem,
+): ReminderRowVm {
+  const expectedDueAt = occurrence?.dueAt ?? reminder.dueAt;
+  return {
+    key: occurrence?.occurrenceId ?? reminder.id,
+    occurrenceId: occurrence?.occurrenceId ?? null,
+    expectedDueAt,
+    reminder,
+    dueLabel: DATE_TIME.format(new Date(expectedDueAt)),
+    recurrenceLabel: recurrenceLabel(reminder),
+  };
+}
+
+@Component({
+  selector: "app-reminders",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: "./reminders.component.html",
+  styleUrl: "./reminders.component.scss",
+})
+export class RemindersComponent implements OnInit {
+  readonly store = inject(RemindersStore);
+  private readonly composer = inject(ReminderComposerService);
+  private readonly tabs = inject(TabsService);
+
+  readonly segment = signal<ReminderSegment>("inbox");
+  readonly confirmingDelete = signal<string | null>(null);
+
+  readonly counts = computed(() => ({
+    inbox: this.store.inbox().length,
+    upcoming: this.store.upcoming().length,
+    completed: this.store.completed().length,
+  }));
+
+  readonly rows = computed<ReminderRowVm[]>(() => {
+    switch (this.segment()) {
+      case "inbox":
+        return this.store
+          .inbox()
+          .map((item) => reminderRow(item.reminder, item));
+      case "upcoming":
+        return this.store.upcoming().map((reminder) => reminderRow(reminder));
+      case "completed":
+        return this.store.completed().map((reminder) => reminderRow(reminder));
+    }
+  });
+
+  readonly groups = computed<ReminderGroupVm[]>(() => {
+    const rows = this.rows();
+    if (this.segment() === "inbox") {
+      const now = Date.now();
+      const overdue = rows.filter((row) => row.expectedDueAt < now);
+      const due = rows.filter((row) => row.expectedDueAt >= now);
+      return [
+        { id: "overdue", label: "Overdue", rows: overdue },
+        { id: "due", label: "Due now", rows: due },
+      ].filter((group) => group.rows.length > 0);
+    }
+    const grouped = new Map<string, { label: string; rows: ReminderRowVm[] }>();
+    for (const row of rows) {
+      const date = new Date(row.expectedDueAt);
+      const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(
+        2,
+        "0",
+      )}`;
+      const current = grouped.get(key);
+      grouped.set(key, {
+        label: current?.label ?? MONTH_YEAR.format(date),
+        rows: [...(current?.rows ?? []), row],
+      });
+    }
+    return [...grouped].map(([id, group]) => ({
+      id: `month-${id}`,
+      label: group.label,
+      rows: group.rows,
+    }));
+  });
+
+  readonly emptyCopy = computed(() => {
+    switch (this.segment()) {
+      case "inbox":
+        return {
+          title: "Inbox clear",
+          body: "Due reminders will stay here until you complete or dismiss them.",
+        };
+      case "upcoming":
+        return {
+          title: "Nothing upcoming",
+          body: "Create a reminder and Murmur will keep it close to your work.",
+        };
+      case "completed":
+        return {
+          title: "No completed reminders",
+          body: "Finished reminders will collect here.",
+        };
+    }
+  });
+
+  ngOnInit(): void {
+    void this.store.initSummary();
+    void this.store.refresh();
+  }
+
+  selectSegment(segment: ReminderSegment): void {
+    this.segment.set(segment);
+    this.confirmingDelete.set(null);
+  }
+
+  newReminder(): void {
+    this.composer.openCreate();
+  }
+
+  edit(reminder: ReminderView): void {
+    this.composer.openEdit(reminder);
+  }
+
+  async complete(row: ReminderRowVm): Promise<void> {
+    await this.store.complete(row.reminder.id, row.expectedDueAt).catch(() => {
+      // Store owns the visible error state.
+    });
+  }
+
+  async dismiss(row: ReminderRowVm): Promise<void> {
+    if (!row.occurrenceId) {
+      return;
+    }
+    await this.store.dismissOccurrence(row.occurrenceId).catch(() => {
+      // Store owns the visible error state.
+    });
+  }
+
+  askDelete(reminderId: string): void {
+    this.confirmingDelete.set(reminderId);
+  }
+
+  cancelDelete(): void {
+    this.confirmingDelete.set(null);
+  }
+
+  async delete(reminderId: string): Promise<void> {
+    await this.store
+      .delete(reminderId)
+      .then(() => this.confirmingDelete.set(null))
+      .catch(() => {
+        // Store owns the visible error state.
+      });
+  }
+
+  openSource(source: ReminderSourceView): void {
+    if (source.kind === "meeting") {
+      void this.tabs.openMeeting(source.id, source.title || "Meeting");
+    } else {
+      void this.tabs.openNote(source.id, source.title || "Note");
+    }
+  }
+}

--- a/src/app/features/reminders/smart-reminder-card/smart-reminder-card.component.html
+++ b/src/app/features/reminders/smart-reminder-card/smart-reminder-card.component.html
@@ -1,0 +1,74 @@
+<section class="smart-card card" aria-label="Reminders for this source">
+  <header class="smart-head">
+    <div>
+      <span class="smart-kicker">✦ Smart reminders</span>
+      <h3>Don’t let this slip</h3>
+    </div>
+    <button
+      type="button"
+      class="btn btn-ghost"
+      [disabled]="!listenerReady()"
+      (click)="newReminder()"
+    >
+      New reminder
+    </button>
+  </header>
+
+  @if (error(); as message) {
+    <div class="smart-error" role="alert">
+      <span>{{ message }}</span>
+      <button
+        type="button"
+        class="btn btn-ghost"
+        [disabled]="!listenerReady()"
+        (click)="retry()"
+      >
+        Retry
+      </button>
+    </div>
+  }
+
+  @if (loading() && rows().length === 0) {
+    <p class="smart-status">Reviewing this source locally…</p>
+  } @else if (rows().length > 0) {
+    <p class="smart-intro">
+      Review these local suggestions. Murmur never creates them automatically.
+    </p>
+    <ul class="suggestion-list">
+      @for (row of rows(); track row.suggestion.id) {
+        <li class="suggestion-row">
+          <div>
+            <strong>{{ row.suggestion.title }}</strong>
+            @if (row.dueLabel; as due) {
+              <span>{{ due }}</span>
+            } @else {
+              <span>Choose a date before creating</span>
+            }
+          </div>
+          <div class="suggestion-actions">
+            <button
+              type="button"
+              class="btn btn-primary"
+              [disabled]="busy().has(row.suggestion.id)"
+              (click)="editAndCreate(row.suggestion)"
+            >
+              Edit &amp; create
+            </button>
+            <button
+              type="button"
+              class="btn btn-ghost"
+              [disabled]="busy().has(row.suggestion.id)"
+              (click)="dismiss(row.suggestion.id)"
+            >
+              {{ busy().has(row.suggestion.id) ? "Dismissing…" : "Dismiss" }}
+            </button>
+          </div>
+        </li>
+      }
+    </ul>
+  } @else if (!error()) {
+    <p class="smart-status">
+      No reminder suggestions here. You can still create one manually.
+    </p>
+  }
+</section>

--- a/src/app/features/reminders/smart-reminder-card/smart-reminder-card.component.scss
+++ b/src/app/features/reminders/smart-reminder-card/smart-reminder-card.component.scss
@@ -1,0 +1,93 @@
+.smart-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-5);
+  border-color: var(--border-strong);
+}
+
+.smart-head,
+.smart-error,
+.suggestion-row,
+.suggestion-actions {
+  display: flex;
+  align-items: center;
+}
+
+.smart-head,
+.smart-error,
+.suggestion-row {
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.smart-head h3,
+.smart-intro,
+.smart-status,
+.smart-error,
+.suggestion-list {
+  margin: 0;
+}
+
+.smart-kicker {
+  color: var(--accent-hover);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.smart-intro,
+.smart-status {
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+}
+
+.smart-error {
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+.suggestion-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: 0;
+  list-style: none;
+}
+
+.suggestion-row {
+  padding: var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-input);
+}
+
+.suggestion-row > div:first-child {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.suggestion-row strong {
+  color: var(--text-primary);
+}
+
+.suggestion-row span {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+.suggestion-actions {
+  flex: none;
+  gap: var(--space-2);
+}
+
+@media (max-width: 720px) {
+  .smart-head,
+  .suggestion-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/src/app/features/reminders/smart-reminder-card/smart-reminder-card.component.ts
+++ b/src/app/features/reminders/smart-reminder-card/smart-reminder-card.component.ts
@@ -1,0 +1,293 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  effect,
+  inject,
+  input,
+  signal,
+} from "@angular/core";
+import type { UnlistenFn } from "@tauri-apps/api/event";
+import { IpcService } from "../../../core/ipc.service";
+import type { ReminderSuggestionView, SourceKind } from "../../../core/models";
+import { DebounceService } from "../../../services/debounce.service";
+import { ReminderComposerService } from "../reminder-composer/reminder-composer.service";
+import { RemindersStore } from "../reminders.store";
+
+const MAX_VISIBLE_SUGGESTIONS = 3;
+const REVISION_AUDIT_DEBOUNCE_MS = 850;
+let nextSmartCardInstance = 0;
+const SUGGESTION_DATE = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+interface SuggestionVm {
+  suggestion: ReminderSuggestionView;
+  dueLabel: string | null;
+}
+
+/**
+ * Review-only contextual reminder surface. Auditing may stage suggestions but
+ * never creates a reminder; every promotion opens the shared composer first.
+ */
+@Component({
+  selector: "app-smart-reminder-card",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: "./smart-reminder-card.component.html",
+  styleUrl: "./smart-reminder-card.component.scss",
+})
+export class SmartReminderCardComponent {
+  private readonly ipc = inject(IpcService);
+  private readonly composer = inject(ReminderComposerService);
+  private readonly store = inject(RemindersStore);
+  private readonly debounce = inject(DebounceService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly sourceKind = input.required<SourceKind>();
+  readonly sourceId = input.required<string>();
+  readonly sourceTitle = input("");
+  /** Keys re-audit to the currently rendered canonical revision. */
+  readonly sourceRevision = input<string | number | null>(null);
+
+  private readonly _suggestions = signal<ReminderSuggestionView[]>([]);
+  readonly suggestions = this._suggestions.asReadonly();
+  readonly loading = signal(false);
+  readonly error = signal<string | null>(null);
+  readonly busy = signal<ReadonlySet<string>>(new Set());
+  readonly listenerReady = signal(false);
+  private requestSequence = 0;
+  private currentIdentity = "";
+  private readonly debounceKey = `smart-reminder-audit-${++nextSmartCardInstance}`;
+  private sourceUpdateUnlisten: UnlistenFn | null = null;
+  private visibilityInvalidatedUnlisten: UnlistenFn | null = null;
+  private destroyed = false;
+
+  readonly rows = computed<SuggestionVm[]>(() =>
+    this._suggestions()
+      .slice(0, MAX_VISIBLE_SUGGESTIONS)
+      .map((suggestion) => ({
+        suggestion,
+        dueLabel:
+          suggestion.suggestedDueAt === null
+            ? null
+            : SUGGESTION_DATE.format(new Date(suggestion.suggestedDueAt)),
+      })),
+  );
+
+  constructor() {
+    // The listener is established before the first audit is allowed to run.
+    // Therefore a canonical write can never land in the mount→audit gap without
+    // either being observed by this event or being included in the initial read.
+    void this.installUpdateListeners();
+
+    effect(() => {
+      if (!this.listenerReady()) {
+        return;
+      }
+      const kind = this.sourceKind();
+      const id = this.sourceId();
+      // These reads are dependencies only. Never cache the parent's title:
+      // listener registration has no replay, so a lock event could have landed
+      // before readiness. Only a post-registration gated audit may return a
+      // title that is safe to put into the composer.
+      this.sourceTitle();
+      this.sourceRevision();
+      this.store.revision();
+      const identity = `${kind}:${id}`;
+
+      if (identity !== this.currentIdentity) {
+        this.currentIdentity = identity;
+        this.invalidatePending();
+        void this.audit(kind, id);
+        return;
+      }
+
+      // The effect reruns only when one of the dependencies above changed.
+      this.invalidatePending();
+      this.scheduleAudit(kind, id);
+    });
+    this.destroyRef.onDestroy(() => {
+      this.destroyed = true;
+      this.sourceUpdateUnlisten?.();
+      this.sourceUpdateUnlisten = null;
+      this.visibilityInvalidatedUnlisten?.();
+      this.visibilityInvalidatedUnlisten = null;
+      this.invalidatePending();
+    });
+  }
+
+  newReminder(): void {
+    if (!this.listenerReady()) {
+      return;
+    }
+    const suggestionSource = this._suggestions()[0]?.source;
+    this.composer.openCreate({
+      source: suggestionSource ?? {
+        kind: this.sourceKind(),
+        id: this.sourceId(),
+        // The parent title is deliberately never trusted here. If the gated
+        // audit produced no suggestion, keep only the opaque anchor; submit
+        // re-gates it and the canonical list can resolve a visible title.
+        title: "",
+      },
+    });
+  }
+
+  editAndCreate(suggestion: ReminderSuggestionView): void {
+    this.composer.openSuggestion(suggestion);
+  }
+
+  async dismiss(suggestionId: string): Promise<void> {
+    if (this.busy().has(suggestionId)) {
+      return;
+    }
+    this.setBusy(suggestionId, true);
+    this.error.set(null);
+    try {
+      await this.ipc.dismissReminderSuggestion(suggestionId);
+      this._suggestions.update((rows) =>
+        rows.filter((row) => row.id !== suggestionId),
+      );
+    } catch {
+      this.error.set("Couldn’t dismiss this suggestion. It may have changed.");
+    } finally {
+      this.setBusy(suggestionId, false);
+    }
+  }
+
+  retry(): void {
+    if (!this.listenerReady()) {
+      return;
+    }
+    void this.audit(this.sourceKind(), this.sourceId());
+  }
+
+  /**
+   * Register directly on every mounted card, including a detached/open meeting
+   * tab. Failure is browser-mock-safe: it cannot block the initial gated audit.
+   */
+  private async installUpdateListeners(): Promise<void> {
+    try {
+      await Promise.all([
+        this.installSourceUpdateListener(),
+        this.installVisibilityInvalidatedListener(),
+      ]);
+      if (!this.destroyed) {
+        this.listenerReady.set(true);
+      }
+    } catch {
+      if (!this.destroyed) {
+        this.invalidatePending();
+        this.error.set(
+          "Smart reminder suggestions aren’t available securely right now.",
+        );
+      }
+    }
+  }
+
+  private async installSourceUpdateListener(): Promise<void> {
+    const unlisten = await this.ipc.onReminderSourceUpdated((payload) => {
+      const kind = this.sourceKind();
+      const id = this.sourceId();
+      if (
+        this.destroyed ||
+        !payload ||
+        !matchesSourceKind(payload.kind) ||
+        payload.kind !== kind ||
+        payload.id !== id
+      ) {
+        return;
+      }
+      this.invalidatePending();
+      this.scheduleAudit(kind, id);
+    });
+    if (this.destroyed) {
+      unlisten();
+      return;
+    }
+    this.sourceUpdateUnlisten = unlisten;
+  }
+
+  private async installVisibilityInvalidatedListener(): Promise<void> {
+    const unlisten = await this.ipc.onReminderVisibilityInvalidated(() => {
+      if (this.destroyed) {
+        return;
+      }
+      const kind = this.sourceKind();
+      const id = this.sourceId();
+      this.invalidatePending();
+      this.scheduleAudit(kind, id);
+    });
+    if (this.destroyed) {
+      unlisten();
+      return;
+    }
+    this.visibilityInvalidatedUnlisten = unlisten;
+  }
+
+  private scheduleAudit(kind: SourceKind, id: string): void {
+    if (this.destroyed) {
+      return;
+    }
+    this.debounce.schedule(
+      this.debounceKey,
+      () => void this.audit(kind, id),
+      REVISION_AUDIT_DEBOUNCE_MS,
+    );
+  }
+
+  private async audit(kind: SourceKind, id: string): Promise<void> {
+    if (!this.listenerReady()) {
+      return;
+    }
+    const sequence = ++this.requestSequence;
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      const rows = await this.ipc.auditReminderSuggestions({ kind, id });
+      if (sequence === this.requestSequence) {
+        this._suggestions.set(rows.slice(0, MAX_VISIBLE_SUGGESTIONS));
+      }
+    } catch {
+      if (sequence === this.requestSequence) {
+        this._suggestions.set([]);
+        this.error.set(
+          "Smart reminder suggestions aren’t available right now.",
+        );
+      }
+    } finally {
+      if (sequence === this.requestSequence) {
+        this.loading.set(false);
+      }
+    }
+  }
+
+  /** Immediately drops source-derived rows and makes every in-flight reply stale. */
+  private invalidatePending(): void {
+    this.debounce.cancel(this.debounceKey);
+    this.requestSequence += 1;
+    this._suggestions.set([]);
+    this.loading.set(false);
+    this.error.set(null);
+  }
+
+  private setBusy(id: string, value: boolean): void {
+    this.busy.update((current) => {
+      const next = new Set(current);
+      if (value) {
+        next.add(id);
+      } else {
+        next.delete(id);
+      }
+      return next;
+    });
+  }
+}
+
+function matchesSourceKind(value: unknown): value is SourceKind {
+  return value === "meeting" || value === "note";
+}


### PR DESCRIPTION
## Summary\n\n- add a first-class Reminders section with Inbox, Upcoming and Completed views, recurrence, due catch-up, badges, and an in-app notification inbox\n- let reminders link meeting and authored-note sources from the composer or directly from note/meeting views\n- add local Smart Reminder audits that rerun after source edits, expose reviewable candidates, and preserve Smart provenance after acceptance\n- gate every source-content read, purge derived source metadata on relock, and preserve recoverable note, attachment, and audio plaintext until verified ciphertext exists\n\n## Verification\n\n- Harness v2: PASS on exact diff 7feb629b01a3a85700f250dcc3c55da52c925f81be0985f08a334ab17caa1907\n- Rust: 2677 passed, 15 ignored\n- Angular lint/build: PASS\n- Playwright: 392 passed, 2 skipped\n- Native Tauri runtime: PASS across restart/relock/SQLCipher/provider matrix; 1 unauthorized loopback connection rejected and 0 external egress connections\n- independent Codex reviews: combined PASS, lock-security PASS, egress-security PASS\n\nNo Claude was used.