### PR TITLE
fix(app): address recording and UI regressions

### DIFF
--- a/e2e/detail/meeting-chat-source-scope.spec.ts
+++ b/e2e/detail/meeting-chat-source-scope.spec.ts
@@ -56,6 +56,23 @@ test("meeting chat pre-fills this meeting + its links and sends chat_meeting wit
   const chat = page.locator("app-meeting-chat");
   await expect(chat).toBeVisible({ timeout: 10_000 });
 
+  // Regression: once the detail entrance animation completes, it must not retain
+  // a transform. Otherwise it captures the fixed drawer and its bottom follows the
+  // long document instead of the viewport.
+  await expect
+    .poll(() =>
+      page
+        .locator(".detail")
+        .evaluate((element) => getComputedStyle(element).transform),
+    )
+    .toBe("none");
+  const drawerBounds = await page.locator(".ask-drawer").boundingBox();
+  const viewport = page.viewportSize();
+  expect(drawerBounds).not.toBeNull();
+  expect(viewport).not.toBeNull();
+  expect(drawerBounds?.y).toBe(0);
+  expect(drawerBounds?.height).toBe(viewport?.height);
+
   // Pre-fill: this meeting (by its TITLE, not id) + its active linked note.
   await expect(chat.locator(".sp-chip-title")).toHaveText([
     "Q2 Roadmap Planning",

--- a/e2e/record/mic-mute-safety.spec.ts
+++ b/e2e/record/mic-mute-safety.spec.ts
@@ -1,0 +1,180 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+test("a failed system-audio proof keeps the microphone live and explains why", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    model_present: () => true,
+    recording_status: () => ({
+      recording: true,
+      meetingId: "m-live",
+      startedAt: new Date(Date.now() - 30_000).toISOString(),
+    }),
+    is_mic_muted: () => false,
+    set_mic_muted: () => {
+      throw new Error("system audio has not produced a frame");
+    },
+  });
+
+  await page.goto("/record");
+
+  const mute = page.getByRole("button", { name: "Mute microphone" });
+  await expect(mute).toBeVisible({ timeout: 10_000 });
+  await mute.click();
+
+  await expect(mute).toHaveAttribute("aria-pressed", "false");
+  await expect(page.getByText(/Microphone stayed on/i)).toBeVisible();
+  await expect(page.getByText(/Mic muted — still capturing others/i)).toHaveCount(0);
+});
+
+test("the mute control waits for its initial backend state before accepting input", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    model_present: () => true,
+    recording_status: () => ({
+      recording: true,
+      meetingId: "m-live",
+      startedAt: new Date(Date.now() - 30_000).toISOString(),
+    }),
+    is_mic_muted: () => {
+      const target = window as unknown as {
+        __resolveInitialMicState?: (muted: boolean) => void;
+      };
+      return new Promise<boolean>((resolve) => {
+        target.__resolveInitialMicState = resolve;
+      });
+    },
+    set_mic_muted: () => {
+      const target = window as unknown as { __micMuteSetCalls?: number };
+      target.__micMuteSetCalls = (target.__micMuteSetCalls ?? 0) + 1;
+    },
+  });
+
+  await page.goto("/record");
+
+  const mute = page.getByRole("button", { name: "Mute microphone" });
+  await expect(mute).toBeVisible({ timeout: 10_000 });
+  await expect(mute).toBeDisabled();
+  await mute.click({ force: true });
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as unknown as { __micMuteSetCalls?: number })
+            .__micMuteSetCalls ?? 0,
+      ),
+    )
+    .toBe(0);
+
+  await page.evaluate(() => {
+    (
+      window as unknown as {
+        __resolveInitialMicState?: (muted: boolean) => void;
+      }
+    ).__resolveInitialMicState?.(false);
+  });
+  await expect(mute).toBeEnabled();
+  await mute.click();
+  await expect(mute).toHaveAttribute("aria-pressed", "true");
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as unknown as { __micMuteSetCalls?: number })
+            .__micMuteSetCalls ?? 0,
+      ),
+    )
+    .toBe(1);
+});
+
+test("a backend watchdog auto-unmute resyncs the control and explains the recovery", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    model_present: () => true,
+    recording_status: () => ({
+      recording: true,
+      meetingId: "m-live",
+      startedAt: new Date(Date.now() - 30_000).toISOString(),
+    }),
+    is_mic_muted: () => false,
+    set_mic_muted: () => undefined,
+  });
+
+  await page.goto("/record");
+
+  const mute = page.getByRole("button", { name: "Mute microphone" });
+  await expect(mute).toBeEnabled({ timeout: 10_000 });
+  await mute.click();
+  await expect(mute).toHaveAttribute("aria-pressed", "true");
+
+  await page.evaluate(() => {
+    (
+      window as unknown as {
+        __demoEmit: (event: string, payload: unknown) => void;
+      }
+    ).__demoEmit("murmur://mic-auto-unmuted", null);
+  });
+
+  await expect(mute).toHaveAttribute("aria-pressed", "false");
+  await expect(page.getByText(/Microphone restored/i)).toBeVisible();
+});
+
+test("the initial mute snapshot waits until the auto-unmute listener is registered", async ({
+  page,
+}) => {
+  const event = "murmur://mic-auto-unmuted";
+  await mockTauri(
+    page,
+    {
+      model_present: () => true,
+      recording_status: () => ({
+        recording: true,
+        meetingId: "m-live",
+        startedAt: new Date(Date.now() - 30_000).toISOString(),
+      }),
+      is_mic_muted: () => {
+        (window as unknown as { __micSnapshotCalled?: boolean })
+          .__micSnapshotCalled = true;
+        return false;
+      },
+    },
+    {},
+    [],
+    [event],
+  );
+
+  await page.goto("/record");
+
+  const mute = page.getByRole("button", { name: "Mute microphone" });
+  await expect(mute).toBeVisible({ timeout: 10_000 });
+  await expect(mute).toBeDisabled();
+  expect(
+    await page.evaluate(
+      () =>
+        (window as unknown as { __micSnapshotCalled?: boolean })
+          .__micSnapshotCalled ?? false,
+    ),
+  ).toBe(false);
+
+  await page.evaluate((eventName) => {
+    (
+      window as unknown as {
+        __demoReleaseEventListeners: (name: string) => void;
+      }
+    ).__demoReleaseEventListeners(eventName);
+  }, event);
+
+  await expect(mute).toBeEnabled();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as unknown as { __micSnapshotCalled?: boolean })
+            .__micSnapshotCalled ?? false,
+      ),
+    )
+    .toBe(true);
+});

--- a/e2e/settings-ai/codex-provider.spec.ts
+++ b/e2e/settings-ai/codex-provider.spec.ts
@@ -241,7 +241,7 @@ test("a delayed Codex catalog cannot overwrite a newer engine selection", async 
         );
       }
       if (args.connection === "anthropic") {
-        return ["claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"];
+        return ["claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5"];
       }
       return [];
     },

--- a/src-tauri/src/audio/system.rs
+++ b/src-tauri/src/audio/system.rs
@@ -112,6 +112,16 @@ fn helper_exit_proves_finalized(success: bool, code: Option<i32>) -> bool {
 }
 
 fn terminate_and_reap(child: &mut Child) -> Option<std::process::ExitStatus> {
+    // A health probe may already have observed and reaped an exited helper. Do not send a signal
+    // to its now-stale numeric pid; return the cached Child status directly.
+    match child.try_wait() {
+        Ok(Some(status)) => return Some(status),
+        Ok(None) => {}
+        Err(error) => {
+            tracing::warn!(target: "audio", error = %error, "system-audio child state unavailable; closing lifetime pipe without a signal");
+            return None;
+        }
+    }
     let _ = Command::new("/bin/kill")
         .arg("-TERM")
         .arg(child.id().to_string())
@@ -229,6 +239,14 @@ impl SystemAudioRecorder {
             .unwrap_or(self.started_at)
     }
 
+    /// Whether system audio can currently cover a muted microphone.
+    /// A historical first frame alone is not enough: the helper may have exited
+    /// later, leaving the recording mic-only again. Fail closed on process-state
+    /// errors as well as a missing first-frame marker.
+    pub(crate) fn can_cover_muted_mic(&mut self) -> bool {
+        self.first_frame_at.get().is_some() && matches!(self.child.try_wait(), Ok(None))
+    }
+
     /// SIGTERM the sidecar so it finalizes the WAV, wait for it, and always return owned teardown
     /// metadata. A failed helper can still leave a valid partial WAV; the recording coordinator
     /// must adopt or proof-delete that exact artifact.
@@ -288,6 +306,16 @@ impl SystemAudioRecorder {
             helper_finalized,
         }
     }
+}
+
+/// Whether a muted microphone must be restored because system audio is not positively live.
+/// Shared by the click-time guard and the 100 ms backend watchdog so helper death after a
+/// successful mute cannot silence the rest of the recording.
+pub(crate) fn mic_must_be_restored(
+    mic_is_muted: bool,
+    system: Option<&mut SystemAudioRecorder>,
+) -> bool {
+    mic_is_muted && !system.is_some_and(SystemAudioRecorder::can_cover_muted_mic)
 }
 
 /// C1 — best-effort teardown for a recorder that is DROPPED without a clean [`SystemAudioRecorder::stop`]
@@ -395,6 +423,32 @@ mod tests {
             !process_present(pid),
             "dropping without stop() must SIGTERM + reap the child — no orphan, no zombie"
         );
+    }
+
+    #[test]
+    fn mic_mute_readiness_requires_a_live_helper_with_a_real_system_audio_frame() {
+        let (mut rec, _) = recorder_over_dummy_child();
+        assert!(
+            mic_must_be_restored(true, Some(&mut rec)),
+            "spawning a helper alone must not authorize muting the only proven audio source"
+        );
+        rec.first_frame_at
+            .set(std::time::Instant::now())
+            .expect("set synthetic first-frame anchor");
+        assert!(
+            !mic_must_be_restored(true, Some(&mut rec)),
+            "a live helper plus its first-frame marker authorizes system-audio fallback"
+        );
+
+        // The mic is now conceptually muted. Kill the helper only AFTER that successful
+        // authorization, then exercise the same predicate used by the live watchdog.
+        let mut mic_muted = true;
+        let _ = rec.child.kill();
+        let _ = rec.child.wait();
+        if mic_must_be_restored(mic_muted, Some(&mut rec)) {
+            mic_muted = false;
+        }
+        assert!(!mic_muted, "helper death after mute must restore the mic");
     }
 
     #[test]

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -177,11 +177,22 @@ pub(crate) fn recording_status_dto(
 /// no real mic audio is captured (privacy). No-op if not recording.
 #[tauri::command]
 pub fn set_mic_muted(state: State<'_, AppState>, muted: bool) -> Result<(), AppError> {
-    let recorder = state
+    let mut recorder = state
         .recorder
         .lock()
         .map_err(|_| AppError::Audio("recorder mutex poisoned".into()))?;
-    if let Some(r) = recorder.as_ref() {
+    if let Some(r) = recorder.as_mut() {
+        // Never silence the only audio source we have actually observed. System capture is
+        // best-effort at Start and can degrade to mic-only on a Mac with missing TCC access or a
+        // device-specific helper failure. A real frame plus a currently-live helper is the
+        // minimum positive proof that "others" is still being recorded; without both the UI
+        // must keep the mic live.
+        if crate::audio::system::mic_must_be_restored(muted, r.system.as_mut()) {
+            return Err(AppError::Audio(
+                "microphone stayed on because system audio has not produced a frame; check Audio Recording or Screen Recording access"
+                    .into(),
+            ));
+        }
         r.set_muted(muted);
     }
     Ok(())

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1591,15 +1591,30 @@ fn spawn_recording_terminal_watchdog(app: AppHandle, meeting_id: String) {
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             let trigger = {
                 let state = app.state::<AppState>();
-                let slot = state
+                let mut slot = state
                     .recorder
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
-                let Some(active) = slot.as_ref() else {
+                let Some(active) = slot.as_mut() else {
                     return;
                 };
                 if active.meeting_id != meeting_id {
                     return;
+                }
+                let mic_is_muted = active.is_muted();
+                if crate::audio::system::mic_must_be_restored(
+                    mic_is_muted,
+                    active.system.as_mut(),
+                ) {
+                    // The helper was healthy when mute was accepted but can fail later. Restore
+                    // the mic within this backend-owned 100 ms heartbeat; renderer health is not
+                    // required, so a hidden/reloaded webview cannot leave the recording silent.
+                    active.set_muted(false);
+                    tracing::warn!(
+                        target: "audio",
+                        "system audio became unavailable while mic-muted; microphone restored"
+                    );
+                    crate::events::emit_mic_auto_unmuted(&app);
                 }
                 if let Some(fault) = active.fault() {
                     Some(RecordingTerminalTrigger::CaptureFault {

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -12559,6 +12559,10 @@
                 ids.contains(&"claude-opus-4-8".to_string()),
                 "curated list must include the default Opus id"
             );
+            assert!(
+                ids.contains(&"claude-sonnet-5".to_string()),
+                "curated list must include the current Sonnet id"
+            );
         }
     }
 

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -379,6 +379,16 @@ pub fn emit_recording_capped(app: &AppHandle) {
 /// that finalizes the exact durable prefix instead of leaving a red-but-still-owned session.
 pub const EVENT_RECORDING_CAPTURE_FAULT: &str = "murmur://recording-capture-fault";
 
+/// System audio disappeared while the microphone was muted. The backend has already restored the
+/// mic before emitting this content-free event; renderers only resync their control and explain it.
+pub const EVENT_MIC_AUTO_UNMUTED: &str = "murmur://mic-auto-unmuted";
+
+pub fn emit_mic_auto_unmuted(app: &AppHandle) {
+    if let Err(error) = app.emit(EVENT_MIC_AUTO_UNMUTED, ()) {
+        tracing::warn!(target: "audio", error = %error, "failed to emit mic-auto-unmuted notice");
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RecordingCaptureFaultPayload {

--- a/src-tauri/src/summarize/provider.rs
+++ b/src-tauri/src/summarize/provider.rs
@@ -10,7 +10,7 @@ use crate::summarize::meta::CallMeta;
 /// Single source of truth for the FE model dropdowns, served through the `list_models` command —
 /// this list previously lived hardcoded in the Settings template. Order is display order (most
 /// capable first). Static compile-time data — no I/O, no egress.
-pub const CLAUDE_MODELS: &[&str] = &["claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"];
+pub const CLAUDE_MODELS: &[&str] = &["claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5"];
 
 /// Curated Codex model ids offered for the `codex_cli` connection.
 ///

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -177,6 +177,7 @@ export const EVENT_STORAGE_PRUNED = "murmur://storage-pruned";
 export const EVENT_RECORDING_CAPPED = "murmur://recording-capped";
 export const EVENT_RECORDING_CAPTURE_FAULT =
   "murmur://recording-capture-fault";
+export const EVENT_MIC_AUTO_UNMUTED = "murmur://mic-auto-unmuted";
 // Brain v2 L5 — a scheduled brief was STAGED (propose-accept; run id + label + size only).
 export const EVENT_BRIEF_PROPOSED = "murmur://brief-proposed";
 // Vault Audit — the audit state changed (a run finished / findings purged by a seal or delete).
@@ -246,8 +247,10 @@ export class IpcService {
 
   /**
    * Mute / unmute the local microphone on the LIVE recorder. Muting silences
-   * only the mic — captured system audio ("others") keeps recording. No-op when
-   * not recording.
+   * only the mic — captured system audio ("others") keeps recording. Muting is
+   * rejected until the backend has observed a real system-audio frame, so a Mac
+   * that degraded to mic-only can never be silenced completely. No-op when not
+   * recording.
    */
   setMicMuted(muted: boolean): Promise<void> {
     return invoke<void>("set_mic_muted", { muted });
@@ -2831,6 +2834,11 @@ export class IpcService {
       EVENT_RECORDING_CAPTURE_FAULT,
       (event) => cb(event.payload),
     );
+  }
+
+  /** System audio vanished while muted; Rust already restored the microphone. */
+  onMicAutoUnmuted(cb: () => void): Promise<UnlistenFn> {
+    return listen<void>(EVENT_MIC_AUTO_UNMUTED, () => cb());
   }
 
   // ── Phase H — brain / in-meeting voice assistant event streams ─────────

--- a/src/app/features/detail/detail/detail.component.scss
+++ b/src/app/features/detail/detail/detail.component.scss
@@ -2,7 +2,10 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-5);
-  animation: rise 380ms var(--transition) both;
+  /* Do not retain rise's final transform: a transformed ancestor becomes the
+     containing block for the fixed Ask drawer, pinning it to document content
+     instead of the viewport after the entrance animation finishes. */
+  animation: rise 380ms var(--transition) backwards;
 }
 
 /* --- Back link --- */

--- a/src/app/features/record/mic-mute-toggle/mic-mute-toggle.component.ts
+++ b/src/app/features/record/mic-mute-toggle/mic-mute-toggle.component.ts
@@ -1,12 +1,15 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  OnDestroy,
   OnInit,
   inject,
   input,
   signal,
 } from "@angular/core";
+import type { UnlistenFn } from "@tauri-apps/api/event";
 import { IpcService } from "../../../core/ipc.service";
+import { ToastService } from "../../../services/toast.service";
 
 /**
  * MIC-MUTE toggle — shown ONLY while recording (the host decides when to render
@@ -29,24 +32,67 @@ import { IpcService } from "../../../core/ipc.service";
   templateUrl: "./mic-mute-toggle.component.html",
   styleUrl: "./mic-mute-toggle.component.scss",
 })
-export class MicMuteToggleComponent implements OnInit {
+export class MicMuteToggleComponent implements OnInit, OnDestroy {
   private readonly ipc = inject(IpcService);
+  private readonly toast = inject(ToastService);
 
   /** Slim, icon-only variant for the floating bar (hides the label + hint). */
   readonly compact = input<boolean>(false);
 
   /** Whether the mic is currently muted (init from the backend; flips optimistically). */
   readonly muted = signal(false);
-  /** True while a setMicMuted IPC call is in flight (debounces double-clicks). */
-  readonly busy = signal(false);
+  /** True until the initial backend state arrives, and during a mute IPC call. */
+  readonly busy = signal(true);
+  private unlistenAutoUnmuted: UnlistenFn | null = null;
+  private destroyed = false;
+  private stateRevision = 0;
 
   async ngOnInit(): Promise<void> {
+    // Establish the event stream before taking the snapshot. If the helper dies
+    // during startup, either the listener observes it or the later snapshot sees
+    // the backend's restored state — there is no gap in between.
+    await this.installAutoUnmuteListener();
     // Seed from the live recorder so the icon reflects reality on mount.
     // Best-effort: a failure (or "not recording" → false) leaves it un-muted.
+    const revision = this.stateRevision;
     try {
-      this.muted.set(await this.ipc.isMicMuted());
+      const muted = await this.ipc.isMicMuted();
+      if (revision === this.stateRevision) {
+        this.muted.set(muted);
+      }
     } catch {
-      this.muted.set(false);
+      if (revision === this.stateRevision) {
+        this.muted.set(false);
+      }
+    } finally {
+      // Do not accept a click before the initial read settles: its stale response
+      // could otherwise overwrite a newer, successfully persisted toggle.
+      this.busy.set(false);
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.destroyed = true;
+    this.unlistenAutoUnmuted?.();
+    this.unlistenAutoUnmuted = null;
+  }
+
+  private async installAutoUnmuteListener(): Promise<void> {
+    try {
+      const unlisten = await this.ipc.onMicAutoUnmuted(() => {
+        this.stateRevision += 1;
+        this.muted.set(false);
+        this.toast.info(
+          "Microphone restored because system audio stopped unexpectedly.",
+        );
+      });
+      if (this.destroyed) {
+        unlisten();
+      } else {
+        this.unlistenAutoUnmuted = unlisten;
+      }
+    } catch {
+      // Best-effort UI resync only. Rust restores the mic independently.
     }
   }
 
@@ -66,6 +112,13 @@ export class MicMuteToggleComponent implements OnInit {
       await this.ipc.setMicMuted(next);
     } catch {
       this.muted.set(!next);
+      if (next) {
+        this.toast.danger(
+          "Microphone stayed on — Murmur hasn't confirmed system audio yet. Check Audio Recording or Screen Recording access.",
+        );
+      } else {
+        this.toast.danger("Couldn't unmute the microphone. Try again.");
+      }
     } finally {
       this.busy.set(false);
     }


### PR DESCRIPTION
## Summary
- keep the meeting Ask drawer fixed to the viewport after the detail entrance animation
- expose Claude Sonnet 5 while retaining the current valid Opus 4.8 model id
- prevent mic mute until system audio is proven live, auto-restore it if the helper later exits, and resync the UI without startup races

## Verification
- `cargo test --lib`: 2678 passed, 0 failed, 15 ignored
- `npx ng lint`: passed
- `npx ng build`: passed
- focused Playwright (Chromium + WebKit): passed
- fresh adversarial Codex review: PASS

Operator requested the normal no-Harness route for these fixes.