### PR TITLE
chore(release): 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4637,7 +4637,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "1.0.3"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "scripts": {
     "start": "cargo build -p murmur-brain && ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "1.0.3"
+version = "1.1.0"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump for release 1.1.0.

Minor bump — the range since v1.0.3 (2026-07-25) is feature-scoped: smart reminder inbox, Codex cloud AI provider, user-authored note templates, Notion/ClickUp read connectors, smart-note engine, workspace glossary, transcription power slider, zero-egress recall net, and three new visibility-safe MCP surfaces.

Touches only the four version files: `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `Cargo.lock`. `identifier` (`com.meetnotes.app`) unchanged.

Local gate green before the bump: `scripts/ci.sh` → `✅ CI: all gates green (stage: full)` (clippy -D warnings, cargo test, audit, deny, build, ng lint, ng build, Playwright Chromium + WebKit, both headless E2E suites).
