### PR TITLE
fix(settings): a glossary example anyone can read

### DIFF
--- a/src/app/features/settings/sections/settings-notes-section/settings-notes-section.component.html
+++ b/src/app/features/settings/sections/settings-notes-section/settings-notes-section.component.html
@@ -129,7 +129,7 @@
                 rows="7"
                 maxlength="16384"
                 spellcheck="false"
-                placeholder="Konnect = Connect, Kinect&#10;FastMCP = Fast MCP&#10;Kong Operator = KO"
+                placeholder="Acme Platform = Acme Plattform&#10;Weekly Sync = weekly sink&#10;Project Northwind = North Wind"
               ></textarea>
               <span class="field-help text-muted">
                 One canonical spelling per line; optional aliases follow an equals


### PR DESCRIPTION
The Workspace glossary placeholder showed one specific workspace's vocabulary (Konnect / FastMCP / Kong Operator), which reads as noise to everyone else and teaches the format poorly.

Replaced with three neutral lines that each demonstrate a different shape:

- `Acme Platform = Acme Plattform` — a misheard proper noun
- `Weekly Sync = weekly sink` — ordinary words the transcriber gets wrong
- `Project Northwind = North Wind` — a spacing variant

Placeholder text only; no behaviour change. The e2e round-trip spec types its own values and does not read the placeholder.

Gates: `ng lint` clean, `ng build` clean, vocabulary gate 150 hits vs baseline 165 (no regression).