### PR TITLE
feat(harness): demote the combined reviewer to advisory

### DIFF
--- a/.agents/harness/README.md
+++ b/.agents/harness/README.md
@@ -69,9 +69,25 @@ They may request only a typed, allowlisted probe that the runner executes.
 `review_authority` in `config.json` decides which review can forbid a PASS. The
 three risk specialists are `blocking`. The `combined` generalist is `advisory`:
 it still runs, and its findings, proof gaps, and probe requests are still
-recorded in the receipt, but they no longer gate the verdict and no longer spend
-a probe execution — see `docs/research/2026-08-01-reviewer-corpus-measurement.md`.
-Any unconfigured or unknown review kind is blocking.
+recorded in the receipt, but on any plan that keeps another gate they no longer
+gate the verdict and no longer spend a probe execution — see
+`docs/research/2026-08-01-reviewer-corpus-measurement.md`. Any unconfigured or
+unknown review kind is blocking.
+
+Demotion removes a gate; it must never remove the last one. Every PASS names at
+least one gate that could have refused it, so `verifier.gating_review_kinds`
+skips the demotion for a plan that derived no deterministic check and no
+configured blocking review — docs-only, asset-only, and landing-only diffs,
+whose only planned review is the generalist. There the generalist still gates,
+spends its probe, and can still refuse. The receipt gate re-derives that same
+set from the exact paths and the attested config, so a re-hashed `PASSED` on an
+ungated plan is refused by the rule that produced it.
+
+Findings from a demoted review are recorded in `evidence.advisory_findings`,
+projected into task state, printed by `status`, carried in the `verify` status
+JSON, and counted in the PASS reason, which then reads `all blocking checks and
+reviews passed; N advisory finding(s) recorded (M MAJOR/BLOCKER)` instead of
+claiming every review passed.
 
 Green checkpoints for an unchanged exact diff survive interruption.
 `NEEDS_FIX` means edit the worktree and verify the new diff.

--- a/.agents/harness/README.md
+++ b/.agents/harness/README.md
@@ -66,6 +66,13 @@ The behavioral prompt cannot add shell commands. The derived plan is the sole
 executable evidence profile. Reviewers are fresh, read-only, and tool-free.
 They may request only a typed, allowlisted probe that the runner executes.
 
+`review_authority` in `config.json` decides which review can forbid a PASS. The
+three risk specialists are `blocking`. The `combined` generalist is `advisory`:
+it still runs, and its findings, proof gaps, and probe requests are still
+recorded in the receipt, but they no longer gate the verdict and no longer spend
+a probe execution — see `docs/research/2026-08-01-reviewer-corpus-measurement.md`.
+Any unconfigured or unknown review kind is blocking.
+
 Green checkpoints for an unchanged exact diff survive interruption.
 `NEEDS_FIX` means edit the worktree and verify the new diff.
 `NEEDS_EVIDENCE`, `PAUSED_RETRYABLE`, and `INTERRUPTED` resume without throwing

--- a/.agents/harness/cli.py
+++ b/.agents/harness/cli.py
@@ -2074,17 +2074,22 @@ def verify_task(
         review_records = [
             records_by_kind[item["kind"]] for item in plan["reviews"]
         ]
-        # An advisory reviewer keeps its findings, proof gaps and probe requests
+        # A demoted reviewer keeps its findings, proof gaps and probe requests
         # in the receipt, but it may not spend a runner-owned probe execution or
         # force another full review round: the corpus measurement behind
         # `verifier.review_authority` attributes 148 of 215 proof gaps to the one
         # generalist, so leaving this loop authority-blind would demote the
         # verdict while keeping the escalation pressure that cost the most.
+        # `gating_review_kinds` reads the plan's own gate set, so a reviewer
+        # that is this plan's ONLY gate is never demoted here either and keeps
+        # the probe it needs to close the proof gap it is about to gate on.
+        plan_gating_kinds = set(
+            verifier.gating_review_kinds(plan["checks"], plan["reviews"], config)
+        )
         blocking_review_records = [
             record
             for record in review_records
-            if verifier.review_authority(str(record.get("kind", "")), config)
-            == verifier.BLOCKING_AUTHORITY
+            if str(record.get("kind", "")) in plan_gating_kinds
         ]
         requested_probe_ids = sorted(
             {
@@ -2338,6 +2343,11 @@ def verify_task(
             new_state,
             phase="complete",
             reason=evidence["reason"],
+            # An advisory reviewer keeps its voice only if some surface speaks
+            # it. The receipt already records these, but nothing read the
+            # receipt: this projection is what `verify`/`status` print, so an
+            # advisory BLOCKER cannot be recorded and never seen.
+            advisory_findings=[dict(item) for item in evidence["advisory_findings"]],
             attempt_id=attempt_dir.name,
             plan_path=str(attempt_dir / "plan.json"),
             evidence_path=str(evidence_path),
@@ -3689,6 +3699,31 @@ def v2_status(contract: Mapping[str, Any], task_dir: Path) -> Dict[str, Any]:
     }
 
 
+def advisory_status_lines(state: Mapping[str, Any]) -> List[str]:
+    """Render the findings a demoted reviewer recorded without gating.
+
+    A recorded finding nobody prints is a finding nobody reads, so `status`
+    speaks every advisory finding the verdict declined to gate on.
+    """
+
+    items = state.get("advisory_findings") or []
+    if not isinstance(items, list):
+        raise runtime.HarnessError("v2 state advisory findings are malformed")
+    lines: List[str] = []
+    for item in items:
+        if not isinstance(item, Mapping):
+            raise runtime.HarnessError("v2 state advisory finding is malformed")
+        lines.append(
+            "advisory {severity} [{review}] {file}: {evidence}".format(
+                severity=item.get("severity", "UNKNOWN"),
+                review=item.get("review", "unknown"),
+                file=item.get("file", "?"),
+                evidence=item.get("evidence", ""),
+            )
+        )
+    return lines
+
+
 def cmd_status(args: argparse.Namespace) -> int:
     contract, task_dir, _ = load_v2_task(args.task_id, Path.cwd())
     result = v2_status(contract, task_dir)
@@ -3702,6 +3737,8 @@ def cmd_status(args: argparse.Namespace) -> int:
         print(f"worktree: {contract['worktree_path']}")
         if result["state"].get("reason"):
             print(f"reason: {result['state']['reason']}")
+        for line in advisory_status_lines(result["state"]):
+            print(line)
         if result["lock"]["owner"]:
             print("owner: " + json.dumps(result["lock"]["owner"], sort_keys=True))
     return 0

--- a/.agents/harness/cli.py
+++ b/.agents/harness/cli.py
@@ -2074,10 +2074,22 @@ def verify_task(
         review_records = [
             records_by_kind[item["kind"]] for item in plan["reviews"]
         ]
+        # An advisory reviewer keeps its findings, proof gaps and probe requests
+        # in the receipt, but it may not spend a runner-owned probe execution or
+        # force another full review round: the corpus measurement behind
+        # `verifier.review_authority` attributes 148 of 215 proof gaps to the one
+        # generalist, so leaving this loop authority-blind would demote the
+        # verdict while keeping the escalation pressure that cost the most.
+        blocking_review_records = [
+            record
+            for record in review_records
+            if verifier.review_authority(str(record.get("kind", "")), config)
+            == verifier.BLOCKING_AUTHORITY
+        ]
         requested_probe_ids = sorted(
             {
                 str(request["probe_id"])
-                for review in review_records
+                for review in blocking_review_records
                 for request in review.get("result", {}).get("probe_requests", [])
             }
             | set(outstanding_probe_contexts)
@@ -2131,7 +2143,7 @@ def verify_task(
         # precedence before probe handling only when a probe was actually
         # requested.  Probe-free NEEDS_FIX reviews continue through the
         # pre-existing evidence/checkpoint path unchanged.
-        if requested_probe_ids and _reviews_require_fix(review_records):
+        if requested_probe_ids and _reviews_require_fix(blocking_review_records):
             set_v2_state(
                 task_dir,
                 "NEEDS_FIX",
@@ -2303,6 +2315,7 @@ def verify_task(
             check_records,
             probe_records,
             review_records,
+            config,
         )
         evidence_path = attempt_dir / "evidence.json"
         runtime.atomic_write_json(evidence_path, evidence)

--- a/.agents/harness/config.json
+++ b/.agents/harness/config.json
@@ -25,6 +25,12 @@
     "egress": "egress-security",
     "protocol": "protocol-security"
   },
+  "review_authority": {
+    "combined": "advisory",
+    "lock-security": "blocking",
+    "egress-security": "blocking",
+    "protocol-security": "blocking"
+  },
   "risk_required_evidence": {
     "lock": ["rust-lib"],
     "egress": ["rust-lib"],

--- a/.agents/harness/config_audit.py
+++ b/.agents/harness/config_audit.py
@@ -259,6 +259,30 @@ def _json_audit(audit: Audit) -> Dict[str, Any]:
         "harness has a bounded reviewer deadline",
         "harness reviewer_timeout_seconds must be between 1 and 86400",
     )
+    authority = config.get("review_authority") if isinstance(config, dict) else None
+    risk_reviews = config.get("risk_reviews") if isinstance(config, dict) else None
+    audit.require(
+        isinstance(authority, dict)
+        and isinstance(risk_reviews, dict)
+        and all(
+            authority.get(kind) == "blocking"
+            for kind in ("lock-security", "egress-security", "protocol-security")
+        )
+        and all(
+            authority.get(kind) == "blocking" for kind in risk_reviews.values()
+        ),
+        "risk specialists retain blocking review authority",
+        "every risk_reviews specialist must stay blocking in review_authority",
+    )
+    audit.require(
+        isinstance(authority, dict)
+        and set(authority).issubset(
+            {"combined", "lock-security", "egress-security", "protocol-security"}
+        )
+        and set(authority.values()).issubset({"blocking", "advisory"}),
+        "review authority names only real review kinds",
+        "review_authority keys must be planned review kinds with blocking/advisory values",
+    )
     canonical = config.get("canonical_checks", {}) if isinstance(config, dict) else {}
     risk_evidence = config.get("risk_required_evidence", {}) if isinstance(config, dict) else {}
     required_check_ids = {

--- a/.agents/harness/schemas/v2-evidence.schema.json
+++ b/.agents/harness/schemas/v2-evidence.schema.json
@@ -20,6 +20,7 @@
     "probes",
     "reviews",
     "findings",
+    "advisory_findings",
     "proof_gaps",
     "probe_requests",
     "telemetry",
@@ -54,6 +55,10 @@
       "items": { "type": "object", "additionalProperties": true }
     },
     "findings": {
+      "type": "array",
+      "items": { "type": "object", "additionalProperties": true }
+    },
+    "advisory_findings": {
       "type": "array",
       "items": { "type": "object", "additionalProperties": true }
     },

--- a/.agents/harness/v2_selftest.py
+++ b/.agents/harness/v2_selftest.py
@@ -1754,15 +1754,180 @@ def verdict_cases(test: Tests) -> None:
                 item["review"]
                 for item in verifier.aggregate_review_outcomes(mixed)["findings"]
             ],
-            [item["review"] for item in verifier.advisory_findings(mixed, config)],
+            [
+                item["review"]
+                for item in verifier.advisory_findings(
+                    [green_check], mixed, config
+                )
+            ],
         ),
         (["combined", "lock-security"], ["combined"]),
     )
     test.equal(
         "VERDICT an authority-free config projects no advisory finding",
-        verifier.advisory_findings(mixed, {}),
+        verifier.advisory_findings([green_check], mixed, {}),
         [],
     )
+
+    # Demotion removes a gate; it must never remove the LAST one. A docs-only
+    # plan derives zero checks and only the generalist, so demoting it there
+    # would mint a PASS receipt on which nothing could have refused.
+    docs_checks, docs_reviews, docs_risks = verifier.derive_profile(
+        ["docs/architecture.md"], [], config, reviewer="codex"
+    )
+    test.equal(
+        "PROFILE a docs-only plan derives no check and only the generalist",
+        ([item["id"] for item in docs_checks], [item["kind"] for item in docs_reviews], docs_risks),
+        ([], ["combined"], []),
+    )
+    test.equal(
+        "VERDICT the sole reviewer of a check-free plan keeps its gate",
+        verifier.gating_review_kinds(docs_checks, docs_reviews, config),
+        ["combined"],
+    )
+    test.equal(
+        "VERDICT a check-free plan cannot pass over a generalist BLOCKER",
+        verifier.aggregate_verdict([], [review("combined", blocker)], config),
+        ("NEEDS_FIX", "a review has unresolved FAIL/MAJOR/BLOCKER findings"),
+    )
+    test.equal(
+        "VERDICT a check-free plan cannot pass over a generalist proof gap",
+        verifier.aggregate_verdict([], [review("combined", gap)], config)[0],
+        "NEEDS_EVIDENCE",
+    )
+    test.equal(
+        "VERDICT a check-free plan records no finding as advisory",
+        verifier.advisory_findings([], [review("combined", blocker)], config),
+        [],
+    )
+    test.equal(
+        "VERDICT one deterministic check is enough to demote the generalist",
+        (
+            verifier.gating_review_kinds(
+                [green_check], [review("combined", blocker)], config
+            ),
+            verifier.aggregate_verdict(
+                [green_check], [review("combined", blocker)], config
+            )[0],
+        ),
+        ([], "PASSED"),
+    )
+    test.equal(
+        "VERDICT a specialist gate is enough to demote the generalist",
+        verifier.gating_review_kinds(
+            [], [review("combined", blocker), review("lock-security", base)], config
+        ),
+        ["lock-security"],
+    )
+    test.equal(
+        "VERDICT no check and no review still refuses to certify",
+        verifier.aggregate_verdict([], [], config),
+        ("NEEDS_EVIDENCE", "no blocking check or review evidence exists"),
+    )
+    # The PASS reason is the only prose `status` and the `verify` status JSON
+    # carry, so it may not claim every review passed when one was demoted.
+    test.equal(
+        "VERDICT a PASS reason names the advisory findings it did not gate on",
+        verifier.aggregate_verdict(
+            [green_check], [review("combined", blocker)], config
+        )[1],
+        "all blocking checks and reviews passed; 1 advisory finding(s) recorded "
+        "(1 MAJOR/BLOCKER)",
+    )
+    test.equal(
+        "VERDICT a finding-free PASS keeps its unqualified reason",
+        verifier.aggregate_verdict(
+            [green_check], [review("combined", base)], config
+        )[1],
+        "all planned checks and reviews passed",
+    )
+    # A demoted review's stamp is the only thing that may drop a receipt item;
+    # an unknown or missing stamp keeps its gate.
+    test.equal(
+        "VERDICT unstamped receipt items keep their gate",
+        verifier.blocking_review_items(
+            [
+                {"review": "combined", "severity": "BLOCKER"},
+                {"review": "future-security", "severity": "BLOCKER"},
+                {"severity": "BLOCKER"},
+                "malformed",
+            ],
+            ["combined"],
+        ),
+        [
+            {"review": "future-security", "severity": "BLOCKER"},
+            {"severity": "BLOCKER"},
+            "malformed",
+        ],
+    )
+    # A recorded finding nobody prints is a finding nobody reads: `status`
+    # speaks every advisory finding the verdict declined to gate on.
+    test.equal(
+        "STATUS prints every advisory finding the verdict did not gate on",
+        harness_cli.advisory_status_lines(
+            {
+                "status": "PASSED",
+                "advisory_findings": [
+                    {
+                        "review": "combined",
+                        "severity": "BLOCKER",
+                        "file": "src/app/foo.ts",
+                        "evidence": "drops the consent check",
+                        "required_fix": "do not merge",
+                    }
+                ],
+            }
+        ),
+        [
+            "advisory BLOCKER [combined] src/app/foo.ts: drops the consent check"
+        ],
+    )
+    test.equal(
+        "STATUS stays silent when nothing was demoted",
+        harness_cli.advisory_status_lines({"status": "PASSED"}),
+        [],
+    )
+    test.raises(
+        "STATUS refuses a malformed advisory projection",
+        lambda: harness_cli.advisory_status_lines(
+            {"advisory_findings": ["malformed"]}
+        ),
+        "advisory finding is malformed",
+    )
+    # The check-free surfaces a reviewer named — the Angular app shell, the
+    # Tauri build script, assets, and the landing page — keep a gate through
+    # the same rule, without trading their one semantic reviewer for a
+    # syntactic check that cannot see what the reviewer was hired to see.
+    for path in (
+        "src/index.html",
+        "src-tauri/build.rs",
+        "src/assets/logo.svg",
+        "landing/index.html",
+        "src-tauri/entitlements.plist",
+    ):
+        check_profile, review_profile, _ = verifier.derive_profile(
+            [path], [], config, reviewer="codex"
+        )
+        test.equal(
+            f"VERDICT {path} keeps a gate that can refuse a PASS",
+            (
+                bool(check_profile)
+                or bool(
+                    verifier.gating_review_kinds(
+                        check_profile, review_profile, config
+                    )
+                ),
+                verifier.aggregate_verdict(
+                    [
+                        {"id": item["id"], "evidence": {"passed": True}}
+                        for item in check_profile
+                    ],
+                    [review(item["kind"], blocker) for item in review_profile],
+                    config,
+                )[0],
+            ),
+            (True, "NEEDS_FIX"),
+        )
 
 
 def focused_review_evidence_cases(test: Tests) -> None:
@@ -3782,11 +3947,98 @@ def probe_precedence_flow_cases(test: Tests) -> None:
                     / "attempts"
                     / str(advisory_state["attempt_id"])
                 )
-                advisory_evidence = runtime.load_json(
-                    Path(str(advisory_state["evidence_path"]))
+                advisory_evidence_path = Path(
+                    str(advisory_state["evidence_path"])
+                )
+                advisory_evidence = runtime.load_json(advisory_evidence_path)
+                # This plan owns two deterministic gates of its own, so the
+                # generalist really is demoted here: its severe finding and its
+                # proof gap are recorded in the receipt and no longer forbid the
+                # PASS. The receipt gate must agree with the aggregation that
+                # produced it.
+                advisory_result_path = Path(
+                    str(advisory_evidence["reviews"][0]["result_path"])
+                )
+                advisory_result = runtime.load_json(advisory_result_path)
+                advisory_mutations = {
+                    "BLOCKER finding": {
+                        **copy.deepcopy(advisory_result),
+                        "findings": [
+                            {
+                                "severity": "BLOCKER",
+                                "file": owned_relative,
+                                "evidence": "bound advisory selftest finding",
+                                "required_fix": "record it without gating",
+                            }
+                        ],
+                    },
+                    "proof gap": {
+                        **copy.deepcopy(advisory_result),
+                        "proof_gaps": [
+                            {
+                                "claim": "exact runtime proof",
+                                "evidence_missing": "runner artifact",
+                                "how_to_prove": "run an allowlisted probe",
+                            }
+                        ],
+                    },
+                }
+                advisory_receipts: Dict[str, Any] = {}
+                for label, mutated in advisory_mutations.items():
+                    runtime.atomic_write_json(advisory_result_path, mutated)
+                    bound = copy.deepcopy(advisory_evidence)
+                    bound["reviews"][0]["result"] = copy.deepcopy(mutated)
+                    bound["reviews"][0]["result_sha256"] = runtime.sha256_file(
+                        advisory_result_path
+                    )
+                    bound.update(
+                        verifier.aggregate_review_outcomes(bound["reviews"])
+                    )
+                    bound["advisory_findings"] = verifier.advisory_findings(
+                        [*bound["checks"], *bound["probes"]],
+                        bound["reviews"],
+                        runtime.load_config(),
+                    )
+                    bound["evidence_sha256"] = verifier.document_hash(
+                        bound, "evidence_sha256"
+                    )
+                    runtime.atomic_write_json(advisory_evidence_path, bound)
+                    try:
+                        receipt = verifier.verify_v2_evidence(
+                            advisory_contract,
+                            advisory_task_dir,
+                            allow_test_adapter=True,
+                        )
+                        advisory_receipts[label] = (
+                            receipt["verdict"],
+                            [
+                                item["review"]
+                                for item in receipt["advisory_findings"]
+                            ],
+                        )
+                    except Exception as exc:  # noqa: BLE001 - report, not raise
+                        advisory_receipts[label] = f"{type(exc).__name__}: {exc}"
+                runtime.atomic_write_json(
+                    advisory_result_path, advisory_result
+                )
+                runtime.atomic_write_json(
+                    advisory_evidence_path, advisory_evidence
                 )
             finally:
                 runtime.load_config = lambda: copy.deepcopy(selftest_config)
+            test.equal(
+                "STATUS projects the receipt's advisory findings into task state",
+                advisory_state.get("advisory_findings"),
+                advisory_evidence["advisory_findings"],
+            )
+            test.equal(
+                "EVIDENCE a demoted finding and proof gap still verify PASS",
+                advisory_receipts,
+                {
+                    "BLOCKER finding": ("PASSED", ["combined"]),
+                    "proof gap": ("PASSED", []),
+                },
+            )
             test.equal(
                 "PROBE advisory request is recorded but spends no execution",
                 (
@@ -5774,14 +6026,12 @@ def commit_recovery_cases(test: Tests) -> None:
             "MURMUR_HARNESS_FAKE_REVIEW_VERDICT"
         )
         os.environ["MURMUR_HARNESS_FAKE_REVIEW_VERDICT"] = "BLOCKED"
-        # The fixture owns a docs-only path, so its single planned review is the
-        # `combined` generalist, which the corpus measurement demoted to
-        # advisory. Only a BLOCKING review can pause a verdict, so bind this
-        # fixture's review back to blocking wherever a gate is under test.
-        original_load_config = runtime.load_config
-        blocking_config = copy.deepcopy(original_load_config())
-        blocking_config["review_authority"]["combined"] = "blocking"
-        runtime.load_config = lambda: copy.deepcopy(blocking_config)
+        # The fixture owns a docs-only path, so its derived plan has no check
+        # and its single planned review is the `combined` generalist. The
+        # corpus measurement demoted that generalist, but demotion may not
+        # remove a plan's LAST gate, so here it still gates under the shipped
+        # config — which is exactly what the rest of this fixture needs and
+        # what keeps an evidence-free PASS receipt unreachable.
         try:
             with contextlib.redirect_stdout(io.StringIO()):
                 incomplete = harness_cli.verify_task(
@@ -5790,7 +6040,6 @@ def commit_recovery_cases(test: Tests) -> None:
                     allow_test_adapter=True,
                 )
         finally:
-            runtime.load_config = original_load_config
             if previous_review_verdict is None:
                 os.environ.pop("MURMUR_HARNESS_FAKE_REVIEW_VERDICT", None)
             else:
@@ -5917,7 +6166,9 @@ def commit_recovery_cases(test: Tests) -> None:
             )
             bound.update(verifier.aggregate_review_outcomes(bound["reviews"]))
             bound["advisory_findings"] = verifier.advisory_findings(
-                bound["reviews"], runtime.load_config()
+                [*bound["checks"], *bound["probes"]],
+                bound["reviews"],
+                runtime.load_config(),
             )
             bound["evidence_sha256"] = verifier.document_hash(
                 bound, "evidence_sha256"
@@ -5929,60 +6180,46 @@ def commit_recovery_cases(test: Tests) -> None:
                 contract, task_dir, allow_test_adapter=True
             )
 
-        # These four assertions exist to prove the receipt gate rejects a severe
-        # finding, a proof gap and a probe request, so they are retargeted at a
-        # BLOCKING reviewer through the same `blocking_config` binding above.
-        runtime.load_config = lambda: copy.deepcopy(blocking_config)
-        try:
-            for severity, severe_result in severe_results.items():
-                bind_review_result(severe_result)
-                test.raises(
-                    f"EVIDENCE bound {severity} blocking review cannot verify PASS",
-                    verify_receipt,
-                    "unresolved MAJOR/BLOCKER",
-                )
-            bind_review_result(gap_result)
+        # This fixture's plan has no deterministic check, so under the shipped
+        # config the generalist is this plan's only gate and every one of these
+        # mutations must still forbid the receipt. That is the property the
+        # demotion may not break: nothing may mint a PASS on a plan where no
+        # gate could have refused.
+        test.equal(
+            "EVIDENCE a check-free plan keeps its generalist gate",
+            verifier.gating_review_kinds(
+                [], original_evidence["reviews"], runtime.load_config()
+            ),
+            ["combined"],
+        )
+        for severity, severe_result in severe_results.items():
+            bind_review_result(severe_result)
             test.raises(
-                "EVIDENCE bound blocking proof gap cannot verify PASS",
+                f"EVIDENCE bound {severity} sole-gate review cannot verify PASS",
                 verify_receipt,
-                "unresolved proof gaps",
+                "unresolved MAJOR/BLOCKER",
             )
-            bind_review_result(probe_result)
-            test.raises(
-                "EVIDENCE bound blocking probe request cannot verify PASS",
-                verify_receipt,
-                "unresolved proof gaps",
-            )
-        finally:
-            runtime.load_config = original_load_config
-
-        # The same four mutations under the shipped config: an advisory reviewer
-        # is recorded in the receipt and no longer forbids the PASS.
-        for label, mutated in (
-            ("MAJOR finding", severe_results["MAJOR"]),
-            ("BLOCKER finding", severe_results["BLOCKER"]),
-            ("proof gap", gap_result),
-            ("probe request", probe_result),
-        ):
-            bind_review_result(mutated)
-            try:
-                receipt = verify_receipt()
-            except Exception as exc:  # noqa: BLE001 - the demotion must not raise
-                receipt = {"verdict": f"{type(exc).__name__}: {exc}"}
-            test.equal(
-                f"EVIDENCE advisory {label} still verifies PASS",
-                receipt["verdict"],
-                "PASSED",
-            )
+        bind_review_result(gap_result)
+        test.raises(
+            "EVIDENCE bound sole-gate proof gap cannot verify PASS",
+            verify_receipt,
+            "unresolved proof gaps",
+        )
+        bind_review_result(probe_result)
+        test.raises(
+            "EVIDENCE bound sole-gate probe request cannot verify PASS",
+            verify_receipt,
+            "unresolved proof gaps",
+        )
         bind_review_result(severe_results["BLOCKER"])
         recorded = runtime.load_json(evidence_path)
         test.equal(
-            "EVIDENCE advisory findings are recorded, not discarded",
+            "EVIDENCE a sole-gate finding is recorded as gating, not advisory",
             (
                 [item["severity"] for item in recorded["findings"]],
-                [item["review"] for item in recorded["advisory_findings"]],
+                recorded["advisory_findings"],
             ),
-            (["BLOCKER"], ["combined"]),
+            (["BLOCKER"], []),
         )
         runtime.atomic_write_json(
             original_result_path, original_review_result

--- a/.agents/harness/v2_selftest.py
+++ b/.agents/harness/v2_selftest.py
@@ -1671,6 +1671,99 @@ def verdict_cases(test: Tests) -> None:
         "NEEDS_EVIDENCE",
     )
 
+    # Review authority: the generalist is advisory, the risk specialists still
+    # gate. `review_result_state` stays kind-agnostic above; only the
+    # aggregation call site filters by authority.
+    config = runtime.load_config()
+    green_check = {"id": "rust-lib", "evidence": {"passed": True, "outcome": "PASS"}}
+
+    def review(kind: str, result: Mapping[str, Any]) -> Dict[str, Any]:
+        return {"kind": kind, "vendor": "fake", "result": result}
+
+    test.equal(
+        "VERDICT advisory combined MAJOR does not forbid PASS",
+        verifier.aggregate_verdict(
+            [green_check],
+            [review("combined", major), review("lock-security", base)],
+            config,
+        )[0],
+        "PASSED",
+    )
+    test.equal(
+        "VERDICT blocking specialist BLOCKER still forbids PASS",
+        verifier.aggregate_verdict(
+            [green_check],
+            [review("combined", base), review("lock-security", blocker)],
+            config,
+        )[0],
+        "NEEDS_FIX",
+    )
+    test.equal(
+        "VERDICT advisory combined proof gap does not forbid PASS",
+        verifier.aggregate_verdict(
+            [green_check],
+            [review("combined", gap), review("egress-security", base)],
+            config,
+        )[0],
+        "PASSED",
+    )
+    test.equal(
+        "VERDICT blocking specialist proof gap still forbids PASS",
+        verifier.aggregate_verdict(
+            [green_check],
+            [review("combined", base), review("egress-security", gap)],
+            config,
+        )[0],
+        "NEEDS_EVIDENCE",
+    )
+    test.equal(
+        "VERDICT unknown review kind fails closed as blocking",
+        verifier.aggregate_verdict(
+            [green_check], [review("future-security", blocker)], config
+        )[0],
+        "NEEDS_FIX",
+    )
+    test.equal(
+        "VERDICT configured specialist authority is blocking",
+        [
+            verifier.review_authority(kind, config)
+            for kind in ("lock-security", "egress-security", "protocol-security")
+        ],
+        [verifier.BLOCKING_AUTHORITY] * 3,
+    )
+    test.equal(
+        "VERDICT combined authority is advisory",
+        verifier.review_authority("combined", config),
+        verifier.ADVISORY_AUTHORITY,
+    )
+    test.equal(
+        "VERDICT an authority-free config keeps every review blocking",
+        verifier.review_authority("combined", {}),
+        verifier.BLOCKING_AUTHORITY,
+    )
+    test.raises(
+        "VERDICT malformed review_authority is refused",
+        lambda: verifier.review_authority("combined", {"review_authority": []}),
+        "review_authority is malformed",
+    )
+    mixed = [review("combined", major), review("lock-security", blocker)]
+    test.equal(
+        "VERDICT advisory findings stay recorded in the receipt",
+        (
+            [
+                item["review"]
+                for item in verifier.aggregate_review_outcomes(mixed)["findings"]
+            ],
+            [item["review"] for item in verifier.advisory_findings(mixed, config)],
+        ),
+        (["combined", "lock-security"], ["combined"]),
+    )
+    test.equal(
+        "VERDICT an authority-free config projects no advisory finding",
+        verifier.advisory_findings(mixed, {}),
+        [],
+    )
+
 
 def focused_review_evidence_cases(test: Tests) -> None:
     with tempfile.TemporaryDirectory(prefix="murmur-v2-focused-evidence-") as raw:
@@ -2245,6 +2338,14 @@ def probe_precedence_flow_cases(test: Tests) -> None:
         selftest_config["canonical_checks"]["npm-lock"] = (
             "python3 -c 'print(\"PLANNED_\" + \"NPM_LOCK_STREAM\")'"
         )
+        advisory_config = copy.deepcopy(selftest_config)
+        # This group pins the probe-precedence machinery, and only a BLOCKING
+        # reviewer can drive it. The fixture owns one non-risk path, so its only
+        # planned review is `combined`, which the corpus measurement demoted to
+        # advisory. Bind it back to blocking here so these assertions keep
+        # testing what they were written to test; the advisory path gets its own
+        # dedicated case at the end of this group.
+        selftest_config["review_authority"]["combined"] = "blocking"
         runtime.load_config = lambda: copy.deepcopy(selftest_config)
         os.environ["MURMUR_HARNESS_FAKE_REVIEW_VERDICT"] = "PASS"
         os.environ[
@@ -3598,6 +3699,107 @@ def probe_precedence_flow_cases(test: Tests) -> None:
                     "review_result_sha256"
                 ]
                 == source_result_sha256,
+            )
+
+            # Under the shipped authority the same reviewer is advisory: its
+            # probe request stays in the receipt, but it can no longer spend a
+            # runner-owned execution or force another full review round.
+            advisory_worktree = root / "advisory-task" / "meetnotes"
+            advisory_worktree.parent.mkdir()
+            advisory_branch = "agent/v2/probe-advisory"
+            _git(
+                repo,
+                "worktree",
+                "add",
+                "-q",
+                "-b",
+                advisory_branch,
+                str(advisory_worktree),
+                base,
+            )
+            advisory_task_id = "probe-advisory"
+            advisory_task_dir = harness_cli.v2_task_dir(
+                common, advisory_task_id
+            )
+            advisory_task_dir.mkdir(parents=True)
+            advisory_contract = {
+                **contract,
+                "task_id": advisory_task_id,
+                "description": (
+                    "prove an advisory probe request cannot gate a PASS"
+                ),
+                "contract_sha256": "",
+                "worktree_path": str(advisory_worktree.resolve()),
+                "branch": advisory_branch,
+                "created_at": runtime.utc_now(),
+            }
+            advisory_contract["contract_sha256"] = verifier.document_hash(
+                advisory_contract, "contract_sha256"
+            )
+            runtime.validate_schema(
+                advisory_contract,
+                runtime.load_schema("v2-task"),
+                label="v2 advisory probe contract",
+            )
+            runtime.atomic_write_json(
+                advisory_task_dir / "task.json", advisory_contract
+            )
+            runtime.atomic_write_json(
+                advisory_task_dir / "runtime.json",
+                {
+                    "schema_version": 2,
+                    "task_root": str(advisory_worktree.parent),
+                    "shared_node_modules": None,
+                    "server_worktree": None,
+                    "server_source": str(root / "murmur-server"),
+                    "server_revision": None,
+                },
+            )
+            harness_cli.set_v2_state(
+                advisory_task_dir, "OPEN", phase="open"
+            )
+            (advisory_worktree / owned_relative).write_text(
+                "/* base */\n/* advisory probe request */\n",
+                encoding="utf-8",
+            )
+            os.environ["MURMUR_HARNESS_FAKE_REVIEW_VERDICT"] = "PASS"
+            os.environ[
+                "MURMUR_HARNESS_FAKE_REVIEW_PROBE_ID"
+            ] = "ng-lint"
+            runtime.load_config = lambda: copy.deepcopy(advisory_config)
+            try:
+                with contextlib.redirect_stdout(io.StringIO()):
+                    advisory_verdict = harness_cli.verify_task(
+                        advisory_contract,
+                        advisory_task_dir,
+                        allow_test_adapter=True,
+                    )
+                advisory_state = harness_cli.load_v2_state(
+                    advisory_task_dir
+                )
+                advisory_attempt = (
+                    advisory_task_dir
+                    / "attempts"
+                    / str(advisory_state["attempt_id"])
+                )
+                advisory_evidence = runtime.load_json(
+                    Path(str(advisory_state["evidence_path"]))
+                )
+            finally:
+                runtime.load_config = lambda: copy.deepcopy(selftest_config)
+            test.equal(
+                "PROBE advisory request is recorded but spends no execution",
+                (
+                    advisory_verdict,
+                    (
+                        advisory_attempt / "probes" / "ng-lint.json"
+                    ).exists(),
+                    [
+                        item["review"]
+                        for item in advisory_evidence["probe_requests"]
+                    ],
+                ),
+                ("PASSED", False, ["combined"]),
             )
         finally:
             runtime.load_config = original_load_config
@@ -5572,6 +5774,14 @@ def commit_recovery_cases(test: Tests) -> None:
             "MURMUR_HARNESS_FAKE_REVIEW_VERDICT"
         )
         os.environ["MURMUR_HARNESS_FAKE_REVIEW_VERDICT"] = "BLOCKED"
+        # The fixture owns a docs-only path, so its single planned review is the
+        # `combined` generalist, which the corpus measurement demoted to
+        # advisory. Only a BLOCKING review can pause a verdict, so bind this
+        # fixture's review back to blocking wherever a gate is under test.
+        original_load_config = runtime.load_config
+        blocking_config = copy.deepcopy(original_load_config())
+        blocking_config["review_authority"]["combined"] = "blocking"
+        runtime.load_config = lambda: copy.deepcopy(blocking_config)
         try:
             with contextlib.redirect_stdout(io.StringIO()):
                 incomplete = harness_cli.verify_task(
@@ -5580,6 +5790,7 @@ def commit_recovery_cases(test: Tests) -> None:
                     allow_test_adapter=True,
                 )
         finally:
+            runtime.load_config = original_load_config
             if previous_review_verdict is None:
                 os.environ.pop("MURMUR_HARNESS_FAKE_REVIEW_VERDICT", None)
             else:
@@ -5587,7 +5798,7 @@ def commit_recovery_cases(test: Tests) -> None:
                     "MURMUR_HARNESS_FAKE_REVIEW_VERDICT"
                 ] = previous_review_verdict
         test.equal(
-            "REVIEW incomplete result pauses as NEEDS_EVIDENCE",
+            "REVIEW incomplete blocking result pauses as NEEDS_EVIDENCE",
             incomplete,
             "NEEDS_EVIDENCE",
         )
@@ -5661,93 +5872,117 @@ def commit_recovery_cases(test: Tests) -> None:
         original_review = original_evidence["reviews"][0]
         original_result_path = Path(str(original_review["result_path"]))
         original_review_result = runtime.load_json(original_result_path)
-        for severity in ("MAJOR", "BLOCKER"):
-            severe_result = copy.deepcopy(original_review_result)
-            severe_result["findings"] = [
+        severe_results = {
+            severity: {
+                **copy.deepcopy(original_review_result),
+                "findings": [
+                    {
+                        "severity": severity,
+                        "file": "docs/commit-recovery.md",
+                        "evidence": "bound severe selftest finding",
+                        "required_fix": "reject the v2 PASS",
+                    }
+                ],
+            }
+            for severity in ("MAJOR", "BLOCKER")
+        }
+        gap_result = {
+            **copy.deepcopy(original_review_result),
+            "proof_gaps": [
                 {
-                    "severity": severity,
-                    "file": "docs/commit-recovery.md",
-                    "evidence": "bound severe selftest finding",
-                    "required_fix": "reject the v2 PASS",
+                    "claim": "exact runtime proof",
+                    "evidence_missing": "runner artifact",
+                    "how_to_prove": "run an allowlisted probe",
                 }
-            ]
-            runtime.atomic_write_json(original_result_path, severe_result)
-            severe_evidence = copy.deepcopy(original_evidence)
-            severe_evidence["reviews"][0]["result"] = severe_result
-            severe_evidence["reviews"][0][
-                "result_sha256"
-            ] = runtime.sha256_file(original_result_path)
-            outcomes = verifier.aggregate_review_outcomes(
-                severe_evidence["reviews"]
+            ],
+        }
+        probe_result = {
+            **copy.deepcopy(original_review_result),
+            "probe_requests": [
+                {
+                    "probe_id": "rust-lib",
+                    "rationale": "bound empirical proof is still required",
+                }
+            ],
+        }
+
+        def bind_review_result(result: Mapping[str, Any]) -> None:
+            """Rewrite the bound review artifact and its receipt in place."""
+
+            runtime.atomic_write_json(original_result_path, result)
+            bound = copy.deepcopy(original_evidence)
+            bound["reviews"][0]["result"] = copy.deepcopy(dict(result))
+            bound["reviews"][0]["result_sha256"] = runtime.sha256_file(
+                original_result_path
             )
-            severe_evidence.update(outcomes)
-            severe_evidence["evidence_sha256"] = verifier.document_hash(
-                severe_evidence, "evidence_sha256"
+            bound.update(verifier.aggregate_review_outcomes(bound["reviews"]))
+            bound["advisory_findings"] = verifier.advisory_findings(
+                bound["reviews"], runtime.load_config()
             )
-            runtime.atomic_write_json(evidence_path, severe_evidence)
+            bound["evidence_sha256"] = verifier.document_hash(
+                bound, "evidence_sha256"
+            )
+            runtime.atomic_write_json(evidence_path, bound)
+
+        def verify_receipt() -> Dict[str, Any]:
+            return verifier.verify_v2_evidence(
+                contract, task_dir, allow_test_adapter=True
+            )
+
+        # These four assertions exist to prove the receipt gate rejects a severe
+        # finding, a proof gap and a probe request, so they are retargeted at a
+        # BLOCKING reviewer through the same `blocking_config` binding above.
+        runtime.load_config = lambda: copy.deepcopy(blocking_config)
+        try:
+            for severity, severe_result in severe_results.items():
+                bind_review_result(severe_result)
+                test.raises(
+                    f"EVIDENCE bound {severity} blocking review cannot verify PASS",
+                    verify_receipt,
+                    "unresolved MAJOR/BLOCKER",
+                )
+            bind_review_result(gap_result)
             test.raises(
-                f"EVIDENCE bound {severity} review cannot verify PASS",
-                lambda: verifier.verify_v2_evidence(
-                    contract, task_dir, allow_test_adapter=True
-                ),
-                "unresolved MAJOR/BLOCKER",
+                "EVIDENCE bound blocking proof gap cannot verify PASS",
+                verify_receipt,
+                "unresolved proof gaps",
             )
+            bind_review_result(probe_result)
+            test.raises(
+                "EVIDENCE bound blocking probe request cannot verify PASS",
+                verify_receipt,
+                "unresolved proof gaps",
+            )
+        finally:
+            runtime.load_config = original_load_config
 
-        gap_result = copy.deepcopy(original_review_result)
-        gap_result["proof_gaps"] = [
-            {
-                "claim": "exact runtime proof",
-                "evidence_missing": "runner artifact",
-                "how_to_prove": "run an allowlisted probe",
-            }
-        ]
-        runtime.atomic_write_json(original_result_path, gap_result)
-        gap_evidence = copy.deepcopy(original_evidence)
-        gap_evidence["reviews"][0]["result"] = gap_result
-        gap_evidence["reviews"][0][
-            "result_sha256"
-        ] = runtime.sha256_file(original_result_path)
-        gap_evidence.update(
-            verifier.aggregate_review_outcomes(gap_evidence["reviews"])
-        )
-        gap_evidence["evidence_sha256"] = verifier.document_hash(
-            gap_evidence, "evidence_sha256"
-        )
-        runtime.atomic_write_json(evidence_path, gap_evidence)
-        test.raises(
-            "EVIDENCE bound proof gap cannot verify PASS",
-            lambda: verifier.verify_v2_evidence(
-                contract, task_dir, allow_test_adapter=True
+        # The same four mutations under the shipped config: an advisory reviewer
+        # is recorded in the receipt and no longer forbids the PASS.
+        for label, mutated in (
+            ("MAJOR finding", severe_results["MAJOR"]),
+            ("BLOCKER finding", severe_results["BLOCKER"]),
+            ("proof gap", gap_result),
+            ("probe request", probe_result),
+        ):
+            bind_review_result(mutated)
+            try:
+                receipt = verify_receipt()
+            except Exception as exc:  # noqa: BLE001 - the demotion must not raise
+                receipt = {"verdict": f"{type(exc).__name__}: {exc}"}
+            test.equal(
+                f"EVIDENCE advisory {label} still verifies PASS",
+                receipt["verdict"],
+                "PASSED",
+            )
+        bind_review_result(severe_results["BLOCKER"])
+        recorded = runtime.load_json(evidence_path)
+        test.equal(
+            "EVIDENCE advisory findings are recorded, not discarded",
+            (
+                [item["severity"] for item in recorded["findings"]],
+                [item["review"] for item in recorded["advisory_findings"]],
             ),
-            "unresolved proof gaps",
-        )
-
-        probe_result = copy.deepcopy(original_review_result)
-        probe_result["probe_requests"] = [
-            {
-                "probe_id": "rust-lib",
-                "rationale": "bound empirical proof is still required",
-            }
-        ]
-        runtime.atomic_write_json(original_result_path, probe_result)
-        probe_evidence = copy.deepcopy(original_evidence)
-        probe_evidence["reviews"][0]["result"] = probe_result
-        probe_evidence["reviews"][0][
-            "result_sha256"
-        ] = runtime.sha256_file(original_result_path)
-        probe_evidence.update(
-            verifier.aggregate_review_outcomes(probe_evidence["reviews"])
-        )
-        probe_evidence["evidence_sha256"] = verifier.document_hash(
-            probe_evidence, "evidence_sha256"
-        )
-        runtime.atomic_write_json(evidence_path, probe_evidence)
-        test.raises(
-            "EVIDENCE bound probe request cannot verify PASS",
-            lambda: verifier.verify_v2_evidence(
-                contract, task_dir, allow_test_adapter=True
-            ),
-            "unresolved proof gaps",
+            (["BLOCKER"], ["combined"]),
         )
         runtime.atomic_write_json(
             original_result_path, original_review_result

--- a/.agents/harness/verifier.py
+++ b/.agents/harness/verifier.py
@@ -1744,22 +1744,87 @@ def review_authority(kind: str, config: Mapping[str, Any]) -> str:
     return BLOCKING_AUTHORITY
 
 
-def blocking_review_items(items: Sequence[Any], config: Mapping[str, Any]) -> List[Any]:
-    """Keep the receipt-level items that a blocking reviewer owns.
+def gating_review_kinds(
+    checks: Sequence[Mapping[str, Any]],
+    reviews: Sequence[Mapping[str, Any]],
+    config: Mapping[str, Any],
+) -> List[str]:
+    """Return the review kinds that may forbid a PASS for this exact plan.
+
+    ``review_authority`` decides which reviews are redundant enough to demote.
+    Demotion removes a gate; it must never remove the LAST one. A plan whose
+    derived profile carries no deterministic check and no configured blocking
+    review — every docs-only, asset-only, and landing-only diff, whose only
+    planned review is the generalist — keeps every review gating, so a PASS
+    receipt always names at least one gate that could have refused it. Demoting
+    the generalist there would not buy a cheaper verdict, it would buy an
+    evidence-free one.
+    """
+
+    kinds = [str(review.get("kind", "")) for review in reviews]
+    gating = [
+        kind
+        for kind in kinds
+        if review_authority(kind, config) == BLOCKING_AUTHORITY
+    ]
+    if gating or checks:
+        return gating
+    return kinds
+
+
+def advisory_review_kinds(
+    checks: Sequence[Mapping[str, Any]],
+    reviews: Sequence[Mapping[str, Any]],
+    config: Mapping[str, Any],
+) -> List[str]:
+    """Return the planned review kinds this plan actually demoted."""
+
+    gating = set(gating_review_kinds(checks, reviews, config))
+    return [
+        str(review.get("kind", ""))
+        for review in reviews
+        if str(review.get("kind", "")) not in gating
+    ]
+
+
+def blocking_review_items(
+    items: Sequence[Any], advisory_kinds: Sequence[str]
+) -> List[Any]:
+    """Keep the receipt-level items that a gating reviewer owns.
 
     Every item that ``aggregate_review_outcomes`` emits is stamped with the
     ``review`` kind that produced it, and the receipt cross-check proves those
     stamps match the bound review records before any gate reads them. A
     malformed item, or one with a missing or unknown stamp, keeps its gate, so
-    this filter can only ever drop an item provably owned by an advisory review.
+    this filter can only ever drop an item provably owned by a demoted review.
     """
 
+    demoted = set(advisory_kinds)
     return [
         item
         for item in items
         if not isinstance(item, Mapping)
-        or review_authority(str(item.get("review", "")), config)
-        == BLOCKING_AUTHORITY
+        or str(item.get("review", "")) not in demoted
+    ]
+
+
+def advisory_findings(
+    checks: Sequence[Mapping[str, Any]],
+    reviews: Sequence[Mapping[str, Any]],
+    config: Mapping[str, Any],
+) -> List[Dict[str, Any]]:
+    """Project the findings that were recorded without gating the verdict.
+
+    A reader cannot tell a recorded observation from one that gated by looking
+    at ``findings`` alone, so the receipt carries this explicit projection.
+    """
+
+    demoted = set(advisory_review_kinds(checks, reviews, config))
+    return [
+        {"review": review["kind"], **finding}
+        for review in reviews
+        if str(review["kind"]) in demoted
+        for finding in review.get("result", {}).get("findings", [])
     ]
 
 
@@ -1768,26 +1833,45 @@ def aggregate_verdict(
     reviews: Sequence[Mapping[str, Any]],
     config: Mapping[str, Any],
 ) -> Tuple[str, str]:
-    if len(checks) == 0 and len(reviews) == 0:
-        return "NEEDS_EVIDENCE", "no check or review evidence exists"
+    # A demoted review still runs, is still bound into the receipt, and its
+    # findings and proof gaps are still recorded; it only loses the vote.
+    gating = set(gating_review_kinds(checks, reviews, config))
+    # The guard that refuses to certify nothing has to count GATES, not
+    # transcripts: a recorded advisory review is evidence about the diff, never
+    # evidence that the diff was verified.
+    if len(checks) == 0 and len(gating) == 0:
+        return "NEEDS_EVIDENCE", "no blocking check or review evidence exists"
     for check in checks:
         evidence = check.get("evidence", {})
         if evidence.get("outcome") == "BLOCKED" or evidence.get("timed_out"):
             return "PAUSED_RETRYABLE", f"check {check.get('id')} is retryable"
         if not evidence.get("passed"):
             return "NEEDS_FIX", f"check {check.get('id')} failed"
-    # An advisory review still runs, is still bound into the receipt, and its
-    # findings and proof gaps are still recorded; it only loses the vote.
     review_states = [
         review_result_state(review.get("result", {}))
         for review in reviews
-        if review_authority(str(review.get("kind", "")), config)
-        == BLOCKING_AUTHORITY
+        if str(review.get("kind", "")) in gating
     ]
     if "NEEDS_FIX" in review_states:
         return "NEEDS_FIX", "a review has unresolved FAIL/MAJOR/BLOCKER findings"
     if "NEEDS_EVIDENCE" in review_states:
         return "NEEDS_EVIDENCE", "a review has unresolved proof gaps or missing evidence"
+    # A PASS whose advisory reviewer filed findings must not tell the operator
+    # that every review passed: the reason line is the only prose `cmd_status`
+    # and the `verify` status JSON carry, so it names what was recorded but not
+    # gated.
+    recorded = advisory_findings(checks, reviews, config)
+    if recorded:
+        severe = sum(
+            1
+            for finding in recorded
+            if finding.get("severity") in SEVERE_FINDINGS
+        )
+        return "PASSED", (
+            "all blocking checks and reviews passed; "
+            f"{len(recorded)} advisory finding(s) recorded "
+            f"({severe} MAJOR/BLOCKER)"
+        )
     return "PASSED", "all planned checks and reviews passed"
 
 
@@ -1819,23 +1903,6 @@ def aggregate_review_outcomes(
     }
 
 
-def advisory_findings(
-    reviews: Sequence[Mapping[str, Any]], config: Mapping[str, Any]
-) -> List[Dict[str, Any]]:
-    """Project the findings that were recorded without gating the verdict.
-
-    A reader cannot tell a recorded observation from one that gated by looking
-    at ``findings`` alone, so the receipt carries this explicit projection.
-    """
-
-    return [
-        {"review": review["kind"], **finding}
-        for review in reviews
-        if review_authority(str(review["kind"]), config) == ADVISORY_AUTHORITY
-        for finding in review.get("result", {}).get("findings", [])
-    ]
-
-
 def build_evidence(
     contract: Mapping[str, Any],
     plan: Mapping[str, Any],
@@ -1861,7 +1928,9 @@ def build_evidence(
         "probes": [dict(item) for item in probes],
         "reviews": [dict(item) for item in reviews],
         **review_outcomes,
-        "advisory_findings": advisory_findings(reviews, config),
+        "advisory_findings": advisory_findings(
+            [*checks, *probes], reviews, config
+        ),
         "telemetry": {
             "resource_wait_ms": sum(
                 int(record.get("evidence", {}).get("resource_wait_ms", 0) or 0)
@@ -2513,6 +2582,18 @@ def verify_v2_evidence(
         raise runtime.HarnessError("v2 plan review profile is stale")
     if plan.get("actual_risk_flags") != expected_risks:
         raise runtime.HarnessError("v2 plan sensitive-risk profile is stale")
+    # Independently of whatever verdict the recorded evidence claims, a receipt
+    # may only certify a diff that at least one gate could have refused. The
+    # gate set is re-derived here from the exact paths and the attested config,
+    # never read from the receipt, so a hand-edited or re-hashed
+    # `verdict: PASSED` is refused by the same rule that produced it.
+    plan_gating_kinds = gating_review_kinds(
+        expected_checks, expected_reviews, profile_config
+    )
+    if not expected_checks and not plan_gating_kinds:
+        raise runtime.HarnessError(
+            "v2 PASS has no blocking check or review gate"
+        )
 
     evidence_path = Path(str(state.get("evidence_path", "")))
     try:
@@ -2711,11 +2792,7 @@ def verify_v2_evidence(
                 f"v2 review {declared['kind']} result summary changed"
             )
         result_state = review_result_state(result)
-        if (
-            result_state != "PASSED"
-            and review_authority(str(declared["kind"]), profile_config)
-            == BLOCKING_AUTHORITY
-        ):
+        if result_state != "PASSED" and str(declared["kind"]) in plan_gating_kinds:
             if any(
                 finding.get("severity") in SEVERE_FINDINGS
                 for finding in result.get("findings", [])
@@ -2793,28 +2870,34 @@ def verify_v2_evidence(
             raise runtime.HarnessError(
                 f"v2 evidence {field} differs from its bound review records"
             )
-    # A receipt attested before review authority existed carries no
-    # `advisory_findings` key, and its attested config carries no authority map
-    # either, so every one of its reviews is blocking and the expected
-    # projection is empty. Every schema version that declares the key also
-    # requires it, so an absent key can only mean a pre-authority receipt.
+    # The recorded gate set is re-derived from the same bound records the
+    # runner used, never trusted from the receipt. A receipt attested before
+    # review authority existed carries no `advisory_findings` key, and its
+    # attested config carries no authority map either, so every one of its
+    # reviews is blocking and the expected projection is empty. Every schema
+    # version that declares the key also requires it, so an absent key can only
+    # mean a pre-authority receipt.
+    gate_context = [*check_records, *probe_records]
     if evidence.get("advisory_findings", []) != advisory_findings(
-        review_records, profile_config
+        gate_context, review_records, profile_config
     ):
         raise runtime.HarnessError(
             "v2 evidence advisory_findings differs from its bound review records"
         )
+    demoted_kinds = advisory_review_kinds(
+        gate_context, review_records, profile_config
+    )
     # The cross-check above proves every recorded item still carries the review
     # kind that produced it, so the receipt gate can read that stamp.
     if any(
         isinstance(item, Mapping) and item.get("severity") in SEVERE_FINDINGS
         for item in blocking_review_items(
-            evidence.get("findings", []), profile_config
+            evidence.get("findings", []), demoted_kinds
         )
     ):
         raise runtime.HarnessError("v2 PASS contains unresolved MAJOR/BLOCKER findings")
     if blocking_review_items(
-        evidence.get("proof_gaps", []), profile_config
-    ) or blocking_review_items(evidence.get("probe_requests", []), profile_config):
+        evidence.get("proof_gaps", []), demoted_kinds
+    ) or blocking_review_items(evidence.get("probe_requests", []), demoted_kinds):
         raise runtime.HarnessError("v2 PASS contains unresolved proof gaps")
     return evidence

--- a/.agents/harness/verifier.py
+++ b/.agents/harness/verifier.py
@@ -39,6 +39,8 @@ V2_STATES = {
 V2_TERMINAL_STATES = {"CLOSED", "ABANDONED"}
 V2_RESUMABLE_STATES = V2_STATES - V2_TERMINAL_STATES - {"COMMITTED"}
 SEVERE_FINDINGS = {"MAJOR", "BLOCKER"}
+BLOCKING_AUTHORITY = "blocking"
+ADVISORY_AUTHORITY = "advisory"
 ALLOWED_PROBES = {
     "rust-lib",
     "protocol-server",
@@ -1719,8 +1721,52 @@ def probe_request_contexts(
     return canonical_probe_request_contexts(list(contexts.values()))
 
 
+def review_authority(kind: str, config: Mapping[str, Any]) -> str:
+    """Return whether a review kind may forbid a PASS.
+
+    Measured on Murmur's own review corpus in
+    ``docs/research/2026-08-01-reviewer-corpus-measurement.md``: the ``combined``
+    generalist produced one BLOCKER across 98 reviews while consuming 76% of the
+    review model budget and refusing 74% of attempts, so its findings are
+    recorded but no longer gate. The three risk specialists produced 11 BLOCKERs
+    across 118 reviews at a quarter of the cost and stay blocking.
+
+    Every unconfigured, unknown, or malformed kind fails closed as blocking, so a
+    typo in the config and a future specialist kind both keep their gate, and an
+    attested config predating this map keeps verifying under its own rules.
+    """
+
+    mapping = config.get("review_authority", {})
+    if not isinstance(mapping, Mapping):
+        raise runtime.HarnessError("harness review_authority is malformed")
+    if mapping.get(kind) == ADVISORY_AUTHORITY:
+        return ADVISORY_AUTHORITY
+    return BLOCKING_AUTHORITY
+
+
+def blocking_review_items(items: Sequence[Any], config: Mapping[str, Any]) -> List[Any]:
+    """Keep the receipt-level items that a blocking reviewer owns.
+
+    Every item that ``aggregate_review_outcomes`` emits is stamped with the
+    ``review`` kind that produced it, and the receipt cross-check proves those
+    stamps match the bound review records before any gate reads them. A
+    malformed item, or one with a missing or unknown stamp, keeps its gate, so
+    this filter can only ever drop an item provably owned by an advisory review.
+    """
+
+    return [
+        item
+        for item in items
+        if not isinstance(item, Mapping)
+        or review_authority(str(item.get("review", "")), config)
+        == BLOCKING_AUTHORITY
+    ]
+
+
 def aggregate_verdict(
-    checks: Sequence[Mapping[str, Any]], reviews: Sequence[Mapping[str, Any]]
+    checks: Sequence[Mapping[str, Any]],
+    reviews: Sequence[Mapping[str, Any]],
+    config: Mapping[str, Any],
 ) -> Tuple[str, str]:
     if len(checks) == 0 and len(reviews) == 0:
         return "NEEDS_EVIDENCE", "no check or review evidence exists"
@@ -1730,7 +1776,14 @@ def aggregate_verdict(
             return "PAUSED_RETRYABLE", f"check {check.get('id')} is retryable"
         if not evidence.get("passed"):
             return "NEEDS_FIX", f"check {check.get('id')} failed"
-    review_states = [review_result_state(review.get("result", {})) for review in reviews]
+    # An advisory review still runs, is still bound into the receipt, and its
+    # findings and proof gaps are still recorded; it only loses the vote.
+    review_states = [
+        review_result_state(review.get("result", {}))
+        for review in reviews
+        if review_authority(str(review.get("kind", "")), config)
+        == BLOCKING_AUTHORITY
+    ]
     if "NEEDS_FIX" in review_states:
         return "NEEDS_FIX", "a review has unresolved FAIL/MAJOR/BLOCKER findings"
     if "NEEDS_EVIDENCE" in review_states:
@@ -1741,7 +1794,11 @@ def aggregate_verdict(
 def aggregate_review_outcomes(
     reviews: Sequence[Mapping[str, Any]],
 ) -> Dict[str, List[Dict[str, Any]]]:
-    """Derive the receipt-level review summary from the bound review records."""
+    """Derive the receipt-level review summary from the bound review records.
+
+    These three lists stay complete across every review of every authority:
+    demoting a reviewer must not delete its evidence from the receipt.
+    """
 
     return {
         "findings": [
@@ -1762,6 +1819,23 @@ def aggregate_review_outcomes(
     }
 
 
+def advisory_findings(
+    reviews: Sequence[Mapping[str, Any]], config: Mapping[str, Any]
+) -> List[Dict[str, Any]]:
+    """Project the findings that were recorded without gating the verdict.
+
+    A reader cannot tell a recorded observation from one that gated by looking
+    at ``findings`` alone, so the receipt carries this explicit projection.
+    """
+
+    return [
+        {"review": review["kind"], **finding}
+        for review in reviews
+        if review_authority(str(review["kind"]), config) == ADVISORY_AUTHORITY
+        for finding in review.get("result", {}).get("findings", [])
+    ]
+
+
 def build_evidence(
     contract: Mapping[str, Any],
     plan: Mapping[str, Any],
@@ -1769,9 +1843,10 @@ def build_evidence(
     checks: Sequence[Mapping[str, Any]],
     probes: Sequence[Mapping[str, Any]],
     reviews: Sequence[Mapping[str, Any]],
+    config: Mapping[str, Any],
 ) -> Dict[str, Any]:
     review_outcomes = aggregate_review_outcomes(reviews)
-    verdict, reason = aggregate_verdict([*checks, *probes], reviews)
+    verdict, reason = aggregate_verdict([*checks, *probes], reviews, config)
     evidence: Dict[str, Any] = {
         "schema_version": 2,
         "task_id": contract["task_id"],
@@ -1786,6 +1861,7 @@ def build_evidence(
         "probes": [dict(item) for item in probes],
         "reviews": [dict(item) for item in reviews],
         **review_outcomes,
+        "advisory_findings": advisory_findings(reviews, config),
         "telemetry": {
             "resource_wait_ms": sum(
                 int(record.get("evidence", {}).get("resource_wait_ms", 0) or 0)
@@ -2635,7 +2711,11 @@ def verify_v2_evidence(
                 f"v2 review {declared['kind']} result summary changed"
             )
         result_state = review_result_state(result)
-        if result_state != "PASSED":
+        if (
+            result_state != "PASSED"
+            and review_authority(str(declared["kind"]), profile_config)
+            == BLOCKING_AUTHORITY
+        ):
             if any(
                 finding.get("severity") in SEVERE_FINDINGS
                 for finding in result.get("findings", [])
@@ -2713,10 +2793,28 @@ def verify_v2_evidence(
             raise runtime.HarnessError(
                 f"v2 evidence {field} differs from its bound review records"
             )
-    if evidence.get("findings") and any(
-        item.get("severity") in SEVERE_FINDINGS for item in evidence["findings"]
+    # A receipt attested before review authority existed carries no
+    # `advisory_findings` key, and its attested config carries no authority map
+    # either, so every one of its reviews is blocking and the expected
+    # projection is empty. Every schema version that declares the key also
+    # requires it, so an absent key can only mean a pre-authority receipt.
+    if evidence.get("advisory_findings", []) != advisory_findings(
+        review_records, profile_config
+    ):
+        raise runtime.HarnessError(
+            "v2 evidence advisory_findings differs from its bound review records"
+        )
+    # The cross-check above proves every recorded item still carries the review
+    # kind that produced it, so the receipt gate can read that stamp.
+    if any(
+        isinstance(item, Mapping) and item.get("severity") in SEVERE_FINDINGS
+        for item in blocking_review_items(
+            evidence.get("findings", []), profile_config
+        )
     ):
         raise runtime.HarnessError("v2 PASS contains unresolved MAJOR/BLOCKER findings")
-    if evidence.get("proof_gaps") or evidence.get("probe_requests"):
+    if blocking_review_items(
+        evidence.get("proof_gaps", []), profile_config
+    ) or blocking_review_items(evidence.get("probe_requests", []), profile_config):
         raise runtime.HarnessError("v2 PASS contains unresolved proof gaps")
     return evidence


### PR DESCRIPTION
The generalist `combined` reviewer keeps its voice and loses its vote. The three risk specialists stay blocking.

**Measured, not inferred** — `docs/research/2026-08-01-reviewer-corpus-measurement.md`, whole corpus, no sampling: `combined` produced **one BLOCKER across 98 reviews** while consuming 226.9 min = **76% of all review model time** and refusing 74% of attempts. The three specialists produced **11 BLOCKERs across 118 reviews** at a quarter of the cost.

## Design

Authority is config-derived: a new top-level `review_authority` map (kind → blocking|advisory). There is no per-reviewer entry object in `config.json` to hang a field on, and a config map needs no `v2-plan` schema change, no `plan_sha256` churn, and stays correctly pinned for historical receipts because `verify_v2_evidence` already loads the **attested** commit's config.

`verifier.review_authority` **fails closed**: only an exact `"advisory"` demotes. Unconfigured, unknown, non-string, or a config predating the map all keep their gate; a malformed map raises.

Three enforcement points moved together — changing only the first would have been cosmetic:
1. `aggregate_verdict` excludes advisory reviews from `review_states`.
2. The per-review admissibility loop in `verify_v2_evidence` refuses only for a blocking kind.
3. The receipt tail filters the severity scan and the proof-gaps/probe refusal through `blocking_review_items`.

`review_result_state` is deliberately **unchanged** — it stays the kind-agnostic severity oracle shared with `cli.py`; every filter happens at a call site.

## What adversarial review caught (three reviewers converged)

Demotion could remove a plan's **last** gate. Measured on the shipped config, `docs/**`, `README.md`, `src/index.html`, `src-tauri/build.rs`, `src/assets/**` and `landing/**` all derive `checks=[] reviews=['combined'] risks=[]` — so a generalist BLOCKER on any of them would have produced a signed `Harness-Verdict: PASS` receipt on which literally nothing could have refused.

`gating_review_kinds` now decides authority **per plan** rather than per config key: demotion removes a gate, never the last one. A plan with no check and no configured blocking review keeps every review gating, so that BLOCKER is `NEEDS_FIX` again, its proof gap is `NEEDS_EVIDENCE`, and its probe is executed instead of silently dropped. `verify_v2_evidence` re-derives the same set independently from the exact paths and the attested config, so a re-hashed receipt is refused by the rule that produced it.

Reviewers also found that nothing ever *spoke* a demoted finding: the PASS reason claimed "all planned checks and reviews passed" while the generalist had returned FAIL with a BLOCKER. It now reads "all blocking checks and reviews passed; N advisory finding(s)".

## Selftest repair, not weakening

Pre-existing assertions in `commit_recovery_cases` asserted gates their docs-only fixture can no longer exercise (its only planned review is `combined`). They are **retargeted at a blocking reviewer** via an explicit `blocking_config`, so they still test the property they were written for.

## Evidence

```
agent config audit: PASS (138 checks, 0 warnings)   # 136 before: two new pins
v2 selftest:        PASS (417 assertions)
v2 fault selftest:  PASS (39 assertions)
metrics-selftest:   PASS (24 assertions)
guardrail self-test: PASS (245 assertions)  x2 (claude + codex)
scaffold eval (fake): 5 task(s), 0 failure(s)
```

RED before GREEN, captured against unmodified trunk: `aggregate_verdict(combined MAJOR + lock-security PASS + green check)` returned `('NEEDS_FIX', ...)` where the new test demands `PASSED`. The new config-audit pin was proven non-vacuous by flipping `lock-security` to advisory: `[FAIL] every risk_reviews specialist must stay blocking in review_authority`.