### PR TITLE
fix(audit): audit local policy reversals; feat(harness): outcome metrics

### DIFF
--- a/.agents/harness/README.md
+++ b/.agents/harness/README.md
@@ -119,13 +119,62 @@ status    inspect state and lock ownership
 commit    create the exact PASS receipt commit
 clean     archive and close/abandon the task
 doctor    audit dependencies, ghosts, and orphan worktrees
-metrics   summarize current Harness event ledgers
+metrics   summarize event ledgers plus reviewer PASS-rate and cost per accepted task
 selftest  run lifecycle, fault, and metrics tests
 ```
 
 There is no executable Harness v1. `scripts/verify-harness-attestation` retains
 read-only support for historical v1 commit trailers so old Git history remains
 auditable.
+
+### `metrics` outcome tables
+
+`metrics` reads only what the runner already wrote. It walks every ledger, and on
+each `review-checkpoint` it loads the record at `record_path` and joins it to that
+attempt's `checks/*.json`. The record — not the checkpoint event — carries
+`duration_ms`, `result.findings`, `result.proof_gaps`, `vendor`, and
+`attempts[].telemetry.usage`, so the record side is authoritative for review
+outcomes. The event-derived `models:`/`reviews:` lines above them count model
+invocations instead, including any that never produced a record; the two are
+deliberately not the same number.
+
+```bash
+# this repo's own store
+scripts/agent-harness metrics
+# the driver clone that actually ran the reviews (repeatable; --limit is per run,
+# and the default of 20 silently truncates a large store)
+scripts/agent-harness metrics --limit 200 \
+  --store ../.murmur-agent-driver/.git/agent-harness
+```
+
+`--store` accepts a `.git` dir, the `agent-harness` store, its `v2` dir, or the
+task root itself, and reports what each argument resolved to — an unresolvable
+store prints `UNRESOLVED` rather than contributing a silent zero. Records are
+deduped by `(store, task, attempt, reviewer)`: the corpus contains checkpoints
+that fire twice against the same rewritten record, and counting events would
+double their tokens and minutes.
+
+`tokens` are `input + output`, normalized across both vendor usage dialects
+(`cached_input_tokens` vs `cache_read_input_tokens`, and so on). Cache and
+reasoning counters are reported separately and never added: `reasoning_output_tokens`
+is a *subset* of `output_tokens` — strictly smaller in all 199 corpus records that
+report it — so summing it inflates the total. Every column carries its own
+coverage, and a pruned record stays `missing` rather than becoming a zero.
+
+USD is opt-in and never inferred. Add an optional top-level `pricing` block to
+`.agents/harness/config.json` and the USD columns appear; omit it and they do not
+exist at all:
+
+```json
+"pricing": {
+  "codex":  { "input_per_mtok": 0.0, "output_per_mtok": 0.0 },
+  "claude": { "input_per_mtok": 0.0, "output_per_mtok": 0.0 }
+}
+```
+
+Rates are keyed by **vendor**, not model: every `codex` record in the corpus
+carries `"model": "unspecified"`. No block ships, because the harness has no
+authoritative price to state.
 
 ## Self-verification
 

--- a/.agents/harness/README.md
+++ b/.agents/harness/README.md
@@ -149,21 +149,43 @@ scripts/agent-harness metrics --limit 200 \
 
 `--store` accepts a `.git` dir, the `agent-harness` store, its `v2` dir, or the
 task root itself, and reports what each argument resolved to — an unresolvable
-store prints `UNRESOLVED` rather than contributing a silent zero. Records are
-deduped by `(store, task, attempt, reviewer)`: the corpus contains checkpoints
-that fire twice against the same rewritten record, and counting events would
-double their tokens and minutes.
+store prints `UNRESOLVED` rather than contributing a silent zero, and a store
+that resolves to an already-counted task root prints `DUPLICATE (already
+counted)` and contributes nothing. That last case is easy to hit: run the
+command above *from* the driver clone and `../.murmur-agent-driver/.git/...`
+resolves back to the store `repo_context` already supplied, which would double
+every absolute count while leaving every rate identical. Records are deduped by
+`(store, task, attempt, reviewer)`: the corpus contains checkpoints that fire
+twice against the same rewritten record, and counting events would double their
+tokens and minutes.
 
-`tokens` are `input + output`, normalized across both vendor usage dialects
-(`cached_input_tokens` vs `cache_read_input_tokens`, and so on). Cache and
-reasoning counters are reported separately and never added: `reasoning_output_tokens`
-is a *subset* of `output_tokens` — strictly smaller in all 199 corpus records that
-report it — so summing it inflates the total. Every column carries its own
-coverage, and a pruned record stays `missing` rather than becoming a zero.
+`tokens` are billable tokens, and what counts as billable is decided per **usage
+dialect**, not per field name — the two vendors disagree about what
+`input_tokens` means:
 
-USD is opt-in and never inferred. Add an optional top-level `pricing` block to
-`.agents/harness/config.json` and the USD columns appear; omit it and they do not
-exist at all:
+| dialect | detected by | billable |
+| --- | --- | --- |
+| Anthropic | `cache_read_input_tokens` / `cache_creation_input_tokens` | `input + cache_read + cache_creation + output` (disjoint counters) |
+| OpenAI | `cached_input_tokens` / `cache_write_input_tokens` | `input + output` (`cached` is a *subset* of `input`) |
+
+A cached Anthropic prompt lives almost entirely in the cache pair: across the 31
+`claude` reviews in the corpus, `input_tokens` totals **70** against 2.70M cache
+tokens, so billing `input + output` alone scored them at 25% of what they
+consumed while `codex` was billed at ~100% — enough to invert a cross-vendor
+comparison. The dialect is read off the usage keys (with `vendor` only as a
+fallback) and reported as `token dialects` so the normalization is visible.
+`reasoning_output_tokens` is never billable in either dialect: it is a *subset*
+of `output_tokens`, strictly smaller in all 199 corpus records that report it.
+Every column carries its own coverage, and a pruned record stays `missing`
+rather than becoming a zero.
+
+`observed USD` is the vendor's own `attempts[].telemetry.cost_usd`, summed and
+reported with coverage. It is measured rather than derived, so it beats any rate
+card where it exists — today that is every `claude` record and no `codex` one.
+
+The rate card is opt-in and never inferred. Add an optional top-level `pricing`
+block to `.agents/harness/config.json` and the `rate-card USD` columns appear;
+omit it and they do not exist at all:
 
 ```json
 "pricing": {
@@ -173,8 +195,10 @@ exist at all:
 ```
 
 Rates are keyed by **vendor**, not model: every `codex` record in the corpus
-carries `"model": "unspecified"`. No block ships, because the harness has no
-authoritative price to state.
+carries `"model": "unspecified"`. They price exactly the tokens `tokens` counts,
+which makes them a coarse *upper* bound for the Anthropic dialect (cache reads
+bill at the fresh-input rate) — prefer `observed USD`. No block ships, because
+the harness has no authoritative price to state.
 
 ## Self-verification
 

--- a/.agents/harness/cli.py
+++ b/.agents/harness/cli.py
@@ -3992,8 +3992,14 @@ def cmd_metrics(args: argparse.Namespace) -> int:
 
     if args.limit < 1:
         raise runtime.HarnessError("metrics --limit must be positive")
+    stores = []
+    for value in args.store:
+        store = Path(value).expanduser()
+        if not store.is_dir():
+            raise runtime.HarnessError(f"metrics --store is not a directory: {value}")
+        stores.append(store.resolve())
     _, common = runtime.repo_context(Path.cwd())
-    report = harness_metrics.collect_metrics(common, limit=args.limit)
+    report = harness_metrics.collect_metrics(common, limit=args.limit, stores=stores)
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))
     else:
@@ -4085,6 +4091,10 @@ def build_parser() -> argparse.ArgumentParser:
     )
     metrics_parser.add_argument("--json", action="store_true")
     metrics_parser.add_argument("--limit", type=int, default=20)
+    # Repeatable. Defaults to this repo's own evidence store; point it at a
+    # driver clone's store to roll up the corpus that actually ran the reviews.
+    # Accepts the .git dir, the agent-harness store, its v2 dir, or the task root.
+    metrics_parser.add_argument("--store", action="append", default=[])
     metrics_parser.set_defaults(handler=cmd_metrics)
     selftest_parser = subparsers.add_parser(
         "selftest", help="run deterministic lifecycle and fault tests"

--- a/.agents/harness/config_audit.py
+++ b/.agents/harness/config_audit.py
@@ -50,10 +50,45 @@ REQUIRED_DENIES = {
 }
 LOCAL_SETTINGS_RELATIVE = (".claude", "settings.local.json")
 LOCAL_POLICY_ACK_KEY = "_ack_policy_overrides"
-LOCAL_POLICY_KEYS = (
-    "sandbox.allowUnsandboxedCommands",
-    "sandbox.filesystem.allowWrite",
-    "permissions.deny",
+# Tracked `sandbox` scalar -> the local value that REVERSES the tracked posture.
+# Direction cannot be inferred from the value: `autoAllowBashIfSandboxed`
+# true -> false only ADDS permission prompts, so it has no reversal at all and
+# carries None.  `_local_settings` fails when the tracked document declares a
+# sandbox scalar missing from this table, so a future hardening in
+# `.claude/settings.json` cannot land silently unmodelled.
+SANDBOX_SCALAR_REVERSALS: Dict[str, Optional[bool]] = {
+    "allowUnsandboxedCommands": True,
+    "autoAllowBashIfSandboxed": None,
+    "enabled": False,
+    "failIfUnavailable": False,
+}
+# Least -> most permissive.  A local `permissions.defaultMode` ranked at or above
+# the tracked one (absent means Claude Code's own `default`) suppresses gating the
+# repository declared; an unrecognized mode cannot be proven safe, so it ranks last.
+PERMISSION_MODES: Tuple[str, ...] = (
+    "plan",
+    "default",
+    "acceptEdits",
+    "bypassPermissions",
+)
+# Shortest literal prefix a tracked deny must expose before it may be matched by
+# containment instead of by exact string.
+MIN_DENY_LITERAL = 4
+LOCAL_POLICY_KEYS: Tuple[str, ...] = tuple(
+    sorted(
+        {
+            "env",
+            "permissions.allow",
+            "permissions.defaultMode",
+            "sandbox.filesystem.allowWrite",
+            "sandbox.filesystem.denyWrite",
+        }
+        | {
+            f"sandbox.{name}"
+            for name, reversal in SANDBOX_SCALAR_REVERSALS.items()
+            if reversal is not None
+        }
+    )
 )
 CODEX_REQUIRED_DENY_PATHS = {
     "~/Desktop",
@@ -720,17 +755,140 @@ def _hook_parity(documents: Mapping[str, Any], audit: Audit) -> None:
     audit.fingerprints["parity-manifest"] = _sha256(_canonical_json(audit.fingerprints))
 
 
-def _covers_git_directory(entry: str) -> bool:
-    """True when a sandbox write grant reaches a Git directory.
+def _lexical(path: PurePosixPath) -> PurePosixPath:
+    """Collapse `.` and `..` without touching the filesystem."""
 
-    Compared on trailing path components only.  The tracked file declares
-    project-relative paths (`../meetnotes/.git`) while a machine-local override
-    declares absolute ones, and the audit must stay hermetic — resolving either
-    form would make the result depend on the machine it runs on.
+    parts: List[str] = []
+    for part in path.parts:
+        if part == ".":
+            continue
+        if part == ".." and parts and parts[-1] not in {"..", "/"}:
+            parts.pop()
+            continue
+        parts.append(part)
+    return PurePosixPath(*parts) if parts else PurePosixPath(".")
+
+
+def _expanded_home(entry: str) -> str:
+    """Expand a leading `~`/`$HOME`/`${HOME}` the way Claude Code would.
+
+    An undeterminable home degrades to the unexpanded text: the `.git` component
+    test still applies, only the ancestor test stops reaching through `~`.
     """
 
-    candidate = PurePosixPath(entry.replace("\\", "/").rstrip("/"))
-    return ".git" in candidate.parts
+    text = entry.strip().replace("\\", "/")
+    try:
+        home = Path.home().as_posix()
+    except (OSError, RuntimeError):
+        return text
+    for token in ("${HOME}", "$HOME", "~"):
+        if text == token:
+            return home
+        if text.startswith(token + "/"):
+            return home + text[len(token) :]
+    return text
+
+
+def _covers_git_directory(entry: str) -> Optional[str]:
+    """Why this sandbox write grant reaches a Git directory, or None.
+
+    Two ways in, and the second is the one a blocked operator reaches for. A
+    literal `.git` component is the obvious form; the failure message names it,
+    so deleting the `/.git` suffix both silences the rule and WIDENS the grant.
+    A sandbox write grant is a SUBTREE grant, so `/`, `$HOME`, and the repository
+    directory itself all still confer write on `<repo>/.git/hooks` — which runs
+    unsandboxed on the operator's next commit.
+
+    The component test is case-folded because the default macOS filesystem is
+    case-insensitive, so `.GIT` names the same directory.
+    """
+
+    text = _expanded_home(entry)
+    trimmed = text.rstrip("/") or "/"
+    candidate = PurePosixPath(trimmed)
+    if any(part.lower() == ".git" for part in candidate.parts):
+        return f"grants sandbox write to a Git directory: {entry}"
+    root = _lexical(PurePosixPath(ROOT.as_posix()))
+    target = _lexical(
+        candidate
+        if candidate.is_absolute()
+        else PurePosixPath((ROOT / trimmed).as_posix())
+    )
+    try:
+        root.relative_to(target)
+    except ValueError:
+        return None
+    return (
+        f"grants sandbox write to {entry}, which covers the repository root "
+        f"{root} and therefore {root.name}/.git"
+    )
+
+
+def _path_components(entry: str) -> Tuple[str, ...]:
+    """Meaningful trailing components of a filesystem policy entry.
+
+    Compared component-wise, never resolved: the tracked file declares
+    project-relative paths (`../meetnotes/.git`) while a machine-local override
+    declares the absolute form of the same directory, and the audit must stay
+    hermetic — resolving either form would make the result depend on the machine
+    it runs on.
+    """
+
+    text = _expanded_home(entry).rstrip("/")
+    return tuple(
+        part for part in PurePosixPath(text).parts if part not in {".", "..", "/"}
+    )
+
+
+def _deny_write_covered(
+    tracked: Tuple[str, ...], local: Sequence[Tuple[str, ...]]
+) -> bool:
+    """True when some local `denyWrite` entry still denies all of `tracked`.
+
+    A deny is a SUBTREE deny, so a local entry covers the tracked one when it
+    names the same directory or an ancestor of it.  On trailing components that
+    is exactly: some leading run of the tracked components is a trailing run of
+    the local ones.
+    """
+
+    if not tracked:
+        return True
+    return any(
+        entry[-size:] == tracked[:size]
+        for entry in local
+        for size in range(1, len(tracked) + 1)
+    )
+
+
+_GLOB_CHARACTER = re.compile(r"[*?\[]")
+
+
+def _permission_target(entry: str) -> str:
+    match = re.fullmatch(r"\s*([A-Za-z_]+)\((.*)\)\s*", entry, re.DOTALL)
+    return match.group(2) if match else entry.strip()
+
+
+def _deny_literal(entry: str) -> Optional[str]:
+    """Literal path prefix a deny rule protects, or None for a pure-glob rule.
+
+    `Read(~/.ssh/**)` protects everything under `~/.ssh/`, so a local
+    `Read(~/.ssh/*)`, `Read(~/.ssh/id_rsa)` or `Bash(cat ~/.ssh/id_rsa)` re-grants
+    it even though none of the three is the tracked string.  `Read(**/*.pem)`
+    exposes no literal prefix at all and can only ever be matched exactly.
+    """
+
+    target = _permission_target(entry)
+    match = _GLOB_CHARACTER.search(target)
+    literal = (target[: match.start()] if match else target).strip()
+    return literal if len(literal) >= MIN_DENY_LITERAL else None
+
+
+def _mode_rank(mode: str) -> int:
+    return (
+        PERMISSION_MODES.index(mode)
+        if mode in PERMISSION_MODES
+        else len(PERMISSION_MODES)
+    )
 
 
 def _mapping(document: Any, key: str) -> Mapping[str, Any]:
@@ -791,7 +949,29 @@ def _local_settings(documents: Mapping[str, Any], audit: Audit) -> None:
     (`--ci` only pins output stability), and threading one through would change
     every section signature — so the existence guard alone keeps this section
     from ever failing a job for a file that cannot be there.
+
+    The one check that runs BEFORE that guard reads only the tracked document:
+    it asserts the reversal model still covers every sandbox scalar the tracked
+    document declares, so a hardening added to `.claude/settings.json` cannot
+    become an unpoliced key that a local override may quietly flip.
     """
+
+    tracked = documents.get(".claude/settings.json")
+    tracked_sandbox = _mapping(tracked, "sandbox")
+    # Runs before the existence guard, and reads only the tracked document: it
+    # asserts this audit still MODELS the posture it claims to defend, which is
+    # exactly the thing CI must not be blind to.
+    unmodelled = sorted(
+        name
+        for name, value in tracked_sandbox.items()
+        if isinstance(value, bool) and name not in SANDBOX_SCALAR_REVERSALS
+    )
+    if unmodelled:
+        audit.error(
+            ".claude/settings.json declares sandbox scalars this audit does not model: "
+            + ", ".join(unmodelled)
+            + "; give each one a SANDBOX_SCALAR_REVERSALS direction"
+        )
 
     path = ROOT.joinpath(*LOCAL_SETTINGS_RELATIVE)
     if not path.is_file():
@@ -807,7 +987,6 @@ def _local_settings(documents: Mapping[str, Any], audit: Audit) -> None:
         if len(audit.errors) == reported:
             audit.error(f"{'/'.join(LOCAL_SETTINGS_RELATIVE)} must contain a JSON object")
         return
-    tracked = documents.get(".claude/settings.json")
     if not isinstance(tracked, dict):
         audit.error("cannot audit the local Claude override without tracked .claude/settings.json")
         return
@@ -815,43 +994,109 @@ def _local_settings(documents: Mapping[str, Any], audit: Audit) -> None:
     acknowledged = _policy_acknowledgements(local, audit)
     findings: List[Tuple[str, str]] = []
 
-    tracked_sandbox = _mapping(tracked, "sandbox")
+    # Every comparison below is DERIVED from the tracked document, never a second
+    # copy of its values: a policy change in .claude/settings.json moves the
+    # comparison with it instead of leaving a stale duplicate behind.
     local_sandbox = _mapping(local, "sandbox")
-    if tracked_sandbox.get("allowUnsandboxedCommands") is False and local_sandbox.get(
-        "allowUnsandboxedCommands"
-    ) is True:
-        findings.append(
-            (
-                "sandbox.allowUnsandboxedCommands",
-                "local Claude override sets sandbox.allowUnsandboxedCommands=true while "
-                ".claude/settings.json declares false",
-            )
-        )
-
-    for entry in _string_list(_mapping(local_sandbox, "filesystem"), "allowWrite"):
-        if _covers_git_directory(entry):
+    for name, reversal in sorted(SANDBOX_SCALAR_REVERSALS.items()):
+        if reversal is None:
+            continue
+        declared = not reversal
+        if tracked_sandbox.get(name) is declared and local_sandbox.get(name) is reversal:
             findings.append(
                 (
-                    "sandbox.filesystem.allowWrite",
-                    f"local Claude override grants sandbox write to a Git directory: {entry}",
+                    f"sandbox.{name}",
+                    f"local Claude override sets sandbox.{name}="
+                    f"{'true' if reversal else 'false'} while .claude/settings.json "
+                    f"declares {'true' if declared else 'false'}",
                 )
             )
 
-    # Derived from the tracked document, never a second copy of its list: a
-    # policy change in .claude/settings.json must move this comparison with it.
-    tracked_deny = set(_string_list(_mapping(tracked, "permissions"), "deny"))
+    local_filesystem = _mapping(local_sandbox, "filesystem")
+    for entry in _string_list(local_filesystem, "allowWrite"):
+        reach = _covers_git_directory(entry)
+        if reach is not None:
+            findings.append(
+                ("sandbox.filesystem.allowWrite", f"local Claude override {reach}")
+            )
+
+    # The sandbox-side deny list, and the same protection as the rule above seen
+    # from the other side. The array REPLACES rather than merges, so a local file
+    # that redeclares it without a tracked entry drops that entry outright.
+    tracked_filesystem = _mapping(tracked_sandbox, "filesystem")
+    if isinstance(local_filesystem.get("denyWrite"), list):
+        local_deny_write = [
+            _path_components(entry)
+            for entry in _string_list(local_filesystem, "denyWrite")
+        ]
+        dropped = [
+            entry
+            for entry in _string_list(tracked_filesystem, "denyWrite")
+            if not _deny_write_covered(_path_components(entry), local_deny_write)
+        ]
+        if dropped:
+            findings.append(
+                (
+                    "sandbox.filesystem.denyWrite",
+                    "local Claude override redeclares sandbox.filesystem.denyWrite "
+                    "without tracked entries: " + ", ".join(dropped),
+                )
+            )
+
+    tracked_permissions = _mapping(tracked, "permissions")
     local_permissions = _mapping(local, "permissions")
-    weakened = tracked_deny & set(_string_list(local_permissions, "allow"))
-    if isinstance(local_permissions.get("deny"), list):
-        weakened |= tracked_deny - set(_string_list(local_permissions, "deny"))
-    if weakened:
+    # Only the ALLOW side can weaken a deny. Claude Code unions deny lists across
+    # settings sources and deny beats allow, so a local deny list that does not
+    # restate a tracked entry has not dropped it — testing for that produced a
+    # failure on a strictly-tightening override and taught the operator to ack
+    # away the key that also covers this real re-grant.
+    local_allow = _string_list(local_permissions, "allow")
+    regrants: List[str] = []
+    for denied in _string_list(tracked_permissions, "deny"):
+        literal = _deny_literal(denied)
+        matches = [
+            allowed
+            for allowed in local_allow
+            if allowed == denied or (literal is not None and literal in allowed)
+        ]
+        if matches:
+            regrants.append(f"{', '.join(matches)} re-grants {denied}")
+    if regrants:
         findings.append(
             (
-                "permissions.deny",
-                "local Claude override weakens tracked permissions.deny entries: "
-                + ", ".join(sorted(weakened)),
+                "permissions.allow",
+                "local Claude override re-grants tracked permissions.deny entries: "
+                + "; ".join(regrants),
             )
         )
+
+    local_mode = local_permissions.get("defaultMode")
+    tracked_mode = tracked_permissions.get("defaultMode")
+    if isinstance(local_mode, str) and local_mode:
+        baseline = tracked_mode if isinstance(tracked_mode, str) and tracked_mode else "default"
+        if local_mode != baseline and _mode_rank(local_mode) >= _mode_rank(baseline):
+            findings.append(
+                (
+                    "permissions.defaultMode",
+                    f"local Claude override sets permissions.defaultMode={local_mode} "
+                    f"while the tracked posture is {baseline}",
+                )
+            )
+
+    # `env` overrides `env`, and .claude/settings.json's MURMUR_FINISH_GUARD is
+    # already asserted load-bearing by `_hook_parity`; hook_guard._finish_guard
+    # returns None outright when it reads "off".
+    tracked_env = _mapping(tracked, "env")
+    local_env = _mapping(local, "env")
+    for name in sorted(tracked_env):
+        if name in local_env and local_env[name] != tracked_env[name]:
+            findings.append(
+                (
+                    "env",
+                    f"local Claude override changes tracked env {name}: "
+                    f"{tracked_env[name]!r} -> {local_env[name]!r}",
+                )
+            )
 
     for key, message in findings:
         reason = acknowledged.get(key)

--- a/.agents/harness/config_audit.py
+++ b/.agents/harness/config_audit.py
@@ -10,7 +10,7 @@ import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 
@@ -48,6 +48,13 @@ REQUIRED_DENIES = {
     "Read(~/.cargo/credentials*)",
     "Read(~/Library/Application Support/MeetNotes/**)",
 }
+LOCAL_SETTINGS_RELATIVE = (".claude", "settings.local.json")
+LOCAL_POLICY_ACK_KEY = "_ack_policy_overrides"
+LOCAL_POLICY_KEYS = (
+    "sandbox.allowUnsandboxedCommands",
+    "sandbox.filesystem.allowWrite",
+    "permissions.deny",
+)
 CODEX_REQUIRED_DENY_PATHS = {
     "~/Desktop",
     "~/Documents",
@@ -713,6 +720,149 @@ def _hook_parity(documents: Mapping[str, Any], audit: Audit) -> None:
     audit.fingerprints["parity-manifest"] = _sha256(_canonical_json(audit.fingerprints))
 
 
+def _covers_git_directory(entry: str) -> bool:
+    """True when a sandbox write grant reaches a Git directory.
+
+    Compared on trailing path components only.  The tracked file declares
+    project-relative paths (`../meetnotes/.git`) while a machine-local override
+    declares absolute ones, and the audit must stay hermetic — resolving either
+    form would make the result depend on the machine it runs on.
+    """
+
+    candidate = PurePosixPath(entry.replace("\\", "/").rstrip("/"))
+    return ".git" in candidate.parts
+
+
+def _mapping(document: Any, key: str) -> Mapping[str, Any]:
+    value = document.get(key) if isinstance(document, Mapping) else None
+    return value if isinstance(value, Mapping) else {}
+
+
+def _string_list(document: Mapping[str, Any], key: str) -> List[str]:
+    value = document.get(key)
+    return [entry for entry in value if isinstance(entry, str)] if isinstance(value, list) else []
+
+
+def _policy_acknowledgements(document: Mapping[str, Any], audit: Audit) -> Dict[str, str]:
+    """Parse the documented `"<key>: <reason>"` escape hatch.
+
+    An acknowledgement downgrades its key to a warning, so it has to carry a
+    recorded justification: a bare key, an empty reason, or a key this audit
+    does not police is itself a failure rather than a mute button.
+    """
+
+    raw = document.get(LOCAL_POLICY_ACK_KEY)
+    if raw is None:
+        return {}
+    if not isinstance(raw, list):
+        audit.error(f"{LOCAL_POLICY_ACK_KEY} must be an array of \"<key>: <reason>\" strings")
+        return {}
+    acknowledged: Dict[str, str] = {}
+    for entry in raw:
+        if not isinstance(entry, str):
+            audit.error(f"{LOCAL_POLICY_ACK_KEY} entries must be strings: {entry!r}")
+            continue
+        key, separator, reason = entry.partition(":")
+        key = key.strip()
+        reason = reason.strip()
+        if not separator or not reason:
+            audit.error(
+                f"{LOCAL_POLICY_ACK_KEY} entry records no reason: {entry!r}; "
+                'use "<key>: <why this machine needs it>"'
+            )
+            continue
+        if key not in LOCAL_POLICY_KEYS:
+            audit.error(
+                f"{LOCAL_POLICY_ACK_KEY} names an unaudited key: {key!r}; "
+                f"expected one of {', '.join(LOCAL_POLICY_KEYS)}"
+            )
+            continue
+        acknowledged[key] = reason
+    return acknowledged
+
+
+def _local_settings(documents: Mapping[str, Any], audit: Audit) -> None:
+    """Hold the untracked per-machine Claude override to the tracked posture.
+
+    `.claude/settings.local.json` is machine-local and git-ignored, so it is the
+    one file that can silently reverse the declared sandbox policy while every
+    parity check and fingerprint still passes.  Absence is the CI contract: the
+    file cannot exist on a runner, `run_audit` has no CI flag to branch on
+    (`--ci` only pins output stability), and threading one through would change
+    every section signature — so the existence guard alone keeps this section
+    from ever failing a job for a file that cannot be there.
+    """
+
+    path = ROOT.joinpath(*LOCAL_SETTINGS_RELATIVE)
+    if not path.is_file():
+        audit.checks.append("no local Claude settings override present")
+        return
+
+    reported = len(audit.errors)
+    local = _load_json(path, audit)
+    if not isinstance(local, dict):
+        # `_load_json` returns None for a read/parse failure it already reported
+        # and for a literal `null` document it did not; only the latter needs a
+        # message, so anything non-object that stayed silent gets one here.
+        if len(audit.errors) == reported:
+            audit.error(f"{'/'.join(LOCAL_SETTINGS_RELATIVE)} must contain a JSON object")
+        return
+    tracked = documents.get(".claude/settings.json")
+    if not isinstance(tracked, dict):
+        audit.error("cannot audit the local Claude override without tracked .claude/settings.json")
+        return
+
+    acknowledged = _policy_acknowledgements(local, audit)
+    findings: List[Tuple[str, str]] = []
+
+    tracked_sandbox = _mapping(tracked, "sandbox")
+    local_sandbox = _mapping(local, "sandbox")
+    if tracked_sandbox.get("allowUnsandboxedCommands") is False and local_sandbox.get(
+        "allowUnsandboxedCommands"
+    ) is True:
+        findings.append(
+            (
+                "sandbox.allowUnsandboxedCommands",
+                "local Claude override sets sandbox.allowUnsandboxedCommands=true while "
+                ".claude/settings.json declares false",
+            )
+        )
+
+    for entry in _string_list(_mapping(local_sandbox, "filesystem"), "allowWrite"):
+        if _covers_git_directory(entry):
+            findings.append(
+                (
+                    "sandbox.filesystem.allowWrite",
+                    f"local Claude override grants sandbox write to a Git directory: {entry}",
+                )
+            )
+
+    # Derived from the tracked document, never a second copy of its list: a
+    # policy change in .claude/settings.json must move this comparison with it.
+    tracked_deny = set(_string_list(_mapping(tracked, "permissions"), "deny"))
+    local_permissions = _mapping(local, "permissions")
+    weakened = tracked_deny & set(_string_list(local_permissions, "allow"))
+    if isinstance(local_permissions.get("deny"), list):
+        weakened |= tracked_deny - set(_string_list(local_permissions, "deny"))
+    if weakened:
+        findings.append(
+            (
+                "permissions.deny",
+                "local Claude override weakens tracked permissions.deny entries: "
+                + ", ".join(sorted(weakened)),
+            )
+        )
+
+    for key, message in findings:
+        reason = acknowledged.get(key)
+        if reason is None:
+            audit.error(message)
+        else:
+            audit.warn(f"{message} [acknowledged: {reason}]")
+    if not findings:
+        audit.checks.append("local Claude settings override preserves the declared posture")
+
+
 def _semantic_lint(audit: Audit) -> None:
     paths = [ROOT / "AGENTS.md", ROOT / "CLAUDE.md"]
     for directory, suffix in (
@@ -1156,6 +1306,7 @@ def run_audit() -> Audit:
     _agent_and_rule_manifest(audit)
     _codex_permission_profiles(audit)
     _hook_parity(documents, audit)
+    _local_settings(documents, audit)
     _adversarial_prompt_contract(audit)
     _semantic_lint(audit)
     _remote_workflow_contract(audit)

--- a/.agents/harness/metrics.py
+++ b/.agents/harness/metrics.py
@@ -15,6 +15,35 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
 
 Observation = Tuple[str, Any]
 RETRY_LABEL = re.compile(r"-try-(\d+)$")
+CONFIG_PATH = Path(__file__).with_name("config.json")
+# `--store <path>` accepts every shape an operator naturally has at hand. First
+# match wins, so `<store>/v2/tasks` is always preferred over the retired v1
+# sibling `<store>/tasks`; a bare directory is accepted only when it already IS
+# a task root, otherwise an unrelated path would silently mint phantom tasks.
+STORE_CANDIDATES: Tuple[Tuple[str, ...], ...] = (
+    ("agent-harness", "v2", "tasks"),
+    ("v2", "tasks"),
+    ("tasks",),
+)
+# `attempts[].telemetry.usage` has two vendor dialects; only `input_tokens` and
+# `output_tokens` are shared. First present key wins — never sum two aliases.
+USAGE_FIELDS: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
+    ("input", ("input_tokens",)),
+    ("output", ("output_tokens",)),
+    ("cached", ("cached_input_tokens", "cache_read_input_tokens")),
+    ("cache_write", ("cache_write_input_tokens", "cache_creation_input_tokens")),
+    ("reasoning", ("reasoning_output_tokens",)),
+)
+TOKEN_LABELS: Tuple[str, ...] = tuple(label for label, _ in USAGE_FIELDS)
+# Only these are billable. `reasoning` is a SUBSET of `output_tokens` — measured
+# strictly less in all 199 corpus records that report it — so adding it inflates
+# the total; cache counters are not priced like fresh input.
+BILLABLE_LABELS: Tuple[str, ...] = ("input", "output")
+PRICE_FIELDS: Tuple[Tuple[str, str], ...] = (
+    ("input", "input_per_mtok"),
+    ("output", "output_per_mtok"),
+)
+ACCEPTED_VERDICT = "PASSED"
 
 
 def _utc_now() -> str:
@@ -124,10 +153,32 @@ def _read(path: Path) -> Dict[str, Any]:
     return result
 
 
-def _discover(common: Path) -> Tuple[List[Dict[str, Any]], int]:
+def _task_roots(
+    common: Path, stores: Sequence[Path]
+) -> List[Tuple[Path, Optional[Path]]]:
+    roots: List[Tuple[Path, Optional[Path]]] = [
+        (common, common / "agent-harness" / "v2" / "tasks")
+    ]
+    for store in stores:
+        origin = Path(store).expanduser().resolve()
+        candidates = [origin.joinpath(*parts) for parts in STORE_CANDIDATES]
+        if origin.name == "tasks":
+            candidates.append(origin)
+        resolved = next(
+            (
+                candidate
+                for candidate in candidates
+                if _is_real(candidate, stat.S_IFDIR)
+            ),
+            None,
+        )
+        roots.append((origin, resolved))
+    return roots
+
+
+def _discover_root(root: Path, root_index: int) -> Tuple[List[Dict[str, Any]], int]:
     records: List[Dict[str, Any]] = []
     unsafe = 0
-    root = common / "agent-harness" / "v2" / "tasks"
     if not _is_real(root, stat.S_IFDIR):
         if root.exists() or root.is_symlink():
             unsafe += 1
@@ -163,6 +214,9 @@ def _discover(common: Path) -> Tuple[List[Dict[str, Any]], int]:
         records.append(
             {
                 "task_id": task.name,
+                "root_index": root_index,
+                "root": root,
+                "task_dir": task,
                 "status": status,
                 "last_event_at": last_at,
                 "last_epoch": last_epoch,
@@ -171,6 +225,28 @@ def _discover(common: Path) -> Tuple[List[Dict[str, Any]], int]:
             }
         )
     return records, unsafe
+
+
+def _discover(
+    common: Path, stores: Sequence[Path] = ()
+) -> Tuple[List[Dict[str, Any]], int, List[Dict[str, Any]]]:
+    records: List[Dict[str, Any]] = []
+    unsafe = 0
+    summaries: List[Dict[str, Any]] = []
+    for index, (origin, root) in enumerate(_task_roots(common, stores)):
+        found: List[Dict[str, Any]] = []
+        if root is not None:
+            found, skipped = _discover_root(root, index)
+            unsafe += skipped
+        records.extend(found)
+        summaries.append(
+            {
+                "path": str(origin),
+                "root": None if root is None else str(root),
+                "tasks": len(found),
+            }
+        )
+    return records, unsafe, summaries
 
 
 def _coverage(observations: Sequence[Observation]) -> Dict[str, Any]:
@@ -383,20 +459,435 @@ def _checks(records: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
     }
 
 
-def collect_metrics(common_dir: Path, *, limit: int = 20) -> Dict[str, Any]:
+def _load_json_file(path: Path) -> Optional[Any]:
+    if not _is_real(path, stat.S_IFREG):
+        return None
+    try:
+        with path.open("r", encoding="utf-8", errors="strict") as handle:
+            return json.load(handle)
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError):
+        return None
+
+
+def _safe_name(value: Any) -> Optional[str]:
+    if not isinstance(value, str) or not value or value in {".", ".."}:
+        return None
+    if "/" in value or "\\" in value or "\x00" in value:
+        return None
+    return value
+
+
+def _resolve_record(task_dir: Path, event: Mapping[str, Any]) -> Optional[Path]:
+    """Resolve store-relatively first so a copied or archived store still joins.
+
+    `record_path` is an absolute path baked in at write time; following it
+    blindly makes `--store` useless for any store that ever moved.
+    """
+    attempt = _safe_name(event.get("attempt_id"))
+    kind = _safe_name(event.get("review_kind"))
+    if attempt is not None and kind is not None:
+        candidate = task_dir / "attempts" / attempt / "reviews" / f"{kind}.json"
+        if _is_real(candidate, stat.S_IFREG):
+            return candidate
+    baked = event.get("record_path")
+    if isinstance(baked, str) and baked:
+        fallback = Path(baked)
+        if _is_real(fallback, stat.S_IFREG):
+            return fallback
+    return None
+
+
+def _attempt_green(task_dir: Path, attempt_id: Any) -> Optional[bool]:
+    """True when every `checks/*.json` of the attempt recorded a PASS outcome.
+
+    The outcome is nested under `evidence`; the flat `outcome` belongs to the
+    `check` EVENT, not to this file.
+    """
+    attempt = _safe_name(attempt_id)
+    if attempt is None:
+        return None
+    checks = task_dir / "attempts" / attempt / "checks"
+    if not _is_real(checks, stat.S_IFDIR):
+        return None
+    try:
+        entries = sorted(checks.iterdir(), key=lambda item: item.name)
+    except OSError:
+        return None
+    outcomes: List[str] = []
+    for entry in entries:
+        if entry.suffix != ".json":
+            continue
+        document = _load_json_file(entry)
+        if not isinstance(document, Mapping):
+            return None
+        evidence = document.get("evidence")
+        outcome = evidence.get("outcome") if isinstance(evidence, Mapping) else None
+        if not isinstance(outcome, str) or not outcome:
+            return None
+        outcomes.append(outcome)
+    if not outcomes:
+        return None
+    return all(outcome == "PASS" for outcome in outcomes)
+
+
+def _usage_tokens(record: Mapping[str, Any]) -> Dict[str, Optional[int]]:
+    totals: Dict[str, Optional[int]] = {label: None for label in TOKEN_LABELS}
+    attempts = record.get("attempts")
+    if not isinstance(attempts, Sequence) or isinstance(attempts, (str, bytes)):
+        return totals
+    for attempt in attempts:
+        if not isinstance(attempt, Mapping):
+            continue
+        telemetry = attempt.get("telemetry")
+        usage = telemetry.get("usage") if isinstance(telemetry, Mapping) else None
+        if not isinstance(usage, Mapping):
+            continue
+        for label, names in USAGE_FIELDS:
+            for name in names:
+                value = usage.get(name)
+                if _valid_integer(value):
+                    totals[label] = (totals[label] or 0) + int(value)
+                    break
+    return totals
+
+
+def _review_rows(
+    records: Sequence[Mapping[str, Any]]
+) -> Tuple[List[Dict[str, Any]], int]:
+    """Deduped `review-checkpoint` events joined to their record and checks.
+
+    The corpus contains checkpoints that fire twice against the same rewritten
+    record file; counting events instead of records double-counts their tokens
+    and model minutes.
+    """
+    deduped: Dict[Tuple[Any, ...], Dict[str, Any]] = {}
+    duplicates = 0
+    green_cache: Dict[Tuple[Any, ...], Optional[bool]] = {}
+    for record in records:
+        task_key = (record["root_index"], record["task_id"])
+        task_dir = record["task_dir"]
+        for event in record["events"]:
+            if event.get("event") != "review-checkpoint":
+                continue
+            attempt_id = event.get("attempt_id")
+            reviewer = event.get("review_kind")
+            key = (task_key, str(attempt_id), str(reviewer))
+            if key in deduped:
+                duplicates += 1
+            green_key = (task_key, str(attempt_id))
+            if green_key not in green_cache:
+                green_cache[green_key] = _attempt_green(task_dir, attempt_id)
+            row: Dict[str, Any] = {
+                "task_key": task_key,
+                "task_id": record["task_id"],
+                "attempt_id": attempt_id,
+                "reviewer": reviewer if isinstance(reviewer, str) and reviewer else "UNKNOWN",
+                "resolved": "missing",
+                "verdict": None,
+                "vendor": None,
+                "duration_ms": None,
+                "proof_gaps": None,
+                "findings": {},
+                "green_checks": green_cache[green_key],
+            }
+            row.update({f"tokens_{label}": None for label in TOKEN_LABELS})
+            path = _resolve_record(task_dir, event)
+            document = None if path is None else _load_json_file(path)
+            if path is not None and not isinstance(document, Mapping):
+                row["resolved"] = "invalid"
+            elif isinstance(document, Mapping):
+                row["resolved"] = "available"
+                row["record_path"] = str(path)
+                kind = document.get("kind")
+                if row["reviewer"] == "UNKNOWN" and isinstance(kind, str) and kind:
+                    row["reviewer"] = kind
+                vendor = document.get("vendor")
+                row["vendor"] = vendor if isinstance(vendor, str) and vendor else None
+                duration = document.get("duration_ms")
+                row["duration_ms"] = duration if _valid_number(duration) else None
+                result = document.get("result")
+                if isinstance(result, Mapping):
+                    verdict = result.get("verdict")
+                    row["verdict"] = (
+                        verdict if isinstance(verdict, str) and verdict else None
+                    )
+                    findings = result.get("findings")
+                    severities: Dict[str, int] = {}
+                    if isinstance(findings, Sequence) and not isinstance(
+                        findings, (str, bytes)
+                    ):
+                        for finding in findings:
+                            if not isinstance(finding, Mapping):
+                                continue
+                            severity = finding.get("severity")
+                            name = (
+                                severity
+                                if isinstance(severity, str) and severity
+                                else "UNKNOWN"
+                            )
+                            severities[name] = severities.get(name, 0) + 1
+                    row["findings"] = severities
+                    gaps = result.get("proof_gaps")
+                    if isinstance(gaps, Sequence) and not isinstance(gaps, (str, bytes)):
+                        row["proof_gaps"] = len(gaps)
+                for label, total in _usage_tokens(document).items():
+                    row[f"tokens_{label}"] = total
+            deduped[key] = row
+    ordered = sorted(deduped, key=lambda key: (key[0][0], key[0][1], key[1], key[2]))
+    return [deduped[key] for key in ordered], duplicates
+
+
+def _billable(row: Mapping[str, Any]) -> Optional[int]:
+    present = [
+        int(row[f"tokens_{label}"])
+        for label in BILLABLE_LABELS
+        if _valid_integer(row.get(f"tokens_{label}"))
+    ]
+    return sum(present) if present else None
+
+
+def _row_usd(
+    row: Mapping[str, Any], pricing: Mapping[str, Mapping[str, float]]
+) -> Optional[float]:
+    rate = pricing.get(row.get("vendor"))
+    if not isinstance(rate, Mapping):
+        return None
+    parts = [
+        float(row[f"tokens_{label}"]) / 1000000.0 * float(rate[key])
+        for label, key in PRICE_FIELDS
+        if _valid_integer(row.get(f"tokens_{label}")) and _valid_number(rate.get(key))
+    ]
+    return math.fsum(parts) if parts else None
+
+
+def _counted(observations: Sequence[Observation]) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for state, value in observations:
+        if state == "available":
+            counts[str(value)] = counts.get(str(value), 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _reviewer_row(rows: Sequence[Mapping[str, Any]], priced: bool) -> Dict[str, Any]:
+    groups = [[row] for row in rows]
+    resolution: List[Observation] = [
+        (str(row["resolved"]), True if row["resolved"] == "available" else None)
+        for row in rows
+    ]
+    verdicts = _observe(
+        groups, "verdict", lambda value: isinstance(value, str) and bool(value)
+    )
+    by_verdict = _counted(verdicts)
+    decided = sum(state == "available" for state, _ in verdicts)
+    passes = by_verdict.get("PASS", 0)
+    findings: Dict[str, int] = {}
+    for row in rows:
+        for severity, count in row["findings"].items():
+            findings[severity] = findings.get(severity, 0) + count
+    tokens: Dict[str, Any] = {
+        label: _numeric(_observe(groups, f"tokens_{label}", _valid_integer))
+        for label in TOKEN_LABELS
+    }
+    billable = [value for value in (_billable(row) for row in rows) if value is not None]
+    tokens["total"] = sum(billable) if billable else None
+    gaps = _numeric(_observe(groups, "proof_gaps", _valid_integer))["total"]
+    summary: Dict[str, Any] = {
+        "reviews": len(rows),
+        "records": _coverage(resolution),
+        "pass": passes,
+        "pass_rate": round(100.0 * passes / decided, 1) if decided else None,
+        "by_verdict": by_verdict,
+        "findings": dict(sorted(findings.items())),
+        "proof_gaps": 0 if gaps is None else gaps,
+        "durations_ms": _numeric(_observe(groups, "duration_ms", _valid_number)),
+        "tokens": tokens,
+        "by_vendor": _counted(
+            _observe(groups, "vendor", lambda value: isinstance(value, str) and bool(value))
+        ),
+        "green_check_reviews": _true_count(
+            _observe(groups, "green_checks", lambda value: isinstance(value, bool))
+        ),
+    }
+    if priced:
+        summary["usd"] = _numeric(_observe(groups, "usd", _valid_number))
+    return summary
+
+
+def _review_outcomes(
+    rows: Sequence[Mapping[str, Any]],
+    duplicates: int,
+    pricing: Optional[Mapping[str, Mapping[str, float]]],
+) -> Dict[str, Any]:
+    by_reviewer: Dict[str, List[Mapping[str, Any]]] = {}
+    for row in rows:
+        by_reviewer.setdefault(str(row["reviewer"]), []).append(row)
+    report = _reviewer_row(rows, pricing is not None)
+    report["duplicate_checkpoints"] = duplicates
+    report["by_reviewer"] = {
+        reviewer: _reviewer_row(by_reviewer[reviewer], pricing is not None)
+        for reviewer in sorted(by_reviewer)
+    }
+    if pricing is not None:
+        by_vendor: Dict[str, List[float]] = {}
+        for row in rows:
+            cost = row.get("usd")
+            if _valid_number(cost) and isinstance(row.get("vendor"), str):
+                by_vendor.setdefault(str(row["vendor"]), []).append(float(cost))
+        usd = report["usd"]
+        usd["by_vendor"] = {
+            vendor: _number(math.fsum(by_vendor[vendor])) for vendor in sorted(by_vendor)
+        }
+        usd["by_reviewer"] = {
+            reviewer: report["by_reviewer"][reviewer]["usd"]["total"]
+            for reviewer in sorted(by_reviewer)
+        }
+        report["usd"] = usd
+    return report
+
+
+def _task_outcomes(
+    records: Sequence[Mapping[str, Any]],
+    rows: Sequence[Mapping[str, Any]],
+    pricing: Optional[Mapping[str, Mapping[str, float]]],
+) -> Dict[str, Any]:
+    per_attempt: Dict[Tuple[Any, ...], str] = {}
+    per_task: Dict[Tuple[Any, ...], str] = {}
+    for record in records:
+        task_key = (record["root_index"], record["task_id"])
+        for event in record["events"]:
+            if event.get("event") != "evidence-checkpoint":
+                continue
+            verdict = event.get("verdict")
+            if not isinstance(verdict, str) or not verdict:
+                continue
+            attempt = event.get("attempt_id")
+            attempt_key = (
+                str(attempt)
+                if isinstance(attempt, str) and attempt
+                else f"_line:{event.get('_ledger')}:{event.get('_line')}"
+            )
+            per_attempt[(task_key, attempt_key)] = verdict
+            per_task[task_key] = verdict
+    tokens_by_verdict: Dict[str, int] = {}
+    usd_by_verdict: Dict[str, List[float]] = {}
+    attributed = 0
+    unattributed = 0
+    billable_rows = 0
+    attributed_usd: List[float] = []
+    unattributed_usd: List[float] = []
+    for row in rows:
+        verdict = per_attempt.get((row["task_key"], str(row["attempt_id"])))
+        tokens = _billable(row)
+        if tokens is not None:
+            billable_rows += 1
+            if verdict is None:
+                unattributed += tokens
+            else:
+                tokens_by_verdict[verdict] = tokens_by_verdict.get(verdict, 0) + tokens
+                attributed += tokens
+        cost = row.get("usd")
+        if pricing is not None and _valid_number(cost):
+            if verdict is None:
+                unattributed_usd.append(float(cost))
+            else:
+                usd_by_verdict.setdefault(verdict, []).append(float(cost))
+                attributed_usd.append(float(cost))
+    accepted = sum(verdict == ACCEPTED_VERDICT for verdict in per_task.values())
+    total_tokens = attributed + unattributed
+    report: Dict[str, Any] = {
+        "outcomes": len(per_attempt),
+        "by_verdict": _counted([("available", value) for value in per_attempt.values()]),
+        "tasks": len(per_task),
+        "by_final_verdict": _counted(
+            [("available", value) for value in per_task.values()]
+        ),
+        "accepted_tasks": accepted,
+        "tokens": {
+            # No priced review is an absent total, never a zero total.
+            "total": total_tokens if billable_rows else None,
+            "attributed": attributed,
+            "unattributed": unattributed,
+            "coverage": _coverage(
+                [
+                    ("available" if _billable(row) is not None else "missing", None)
+                    for row in rows
+                ]
+            ),
+        },
+        "tokens_by_verdict": dict(sorted(tokens_by_verdict.items())),
+        "tokens_per_accepted_task": _number(total_tokens / accepted)
+        if accepted and billable_rows
+        else None,
+    }
+    if pricing is not None:
+        total_usd = math.fsum(attributed_usd + unattributed_usd)
+        report["usd"] = {
+            "total": _number(total_usd) if (attributed_usd or unattributed_usd) else None,
+            "by_verdict": {
+                verdict: _number(math.fsum(usd_by_verdict[verdict]))
+                for verdict in sorted(usd_by_verdict)
+            },
+        }
+        report["usd_per_accepted_task"] = (
+            _number(total_usd / accepted)
+            if accepted and (attributed_usd or unattributed_usd)
+            else None
+        )
+    return report
+
+
+def _pricing(config_path: Path) -> Optional[Dict[str, Dict[str, float]]]:
+    """Vendor -> per-Mtok rates, or None. An absent block means an absent column.
+
+    Read directly, never through `runtime.load_config`: metrics is a lazy,
+    stdlib-only read-only extension and must not pull in protocol code.
+    """
+    document = _load_json_file(config_path)
+    if not isinstance(document, Mapping):
+        return None
+    block = document.get("pricing")
+    if not isinstance(block, Mapping):
+        return None
+    priced: Dict[str, Dict[str, float]] = {}
+    for vendor, rate in block.items():
+        if not isinstance(vendor, str) or not vendor or not isinstance(rate, Mapping):
+            continue
+        entry = {
+            key: float(rate[key])
+            for _, key in PRICE_FIELDS
+            if _valid_number(rate.get(key))
+        }
+        if entry:
+            priced[vendor] = dict(sorted(entry.items()))
+    return dict(sorted(priced.items())) or None
+
+
+def collect_metrics(
+    common_dir: Path,
+    *,
+    limit: int = 20,
+    stores: Sequence[Path] = (),
+    config_path: Optional[Path] = None,
+) -> Dict[str, Any]:
     if limit < 1:
         raise ValueError("metrics limit must be positive")
     common = common_dir.resolve()
-    records, unsafe = _discover(common)
+    records, unsafe, store_summaries = _discover(common, stores)
     records.sort(
         key=lambda record: (
             record["last_epoch"] is not None,
             record["last_epoch"] or 0,
             record["task_id"],
+            record["root_index"],
         ),
         reverse=True,
     )
     selected = records[:limit]
+    pricing = _pricing(CONFIG_PATH if config_path is None else config_path)
+    review_rows, duplicate_checkpoints = _review_rows(selected)
+    if pricing is not None:
+        for row in review_rows:
+            row["usd"] = _row_usd(row, pricing)
     status_counts: Dict[str, int] = {}
     for record in selected:
         status = record["status"] or "UNKNOWN"
@@ -429,6 +920,7 @@ def collect_metrics(common_dir: Path, *, limit: int = 20) -> Dict[str, Any]:
             "discovered_tasks": len(records),
             "selected_tasks": len(selected),
             "order": "latest valid event timestamp descending; task id tie-break",
+            "stores": store_summaries,
         },
         "tasks": {
             "count": len(selected),
@@ -437,6 +929,7 @@ def collect_metrics(common_dir: Path, *, limit: int = 20) -> Dict[str, Any]:
             "records": [
                 {
                     "task_id": record["task_id"],
+                    "store": str(record["root"]),
                     "status": record["status"] or "UNKNOWN",
                     "last_event_at": record["last_event_at"],
                     "event_ledgers": len(record["reads"]),
@@ -447,6 +940,10 @@ def collect_metrics(common_dir: Path, *, limit: int = 20) -> Dict[str, Any]:
         "models": _models(model_groups),
         "checks": _checks(selected),
         "reviews": _reviews(model_groups),
+        "review_outcomes": _review_outcomes(
+            review_rows, duplicate_checkpoints, pricing
+        ),
+        "task_outcomes": _task_outcomes(selected, review_rows, pricing),
         "events": {
             "ledgers": {
                 "discovered": len(reads),
@@ -482,6 +979,96 @@ def _duration_text(value: Mapping[str, Any]) -> str:
     return f"{summary}; coverage {_coverage_text(value['coverage'])}"
 
 
+def _rate_text(value: Optional[float]) -> str:
+    return "n/a" if value is None else f"{value:.1f}%"
+
+
+def _minutes_text(value: Mapping[str, Any]) -> str:
+    total = value["total"]
+    return "n/a" if total is None else f"{total / 60000.0:.1f}"
+
+
+def _tokens_text(value: Optional[int]) -> str:
+    return "n/a" if value is None else str(value)
+
+
+def _reviewer_text(name: str, row: Mapping[str, Any]) -> str:
+    line = (
+        f"  {name}: {row['reviews']} reviews, {row['pass']} PASS "
+        f"({_rate_text(row['pass_rate'])}); "
+        f"findings {json.dumps(row['findings'], sort_keys=True)}; "
+        f"{row['proof_gaps']} proof gaps; "
+        f"{row['green_check_reviews']['count']} on all-green checks; "
+        f"{_minutes_text(row['durations_ms'])} model min; "
+        f"{_tokens_text(row['tokens']['total'])} tokens "
+        f"(records {_coverage_text(row['records'])})"
+    )
+    if "usd" in row:
+        line += f"; USD {row['usd']['total']}"
+    return line
+
+
+def _outcome_lines(report: Mapping[str, Any]) -> List[str]:
+    reviews = report["review_outcomes"]
+    outcomes = report["task_outcomes"]
+    header = (
+        f"review outcomes: {reviews['reviews']} reviews, {reviews['pass']} PASS "
+        f"({_rate_text(reviews['pass_rate'])}); "
+        f"verdicts {json.dumps(reviews['by_verdict'], sort_keys=True)}; "
+        f"vendors {json.dumps(reviews['by_vendor'], sort_keys=True)}; "
+        f"{reviews['duplicate_checkpoints']} duplicate checkpoints skipped; "
+        f"records {_coverage_text(reviews['records'])}"
+    )
+    lines = [header]
+    lines.extend(
+        _reviewer_text(name, row) for name, row in reviews["by_reviewer"].items()
+    )
+    lines.append(
+        f"task outcomes: {outcomes['outcomes']} verification outcomes over "
+        f"{outcomes['tasks']} tasks; "
+        f"attempt verdicts {json.dumps(outcomes['by_verdict'], sort_keys=True)}; "
+        f"final task verdicts "
+        f"{json.dumps(outcomes['by_final_verdict'], sort_keys=True)}"
+    )
+    accepted = (
+        "n/a"
+        if outcomes["tokens_per_accepted_task"] is None
+        else str(outcomes["tokens_per_accepted_task"])
+    )
+    cost = (
+        f"tokens per accepted task: {accepted} "
+        f"({outcomes['accepted_tasks']} accepted tasks; "
+        f"{_tokens_text(outcomes['tokens']['total'])} review tokens, "
+        f"{outcomes['tokens']['unattributed']} unattributed; "
+        f"tokens by verdict "
+        f"{json.dumps(outcomes['tokens_by_verdict'], sort_keys=True)})"
+    )
+    if "usd_per_accepted_task" in outcomes:
+        priced = outcomes["usd_per_accepted_task"]
+        cost += (
+            f"; USD per accepted task "
+            f"{'n/a' if priced is None else priced} "
+            f"(total USD {outcomes['usd']['total']})"
+        )
+    lines.append(cost)
+    return lines
+
+
+def _store_lines(selection: Mapping[str, Any]) -> List[str]:
+    stores = selection["stores"]
+    if len(stores) < 2:
+        return []
+    return [
+        "stores: "
+        + "; ".join(
+            f"{store['path']} -> "
+            f"{'UNRESOLVED' if store['root'] is None else store['root']} "
+            f"({store['tasks']} tasks)"
+            for store in stores
+        )
+    ]
+
+
 def render_text(report: Mapping[str, Any]) -> str:
     selection = report["selection"]
     tasks = report["tasks"]
@@ -506,6 +1093,7 @@ def render_text(report: Mapping[str, Any]) -> str:
                 f"{selection['discovered_tasks']} most recent tasks "
                 f"(limit {selection['limit']})"
             ),
+            *_store_lines(selection),
             (
                 f"tasks: status {json.dumps(tasks['by_status'], sort_keys=True)}; "
                 f"coverage {_coverage_text(tasks['status_coverage'])}"
@@ -523,6 +1111,7 @@ def render_text(report: Mapping[str, Any]) -> str:
                 f"{reviews['timeouts']['count']} timeouts; "
                 f"durations {_duration_text(reviews['durations_ms'])}"
             ),
+            *_outcome_lines(report),
             (
                 f"checks: {checks['runs']} runs, {checks['timeouts']['count']} timeouts; "
                 f"outcomes {json.dumps(checks['by_outcome'], sort_keys=True)}; "

--- a/.agents/harness/metrics.py
+++ b/.agents/harness/metrics.py
@@ -35,10 +35,36 @@ USAGE_FIELDS: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
     ("reasoning", ("reasoning_output_tokens",)),
 )
 TOKEN_LABELS: Tuple[str, ...] = tuple(label for label, _ in USAGE_FIELDS)
-# Only these are billable. `reasoning` is a SUBSET of `output_tokens` — measured
-# strictly less in all 199 corpus records that report it — so adding it inflates
-# the total; cache counters are not priced like fresh input.
-BILLABLE_LABELS: Tuple[str, ...] = ("input", "output")
+# The two dialects DISAGREE about what `input_tokens` means, so what is billable
+# is defined per dialect and never per field name.
+#   Anthropic: `input_tokens`, `cache_read_input_tokens` and
+#     `cache_creation_input_tokens` are DISJOINT counters, and a cached review
+#     reports nearly its whole prompt in the cache pair — measured over the 31
+#     claude reviews in the corpus, `input_tokens` totals 70 against 2.70M cache
+#     tokens. Billing `input` alone scored those reviews at 25.0% of what they
+#     actually consumed while codex was billed at ~100%, which inverts any
+#     cross-vendor or cross-reviewer comparison drawn from the result.
+#   OpenAI: `cached_input_tokens` is a SUBSET of `input_tokens`; adding it
+#     double-counts the cached prefix.
+# `reasoning_output_tokens` is a subset of `output_tokens` in both dialects —
+# measured strictly less in all 199 corpus records that report it — so it is
+# never billable.
+BILLABLE_LABELS_BY_DIALECT: Dict[str, Dict[str, Tuple[str, ...]]] = {
+    "anthropic": {"input": ("input", "cached", "cache_write"), "output": ("output",)},
+    "openai": {"input": ("input",), "output": ("output",)},
+}
+# The dialect is read off the usage KEYS, not off `vendor`: the keys are direct
+# evidence of which arithmetic applies to the very fields being summed, so a
+# record whose vendor label is missing or unexpected still bills correctly.
+# `vendor` is only the fallback, and an undetectable record falls back to the
+# OpenAI shape — it cannot carry the Anthropic cache keys or it would have been
+# detected, so `input + output` is the whole of what it reports.
+USAGE_DIALECTS: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
+    ("anthropic", ("cache_read_input_tokens", "cache_creation_input_tokens")),
+    ("openai", ("cached_input_tokens", "cache_write_input_tokens")),
+)
+VENDOR_DIALECTS: Dict[str, str] = {"claude": "anthropic", "codex": "openai"}
+DEFAULT_DIALECT = "openai"
 PRICE_FIELDS: Tuple[Tuple[str, str], ...] = (
     ("input", "input_per_mtok"),
     ("output", "output_per_mtok"),
@@ -155,10 +181,21 @@ def _read(path: Path) -> Dict[str, Any]:
 
 def _task_roots(
     common: Path, stores: Sequence[Path]
-) -> List[Tuple[Path, Optional[Path]]]:
-    roots: List[Tuple[Path, Optional[Path]]] = [
-        (common, common / "agent-harness" / "v2" / "tasks")
-    ]
+) -> List[Tuple[Path, Optional[Path], bool]]:
+    """`(argument, task root, already counted)` per store, default store first.
+
+    A `--store` that resolves to an ALREADY registered task root is marked and
+    then skipped rather than ingested a second time. `_review_rows` keys on
+    `(root_index, task_id)`, so a second root index turns every task into a new
+    task: absolute counts double while every rate stays identical, which makes
+    the doubling invisible in the output. It is reachable straight from the
+    documented command — `--store ../.murmur-agent-driver/.git/agent-harness`
+    run from the driver clone resolves back to that clone's own store, which
+    `runtime.repo_context` has already supplied as `common`.
+    """
+    default = common / "agent-harness" / "v2" / "tasks"
+    roots: List[Tuple[Path, Optional[Path], bool]] = [(common, default, False)]
+    seen = {default.resolve()}
     for store in stores:
         origin = Path(store).expanduser().resolve()
         candidates = [origin.joinpath(*parts) for parts in STORE_CANDIDATES]
@@ -172,7 +209,10 @@ def _task_roots(
             ),
             None,
         )
-        roots.append((origin, resolved))
+        duplicate = resolved is not None and resolved.resolve() in seen
+        if resolved is not None:
+            seen.add(resolved.resolve())
+        roots.append((origin, resolved, duplicate))
     return roots
 
 
@@ -233,9 +273,9 @@ def _discover(
     records: List[Dict[str, Any]] = []
     unsafe = 0
     summaries: List[Dict[str, Any]] = []
-    for index, (origin, root) in enumerate(_task_roots(common, stores)):
+    for index, (origin, root, duplicate) in enumerate(_task_roots(common, stores)):
         found: List[Dict[str, Any]] = []
-        if root is not None:
+        if root is not None and not duplicate:
             found, skipped = _discover_root(root, index)
             unsafe += skipped
         records.extend(found)
@@ -243,6 +283,7 @@ def _discover(
             {
                 "path": str(origin),
                 "root": None if root is None else str(root),
+                "duplicate": duplicate,
                 "tasks": len(found),
             }
         )
@@ -530,25 +571,52 @@ def _attempt_green(task_dir: Path, attempt_id: Any) -> Optional[bool]:
     return all(outcome == "PASS" for outcome in outcomes)
 
 
-def _usage_tokens(record: Mapping[str, Any]) -> Dict[str, Optional[int]]:
-    totals: Dict[str, Optional[int]] = {label: None for label in TOKEN_LABELS}
+def _attempt_telemetry(record: Mapping[str, Any]) -> List[Mapping[str, Any]]:
     attempts = record.get("attempts")
     if not isinstance(attempts, Sequence) or isinstance(attempts, (str, bytes)):
-        return totals
-    for attempt in attempts:
-        if not isinstance(attempt, Mapping):
-            continue
-        telemetry = attempt.get("telemetry")
-        usage = telemetry.get("usage") if isinstance(telemetry, Mapping) else None
+        return []
+    return [
+        attempt["telemetry"]
+        for attempt in attempts
+        if isinstance(attempt, Mapping) and isinstance(attempt.get("telemetry"), Mapping)
+    ]
+
+
+def _usage_tokens(
+    record: Mapping[str, Any]
+) -> Tuple[Dict[str, Optional[int]], Optional[str]]:
+    """Per-label token totals plus the usage dialect they were reported in."""
+    totals: Dict[str, Optional[int]] = {label: None for label in TOKEN_LABELS}
+    dialects: set[str] = set()
+    for telemetry in _attempt_telemetry(record):
+        usage = telemetry.get("usage")
         if not isinstance(usage, Mapping):
             continue
+        for dialect, markers in USAGE_DIALECTS:
+            if any(marker in usage for marker in markers):
+                dialects.add(dialect)
         for label, names in USAGE_FIELDS:
             for name in names:
                 value = usage.get(name)
                 if _valid_integer(value):
                     totals[label] = (totals[label] or 0) + int(value)
                     break
-    return totals
+    return totals, dialects.pop() if len(dialects) == 1 else None
+
+
+def _observed_cost(record: Mapping[str, Any]) -> Optional[float]:
+    """The vendor's own measured `telemetry.cost_usd`, summed over attempts.
+
+    Measured, not derived, so it beats any rate card where it exists. It exists
+    on every claude record in the corpus and on no codex one, which is why it is
+    an additional coverage-carrying column and never a replacement for `tokens`.
+    """
+    values = [
+        float(telemetry["cost_usd"])
+        for telemetry in _attempt_telemetry(record)
+        if _valid_number(telemetry.get("cost_usd"))
+    ]
+    return math.fsum(values) if values else None
 
 
 def _review_rows(
@@ -585,6 +653,8 @@ def _review_rows(
                 "resolved": "missing",
                 "verdict": None,
                 "vendor": None,
+                "dialect": None,
+                "observed_usd": None,
                 "duration_ms": None,
                 "proof_gaps": None,
                 "findings": {},
@@ -630,17 +700,28 @@ def _review_rows(
                     gaps = result.get("proof_gaps")
                     if isinstance(gaps, Sequence) and not isinstance(gaps, (str, bytes)):
                         row["proof_gaps"] = len(gaps)
-                for label, total in _usage_tokens(document).items():
+                totals, dialect = _usage_tokens(document)
+                for label, total in totals.items():
                     row[f"tokens_{label}"] = total
+                row["dialect"] = dialect or VENDOR_DIALECTS.get(str(row["vendor"]))
+                row["observed_usd"] = _observed_cost(document)
             deduped[key] = row
     ordered = sorted(deduped, key=lambda key: (key[0][0], key[0][1], key[1], key[2]))
     return [deduped[key] for key in ordered], duplicates
 
 
+def _billable_labels(dialect: Any) -> Dict[str, Tuple[str, ...]]:
+    return BILLABLE_LABELS_BY_DIALECT.get(
+        str(dialect), BILLABLE_LABELS_BY_DIALECT[DEFAULT_DIALECT]
+    )
+
+
 def _billable(row: Mapping[str, Any]) -> Optional[int]:
+    labels = _billable_labels(row.get("dialect"))
     present = [
         int(row[f"tokens_{label}"])
-        for label in BILLABLE_LABELS
+        for group in labels.values()
+        for label in group
         if _valid_integer(row.get(f"tokens_{label}"))
     ]
     return sum(present) if present else None
@@ -649,12 +730,20 @@ def _billable(row: Mapping[str, Any]) -> Optional[int]:
 def _row_usd(
     row: Mapping[str, Any], pricing: Mapping[str, Mapping[str, float]]
 ) -> Optional[float]:
+    """Rate-card cost over exactly the tokens `_billable` counts.
+
+    A coarse upper bound for the Anthropic dialect: cache reads are priced here
+    at the fresh-input rate. `observed_usd` is the vendor's own measurement and
+    is authoritative wherever it is present.
+    """
     rate = pricing.get(row.get("vendor"))
     if not isinstance(rate, Mapping):
         return None
+    labels = _billable_labels(row.get("dialect"))
     parts = [
         float(row[f"tokens_{label}"]) / 1000000.0 * float(rate[key])
-        for label, key in PRICE_FIELDS
+        for side, key in PRICE_FIELDS
+        for label in labels[side]
         if _valid_integer(row.get(f"tokens_{label}")) and _valid_number(rate.get(key))
     ]
     return math.fsum(parts) if parts else None
@@ -701,8 +790,14 @@ def _reviewer_row(rows: Sequence[Mapping[str, Any]], priced: bool) -> Dict[str, 
         "proof_gaps": 0 if gaps is None else gaps,
         "durations_ms": _numeric(_observe(groups, "duration_ms", _valid_number)),
         "tokens": tokens,
+        "observed_usd": _numeric(_observe(groups, "observed_usd", _valid_number)),
         "by_vendor": _counted(
             _observe(groups, "vendor", lambda value: isinstance(value, str) and bool(value))
+        ),
+        # Which arithmetic produced `tokens.total`, so the normalization is
+        # visible in the report rather than only in the source.
+        "by_dialect": _counted(
+            _observe(groups, "dialect", lambda value: isinstance(value, str) and bool(value))
         ),
         "green_check_reviews": _true_count(
             _observe(groups, "green_checks", lambda value: isinstance(value, bool))
@@ -819,6 +914,25 @@ def _task_outcomes(
         if accepted and billable_rows
         else None,
     }
+    # Vendor-measured, so it is reported whether or not a rate card exists.
+    observed = [
+        float(row["observed_usd"]) for row in rows if _valid_number(row.get("observed_usd"))
+    ]
+    observed_total = math.fsum(observed) if observed else None
+    report["observed_usd"] = {
+        "total": None if observed_total is None else _number(observed_total),
+        "coverage": _coverage(
+            [
+                ("available" if _valid_number(row.get("observed_usd")) else "missing", None)
+                for row in rows
+            ]
+        ),
+    }
+    report["observed_usd_per_accepted_task"] = (
+        _number(observed_total / accepted)
+        if accepted and observed_total is not None
+        else None
+    )
     if pricing is not None:
         total_usd = math.fsum(attributed_usd + unattributed_usd)
         report["usd"] = {
@@ -1003,8 +1117,14 @@ def _reviewer_text(name: str, row: Mapping[str, Any]) -> str:
         f"{_tokens_text(row['tokens']['total'])} tokens "
         f"(records {_coverage_text(row['records'])})"
     )
+    observed = row["observed_usd"]
+    if observed["total"] is not None:
+        line += (
+            f"; observed USD {observed['total']} "
+            f"(coverage {_coverage_text(observed['coverage'])})"
+        )
     if "usd" in row:
-        line += f"; USD {row['usd']['total']}"
+        line += f"; rate-card USD {row['usd']['total']}"
     return line
 
 
@@ -1016,6 +1136,7 @@ def _outcome_lines(report: Mapping[str, Any]) -> List[str]:
         f"({_rate_text(reviews['pass_rate'])}); "
         f"verdicts {json.dumps(reviews['by_verdict'], sort_keys=True)}; "
         f"vendors {json.dumps(reviews['by_vendor'], sort_keys=True)}; "
+        f"token dialects {json.dumps(reviews['by_dialect'], sort_keys=True)}; "
         f"{reviews['duplicate_checkpoints']} duplicate checkpoints skipped; "
         f"records {_coverage_text(reviews['records'])}"
     )
@@ -1043,10 +1164,17 @@ def _outcome_lines(report: Mapping[str, Any]) -> List[str]:
         f"tokens by verdict "
         f"{json.dumps(outcomes['tokens_by_verdict'], sort_keys=True)})"
     )
+    observed = outcomes["observed_usd_per_accepted_task"]
+    if observed is not None:
+        cost += (
+            f"; observed USD per accepted task {observed} "
+            f"(total observed USD {outcomes['observed_usd']['total']}, "
+            f"coverage {_coverage_text(outcomes['observed_usd']['coverage'])})"
+        )
     if "usd_per_accepted_task" in outcomes:
         priced = outcomes["usd_per_accepted_task"]
         cost += (
-            f"; USD per accepted task "
+            f"; rate-card USD per accepted task "
             f"{'n/a' if priced is None else priced} "
             f"(total USD {outcomes['usd']['total']})"
         )
@@ -1054,19 +1182,21 @@ def _outcome_lines(report: Mapping[str, Any]) -> List[str]:
     return lines
 
 
+def _store_text(store: Mapping[str, Any]) -> str:
+    root = "UNRESOLVED" if store["root"] is None else store["root"]
+    tail = (
+        "DUPLICATE (already counted)"
+        if store["duplicate"]
+        else f"{store['tasks']} tasks"
+    )
+    return f"{store['path']} -> {root} ({tail})"
+
+
 def _store_lines(selection: Mapping[str, Any]) -> List[str]:
     stores = selection["stores"]
     if len(stores) < 2:
         return []
-    return [
-        "stores: "
-        + "; ".join(
-            f"{store['path']} -> "
-            f"{'UNRESOLVED' if store['root'] is None else store['root']} "
-            f"({store['tasks']} tasks)"
-            for store in stores
-        )
-    ]
+    return ["stores: " + "; ".join(_store_text(store) for store in stores)]
 
 
 def render_text(report: Mapping[str, Any]) -> str:

--- a/.agents/harness/metrics_selftest.py
+++ b/.agents/harness/metrics_selftest.py
@@ -62,6 +62,7 @@ def _review_record(
     usage: Mapping[str, Any],
     severities: Any = (),
     proof_gaps: Any = (),
+    cost_usd: Any = None,
 ) -> Mapping[str, Any]:
     return {
         "schema_version": 2,
@@ -80,7 +81,7 @@ def _review_record(
                 "ok": True,
                 "transient": False,
                 "vendor": vendor,
-                "telemetry": {"cost_usd": None, "usage": dict(usage)},
+                "telemetry": {"cost_usd": cost_usd, "usage": dict(usage)},
             }
         ],
         "result": {
@@ -201,14 +202,20 @@ def _outcome_fixture(tasks: Path) -> None:
             "claude",
             "FAIL",
             90000,
+            # Copied verbatim from a real claude review record in the corpus.
+            # The Anthropic dialect puts essentially the whole prompt in the
+            # cache pair and leaves `input_tokens` at a literal 2, so a fixture
+            # that models it as a plausible-looking 2000 cannot tell the two
+            # dialects apart and the normalization assertion goes vacuous.
             {
-                "input_tokens": 2000,
-                "output_tokens": 200,
-                "cache_read_input_tokens": 300,
-                "cache_creation_input_tokens": 700,
+                "input_tokens": 2,
+                "output_tokens": 21730,
+                "cache_read_input_tokens": 3871,
+                "cache_creation_input_tokens": 57500,
             },
             ["MAJOR", "BLOCKER"],
             ["gap-a", "gap-b"],
+            cost_usd=1.45,
         ),
     )
     _write_json(needs_fix_attempt / "checks" / "ng-lint.json", _check_record("ng-lint", "FAIL"))
@@ -286,11 +293,6 @@ def outcome_cases(test: Tests) -> None:
             (180000, 60000, 90000),
         )
         test.equal(
-            "REVIEW-OUTCOME billable tokens are input plus output",
-            reviews["tokens"]["total"],
-            3850,
-        )
-        test.equal(
             "REVIEW-OUTCOME both vendor usage dialects are normalized",
             (
                 reviews["tokens"]["input"]["total"],
@@ -298,12 +300,41 @@ def outcome_cases(test: Tests) -> None:
                 reviews["tokens"]["cached"]["total"],
                 reviews["tokens"]["cache_write"]["total"],
             ),
-            (3500, 350, 500, 1100),
+            (1502, 21880, 4071, 57900),
+        )
+        test.equal(
+            "REVIEW-OUTCOME the usage dialect is attributed per record",
+            reviews["by_dialect"],
+            {"anthropic": 1, "openai": 2},
+        )
+        # codex: 1000+100 and 500+50 — `cached_input_tokens` is a SUBSET of
+        # `input_tokens` there, so adding it would double-count.
+        # claude: 2+3871+57500+21730 — those cache counters are DISJOINT from
+        # `input_tokens`, so billing `input + output` alone would score this
+        # 96k-token review at 21732 tokens, 26% of what it consumed.
+        test.equal(
+            "REVIEW-OUTCOME billable tokens follow each record's own dialect",
+            reviews["tokens"]["total"],
+            1100 + 550 + 83103,
+        )
+        test.equal(
+            "REVIEW-OUTCOME the Anthropic dialect bills its cache counters",
+            reviews["by_reviewer"]["combined"]["tokens"]["total"] - 1100,
+            83103,
         )
         test.equal(
             "REVIEW-OUTCOME reasoning tokens are reported but never billed",
             (reviews["tokens"]["reasoning"]["total"], reviews["tokens"]["total"]),
-            (10, 3850),
+            (10, 84753),
+        )
+        test.equal(
+            "REVIEW-OUTCOME the vendor's own measured cost is surfaced",
+            (
+                reviews["observed_usd"]["total"],
+                reviews["observed_usd"]["coverage"]["available"],
+                reviews["observed_usd"]["coverage"]["missing"],
+            ),
+            (1.45, 1, 3),
         )
         test.equal(
             "REVIEW-OUTCOME absent cache counters stay uncovered",
@@ -348,7 +379,7 @@ def outcome_cases(test: Tests) -> None:
         test.equal(
             "REVIEW-OUTCOME per-reviewer tokens and minutes are per reviewer",
             (combined["tokens"]["total"], combined["durations_ms"]["total"]),
-            (3300, 150000),
+            (84203, 150000),
         )
         test.equal(
             "REVIEW-OUTCOME a reviewer with no resolved record invents no rate",
@@ -371,12 +402,20 @@ def outcome_cases(test: Tests) -> None:
         test.equal(
             "TASK-OUTCOME review tokens are attributed to the outcome that consumed them",
             outcomes["tokens_by_verdict"],
-            {"NEEDS_FIX": 2200, "PASSED": 1650},
+            {"NEEDS_FIX": 83103, "PASSED": 1650},
         )
         test.equal(
             "TASK-OUTCOME cost per accepted task divides only by accepted tasks",
             (outcomes["tokens"]["total"], outcomes["tokens_per_accepted_task"]),
-            (3850, 1925),
+            (84753, 42376.5),
+        )
+        test.equal(
+            "TASK-OUTCOME observed cost per accepted task needs no rate card",
+            (
+                outcomes["observed_usd"]["total"],
+                outcomes["observed_usd_per_accepted_task"],
+            ),
+            (1.45, 0.725),
         )
         test.equal(
             "TASK-OUTCOME an unpriceable review is uncovered, not free",
@@ -398,9 +437,16 @@ def outcome_cases(test: Tests) -> None:
         )
         test.true(
             "TEXT cost per accepted task is rendered",
-            "tokens per accepted task: 1925" in text,
+            "tokens per accepted task: 42376.5" in text,
         )
-        test.true("TEXT omits USD when unpriced", "USD" not in text)
+        test.true(
+            "TEXT omits the rate-card column when unpriced",
+            "rate-card USD" not in text,
+        )
+        test.true(
+            "TEXT reports the measured cost even with no rate card",
+            "observed USD per accepted task 0.725" in text,
+        )
 
         first = metrics.collect_metrics(common, limit=20, config_path=unpriced)
         second = metrics.collect_metrics(common, limit=20, config_path=unpriced)
@@ -429,9 +475,11 @@ def outcome_cases(test: Tests) -> None:
         )
         with_usd = metrics.collect_metrics(common, limit=20, config_path=priced)
         test.equal(
-            "PRICING per-vendor rates price each vendor's own tokens",
+            "PRICING per-vendor rates price exactly the tokens each dialect bills",
             with_usd["review_outcomes"]["usd"]["by_vendor"],
-            {"claude": 0.015, "codex": 0.0045},
+            # claude: (2 + 3871 + 57500)/1e6*5 + 21730/1e6*25
+            # codex:  (1000 + 500)/1e6*2 + (100 + 50)/1e6*10
+            {"claude": 0.850115, "codex": 0.0045},
         )
         test.equal(
             "PRICING total USD and USD per accepted task follow the same join",
@@ -439,7 +487,7 @@ def outcome_cases(test: Tests) -> None:
                 with_usd["review_outcomes"]["usd"]["total"],
                 with_usd["task_outcomes"]["usd_per_accepted_task"],
             ),
-            (0.0195, 0.00975),
+            (0.854615, 0.427308),
         )
         test.true(
             "PRICING a malformed block is ignored rather than guessed",
@@ -475,6 +523,45 @@ def outcome_cases(test: Tests) -> None:
             "STORE an unresolvable store is reported, not silently empty",
             unresolved["selection"]["stores"][1]["root"],
             None,
+        )
+
+        # Absolute counts double while every rate stays identical, so nothing in
+        # the output looks anomalous. `--store <this repo's own store>` run from
+        # the driver clone is the documented command's own failure mode.
+        def totals(report: Mapping[str, Any]) -> Any:
+            return (
+                report["selection"]["discovered_tasks"],
+                report["review_outcomes"]["reviews"],
+                report["review_outcomes"]["tokens"]["total"],
+                report["task_outcomes"]["accepted_tasks"],
+                report["review_outcomes"]["durations_ms"]["total"],
+            )
+
+        once = metrics.collect_metrics(
+            common, limit=20, stores=[store], config_path=unpriced
+        )
+        twice = metrics.collect_metrics(
+            common, limit=20, stores=[store, store / "v2"], config_path=unpriced
+        )
+        test.equal(
+            "STORE the same task root passed twice is counted once",
+            totals(twice),
+            totals(once),
+        )
+        test.true(
+            "STORE a duplicate store is reported rather than silently elided",
+            twice["selection"]["stores"][2]["duplicate"] is True
+            and twice["selection"]["stores"][2]["tasks"] == 0
+            and "DUPLICATE (already counted)" in metrics.render_text(twice),
+        )
+        plain = metrics.collect_metrics(common, limit=20, config_path=unpriced)
+        self_referential = metrics.collect_metrics(
+            common, limit=20, stores=[common], config_path=unpriced
+        )
+        test.equal(
+            "STORE the default store passed as --store is not counted twice",
+            totals(self_referential),
+            totals(plain),
         )
         test.equal(
             "STORE same task id in two stores does not collide",

--- a/.agents/harness/metrics_selftest.py
+++ b/.agents/harness/metrics_selftest.py
@@ -49,6 +49,448 @@ def _state(at: str, status: str) -> Mapping[str, Any]:
     }
 
 
+def _write_json(path: Path, document: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(document, sort_keys=True), encoding="utf-8")
+
+
+def _review_record(
+    kind: str,
+    vendor: str,
+    verdict: str,
+    duration_ms: int,
+    usage: Mapping[str, Any],
+    severities: Any = (),
+    proof_gaps: Any = (),
+) -> Mapping[str, Any]:
+    return {
+        "schema_version": 2,
+        "kind": kind,
+        "label": f"review-{kind}-try-1",
+        "vendor": vendor,
+        "model": "unspecified",
+        "created_at": "2026-07-05T10:00:00Z",
+        "duration_ms": duration_ms,
+        "attempts": [
+            {
+                "attempt": 1,
+                "created_at": "2026-07-05T10:00:00Z",
+                "duration_ms": duration_ms,
+                "label": f"review-{kind}-try-1",
+                "ok": True,
+                "transient": False,
+                "vendor": vendor,
+                "telemetry": {"cost_usd": None, "usage": dict(usage)},
+            }
+        ],
+        "result": {
+            "verdict": verdict,
+            "summary": f"{kind} {verdict}",
+            "requirements_covered": [],
+            "findings": [
+                {
+                    "severity": severity,
+                    "file": "src-tauri/src/lib.rs",
+                    "evidence": "fixture",
+                    "required_fix": "fixture",
+                }
+                for severity in severities
+            ],
+            "proof_gaps": list(proof_gaps),
+            "probe_requests": [],
+        },
+    }
+
+
+def _check_record(check_id: str, outcome: str) -> Mapping[str, Any]:
+    return {
+        "schema_version": 2,
+        "id": check_id,
+        "command": f"run {check_id}",
+        "created_at": "2026-07-05T10:00:00Z",
+        "evidence": {
+            "outcome": outcome,
+            "passed": outcome == "PASS",
+            "exit_code": 0 if outcome == "PASS" else 1,
+            "duration_ms": 1000,
+        },
+    }
+
+
+def _review_checkpoint(
+    at: str, attempt_id: str, kind: str, record_path: Path, verdict: str
+) -> Mapping[str, Any]:
+    return {
+        "at": at,
+        "event": "review-checkpoint",
+        "attempt_id": attempt_id,
+        "review_kind": kind,
+        "record_path": str(record_path),
+        "verdict": verdict,
+    }
+
+
+def _evidence_checkpoint(
+    at: str, attempt_id: str, evidence_path: Path, verdict: str
+) -> Mapping[str, Any]:
+    return {
+        "at": at,
+        "event": "evidence-checkpoint",
+        "attempt_id": attempt_id,
+        "evidence_path": str(evidence_path),
+        "evidence_sha256": "0" * 64,
+        "verdict": verdict,
+    }
+
+
+def _outcome_fixture(tasks: Path) -> None:
+    """Two reviewed tasks (one PASSED, one NEEDS_FIX) plus one unreviewed PASSED task."""
+    passed = tasks / "task-p"
+    passed_attempt = passed / "attempts" / "att-p"
+    combined_p = passed_attempt / "reviews" / "combined.json"
+    _write_json(
+        combined_p,
+        _review_record(
+            "combined",
+            "codex",
+            "PASS",
+            60000,
+            {
+                "input_tokens": 1000,
+                "output_tokens": 100,
+                "cached_input_tokens": 200,
+                "cache_write_input_tokens": 400,
+                "reasoning_output_tokens": 10,
+            },
+            ["MINOR"],
+            ["gap-p"],
+        ),
+    )
+    lock_p = passed_attempt / "reviews" / "lock-security.json"
+    _write_json(
+        lock_p,
+        _review_record(
+            "lock-security",
+            "codex",
+            "PASS",
+            30000,
+            {"input_tokens": 500, "output_tokens": 50},
+        ),
+    )
+    _write_json(passed_attempt / "checks" / "rust-lib.json", _check_record("rust-lib", "PASS"))
+    passed_evidence = passed_attempt / "evidence.json"
+    _write_json(passed_evidence, {"schema_version": 2, "verdict": "PASSED"})
+    _append(
+        passed / "events.jsonl",
+        _state("2026-07-05T10:00:00Z", "OPEN"),
+        _review_checkpoint("2026-07-05T10:01:00Z", "att-p", "combined", combined_p, "PASS"),
+        _review_checkpoint(
+            "2026-07-05T10:02:00Z", "att-p", "lock-security", lock_p, "PASS"
+        ),
+        _evidence_checkpoint("2026-07-05T10:03:00Z", "att-p", passed_evidence, "PASSED"),
+        _state("2026-07-05T10:04:00Z", "COMMITTED"),
+    )
+
+    needs_fix = tasks / "task-n"
+    needs_fix_attempt = needs_fix / "attempts" / "att-n"
+    combined_n = needs_fix_attempt / "reviews" / "combined.json"
+    _write_json(
+        combined_n,
+        _review_record(
+            "combined",
+            "claude",
+            "FAIL",
+            90000,
+            {
+                "input_tokens": 2000,
+                "output_tokens": 200,
+                "cache_read_input_tokens": 300,
+                "cache_creation_input_tokens": 700,
+            },
+            ["MAJOR", "BLOCKER"],
+            ["gap-a", "gap-b"],
+        ),
+    )
+    _write_json(needs_fix_attempt / "checks" / "ng-lint.json", _check_record("ng-lint", "FAIL"))
+    absent = needs_fix_attempt / "reviews" / "egress-security.json"
+    needs_fix_evidence = needs_fix_attempt / "evidence.json"
+    _write_json(needs_fix_evidence, {"schema_version": 2, "verdict": "NEEDS_FIX"})
+    _append(
+        needs_fix / "events.jsonl",
+        _state("2026-07-06T10:00:00Z", "OPEN"),
+        _review_checkpoint("2026-07-06T10:01:00Z", "att-n", "combined", combined_n, "FAIL"),
+        # Same attempt, same reviewer, rewritten record: one review, two events.
+        _review_checkpoint("2026-07-06T10:02:00Z", "att-n", "combined", combined_n, "FAIL"),
+        # A checkpoint whose record was pruned: absent must stay absent, never zero.
+        _review_checkpoint(
+            "2026-07-06T10:03:00Z", "att-n", "egress-security", absent, "PASS"
+        ),
+        _evidence_checkpoint(
+            "2026-07-06T10:04:00Z", "att-n", needs_fix_evidence, "NEEDS_FIX"
+        ),
+        _state("2026-07-06T10:05:00Z", "NEEDS_FIX"),
+    )
+
+    quiet = tasks / "task-q"
+    quiet_evidence = quiet / "attempts" / "att-q" / "evidence.json"
+    _write_json(quiet_evidence, {"schema_version": 2, "verdict": "PASSED"})
+    _append(
+        quiet / "events.jsonl",
+        _state("2026-07-07T10:00:00Z", "OPEN"),
+        _evidence_checkpoint("2026-07-07T10:01:00Z", "att-q", quiet_evidence, "PASSED"),
+        _state("2026-07-07T10:02:00Z", "COMMITTED"),
+    )
+
+
+def outcome_cases(test: Tests) -> None:
+    with tempfile.TemporaryDirectory(prefix="murmur-metrics-") as raw:
+        base = Path(raw)
+        common = base / ".git"
+        _outcome_fixture(common / "agent-harness" / "v2" / "tasks")
+        # An explicit unpriced config keeps these assertions independent of
+        # whether the shipped harness config ever gains a "pricing" block.
+        unpriced = base / "unpriced-config.json"
+        unpriced.write_text(json.dumps({"schema_version": 2}), encoding="utf-8")
+        report = metrics.collect_metrics(common, limit=20, config_path=unpriced)
+        reviews = report["review_outcomes"]
+        outcomes = report["task_outcomes"]
+
+        test.equal(
+            "REVIEW-OUTCOME duplicate checkpoints collapse to one review",
+            (reviews["reviews"], reviews["duplicate_checkpoints"]),
+            (4, 1),
+        )
+        test.equal(
+            "REVIEW-OUTCOME a pruned record is missing, never zero",
+            reviews["records"],
+            {"available": 3, "missing": 1, "invalid": 0, "total": 4, "percent": 75.0},
+        )
+        test.equal(
+            "REVIEW-OUTCOME PASS-rate is computed over resolved records only",
+            (reviews["pass"], reviews["pass_rate"], reviews["by_verdict"]),
+            (2, 66.7, {"FAIL": 1, "PASS": 2}),
+        )
+        test.equal(
+            "REVIEW-OUTCOME findings are counted by severity",
+            reviews["findings"],
+            {"BLOCKER": 1, "MAJOR": 1, "MINOR": 1},
+        )
+        test.equal("REVIEW-OUTCOME proof gaps are counted", reviews["proof_gaps"], 3)
+        test.equal(
+            "REVIEW-OUTCOME model time sums record durations",
+            (
+                reviews["durations_ms"]["total"],
+                reviews["durations_ms"]["p50"],
+                reviews["durations_ms"]["p90"],
+            ),
+            (180000, 60000, 90000),
+        )
+        test.equal(
+            "REVIEW-OUTCOME billable tokens are input plus output",
+            reviews["tokens"]["total"],
+            3850,
+        )
+        test.equal(
+            "REVIEW-OUTCOME both vendor usage dialects are normalized",
+            (
+                reviews["tokens"]["input"]["total"],
+                reviews["tokens"]["output"]["total"],
+                reviews["tokens"]["cached"]["total"],
+                reviews["tokens"]["cache_write"]["total"],
+            ),
+            (3500, 350, 500, 1100),
+        )
+        test.equal(
+            "REVIEW-OUTCOME reasoning tokens are reported but never billed",
+            (reviews["tokens"]["reasoning"]["total"], reviews["tokens"]["total"]),
+            (10, 3850),
+        )
+        test.equal(
+            "REVIEW-OUTCOME absent cache counters stay uncovered",
+            reviews["tokens"]["cached"]["coverage"],
+            {"available": 2, "missing": 2, "invalid": 0, "total": 4, "percent": 50.0},
+        )
+        test.equal(
+            "REVIEW-OUTCOME vendors are attributed from the record",
+            reviews["by_vendor"],
+            {"claude": 1, "codex": 2},
+        )
+        test.equal(
+            "REVIEW-OUTCOME green-check reviews read the nested check outcome",
+            reviews["green_check_reviews"],
+            {
+                "count": 2,
+                "coverage": {
+                    "available": 4,
+                    "missing": 0,
+                    "invalid": 0,
+                    "total": 4,
+                    "percent": 100.0,
+                },
+            },
+        )
+        test.equal(
+            "REVIEW-OUTCOME reviewer rows are ordered deterministically",
+            list(reviews["by_reviewer"]),
+            ["combined", "egress-security", "lock-security"],
+        )
+        combined = reviews["by_reviewer"]["combined"]
+        test.equal(
+            "REVIEW-OUTCOME per-reviewer PASS-rate is per reviewer",
+            (combined["reviews"], combined["pass"], combined["pass_rate"]),
+            (2, 1, 50.0),
+        )
+        test.equal(
+            "REVIEW-OUTCOME per-reviewer findings and gaps are per reviewer",
+            (combined["findings"], combined["proof_gaps"]),
+            ({"BLOCKER": 1, "MAJOR": 1, "MINOR": 1}, 3),
+        )
+        test.equal(
+            "REVIEW-OUTCOME per-reviewer tokens and minutes are per reviewer",
+            (combined["tokens"]["total"], combined["durations_ms"]["total"]),
+            (3300, 150000),
+        )
+        test.equal(
+            "REVIEW-OUTCOME a reviewer with no resolved record invents no rate",
+            (
+                reviews["by_reviewer"]["egress-security"]["pass_rate"],
+                reviews["by_reviewer"]["egress-security"]["tokens"]["total"],
+            ),
+            (None, None),
+        )
+        test.equal(
+            "TASK-OUTCOME verification verdicts are counted per attempt",
+            (outcomes["outcomes"], outcomes["by_verdict"]),
+            (3, {"NEEDS_FIX": 1, "PASSED": 2}),
+        )
+        test.equal(
+            "TASK-OUTCOME final task verdict is the last checkpoint",
+            (outcomes["tasks"], outcomes["by_final_verdict"], outcomes["accepted_tasks"]),
+            (3, {"NEEDS_FIX": 1, "PASSED": 2}, 2),
+        )
+        test.equal(
+            "TASK-OUTCOME review tokens are attributed to the outcome that consumed them",
+            outcomes["tokens_by_verdict"],
+            {"NEEDS_FIX": 2200, "PASSED": 1650},
+        )
+        test.equal(
+            "TASK-OUTCOME cost per accepted task divides only by accepted tasks",
+            (outcomes["tokens"]["total"], outcomes["tokens_per_accepted_task"]),
+            (3850, 1925),
+        )
+        test.equal(
+            "TASK-OUTCOME an unpriceable review is uncovered, not free",
+            outcomes["tokens"]["coverage"],
+            {"available": 3, "missing": 1, "invalid": 0, "total": 4, "percent": 75.0},
+        )
+        test.true(
+            "PRICING absent block means absent column",
+            "usd" not in reviews and "usd_per_accepted_task" not in outcomes,
+        )
+        text = metrics.render_text(report)
+        test.true(
+            "TEXT review outcomes name the PASS-rate",
+            "review outcomes: 4 reviews, 2 PASS (66.7%)" in text,
+        )
+        test.true(
+            "TEXT per-reviewer row is rendered",
+            "combined: 2 reviews, 1 PASS (50.0%)" in text,
+        )
+        test.true(
+            "TEXT cost per accepted task is rendered",
+            "tokens per accepted task: 1925" in text,
+        )
+        test.true("TEXT omits USD when unpriced", "USD" not in text)
+
+        first = metrics.collect_metrics(common, limit=20, config_path=unpriced)
+        second = metrics.collect_metrics(common, limit=20, config_path=unpriced)
+        first.pop("generated_at")
+        second.pop("generated_at")
+        test.equal("REVIEW-OUTCOME the whole report is deterministic", first, second)
+        test.equal(
+            "PRICING the shipped harness config is the default source",
+            "usd" in metrics.collect_metrics(common, limit=20)["review_outcomes"],
+            metrics._pricing(metrics.CONFIG_PATH) is not None,
+        )
+
+        priced = base / "priced-config.json"
+        priced.write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "pricing": {
+                        "codex": {"input_per_mtok": 2.0, "output_per_mtok": 10.0},
+                        "claude": {"input_per_mtok": 5.0, "output_per_mtok": 25.0},
+                    },
+                },
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+        with_usd = metrics.collect_metrics(common, limit=20, config_path=priced)
+        test.equal(
+            "PRICING per-vendor rates price each vendor's own tokens",
+            with_usd["review_outcomes"]["usd"]["by_vendor"],
+            {"claude": 0.015, "codex": 0.0045},
+        )
+        test.equal(
+            "PRICING total USD and USD per accepted task follow the same join",
+            (
+                with_usd["review_outcomes"]["usd"]["total"],
+                with_usd["task_outcomes"]["usd_per_accepted_task"],
+            ),
+            (0.0195, 0.00975),
+        )
+        test.true(
+            "PRICING a malformed block is ignored rather than guessed",
+            metrics.collect_metrics(
+                common, limit=20, config_path=base / "no-such-config.json"
+            )["review_outcomes"].get("usd")
+            is None,
+        )
+
+        store = base / "elsewhere" / "agent-harness"
+        _outcome_fixture(store / "v2" / "tasks")
+        for label, candidate in (
+            ("git common dir", store.parent),
+            ("store root", store),
+            ("v2 dir", store / "v2"),
+            ("tasks dir", store / "v2" / "tasks"),
+        ):
+            merged = metrics.collect_metrics(
+                common, limit=20, stores=[candidate], config_path=unpriced
+            )
+            test.equal(
+                f"STORE {label} resolves to the same task root",
+                (
+                    merged["selection"]["discovered_tasks"],
+                    merged["review_outcomes"]["reviews"],
+                ),
+                (6, 8),
+            )
+        unresolved = metrics.collect_metrics(
+            common, limit=20, stores=[base], config_path=unpriced
+        )
+        test.equal(
+            "STORE an unresolvable store is reported, not silently empty",
+            unresolved["selection"]["stores"][1]["root"],
+            None,
+        )
+        test.equal(
+            "STORE same task id in two stores does not collide",
+            [
+                (item["task_id"], item["store"])
+                for item in metrics.collect_metrics(
+                    common, limit=2, stores=[store], config_path=unpriced
+                )["tasks"]["records"]
+            ],
+            [
+                ("task-q", str((store / "v2" / "tasks").resolve())),
+                ("task-q", str((common / "agent-harness" / "v2" / "tasks").resolve())),
+            ],
+        )
+
+
 def cases(test: Tests) -> None:
     with tempfile.TemporaryDirectory(prefix="murmur-metrics-") as raw:
         common = Path(raw) / ".git"
@@ -294,6 +736,7 @@ def cases(test: Tests) -> None:
 def main() -> int:
     test = Tests()
     cases(test)
+    outcome_cases(test)
     if test.failures:
         for failure in test.failures:
             print(f"metrics-selftest: FAIL: {failure}")

--- a/.agents/harness/v2_selftest.py
+++ b/.agents/harness/v2_selftest.py
@@ -23,6 +23,7 @@ import time
 from typing import Any, Dict, List, Mapping, Optional, Sequence
 
 import cli as harness_cli
+import config_audit
 import runtime
 import verifier
 
@@ -7110,6 +7111,269 @@ def egress_review_scope_prompt_cases(test: Tests) -> None:
     )
 
 
+LOCAL_SETTINGS_TRACKED_FIXTURE: Dict[str, Any] = {
+    # Deliberately NOT config_audit.REQUIRED_DENIES: the deny comparison has to
+    # be derived from whatever the tracked file declares, so a fixture-only
+    # entry proves the check reads the document instead of a module constant.
+    "permissions": {"deny": ["Read(~/fixture-only-secret/**)", "Read(**/fixture.pem)"]},
+    "sandbox": {
+        "allowUnsandboxedCommands": False,
+        "filesystem": {
+            "allowWrite": ["../.murmur-agent-tasks"],
+            "denyWrite": ["../meetnotes/.git"],
+        },
+    },
+}
+
+
+def _local_settings_audit(
+    root: Path, local: Optional[Mapping[str, Any]]
+) -> config_audit.Audit:
+    """Run `_local_settings` against a temp tree with `local` as the override."""
+
+    tracked = copy.deepcopy(LOCAL_SETTINGS_TRACKED_FIXTURE)
+    claude = root / ".claude"
+    claude.mkdir(parents=True, exist_ok=True)
+    runtime.atomic_write_json(claude / "settings.json", tracked)
+    override = claude / "settings.local.json"
+    if local is None:
+        if override.exists():
+            override.unlink()
+    else:
+        runtime.atomic_write_json(override, local)
+    audit = config_audit.Audit()
+    original_root = config_audit.ROOT
+    config_audit.ROOT = root
+    try:
+        config_audit._local_settings({".claude/settings.json": tracked}, audit)
+    finally:
+        config_audit.ROOT = original_root
+    return audit
+
+
+def local_settings_policy_cases(test: Tests) -> None:
+    """Pin the untracked Claude override against the tracked sandbox posture."""
+
+    with tempfile.TemporaryDirectory(prefix="murmur-local-settings-") as raw:
+        root = Path(raw)
+
+        absent = _local_settings_audit(root, None)
+        test.equal(
+            "absent local override raises nothing (the CI case)",
+            (absent.errors, absent.warnings),
+            ([], []),
+        )
+        test.true(
+            "absent local override still records a positive check",
+            any("no local Claude settings override" in check for check in absent.checks),
+        )
+
+        unsandboxed = _local_settings_audit(
+            root, {"sandbox": {"allowUnsandboxedCommands": True}}
+        )
+        test.true(
+            "re-enabled allowUnsandboxedCommands is a single failure",
+            len(unsandboxed.errors) == 1
+            and "sandbox.allowUnsandboxedCommands=true" in unsandboxed.errors[0],
+        )
+        test.equal(
+            "re-enabled allowUnsandboxedCommands never downgrades itself",
+            unsandboxed.warnings,
+            [],
+        )
+
+        git_entry = "/Users/fixture/Projects/meetnotes/.git"
+        git_write = _local_settings_audit(
+            root,
+            {
+                "sandbox": {
+                    "filesystem": {
+                        "allowWrite": [
+                            "/Users/fixture/.cargo",
+                            git_entry,
+                            "/Users/fixture/Projects/meetnotes/.git/agent-harness",
+                        ]
+                    }
+                }
+            },
+        )
+        test.equal("git write grants fail once per entry", len(git_write.errors), 2)
+        test.true(
+            "git write failure names the offending absolute entry verbatim",
+            any(error.endswith(git_entry) for error in git_write.errors),
+        )
+        lookalike = _local_settings_audit(
+            root,
+            {
+                "sandbox": {
+                    "filesystem": {
+                        "allowWrite": [
+                            "/Users/fixture/.gitconfig",
+                            "/Users/fixture/Projects/gitlab-runner",
+                            "/Users/fixture/Projects/.murmur-agent-tasks",
+                        ]
+                    }
+                }
+            },
+        )
+        test.equal(
+            "paths that merely start with 'git' are not Git directories",
+            (lookalike.errors, lookalike.warnings),
+            ([], []),
+        )
+
+        test.true(
+            "the deny fixture is not reachable through REQUIRED_DENIES",
+            "Read(~/fixture-only-secret/**)" not in config_audit.REQUIRED_DENIES,
+        )
+        regrant = _local_settings_audit(
+            root, {"permissions": {"allow": ["Read(~/fixture-only-secret/**)"]}}
+        )
+        test.true(
+            "a local allow that re-grants a tracked deny fails",
+            len(regrant.errors) == 1
+            and "Read(~/fixture-only-secret/**)" in regrant.errors[0],
+        )
+        truncated = _local_settings_audit(
+            root, {"permissions": {"deny": ["Read(~/fixture-only-secret/**)"]}}
+        )
+        test.true(
+            "a local deny list that drops a tracked entry fails",
+            len(truncated.errors) == 1 and "Read(**/fixture.pem)" in truncated.errors[0],
+        )
+        test.equal(
+            "omitting permissions entirely is not a weakening",
+            _local_settings_audit(root, {"sandbox": {"enabled": True}}).errors,
+            [],
+        )
+
+        acknowledged = _local_settings_audit(
+            root,
+            {
+                "_ack_policy_overrides": [
+                    "sandbox.allowUnsandboxedCommands: fixture release step needs codesign"
+                ],
+                "sandbox": {"allowUnsandboxedCommands": True},
+            },
+        )
+        test.equal("an acknowledged override clears the failure", acknowledged.errors, [])
+        test.true(
+            "an acknowledged override is recorded as one reasoned warning",
+            len(acknowledged.warnings) == 1
+            and "sandbox.allowUnsandboxedCommands=true" in acknowledged.warnings[0]
+            and "fixture release step needs codesign" in acknowledged.warnings[0],
+        )
+
+        scoped = _local_settings_audit(
+            root,
+            {
+                "_ack_policy_overrides": [
+                    "sandbox.allowUnsandboxedCommands: fixture release step needs codesign"
+                ],
+                "sandbox": {
+                    "allowUnsandboxedCommands": True,
+                    "filesystem": {"allowWrite": [git_entry]},
+                },
+            },
+        )
+        test.true(
+            "an acknowledgement downgrades only the key it names",
+            len(scoped.errors) == 1
+            and len(scoped.warnings) == 1
+            and git_entry in scoped.errors[0],
+        )
+
+        for label, entry in (
+            ("bare key", "sandbox.allowUnsandboxedCommands"),
+            ("empty reason", "sandbox.allowUnsandboxedCommands:   "),
+        ):
+            reasonless = _local_settings_audit(
+                root,
+                {
+                    "_ack_policy_overrides": [entry],
+                    "sandbox": {"allowUnsandboxedCommands": True},
+                },
+            )
+            test.equal(
+                f"a reasonless acknowledgement ({label}) mutes nothing",
+                reasonless.warnings,
+                [],
+            )
+            test.true(
+                f"a reasonless acknowledgement ({label}) fails twice over",
+                len(reasonless.errors) == 2
+                and any("records no reason" in error for error in reasonless.errors),
+            )
+
+        mistyped = _local_settings_audit(
+            root,
+            {
+                "_ack_policy_overrides": ["sandbox.allowUnsandboxed: typo"],
+                "sandbox": {"allowUnsandboxedCommands": True},
+            },
+        )
+        test.true(
+            "an acknowledgement naming an unaudited key cannot silence a rule",
+            len(mistyped.errors) == 2
+            and any("unaudited key" in error for error in mistyped.errors),
+        )
+
+        clean = _local_settings_audit(
+            root,
+            {
+                "permissions": {"allow": []},
+                "sandbox": {
+                    "enabled": True,
+                    "network": {"allowedDomains": ["github.com"]},
+                    "filesystem": {
+                        "allowWrite": ["/Users/fixture/.cargo"],
+                        "allowRead": ["/Users/fixture/.config/gh"],
+                    },
+                },
+            },
+        )
+        test.equal(
+            "a widening-only local override passes",
+            (clean.errors, clean.warnings),
+            ([], []),
+        )
+        test.true(
+            "a passing local override records a positive check",
+            any("preserves the declared posture" in check for check in clean.checks),
+        )
+
+        def audit_raw_override(text: str) -> config_audit.Audit:
+            (root / ".claude" / "settings.local.json").write_text(text, encoding="utf-8")
+            audit = config_audit.Audit()
+            original_root = config_audit.ROOT
+            config_audit.ROOT = root
+            try:
+                config_audit._local_settings(
+                    {
+                        ".claude/settings.json": copy.deepcopy(
+                            LOCAL_SETTINGS_TRACKED_FIXTURE
+                        )
+                    },
+                    audit,
+                )
+            finally:
+                config_audit.ROOT = original_root
+            return audit
+
+        unparseable = audit_raw_override("{ not json")
+        test.true(
+            "an unparseable local override fails instead of being skipped",
+            len(unparseable.errors) == 1 and "invalid JSON" in unparseable.errors[0],
+        )
+        for label, text in (("null", "null"), ("array", "[]")):
+            non_object = audit_raw_override(text)
+            test.true(
+                f"a non-object local override ({label}) fails exactly once",
+                len(non_object.errors) == 1
+                and "must contain a JSON object" in non_object.errors[0],
+            )
+
+
 def main() -> int:
     test = Tests()
     open_branch_ownership_cases(test)
@@ -7133,6 +7397,7 @@ def main() -> int:
     protocol_and_runtime_cases(test)
     commit_recovery_cases(test)
     plan_and_probe_cases(test)
+    local_settings_policy_cases(test)
     clean_cases(test)
     lock_review_scope_prompt_cases(test)
     egress_review_scope_prompt_cases(test)

--- a/.agents/harness/v2_selftest.py
+++ b/.agents/harness/v2_selftest.py
@@ -7115,23 +7115,31 @@ LOCAL_SETTINGS_TRACKED_FIXTURE: Dict[str, Any] = {
     # Deliberately NOT config_audit.REQUIRED_DENIES: the deny comparison has to
     # be derived from whatever the tracked file declares, so a fixture-only
     # entry proves the check reads the document instead of a module constant.
+    "env": {"FIXTURE_GUARD": "enforce", "FIXTURE_AUTOFMT": "0"},
     "permissions": {"deny": ["Read(~/fixture-only-secret/**)", "Read(**/fixture.pem)"]},
     "sandbox": {
         "allowUnsandboxedCommands": False,
+        "autoAllowBashIfSandboxed": True,
+        "enabled": True,
+        "failIfUnavailable": True,
         "filesystem": {
             "allowWrite": ["../.murmur-agent-tasks"],
-            "denyWrite": ["../meetnotes/.git"],
+            "denyWrite": ["../meetnotes/.git", "../murmur-server/.git"],
         },
     },
 }
 
 
 def _local_settings_audit(
-    root: Path, local: Optional[Mapping[str, Any]]
+    root: Path,
+    local: Optional[Mapping[str, Any]],
+    tracked_override: Optional[Mapping[str, Any]] = None,
 ) -> config_audit.Audit:
     """Run `_local_settings` against a temp tree with `local` as the override."""
 
-    tracked = copy.deepcopy(LOCAL_SETTINGS_TRACKED_FIXTURE)
+    tracked = copy.deepcopy(
+        LOCAL_SETTINGS_TRACKED_FIXTURE if tracked_override is None else tracked_override
+    )
     claude = root / ".claude"
     claude.mkdir(parents=True, exist_ok=True)
     runtime.atomic_write_json(claude / "settings.json", tracked)
@@ -7182,6 +7190,106 @@ def local_settings_policy_cases(test: Tests) -> None:
             [],
         )
 
+        # Turning the sandbox OFF is a strictly larger reversal than permitting
+        # escapes from it, and it reaches the same way: local project settings
+        # outrank project settings for every sibling scalar in the object.
+        for name in ("enabled", "failIfUnavailable"):
+            disabled = _local_settings_audit(root, {"sandbox": {name: False}})
+            test.true(
+                f"a local override may not turn off sandbox.{name}",
+                len(disabled.errors) == 1
+                and f"sandbox.{name}=false" in disabled.errors[0],
+            )
+            test.true(
+                f"sandbox.{name} is acknowledgeable under its own key",
+                f"sandbox.{name}" in config_audit.LOCAL_POLICY_KEYS,
+            )
+        test.equal(
+            "a tightening sandbox scalar is not a reversal",
+            _local_settings_audit(
+                root, {"sandbox": {"autoAllowBashIfSandboxed": False}}
+            ).errors,
+            [],
+        )
+        unmodelled_tracked = copy.deepcopy(LOCAL_SETTINGS_TRACKED_FIXTURE)
+        unmodelled_tracked["sandbox"]["someFutureHardening"] = True
+        unmodelled = _local_settings_audit(root, None, unmodelled_tracked)
+        test.true(
+            "a tracked sandbox scalar this audit does not model fails, even with no override",
+            len(unmodelled.errors) == 1
+            and "someFutureHardening" in unmodelled.errors[0],
+        )
+
+        bypass = _local_settings_audit(
+            root, {"permissions": {"defaultMode": "bypassPermissions"}}
+        )
+        test.true(
+            "a local permissions.defaultMode that suppresses gating fails",
+            len(bypass.errors) == 1
+            and "permissions.defaultMode=bypassPermissions" in bypass.errors[0],
+        )
+        test.equal(
+            "a stricter local permissions.defaultMode passes",
+            _local_settings_audit(root, {"permissions": {"defaultMode": "plan"}}).errors,
+            [],
+        )
+
+        guard_off = _local_settings_audit(
+            root, {"env": {"FIXTURE_GUARD": "off", "FIXTURE_UNTRACKED": "1"}}
+        )
+        test.true(
+            "a local env value that reverses a tracked one fails",
+            len(guard_off.errors) == 1
+            and "FIXTURE_GUARD" in guard_off.errors[0]
+            and "FIXTURE_UNTRACKED" not in guard_off.errors[0],
+        )
+        test.equal(
+            "restating a tracked env value is not a reversal",
+            _local_settings_audit(root, {"env": {"FIXTURE_GUARD": "enforce"}}).errors,
+            [],
+        )
+
+        dropped_deny_write = _local_settings_audit(
+            root,
+            {
+                "sandbox": {
+                    "filesystem": {"denyWrite": ["/Users/fixture/murmur-server/.git"]}
+                }
+            },
+        )
+        test.true(
+            "a redeclared denyWrite that drops a tracked entry fails",
+            len(dropped_deny_write.errors) == 1
+            and "../meetnotes/.git" in dropped_deny_write.errors[0]
+            and "../murmur-server/.git" not in dropped_deny_write.errors[0],
+        )
+        test.equal(
+            "an absolute denyWrite still covering every tracked entry passes",
+            _local_settings_audit(
+                root,
+                {
+                    "sandbox": {
+                        "filesystem": {
+                            "denyWrite": [
+                                "/Users/fixture/Projects/meetnotes/.git",
+                                # An ancestor denies the subtree, so it covers
+                                # ../murmur-server/.git too.
+                                "/Users/fixture/Projects/murmur-server",
+                            ]
+                        }
+                    }
+                },
+            ).errors,
+            [],
+        )
+        test.equal(
+            "not redeclaring denyWrite at all is not a drop",
+            _local_settings_audit(
+                root, {"sandbox": {"filesystem": {"allowRead": ["/Users/fixture/x"]}}}
+            ).errors,
+            [],
+        )
+
         git_entry = "/Users/fixture/Projects/meetnotes/.git"
         git_write = _local_settings_audit(
             root,
@@ -7221,6 +7329,51 @@ def local_settings_policy_cases(test: Tests) -> None:
             (lookalike.errors, lookalike.warnings),
             ([], []),
         )
+        test.true(
+            "a case-variant .git component is still a Git directory",
+            len(
+                _local_settings_audit(
+                    root,
+                    {
+                        "sandbox": {
+                            "filesystem": {
+                                "allowWrite": ["/Users/fixture/Projects/meetnotes/.GIT"]
+                            }
+                        }
+                    },
+                ).errors
+            )
+            == 1,
+        )
+        # A write grant is a SUBTREE grant, so the one-component-shallower edit an
+        # operator makes to silence the rule above WIDENS it: <repo>/.git/hooks
+        # stays reachable and runs unsandboxed on the next commit.
+        for label, entry in (
+            ("the repository root itself", str(root)),
+            ("a parent of the repository root", str(root.parent)),
+            ("the filesystem root", "/"),
+            ("a relative self-grant", "."),
+        ):
+            ancestor = _local_settings_audit(
+                root, {"sandbox": {"filesystem": {"allowWrite": [entry]}}}
+            )
+            test.true(
+                f"a write grant covering {label} reaches .git and fails",
+                len(ancestor.errors) == 1
+                and "covers the repository root" in ancestor.errors[0],
+            )
+        test.equal(
+            "a sibling of the repository root is not an ancestor of it",
+            _local_settings_audit(
+                root,
+                {
+                    "sandbox": {
+                        "filesystem": {"allowWrite": ["../.murmur-agent-tasks"]}
+                    }
+                },
+            ).errors,
+            [],
+        )
 
         test.true(
             "the deny fixture is not reachable through REQUIRED_DENIES",
@@ -7234,12 +7387,35 @@ def local_settings_policy_cases(test: Tests) -> None:
             len(regrant.errors) == 1
             and "Read(~/fixture-only-secret/**)" in regrant.errors[0],
         )
-        truncated = _local_settings_audit(
-            root, {"permissions": {"deny": ["Read(~/fixture-only-secret/**)"]}}
+        for label, allowed in (
+            ("narrower glob", "Read(~/fixture-only-secret/*)"),
+            ("single file", "Read(~/fixture-only-secret/key.txt)"),
+            ("another tool", "Bash(cat ~/fixture-only-secret/key.txt)"),
+        ):
+            widened = _local_settings_audit(root, {"permissions": {"allow": [allowed]}})
+            test.true(
+                f"a re-grant that is not the tracked string still fails ({label})",
+                len(widened.errors) == 1 and allowed in widened.errors[0],
+            )
+        test.equal(
+            "an allow that shares no literal prefix with a tracked deny passes",
+            _local_settings_audit(
+                root,
+                {"permissions": {"allow": ["Read(docs/**/*.md)", "Bash(ls:*)"]}},
+            ).errors,
+            [],
         )
-        test.true(
-            "a local deny list that drops a tracked entry fails",
-            len(truncated.errors) == 1 and "Read(**/fixture.pem)" in truncated.errors[0],
+        # Claude Code unions deny lists across settings sources and deny beats
+        # allow, so a local deny list can only ever ADD. Failing here accused an
+        # operator of weakening entries they never touched and pushed them onto
+        # the acknowledgement that also mutes the real re-grant above.
+        tightened = _local_settings_audit(
+            root, {"permissions": {"deny": ["Read(~/.kube/**)"]}}
+        )
+        test.equal(
+            "a strictly-tightening local deny list is not a weakening",
+            (tightened.errors, tightened.warnings),
+            ([], []),
         )
         test.equal(
             "omitting permissions entirely is not a weakening",

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -7,6 +7,7 @@ Claude Code is one adapter to the vendor-neutral development harness in
 | --- | --- |
 | `../CLAUDE.md` | Autoloaded project charter and rule index |
 | `settings.json` | Project permissions, sandbox policy, and hook wiring |
+| `settings.local.json` | Untracked per-machine deltas — audited, and never a policy reversal |
 | `rules/` | Binding Rust, Angular, lock, and agent-loop rules |
 | `agents/` | Thin specialist role prompts |
 | `skills/` | Claude-facing mirrors of shared executable runbooks |
@@ -30,6 +31,53 @@ The finish guard is fail-closed. It accepts only a runner-created PASS bound to
 the exact staged diff, active instructions, dependency revisions, green checks,
 and independent review sessions. `scripts/agent-config-audit --ci` prevents the
 Claude and Codex adapters from silently drifting.
+
+## Local overrides (`settings.local.json`)
+
+`settings.json` is the declared posture. `settings.local.json` is untracked and
+git-ignored, so it is the one file that can change the EFFECTIVE runtime policy
+while every parity check and fingerprint above still passes. The audit's
+`_local_settings` section closes that gap: it reads the local file when present
+and compares it against the tracked document. The file cannot exist on a CI
+runner, so its absence is a pass and the check can never fail a remote job.
+
+A local override **may widen** — extra `sandbox.filesystem.allowRead`/`allowWrite`
+paths outside the repository, extra `sandbox.network.allowedDomains`, extra
+`permissions.allow` entries the tracked policy does not deny. It **may not
+reverse** what the repository declares:
+
+- `sandbox.allowUnsandboxedCommands: true` while `settings.json` declares `false`;
+- a `sandbox.filesystem.allowWrite` entry covering any `.git` directory;
+- a `permissions.allow` entry that re-grants, or a `permissions.deny` list that
+  drops, anything the tracked `permissions.deny` declares (the comparison is
+  derived from `settings.json`, so it follows a legitimate policy change).
+
+**Local convenience must never widen the declared posture.** The harness does
+not borrow this file: `.agents/harness/runtime.py` provisions each review with
+its own sandbox, inlining `autoAllowBashIfSandboxed: false` /
+`allowUnsandboxedCommands: false` for Claude reviewers and the
+`murmur_harness_reviewer` permission profile with `network.enabled = false` for
+Codex ones. Loosening the project sandbox therefore buys nothing inside the
+harness and only weakens ordinary sessions.
+
+When a machine genuinely needs one of those reversals, record it rather than
+hide it. A top-level `_ack_policy_overrides` array of `"<key>: <reason>"`
+strings downgrades the named key from a failure to a warning:
+
+```json
+{
+  "_ack_policy_overrides": [
+    "sandbox.allowUnsandboxedCommands: release machine signs and notarizes"
+  ]
+}
+```
+
+The auditable keys are `sandbox.allowUnsandboxedCommands`,
+`sandbox.filesystem.allowWrite`, and `permissions.deny`. An acknowledgement is a
+recorded justification, not a mute button: a bare key, an empty reason, or an
+unrecognized key is itself a failure, an acknowledgement downgrades only the key
+it names, and the resulting `[WARN]` line keeps the reversal visible in every
+audit run.
 
 Quick verification:
 

--- a/.claude/README.md
+++ b/.claude/README.md
@@ -43,14 +43,33 @@ runner, so its absence is a pass and the check can never fail a remote job.
 
 A local override **may widen** — extra `sandbox.filesystem.allowRead`/`allowWrite`
 paths outside the repository, extra `sandbox.network.allowedDomains`, extra
-`permissions.allow` entries the tracked policy does not deny. It **may not
-reverse** what the repository declares:
+`permissions.allow` entries the tracked policy does not deny, extra
+`permissions.deny` entries of its own (deny lists union across sources, so a
+local deny can only ever tighten). It **may not reverse** what the repository
+declares:
 
-- `sandbox.allowUnsandboxedCommands: true` while `settings.json` declares `false`;
-- a `sandbox.filesystem.allowWrite` entry covering any `.git` directory;
-- a `permissions.allow` entry that re-grants, or a `permissions.deny` list that
-  drops, anything the tracked `permissions.deny` declares (the comparison is
-  derived from `settings.json`, so it follows a legitimate policy change).
+- any tracked `sandbox` scalar flipped to its permissive side —
+  `enabled`/`failIfUnavailable` `true → false`, `allowUnsandboxedCommands`
+  `false → true`. Direction is per key: `autoAllowBashIfSandboxed: false` only
+  adds prompts and is allowed. The audit fails if `settings.json` ever grows a
+  sandbox scalar whose direction is not modelled, so the rule cannot rot;
+- a `permissions.defaultMode` at or above the tracked one on the
+  `plan < default < acceptEdits < bypassPermissions` ladder;
+- a `sandbox.filesystem.allowWrite` entry covering any `.git` directory **or any
+  ancestor of the repository root** (a write grant is a subtree grant, so `/`,
+  `$HOME`, and the repo directory itself all reach `<repo>/.git/hooks`);
+- a redeclared `sandbox.filesystem.denyWrite` that drops a tracked entry — the
+  array replaces rather than merges, so omitting one removes it;
+- a `permissions.allow` entry that re-grants anything the tracked
+  `permissions.deny` protects, matched on the deny rule's literal path prefix
+  rather than on the exact string, so `Read(~/.ssh/*)` and
+  `Bash(cat ~/.ssh/id_rsa)` are caught as well as `Read(~/.ssh/**)`;
+- an `env` value that differs from the one `settings.json` declares — notably
+  `MURMUR_FINISH_GUARD`, which `hook_guard._finish_guard` disables outright when
+  it reads `off`.
+
+Every one of those comparisons is derived from `settings.json`, so a legitimate
+policy change moves the rule with it instead of leaving a stale second copy.
 
 **Local convenience must never widen the declared posture.** The harness does
 not borrow this file: `.agents/harness/runtime.py` provisions each review with
@@ -72,9 +91,12 @@ strings downgrades the named key from a failure to a warning:
 }
 ```
 
-The auditable keys are `sandbox.allowUnsandboxedCommands`,
-`sandbox.filesystem.allowWrite`, and `permissions.deny`. An acknowledgement is a
-recorded justification, not a mute button: a bare key, an empty reason, or an
+The auditable keys are `env`, `permissions.allow`, `permissions.defaultMode`,
+`sandbox.allowUnsandboxedCommands`, `sandbox.enabled`,
+`sandbox.failIfUnavailable`, `sandbox.filesystem.allowWrite`, and
+`sandbox.filesystem.denyWrite` — one key per reversal, so acknowledging a
+sandbox scalar cannot also silence a credential re-grant. An acknowledgement is
+a recorded justification, not a mute button: a bare key, an empty reason, or an
 unrecognized key is itself a failure, an acknowledgement downgrades only the key
 it names, and the resulting `[WARN]` line keeps the reversal visible in every
 audit run.

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 .playwright-mcp/
 /settings-audio-controls.png
 .claude/worktrees/
+# Per-machine Claude override — audited by config_audit._local_settings, never committed
+.claude/settings.local.json
 .codex/worktrees/
 .codex/tmp/
 .codex/claude-settings.local.migrated.json

--- a/docs/research/2026-08-01-reviewer-corpus-measurement.md
+++ b/docs/research/2026-08-01-reviewer-corpus-measurement.md
@@ -85,6 +85,34 @@ for ledger in (evidence_store).rglob('events.jsonl'):
 No sampling: 348 ledgers, 216 review checkpoints, 100% of `record_path`s resolved. The corpus
 spans 2026-07-28 → 2026-07-31 and both vendors (`codex` and `claude`).
 
+### This is now a command, not an archaeology expedition
+
+The join above shipped as `scripts/agent-harness metrics --store <evidence-store>`
+(`.agents/harness/metrics.py`, `_review_rows` → `_review_outcomes` / `_task_outcomes`). Re-running
+it against the same store with the corpus restricted to `created_at < 2026-08-01` reproduces this
+table cell-for-cell for `egress-security` (65 / 69% / 17 findings / 5 BLOCKER / 38.8 min / 13%) and
+`lock-security` (53 / 75% / 11 / 6 / 33.0 min / 11%), and reproduces the headline **76%**
+generalist share of model time. Two arithmetic corrections fall out of that replay:
+
+1. **216 is an event count; there are 214 distinct reviews.** Two `combined` checkpoints —
+   `continuity-research-docs-20260728` and `dependency-rollup-v2-final-r2-20260728` — fire twice
+   against the same rewritten record. They contribute exactly the 2 reviews, 8 findings and 5.4
+   minutes by which this table exceeds a record-deduplicated count. The command deduplicates by
+   `(store, task, attempt, reviewer)` and prints how many events it skipped.
+2. **12.47M double-counts reasoning tokens.** `12,474,552` is
+   `input + output + reasoning_output_tokens` over the 216 events. `reasoning_output_tokens` is a
+   *subset* of `output_tokens` — measured strictly smaller in all 199 corpus records that report
+   it — so it must not be added. Billable is `input + output`: **12,280,942** over the 214 distinct
+   reviews at this cutoff.
+
+Neither correction moves the verdict; the generalist's share of model time is unchanged.
+
+The full store has since grown past this snapshot (232 reviews, 12.84M billable tokens, 343.4 min),
+and the growth is concentrated in nine `claude` `egress-security` reviews run on 2026-08-01 that
+alone account for 75 of that reviewer's now-92 findings and roughly 40 of its 78.9 minutes. A
+`combined`-vs-specialist comparison drawn from the current store is therefore also a
+`codex`-vs-`claude` comparison; this table is the clean snapshot.
+
 ## What this does NOT establish
 
 - **False-positive rate.** "MAJOR" is the reviewer's own label. Classifying each of the 90

--- a/docs/research/2026-08-01-reviewer-corpus-measurement.md
+++ b/docs/research/2026-08-01-reviewer-corpus-measurement.md
@@ -92,7 +92,7 @@ The join above shipped as `scripts/agent-harness metrics --store <evidence-store
 it against the same store with the corpus restricted to `created_at < 2026-08-01` reproduces this
 table cell-for-cell for `egress-security` (65 / 69% / 17 findings / 5 BLOCKER / 38.8 min / 13%) and
 `lock-security` (53 / 75% / 11 / 6 / 33.0 min / 11%), and reproduces the headline **76%**
-generalist share of model time. Two arithmetic corrections fall out of that replay:
+generalist share of model time. Three arithmetic corrections fall out of that replay:
 
 1. **216 is an event count; there are 214 distinct reviews.** Two `combined` checkpoints —
    `continuity-research-docs-20260728` and `dependency-rollup-v2-final-r2-20260728` — fire twice
@@ -102,16 +102,31 @@ generalist share of model time. Two arithmetic corrections fall out of that repl
 2. **12.47M double-counts reasoning tokens.** `12,474,552` is
    `input + output + reasoning_output_tokens` over the 216 events. `reasoning_output_tokens` is a
    *subset* of `output_tokens` — measured strictly smaller in all 199 corpus records that report
-   it — so it must not be added. Billable is `input + output`: **12,280,942** over the 214 distinct
-   reviews at this cutoff.
+   it — so it must not be added.
+3. **`input_tokens` is not the prompt in both dialects, and treating it as one under-counted every
+   `claude` review by 75%.** Anthropic reports `input_tokens`, `cache_read_input_tokens` and
+   `cache_creation_input_tokens` as DISJOINT counters and puts a cached prompt almost entirely in
+   the cache pair: across the 31 `claude` records here, `input_tokens` totals **70** — per-record
+   values are literally 2 or 4 — against 2.23M cache-creation and 0.47M cache-read tokens. OpenAI
+   reports `cached_input_tokens` as a *subset* of `input_tokens`. So billable is per dialect, not
+   per field name: `input + cache_read + cache_creation + output` for Anthropic,
+   `input + output` for OpenAI (`.agents/harness/metrics.py`, `BILLABLE_LABELS_BY_DIALECT`).
+   Corrected billable is **14,305,563** over the 214 distinct reviews at this cutoff.
 
-Neither correction moves the verdict; the generalist's share of model time is unchanged.
+None of the three moves the verdict; the generalist's share of model time is unchanged. Correction 3
+does move the token columns materially, so any per-reviewer token figure predating it is 75% low
+for every `claude` row and must not be compared against a `codex` row.
 
-The full store has since grown past this snapshot (232 reviews, 12.84M billable tokens, 343.4 min),
+The full store has since grown past this snapshot (232 reviews, 15.54M billable tokens, 343.4 min),
 and the growth is concentrated in nine `claude` `egress-security` reviews run on 2026-08-01 that
-alone account for 75 of that reviewer's now-92 findings and roughly 40 of its 78.9 minutes. A
-`combined`-vs-specialist comparison drawn from the current store is therefore also a
-`codex`-vs-`claude` comparison; this table is the clean snapshot.
+alone account for 75 of that reviewer's now-92 findings and roughly 40 of its 78.9 minutes. The
+vendor split is **not** aligned with the reviewer split — the other 22 `claude` reviews are
+`combined` runs from 2026-07-28/29 — so a `combined`-vs-specialist comparison drawn from the
+current store is confounded by vendor at both ends; this table is the clean snapshot.
+
+Where a `claude` record carries `telemetry.cost_usd` the command now reports it as `observed USD`.
+It is measured rather than derived and needs no rate card: **$44.95** over the 31 `claude` records
+in the full store, and it exists on none of the 201 `codex` records.
 
 ## What this does NOT establish
 


### PR DESCRIPTION
Two gaps the audit of this repo's own agent layer turned up: a policy file nothing checked, and a pile of evidence nothing read.

## 1. `.claude/settings.local.json` comes under the audit

The tracked `.claude/settings.json` declares a deliberate sandbox posture. The **untracked** local override silently reversed parts of it — `allowUnsandboxedCommands: true`, plus a filesystem write grant covering the repo's own `.git`. So the whole apparatus of parity checks and fingerprints policed the *declared* policy while the *effective* runtime policy sat beside it, unexamined.

`_local_settings` now fails locally when an override disables the sandbox, re-grants something the tracked `permissions.deny` forbids, or hands write access to a Git directory. `_ack_policy_overrides` downgrades a named key to a warning **only with a written reason** — the point is a recorded justification, not a mute button.

**CI-safe by construction**: the section returns on the first statement when the file is absent, which is always true in CI. Pinned by two selftests, because replacing that guard with a `_load_json` call would emit `missing JSON file` as an error and turn every CI run red. The file is now also named in the tracked `.gitignore` — previously a fresh clone was one `git add -A` away from committing a machine-local override.

## 2. `agent-harness metrics` reports outcomes

Every review record already carried `duration_ms` and `attempts[].telemetry.usage`, and nothing read it. It took an ad-hoc archaeology pass to discover the generalist reviewer was spending 76% of the review budget for one BLOCKER in 98 reviews. That should be a command.

Adds per-reviewer (reviews, PASS-rate, findings by severity, model minutes, tokens) and per-outcome tables, plus tokens per accepted task. USD appears only if `config.json` carries a `pricing` block — absent block, absent column, never an invented price.

## What adversarial review caught — two BLOCKERs, both real

**The audit could be bypassed entirely.** It checked `allowUnsandboxedCommands` but not `sandbox.enabled: false`, which disables the sandbox outright. A local file could therefore reverse the posture *through the front door* while passing the check written to stop exactly that. Also fixed alongside it: `env.MURMUR_FINISH_GUARD: "off"` defeating the commit guard, dropping `.git` from `denyWrite`, a parent-directory grant slipping past a literal `.git` component match, and a *stricter* local deny-list being reported as a weakening.

**The token numbers were wrong by ~4×.** `tokens` counted Claude reviews at roughly 25% of real usage, because vendors report usage in different dialects. Cost tables that are silently wrong are worse than none — this repo already demoted a reviewer on numbers from this store. Fixed with per-dialect billing; `metrics_selftest` grew from 24 to 70 assertions.

All nine BLOCKER/MAJOR findings are fixed, none refuted.

## Gates

```
agent config audit: PASS (139 checks, 0 warnings)
v2 selftest:        PASS (459 assertions)
v2 fault selftest:  PASS (39 assertions)
metrics-selftest:   PASS (70 assertions)     # was 24
guardrail self-test: PASS (245 assertions) x2
scaffold eval (fake): 8 task(s), 0 failure(s)
```

RED-before-GREEN throughout: the local-settings rules were proven against the operator's real override file (captured, then deleted), and against the base revision where `_local_settings` does not exist and all 24 assertions are unreachable.