### PR TITLE
fix(eval): unbias the instrument; revert the reviewer demotion it would have justified

### DIFF
--- a/.agents/harness/README.md
+++ b/.agents/harness/README.md
@@ -66,13 +66,24 @@ The behavioral prompt cannot add shell commands. The derived plan is the sole
 executable evidence profile. Reviewers are fresh, read-only, and tool-free.
 They may request only a typed, allowlisted probe that the runner executes.
 
-`review_authority` in `config.json` decides which review can forbid a PASS. The
-three risk specialists are `blocking`. The `combined` generalist is `advisory`:
-it still runs, and its findings, proof gaps, and probe requests are still
-recorded in the receipt, but on any plan that keeps another gate they no longer
-gate the verdict and no longer spend a probe execution — see
-`docs/research/2026-08-01-reviewer-corpus-measurement.md`. Any unconfigured or
-unknown review kind is blocking.
+`review_authority` in `config.json` decides which review can forbid a PASS. A
+kind set to `advisory` still runs, and its findings, proof gaps, and probe
+requests are still recorded in the receipt, but on any plan that keeps another
+gate they no longer gate the verdict and no longer spend a probe execution. Any
+unconfigured or unknown review kind is blocking.
+
+**All four planned kinds currently ship `blocking`,** including the `combined`
+generalist, and `scripts/agent-config-audit` pins that. The generalist was
+briefly demoted on the corpus measurement in
+`docs/research/2026-08-01-reviewer-corpus-measurement.md`; that measurement
+ranked reviewers by BLOCKER count, while the gate that forbids a PASS reads
+`verifier.SEVERE_FINDINGS` (`MAJOR` + `BLOCKER`). Re-counted on that metric over
+the same 232-review corpus, the generalist had the highest density of
+PASS-forbidding findings, not the lowest — 116 over 105 reviews (1.10 each)
+against 0.41 for `egress-security` and 0.13 for `lock-security` — so the
+demotion was reverted. The demotion mechanism below stays live and tested on its
+own config fixtures; changing the shipped decision means editing both the config
+and its pin.
 
 Demotion removes a gate; it must never remove the last one. Every PASS names at
 least one gate that could have refused it, so `verifier.gating_review_kinds`

--- a/.agents/harness/cli.py
+++ b/.agents/harness/cli.py
@@ -2077,10 +2077,12 @@ def verify_task(
         ]
         # A demoted reviewer keeps its findings, proof gaps and probe requests
         # in the receipt, but it may not spend a runner-owned probe execution or
-        # force another full review round: the corpus measurement behind
+        # force another full review round: the review corpus behind
         # `verifier.review_authority` attributes 148 of 215 proof gaps to the one
         # generalist, so leaving this loop authority-blind would demote the
         # verdict while keeping the escalation pressure that cost the most.
+        # No kind is demoted in the shipped config today; this stays live so a
+        # future demotion cannot reintroduce that asymmetry.
         # `gating_review_kinds` reads the plan's own gate set, so a reviewer
         # that is this plan's ONLY gate is never demoted here either and keeps
         # the probe it needs to close the proof gap it is about to gate on.

--- a/.agents/harness/config.json
+++ b/.agents/harness/config.json
@@ -27,18 +27,33 @@
     "protocol": "protocol-security"
   },
   "review_authority": {
-    "combined": "advisory",
+    "combined": "blocking",
     "lock-security": "blocking",
     "egress-security": "blocking",
     "protocol-security": "blocking"
   },
   "risk_required_evidence": {
-    "lock": ["rust-lib"],
-    "egress": ["rust-lib"],
-    "protocol": ["rust-lib", "protocol-server"],
-    "runtime": ["tauri-boot"],
-    "ui": ["ng-lint", "ng-build", "playwright"],
-    "performance": ["perf-contracts"]
+    "lock": [
+      "rust-lib"
+    ],
+    "egress": [
+      "rust-lib"
+    ],
+    "protocol": [
+      "rust-lib",
+      "protocol-server"
+    ],
+    "runtime": [
+      "tauri-boot"
+    ],
+    "ui": [
+      "ng-lint",
+      "ng-build",
+      "playwright"
+    ],
+    "performance": [
+      "perf-contracts"
+    ]
   },
   "canonical_checks": {
     "rust-lib": "(cd src-tauri && CARGO_BUILD_JOBS=2 cargo test --lib -- --test-threads=1)",
@@ -82,6 +97,9 @@
       "src-tauri/src/commands/mod.rs",
       "src-tauri/src/commands/meetings.rs",
       "src-tauri/src/commands/notes.rs",
+      "src-tauri/src/commands/documents.rs",
+      "src-tauri/src/commands/links.rs",
+      "src-tauri/src/commands/reminders.rs",
       "src-tauri/src/mcp.rs",
       "src/app/**/lock*",
       "src/app/**/share*",

--- a/.agents/harness/config_audit.py
+++ b/.agents/harness/config_audit.py
@@ -303,18 +303,33 @@ def _json_audit(audit: Audit) -> Dict[str, Any]:
     )
     authority = config.get("review_authority") if isinstance(config, dict) else None
     risk_reviews = config.get("risk_reviews") if isinstance(config, dict) else None
+    # Demoting a reviewer is a measured decision, and the first one shipped was
+    # measured against the wrong threshold: it ranked reviewers by BLOCKER count
+    # while the gate that actually forbids a PASS reads
+    # `verifier.SEVERE_FINDINGS` (MAJOR + BLOCKER). Re-counted on that metric
+    # over the same 232-review corpus, the `combined` generalist had the HIGHEST
+    # density of PASS-forbidding findings, not the lowest: 116 severe findings
+    # over 105 reviews (1.10 each) against 30/74 (0.41) for egress-security and
+    # 7/53 (0.13) for lock-security. So every planned review kind ships blocking,
+    # and a future demotion has to change this pin deliberately rather than
+    # inherit one by editing a single config value.
     audit.require(
         isinstance(authority, dict)
         and isinstance(risk_reviews, dict)
         and all(
             authority.get(kind) == "blocking"
-            for kind in ("lock-security", "egress-security", "protocol-security")
+            for kind in (
+                "combined",
+                "lock-security",
+                "egress-security",
+                "protocol-security",
+            )
         )
         and all(
             authority.get(kind) == "blocking" for kind in risk_reviews.values()
         ),
-        "risk specialists retain blocking review authority",
-        "every risk_reviews specialist must stay blocking in review_authority",
+        "every planned review kind retains blocking review authority",
+        "review_authority must keep combined and every risk_reviews specialist blocking",
     )
     audit.require(
         isinstance(authority, dict)

--- a/.agents/harness/v2_selftest.py
+++ b/.agents/harness/v2_selftest.py
@@ -1673,10 +1673,28 @@ def verdict_cases(test: Tests) -> None:
         "NEEDS_EVIDENCE",
     )
 
-    # Review authority: the generalist is advisory, the risk specialists still
-    # gate. `review_result_state` stays kind-agnostic above; only the
-    # aggregation call site filters by authority.
+    # Review authority: a kind the config demotes records but does not gate, a
+    # kind it binds gates, and an unnamed kind fails closed. `review_result_state`
+    # stays kind-agnostic above; only the aggregation call site filters by
+    # authority.
+    #
+    # Which kinds the SHIPPED config demotes is a measured decision that has
+    # already flipped once, so these assertions build their own fixtures:
+    # `demoted_config` demotes the generalist, `gating_config` binds it. Reading
+    # the shipped decision here would empty every one of them the day it
+    # changes — exactly what happened when `combined` went back to blocking. The
+    # shipped decision gets one explicit pin of its own, below.
     config = runtime.load_config()
+    demoted_config = copy.deepcopy(config)
+    demoted_config["review_authority"] = {
+        **config["review_authority"],
+        "combined": verifier.ADVISORY_AUTHORITY,
+    }
+    gating_config = copy.deepcopy(config)
+    gating_config["review_authority"] = {
+        **config["review_authority"],
+        "combined": verifier.BLOCKING_AUTHORITY,
+    }
     green_check = {"id": "rust-lib", "evidence": {"passed": True, "outcome": "PASS"}}
 
     def review(kind: str, result: Mapping[str, Any]) -> Dict[str, Any]:
@@ -1687,16 +1705,25 @@ def verdict_cases(test: Tests) -> None:
         verifier.aggregate_verdict(
             [green_check],
             [review("combined", major), review("lock-security", base)],
-            config,
+            demoted_config,
         )[0],
         "PASSED",
+    )
+    test.equal(
+        "VERDICT blocking combined MAJOR forbids PASS",
+        verifier.aggregate_verdict(
+            [green_check],
+            [review("combined", major), review("lock-security", base)],
+            gating_config,
+        )[0],
+        "NEEDS_FIX",
     )
     test.equal(
         "VERDICT blocking specialist BLOCKER still forbids PASS",
         verifier.aggregate_verdict(
             [green_check],
             [review("combined", base), review("lock-security", blocker)],
-            config,
+            demoted_config,
         )[0],
         "NEEDS_FIX",
     )
@@ -1705,38 +1732,65 @@ def verdict_cases(test: Tests) -> None:
         verifier.aggregate_verdict(
             [green_check],
             [review("combined", gap), review("egress-security", base)],
-            config,
+            demoted_config,
         )[0],
         "PASSED",
+    )
+    test.equal(
+        "VERDICT blocking combined proof gap forbids PASS",
+        verifier.aggregate_verdict(
+            [green_check],
+            [review("combined", gap), review("egress-security", base)],
+            gating_config,
+        )[0],
+        "NEEDS_EVIDENCE",
     )
     test.equal(
         "VERDICT blocking specialist proof gap still forbids PASS",
         verifier.aggregate_verdict(
             [green_check],
             [review("combined", base), review("egress-security", gap)],
-            config,
+            demoted_config,
         )[0],
         "NEEDS_EVIDENCE",
     )
     test.equal(
         "VERDICT unknown review kind fails closed as blocking",
         verifier.aggregate_verdict(
-            [green_check], [review("future-security", blocker)], config
+            [green_check], [review("future-security", blocker)], demoted_config
         )[0],
         "NEEDS_FIX",
     )
+    # The shipped decision, pinned once. Every mechanism assertion in this group
+    # runs on its own fixture and stays green whichever way this pin goes, so a
+    # future demotion has to edit this line and the matching `config_audit`
+    # requirement on purpose. `config_audit` owns the enforcing copy; this one
+    # keeps the harness selftest honest about which config it ships with.
     test.equal(
-        "VERDICT configured specialist authority is blocking",
-        [
-            verifier.review_authority(kind, config)
-            for kind in ("lock-security", "egress-security", "protocol-security")
-        ],
-        [verifier.BLOCKING_AUTHORITY] * 3,
+        "VERDICT every shipped review kind is blocking",
+        {
+            kind: verifier.review_authority(kind, config)
+            for kind in (
+                "combined",
+                "lock-security",
+                "egress-security",
+                "protocol-security",
+            )
+        },
+        {
+            "combined": verifier.BLOCKING_AUTHORITY,
+            "lock-security": verifier.BLOCKING_AUTHORITY,
+            "egress-security": verifier.BLOCKING_AUTHORITY,
+            "protocol-security": verifier.BLOCKING_AUTHORITY,
+        },
     )
     test.equal(
-        "VERDICT combined authority is advisory",
-        verifier.review_authority("combined", config),
-        verifier.ADVISORY_AUTHORITY,
+        "VERDICT combined authority follows the config that names it",
+        (
+            verifier.review_authority("combined", demoted_config),
+            verifier.review_authority("combined", gating_config),
+        ),
+        (verifier.ADVISORY_AUTHORITY, verifier.BLOCKING_AUTHORITY),
     )
     test.equal(
         "VERDICT an authority-free config keeps every review blocking",
@@ -1759,11 +1813,17 @@ def verdict_cases(test: Tests) -> None:
             [
                 item["review"]
                 for item in verifier.advisory_findings(
-                    [green_check], mixed, config
+                    [green_check], mixed, demoted_config
+                )
+            ],
+            [
+                item["review"]
+                for item in verifier.advisory_findings(
+                    [green_check], mixed, gating_config
                 )
             ],
         ),
-        (["combined", "lock-security"], ["combined"]),
+        (["combined", "lock-security"], ["combined"], []),
     )
     test.equal(
         "VERDICT an authority-free config projects no advisory finding",
@@ -1773,9 +1833,13 @@ def verdict_cases(test: Tests) -> None:
 
     # Demotion removes a gate; it must never remove the LAST one. A docs-only
     # plan derives zero checks and only the generalist, so demoting it there
-    # would mint a PASS receipt on which nothing could have refused.
+    # would mint a PASS receipt on which nothing could have refused. Every
+    # assertion below runs on `demoted_config`, because the rule it pins only
+    # has anything to say about a config that demotes something: under a config
+    # where every kind gates, each of them would hold for a reason that has
+    # nothing to do with the last-gate rule.
     docs_checks, docs_reviews, docs_risks = verifier.derive_profile(
-        ["docs/architecture.md"], [], config, reviewer="codex"
+        ["docs/architecture.md"], [], demoted_config, reviewer="codex"
     )
     test.equal(
         "PROFILE a docs-only plan derives no check and only the generalist",
@@ -1784,32 +1848,38 @@ def verdict_cases(test: Tests) -> None:
     )
     test.equal(
         "VERDICT the sole reviewer of a check-free plan keeps its gate",
-        verifier.gating_review_kinds(docs_checks, docs_reviews, config),
+        verifier.gating_review_kinds(docs_checks, docs_reviews, demoted_config),
         ["combined"],
     )
     test.equal(
         "VERDICT a check-free plan cannot pass over a generalist BLOCKER",
-        verifier.aggregate_verdict([], [review("combined", blocker)], config),
+        verifier.aggregate_verdict(
+            [], [review("combined", blocker)], demoted_config
+        ),
         ("NEEDS_FIX", "a review has unresolved FAIL/MAJOR/BLOCKER findings"),
     )
     test.equal(
         "VERDICT a check-free plan cannot pass over a generalist proof gap",
-        verifier.aggregate_verdict([], [review("combined", gap)], config)[0],
+        verifier.aggregate_verdict(
+            [], [review("combined", gap)], demoted_config
+        )[0],
         "NEEDS_EVIDENCE",
     )
     test.equal(
         "VERDICT a check-free plan records no finding as advisory",
-        verifier.advisory_findings([], [review("combined", blocker)], config),
+        verifier.advisory_findings(
+            [], [review("combined", blocker)], demoted_config
+        ),
         [],
     )
     test.equal(
         "VERDICT one deterministic check is enough to demote the generalist",
         (
             verifier.gating_review_kinds(
-                [green_check], [review("combined", blocker)], config
+                [green_check], [review("combined", blocker)], demoted_config
             ),
             verifier.aggregate_verdict(
-                [green_check], [review("combined", blocker)], config
+                [green_check], [review("combined", blocker)], demoted_config
             )[0],
         ),
         ([], "PASSED"),
@@ -1817,13 +1887,15 @@ def verdict_cases(test: Tests) -> None:
     test.equal(
         "VERDICT a specialist gate is enough to demote the generalist",
         verifier.gating_review_kinds(
-            [], [review("combined", blocker), review("lock-security", base)], config
+            [],
+            [review("combined", blocker), review("lock-security", base)],
+            demoted_config,
         ),
         ["lock-security"],
     )
     test.equal(
         "VERDICT no check and no review still refuses to certify",
-        verifier.aggregate_verdict([], [], config),
+        verifier.aggregate_verdict([], [], demoted_config),
         ("NEEDS_EVIDENCE", "no blocking check or review evidence exists"),
     )
     # The PASS reason is the only prose `status` and the `verify` status JSON
@@ -1831,7 +1903,7 @@ def verdict_cases(test: Tests) -> None:
     test.equal(
         "VERDICT a PASS reason names the advisory findings it did not gate on",
         verifier.aggregate_verdict(
-            [green_check], [review("combined", blocker)], config
+            [green_check], [review("combined", blocker)], demoted_config
         )[1],
         "all blocking checks and reviews passed; 1 advisory finding(s) recorded "
         "(1 MAJOR/BLOCKER)",
@@ -1839,7 +1911,7 @@ def verdict_cases(test: Tests) -> None:
     test.equal(
         "VERDICT a finding-free PASS keeps its unqualified reason",
         verifier.aggregate_verdict(
-            [green_check], [review("combined", base)], config
+            [green_check], [review("combined", base)], demoted_config
         )[1],
         "all planned checks and reviews passed",
     )
@@ -1899,7 +1971,9 @@ def verdict_cases(test: Tests) -> None:
     # The check-free surfaces a reviewer named — the Angular app shell, the
     # Tauri build script, assets, and the landing page — keep a gate through
     # the same rule, without trading their one semantic reviewer for a
-    # syntactic check that cannot see what the reviewer was hired to see.
+    # syntactic check that cannot see what the reviewer was hired to see. These
+    # too run on `demoted_config`: it is the config that could strip their only
+    # gate, so it is the config that proves the rule holds for real repo paths.
     for path in (
         "src/index.html",
         "src-tauri/build.rs",
@@ -1908,7 +1982,7 @@ def verdict_cases(test: Tests) -> None:
         "src-tauri/entitlements.plist",
     ):
         check_profile, review_profile, _ = verifier.derive_profile(
-            [path], [], config, reviewer="codex"
+            [path], [], demoted_config, reviewer="codex"
         )
         test.equal(
             f"VERDICT {path} keeps a gate that can refuse a PASS",
@@ -1916,7 +1990,7 @@ def verdict_cases(test: Tests) -> None:
                 bool(check_profile)
                 or bool(
                     verifier.gating_review_kinds(
-                        check_profile, review_profile, config
+                        check_profile, review_profile, demoted_config
                     )
                 ),
                 verifier.aggregate_verdict(
@@ -1925,7 +1999,7 @@ def verdict_cases(test: Tests) -> None:
                         for item in check_profile
                     ],
                     [review(item["kind"], blocker) for item in review_profile],
-                    config,
+                    demoted_config,
                 )[0],
             ),
             (True, "NEEDS_FIX"),
@@ -2809,14 +2883,22 @@ def probe_precedence_flow_cases(test: Tests) -> None:
         selftest_config["canonical_checks"]["npm-lock"] = (
             "python3 -c 'print(\"PLANNED_\" + \"NPM_LOCK_STREAM\")'"
         )
+        # Both authorities are pinned on fixtures, never inherited from the
+        # shipped config: this group needs one config where the generalist gates
+        # and one where it is demoted, and which of the two the repo ships is a
+        # decision that has already flipped once.
         advisory_config = copy.deepcopy(selftest_config)
+        advisory_config["review_authority"]["combined"] = (
+            verifier.ADVISORY_AUTHORITY
+        )
         # This group pins the probe-precedence machinery, and only a BLOCKING
         # reviewer can drive it. The fixture owns one non-risk path, so its only
-        # planned review is `combined`, which the corpus measurement demoted to
-        # advisory. Bind it back to blocking here so these assertions keep
-        # testing what they were written to test; the advisory path gets its own
-        # dedicated case at the end of this group.
-        selftest_config["review_authority"]["combined"] = "blocking"
+        # planned review is `combined`; bind it to blocking here so these
+        # assertions keep testing what they were written to test. The advisory
+        # path gets its own dedicated case at the end of this group.
+        selftest_config["review_authority"]["combined"] = (
+            verifier.BLOCKING_AUTHORITY
+        )
         runtime.load_config = lambda: copy.deepcopy(selftest_config)
         os.environ["MURMUR_HARNESS_FAKE_REVIEW_VERDICT"] = "PASS"
         os.environ[
@@ -4182,7 +4264,7 @@ def probe_precedence_flow_cases(test: Tests) -> None:
                 == source_result_sha256,
             )
 
-            # Under the shipped authority the same reviewer is advisory: its
+            # Under a config that demotes it, the same reviewer is advisory: its
             # probe request stays in the receipt, but it can no longer spend a
             # runner-owned execution or force another full review round.
             advisory_worktree = root / "advisory-task" / "meetnotes"

--- a/.agents/harness/verifier.py
+++ b/.agents/harness/verifier.py
@@ -1884,12 +1884,19 @@ def probe_request_contexts(
 def review_authority(kind: str, config: Mapping[str, Any]) -> str:
     """Return whether a review kind may forbid a PASS.
 
-    Measured on Murmur's own review corpus in
-    ``docs/research/2026-08-01-reviewer-corpus-measurement.md``: the ``combined``
-    generalist produced one BLOCKER across 98 reviews while consuming 76% of the
-    review model budget and refusing 74% of attempts, so its findings are
-    recorded but no longer gate. The three risk specialists produced 11 BLOCKERs
-    across 118 reviews at a quarter of the cost and stay blocking.
+    The mechanism is config-driven and decision-free: whatever
+    ``review_authority`` marks ``advisory`` records its findings without gating,
+    and everything else gates.
+
+    All four planned kinds currently ship ``blocking``. The ``combined``
+    generalist was briefly demoted on
+    ``docs/research/2026-08-01-reviewer-corpus-measurement.md``, which ranked
+    reviewers by BLOCKER count; the gate that forbids a PASS reads
+    ``SEVERE_FINDINGS`` (``MAJOR`` + ``BLOCKER``). Re-counted on that metric over
+    the same 232-review corpus the generalist led on PASS-forbidding density
+    (116 over 105 reviews, against 0.41 per review for ``egress-security`` and
+    0.13 for ``lock-security``), so the demotion was reverted and
+    ``config_audit`` pins every kind blocking.
 
     Every unconfigured, unknown, or malformed kind fails closed as blocking, so a
     typo in the config and a future specialist kind both keep their gate, and an

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,7 +169,35 @@ The four shipped classes and their oracles: seal content loss →
 `commands/tests/lock_read_gate_tests.rs`; macOS FFI abort at launch →
 `scripts/harness-runtime-smoke.py`; packaged-WebKit CSP style loss →
 `e2e/render/csp-style-src.spec.ts`. A rule or skill you cannot express as an oracle is a rule whose
-effect you are not measuring. `scripts/agent-eval` measures the scaffold itself.
+effect you are not measuring.
+
+**Track C — a scaffold edit is not done until it is measured.** When a diff touches
+`.claude/rules/**`, `.codex/rules/**`, `.claude/skills/**`, `.agents/skills/**`, `CLAUDE.md`,
+`AGENTS.md`, or a reviewer prompt, run the comparison and put its table in the PR body:
+
+```bash
+python3 eval/agents/matrix.py \
+  --agent 'claude=claude -p --permission-mode acceptEdits' \
+  --scaffold none --scaffold full --repeat 3 --seed 1 \
+  --json eval/agents/results/<slug>.json
+```
+
+The control arm gets no scaffold, the treatment arm gets the real always-on envelope, so the delta
+is the edit's effect and nothing else. It costs live model calls, which is why CI runs only
+`--mode fake` (that arm proves the GRADERS still reject a wrong answer — a grader that has lost its
+teeth accepts both arms and every later measurement silently reports success).
+
+Two honest limits, both recorded per task in `eval/agents/README.md`: of the eight tasks only
+`additive-migration` is currently `CAN_MEASURE`; the rest ceiling out because a competent model
+already knows the answer. And `files_changed: []` on an `expected_change: true` task means the run
+never reached the behaviour under test — that is an instrument failure, not a wrong answer. A delta
+of zero across ceiling tasks says nothing about the edit; say so rather than reporting it as
+evidence the rule works.
+
+**Read the cost before arguing about it.** `scripts/agent-harness metrics --store
+../.murmur-agent-driver/.git/agent-harness` reports reviewer PASS-rate, findings by severity, model
+minutes and tokens per accepted task. Every claim about a reviewer earning or not earning its place
+belongs to that command, not to an impression.
 
 ## Opt-in harness (`/harness`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,3 +171,49 @@ The four shipped classes and their oracles: seal content loss →
 `scripts/harness-runtime-smoke.py`; packaged-WebKit CSP style loss →
 `e2e/render/csp-style-src.spec.ts`. A rule or skill you cannot express as an oracle is a rule whose
 effect you are not measuring.
+
+**Track C — a scaffold edit is not done until it is measured.** When a diff touches
+`.claude/rules/**`, `.codex/rules/**`, `.claude/skills/**`, `.agents/skills/**`, `CLAUDE.md`,
+`AGENTS.md`, or a reviewer prompt, run the comparison and put its table in the PR body:
+
+```bash
+python3 eval/agents/matrix.py \
+  --agent 'claude=claude -p --permission-mode acceptEdits' \
+  --scaffold none --scaffold full --repeat 3 --seed 1 \
+  --json eval/agents/results/<slug>.json
+```
+
+The control arm gets no scaffold, the treatment arm gets the real always-on envelope, so the delta
+is the edit's effect and nothing else. It costs live model calls, which is why CI runs only
+`--mode fake` (that arm proves the GRADERS still reject a wrong answer — a grader that has lost its
+teeth accepts both arms and every later measurement silently reports success).
+
+Two honest limits, both recorded per task in `eval/agents/README.md`: of the eight tasks only
+`additive-migration` is currently `CAN_MEASURE`; the rest ceiling out because a competent model
+already knows the answer. And `files_changed: []` on an `expected_change: true` task means the run
+never reached the behaviour under test — that is an instrument failure, not a wrong answer. A delta
+of zero across ceiling tasks says nothing about the edit; say so rather than reporting it as
+evidence the rule works.
+
+**Read the cost before arguing about it.** `scripts/agent-harness metrics --store
+../.murmur-agent-driver/.git/agent-harness` reports reviewer PASS-rate, findings by severity, model
+minutes and tokens per accepted task. Every claim about a reviewer earning or not earning its place
+belongs to that command, not to an impression.
+
+## Opt-in harness (`/harness`)
+
+The harness is **opt-in**. Normal commits run freely; only `secret-scan` and
+direct-push-to-`murmur` protection are always on. Reach for rigor deliberately:
+
+- Invoke the harness directly:
+  `scripts/agent-harness open <task-id> --prompt "…" --owned <path>`, implement in the printed worktree, then `plan`, `verify`/`resume`, `commit`, and finally `clean` after merge.
+- Use it for lock/crypto/egress/protocol changes or anything you want a fresh
+  adversarial reviewer to verify. Skip it for docs/chores/low-risk edits.
+- Guard behavior is identical across vendors (same `hook_guard.py`): a commit in
+  a worktree with **no** active task is allowed; a worktree **with** a task
+  enforces the full hash-bound attestation.
+- Choose the fresh reviewer with `--reviewer codex|claude`; the default is
+  `codex`. The reviewer has no developer-session context and no local tools.
+  `lock`/`egress`/`protocol` specialist reviews prefer the opposite vendor; when
+  that vendor is unavailable, bind the explicit
+  `--allow-same-vendor-high-risk` exception instead of silently spending it.

--- a/eval/agents/runner.py
+++ b/eval/agents/runner.py
@@ -434,13 +434,26 @@ def changed_paths(before: Mapping[str, str], after: Mapping[str, str]) -> List[s
     )
 
 
-def echoable_fragments(prompt: str, workspace: Path) -> List[str]:
+def echoable_fragments(
+    prompt: str, workspace: Path, injected: Sequence[str] = ()
+) -> List[str]:
     """Every line and sentence the agent could REPRODUCE instead of author.
 
-    The prompt it was given, plus every file it was given: the bare fixture in the control arm, the
-    fixture PLUS the injected scaffold in the treatment arms. Deliberately asymmetric in the same
-    direction as the arms themselves — the treatment arm has strictly more to quote, and that extra
-    quotable material is exactly the free score being removed.
+    The prompt it was given, plus the FIXTURE it was given. Injected scaffold files are excluded,
+    and that exclusion is the whole point: this filter must be IDENTICAL across arms or it stops
+    measuring the arms and starts measuring itself.
+
+    Counted with the scaffold included, it grew 17 -> 231 -> 1255 fragments across none/rules/full
+    on `additive-migration`, so the treatment arm had ~74x more of its answer deleted before
+    grading. An agent that ABSORBED a rule states its conclusion in that rule's words — which is
+    the scaffold working — and a fragment filter cannot tell that apart from parroting. Charging
+    for it biases every delta toward zero, i.e. toward the one conclusion ("rules do not help")
+    that would be both wrong and expensive.
+
+    Parroting is still not rewarded: `graders/smoke.py::grounded_claims` drops the CLAUSE carrying
+    a citation before any substance check, so an answer whose only support is "the rule says so"
+    scores nothing. That defence belongs in the grader, where it can see claim structure — not
+    here, where it can only see bytes.
 
     Take this snapshot BEFORE the CLI runs. Files the agent WRITES are its own work, and a findings
     note it wrote and then printed must not be mistaken for material it echoed.
@@ -454,9 +467,12 @@ def echoable_fragments(prompt: str, workspace: Path) -> List[str]:
                 fragments.add(_normalized(sentence))
 
     collect(prompt)
+    excluded = {str(item) for item in injected}
     for path in sorted(workspace.rglob("*")):
         if not path.is_file():
             continue
+        if str(path.relative_to(workspace)) in excluded:
+            continue  # scaffold: shared vocabulary, not echoable material — see the docstring
         try:
             collect(path.read_text(encoding="utf-8"))
         except (OSError, UnicodeDecodeError):
@@ -588,7 +604,8 @@ def run_agent(
         task, None, workdir / f"{scaffold}-{run_index}", scaffold=scaffold
     )
     # Snapshot what the agent is ABOUT to be able to quote, before it can write anything itself.
-    echoable = echoable_fragments(task["prompt"], workspace)
+    # `injected` is excluded so the filter is arm-invariant: see echoable_fragments.
+    echoable = echoable_fragments(task["prompt"], workspace, injected)
     # And snapshot the bytes, so the record can say whether the agent actually TOUCHED anything.
     # A run that edited nothing is the instrument's floor, not a wrong answer: it is what a CLI
     # whose write tools are disabled looks like, and it is indistinguishable from a real failure
@@ -1161,6 +1178,35 @@ def selftest() -> int:
         else:
             print(f"PASS  {'transcript-echo':<28} [selftest]  "
                   "verbosity does not move the score; raw stdout still would")
+
+        # --- the echo filter must be ARM-INVARIANT, or it measures itself ---
+        # Counted with the scaffold included it was 17 -> 231 -> 1255 fragments across
+        # none/rules/full, so the treatment arm had ~74x more of its answer deleted before
+        # grading. An agent that absorbed a rule states its conclusion in that rule's words;
+        # a byte filter cannot tell that from parroting, so charging for it biases every delta
+        # toward "rules do not help" — the one wrong conclusion that is also expensive.
+        arm_problems: List[str] = []
+        for task in load_tasks(None):
+            counts = {}
+            for arm in SCAFFOLD_ARMS:
+                with tempfile.TemporaryDirectory(prefix="murmur-echo-arm-") as arm_tmp:
+                    ws, injected_paths = materialize(
+                        task, None, Path(arm_tmp), scaffold=arm
+                    )
+                    counts[arm] = len(
+                        echoable_fragments(task["prompt"], ws, injected_paths)
+                    )
+            if len(set(counts.values())) != 1:
+                arm_problems.append(
+                    f"{task['task_id']}: fragment count differs by arm "
+                    + ", ".join(f"{arm}={n}" for arm, n in counts.items())
+                )
+        if arm_problems:
+            failures += 1
+            print(f"FAIL  {'echo-arm-invariance':<28} [selftest]  {'; '.join(arm_problems)}")
+        else:
+            print(f"PASS  {'echo-arm-invariance':<28} [selftest]  "
+                  "the echo filter deletes the same material in every arm")
 
         # --- signals a grader treats as independent must have DISJOINT vocabularies ---
         # ANGULAR_DECLINES and ANGULAR_REASONS shared eight tokens, so one phrase satisfied both:

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -99,7 +99,11 @@ rust_gate() {
   #    That is what keeps the graders honest — a grader that has lost its teeth accepts both arms
   #    and the live `--mode agent` measurement silently starts reporting success for everything.
   #    Free, deterministic, seconds; the live arm costs model calls and stays out of CI. ──
-  echo "── development agent scaffold eval (graders, no model) ──"
+  echo "── development agent scaffold eval (graders + instrument, no model) ──"
+  # --selftest first: it guards the INSTRUMENT (arm-invariant echo filter, non-vacuous graders,
+  # scaffold actually injected, ERROR excluded from pass counts). --mode fake guards the GRADERS.
+  # Neither costs a model call. Without the first, a biased instrument reports plausible numbers.
+  python3 eval/agents/runner.py --selftest
   python3 eval/agents/runner.py --mode fake
 
   # ── User-facing vocabulary. WARN mode: it reports, and it FAILS only on a REGRESSION


### PR DESCRIPTION
Three changes, in order of how much damage they were doing.

## 1. The echo filter was biased against the arm under test

`echoable_fragments` ran **after** scaffold injection, so it consumed the injected rule files. Measured per arm on `additive-migration`:

```
none 17   ->   rules 231   ->   full 1255      fragments deleted before grading
```

The treatment arm had ~74× more of its answer removed. The RED proof shows the skew on **all eight** tasks.

The docstring called it deliberate — *"the treatment arm has strictly more to quote, and that extra quotable material is exactly the free score being removed"*. That conflates two different behaviours. An agent that **absorbed** a rule states its conclusion in that rule's words — which is the scaffold working — and a byte-level filter cannot tell that apart from parroting. Charging for it biases every delta toward zero, i.e. toward *"rules do not help"*: the one conclusion that would be both wrong and expensive to act on.

Parroting is still not rewarded — `grounded_claims` drops the citation-bearing **clause** before any substance check, so an answer supported only by "the rule says so" scores nothing. That defence belongs in the grader, which can see claim structure, not in a filter that sees bytes.

Pinned by `echo-arm-invariance`; non-vacuous (deleting the exclusion reddens all eight).

## 2. `--selftest` joins the gate

`--mode fake` guards the **graders**. `--selftest` guards the **instrument** — arm-invariance, non-vacuous graders, scaffold actually injected, ERROR excluded from pass counts. Neither costs a model call, and without the second a biased instrument keeps producing plausible numbers. 548 lines of assertions were enforced nowhere.

## 3. The reviewer demotion is reverted — it was decided on the wrong metric

#541 rested on BLOCKER counts. But PASS is forbidden by `SEVERE_FINDINGS = {"MAJOR", "BLOCKER"}`, so BLOCKER alone was never the deciding metric. Re-measured over the whole corpus with this repo's own `agent-harness metrics`, on the threshold that actually gates:

| Reviewer | severe / reviews | per review |
|---|---:|---:|
| `combined` | 116 / 105 | **1.10** |
| `egress-security` | 30 / 74 | 0.41 |
| `lock-security` | 7 / 53 | 0.13 |

The generalist **led** both specialists on findings that forbid a PASS. Every shipped kind is `blocking` again.

The `review_authority` **mechanism stays** — fail-closed, per-plan, and the last-gate rule from `fb0eb8b` is load-bearing whichever kinds are demoted. What changes is the shipped decision that used it.

The selftests asserted that decision as though it were the mechanism, so they move onto explicit fixtures and now pin **both** directions on the same kind. Two further assertions and one whole group turned out to be load-bearing on the demotion without saying so: `probe_precedence_flow_cases` deep-copied the real config *before* its override, silently inheriting production and crashing with a `KeyError` once production changed.

`config_audit` widens its specialist pin to all four kinds, so demoting a reviewer again must be deliberate.

**And the taxonomy hole that made this urgent:** `risk_classification.lock` gains `commands/{documents,links,reminders}.rs`. Each was verified to call a gate helper, so each could carry a sealed-content read while planning no security specialist — precisely what the simplification plan warned would turn live if the always-on reviewer were demoted first.

## Plus: Track C, so the instruments are not optional

A scaffold edit is not done until it is measured — same shape as Track B (a bug class is not fixed until an oracle exists), fired by a mechanical path test, with both honest limits recorded: only `additive-migration` currently measures anything, and `files_changed: []` is an instrument floor rather than a wrong answer.

```
agent config audit: PASS (151 checks, 0 warnings)
v2 selftest:        PASS (540 assertions)
v2 fault selftest:  PASS (39 assertions)
metrics-selftest:   PASS (70 assertions)
guardrail self-test: PASS (245 assertions) x2
scaffold eval:      8 tasks, 0 failures (--mode fake and --selftest)
```