### PR TITLE
feat(settings): the model catalog is a hint, never an allowlist

### DIFF
--- a/e2e/settings-ai/codex-provider.spec.ts
+++ b/e2e/settings-ai/codex-provider.spec.ts
@@ -74,9 +74,15 @@ test("Codex can be selected globally and per feature with its catalog and brande
   await expect(defaultModel.locator("[data-provider-default]")).toHaveText(
     "Default (provider's pick)",
   );
-  await expect(defaultModel).toHaveValue("");
-  await expect(defaultModel.locator(":checked")).toHaveText(
-    "Default (provider's pick)",
+  // A6: the stored id SURVIVES an engine switch. Blanking it was the same defect as
+  // `repairForeignRoleModels` — a hint catalog treated as authoritative, destroying a choice it
+  // did not recognise. The UI now keeps the value and explains the mismatch instead.
+  await expect(defaultModel.locator("[data-provider-default]")).toBeAttached();
+  await expect(
+    setup.locator('input[formcontrolname="providerModel"]'),
+  ).toHaveValue("claude-opus-4-8");
+  await expect(setup.locator("[data-unlisted-model]")).toContainText(
+    "claude-opus-4-8",
   );
   await expect(page.locator("app-ai-privacy-strip")).toContainText(
     "Codex → OpenAI (via the Codex CLI)",
@@ -235,13 +241,28 @@ test("a delayed Codex catalog cannot overwrite a newer engine selection", async 
       if (args.connection === "codex_cli") {
         return new Promise((resolve) =>
           setTimeout(
-            () => resolve(["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]),
+            () =>
+              resolve({
+                source: "bundled",
+                options: [
+                  { id: "gpt-5.6-sol", label: "GPT-5.6 Sol — highest quality", source: "bundled" },
+                  { id: "gpt-5.6-terra", label: "GPT-5.6 Terra — balanced", source: "bundled" },
+                  { id: "gpt-5.6-luna", label: "GPT-5.6 Luna — fastest", source: "bundled" },
+                ],
+              }),
             200,
           ),
         );
       }
       if (args.connection === "anthropic") {
-        return ["claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5"];
+        return {
+          source: "bundled",
+          options: [
+            { id: "claude-opus-5", label: "Claude Opus 5 — highest quality", source: "bundled" },
+            { id: "claude-sonnet-5", label: "Claude Sonnet 5 — balanced", source: "bundled" },
+            { id: "claude-haiku-4-5", label: "Claude Haiku 4.5 — fastest", source: "bundled" },
+          ],
+        };
       }
       return [];
     },
@@ -255,14 +276,19 @@ test("a delayed Codex catalog cannot overwrite a newer engine selection", async 
   await engine.selectOption("anthropic");
 
   const model = setup.locator('select[formcontrolname="providerModel"]');
+  // The property under test is that a LATE catalog response cannot overwrite a NEWER engine
+  // selection. Comparing the value against itself would detect the late write but pin nothing, so
+  // name the value that must be there: the SEEDED id. It survives both engine switches because a
+  // catalog is a hint — Anthropic's list does not contain it and keeps it anyway — which is the
+  // same invariant stated from the other side.
   await expect(engine).toHaveValue("anthropic");
-  await expect(model).toHaveValue("");
+  await expect(model).toHaveValue("gpt-5.6-terra");
   await page.waitForTimeout(250);
   await expect(engine).toHaveValue("anthropic");
-  await expect(model).toHaveValue("");
+  await expect(model).toHaveValue("gpt-5.6-terra");
 });
 
-test("an empty Codex catalog clears a foreign default-engine model", async ({
+test("an empty Codex catalog KEEPS a foreign default-engine model", async ({
   page,
 }) => {
   await page.addInitScript(() => {
@@ -273,7 +299,7 @@ test("an empty Codex catalog clears a foreign default-engine model", async ({
     ).__demoConfig = { providerModel: "claude-opus-4-8" };
   });
   await mockTauri(page, {
-    list_models: () => [],
+    list_models: () => ({ source: "live", options: [] }),
   });
 
   await page.goto("/settings");
@@ -282,9 +308,11 @@ test("an empty Codex catalog clears a foreign default-engine model", async ({
   await setup
     .locator('select[formcontrolname="providerId"]')
     .selectOption("codex_cli");
+  // An EMPTY catalog proves nothing about the id either — a bundled list that happens to be empty
+  // is still just a hint, so the stored value is kept rather than blanked.
   await expect(
     setup.locator('input[formcontrolname="providerModel"]'),
-  ).toHaveValue("");
+  ).toHaveValue("claude-opus-4-8");
 });
 
 test("a failed Codex catalog request preserves the stored model id", async ({
@@ -314,7 +342,14 @@ test("a failed Codex catalog request preserves the stored model id", async ({
   ).toHaveValue("claude-opus-4-8");
 });
 
-test("a loaded Codex role clears and persists a foreign Claude model id", async ({
+/**
+ * INVERTED on 2026-08-01. This used to assert that a role model absent from the connection's
+ * catalog was cleared to "" AND persisted. That behaviour (`settings.store.ts::
+ * repairForeignRoleModels`) is what made a newly released model unusable: it was not merely
+ * missing from the dropdown, it was erased from config the moment the catalog loaded. The catalog
+ * is now a HINT, so an unrecognised id is a custom id and must survive untouched.
+ */
+test("a loaded Codex role KEEPS a model id the catalog does not list", async ({
   page,
 }) => {
   await page.addInitScript(() => {
@@ -344,25 +379,21 @@ test("a loaded Codex role clears and persists a foreign Claude model id", async 
   const notesRow = page.locator('[data-role="notes"]');
   await expect(notesRow).toBeVisible();
   await expect(notesRow.locator("select").first()).toHaveValue("codex_cli");
-  await expect(notesRow.locator("select").nth(1)).toHaveValue("");
-  await expect
-    .poll(() =>
-      page.evaluate(
-        () =>
-          (
-            window as unknown as {
-              __savedCodexRoleRepair?: {
-                roleNotesConnection?: string;
-                roleNotesModel?: string;
-              };
-            }
-          ).__savedCodexRoleRepair,
-      ),
-    )
-    .toMatchObject({
-      roleNotesConnection: "codex_cli",
-      roleNotesModel: "",
-    });
+  // The id stays selectable as a custom entry rather than being blanked.
+  await expect(notesRow.locator("select").nth(1)).toHaveValue("claude-opus-4-8");
+  // ...and nothing writes a "repair" to config behind the user's back.
+  const saved = await page.evaluate(
+    () =>
+      (
+        window as unknown as {
+          __savedCodexRoleRepair?: { roleNotesModel?: string };
+        }
+      ).__savedCodexRoleRepair,
+  );
+  expect(
+    saved === undefined || saved.roleNotesModel === "claude-opus-4-8",
+    `an unlisted id must not be rewritten; config was saved as ${JSON.stringify(saved)}`,
+  ).toBeTruthy();
 });
 
 test("Codex cloud-consent copy names OpenAI's cloud", async ({ page }) => {

--- a/e2e/settings-ai/model-picker.spec.ts
+++ b/e2e/settings-ai/model-picker.spec.ts
@@ -1,0 +1,633 @@
+import { expect, test } from "@playwright/test";
+import { mockTauri } from "./mock-invoke";
+
+/**
+ * The model catalog is a HINT, never an allowlist.
+ *
+ * Before this spec, `list_models` returned bare id strings from two `&[&str]` constants in
+ * `summarize/provider.rs`, and `settings.store.ts::repairForeignRoleModels` treated those
+ * constants as authoritative: any stored model id absent from them was set to `""` **and
+ * persisted**. So a newly released model was not merely missing from the dropdown — selecting it
+ * was impossible (the free-text input only rendered when the catalog was EMPTY) and any id already
+ * in config was destroyed the moment the catalog loaded.
+ *
+ * Both tests below are RED on that code: the first because the id is erased, the second because
+ * there is no input to type into while a non-empty catalog is present.
+ */
+
+const CATALOG = [
+  { id: "claude-opus-5", label: "Claude Opus 5 — highest quality", source: "bundled" },
+  { id: "claude-sonnet-5", label: "Claude Sonnet 5 — balanced", source: "bundled" },
+];
+
+/** A model id no catalog knows about — stands in for "released after this build shipped". */
+const FUTURE_MODEL = "claude-opus-6";
+
+async function openAiSettings(page: import("@playwright/test").Page, storedModel: string) {
+  await page.addInitScript((model) => {
+    (
+      window as unknown as { __demoConfig?: Record<string, unknown> }
+    ).__demoConfig = { providerModel: model, roleNotesConnection: "claude_code" };
+  }, storedModel);
+
+  await mockTauri(
+    page,
+    {
+      save_config: (args: { config: Record<string, unknown> }) => {
+        const w = window as unknown as {
+          __savedConfig?: Record<string, unknown>;
+          __demoConfig?: Record<string, unknown>;
+        };
+        w.__savedConfig = args.config;
+        w.__demoConfig = Object.assign({}, w.__demoConfig, args.config);
+        return null;
+      },
+      list_models: () => ({
+        source: "bundled",
+        options: [
+          { id: "claude-opus-5", label: "Claude Opus 5 — highest quality", source: "bundled" },
+          { id: "claude-sonnet-5", label: "Claude Sonnet 5 — balanced", source: "bundled" },
+        ],
+      }),
+      provider_statuses: () => [
+        { id: "claude_code", available: true },
+        { id: "codex_cli", available: true },
+        { id: "anthropic", available: true },
+      ],
+    },
+    {},
+  );
+  // The AI section is reached by clicking its nav entry, not by a direct route — same path
+  // `codex-provider.spec.ts` uses, and the only one that mounts the setup block.
+  await page.goto("/settings");
+  await page.getByText("AI & Models").first().click();
+  await page.locator(".model-row").first().waitFor({ state: "visible" });
+}
+
+test("a model id the catalog does not know is never erased", async ({ page }) => {
+  await openAiSettings(page, FUTURE_MODEL);
+
+  // WAIT FOR THE FETCH FIRST. The old bug fired asynchronously, AFTER `list_models` resolved, so
+  // polling a value that is already correct at t=0 could succeed before the code under test even
+  // ran — the poll would pass against the seeded value and prove nothing. Wait for the rendered
+  // catalog, which only appears once the fetch resolved, then assert the id survived it.
+  await expect(
+    page.locator(".model-row select.model-select option", {
+      hasText: "Claude Sonnet 5",
+    }),
+  ).toHaveCount(1);
+  await expect
+    .poll(async () =>
+      page.evaluate(
+        () => (window as unknown as { __demoConfig?: Record<string, unknown> }).__demoConfig
+          ?.["providerModel"],
+      ),
+    )
+    .toBe(FUTURE_MODEL);
+
+  const saved = await page.evaluate(
+    () =>
+      (window as unknown as { __savedConfig?: Record<string, unknown> }).__savedConfig?.[
+        "providerModel"
+      ],
+  );
+  expect(
+    saved === undefined || saved === FUTURE_MODEL,
+    `a catalog that omits an id must not rewrite it; config was saved as ${JSON.stringify(saved)}`,
+  ).toBeTruthy();
+});
+
+test("an unlisted model id is typeable even when the catalog is non-empty", async ({ page }) => {
+  await openAiSettings(page, "claude-sonnet-5");
+
+  // The catalog has two entries, so the OLD template rendered a <select> and no input at all.
+  const input = page.locator(".model-row input.model-input").first();
+  await expect(
+    input,
+    "the free-text model id must be available alongside a non-empty catalog, or a newly " +
+      "released model cannot be selected until someone edits provider.rs",
+  ).toBeVisible();
+
+  await input.fill(FUTURE_MODEL);
+  await input.blur();
+  await expect.poll(async () => input.inputValue()).toBe(FUTURE_MODEL);
+});
+
+test("an id the boundary would refuse is cleared visibly, not silently", async ({ page }) => {
+  // The gap this closes: every other spec types a SHORT valid id and asserts the input value. None
+  // typed one the persistence boundary rejects, so none proved what actually lands in config — the
+  // case where the UI could show one thing and `save_config` store another.
+  const tooLong = `hf.co/${"a".repeat(60)}/model:Q4_K_M`;
+  expect(tooLong.length).toBeGreaterThan(64);
+
+  await openAiSettings(page, tooLong);
+  await page
+    .locator('select[formcontrolname="providerId"]')
+    .first()
+    .selectOption("claude_code");
+
+  // claude_code puts the id on a command line, so this one cannot be sent. The UI clears it in the
+  // same interaction and says so, rather than leaving it on screen for autosave to drop.
+  await expect(page.locator("[data-dropped-model]")).toContainText(tooLong);
+  await expect(
+    page.locator(".model-row input.model-input").first(),
+    "the field must not still show a value the backend will not keep",
+  ).toHaveValue("");
+
+});
+
+test("dropping an unusable model does not cancel the new engine's catalog fetch", async ({
+  page,
+}) => {
+  // `onEngineChanged` used to `return` immediately after clearing an unusable id, so the newly
+  // selected engine never had `ensureModels` called: the picker showed no options AND no "this list
+  // ships with the app" provenance. The user was told what was removed and then shown an empty list
+  // with no explanation of why it was empty.
+  //
+  // The engine here must be one whose catalog is NOT already loaded. A first attempt at this
+  // assertion switched to `claude_code` — the DEFAULT — whose catalog was fetched at load, so the
+  // assertion held with the bug still present. It passed the RED check and proved nothing.
+  const tooLong = `hf.co/${"a".repeat(60)}/model:Q4_K_M`;
+  await openAiSettings(page, tooLong);
+  await expect(page.locator(".model-row select.model-select option", { hasText: "Claude Sonnet 5" }))
+    .toHaveCount(1);
+
+  await page
+    .locator('select[formcontrolname="providerId"]')
+    .first()
+    .selectOption("codex_cli");
+
+  await expect(page.locator("[data-dropped-model]")).toContainText(tooLong);
+  await expect(
+    page.locator(".model-row select.model-select option", { hasText: "Claude Sonnet 5" }),
+    "the new engine's catalog must load even when the switch dropped the previous model",
+  ).toHaveCount(1);
+  await expect(
+    page.locator("[data-bundled-catalog]"),
+    "a bundled catalog must still say so; silence reads as 'this list is current'",
+  ).toBeVisible();
+
+  // And what is actually persisted agrees with what is shown.
+  await expect
+    .poll(async () =>
+      page.evaluate(
+        () =>
+          (window as unknown as { __savedConfig?: Record<string, unknown> }).__savedConfig?.[
+            "providerModel"
+          ],
+      ),
+    )
+    .not.toBe(tooLong);
+});
+
+test("a SHAPE the boundary refuses is cleared too, not only an over-long one", async ({
+  page,
+}) => {
+  // Length was the only refusal the UI mirrored, so `./model` and `-m` — which the boundary also
+  // rejects, the second because argv would read it as a flag — were shown as accepted and then
+  // dropped on save. The UI now mirrors the whole predicate, not one clause of it.
+  await openAiSettings(page, "./model");
+  await page
+    .locator('select[formcontrolname="providerId"]')
+    .first()
+    .selectOption("claude_code");
+
+  await expect(page.locator("[data-dropped-model]")).toContainText("./model");
+  await expect(
+    page.locator(".model-row input.model-input").first(),
+  ).toHaveValue("");
+});
+
+test("refresh button tracks the ENGINE, not the mocked catalog source", async ({ page }) => {
+  // Refresh visibility is driven by `LIVE_CATALOG_CONNECTION_IDS` — a static property of the
+  // connection — NOT by the `source` a catalog response happens to carry. That distinction is the
+  // whole point: deriving it from the response hid the button after a failed fetch and showed it
+  // for a bundled arm before the first response.
+  //
+  // So this test pins the ENGINE as the input, and deliberately mocks a contradictory `source` to
+  // prove the response cannot move it. Asserting against the mocked `source` would have been
+  // vacuous — the frontend never reads it.
+  await openAiSettings(page, "claude-sonnet-5");
+  await expect(
+    page.locator(".model-refresh"),
+    "claude_code is a bundled arm: Refresh could not change anything, so it is not offered",
+  ).toHaveCount(0);
+  await expect(page.locator("[data-bundled-catalog]")).toBeVisible();
+
+  // The LIVE half of this property is asserted on the role rows, not here: the Setup card still
+  // defers `ollama`/`gateway` to Advanced, and inlining their picker is the follow-up task. See
+  // `a role row with an EMPTY live catalog still offers Refresh`, which proves the engine — not
+  // the response — decides, by offering Refresh for a live arm whose catalog came back empty.
+});
+
+/** Open the per-feature role rows, where `ollama` and `gateway` — the live arms — are selectable. */
+async function openRoleRows(
+  page: import("@playwright/test").Page,
+  catalog: unknown,
+  roleConnection = "ollama",
+): Promise<void> {
+  // Pass the catalog as a CONSTANT, not as an override. `mockTauri` serializes overrides with
+  // `Function.prototype.toString()`, so `() => catalog` arrives page-side as literally that text
+  // and `catalog` — a closure variable in the Node process — is undefined there. Constants go
+  // through `JSON.stringify`, which is what a value captured out here needs.
+  // `save_config` is recorded so a spec can assert what PERSISTED, not only what the form shows.
+  // The two disagreeing is the defect class this file exists to catch, and a form-only assertion
+  // is blind to it by construction. The override closes over nothing — `mockTauri` serializes it
+  // with `Function.prototype.toString()`, so a captured Node variable would arrive undefined.
+  await mockTauri(
+    page,
+    {
+      save_config: (args: { config: Record<string, unknown> }) => {
+        const w = window as unknown as {
+          __savedConfig?: Record<string, unknown>;
+          __demoConfig?: Record<string, unknown>;
+        };
+        w.__savedConfig = args.config;
+        w.__demoConfig = Object.assign({}, w.__demoConfig, args.config);
+        return null;
+      },
+    },
+    { list_models: catalog },
+  );
+  await page.goto("/settings");
+  await page.getByText("AI & Models").first().click();
+  // TWO disclosures, nested. `app-ai-role-rows` lives inside `ai-advanced-block`, so its own
+  // toggle exists in the DOM but is NOT VISIBLE until Advanced is open — which is why clicking it
+  // directly appeared to do nothing and `aria-expanded` stayed "false".
+  await page.getByRole("button", { name: /Advanced/ }).click();
+  await page.locator("app-ai-role-rows button.role-toggle").click();
+  const row = page.locator('[data-role="notes"]');
+  await row.waitFor({ state: "visible" });
+  // Pick the connection through the UI. Seeding `roleNotesConnection` in `__demoConfig` does not
+  // reach the row — it renders "Inherit default" — and a row on the inherit branch has no model
+  // picker at all, which is what makes the assertions below vacuous rather than failing honestly.
+  await row.locator("select").first().selectOption(roleConnection);
+  // Wait for the model row the connection change creates. `selectOption` resolves as soon as the
+  // DOM value is set, but the catalog fetch and the re-render that follows are asynchronous — every
+  // assertion below races them otherwise.
+  await row.locator(".role-model-row").waitFor({ state: "visible" });
+}
+
+test("a role row can type an unlisted id against a NON-EMPTY catalog", async ({ page }) => {
+  // The same defect the Setup card had: the free-text input sat in the `@else` of the catalog
+  // check, so a non-empty catalog made every unlisted id unreachable on this surface.
+  await openRoleRows(page, {
+    source: "live",
+    options: [{ id: "llama3.1:8b", label: "llama3.1:8b", source: "live" }],
+  });
+  const row = page.locator('[data-role="notes"]');
+  await expect(row.locator("select.role-model-select")).toBeVisible();
+  const input = row.locator("input.role-model-input");
+  await expect(
+    input,
+    "a role row must accept a newer model id even when its catalog is non-empty",
+  ).toBeVisible();
+  await input.fill("llama4:70b");
+  await input.blur();
+  await expect.poll(async () => input.inputValue()).toBe("llama4:70b");
+});
+
+test("a role row KEEPS a usable model across a connection change and says it is unlisted", async ({
+  page,
+}) => {
+  // `setRoleConnection` used to blank the model on every connection change, justified as "a model
+  // belongs to the arm it was picked for". That is the same instinct `repairForeignRoleModels` was
+  // deleted for: it destroys a choice the new arm could have honoured, and nothing offers it back.
+  // The Setup card already settled the rule — keep an id the engine can SEND, explain that the
+  // catalog does not list it, clear only an id the engine cannot send at all — and a role row is
+  // the same question asked one row lower, so the two surfaces must not disagree.
+  await openRoleRows(
+    page,
+    {
+      source: "live",
+      options: [{ id: "llama3.1:8b", label: "llama3.1:8b", source: "live" }],
+    },
+    "ollama",
+  );
+  const row = page.locator('[data-role="notes"]');
+  const model = row.locator("input.role-model-input");
+  // An id the catalog does NOT list — the whole point is that such an id is legitimate. A listed
+  // one would prove less: it needs no explanation, and the row correctly stays silent for it.
+  await model.fill("llama4:70b");
+  await model.blur();
+  await expect.poll(async () => model.inputValue()).toBe("llama4:70b");
+
+  await row.locator("select").first().selectOption("claude_code");
+  await expect(
+    model,
+    "a shape the new arm can send must survive the switch — destroying it is the defect this " +
+      "whole change exists to remove",
+  ).toHaveValue("llama4:70b");
+  await expect(
+    row.locator("[data-role-kept-model]"),
+    "keeping an unlisted id silently is only half right; the row must say why it is not in the list",
+  ).toContainText("llama4:70b");
+});
+
+test("a role row clears a model the new engine cannot send, and names it", async ({ page }) => {
+  // The other half of A5. `claude_code` puts the id on a command line, so the 64-char argv ceiling
+  // applies and a long Hugging Face id — perfectly legal under Ollama — cannot survive. Clearing is
+  // right here; doing it without a word is not.
+  const hfModel = `hf.co/${"a".repeat(60)}/model:Q4_K_M`;
+  await openRoleRows(
+    page,
+    { source: "live", options: [{ id: hfModel, label: hfModel, source: "live" }] },
+    "ollama",
+  );
+  const row = page.locator('[data-role="notes"]');
+  const model = row.locator("input.role-model-input");
+  await model.fill(hfModel);
+  await model.blur();
+  await expect.poll(async () => model.inputValue()).toBe(hfModel);
+
+  await row.locator("select").first().selectOption("claude_code");
+  await expect(
+    model,
+    "an id the arm cannot put on a command line must not be left on screen as if it were kept",
+  ).toHaveValue("");
+  await expect(
+    row.locator("[data-role-cleared-model]"),
+    "a clear the user did not ask for must name what it removed",
+  ).toContainText(hfModel);
+});
+
+test("switching a role to on-device KEEPS a real registry model id", async ({ page }) => {
+  // The condition the sibling test below cannot reach. `llama3.1:8b` is deliberately NOT an
+  // on-device model, so a rule that clears EVERYTHING on the way to `local` passes that test while
+  // destroying a legitimate choice — which is what the first version of this code did.
+  //
+  // The local arm consumes the role model as a REGISTRY KEY (`resolve_brain_model` looks it up in
+  // `BRAIN_MODELS`), so `qwen25-3b` is a working per-role on-device override. Membership decides,
+  // not the absence of a visible model field.
+  await openRoleRows(
+    page,
+    { source: "live", options: [{ id: "qwen25-3b", label: "qwen25-3b", source: "live" }] },
+    "ollama",
+  );
+  const row = page.locator('[data-role="notes"]');
+  await row.locator("input.role-model-input").fill("qwen25-3b");
+  await row.locator("input.role-model-input").blur();
+  await expect.poll(async () => row.locator("input.role-model-input").inputValue()).toBe(
+    "qwen25-3b",
+  );
+
+  await row.locator("select").first().selectOption("local");
+  await expect(row.locator(".role-model-row")).toHaveCount(0);
+  await expect(
+    row.locator("[data-role-cleared-model]"),
+    "an id this engine CAN use must not be reported as cleared",
+  ).toHaveCount(0);
+
+  await row.locator("select").first().selectOption("ollama");
+  await expect(
+    row.locator("input.role-model-input"),
+    "a valid on-device model id is a working per-role override, so it must survive",
+  ).toHaveValue("qwen25-3b");
+});
+
+test("switching a role to the on-device engine clears an unusable model AND says so", async ({
+  page,
+}) => {
+  // `local` renders no model control, which is what made this look like a case for silent
+  // retention. It is the opposite: the local arm CONSUMES the role model —
+  // `make_provider_resolved` uses it in place of `brain_model_id` and then `resolve_brain_model`
+  // fails the note with `Unavailable` — so a retained `llama3.1:8b` does not sit there harmlessly,
+  // it breaks on-device notes. It must be cleared, and because the row has no model field, the
+  // notice has to live OUTSIDE the model block or the clear is invisible again.
+  await openRoleRows(
+    page,
+    {
+      source: "live",
+      options: [{ id: "llama3.1:8b", label: "llama3.1:8b", source: "live" }],
+    },
+    "ollama",
+  );
+  const row = page.locator('[data-role="notes"]');
+  const model = row.locator("input.role-model-input");
+  await model.fill("llama3.1:8b");
+  await model.blur();
+  await expect.poll(async () => model.inputValue()).toBe("llama3.1:8b");
+
+  await row.locator("select").first().selectOption("local");
+  await expect(row.locator(".role-model-row")).toHaveCount(0);
+  await expect(
+    row.locator("[data-role-cleared-model]"),
+    "a row with no model field is exactly where a silent clear hides — the notice must reach it",
+  ).toContainText("llama3.1:8b");
+
+  await row.locator("select").first().selectOption("ollama");
+  await expect(
+    row.locator("input.role-model-input"),
+    "the clear is real, not cosmetic: the id must not reappear",
+  ).toHaveValue("");
+});
+
+test("switching a role to Inherit keeps the model, because nothing reads it there", async ({
+  page,
+}) => {
+  // The other half, and the reason this is not simply "clear whenever the field is hidden".
+  // `roles::is_explicit` keys on the CONNECTION key alone, so an inheriting role resolves through
+  // `legacy_default_target`, which never reads `role_*_model`. Nothing consumes the value, so
+  // destroying it would be pure loss — and invisible, since Inherit renders no model control.
+  //
+  // The id is LONG on purpose. An earlier version used `llama3.1:8b`, which is valid on every arm,
+  // so it could not detect the real failure: the UI kept the model while `dto_to_config` resolved
+  // the empty role connection to the DEFAULT engine and judged it by the CLI rule. With
+  // `claude_code` as the default — the shipped default — a legitimate long Ollama id was blanked by
+  // the next autosave. A fixture that passes both predicates cannot tell the two rules apart.
+  const hfModel = `hf.co/${"a".repeat(60)}/model:Q4_K_M`;
+  await openRoleRows(
+    page,
+    { source: "live", options: [{ id: hfModel, label: hfModel, source: "live" }] },
+    "ollama",
+  );
+  const row = page.locator('[data-role="notes"]');
+  const model = row.locator("input.role-model-input");
+  await model.fill(hfModel);
+  await model.blur();
+  await expect.poll(async () => model.inputValue()).toBe(hfModel);
+
+  await row.locator("select").first().selectOption("");
+  await expect(row.locator(".role-model-row")).toHaveCount(0);
+  await row.locator("select").first().selectOption("ollama");
+  await expect(
+    row.locator("input.role-model-input"),
+    "a detour through Inherit must not destroy a choice nothing there could have used",
+  ).toHaveValue(hfModel);
+
+  // The form is only half the claim — what PERSISTED has to agree, since the defect was the
+  // boundary silently disagreeing with the field.
+  await expect
+    .poll(async () =>
+      page.evaluate(
+        () =>
+          (window as unknown as { __demoConfig?: Record<string, unknown> }).__demoConfig?.[
+            "roleNotesModel"
+          ],
+      ),
+    )
+    .toBe(hfModel);
+});
+
+test("the length mirror counts UTF-8 BYTES, like the backend does", async ({ page }) => {
+  // Rust `str::len()` counts bytes; JavaScript `String.length` counts UTF-16 code units. While the
+  // JSON arms carried an ASCII allowlist the two agreed by construction — removing it (correctly:
+  // it refused real ids) made non-ASCII reachable and the counts diverge.
+  //
+  // 300 × `é` is 300 code units and 600 bytes. Under the UTF-16 count it is comfortably inside the
+  // 512 ceiling, so the field would show it accepted; `dto_to_config` measures bytes, refuses it,
+  // and `AppConfig::load` clears it on the next launch. That is precisely the "the UI displays a
+  // value persistence already discarded" defect this mirror exists to prevent, reintroduced through
+  // a unit mismatch rather than a rule mismatch.
+  const nonAscii = "é".repeat(300);
+  expect(nonAscii.length, "fixture must pass a UTF-16 count").toBeLessThanOrEqual(512);
+  expect(
+    new TextEncoder().encode(nonAscii).length,
+    "...while failing a UTF-8 one, or the test proves nothing",
+  ).toBeGreaterThan(512);
+
+  await openAiSettings(page, "");
+  // `anthropic` is a JSON-body arm, so this id is refused for LENGTH alone — not for its character
+  // class, which that arm no longer restricts.
+  await page
+    .locator("app-ai-setup-block")
+    .locator('select[formcontrolname="providerId"]')
+    .selectOption("anthropic");
+  await page.locator("input.model-input").fill(nonAscii);
+  await expect(
+    page.locator("[data-model-refused]"),
+    "an id the backend measures as over-long must be flagged, whatever JavaScript counts",
+  ).toBeVisible();
+
+  // The same mirror question one character class further out. Rust's `char::is_control` is true for
+  // C1 (U+0080–U+009F) as well as C0 and DEL; the JS class stopped at DEL, so U+0085 (NEL) was
+  // shown as accepted and refused on save. `\s` does not cover it, which is why it was missed.
+  // Built from its code point rather than typed: a literal control character in a source file
+  // is exactly what made `model-id.ts` reach reviewers as an unreadable binary blob.
+  const withNel = `claude${String.fromCharCode(0x85)}opus`;
+  await page.locator("input.model-input").fill(withNel);
+  await expect(
+    page.locator("[data-model-refused]"),
+    "a C1 control character is a control character to Rust, so the mirror must refuse it too",
+  ).toBeVisible();
+
+  // ...and a legitimate non-ASCII id on a JSON-body arm is still accepted — the allowlist was
+  // removed on purpose, and this keeps the two refusals above from passing for the wrong reason.
+  await page.locator("input.model-input").fill("vendor/modèle+preview");
+  await expect(page.locator("[data-model-refused]")).toHaveCount(0);
+});
+
+test("a role row flags a typed id the boundary would refuse", async ({ page }) => {
+  // The role rows render the free-text id unconditionally now, so they inherit the Setup card's
+  // obligation: `dto_to_config` refuses `-m` and keeps the PREVIOUS stored value, and a row that
+  // goes on displaying the typed string is stating something untrue.
+  await openRoleRows(
+    page,
+    {
+      source: "bundled",
+      options: [{ id: "claude-opus-5", label: "Claude Opus 5", source: "bundled" }],
+    },
+    "claude_code",
+  );
+  const row = page.locator('[data-role="notes"]');
+  const model = row.locator("input.role-model-input");
+
+  await model.fill("-m");
+  await expect(
+    row.locator("[data-role-model-refused]"),
+    "a refused id must be flagged on the surface that accepted it, not only on the Setup card",
+  ).toBeVisible();
+
+  await model.fill("claude-opus-5");
+  await expect(row.locator("[data-role-model-refused]")).toHaveCount(0);
+});
+
+test("a typed model id the backend would refuse says so while it is on screen", async ({
+  page,
+}) => {
+  // `onEngineChanged` only inspects the value at the instant the engine changes, but the free-text
+  // id is now always rendered — so an id typed into a SETTLED form reached `dto_to_config`, was
+  // dropped there, and the field went on displaying it. The field showing a value the backend has
+  // already discarded is the UI stating something untrue, so the check has to react to the value,
+  // not to the engine.
+  await openAiSettings(page, "");
+  const model = page.locator("input.model-input");
+
+  // A leading `-` is read as a flag on an argv engine, so `valid_model_id` refuses it — the same
+  // rejection an over-long id gets, but reachable by typing three characters.
+  await model.fill("-m");
+  await expect(
+    page.locator("[data-model-refused]"),
+    "an id that will not survive save must be flagged before save, not silently dropped",
+  ).toBeVisible();
+
+  // And the notice must be about THIS value, not a sticky flag: a legal id clears it.
+  await model.fill("claude-opus-5");
+  await expect(page.locator("[data-model-refused]")).toHaveCount(0);
+});
+
+test("a role row with an EMPTY live catalog still offers Refresh", async ({ page }) => {
+  // The case a per-option `source` could not express: a gateway answering successfully with zero
+  // models is exactly when the user wants to retry, and an empty option list has no option to read
+  // a source from. Provenance lives on the catalog, so the empty one still says it was fetched.
+  await openRoleRows(page, { source: "live", options: [] }, "gateway");
+  const row = page.locator('[data-role="notes"]');
+  await expect(
+    row.locator(".role-model-refresh"),
+    "an empty LIVE catalog is precisely when Refresh matters",
+  ).toBeVisible();
+  await expect(
+    row.locator("[data-role-bundled-catalog]"),
+    "a live catalog must never claim to ship with the app, however empty it is",
+  ).toHaveCount(0);
+});
+
+test("a role row with a bundled catalog says so instead of offering Refresh", async ({ page }) => {
+  await openRoleRows(
+    page,
+    {
+      source: "bundled",
+      options: [
+        { id: "claude-opus-5", label: "Claude Opus 5 — highest quality", source: "bundled" },
+      ],
+    },
+    "claude_code",
+  );
+  const row = page.locator('[data-role="notes"]');
+  await expect(row.locator(".role-model-refresh")).toHaveCount(0);
+  await expect(row.locator("[data-role-bundled-catalog]")).toBeVisible();
+});
+
+test("engine switch that drops a model explains itself", async ({ page }) => {
+  await openAiSettings(page, FUTURE_MODEL);
+  const engine = page.locator('select[formcontrolname="providerId"]').first();
+  await engine.selectOption("codex_cli");
+
+  // The id must survive the switch — being absent from a hint catalog commonly just means the
+  // model shipped after this build.
+  await expect(page.locator("[data-unlisted-model]")).toContainText(FUTURE_MODEL);
+  const input = page.locator(".model-row input.model-input").first();
+  await expect(input).toHaveValue(FUTURE_MODEL);
+});
+
+test("options render labels, not raw ids", async ({ page }) => {
+  await openAiSettings(page, "claude-sonnet-5");
+
+  const options = page.locator(".model-row select.model-select option");
+  const texts = await options.allTextContents();
+  for (const entry of CATALOG) {
+    expect(
+      texts.some((t) => t.includes(entry.label)),
+      `option list must show "${entry.label}", got ${JSON.stringify(texts)}`,
+    ).toBeTruthy();
+  }
+  expect(
+    texts.some((t) => t.trim() === entry_id_only()),
+    "a bare id with no label means the picker regressed to rendering raw ids",
+  ).toBeFalsy();
+});
+
+/** The raw id the old template would have rendered for the first catalog entry. */
+function entry_id_only(): string {
+  return CATALOG[0].id;
+}

--- a/scripts/screenshots/mock-tauri.js
+++ b/scripts/screenshots/mock-tauri.js
@@ -729,11 +729,34 @@ scope to the GA-critical path only.
 
       // ── gateway / egress ──
       case "list_gateway_models": return [];
-      case "list_models":
-        if (args && args.connection === "ollama") return ["llama3.1:8b", "qwen2.5:7b", "mistral:7b"];
-        if (args && args.connection === "gateway") return [];
-        if (args && args.connection === "codex_cli") return ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"];
-        return ["claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"];
+      // `list_models` returns ModelCatalog { source, options }. Provenance is on the CATALOG so an
+      // empty live catalog — a gateway answering with zero models — still says it was fetched, and
+      // Refresh stays offered. A bundled catalog is a HINT: an id absent from it is a valid
+      // custom id.
+      case "list_models": {
+        const live = (ids) => ({
+          source: "live",
+          options: ids.map((id) => ({ id, label: id, source: "live" })),
+        });
+        const bundled = (rows) => ({
+          source: "bundled",
+          options: rows.map(([id, label]) => ({ id, label, source: "bundled" })),
+        });
+        if (args && args.connection === "ollama")
+          return live(["llama3.1:8b", "qwen2.5:7b", "mistral:7b"]);
+        if (args && args.connection === "gateway") return live([]);
+        if (args && args.connection === "codex_cli")
+          return bundled([
+            ["gpt-5.6-sol", "GPT-5.6 Sol — highest quality"],
+            ["gpt-5.6-terra", "GPT-5.6 Terra — balanced"],
+            ["gpt-5.6-luna", "GPT-5.6 Luna — fastest"],
+          ]);
+        return bundled([
+          ["claude-opus-5", "Claude Opus 5 — highest quality"],
+          ["claude-sonnet-5", "Claude Sonnet 5 — balanced"],
+          ["claude-haiku-4-5", "Claude Haiku 4.5 — fastest"],
+        ]);
+      }
       case "gateway_health": return { reachable: false, modelCount: 0 };
       case "get_egress_ledger": return EGRESS;
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5044,22 +5044,180 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
 /// the security-sensitive `cloud_egress_consented` is PRESERVED from `current` and never taken from
 /// the DTO (BLK-4) — so a settings save can neither grant nor clear cloud-egress consent. The
 /// dedicated `consent_to_cloud_egress` command is the only path that flips it.
+/// Keep a proposed model id only if it passes `accept`; otherwise fall back to the stored value,
+/// and to empty ("let the provider pick") when that is unusable too.
+///
+/// The fallback is validated as well: a config written before this boundary existed can already
+/// hold a hostile id, and returning it unchecked would preserve exactly what the guard exists to
+/// remove.
+/// Whether this connection turns its model id into a CLI ARGUMENT, and therefore takes the strict
+/// short-slug ceiling rather than the looser JSON-body one.
+///
+/// FAILS CLOSED. The listed connections are the ones PROVEN to send the id in a JSON request body
+/// (`anthropic`, `ollama`, `gateway`) plus the two that run no external model at all (`local`,
+/// `off`); everything else — including `""` and any connection added later — is treated as
+/// argv-building and gets the strict predicate.
+///
+/// Written as a JSON-body allowlist for exactly that reason. The obvious spelling,
+/// `matches!(connection, "claude_code" | "codex_cli")`, fails OPEN: a new CLI-backed provider, or a
+/// typo, would silently inherit the 200-character ceiling and could store an id `model_args`
+/// refuses at the wire while `effective_model_requested` still reports it to the egress ledger.
+/// Being wrong in this direction costs a rejected long id; being wrong in the other costs a lying
+/// ledger.
+pub(crate) fn connection_builds_argv(connection: &str) -> bool {
+    !matches!(
+        connection,
+        "anthropic" | "ollama" | "gateway" | "local" | "off"
+    )
+}
+
+/// THE rule, in one place: a model id is validated against the connection that will SEND it.
+///
+/// Every model field routes through here — `provider_model` by `provider_id`, each role model by
+/// its own role connection, and the per-connection fields by the connection they belong to. Stating
+/// the rule and then hard-coding one field to a fixed predicate is how the last two rounds of
+/// defects happened; there are no exceptions left to get wrong.
+/// Resolve what a stored connection string MEANS before judging a model id against it.
+///
+/// An empty role connection is not an unknown connection — in this app it means "inherit the
+/// default", and `roles::resolve` follows that to `provider_id`. Treating `""` as unknown made the
+/// fail-closed default fire on inherited roles, so a legitimate 65–200 character Ollama id was
+/// cleared even though the arm that would send it is Ollama. Fail-closed is right for a connection
+/// nobody recognises; it is wrong for one whose meaning is defined.
+pub(crate) fn effective_connection(connection: &str, config_provider_id: &str) -> String {
+    let connection = connection.trim();
+    if connection.is_empty() {
+        return config_provider_id.trim().to_string();
+    }
+    connection.to_string()
+}
+
+pub(crate) fn model_predicate_for(connection: &str) -> fn(&str) -> bool {
+    if connection_builds_argv(connection) {
+        crate::summarize::provider::valid_model_id
+    } else {
+        crate::summarize::provider::valid_catalog_model_id
+    }
+}
+
+/// Keep a proposed model id only if the target connection can actually send it.
+///
+/// When BOTH the proposal and the stored value fail, the answer is empty — "let the provider pick".
+/// That is a deliberate choice, not an oversight: switching from a JSON-body arm to a CLI arm can
+/// strand a 65–200 character Hugging Face id that `claude_code` will never put on the wire, and the
+/// only alternatives are worse. Keeping it means `effective_model_requested` reports a model to the
+/// egress ledger that `model_args` silently drops — the ledger lie A6 exists to prevent. Rejecting
+/// the whole save means an engine switch fails because of a field the user did not touch. Empty is
+/// the one outcome where the stored value and the wire agree, and the provider's own default is a
+/// working configuration rather than a broken one.
+///
+/// The loss is not silent at the layer that can speak: `AppConfig::load` logs it, and the Settings
+/// UI keeps and explains an unlisted id rather than dropping it mid-edit
+/// (`unlistedAfterEngineSwitch`).
+fn sanitized_model(proposed: String, previous: &str, accept: fn(&str) -> bool) -> String {
+    if proposed.trim().is_empty() || accept(&proposed) {
+        proposed.trim().to_string()
+    } else if accept(previous) {
+        previous.trim().to_string()
+    } else {
+        String::new()
+    }
+}
+
 fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
     // Normalize empty strings on optional fields to None so they round-trip cleanly.
     let norm = |s: Option<String>| s.filter(|v| !v.trim().is_empty());
+    // The picker's catalog is a HINT, so `providerModel` and the per-role models are now free
+    // text. Refuse a value that is not a plain model slug HERE, at the persistence boundary,
+    // rather than dropping it later at the CLI.
+    //
+    // Dropping it later would make the EGRESS LEDGER LIE: `summarize::effective_model_requested`
+    // reads the stored value independently of what `claude_code::model_args` actually puts on the
+    // wire, so a rejected id would be RECORDED as requested while the provider silently ran its
+    // own default. Refusing to persist it means the ledger and the wire cannot disagree — and the
+    // CLI-side `valid_model_id` checks become defence in depth over an already-clean value.
+    // The fallback is validated too. A config persisted BEFORE this boundary existed can already
+    // hold a hostile id, and falling back to it unchecked would leave the very value this guard
+    // exists to stop. When neither the proposal nor the stored value is a valid slug the answer is
+    // empty — "let the provider pick", which is an explicit, supported choice.
+    // ONE rule for every model field: validate against the connection that will SEND the id.
+    // `claude_code` / `codex_cli` build `--model <id>` argv, where the short-slug ceiling is part of
+    // the defence; `anthropic`, `ollama` and `gateway` put the id in a JSON body, where a long
+    // Hugging Face path is legitimate. Every SHAPE refusal applies to both.
+    let provider_conn = d.provider_id.clone();
+    let notes_conn = d.role_notes_connection.clone();
+    let ask_conn = d.role_ask_connection.clone();
+    let live_conn = d.role_live_connection.clone();
+
+    // Judge against the EFFECTIVE connection — the one that will actually send the id — because
+    // that is what `roles::resolve` hands to the factory and what `effective_model_requested`
+    // reports to the egress ledger. An inherited (empty) role connection resolves to `provider_id`.
+    let for_connection = |proposed: String, previous: &str, connection: &str| -> String {
+        let effective = effective_connection(connection, &provider_conn);
+        sanitized_model(proposed, previous, model_predicate_for(&effective))
+    };
+    // A ROLE model, whose connection may be `""` = INHERIT.
+    //
+    // An inheriting role is judged by TRANSPORT SAFETY ONLY, never by the default engine's rule.
+    // This used to resolve `""` to `provider_id` and apply that arm's predicate, on the belief that
+    // an inherited role sends its own model. It does not: `roles::is_explicit` keys on the
+    // connection key alone, so `resolve` goes to `legacy_default_target` and never reads
+    // `role_*_model` at all. Judging an inert value by the CLI rule DESTROYED it — a legitimate
+    // long Ollama id, kept deliberately by the UI on the way to Inherit, was blanked by the very
+    // next autosave because the default engine happened to be `claude_code`. The UI promised
+    // retention and the boundary broke the promise.
+    //
+    // The moment the role points at a real connection again, `for_connection` judges it there and
+    // clears it if that arm cannot send it — with the row saying so.
+    let for_role = |proposed: String, previous: &str, connection: &str| -> String {
+        if connection.trim().is_empty() {
+            return sanitized_model(
+                proposed,
+                previous,
+                crate::summarize::provider::valid_catalog_model_id,
+            );
+        }
+        sanitized_model(proposed, previous, model_predicate_for(connection.trim()))
+    };
+    // A role can point at ANY connection, so the predicate must follow the CONNECTION, not the
+    // field. Applying the loose one uniformly was wrong: a role targeting `claude_code` could
+    // store a 65–200 character id, which `model_args` then refuses at the wire — so the id would
+    // sit in config and be reported by `effective_model_requested` to the egress ledger while
+    // `--model` was silently omitted. That is the ledger-lies failure A6 exists to prevent,
+    // reintroduced through a different door.
+    // Snapshot the role connections BEFORE the struct literal: fields are evaluated in written
+    // order, and each `role_*_connection` is moved out of the DTO above the matching `_model`.
+
     AppConfig {
         provider_id: d.provider_id,
         vault_path: norm(d.vault_path),
         vault_subfolder: norm(d.vault_subfolder),
         whisper_model_path: norm(d.whisper_model_path),
         language: norm(d.language),
-        anthropic_model: d.anthropic_model,
+        anthropic_model: for_connection(d.anthropic_model, &current.anthropic_model, "anthropic"),
         // Brain/AI model + effort ARE settable from the DTO (the Settings UI owns the pickers),
         // exactly like `anthropic_model` — plain strings, NOT preserve-only. `""` = provider default.
-        provider_model: d.provider_model,
+        //
+        // Judged by `provider_id`, like every other model field, because that is the only arm that
+        // ever reads it. This was UNCONDITIONALLY STRICT for several rounds, justified by "a role
+        // with an explicit CLI connection but a blank model inherits `provider_model`". That claim
+        // is FALSE, and `the_resolved_target_model_is_always_one_the_wire_will_send` now asserts so:
+        // `roles::is_explicit` keys on the connection alone and `explicit_target` reads only that
+        // role's own model key, so an explicit role never inherits this value. The one reader is
+        // `legacy_default_target`, which returns it for `claude_code`/`codex_cli`/`anthropic` and
+        // `""` for `ollama`/`gateway`.
+        //
+        // The over-broad rule was not merely redundant, it destroyed data: under `anthropic` — a
+        // JSON-body arm — a legitimate 65–200 character vendor id was refused and the field reset,
+        // which is exactly the A1/A2 violation this whole change exists to end.
+        //
+        // Switching engines stays safe because this runs on EVERY save with the DTO's NEW
+        // `provider_id`: moving to an argv arm re-judges the stored id under the strict rule and
+        // clears it there, so the ledger can never report a model the wire drops.
+        provider_model: for_connection(d.provider_model, &current.provider_model, &provider_conn),
         provider_effort: d.provider_effort,
         ollama_base_url: d.ollama_base_url,
-        ollama_model: d.ollama_model,
+        ollama_model: for_connection(d.ollama_model, &current.ollama_model, "ollama"),
         claude_binary: d.claude_binary,
         input_device: norm(d.input_device),
         capture_system_audio: d.capture_system_audio,
@@ -5258,7 +5416,7 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         // AI Gateway fields ARE settable from the DTO (the Settings UI owns them). An omitted value
         // deserializes to `""` (`#[serde(default)]`), which is a valid "unset" state.
         gateway_base_url: d.gateway_base_url,
-        gateway_model: d.gateway_model,
+        gateway_model: for_connection(d.gateway_model, &current.gateway_model, "gateway"),
         // M3-CLIENT: the sharing-server base URL IS settable from the DTO (Settings → Account owns
         // it). An omitted value defaults to `""` (unset) — no behavioral change for existing installs.
         share_base_url: d.share_base_url,
@@ -5289,13 +5447,13 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         // `gateway_model` — plain strings, `""` = inherit legacy. An omitted key deserializes to
         // `""` (`#[serde(default)]`), so an older FE payload can never flip a role.
         role_notes_connection: d.role_notes_connection,
-        role_notes_model: d.role_notes_model,
+        role_notes_model: for_role(d.role_notes_model, &current.role_notes_model, &notes_conn),
         role_notes_effort: d.role_notes_effort,
         role_ask_connection: d.role_ask_connection,
-        role_ask_model: d.role_ask_model,
+        role_ask_model: for_role(d.role_ask_model, &current.role_ask_model, &ask_conn),
         role_ask_effort: d.role_ask_effort,
         role_live_connection: d.role_live_connection,
-        role_live_model: d.role_live_model,
+        role_live_model: for_role(d.role_live_model, &current.role_live_model, &live_conn),
         role_live_effort: d.role_live_effort,
     }
 }

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -88,26 +88,167 @@ pub async fn list_gateway_models(
 ///   - `"local"` → the on-device `reason::BRAIN_MODELS` registry ids,
 ///   - `"off"` → empty (a valid connection that runs no models),
 ///   - anything else → `AppError::InvalidArg`.
-pub(crate) fn static_connection_models(connection: &str) -> Result<Vec<String>, AppError> {
+pub(crate) fn static_connection_models(connection: &str) -> Result<ModelCatalogDto, AppError> {
+    let bundled = |m: &crate::summarize::provider::CloudModel| ModelOptionDto {
+        id: m.id.to_string(),
+        label: format!("{} — {}", m.label, m.note),
+        source: SOURCE_BUNDLED.to_string(),
+    };
     match connection {
-        "claude_code" | "anthropic" => Ok(crate::summarize::provider::CLAUDE_MODELS
-            .iter()
-            .map(|id| id.to_string())
-            .collect()),
-        "codex_cli" => Ok(crate::summarize::provider::CODEX_MODELS
-            .iter()
-            .map(|id| id.to_string())
-            .collect()),
-        "local" => Ok(crate::reason::BRAIN_MODELS
-            .iter()
-            .map(|m| m.id.to_string())
-            .collect()),
-        "off" => Ok(vec![]),
+        "claude_code" | "anthropic" => Ok(ModelCatalogDto::bundled(
+            crate::summarize::provider::CLAUDE_MODELS
+                .iter()
+                .map(bundled)
+                .collect(),
+        )),
+        "codex_cli" => Ok(ModelCatalogDto::bundled(
+            crate::summarize::provider::CODEX_MODELS
+                .iter()
+                .map(bundled)
+                .collect(),
+        )),
+        // The on-device registry is authoritative for what is installable, so it is not a "hint"
+        // in the same sense — but it is still compile-time data, so it reports `bundled` and the
+        // picker keeps offering a free-text id for anything the user side-loads.
+        "local" => Ok(ModelCatalogDto::bundled(
+            crate::reason::BRAIN_MODELS
+                .iter()
+                .map(|m| ModelOptionDto {
+                    id: m.id.to_string(),
+                    label: m.name.to_string(),
+                    source: SOURCE_BUNDLED.to_string(),
+                })
+                .collect(),
+        )),
+        "off" => Ok(ModelCatalogDto::bundled(vec![])),
         other => Err(AppError::InvalidArg(format!(
             "unknown connection '{other}' — expected claude_code, codex_cli, anthropic, ollama, gateway, local, or off"
         ))),
     }
 }
+
+/// Catalog fetched from a real endpoint during THIS call — Refresh is meaningful.
+pub(crate) const SOURCE_LIVE: &str = "live";
+/// Catalog baked into the binary — Refresh would be a lie, and the list may be out of date.
+pub(crate) const SOURCE_BUNDLED: &str = "bundled";
+
+/// A connection's catalog plus WHERE IT CAME FROM.
+///
+/// Provenance lives on the catalog rather than on each option because the case that matters most is
+/// the EMPTY one: a gateway or Ollama daemon that answers successfully with zero models is exactly
+/// when the user wants Refresh, and an empty option list carries no provenance to read. Deriving
+/// liveness from `options.some(source == "live")` hid the button in that case.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelCatalogDto {
+    pub source: String,
+    pub options: Vec<ModelOptionDto>,
+}
+
+impl ModelCatalogDto {
+    fn live(options: Vec<ModelOptionDto>) -> Self {
+        Self {
+            source: SOURCE_LIVE.to_string(),
+            options,
+        }
+    }
+
+    fn bundled(options: Vec<ModelOptionDto>) -> Self {
+        Self {
+            source: SOURCE_BUNDLED.to_string(),
+            options,
+        }
+    }
+}
+
+/// One selectable model, as the picker needs it.
+///
+/// `label` is what the user reads; `id` is what is passed verbatim to the CLI/API. `source` tells
+/// the FE whether the list came off the wire this call (`"live"`) or out of the binary
+/// (`"bundled"`), which is the difference between offering a Refresh button that does something
+/// and offering one that cannot.
+///
+/// **This DTO is a hint, never an allowlist.** An id the user typed that appears in no catalog is
+/// a custom id and must be preserved as-is by every consumer.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelOptionDto {
+    pub id: String,
+    pub label: String,
+    pub source: String,
+}
+
+/// Wrap ids from a live endpoint. The id IS the label, and that is the correct answer.
+///
+/// This deliberately does NOT prettify. Three attempts at a `humanize_model_id` were made and each
+/// broke the injectivity it claimed: trimming collapsed `"model"` with `" model "`; mapping `-` and
+/// `_` to a space collapsed `plain-model` with `plain_model`; capitalising collapsed `model` with
+/// `Model`. Uppercasing is lossy on case, so "prettier AND injective" is not achievable by
+/// rewriting the id at all.
+///
+/// It is also unnecessary. The raw-id complaint was about BUNDLED catalogs, where an id like
+/// `gpt-5.6-sol` says nothing — and those get real names from the registry
+/// (`"{label} — {note}"`). A LIVE id is already the name the user knows the model by: `llama3.1:8b`
+/// is what Ollama calls it and what they typed to pull it. Inventing a prettier form adds no
+/// information and cost three rounds of collisions.
+fn live_options(ids: Vec<String>) -> Vec<ModelOptionDto> {
+    ids.into_iter()
+        .map(|id| ModelOptionDto {
+            label: live_label(&id),
+            id,
+            source: SOURCE_LIVE.to_string(),
+        })
+        .collect()
+}
+
+/// A readable label for a live id that CANNOT collide with another id's label.
+///
+/// `llama3.1:8b` → `Llama3.1 8b — llama3.1:8b`; `hf.co/TheBloke/x:Q4` → `X Q4 — hf.co/TheBloke/x:Q4`.
+///
+/// The prettified part is lossy — three earlier attempts proved it. Trimming collapsed `"model"`
+/// with `" model "`; mapping `-`/`_` to a space collapsed `plain-model` with `plain_model`;
+/// capitalising collapsed `model` with `Model`. Any transform that normalises must, by definition,
+/// map two distinct ids together somewhere.
+///
+/// So the exact id is APPENDED rather than replaced. The label is then injective by construction —
+/// it contains the id verbatim — while still leading with something a human reads. That is the only
+/// shape that satisfies both "human label" and "distinct ids never collapse"; picking one or the
+/// other is what cost three review rounds.
+fn live_label(id: &str) -> String {
+    let tail = id.rsplit('/').next().unwrap_or(id);
+    let pretty = tail
+        .split([':', '-', '_'])
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let mut chars = part.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    // ALWAYS prefixed. Returning the bare id for an already-capitalised, separator-free slug
+    // (`Model`) made exactly those options render as raw ids — the thing the label field exists to
+    // prevent — while `model` beside it got a label. A little redundancy beats an inconsistent
+    // surface.
+    //
+    // A punctuation-only id (`_`, `:`) prettifies to nothing, and a live endpoint is free to return
+    // one — `valid_catalog_model_id` accepts it. It gets a name rather than falling through to the
+    // raw id, so no option anywhere renders unlabelled.
+    if pretty.is_empty() {
+        return format!("Unnamed model — {id}");
+    }
+    format!("{pretty} — {id}")
+}
+
+/// Test-only door onto [`live_options`], which is private because nothing outside this module has
+/// any business building a live catalog.
+#[cfg(test)]
+pub(crate) fn live_options_for_test(ids: Vec<String>) -> Vec<ModelOptionDto> {
+    live_options(ids)
+}
+
 
 /// Unified model catalog for a connection — the ONE source of truth behind the FE per-role
 /// model dropdowns. Dispatch by `connection`:
@@ -125,9 +266,9 @@ pub(crate) fn static_connection_models(connection: &str) -> Result<Vec<String>, 
 pub async fn list_models(
     state: State<'_, AppState>,
     connection: String,
-) -> Result<Vec<String>, AppError> {
+) -> Result<ModelCatalogDto, AppError> {
     match connection.as_str() {
-        "gateway" => gateway_model_ids(&state).await,
+        "gateway" => Ok(ModelCatalogDto::live(live_options(gateway_model_ids(&state).await?))),
         "ollama" => {
             let base_url = {
                 let config = state
@@ -138,9 +279,11 @@ pub async fn list_models(
             };
             // OllamaProvider::new normalizes an empty base URL to the localhost default and
             // trims trailing slashes; the model arg is unused for a catalog fetch.
-            crate::summarize::ollama::OllamaProvider::new(base_url, String::new())
-                .list_models()
-                .await
+            Ok(ModelCatalogDto::live(live_options(
+                crate::summarize::ollama::OllamaProvider::new(base_url, String::new())
+                    .list_models()
+                    .await?,
+            )))
         }
         other => static_connection_models(other),
     }

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -12543,47 +12543,1131 @@
 
     // ─── list_models — static connection catalogs (pure, no network) ─────────────────────────
 
-    /// `claude_code` and `anthropic` both serve the curated CLAUDE_MODELS constant — the single
-    /// source of truth that replaced the FE-hardcoded dropdown list.
+    /// STRUCTURAL, not literal. The previous pair of tests asserted the returned ids equalled the
+    /// constants *verbatim*, which meant shipping a newly released model required editing a test
+    /// as well as the list — exactly the per-model cost this change exists to remove. What must
+    /// hold is the SHAPE: every option is usable and labelled, and a compile-time list is honestly
+    /// declared as such so the FE can offer a free-text id instead of trusting it.
     #[test]
-    fn list_models_claude_connections_return_curated_constant() {
-        for conn in ["claude_code", "anthropic"] {
-            let ids = static_connection_models(conn)
+    fn bundled_catalogs_are_labelled_and_declare_themselves_bundled() {
+        for conn in ["claude_code", "anthropic", "codex_cli", "local"] {
+            let catalog = static_connection_models(conn)
                 .unwrap_or_else(|e| panic!("{conn} must resolve statically: {e:?}"));
-            let want: Vec<String> = crate::summarize::provider::CLAUDE_MODELS
-                .iter()
-                .map(|id| id.to_string())
-                .collect();
-            assert_eq!(ids, want, "{conn} must serve CLAUDE_MODELS verbatim");
-            assert!(
-                ids.contains(&"claude-opus-4-8".to_string()),
-                "curated list must include the default Opus id"
+            assert_eq!(
+                catalog.source,
+                crate::commands::SOURCE_BUNDLED,
+                "{conn}: a compile-time catalog must declare itself bundled AT THE CATALOG level, \
+                 so an EMPTY one still carries provenance"
             );
-            assert!(
-                ids.contains(&"claude-sonnet-5".to_string()),
-                "curated list must include the current Sonnet id"
+            let options = catalog.options;
+            assert!(!options.is_empty(), "{conn} must offer at least one model");
+            for option in &options {
+                assert!(!option.id.trim().is_empty(), "{conn}: empty model id");
+                assert!(
+                    !option.label.trim().is_empty(),
+                    "{conn}: option {} has no label — the picker would render a raw id",
+                    option.id
+                );
+                assert_eq!(
+                    option.source,
+                    crate::commands::SOURCE_BUNDLED,
+                    "{conn}: a compile-time list must not claim to be live, or the FE offers a \
+                     Refresh button that cannot do anything"
+                );
+            }
+            let ids: Vec<&str> = options.iter().map(|o| o.id.as_str()).collect();
+            let mut sorted = ids.clone();
+            sorted.sort_unstable();
+            sorted.dedup();
+            assert_eq!(sorted.len(), ids.len(), "{conn}: duplicate model id");
+        }
+    }
+
+    /// The ledger and the wire must never disagree about which model was requested.
+    ///
+    /// `summarize::effective_model_requested` reads the STORED value, while
+    /// `claude_code::model_args` decides what actually goes on the wire. An earlier attempt at
+    /// this fix rejected hostile ids only at the CLI, which meant a rejected id was still
+    /// RECORDED in the egress ledger as requested while the provider silently ran its own
+    /// default — a lying audit trail. Refusing to persist it is what keeps the two in sync.
+    #[test]
+    fn a_hostile_model_id_is_refused_at_the_persistence_boundary() {
+        let current = crate::settings::config::AppConfig {
+            provider_model: "claude-sonnet-5".into(),
+            role_notes_model: "claude-sonnet-5".into(),
+            ..Default::default()
+        };
+        let mut dto = config_to_dto(&current);
+        dto.provider_model = "--sandbox danger-full-access".into();
+        dto.role_notes_model = "claude opus 5".into();
+
+        let saved = dto_to_config(dto, &current);
+        assert_eq!(
+            saved.provider_model, "claude-sonnet-5",
+            "a hostile id must not be persisted — the ledger reads exactly this field"
+        );
+        assert_eq!(
+            saved.role_notes_model, "claude-sonnet-5",
+            "same for every per-role model"
+        );
+
+        // A legitimate unlisted id — the whole point of the hint catalog — still goes through.
+        let mut dto = config_to_dto(&current);
+        dto.provider_model = "claude-opus-6".into();
+        assert_eq!(dto_to_config(dto, &current).provider_model, "claude-opus-6");
+
+        // Blank stays blank: "let the provider pick" is a supported, explicit choice.
+        let mut dto = config_to_dto(&current);
+        dto.provider_model = "  ".into();
+        assert_eq!(dto_to_config(dto, &current).provider_model, "");
+    }
+
+    /// The save boundary is not enough on its own: a hostile id written BEFORE that boundary
+    /// existed, or by hand, survives until the next save — and until then the egress ledger reads
+    /// it (`effective_model_requested`) while the CLI silently omits `--model`, so the ledger
+    /// records a request that never went out. `AppConfig::load` therefore clears it too, which is
+    /// what makes "ledger and wire agree by construction" true for every LOADABLE configuration.
+    #[test]
+    fn a_hostile_model_id_already_on_disk_is_cleared_on_load() {
+        let db = Db::open_with_key(&tmp_db_path("hostile-model-load"), DB_KEY).expect("open");
+        db.migrate().expect("migrate");
+        // Write past the config API, exactly as an older build or a hand edit would have.
+        db.set_setting("provider_model", "--sandbox danger-full-access")
+            .expect("seed provider_model");
+        db.set_setting("role_notes_model", "claude opus 5")
+            .expect("seed role_notes_model");
+        db.set_setting("role_ask_model", "claude-opus-5")
+            .expect("seed a LEGITIMATE unlisted id");
+
+        let cfg = crate::settings::config::AppConfig::load(&db).expect("load");
+        assert_eq!(
+            cfg.provider_model, "",
+            "a hostile stored id must not survive a load — the ledger reads this field"
+        );
+        assert_eq!(cfg.role_notes_model, "", "same for every per-role model");
+        assert_eq!(
+            cfg.role_ask_model, "claude-opus-5",
+            "a legitimate unlisted id must survive; that is the whole point of a hint catalog"
+        );
+
+        // The load sweep judges `provider_model` by `provider_id`, like the save boundary. It was
+        // briefly pinned to `"claude_code"` here, which meant a legitimate long Anthropic id was
+        // cleared on EVERY LAUNCH — silently, since load performs no user-visible edit.
+        let db = Db::open_with_key(&tmp_db_path("long-anthropic-model-load"), DB_KEY).expect("open");
+        db.migrate().expect("migrate");
+        let long = format!("hf.co/{}/model:Q4_K_M", "a".repeat(60));
+        db.set_setting("provider_id", "anthropic").expect("seed provider_id");
+        db.set_setting("provider_model", &long).expect("seed provider_model");
+        assert_eq!(
+            crate::settings::config::AppConfig::load(&db)
+                .expect("load")
+                .provider_model,
+            long,
+            "a JSON-body arm's long vendor id must survive a load"
+        );
+
+        // ...and the same id under an ARGV engine is still cleared, so the rule stayed a rule.
+        let db = Db::open_with_key(&tmp_db_path("long-argv-model-load"), DB_KEY).expect("open");
+        db.migrate().expect("migrate");
+        db.set_setting("provider_id", "claude_code").expect("seed provider_id");
+        db.set_setting("provider_model", &long).expect("seed provider_model");
+        assert_eq!(
+            crate::settings::config::AppConfig::load(&db)
+                .expect("load")
+                .provider_model,
+            "",
+            "an id `--model` cannot carry must not survive a load on an argv engine"
+        );
+    }
+
+    /// THE A6 INVARIANT, stated once: what is STORED is exactly what the wire will accept.
+    ///
+    /// The predicate must follow the CONNECTION, not the field. A role pointing at `claude_code`
+    /// stores an id that becomes `--model <id>` argv, so it takes the strict short-slug ceiling; a
+    /// role pointing at `ollama` sends the id in a JSON body, where a long Hugging Face path is
+    /// legitimate. Applying one rule to both broke it in both directions across three review
+    /// rounds: the strict one rejected real Ollama ids, and the loose one let a 65-200 character id
+    /// sit in config for a CLI role — reported to the egress ledger by
+    /// `effective_model_requested` while `model_args` silently dropped `--model`. A stored value
+    /// the wire will not send is the ledger lying, which is the whole reason A6 exists.
+    #[test]
+    fn a_role_model_is_validated_against_its_own_connection() {
+        let long_but_valid = format!("hf.co/{}/model:Q4_K_M", "a".repeat(60));
+        assert!(long_but_valid.len() > 64, "fixture must exceed the argv ceiling");
+
+        // ARGV arm: too long for `--model`, so it must not be stored.
+        let current = crate::settings::config::AppConfig {
+            role_notes_connection: "claude_code".into(),
+            role_notes_model: "claude-sonnet-5".into(),
+            ..Default::default()
+        };
+        let mut dto = config_to_dto(&current);
+        dto.role_notes_model = long_but_valid.clone();
+        assert_eq!(
+            dto_to_config(dto, &current).role_notes_model,
+            "claude-sonnet-5",
+            "a CLI role must not store an id `model_args` would refuse — the ledger reads this"
+        );
+
+        // JSON-BODY arm: the same id is a real catalog entry and must round-trip untouched.
+        let current = crate::settings::config::AppConfig {
+            role_notes_connection: "ollama".into(),
+            role_notes_model: "llama3.1:8b".into(),
+            ..Default::default()
+        };
+        let mut dto = config_to_dto(&current);
+        dto.role_notes_model = long_but_valid.clone();
+        assert_eq!(
+            dto_to_config(dto, &current).role_notes_model,
+            long_but_valid,
+            "an Ollama role must keep a long Hugging Face id — refusing it protects nothing"
+        );
+
+        // AN EMPTY ROLE CONNECTION MEANS "INHERIT", and an inheriting role's model is INERT.
+        //
+        // This block used to resolve `""` to `provider_id` and apply that arm's rule, on the
+        // premise that `roles::resolve` follows the inheritance for the MODEL too. It does not —
+        // `is_explicit` keys on the connection key alone, so an inheriting role goes through
+        // `legacy_default_target`, which reads `provider_model` and never `role_*_model`. Judging
+        // the inert value by the default engine's CLI rule DESTROYED it: the UI deliberately keeps
+        // a role's model on the way to Inherit (nothing there can use it, so clearing would be
+        // silent loss on a row with no model control), and the very next autosave blanked it
+        // whenever the default engine happened to be `claude_code`.
+        for default_engine in ["ollama", "claude_code", "anthropic"] {
+            let current = crate::settings::config::AppConfig {
+                provider_id: default_engine.into(),
+                role_notes_connection: String::new(),
+                role_notes_model: "llama3.1:8b".into(),
+                ..Default::default()
+            };
+            let mut dto = config_to_dto(&current);
+            dto.role_notes_model = long_but_valid.clone();
+            assert_eq!(
+                dto_to_config(dto, &current).role_notes_model,
+                long_but_valid,
+                "an INHERITING role's model is never sent, so {default_engine:?} being the default \
+                 must not destroy it"
+            );
+        }
+        // Transport safety still applies to an inherited role — it is inert, not unchecked.
+        let current = crate::settings::config::AppConfig {
+            provider_id: "claude_code".into(),
+            role_notes_connection: String::new(),
+            role_notes_model: "llama3.1:8b".into(),
+            ..Default::default()
+        };
+        let mut dto = config_to_dto(&current);
+        dto.role_notes_model = "--sandbox danger-full-access".into();
+        assert_eq!(
+            dto_to_config(dto, &current).role_notes_model,
+            "llama3.1:8b",
+            "an argv shape is refused even where the value is inert"
+        );
+        // And the moment the role points at a CLI arm, that arm's rule applies and clears it.
+        let current = crate::settings::config::AppConfig {
+            provider_id: "ollama".into(),
+            role_notes_connection: "claude_code".into(),
+            role_notes_model: "claude-sonnet-5".into(),
+            ..Default::default()
+        };
+        let mut dto = config_to_dto(&current);
+        dto.role_notes_model = long_but_valid.clone();
+        assert_eq!(
+            dto_to_config(dto, &current).role_notes_model,
+            "claude-sonnet-5",
+            "an EXPLICIT CLI role must not store an id argv cannot carry"
+        );
+
+        // FAIL CLOSED for a connection nobody recognises — a future CLI provider, a typo. That is
+        // different from `""`, whose meaning IS defined (above).
+        for unknown in ["some_future_cli", "claude_code"] {
+            let current = crate::settings::config::AppConfig {
+                role_notes_connection: unknown.into(),
+                role_notes_model: "claude-sonnet-5".into(),
+                ..Default::default()
+            };
+            let mut dto = config_to_dto(&current);
+            dto.role_notes_model = long_but_valid.clone();
+            assert_eq!(
+                dto_to_config(dto, &current).role_notes_model,
+                "claude-sonnet-5",
+                "connection {unknown:?} must default to the STRICT predicate, not the loose one"
+            );
+        }
+
+        // SWITCHING ARMS. A long id stored while the role pointed at Ollama must not survive a move
+        // to a CLI connection — the fallback is re-validated under the NEW arm, so it clears rather
+        // than lingering as a value the wire will silently drop.
+        let current = crate::settings::config::AppConfig {
+            role_notes_connection: "ollama".into(),
+            role_notes_model: long_but_valid.clone(),
+            ..Default::default()
+        };
+        let mut dto = config_to_dto(&current);
+        dto.role_notes_connection = "claude_code".into();
+        assert_eq!(
+            dto_to_config(dto, &current).role_notes_model,
+            "",
+            "switching to a CLI arm must drop an id that arm cannot send"
+        );
+
+        // And the shape refusals hold on BOTH arms, whatever the connection.
+        for connection in ["claude_code", "ollama"] {
+            let current = crate::settings::config::AppConfig {
+                role_notes_connection: connection.into(),
+                role_notes_model: "llama3.1:8b".into(),
+                ..Default::default()
+            };
+            let mut dto = config_to_dto(&current);
+            dto.role_notes_model = "--sandbox danger-full-access".into();
+            assert_eq!(
+                dto_to_config(dto, &current).role_notes_model,
+                "llama3.1:8b",
+                "{connection}: an argv-injection shape is refused regardless of arm"
             );
         }
     }
 
-    /// Codex exposes its own curated current catalog, in the UI's intended display order.
+    /// THE RULE HAS NO EXCEPTIONS: every model field follows the connection that will send it.
+    ///
+    /// Two review rounds were spent on fields that stated this rule and then bypassed it —
+    /// `provider_model` pinned to the strict predicate regardless of `provider_id`, and the
+    /// per-connection fields left unguarded entirely. This pins the rule itself rather than any one
+    /// field, so the next field added cannot quietly become an exception.
     #[test]
-    fn list_models_codex_returns_curated_constant() {
-        let ids =
-            static_connection_models("codex_cli").expect("codex_cli must resolve statically");
-        let want: Vec<String> = crate::summarize::provider::CODEX_MODELS
-            .iter()
-            .map(|id| id.to_string())
-            .collect();
-        assert_eq!(ids, want, "codex_cli must serve CODEX_MODELS verbatim");
+    fn every_model_field_follows_its_own_connection() {
+        use crate::commands::{connection_builds_argv, model_predicate_for};
+        let long = format!("hf.co/{}/model:Q4_K_M", "a".repeat(60));
+        assert!(long.len() > 64);
+
+        // The JSON-body arms accept it; the argv arms do not. Same id, opposite answers, and the
+        // ONLY input is the connection.
+        for body_arm in ["anthropic", "ollama", "gateway"] {
+            assert!(!connection_builds_argv(body_arm));
+            assert!(model_predicate_for(body_arm)(&long), "{body_arm} sends JSON");
+        }
+        for argv_arm in ["claude_code", "codex_cli", "", "some_future_cli"] {
+            assert!(connection_builds_argv(argv_arm), "{argv_arm} must fail closed to argv");
+            assert!(!model_predicate_for(argv_arm)(&long), "{argv_arm} builds argv");
+        }
+
+        // `provider_model` is the ONE exception, and deliberately so: it is ALWAYS strict, whatever
+        // `provider_id` says. `roles::legacy_default_target` hands it to `claude_code`, `codex_cli`
+        // and `anthropic`, and a role with an explicit CLI connection but a blank model inherits
+        // it — so this single value can reach an argv arm regardless of the provider selected
+        // today. Keying it to the current `provider_id` let a long id stored under Ollama become a
+        // `claude_code` role's model, which `model_args` drops while the ledger still reports it.
+        // See `the_resolved_target_model_is_always_one_the_wire_will_send`.
+        // `provider_model` follows `provider_id`, because that is its only reader
+        // (`roles::legacy_default_target`). An explicit role does NOT inherit it — see
+        // `the_resolved_target_model_is_always_one_the_wire_will_send` — and the unconditional
+        // strict rule this replaced destroyed legitimate long vendor ids on the Anthropic arm.
+        let current = crate::settings::config::AppConfig {
+            provider_id: "anthropic".into(),
+            provider_model: "claude-sonnet-5".into(),
+            ..Default::default()
+        };
+        let mut dto = config_to_dto(&current);
+        dto.provider_model = long.clone();
         assert_eq!(
-            ids,
-            vec![
-                "gpt-5.6-sol".to_string(),
-                "gpt-5.6-terra".to_string(),
-                "gpt-5.6-luna".to_string(),
-            ]
+            dto_to_config(dto, &current).provider_model,
+            long,
+            "anthropic sends the model in a JSON body, so a long vendor id is legitimate there"
         );
+
+        // ...but the SAME id is refused the moment the engine becomes an argv arm. This is the
+        // safety property that made the over-broad rule look necessary: `dto_to_config` runs on
+        // every save with the DTO's NEW `provider_id`, so switching engines re-judges the stored id
+        // rather than carrying it onto a command line where `model_args` would drop it while
+        // `effective_model_requested` still reported it to the ledger.
+        let stored_long = crate::settings::config::AppConfig {
+            provider_id: "anthropic".into(),
+            provider_model: long.clone(),
+            ..Default::default()
+        };
+        let mut switching = config_to_dto(&stored_long);
+        switching.provider_id = "claude_code".into();
+        let after = dto_to_config(switching, &stored_long);
+        assert_eq!(
+            after.provider_model, "",
+            "switching to an argv engine must not carry a JSON-body-length id onto the command line"
+        );
+
+        // And a short id survives that same switch — otherwise the assertion above would be
+        // satisfied by a rule that simply wipes the field on every engine change.
+        let stored_short = crate::settings::config::AppConfig {
+            provider_id: "anthropic".into(),
+            provider_model: "claude-sonnet-5".into(),
+            ..Default::default()
+        };
+        let mut switching = config_to_dto(&stored_short);
+        switching.provider_id = "claude_code".into();
+        assert_eq!(
+            dto_to_config(switching, &stored_short).provider_model,
+            "claude-sonnet-5",
+            "a valid short id must survive an engine switch"
+        );
+
+        // The per-connection fields are guarded too — they were unguarded for two rounds. A refused
+        // proposal falls back to the STORED value (never to whatever was proposed), so the
+        // assertion is that the hostile string does not land, not that the field empties.
+        let current = crate::settings::config::AppConfig {
+            anthropic_model: "claude-sonnet-5".into(),
+            ollama_model: "llama3.1:8b".into(),
+            ..Default::default()
+        };
+        let mut dto = config_to_dto(&current);
+        dto.anthropic_model = "--sandbox danger-full-access".into();
+        dto.ollama_model = "../../etc/passwd".into();
+        dto.gateway_model = long.clone();
+        let saved = dto_to_config(dto, &current);
+        assert_eq!(
+            saved.anthropic_model, "claude-sonnet-5",
+            "an argv shape is refused on every arm, keeping the stored value"
+        );
+        assert_eq!(
+            saved.ollama_model, "llama3.1:8b",
+            "a path segment is refused on every arm, keeping the stored value"
+        );
+        assert_eq!(saved.gateway_model, long, "but a long JSON-body id is fine");
+
+        // A punctuation-only id prettifies to nothing. A live endpoint may return one — the
+        // predicate accepts it — and it must still get a name rather than rendering as a raw id.
+        for odd in ["_", ":", "-x"] {
+            let options = crate::commands::live_options_for_test(vec![odd.to_string()]);
+            assert!(
+                options[0].label.contains(odd) && options[0].label != odd,
+                "{odd:?} must be labelled AND still embed its id; got {:?}",
+                options[0].label
+            );
+        }
+    }
+
+    /// A6 PROVED ON THE RESOLVED TARGET, which is the only place it is actually true.
+    ///
+    /// Every earlier version proved it FIELD BY FIELD, and that kept missing cases because the
+    /// ledger does not read a field — it reads `effective_model_requested(target, config)`, where
+    /// `target` came out of `roles::resolve`. The gap that survived four rounds: a role with an
+    /// EXPLICIT `claude_code` connection and a BLANK model inherits `provider_model`, so a
+    /// 200-character id stored while `provider_id` was Ollama became that role's model on an argv
+    /// arm — dropped by `model_args`, still reported to the ledger.
+    ///
+    /// So this walks the resolution the runtime walks, over the combinations that produced every
+    /// past defect, and asserts the one property that matters: what the ledger would report is
+    /// exactly what the wire would carry.
+    #[test]
+    fn the_resolved_target_model_is_always_one_the_wire_will_send() {
+        use crate::summarize::roles::{resolve, Role};
+        let long = format!("hf.co/{}/model:Q4_K_M", "a".repeat(60));
+
+        for (provider_id, role_connection) in [
+            ("ollama", "claude_code"),  // the gap: explicit CLI role inheriting an Ollama default
+            ("ollama", ""),             // inherited role under a JSON default
+            ("claude_code", ""),        // inherited role under a CLI default
+            ("anthropic", "codex_cli"), // explicit CLI role under a direct-API default
+            ("gateway", "ollama"),      // JSON everywhere
+        ] {
+            let stored = crate::settings::config::AppConfig {
+                provider_id: provider_id.into(),
+                role_notes_connection: role_connection.into(),
+                ..Default::default()
+            };
+            // Try to store the long id in EVERY field a resolved target could draw from — not
+            // just the two a role reads directly. Leaving `anthropic_model` / `ollama_model` /
+            // `gateway_model` out of this sweep is what let the previous version of this test pass
+            // while a path through them was still open.
+            let mut dto = config_to_dto(&stored);
+            dto.provider_model = long.clone();
+            dto.role_notes_model = long.clone();
+            dto.anthropic_model = long.clone();
+            dto.ollama_model = long.clone();
+            dto.gateway_model = long.clone();
+            let saved = dto_to_config(dto, &stored);
+
+            let target = resolve(Role::Notes, &saved);
+            if target.model.is_empty() {
+                continue; // "let the connection pick" is always safe
+            }
+            let usable = crate::commands::model_predicate_for(&target.connection)(&target.model);
+            assert!(
+                usable,
+                "provider_id={provider_id:?} role={role_connection:?} resolved to \
+                 connection {:?} with model {:?}, which that arm cannot send — the ledger would \
+                 report a model the wire drops",
+                target.connection, target.model
+            );
+        }
+
+        // SECOND PASS, and the reason this test is worth anything on the argv legs.
+        //
+        // Above, the long fixture goes into every field and `dto_to_config` clears it from
+        // `provider_model` and `role_notes_model` before resolution — so on EVERY argv leg
+        // `target.model` came back empty, the `continue` fired, and the assertion never executed.
+        // The pass was real but vacuous at exactly the place the A6 ledger-lie would live.
+        //
+        // So seed a legitimate short id in the field each leg actually reads, and leave the long one
+        // in `anthropic_model` / `ollama_model` / `gateway_model`. Every leg then resolves NON-EMPTY
+        // and the assertions run — including the one that answers the open question directly: the
+        // resolved model is never drawn from a loosely-validated field.
+        //
+        // Which field a leg reads is not a guess; it is what `roles.rs` does. `explicit_target`
+        // reads ONLY that role's own `role_*_model` — an explicit role connection does NOT inherit
+        // `provider_model` — and `legacy_default_target` carries `provider_model` only for
+        // `claude_code`/`codex_cli`/`anthropic`, returning "" for `ollama`/`gateway`. That is why
+        // seeding `provider_model` on the `("ollama", "claude_code")` leg leaves it empty, and the
+        // first version of this pass failed on precisely that: the inheritance the A6 note feared
+        // does not exist for explicit role keys.
+        let mut argv_legs_asserted = 0;
+        for (provider_id, role_connection, seed_role_model) in [
+            ("ollama", "claude_code", true),   // explicit role → reads role_notes_model
+            ("anthropic", "codex_cli", true),  // explicit role → reads role_notes_model
+            ("claude_code", "", false),        // inherit → legacy_default_target reads provider_model
+        ] {
+            let stored = crate::settings::config::AppConfig {
+                provider_id: provider_id.into(),
+                role_notes_connection: role_connection.into(),
+                ..Default::default()
+            };
+            let mut dto = config_to_dto(&stored);
+            dto.provider_model = "claude-opus-5".into();
+            dto.role_notes_model = if seed_role_model {
+                "claude-opus-5".into()
+            } else {
+                String::new()
+            };
+            dto.anthropic_model = long.clone();
+            dto.ollama_model = long.clone();
+            dto.gateway_model = long.clone();
+            let saved = dto_to_config(dto, &stored);
+
+            let target = resolve(Role::Notes, &saved);
+            assert!(
+                crate::commands::connection_builds_argv(&target.connection),
+                "leg provider_id={provider_id:?} role={role_connection:?} was chosen because it \
+                 resolves to an argv arm, but resolved to {:?}",
+                target.connection
+            );
+            assert!(
+                !target.model.is_empty(),
+                "provider_id={provider_id:?} role={role_connection:?} resolved to an EMPTY model, \
+                 so this leg proves nothing — the vacuity this pass exists to remove"
+            );
+            assert_ne!(
+                target.model, long,
+                "an argv arm resolved to a loosely-validated field's value; `model_args` would \
+                 drop it while `effective_model_requested` still reported it to the ledger"
+            );
+            assert!(
+                crate::commands::model_predicate_for(&target.connection)(&target.model),
+                "provider_id={provider_id:?} role={role_connection:?} resolved to connection {:?} \
+                 with model {:?}, which that arm cannot send",
+                target.connection, target.model
+            );
+            argv_legs_asserted += 1;
+        }
+        assert_eq!(
+            argv_legs_asserted, 3,
+            "every argv leg must reach a real assertion"
+        );
+
+        // The structural fact the two passes above rest on, asserted rather than assumed: an
+        // EXPLICIT role connection does not inherit `provider_model`. If a later edit made it
+        // inherit, the loose/strict split would stop being sound and both passes would quietly
+        // start testing something else.
+        let inheriting = crate::settings::config::AppConfig {
+            provider_id: "ollama".into(),
+            provider_model: "claude-opus-5".into(),
+            role_notes_connection: "claude_code".into(),
+            role_notes_model: String::new(),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve(Role::Notes, &inheriting).model,
+            "",
+            "an explicit role connection must read its OWN model key only; inheriting \
+             `provider_model` here is the shape that would let a JSON-arm id reach an argv arm"
+        );
+    }
+
+    /// A6 STATED DIRECTLY: the LEDGER value equals the WIRE value.
+    ///
+    /// Every earlier test asserted a proxy — that the resolved model satisfies its arm's predicate —
+    /// and none ever called `effective_model_requested`, the function the ledger actually records.
+    /// So "ledger and wire agree by construction" was argued, not executed, and the legs where the
+    /// resolved model is EMPTY were skipped outright. Those are the interesting ones: an empty
+    /// resolved model makes `effective_model_requested` fall back to the arm's own config field, and
+    /// whether the wire then carries that same value is precisely the open question.
+    ///
+    /// This asks each side what it would do and compares them:
+    ///   - argv arms — the wire is the REAL argv from `model_args`, not a re-derivation;
+    ///   - JSON arms — the wire is whatever the request body would carry, which for an empty
+    ///     resolved model is the arm's own field (mirroring `make_provider_resolved`).
+    #[test]
+    fn the_ledger_reports_exactly_what_the_wire_sends() {
+        use crate::summarize::roles::{resolve, Role};
+        let long = format!("hf.co/{}/model:Q4_K_M", "a".repeat(60));
+
+        let after_model_flag = |args: Vec<String>| -> String {
+            args.iter()
+                .position(|a| a == "--model")
+                .and_then(|i| args.get(i + 1).cloned())
+                .unwrap_or_default()
+        };
+
+        let mut checked = 0;
+        for (provider_id, role_connection, seed, long_provider_model) in [
+            ("ollama", "claude_code", "", false),
+            ("ollama", "claude_code", "claude-opus-5", false),
+            ("ollama", "", "", false),
+            ("claude_code", "", "claude-opus-5", false),
+            ("claude_code", "", "", false),
+            ("anthropic", "codex_cli", "gpt-5.6-sol", false),
+            ("gateway", "ollama", "", false),
+            ("anthropic", "", "", false),
+            // THE SYMMETRIC ARGV LEG, previously absent — and the one that would expose an A6 lie.
+            //
+            // `provider_id` is a JSON-body arm, so `provider_model` is legitimately accepted at a
+            // length and character class no CLI could carry. The role is an EXPLICIT argv arm with
+            // a BLANK model, so `target.model` is empty and `model_args` emits no `--model`. If
+            // `effective_model_requested` had a `claude_code`/`codex_cli` fallback to
+            // `config.provider_model` — mirroring the three it does have — the ledger would record
+            // a 200-character id that never left the machine. It has no such arm (`_ => ""`), and
+            // that is now asserted here rather than argued in a comment.
+            ("ollama", "claude_code", "", true),
+            ("gateway", "codex_cli", "", true),
+        ] {
+            let stored = crate::settings::config::AppConfig {
+                provider_id: provider_id.into(),
+                role_notes_connection: role_connection.into(),
+                ..Default::default()
+            };
+            let mut dto = config_to_dto(&stored);
+            dto.role_notes_model = seed.into();
+            // Every field a fallback could read holds the long fixture, so a leg that silently
+            // reached for the wrong one shows up as a mismatch rather than passing by luck.
+            dto.provider_model = if long_provider_model {
+                long.clone()
+            } else if seed.is_empty() {
+                String::new()
+            } else {
+                seed.into()
+            };
+            dto.anthropic_model = long.clone();
+            dto.ollama_model = long.clone();
+            dto.gateway_model = long.clone();
+            let saved = dto_to_config(dto, &stored);
+
+            let target = resolve(Role::Notes, &saved);
+            let ledger = crate::summarize::effective_model_requested(&target, &saved);
+            let wire = match target.connection.as_str() {
+                "claude_code" => after_model_flag(crate::summarize::claude_code::model_args(
+                    &target.model,
+                )),
+                "codex_cli" => {
+                    after_model_flag(crate::summarize::codex_cli::model_args(&target.model))
+                }
+                // The JSON arms are NOT re-implemented here. `make_provider_resolved`'s
+                // anthropic/ollama/gateway arms now call `effective_model_requested` themselves, so
+                // asking it again is asking the production expression — not a copy of it that a
+                // future edit could silently desynchronise. The argv arms above stay the real
+                // check: they are the only ones where the two sides can genuinely differ.
+                "anthropic" | "ollama" | "gateway" => {
+                    crate::summarize::effective_model_requested(&target, &saved)
+                }
+                _ => String::new(),
+            };
+            assert_eq!(
+                ledger, wire,
+                "provider_id={provider_id:?} role={role_connection:?} seed={seed:?} resolved to \
+                 {:?}: the ledger would record {ledger:?} while the wire carries {wire:?}",
+                target.connection
+            );
+            if long_provider_model {
+                // Prove the leg is not vacuous in the way that matters: the long id really IS
+                // stored (so a fallback could have reached it) and the resolved model really IS
+                // empty (so only a fallback could have produced a non-empty ledger value).
+                assert_eq!(
+                    saved.provider_model, long,
+                    "the fixture must survive on a JSON-body engine, or this leg tests nothing"
+                );
+                assert!(
+                    target.model.is_empty(),
+                    "this leg needs an EMPTY resolved model to exercise the fallback path"
+                );
+                assert_eq!(ledger, "", "an argv arm has no config fallback, and must not gain one");
+            }
+            checked += 1;
+        }
+        assert_eq!(checked, 10, "every leg must be compared");
+
+        // The failure this guards against, shown to be detectable: an id the argv arm refuses,
+        // reported by the ledger. Reaching it requires bypassing the persistence boundary — which
+        // is the point, since that boundary is what makes the property true.
+        let cfg = crate::settings::config::AppConfig::default();
+        let hostile = crate::summarize::roles::RoleTarget {
+            connection: "claude_code".into(),
+            model: "--sandbox danger-full-access".into(),
+            effort: String::new(),
+        };
+        assert_eq!(
+            crate::summarize::effective_model_requested(&hostile, &cfg),
+            "--sandbox danger-full-access",
+            "the ledger reports the stored value verbatim, so a bad stored value IS a lie"
+        );
+        assert_eq!(
+            after_model_flag(crate::summarize::claude_code::model_args(&hostile.model)),
+            "",
+            "...while the wire sends nothing — the disagreement the boundary exists to prevent"
+        );
+    }
+
+    /// The loose JSON-arm predicate is safe for `local`, because that arm is a REGISTRY LOOKUP.
+    ///
+    /// `connection_builds_argv` classifies `local` as a JSON-body arm, so a role model bound to it
+    /// takes `valid_catalog_model_id` — no character allowlist, 512 bytes. That is only defensible
+    /// if the local arm treats the id as a KEY, never as a path. `reason::resolve_brain_model`
+    /// looks the id up with `brain_model_by_id` / `retired_model_by_id` and joins `models_dir()`
+    /// with the REGISTRY's own `filename`; the user's string is never a path component. An
+    /// unrecognised id therefore resolves to `None`, which `make_provider_resolved` turns into
+    /// `AppError::Unavailable` — fail-closed, and never a silent cloud fallback.
+    #[test]
+    fn a_local_role_model_is_a_registry_key_not_a_path() {
+        use crate::reason::resolve_brain_model;
+        for hostile in [
+            "/etc/passwd",
+            "../../etc/passwd",
+            "hf.co/whatever/model:Q4_K_M",
+            "not-a-registry-id",
+        ] {
+            assert_eq!(
+                resolve_brain_model(None, Some(hostile)).expect("resolve must not error"),
+                None,
+                "{hostile:?} is not a registry id, so it must resolve to None rather than to a path"
+            );
+        }
+        // A 512-byte id — the ceiling the loose predicate now permits — behaves the same.
+        let max_len = "a".repeat(512);
+        assert_eq!(resolve_brain_model(None, Some(&max_len)).expect("resolve"), None);
+    }
+
+    /// The load sweep and the save boundary must agree for EVERY stored `provider_id`, including
+    /// the empty one an unconfigured or hand-edited row can hold.
+    #[test]
+    fn an_empty_provider_id_is_judged_the_same_on_load_and_on_save() {
+        let long = format!("hf.co/{}/model:Q4_K_M", "a".repeat(60));
+        let db = Db::open_with_key(&tmp_db_path("empty-provider-id"), DB_KEY).expect("open");
+        db.migrate().expect("migrate");
+        db.set_setting("provider_id", "").expect("seed provider_id");
+        db.set_setting("provider_model", &long).expect("seed provider_model");
+        let loaded = crate::settings::config::AppConfig::load(&db).expect("load");
+        // Whether an empty engine is even REACHABLE decides how much this leg matters. Record the
+        // answer instead of assuming it: if load normalises the blank away, the divergence this
+        // test guards is unreachable in practice and the assertion below is belt-and-braces; if it
+        // does not, the assertion is load-bearing. Either way the next reader is not left guessing.
+        let empty_engine_is_reachable = loaded.provider_id.trim().is_empty();
+
+        let current = crate::settings::config::AppConfig {
+            provider_id: String::new(),
+            provider_model: String::new(),
+            ..Default::default()
+        };
+        let mut dto = config_to_dto(&current);
+        dto.provider_id = String::new();
+        dto.provider_model = long.clone();
+        let saved = dto_to_config(dto, &current);
+
+        assert_eq!(
+            loaded.provider_model, saved.provider_model,
+            "load and save must not disagree on an empty engine; one of them would then \
+             silently undo the other on the next launch (empty engine reachable after load: \
+             {empty_engine_is_reachable})"
+        );
+    }
+
+    /// A6 ON THE SERIALIZED BODY: what the ledger records is the `model` field the request carries.
+    ///
+    /// Every previous version of this stopped at the resolved target. The argv arms were then
+    /// compared against real argv, but the JSON arms were compared against a re-derivation of the
+    /// factory's fallback — first a copy of it, then (after the factory was routed through
+    /// `effective_model_requested`) the same function called twice, which is a tautology dressed as
+    /// a test. This goes one link further out, to the bytes: the value the ledger reports is looked
+    /// up in the body each arm actually builds.
+    ///
+    /// WHAT THIS DOES NOT PROVE, stated so it is not mistaken for more than it is: the factory
+    /// hands that value to the provider (one expression — `let model =
+    /// effective_model_requested(target, config);` at each of the three arms) and the provider hands
+    /// its `model` field to the builder. Those two links are read from the source, not executed,
+    /// because constructing an `AnthropicProvider` requires a Keychain secret and the providers'
+    /// `model` fields are private to their own modules.
+    #[test]
+    fn the_ledger_value_is_the_model_field_of_the_serialized_body() {
+        use crate::summarize::roles::{resolve, Role};
+        let long = format!("hf.co/{}/model:Q4_K_M", "a".repeat(60));
+
+        for (provider_id, field_value) in [
+            ("ollama", long.clone()),
+            ("gateway", long.clone()),
+            ("anthropic", "claude-sonnet-5".to_string()),
+        ] {
+            let stored = crate::settings::config::AppConfig {
+                provider_id: provider_id.into(),
+                ..Default::default()
+            };
+            let mut dto = config_to_dto(&stored);
+            // The arm's OWN field carries the value; `provider_model` stays empty so the resolved
+            // target's model is empty and the ledger has to use the per-connection fallback — the
+            // path that would otherwise go unexercised.
+            match provider_id {
+                "ollama" => dto.ollama_model = field_value.clone(),
+                "gateway" => dto.gateway_model = field_value.clone(),
+                _ => dto.anthropic_model = field_value.clone(),
+            }
+            let saved = dto_to_config(dto, &stored);
+
+            let target = resolve(Role::Notes, &saved);
+            assert!(
+                target.model.is_empty(),
+                "{provider_id}: this leg needs an EMPTY resolved model to exercise the fallback"
+            );
+            let ledger = crate::summarize::effective_model_requested(&target, &saved);
+            assert_eq!(
+                ledger, field_value,
+                "{provider_id}: the ledger must fall back to that arm's own configured model"
+            );
+
+            // The bytes. `anthropic` builds its body inline from `self.model` and has no extractable
+            // builder, so the two arms that do are checked here; the anthropic link is the source
+            // reading named above.
+            let body = match provider_id {
+                "ollama" => crate::summarize::ollama::generate_body_for_test(&ledger, "prompt"),
+                _ => crate::summarize::gateway::chat_body(&ledger, "system", "user"),
+            };
+            if provider_id == "anthropic" {
+                // `anthropic` builds its body inline from `self.model`, so the check runs one step
+                // earlier — on the field that body reads.
+                let provider = crate::summarize::anthropic::AnthropicProvider::with_effort(
+                    None,
+                    ledger.clone(),
+                    String::new(),
+                );
+                assert_eq!(
+                    provider.model_for_test(),
+                    ledger,
+                    "anthropic: the provider must carry exactly the model the ledger recorded"
+                );
+                continue;
+            }
+            assert_eq!(
+                body.get("model").and_then(|m| m.as_str()),
+                Some(ledger.as_str()),
+                "{provider_id}: the request body's model must be exactly what the ledger recorded"
+            );
+        }
+    }
+
+    /// THE ONE PLACE LEDGER AND WIRE GENUINELY DIFFER, pinned rather than left to be rediscovered.
+    ///
+    /// When BOTH the resolved model and the arm's own config field are empty, the ledger records
+    /// `""` while `AnthropicProvider` substitutes its compiled-in `DEFAULT_MODEL` and the request
+    /// carries that. Byte-for-byte they disagree.
+    ///
+    /// This PRE-DATES the change (`effective_model_requested` and the `DEFAULT_MODEL` substitution
+    /// are both untouched) and it moves nothing that matters for egress: the destination, the cloud
+    /// classification, the consent gate and the redaction wrapper are identical, and `""` is the
+    /// ledger's existing convention for "the provider chose". But routing the factory arm through
+    /// `effective_model_requested` puts it inside this change's blast radius, so it is recorded here
+    /// as known and asserted, instead of surfacing later as a surprise in a privacy receipt.
+    ///
+    /// Deliberately NOT "fixed" here: making the ledger report a provider's private default is a
+    /// change to what the ledger MEANS, which belongs in its own diff with its own review.
+    #[test]
+    fn an_empty_anthropic_model_is_the_known_ledger_wire_gap() {
+        let cfg = crate::settings::config::AppConfig {
+            provider_id: "anthropic".into(),
+            provider_model: String::new(),
+            anthropic_model: String::new(),
+            ..Default::default()
+        };
+        let target = crate::summarize::roles::resolve(crate::summarize::roles::Role::Notes, &cfg);
+        let ledger = crate::summarize::effective_model_requested(&target, &cfg);
+        assert_eq!(ledger, "", "with nothing configured the ledger records 'provider chose'");
+
+        let provider =
+            crate::summarize::anthropic::AnthropicProvider::with_effort(None, ledger.clone(), String::new());
+        assert_ne!(
+            provider.model_for_test(),
+            ledger,
+            "if these ever become equal the substitution was removed — update this test's premise \
+             rather than deleting it"
+        );
+        assert!(
+            !provider.model_for_test().is_empty(),
+            "the wire always carries a concrete model; it is the LEDGER that records the blank"
+        );
+    }
+
+    /// EXHAUSTIVENESS: `AppConfig::save` is the only production writer of the model-id keys.
+    ///
+    /// Both sanitizers are proven individually, but "ledger and wire agree by construction" needs
+    /// them to be the ONLY doors. `a_hostile_model_id_already_on_disk_is_cleared_on_load` writes
+    /// past the config API with `db.set_setting`, which shows such a path exists in-process — so a
+    /// command doing the same would let an unsanitised id sit in the DB and be read by
+    /// `effective_model_requested` before any save re-judged it. This scans the source rather than
+    /// arguing from one, and fails on a new writer instead of on the incident it would cause.
+    #[test]
+    fn appconfig_save_is_the_only_writer_of_model_id_settings() {
+        const KEYS: &[&str] = &[
+            "PROVIDER_MODEL",
+            "ANTHROPIC_MODEL",
+            "OLLAMA_MODEL",
+            "GATEWAY_MODEL",
+            "ROLE_NOTES_MODEL",
+            "ROLE_ASK_MODEL",
+            "ROLE_LIVE_MODEL",
+        ];
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut offenders = Vec::new();
+        let mut stack = vec![root];
+        while let Some(dir) = stack.pop() {
+            for entry in std::fs::read_dir(&dir).expect("read_dir") {
+                let path = entry.expect("entry").path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                    continue;
+                }
+                let name = path.to_string_lossy().to_string();
+                // The sanctioned writer, and the test files that deliberately seed past it.
+                if name.ends_with("settings/config.rs") || name.contains("tests") {
+                    continue;
+                }
+                let text = std::fs::read_to_string(&path).expect("read");
+                for (n, line) in text.lines().enumerate() {
+                    if !line.contains("set_setting") {
+                        continue;
+                    }
+                    if KEYS.iter().any(|k| line.contains(k))
+                        || ["\"provider_model\"", "\"anthropic_model\"", "\"ollama_model\"",
+                            "\"gateway_model\"", "\"role_notes_model\"", "\"role_ask_model\"",
+                            "\"role_live_model\""]
+                            .iter()
+                            .any(|k| line.contains(k))
+                    {
+                        offenders.push(format!("{name}:{}", n + 1));
+                    }
+                }
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "a model-id setting is written outside AppConfig::save, bypassing both sanitizers: {offenders:?}"
+        );
+    }
+
+    /// A7 GUARD. This diff changes which model ids can be CHOSEN and how they are DISPLAYED. It
+    /// must not move a provider between the local and cloud classes, because that class is what
+    /// decides whether the consent gate, the redaction firewall and the egress ledger apply.
+    /// Pinned as a full table so a later edit to the provider list cannot silently reclassify one.
+    #[test]
+    fn provider_cloud_local_classification_is_unchanged_by_the_picker_diff() {
+        use crate::summarize::egress_is_cloud;
+        let config = crate::settings::config::AppConfig::default();
+        for (id, expected_cloud) in [
+            ("claude_code", true),
+            ("anthropic", true),
+            ("codex_cli", true),
+            ("gateway", true),
+            ("local", false),
+        ] {
+            assert_eq!(
+                egress_is_cloud(id, &config),
+                expected_cloud,
+                "{id} changed cloud/local class — consent, redaction and ledger routing hang off this"
+            );
+        }
+        // `off` is a valid connection that runs no model at all, and it is on-device by definition.
+        assert!(
+            !egress_is_cloud("off", &config),
+            "off runs nothing and must never be classified as cloud"
+        );
+        // An unknown provider must FAIL CLOSED (treated as cloud), never default to local.
+        assert!(
+            egress_is_cloud("something-new", &config),
+            "an unrecognised provider must be treated as cloud, not silently exempted"
+        );
+
+        // `ollama` is the ONE provider whose class is config-dependent: loopback is local, a remote
+        // host is cloud and therefore consent-gated, redacted and ledgered. Both legs are pinned
+        // because a picker change that shifted only the remote leg would move an egress decision
+        // while every fixed-class row above still read as unchanged.
+        for (base_url, expected_cloud) in [
+            ("http://127.0.0.1:11434", false),
+            ("http://localhost:11434", false),
+            ("http://[::1]:11434", false),
+            ("http://ollama.example.com:11434", true),
+            ("https://10.0.0.9:11434", true),
+            // FAIL-CLOSED, and this leg is the one worth pinning: an unparseable URL — including
+            // the empty default — is treated as CLOUD, so a misconfigured Ollama demands consent
+            // and gets redacted rather than quietly bypassing both. `egress_is_cloud` says so in
+            // as many words (`Err(_) => true, // unparseable → fail safe`).
+            ("", true),
+            ("not a url", true),
+        ] {
+            let config = crate::settings::config::AppConfig {
+                ollama_base_url: base_url.to_string(),
+                ..Default::default()
+            };
+            assert_eq!(
+                egress_is_cloud("ollama", &config),
+                expected_cloud,
+                "ollama at {base_url:?} must be classified {}",
+                if expected_cloud { "cloud" } else { "local" }
+            );
+        }
+    }
+
+    /// A LIVE id is already the name the user knows the model by, so it IS the label.
+    ///
+    /// Three attempts at a `humanize_model_id` were reverted, each having broken the injectivity it
+    /// claimed: trimming collapsed `"model"` with `" model "`; mapping `-` and `_` to a space
+    /// collapsed `plain-model` with `plain_model`; capitalising collapsed `model` with `Model`.
+    /// Uppercasing is lossy on case, so "prettier AND injective" cannot be had by rewriting the id.
+    /// It was also unnecessary: the raw-id complaint was about BUNDLED catalogs, and those carry
+    /// real names from the registry. Identity is the correct transform here, and it is trivially
+    /// injective.
+    #[test]
+    fn a_live_catalog_label_is_readable_and_still_injective() {
+        let ids = vec![
+            "llama3.1:8b".to_string(),
+            "plain-model".to_string(),
+            // The pairs every previous transform collapsed: separator-only and case-only.
+            "plain_model".to_string(),
+            "Model".to_string(),
+            "model".to_string(),
+            "hf.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF:Q4_K_M".to_string(),
+        ];
+        let options = crate::commands::live_options_for_test(ids.clone());
+        assert_eq!(options.len(), ids.len());
+        for (option, id) in options.iter().zip(&ids) {
+            assert_eq!(&option.id, id, "the id is passed through untouched");
+            assert!(
+                option.label.contains(id),
+                "the label must embed the exact id — that is what makes it injective; got {:?}",
+                option.label
+            );
+            assert_eq!(option.source, crate::commands::SOURCE_LIVE);
+        }
+        // Readable: the label leads with a prettified form, not the bare slug.
+        let first = &options[0].label;
+        assert!(
+            first.starts_with("Llama3.1 8b — "),
+            "a live label must lead with something a human reads; got {first:?}"
+        );
+        // INJECTIVE, tested as a SET. Asserting each spelling on its own line is what let
+        // `plain-model` and `plain_model` both become "Plain Model" unnoticed.
+        let labels: std::collections::HashSet<&String> =
+            options.iter().map(|o| &o.label).collect();
+        assert_eq!(labels.len(), ids.len(), "labels must stay distinguishable");
+    }
+
+    /// The predicate must accept every id the LIVE catalogs can actually return. `gateway` and
+    /// `ollama` put the id in a JSON body rather than argv, so an argv-shaped restriction there
+    /// would reject ids this change makes selectable while protecting nothing.
+    #[test]
+    fn a_live_ollama_id_survives_the_persistence_boundary() {
+        use crate::summarize::provider::{valid_catalog_model_id, valid_model_id};
+        for real in [
+            "hf.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF:Q4_K_M",
+            "user@host/model:latest",
+            "llama3.1:8b",
+            "qwen2.5-coder:32b-instruct-q8_0",
+        ] {
+            assert!(
+                valid_catalog_model_id(real),
+                "{real:?} is a real Ollama catalog id and must round-trip on a JSON-body arm"
+            );
+        }
+        // The looser predicate is looser on LENGTH ONLY. Every argv-injection shape stays refused
+        // on both, because none of them is a real model id on any arm.
+        for hostile in ["--sandbox danger-full-access", "../../etc/passwd", "a b", "./m"] {
+            assert!(!valid_model_id(hostile), "{hostile:?} must be refused (argv)");
+            assert!(
+                !valid_catalog_model_id(hostile),
+                "{hostile:?} must be refused (json body) — looser length must not mean looser shape"
+            );
+        }
+        // ...and the argv ceiling still bites where it belongs.
+        let long = "a".repeat(65);
+        assert!(!valid_model_id(&long), "an argv id stays short-slug bounded");
+        assert!(valid_catalog_model_id(&long), "a body id may be longer");
+    }
+
+    /// A hint-catalog means any string the user types reaches `--model <id>` on a real CLI. That
+    /// argument takes the NEXT argv entry, so a value beginning with `-` is read as a FLAG.
+    /// RED before `valid_model_id` existed: every one of these was forwarded verbatim.
+    #[test]
+    fn a_hostile_model_id_is_never_forwarded_to_a_cli() {
+        use crate::summarize::provider::valid_model_id;
+        for hostile in [
+            "--sandbox danger-full-access",
+            "-m",
+            "--dangerously-skip-permissions",
+            "claude-opus-5 --sandbox danger-full-access",
+            "claude\nopus",
+            "claude opus 5",
+            "claude\topus",
+            "claude\u{0}opus",
+            "$(rm -rf ~)",
+            "`id`",
+            // `/` is legal for `vendor/model`, so a relative-path segment must be refused on its
+            // own terms — every character here is otherwise allowed and it is under the cap.
+            "../../etc/passwd",
+            "vendor/../secret",
+            "./model",
+            // Over the sanity bound. The cap is 200, not 64: Ollama's live catalog returns
+            // Hugging Face paths that pass 64 comfortably, and rejecting them would have blocked
+            // ids this change makes selectable while protecting nothing — those arms send the id
+            // in a JSON body, never as argv.
+            // Over the ARGV ceiling (64). The JSON-body arms use a looser bound —
+            // see `a_live_ollama_id_survives_the_persistence_boundary`.
+            "a".repeat(65).as_str(),
+            "",
+            "   ",
+        ] {
+            assert!(
+                !valid_model_id(hostile),
+                "must reject {hostile:?} before it becomes a CLI argument"
+            );
+        }
+        // ...while every shape a real catalog actually emits still passes.
+        for good in [
+            "claude-opus-5",
+            "gpt-5.6-sol",
+            "claude-haiku-4-5-20251001",
+            "llama3.1:8b",
+            "qwen2.5:7b",
+            "vendor/model-name",
+            "  claude-sonnet-5  ",
+        ] {
+            assert!(valid_model_id(good), "must accept the real id {good:?}");
+        }
+    }
+
+    /// The catalog is a HINT, never an allowlist: nothing in the backend may reject or rewrite an
+    /// id merely because it is absent. `static_connection_models` is a lookup, not a validator —
+    /// it takes a CONNECTION, never a model id, so there is no place for it to refuse one.
+    #[test]
+    fn an_unknown_connection_errors_but_an_unknown_model_id_has_no_gate_to_fail() {
+        assert!(
+            static_connection_models("nope").is_err(),
+            "an unknown connection is a programming error and must surface"
+        );
+        // Every legal connection resolves without ever being shown a model id.
+        for conn in ["claude_code", "anthropic", "codex_cli", "local", "off"] {
+            assert!(static_connection_models(conn).is_ok(), "{conn} must resolve");
+        }
     }
 
     #[test]
@@ -12620,23 +13704,64 @@
         assert_eq!(unavailable[1].reason.as_deref(), Some(reason.as_str()));
     }
 
-    /// `local` serves exactly the BRAIN_MODELS registry ids, in registry order.
+    /// `local` serves exactly the BRAIN_MODELS registry ids, in registry order. Unlike the cloud
+    /// hint lists this one IS authoritative — it mirrors what `download_brain_model` can install —
+    /// so the id set is still pinned; only the label/source wrapper is new.
     #[test]
     fn list_models_local_matches_brain_registry_ids() {
-        let ids = static_connection_models("local").expect("local must resolve statically");
+        let options = static_connection_models("local")
+            .expect("local must resolve statically")
+            .options;
+        let ids: Vec<String> = options.iter().map(|o| o.id.clone()).collect();
         let want: Vec<String> = crate::reason::BRAIN_MODELS
             .iter()
             .map(|m| m.id.to_string())
             .collect();
         assert_eq!(ids, want, "local must mirror the BRAIN_MODELS registry ids");
         assert!(!ids.is_empty(), "the brain registry is never empty");
+        for option in &options {
+            assert_eq!(
+                option.label,
+                crate::reason::brain_model_by_id(&option.id)
+                    .expect("every local option is a registry model")
+                    .name,
+                "the local picker must show the registry's display name, not the raw id"
+            );
+        }
     }
 
     /// `off` is a valid connection with no models — empty list, not an error.
     #[test]
     fn list_models_off_returns_empty() {
-        let ids = static_connection_models("off").expect("off must resolve statically");
-        assert!(ids.is_empty(), "off runs no models");
+        let catalog = static_connection_models("off").expect("off must resolve statically");
+        assert!(catalog.options.is_empty(), "off runs no models");
+        // The empty case is precisely where provenance must survive: an empty catalog that lost its
+        // source is what hid Refresh from a live endpoint answering with zero models.
+        assert_eq!(catalog.source, crate::commands::SOURCE_BUNDLED);
+    }
+
+    /// The reason provenance sits on the CATALOG and not on each option.
+    ///
+    /// A gateway or Ollama daemon that answers successfully with zero models is exactly when the
+    /// user wants Refresh — and an empty option list has no option to read a `source` from. Deriving
+    /// liveness as `options.any(|o| o.source == "live")` reported "bundled" for that case and hid
+    /// the button. The catalog-level field cannot be emptied away.
+    #[test]
+    fn empty_live_catalog_keeps_its_provenance() {
+        let empty = crate::commands::ModelCatalogDto {
+            source: crate::commands::SOURCE_LIVE.to_string(),
+            options: vec![],
+        };
+        assert!(empty.options.is_empty());
+        assert_eq!(
+            empty.source,
+            crate::commands::SOURCE_LIVE,
+            "an empty LIVE catalog must still report that it was fetched"
+        );
+        // Serialized shape the FE reads: `source` is a sibling of `options`, never inside them.
+        let json = serde_json::to_value(&empty).expect("catalog serializes");
+        assert_eq!(json["source"], "live");
+        assert!(json["options"].as_array().expect("options array").is_empty());
     }
 
     /// An unknown connection id refuses with `InvalidArg` — never a panic, never an empty Ok.

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -1206,6 +1206,51 @@ impl AppConfig {
             cfg.audio_auto_prune = v == "true";
         }
 
+        // SANITIZE MODEL IDS ON LOAD, not only on save, and by the SAME rule `dto_to_config`
+        // uses: the predicate follows the connection that will SEND the id. The two must agree, or
+        // a value one accepts the other clears on the next launch.
+        //
+        // Load-time matters on its own: a row written before this boundary existed — or by hand —
+        // stays hostile until the next save, and in that window `effective_model_requested` reports
+        // it to the egress ledger while the wire silently drops it. That is the ledger lying.
+        let provider_id = cfg.provider_id.clone();
+        let by_connection = [
+            // Judged by `provider_id` — the only arm that reads it. It was pinned to
+            // `"claude_code"` here on the belief that an explicit CLI role inherits this value;
+            // `roles::is_explicit` keys on the connection alone, so it does not, and pinning it
+            // cleared a legitimate long Anthropic id on every launch.
+            (&mut cfg.provider_model, provider_id.clone()),
+            (&mut cfg.role_notes_model, cfg.role_notes_connection.clone()),
+            (&mut cfg.role_ask_model, cfg.role_ask_connection.clone()),
+            (&mut cfg.role_live_model, cfg.role_live_connection.clone()),
+            (&mut cfg.anthropic_model, "anthropic".to_string()),
+            (&mut cfg.ollama_model, "ollama".to_string()),
+            (&mut cfg.gateway_model, "gateway".to_string()),
+        ];
+        for (field, connection) in by_connection {
+            if field.is_empty() {
+                continue;
+            }
+            // An INHERITED (empty) role connection is judged by transport safety alone, matching
+            // `dto_to_config`'s `for_role`. Resolving `""` to `provider_id` here was destructive
+            // for the same reason it was there: `roles::is_explicit` keys on the connection key,
+            // so an inheriting role never reads `role_*_model`, and applying the default engine's
+            // CLI rule cleared a legitimate long id on every launch. The fixed-arm fields below
+            // pass their own connection, so they are unaffected.
+            let usable = if connection.trim().is_empty() {
+                crate::summarize::provider::valid_catalog_model_id(field)
+            } else {
+                crate::commands::model_predicate_for(connection.trim())(field)
+            };
+            if !usable {
+                tracing::warn!(
+                    target: "config",
+                    "stored model id is not usable on its connection; clearing to the default"
+                );
+                field.clear();
+            }
+        }
+
         Ok(cfg)
     }
 

--- a/src-tauri/src/summarize/anthropic.rs
+++ b/src-tauri/src/summarize/anthropic.rs
@@ -35,6 +35,16 @@ impl AnthropicProvider {
         Self::with_effort(api_key, model, String::new())
     }
 
+    /// Test-only view of the model this provider will put in its request body.
+    ///
+    /// The body is built inline in `summarize`/`complete` from `self.model`, so there is no builder
+    /// to call from another module. The A6 ledger-versus-body test needs to see this value; a
+    /// `#[cfg(test)]` accessor is the way to give it that without widening production API.
+    #[cfg(test)]
+    pub(crate) fn model_for_test(&self) -> &str {
+        &self.model
+    }
+
     /// Like [`new`], plus an explicit reasoning-effort tier (`""`/`"default"` = provider default).
     pub fn with_effort(api_key: Option<String>, model: String, effort: String) -> Self {
         let model = if model.trim().is_empty() {

--- a/src-tauri/src/summarize/claude_code.rs
+++ b/src-tauri/src/summarize/claude_code.rs
@@ -1014,12 +1014,18 @@ fn build_claude_command(bin: &str, system_prompt: &str, model: &str, inherit_env
 /// The `--model <id>` argument pair to append for a given model override, or `&[]` when the
 /// override is empty/blank (let the CLI use its default). Pure + unit-testable — the exact
 /// branch used at both call sites in `summarize`/`complete` (`if !self.model.trim().is_empty()`).
-fn model_args(model: &str) -> Vec<String> {
-    if model.trim().is_empty() {
-        Vec::new()
-    } else {
-        vec!["--model".to_string(), model.to_string()]
+///
+/// `pub(crate)` so the A6 ledger-versus-wire test can ask this arm what it would ACTUALLY send,
+/// instead of re-implementing the rule in the test and proving only that two copies agree.
+pub(crate) fn model_args(model: &str) -> Vec<String> {
+    // Since the Settings catalog became a hint rather than an allowlist, this string can be
+    // anything the user typed. `--model` takes the NEXT argv entry, so an id like
+    // `--sandbox danger-full-access` would be parsed by the CLI as a flag. Reject anything that is
+    // not a plain slug and fall back to the CLI's own default.
+    if !crate::summarize::provider::valid_model_id(model) {
+        return Vec::new();
     }
+    vec!["--model".to_string(), model.trim().to_string()]
 }
 
 /// True iff `text`'s first non-empty line is exactly a three-dash YAML fence (allowing
@@ -1094,6 +1100,86 @@ mod tests {
             model_args("claude-opus-4-8"),
             vec!["--model".to_string(), "claude-opus-4-8".to_string()]
         );
+    }
+
+    /// A6, asserted on the ARGV the CLI would actually receive — not on the predicate.
+    ///
+    /// Testing `!valid_model_id(hostile)` alone proves the predicate rejects a string; it does not
+    /// prove this call site consults it. `--model` consumes the NEXT argv entry, so the property
+    /// that matters is that a hostile value never becomes an argument at all: no `--model`, and no
+    /// trace of the value anywhere in the vector.
+    #[test]
+    fn a_hostile_model_id_never_reaches_argv() {
+        for hostile in [
+            "--sandbox danger-full-access",
+            "-m",
+            "--dangerously-skip-permissions",
+            "claude-opus-5 --sandbox danger-full-access",
+            "claude\nopus",
+            "../../etc/passwd",
+            "$(rm -rf ~)",
+        ] {
+            let argv = model_args(hostile);
+            assert!(
+                argv.is_empty(),
+                "{hostile:?} must not produce any argument; got {argv:?}"
+            );
+            assert!(
+                !argv.iter().any(|arg| arg.contains(hostile.trim())),
+                "no fragment of {hostile:?} may survive into argv"
+            );
+        }
+        // ...while a legitimate UNLISTED id — the whole point of a hint catalog — still gets sent.
+        assert_eq!(
+            model_args("claude-opus-6"),
+            vec!["--model".to_string(), "claude-opus-6".to_string()],
+            "a valid id absent from every bundled catalog must still reach the CLI"
+        );
+        // Surrounding whitespace is trimmed rather than rejected, and never splits into two args.
+        assert_eq!(
+            model_args("  llama3.1:8b  "),
+            vec!["--model".to_string(), "llama3.1:8b".to_string()]
+        );
+    }
+
+    /// The same property asserted on the CONSTRUCTED COMMAND, not only on the helper.
+    ///
+    /// `a_hostile_model_id_never_reaches_argv` pins `model_args`, which proves the helper is sound
+    /// but not that the command builder routes through it — `build_claude_command` takes `model`
+    /// as its own parameter and could keep a private `if !model.trim().is_empty()` branch, which is
+    /// exactly the shape that used to be there. The codex arm already asserts on its built command;
+    /// this closes the same gap here so neither arm rests on an untested call edge.
+    #[test]
+    fn a_hostile_model_id_never_reaches_the_built_claude_argv() {
+        for hostile in [
+            "--sandbox danger-full-access",
+            "-m",
+            "--dangerously-skip-permissions",
+            "claude\nopus",
+            "../../etc/passwd",
+        ] {
+            let args = args_of(&build_claude_command("claude", "SYSTEM", hostile, false));
+            assert!(
+                !args.iter().any(|arg| arg == "--model"),
+                "{hostile:?} produced a --model flag in the built command: {args:?}"
+            );
+            // Compare whole argv ENTRIES, not substrings: the hermetic flags legitimately contain
+            // `-m` (`--strict-mcp-config`), so a `contains` check reports a leak that is not one.
+            // Each whitespace-separated token is checked so a builder that split the value into
+            // several args would still be caught.
+            for token in hostile.split_whitespace() {
+                assert!(
+                    !args.iter().any(|arg| arg == token),
+                    "token {token:?} of {hostile:?} reached the built argv: {args:?}"
+                );
+            }
+        }
+        // ...and a legitimate unlisted id DOES reach the command, or the guard would be vacuous:
+        // a builder that never passed `--model` at all would satisfy every assertion above.
+        let args = args_of(&build_claude_command("claude", "SYSTEM", "claude-opus-6", false));
+        let flag = args.iter().position(|arg| arg == "--model");
+        assert!(flag.is_some(), "a valid id must still reach argv: {args:?}");
+        assert_eq!(args[flag.unwrap() + 1], "claude-opus-6");
     }
 
     #[test]

--- a/src-tauri/src/summarize/codex_cli.rs
+++ b/src-tauri/src/summarize/codex_cli.rs
@@ -805,14 +805,26 @@ fn configure_codex_command_prefix_with_tool_guard(
     cmd
 }
 
+/// The `--model <id>` argument pair for this arm, or `&[]` when the id is blank or unusable.
+///
+/// Same argv-injection guard as `claude_code::model_args`, and now the same SHAPE: the rule was
+/// inline in `finish_codex_command`, which meant the two CLI arms could drift and neither could be
+/// asked "what would you actually send?" without building a whole command. `pub(crate)` so the A6
+/// ledger-versus-wire test can ask exactly that, rather than re-implementing the rule in the test
+/// and proving only that two copies of it agree.
+pub(crate) fn model_args(model: &str) -> Vec<String> {
+    if !crate::summarize::provider::valid_model_id(model) {
+        return Vec::new();
+    }
+    vec!["--model".to_string(), model.trim().to_string()]
+}
+
 fn finish_codex_command(mut cmd: Command, model: &str, codex_home: &Path) -> Command {
     // The public JSONL stream intentionally omits internal unsupported-call events. Restrict the
     // child logger to the tool router's errors so Murmur can reject such an event without enabling
     // request/prompt tracing or recording content.
     cmd.env("RUST_LOG", CODEX_TOOL_ROUTER_LOG);
-    if !model.trim().is_empty() {
-        cmd.arg("--model").arg(model.trim());
-    }
+    cmd.args(model_args(model));
     cmd.arg("--json")
         .arg("-")
         .stdin(Stdio::piped())
@@ -2129,6 +2141,33 @@ mod tests {
             Path::new("/tmp/murmur-codex-test-home"),
         ));
         assert!(!args.iter().any(|arg| arg == "--model"));
+    }
+
+    /// A6 on the OTHER CLI arm, asserted on real argv. `--model` takes the next argv entry, so a
+    /// value beginning with `-` would be read by `codex exec` as a flag.
+    #[test]
+    fn a_hostile_model_id_never_reaches_codex_argv() {
+        let home = Path::new("/tmp/murmur-codex-hostile-home");
+        for hostile in [
+            "--sandbox danger-full-access",
+            "-m",
+            "codex --dangerously-bypass-approvals-and-sandbox",
+            "../../etc/passwd",
+        ] {
+            let args = args(&build_codex_command("codex", hostile, home));
+            assert!(
+                !args.iter().any(|arg| arg == "--model"),
+                "{hostile:?} must not produce a --model flag; got {args:?}"
+            );
+            assert!(
+                !args.iter().any(|arg| arg.contains(hostile.trim())),
+                "no fragment of {hostile:?} may survive into argv"
+            );
+        }
+        // A legitimate unlisted id still reaches the CLI — the point of a hint catalog.
+        let args = args(&build_codex_command("codex", "gpt-5.7-nova", home));
+        assert!(args.iter().any(|arg| arg == "--model"));
+        assert!(args.iter().any(|arg| arg == "gpt-5.7-nova"));
     }
 
     #[test]

--- a/src-tauri/src/summarize/gateway.rs
+++ b/src-tauri/src/summarize/gateway.rs
@@ -731,6 +731,49 @@ mod tests {
     /// `chat_endpoint` applies the path-resolution heuristic: root/`/v1` → append
     /// `chat/completions`; any other path (custom Kong route, already-full endpoint) → as-is.
     #[test]
+    /// THE JUSTIFICATION FOR DROPPING THE CHARACTER ALLOWLIST, made executable.
+    ///
+    /// `valid_catalog_model_id` no longer restricts characters on the JSON-body arms, on the
+    /// argument that the id "never becomes argv, a URL path or a filename". That was asserted in a
+    /// doc comment and nowhere executed, which is a poor place for a security argument to live.
+    ///
+    /// Here it is executed: a model id carrying every character that would matter if it were ever
+    /// interpolated into a URL — `%` (percent-encoding), `?` (query), `#` (fragment), `/` (path),
+    /// `..` (traversal), a backslash and a non-ASCII character — leaves BOTH endpoints byte-identical
+    /// to the ones a benign id produces. The endpoints are pure functions of the base URL, so the
+    /// id has no way in.
+    #[test]
+    fn a_gateway_model_id_can_never_reach_the_request_url() {
+        let hostile = "vendor/../..%2f?x=1#frag\\modèle+preview";
+        for base in [
+            "http://localhost:4000/v1",
+            "http://localhost:4000",
+            "https://gw.example.com/route/x",
+        ] {
+            let benign =
+                OpenAiCompatProvider::new(base.to_string(), "gpt-4o".to_string(), None).unwrap();
+            let nasty =
+                OpenAiCompatProvider::new(base.to_string(), hostile.to_string(), None).unwrap();
+            assert_eq!(
+                benign.chat_endpoint().as_str(),
+                nasty.chat_endpoint().as_str(),
+                "the chat endpoint for {base:?} must not depend on the model id"
+            );
+            assert_eq!(
+                benign.models_endpoint().map(|u| u.to_string()),
+                nasty.models_endpoint().map(|u| u.to_string()),
+                "the catalog endpoint for {base:?} must not depend on the model id"
+            );
+            assert!(
+                !nasty.chat_endpoint().as_str().contains("frag")
+                    && !nasty.chat_endpoint().as_str().contains("preview"),
+                "no fragment of the model id may appear in the URL: {}",
+                nasty.chat_endpoint()
+            );
+        }
+    }
+
+    #[test]
     fn chat_endpoint_preserves_base_path() {
         // /v1 base — must append /chat/completions.
         let p = OpenAiCompatProvider::new(

--- a/src-tauri/src/summarize/gateway.rs
+++ b/src-tauri/src/summarize/gateway.rs
@@ -728,9 +728,6 @@ mod tests {
         );
     }
 
-    /// `chat_endpoint` applies the path-resolution heuristic: root/`/v1` → append
-    /// `chat/completions`; any other path (custom Kong route, already-full endpoint) → as-is.
-    #[test]
     /// THE JUSTIFICATION FOR DROPPING THE CHARACTER ALLOWLIST, made executable.
     ///
     /// `valid_catalog_model_id` no longer restricts characters on the JSON-body arms, on the
@@ -773,6 +770,8 @@ mod tests {
         }
     }
 
+    /// `chat_endpoint` applies the path-resolution heuristic: root/`/v1` → append
+    /// `chat/completions`; any other path (custom Kong route, already-full endpoint) → as-is.
     #[test]
     fn chat_endpoint_preserves_base_path() {
         // /v1 base — must append /chat/completions.

--- a/src-tauri/src/summarize/mod.rs
+++ b/src-tauri/src/summarize/mod.rs
@@ -289,11 +289,11 @@ fn make_provider_resolved(
             let api_key = crate::secrets::get_secret(ANTHROPIC_KEY_ACCOUNT)?;
             // A resolved model takes precedence over the legacy `anthropic_model`; effort is
             // the adaptive-thinking tier (provider default when empty).
-            let model = if target.model.trim().is_empty() {
-                config.anthropic_model.clone()
-            } else {
-                target.model.clone()
-            };
+            // THE SAME EXPRESSION THE LEDGER USES. Each arm used to re-implement this fallback,
+            // so "ledger and wire agree" held only while two copies happened to match — a future
+            // edit to one would have made the ledger report a model the request never carried.
+            // Calling `effective_model_requested` here makes the agreement structural.
+            let model = effective_model_requested(target, config);
             Arc::new(AnthropicProvider::with_effort(
                 api_key,
                 model,
@@ -301,11 +301,11 @@ fn make_provider_resolved(
             ))
         }
         PROVIDER_OLLAMA => {
-            let model = if target.model.trim().is_empty() {
-                config.ollama_model.clone()
-            } else {
-                target.model.clone()
-            };
+            // THE SAME EXPRESSION THE LEDGER USES. Each arm used to re-implement this fallback,
+            // so "ledger and wire agree" held only while two copies happened to match — a future
+            // edit to one would have made the ledger report a model the request never carried.
+            // Calling `effective_model_requested` here makes the agreement structural.
+            let model = effective_model_requested(target, config);
             let ollama_is_local = !egress_is_cloud(id, config);
             let ollama = Arc::new(OllamaProvider::with_model_admission(
                 config.ollama_base_url.clone(),
@@ -328,11 +328,11 @@ fn make_provider_resolved(
             let api_key = crate::secrets::get_secret(GATEWAY_KEY_ACCOUNT)
                 .ok()
                 .flatten();
-            let model = if target.model.trim().is_empty() {
-                config.gateway_model.clone()
-            } else {
-                target.model.clone()
-            };
+            // THE SAME EXPRESSION THE LEDGER USES. Each arm used to re-implement this fallback,
+            // so "ledger and wire agree" held only while two copies happened to match — a future
+            // edit to one would have made the ledger report a model the request never carried.
+            // Calling `effective_model_requested` here makes the agreement structural.
+            let model = effective_model_requested(target, config);
             // R1/R4 enforced at construction via `validate_gateway_url` inside `new()`.
             Arc::new(crate::summarize::gateway::OpenAiCompatProvider::new(
                 config.gateway_base_url.clone(),
@@ -654,6 +654,49 @@ mod tests {
         )
         .expect("registered Codex id must build through the production factory");
         assert_eq!(provider.id(), PROVIDER_CODEX_CLI);
+    }
+
+    /// A `local` ROLE MODEL THAT IS NOT A REGISTRY ID FAILS CLOSED — asserted, not argued.
+    ///
+    /// The Settings UI keeps a role's model across a switch to `local` only when it matches
+    /// `BRAIN_MODELS`, precisely because this arm consumes it: a non-matching id OVERRIDES
+    /// `brain_model_id` and there is then no on-device model to load. That claim was made twice in
+    /// this change — once wrongly, in the opposite direction — and never executed. What matters for
+    /// privacy is not merely that it errors, but WHICH way it errors: `Unavailable`, with no
+    /// provider constructed, never a silent fall back to a cloud arm.
+    #[test]
+    fn an_unknown_local_role_model_fails_closed_without_building_any_provider() {
+        let config = AppConfig {
+            // Consent is GRANTED here on purpose. If this arm ever fell through to a cloud provider,
+            // a withheld consent would mask it behind a consent error and the test would pass for
+            // the wrong reason.
+            cloud_egress_consented: true,
+            provider_id: PROVIDER_ANTHROPIC.to_string(),
+            anthropic_model: "claude-sonnet-5".to_string(),
+            ..AppConfig::default()
+        };
+        for unknown in ["llama3.1:8b", "not-a-registry-id", "/etc/passwd"] {
+            let target = roles::RoleTarget {
+                connection: roles::CONN_LOCAL.to_string(),
+                model: unknown.to_string(),
+                effort: String::new(),
+            };
+            let built = make_provider_resolved(
+                &target,
+                &config,
+                &Arc::new(tokio::sync::Semaphore::new(1)),
+                None,
+                None,
+            );
+            match built {
+                Err(crate::error::AppError::Unavailable(_)) => {}
+                Err(other) => panic!("{unknown:?} must fail as Unavailable, got {other:?}"),
+                Ok(_) => panic!(
+                    "{unknown:?} built a provider on the local arm — an on-device role must never \
+                     silently resolve to something that can egress"
+                ),
+            }
+        }
     }
 
     #[tokio::test]

--- a/src-tauri/src/summarize/ollama.rs
+++ b/src-tauri/src/summarize/ollama.rs
@@ -379,6 +379,15 @@ struct TagEntry {
     name: String,
 }
 
+/// Test-only view of [`generate_body`] for the cross-module A6 body assertion.
+///
+/// `generate_body` is private to this module and stays that way; the ledger-versus-body test lives
+/// in `commands/tests` because that is where the persistence boundary it starts from is.
+#[cfg(test)]
+pub(crate) fn generate_body_for_test(model: &str, prompt: &str) -> serde_json::Value {
+    generate_body(model, prompt, None)
+}
+
 fn generate_body(model: &str, prompt: &str, system: Option<&str>) -> serde_json::Value {
     match system {
         Some(system) => json!({
@@ -565,6 +574,78 @@ impl SummarizerProvider for OllamaProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// THE OTHER HALF of the justification for dropping the character allowlist on the JSON arms.
+    ///
+    /// `gateway.rs::a_gateway_model_id_can_never_reach_the_request_url` proves it for the gateway by
+    /// comparing constructed endpoints. Ollama builds its URLs inline from `self.base_url`, so there
+    /// is no endpoint accessor to compare — and "the model is not in the URL" was therefore left as
+    /// a claim in a doc comment, which is where the reviewers kept, correctly, refusing to accept it.
+    ///
+    /// So assert it against the SOURCE: every URL this module builds must interpolate `base_url` and
+    /// nothing else. A future edit that reached for `self.model` while composing a path — the only
+    /// way a `%`, `?`, `#` or `..` in an id could ever matter here — fails this test instead of
+    /// shipping.
+    #[test]
+    fn no_json_arm_url_is_built_from_the_model_id() {
+        let mut sites = 0;
+        for source in [
+            include_str!("ollama.rs"),
+            include_str!("gateway.rs"),
+            include_str!("anthropic.rs"),
+        ] {
+            sites += assert_no_model_id_in_urls(source);
+        }
+        // VACUITY FLOOR across the three files together, not per file: `anthropic.rs` composes no
+        // URL at all (its endpoint is the `API_URL` const), so demanding sites there would force a
+        // fake one. A matcher that stopped matching still cannot pass silently.
+        assert!(
+            sites >= 3,
+            "expected several JSON-arm URL composition sites; found {sites}, so this guard is no \
+             longer looking at what it thinks it is"
+        );
+    }
+
+    /// Shared by the three JSON-body arms. `anthropic.rs` composes no URL at all — its endpoint is
+    /// the `API_URL` const — so it contributes zero sites and is checked for the absence rather than
+    /// the shape; `gateway.rs` builds from `self.base`; `ollama.rs` from `self.base_url`.
+    fn assert_no_model_id_in_urls(source: &str) -> usize {
+        // A URL COMPOSITION is a format string whose first thing is an interpolation immediately
+        // followed by the path — `{}/api/tags`, `{base_url}/api/generate`. Matching merely
+        // "`format!` and `/api/` on one line" also caught an error MESSAGE that names the endpoint
+        // (`"failed to read Ollama /api/tags body: {e}"`), which composes no URL at all. The marker
+        // is assembled at runtime so this very line does not match itself — `include_str!` reads
+        // this file, self-reference included.
+        let marker = ["}", "/api/"].concat();
+        let mut url_lines = 0;
+        for (n, line) in source.lines().enumerate() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("//") || !line.contains("format!") || !line.contains(&marker) {
+                continue;
+            }
+            url_lines += 1;
+            assert!(
+                line.contains("base_url") || line.contains("self.base"),
+                "line {}: a JSON-arm URL must be composed from its BASE, nothing else: {line}",
+                n + 1
+            );
+            assert!(
+                !line.contains("model"),
+                "line {}: the model id must never be part of a URL — it is a JSON body value, \
+                 which is the entire basis for allowing arbitrary characters in it: {line}",
+                n + 1
+            );
+        }
+        // A FLOOR, not an exact count. The value of this test is in the per-line assertions above;
+        // the floor exists only so a matcher that stopped matching cannot pass silently — which is
+        // how a source-scanning guard usually dies. Pinning the exact number instead would break on
+        // any honest refactor that adds or removes an endpoint, teaching the next person to relax
+        // the guard rather than to read it.
+        // A FLOOR PER FILE would be wrong — `anthropic.rs` legitimately composes no URL (its
+        // endpoint is a const), so requiring sites there would force a fake one. The vacuity guard
+        // lives in the caller instead: across the three files together there must be several.
+        url_lines
+    }
 
     #[test]
     fn generate_http_error_keeps_status_but_omits_untrusted_body() {

--- a/src-tauri/src/summarize/provider.rs
+++ b/src-tauri/src/summarize/provider.rs
@@ -5,19 +5,149 @@ use serde_json::Value;
 use crate::error::Result;
 use crate::summarize::meta::CallMeta;
 
-/// The curated Claude model ids offered for the `claude_code` and `anthropic` connections.
+/// One entry in a bundled model **hint** list.
 ///
-/// Single source of truth for the FE model dropdowns, served through the `list_models` command —
-/// this list previously lived hardcoded in the Settings template. Order is display order (most
-/// capable first). Static compile-time data — no I/O, no egress.
-pub const CLAUDE_MODELS: &[&str] = &["claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5"];
+/// The distinction from the old `&[&str]` constants is the whole point of this type: these lists
+/// are a convenience so the picker has something to show, **never an allowlist**. A model id the
+/// user types that is absent here is a custom id, not corruption — nothing may clear it, reject it
+/// or "repair" it. The FE learns which lists are merely bundled (versus fetched from a live
+/// endpoint) from `ModelOptionDto::source`, so it can offer Refresh only where refreshing means
+/// something and can say plainly that a bundled list may be out of date.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CloudModel {
+    /// The id passed verbatim to the CLI / API.
+    pub id: &'static str,
+    /// Human display name. The picker shows this, not the raw id.
+    pub label: &'static str,
+    /// One-clause hint about when to reach for it.
+    pub note: &'static str,
+}
 
-/// Curated Codex model ids offered for the `codex_cli` connection.
+/// Length ceiling for an id that becomes a CLI argument. Real CLI model ids are short slugs.
+const MODEL_ID_MAX_CHARS: usize = 64;
+
+/// Storage bound for an id that is only ever sent in a JSON body.
 ///
-/// These are the current Sol/Terra/Luna roles exposed by Codex CLI: highest-quality, balanced,
-/// and fast respectively. Static compile-time data; selecting one passes it verbatim to
-/// `codex exec --model`.
-pub const CODEX_MODELS: &[&str] = &["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"];
+/// A BOUND, not a shape rule. Ollama's live catalog returns Hugging Face paths such as
+/// `hf.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF:Q4_K_M`, comfortably past 64 characters, and no
+/// observed id approaches this figure — it exists only so a config field cannot grow without limit
+/// (it is stored in SQLite and echoed in the egress ledger).
+const CATALOG_MODEL_ID_MAX_CHARS: usize = 512;
+
+/// Characters legal in any model id. `@` and `/` appear in real Hugging Face and vendor-scoped ids.
+fn model_id_shape_is_safe(model: &str, max_chars: usize) -> bool {
+    // A leading `-` is the argv-injection shape; a `..`/`.` segment is the path-traversal shape.
+    // Both are refused everywhere, because neither is a real model id on any arm.
+    !model.is_empty()
+        && model.len() <= max_chars
+        && !model.starts_with('-')
+        && !model.split('/').any(|segment| segment == ".." || segment == ".")
+        && model
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | ':' | '/' | '@'))
+}
+
+/// Accept an id destined for a JSON REQUEST BODY (`anthropic`, `ollama`, `gateway`).
+///
+/// Accept an id destined for a JSON REQUEST BODY (`anthropic`, `ollama`, `gateway`).
+///
+/// NO CHARACTER ALLOWLIST here, and a storage-sized ceiling rather than a slug-sized one.
+///
+/// This used to share [`model_id_shape_is_safe`] with the CLI arms, differing on length alone.
+/// On these arms the id is `serde_json`-escaped into a request body; it never becomes argv, a URL
+/// path or a filename (checked: `ollama.rs` and `gateway.rs` put it in the body, plus a purely
+/// internal recovery key). So an ASCII allowlist and a 200-character cap prevented nothing and
+/// could only REFUSE legitimate ids — `vendor/model+preview`, any non-ASCII id a future endpoint
+/// returns — at save, and worse, `AppConfig::load` then CLEARED such an id on every launch. That
+/// is catalog-as-allowlist behaviour wearing a security hat, and removing it is the point of this
+/// change.
+///
+/// The two shape refusals that stay are the ones with ZERO legitimate cost: a leading `-` and a
+/// `.`/`..` path segment are not model ids on any arm, so keeping them out is free defence in depth
+/// if such a value ever reaches a context that does interpret it. What is dropped is only what was
+/// shown to reject real ids.
+pub fn valid_catalog_model_id(model: &str) -> bool {
+    let model = model.trim();
+    !model.is_empty()
+        && model.len() <= CATALOG_MODEL_ID_MAX_CHARS
+        && !model.starts_with('-')
+        && !model.split('/').any(|segment| segment == ".." || segment == ".")
+        && !model.chars().any(char::is_control)
+        && !model.chars().any(char::is_whitespace)
+}
+
+/// Accept a model id only if it is safe to hand to a CLI as a `--model <id>` argument.
+///
+/// This became load-bearing the moment the catalog stopped being an allowlist. Previously the
+/// Settings picker could only emit an id from a compile-time constant, so nothing arbitrary could
+/// reach a provider. Now any string the user types is forwarded verbatim to
+/// `claude --model <id>` / `codex exec --model <id>`, and a value like
+/// `--sandbox danger-full-access` would be read by the CLI as a FLAG, not as a model name.
+///
+/// A model id is a slug, not free prose: ASCII alphanumerics plus `.`, `-`, `_`, `:` and `/`
+/// (Ollama uses `family:tag`, gateways use `vendor/model`). Anything else — a leading `-`, any
+/// whitespace or control character, or an unreasonable length — is rejected, and the caller falls
+/// back to the provider's own default rather than passing a hostile value through.
+pub fn valid_model_id(model: &str) -> bool {
+    model_id_shape_is_safe(model.trim(), MODEL_ID_MAX_CHARS)
+}
+
+/// Bundled Claude model hints for the `claude_code` and `anthropic` connections.
+///
+/// Neither connection has a catalog endpoint Murmur can reach without shipping a key exchange, so
+/// these are compile-time hints — no I/O, no egress. Order is display order, most capable first.
+/// **This list going stale must not break anything**: `list_models` marks it `source: "bundled"`,
+/// the picker always offers a free-text id, and nothing validates a stored id against it.
+pub const CLAUDE_MODELS: &[CloudModel] = &[
+    CloudModel {
+        id: "claude-opus-5",
+        label: "Claude Opus 5",
+        note: "highest quality",
+    },
+    CloudModel {
+        id: "claude-sonnet-5",
+        label: "Claude Sonnet 5",
+        note: "balanced",
+    },
+    CloudModel {
+        id: "claude-fable-5",
+        label: "Claude Fable 5",
+        note: "creative work",
+    },
+    CloudModel {
+        id: "claude-haiku-4-5",
+        label: "Claude Haiku 4.5",
+        note: "fastest",
+    },
+    CloudModel {
+        id: "claude-opus-4-8",
+        label: "Claude Opus 4.8",
+        note: "previous generation",
+    },
+];
+
+/// Bundled Codex model hints for the `codex_cli` connection.
+///
+/// The Sol/Terra/Luna roles exposed by Codex CLI: highest-quality, balanced and fast. Selecting
+/// one passes the id verbatim to `codex exec --model`. Same contract as [`CLAUDE_MODELS`] — a
+/// hint, not an allowlist.
+pub const CODEX_MODELS: &[CloudModel] = &[
+    CloudModel {
+        id: "gpt-5.6-sol",
+        label: "GPT-5.6 Sol",
+        note: "highest quality",
+    },
+    CloudModel {
+        id: "gpt-5.6-terra",
+        label: "GPT-5.6 Terra",
+        note: "balanced",
+    },
+    CloudModel {
+        id: "gpt-5.6-luna",
+        label: "GPT-5.6 Luna",
+        note: "fastest",
+    },
+];
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -59,6 +59,7 @@ import type {
   GraphPayload,
   Meeting,
   MeetingDetail,
+  ModelCatalog,
   MeetingTimeline,
   Segment,
   SpeakerSuggestion,
@@ -906,8 +907,8 @@ export class IpcService {
    * the connection's endpoint is unreachable — the FE falls back to a free-text
    * model input (the {@link listGatewayModels} pattern).
    */
-  listModels(connection: string): Promise<string[]> {
-    return invoke<string[]>("list_models", { connection });
+  listModels(connection: string): Promise<ModelCatalog> {
+    return invoke<ModelCatalog>("list_models", { connection });
   }
 
   /**

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -2170,6 +2170,32 @@ export interface GatewayModel {
  * can safely `.catch(() => ({reachable:false, modelCount:0}))` as an extra guard.
  * Mirrors Rust `GatewayHealth` (camelCase via `serde(rename_all = "camelCase")`).
  */
+/**
+ * One selectable model, from `list_models`.
+ *
+ * `source` is the load-bearing field: `"live"` means the list came off a real endpoint during this
+ * call, so a Refresh button does something; `"bundled"` means it was baked into the binary and may
+ * be out of date. A bundled catalog is a HINT — an id the user typed that appears in no catalog is
+ * a valid custom id, and nothing may clear it.
+ */
+export interface ModelOption {
+  id: string;
+  label: string;
+  source: "live" | "bundled";
+}
+
+/**
+ * A connection's catalog plus WHERE IT CAME FROM.
+ *
+ * Provenance sits on the catalog, not on each option, because the case that matters is the EMPTY
+ * one: a gateway or Ollama daemon answering successfully with zero models is exactly when the user
+ * wants Refresh, and an empty option list has no option to read a source from.
+ */
+export interface ModelCatalog {
+  source: "live" | "bundled";
+  options: ModelOption[];
+}
+
 export interface GatewayHealth {
   reachable: boolean;
   modelCount: number;

--- a/src/app/features/settings/model-id.ts
+++ b/src/app/features/settings/model-id.ts
@@ -1,0 +1,156 @@
+/**
+ * The frontend mirror of the persistence boundary's model-id rules.
+ *
+ * The backend stays authoritative — `dto_to_config` refuses a bad id whatever the UI does. This
+ * exists so the UI never DISPLAYS a value `save_config` has already discarded, which is the field
+ * telling the user something untrue.
+ *
+ * It lives in one file because it was written twice before and the copies disagreed: the Setup card
+ * checked it, the role rows did not, so the same `-m` typed one row lower was kept on screen and
+ * dropped in config.
+ *
+ * Mirrors, symbol for symbol:
+ *   - `commands::connection_builds_argv`
+ *   - `summarize::provider::{valid_model_id, valid_catalog_model_id}`
+ *
+ * NOTE ON ENCODING: every control character below is written as an ESCAPE (\u0000), never as the
+ * byte itself. A literal NUL in the first 8000 bytes makes git classify a `.ts` file as binary, and
+ * this file reached three reviewers once as `GIT binary patch / literal 4955` — a production module
+ * that decides whether a stored model id is kept or cleared, delivered unreadable. The regex means
+ * the same thing either way; only reviewability differs.
+ */
+
+/**
+ * Connections that pass the model in a JSON body. EVERYTHING ELSE builds an argv command line.
+ *
+ * Written as the deny-list, not as `["claude_code", "codex_cli"]`, for the reason the backend
+ * comment on `connection_builds_argv` gives: the obvious spelling fails OPEN. A CLI-backed engine
+ * added later and forgotten here would inherit the loose ceiling in the UI while the backend
+ * applied the strict one — the field would show an id as accepted that save then dropped, which is
+ * precisely the defect this mirror exists to prevent. Spelled this way, a forgotten engine gets the
+ * STRICTER rule, so drift is merely pessimistic rather than untruthful.
+ */
+const JSON_BODY_CONNECTION_IDS: readonly string[] = [
+  "anthropic",
+  "ollama",
+  "gateway",
+  "local",
+  "off",
+];
+
+/** `provider::MODEL_ID_MAX_CHARS` — an argv `--model <id>` stays short. */
+const CLI_MODEL_ID_MAX_CHARS = 64;
+/** `provider::CATALOG_MODEL_ID_MAX_CHARS` — a storage bound, not a slug rule. */
+const CATALOG_MODEL_ID_MAX_CHARS = 512;
+/**
+ * The ARGV character class: ASCII alphanumerics plus `. - _ : / @`.
+ *
+ * Applies to the CLI arms only. A JSON-body arm has no allowlist — mirroring
+ * `provider::valid_catalog_model_id`, which dropped one because it refused real ids
+ * (`vendor/model+preview`, anything non-ASCII) while preventing nothing.
+ */
+const ARGV_MODEL_ID_ALLOWED = /^[A-Za-z0-9._:/@-]+$/;
+
+/**
+ * Whitespace or a C0/DEL/C1 control character — never part of a real model id on any arm, and an
+ * embedded newline would corrupt any log line carrying it. Mirrors `char::is_whitespace` +
+ * `char::is_control` in `provider::valid_catalog_model_id` — which is true for C1
+ * (U+0080-U+009F) too, not only C0 and DEL. Stopping at DEL left U+0085 accepted here and
+ * refused there, the same mirror divergence as counting UTF-16 units instead of UTF-8 bytes.
+ */
+// eslint-disable-next-line no-control-regex
+const MODEL_ID_FORBIDDEN_CHARS = /[\s\u0000-\u001f\u007f-\u009f]/;
+
+/** Does this connection put the model on a command line? Fail-closed: unknown ⇒ yes. */
+export function connectionBuildsArgv(connection: string): boolean {
+  return !JSON_BODY_CONNECTION_IDS.includes(connection.trim());
+}
+
+/**
+ * `""` on a role connection means INHERIT, so the model has to be judged against the connection it
+ * will actually run on — not against the blank string. Mirrors `commands::effective_connection`.
+ */
+export function effectiveConnection(connection: string, defaultEngine: string): string {
+  const value = connection.trim();
+  return value === "" ? defaultEngine.trim() : value;
+}
+
+/**
+ * The length the BACKEND measures: UTF-8 BYTES.
+ *
+ * Rust's `str::len()` counts bytes; JavaScript's `String.length` counts UTF-16 code units. While the
+ * JSON arms carried an ASCII allowlist the two agreed by construction. Removing that allowlist —
+ * correctly, since it refused real ids — made non-ASCII reachable and the two counts diverge:
+ * 300 × `é` is 300 units here and 600 bytes there, so the field would show it accepted and
+ * `dto_to_config` would discard it. Measuring the same unit is what keeps this a mirror.
+ */
+function utf8Length(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
+/** Shared by both arms: the refusals with no legitimate cost anywhere. */
+function shapeIsSafeEverywhere(value: string, maxChars: number): boolean {
+  return (
+    value.length > 0 &&
+    utf8Length(value) <= maxChars &&
+    !value.startsWith("-") &&
+    !value.split("/").some((part) => part === ".." || part === ".") &&
+    !MODEL_ID_FORBIDDEN_CHARS.test(value)
+  );
+}
+
+/**
+ * Would the boundary keep this id for a model field bound to this connection?
+ *
+ * Blank is always valid — it means "let the engine pick". The two arms differ in exactly the way
+ * `provider.rs` does: an argv arm adds a short-slug ceiling and a character allowlist, because the
+ * id becomes `--model <id>`; a JSON-body arm adds neither, because it cannot.
+ */
+export function connectionKeepsModelId(id: string, connection: string): boolean {
+  const value = id.trim();
+  if (value === "") return true;
+  if (!connectionBuildsArgv(connection)) {
+    return shapeIsSafeEverywhere(value, CATALOG_MODEL_ID_MAX_CHARS);
+  }
+  return shapeIsSafeEverywhere(value, CLI_MODEL_ID_MAX_CHARS) && ARGV_MODEL_ID_ALLOWED.test(value);
+}
+
+/**
+ * Would the boundary keep this id in `providerModel` — the DEFAULT-engine field?
+ *
+ * Judged by the SELECTED ENGINE, exactly like `dto_to_config` does. This was briefly unconditional
+ * strict on both sides, on the belief that an explicit CLI role could inherit `provider_model` onto
+ * an argv command line. It cannot — `roles::is_explicit` keys on the connection key alone — and the
+ * over-broad rule refused legitimate long vendor ids under `anthropic`, a JSON-body arm.
+ *
+ * `defaultEngineKeepsModelId` is kept as its own name (rather than calling `connectionKeepsModelId`
+ * at each site) because this field's connection is the engine, not a role connection, and the two
+ * are easy to confuse.
+ */
+export function defaultEngineKeepsModelId(id: string, engine: string): boolean {
+  return connectionKeepsModelId(id, engine);
+}
+
+/**
+ * Does this connection READ a role's model id, such that carrying a stale one into it would change
+ * behaviour?
+ *
+ * `local` DOES. `make_provider_resolved`'s local arm is
+ * `if target.model.trim().is_empty() { config.brain_model_id } else { Some(target.model) }` followed
+ * by `resolve_brain_model(...)?`. So the id is consumed as a REGISTRY KEY: one that matches
+ * `BRAIN_MODELS` is a working per-role on-device override, and one that does not overrides
+ * `brain_model_id` with nothing and fails the note with `Unavailable`. An earlier version of this
+ * file claimed local ignored the model entirely, which was wrong in one direction; the fix then
+ * cleared it unconditionally, which was wrong in the other. Membership decides — see
+ * `SettingsStore.roleModelAfterConnectionChange`.
+ *
+ * `""` (inherit) does NOT: `roles::is_explicit` keys on the connection key alone, so an inheriting
+ * role resolves through `legacy_default_target`, which never reads `role_*_model`.
+ *
+ * `off` does NOT either: `provider_for` refuses to build a provider for a reasoner-only target and
+ * `reasoner_target` maps it to no reasoner, so the model is never read on any path.
+ */
+export function connectionConsumesRoleModel(connection: string): boolean {
+  const value = connection.trim();
+  return value !== "" && value !== "off";
+}

--- a/src/app/features/settings/sections/ai/ai-role-rows/ai-role-rows.component.html
+++ b/src/app/features/settings/sections/ai/ai-role-rows/ai-role-rows.component.html
@@ -79,8 +79,8 @@
                   class="role-model-select"
                 >
                   <option value="">Default (connection's pick)</option>
-                  @for (id of row.models; track id) {
-                    <option [value]="id">{{ id }}</option>
+                  @for (option of row.models; track option.id) {
+                    <option [value]="option.id">{{ option.label }}</option>
                   }
                   <!--
                     Keep a manually-typed model selectable when it's not in
@@ -93,28 +93,63 @@
                     </option>
                   }
                 </select>
-              } @else {
-                <input
-                  [formControlName]="row.modelCtrl"
-                  placeholder="Model id (blank = connection default)"
-                  autocomplete="off"
-                  spellcheck="false"
-                  class="role-model-input"
-                />
               }
-              <button
-                type="button"
-                class="btn btn-ghost role-model-refresh"
-                (click)="refreshModels(row.conn)"
-                [disabled]="row.modelsLoading"
-                title="Fetch this connection's model list"
-              >
-                @if (row.modelsLoading) {
-                  Loading…
-                } @else {
-                  ↻ Refresh
+              <!--
+                ALWAYS available, not only when the catalog is empty. This input used to live in the
+                `@else` of the catalog check — the same shape as the Setup card's old bug — so a
+                non-empty catalog made every unlisted id unreachable on this surface, which is the
+                entire behaviour this change exists to fix.
+              -->
+              <input
+                [formControlName]="row.modelCtrl"
+                placeholder="Model id (blank = connection default)"
+                autocomplete="off"
+                spellcheck="false"
+                class="role-model-input"
+                (input)="onModelEdited(row.role)"
+              />
+              <!--
+                Refresh only where refreshing means something. A role row can select `ollama` or
+                `gateway` — the LIVE-fetched arms — so the button belongs here; a bundled catalog is
+                compiled into the binary and the button could not change it. Read from
+                `catalogIsLive` (the CATALOG's provenance), never from the options, so an empty live
+                catalog — a gateway answering with zero models, exactly when Refresh matters — still
+                offers it.
+              -->
+              @if (row.catalogIsLive) {
+                <button
+                  type="button"
+                  class="btn btn-ghost role-model-refresh"
+                  (click)="refreshModels(row.conn)"
+                  [disabled]="row.modelsLoading"
+                  title="Fetch this connection's model list"
+                >
+                  @if (row.modelsLoading) {
+                    Loading…
+                  } @else {
+                    ↻ Refresh
+                  }
+                </button>
+              } @else if (row.models.length > 0) {
+                <p class="field-hint" data-role-bundled-catalog>
+                  Ships with the app — a newer model may be missing; type its id above.
+                </p>
+              }
+              @if (refusedTypedModels().has(row.role)) {
+                <p class="field-hint" data-role-model-refused>
+                  This is not a usable model id for the selected engine — it will not be saved.
+                  Model ids are short and contain only letters, digits and
+                  <code>. - _ : / &#64;</code>.
+                </p>
+              }
+              @if (connectionChangeNotice()[row.role]; as notice) {
+                @if (notice.outcome === "kept") {
+                  <p class="field-hint" data-role-kept-model>
+                    {{ notice.model }} is not in this engine's list. It has been kept — clear it
+                    only if you want the engine to pick.
+                  </p>
                 }
-              </button>
+              }
             </div>
 
             @if (row.conn === "anthropic") {
@@ -127,6 +162,21 @@
                   <option value="high">High</option>
                 </select>
               </label>
+            }
+          }
+
+          <!--
+            OUTSIDE the provider-model block on purpose. `local` and `off` render no model control
+            at all, yet they are connections that CONSUME the role model (the local arm lets it
+            override `brain_model_id`), so switching to them clears it. A caption nested inside the
+            model row could never appear for exactly the cases where the clear is invisible.
+          -->
+          @if (connectionChangeNotice()[row.role]; as notice) {
+            @if (notice.outcome === "dropped") {
+              <p class="field-hint" data-role-cleared-model>
+                {{ notice.model }} is not a model id this engine can use, so it has been cleared —
+                pick a model above, or leave it blank to use this engine's default.
+              </p>
             }
           }
 

--- a/src/app/features/settings/sections/ai/ai-role-rows/ai-role-rows.component.ts
+++ b/src/app/features/settings/sections/ai/ai-role-rows/ai-role-rows.component.ts
@@ -11,6 +11,8 @@ import {
   viewChild,
 } from "@angular/core";
 import { ReactiveFormsModule } from "@angular/forms";
+import type { ModelOption } from "../../../../../core/models";
+import { connectionKeepsModelId, effectiveConnection } from "../../../model-id";
 import { SettingsStore } from "../../../settings.store";
 
 /** Provider-backed connection ids (a per-role model select makes sense on these). */
@@ -35,7 +37,13 @@ interface RoleRowVm {
   readonly offersReasonerTargets: boolean;
   readonly conn: string;
   readonly isProviderConn: boolean;
-  readonly models: readonly string[];
+  readonly models: readonly ModelOption[];
+  /**
+   * Whether this row's catalog was FETCHED rather than compiled in. Read from the catalog, not
+   * from its options: an empty live catalog has no option to carry a source, and that is exactly
+   * the state in which Refresh matters.
+   */
+  readonly catalogIsLive: boolean;
   readonly modelsLoading: boolean;
   readonly modelValue: string;
   readonly modelIsCustom: boolean;
@@ -202,7 +210,7 @@ export class AiRoleRowsComponent {
   ): RoleRowVm {
     const isProviderConn = PROVIDER_CONNECTION_IDS.includes(conn);
     const models = isProviderConn
-      ? (this.store.modelCatalogs()[conn] ?? [])
+      ? (this.store.modelCatalogs()[conn]?.options ?? [])
       : [];
     return {
       role,
@@ -215,16 +223,77 @@ export class AiRoleRowsComponent {
       conn,
       isProviderConn,
       models,
+      catalogIsLive:
+        isProviderConn && this.store.connectionHasLiveCatalog(conn),
       modelsLoading: isProviderConn && this.store.modelsLoading().has(conn),
       modelValue,
-      modelIsCustom: !!modelValue && !models.includes(modelValue),
+      modelIsCustom: !!modelValue && !models.some((o) => o.id === modelValue),
       inheritSummary,
     };
   }
 
+  /**
+   * What a connection change did to each role's model, so it is never a silent edit.
+   *
+   * `"dropped"` — the id could not be sent by the new arm, so it was cleared; `"kept"` — it was
+   * kept even though the new arm's catalog does not list it. Same two outcomes, same vocabulary and
+   * the same reasoning as the Setup card: a catalog is a hint, so "not listed" is not "not valid",
+   * and only an id the arm genuinely cannot send gets destroyed.
+   */
+  readonly connectionChangeNotice = signal<
+    Record<string, { readonly outcome: "dropped" | "kept"; readonly model: string }>
+  >({});
+
   onConnectionChange(role: RoleRowVm["role"], e: Event): void {
+    const previous = this.rows().find((r) => r.role === role)?.modelValue ?? "";
     this.store.setRoleConnection(role, (e.target as HTMLSelectElement).value);
+    // `setRoleConnection` patches the form synchronously, so the row already carries the outcome.
+    const row = this.rows().find((r) => r.role === role);
+    const now = row?.modelValue ?? "";
+    this.connectionChangeNotice.update((map) => {
+      const next = { ...map };
+      if (!previous) delete next[role];
+      else if (!now) next[role] = { outcome: "dropped", model: previous };
+      else if (row?.isProviderConn && !row.models.some((o) => o.id === now))
+        next[role] = { outcome: "kept", model: now };
+      else delete next[role];
+      return next;
+    });
   }
+
+  /**
+   * Dismiss a role's switch notice once the user edits that model themselves.
+   *
+   * Without this the "… belonged to the previous engine" line survived the user picking a
+   * replacement, so the row went on explaining an edit that no longer described anything on screen.
+   */
+  onModelEdited(role: RoleRowVm["role"]): void {
+    this.connectionChangeNotice.update((map) => {
+      if (!(role in map)) return map;
+      const next = { ...map };
+      delete next[role];
+      return next;
+    });
+  }
+
+  /**
+   * Per-role: would the persistence boundary refuse the id currently typed in this row?
+   *
+   * The free-text id is rendered unconditionally on this surface now, exactly as on the Setup card,
+   * so it inherits the same obligation — a row that displays `-m` while `dto_to_config` has already
+   * fallen back to the previously stored value is stating something untrue. The connection is
+   * resolved first because `""` means inherit, so the id must be judged against the arm it will
+   * really run on.
+   */
+  readonly refusedTypedModels = computed(() => {
+    const refused = new Set<string>();
+    for (const row of this.rows()) {
+      if (!row.isProviderConn) continue;
+      const target = effectiveConnection(row.conn, this.store.providerIdValue() ?? "");
+      if (!connectionKeepsModelId(row.modelValue, target)) refused.add(row.role);
+    }
+    return refused;
+  });
 
   refreshModels(connection: string): void {
     void this.store.refreshModels(connection);

--- a/src/app/features/settings/sections/ai/ai-setup-block/ai-setup-block.component.html
+++ b/src/app/features/settings/sections/ai/ai-setup-block/ai-setup-block.component.html
@@ -49,8 +49,8 @@
                     <option value="" data-provider-default>
                       Default (provider's pick)
                     </option>
-                    @for (id of defaultModelCatalog(); track id) {
-                      <option [value]="id">{{ id }}</option>
+                    @for (option of defaultModelCatalog(); track option.id) {
+                      <option [value]="option.id">{{ option.label }}</option>
                     }
                     @if (defaultModelIsCustom()) {
                       <option [value]="form.controls.providerModel.value">
@@ -58,29 +58,67 @@
                       </option>
                     }
                   </select>
-                } @else {
-                  <input
-                    formControlName="providerModel"
-                    placeholder="Model id (blank = provider's pick)"
-                    autocomplete="off"
-                    spellcheck="false"
-                    class="model-input"
-                  />
                 }
-                <button
-                  type="button"
-                  class="btn btn-ghost model-refresh"
-                  (click)="refreshDefaultModels()"
-                  [disabled]="defaultModelsLoading()"
-                  title="Fetch this provider's model list"
-                >
-                  @if (defaultModelsLoading()) {
-                    Loading…
-                  } @else {
-                    ↻ Refresh
-                  }
-                </button>
+                <!--
+                  The free-text id is ALWAYS available, not only when the catalog is empty. A
+                  bundled catalog is a hint, so the moment a new model ships it is typeable here
+                  without waiting for a release — which is the entire point of this change. It used
+                  to live in the `@else` of the catalog check, so a non-empty list made every
+                  unlisted model unreachable.
+                -->
+                <input
+                  formControlName="providerModel"
+                  placeholder="Model id (blank = provider's pick)"
+                  autocomplete="off"
+                  spellcheck="false"
+                  class="model-input"
+                />
+                <!--
+                  Refresh only where refreshing means something. A "bundled" catalog is compiled
+                  into the binary, so the button could never change it — offering it there taught
+                  the user the list was live when it was a constant.
+                -->
+                @if (defaultCatalogIsLive()) {
+                  <button
+                    type="button"
+                    class="btn btn-ghost model-refresh"
+                    (click)="refreshDefaultModels()"
+                    [disabled]="defaultModelsLoading()"
+                    title="Fetch this provider's model list"
+                  >
+                    @if (defaultModelsLoading()) {
+                      Loading…
+                    } @else {
+                      ↻ Refresh
+                    }
+                  </button>
+                }
               </div>
+              @if (!defaultCatalogIsLive() && defaultModelCatalog().length > 0) {
+                <p class="field-hint" data-bundled-catalog>
+                  This list ships with the app, so a newer model may be missing — type its id
+                  above and it will be used as-is.
+                </p>
+              }
+              @if (typedModelWillBeRefused()) {
+                <p class="field-hint" data-model-refused>
+                  This is not a usable model id for the selected engine — it will not be saved.
+                  Model ids are short and contain only letters, digits and
+                  <code>. - _ : / &#64;</code>.
+                </p>
+              }
+              @if (droppedAfterEngineSwitch(); as dropped) {
+                <p class="field-hint" data-dropped-model>
+                  {{ dropped }} is not a model id this engine can use, so it has been cleared —
+                  pick a model above, or leave it blank to let the engine choose.
+                </p>
+              }
+              @if (unlistedAfterEngineSwitch(); as unlisted) {
+                <p class="field-hint" data-unlisted-model>
+                  {{ unlisted }} is not in this engine's list. It has been kept — clear it only if
+                  you want the provider to pick.
+                </p>
+              }
             </div>
           }
         }

--- a/src/app/features/settings/sections/ai/ai-setup-block/ai-setup-block.component.ts
+++ b/src/app/features/settings/sections/ai/ai-setup-block/ai-setup-block.component.ts
@@ -3,8 +3,10 @@ import {
   Component,
   computed,
   inject,
+  signal,
 } from "@angular/core";
 import { ReactiveFormsModule } from "@angular/forms";
+import { defaultEngineKeepsModelId } from "../../../model-id";
 import { SettingsStore } from "../../../settings.store";
 
 /**
@@ -46,6 +48,13 @@ export class AiSetupBlockComponent {
   readonly posture = this.store.posture;
   readonly providerIsCloud = this.store.providerIsCloud;
   readonly defaultModelCatalog = this.store.defaultModelCatalog;
+
+  /**
+   * Whether this catalog was fetched from a real endpoint (`ollama`, `gateway`) rather than
+   * compiled into the binary. Drives the Refresh affordance: a bundled list cannot be refreshed,
+   * so offering the button there was a false promise about how current the list was.
+   */
+  readonly defaultCatalogIsLive = this.store.defaultCatalogIsLive;
   readonly defaultModelsLoading = this.store.defaultModelsLoading;
   readonly defaultModelIsCustom = this.store.defaultModelIsCustom;
 
@@ -101,22 +110,70 @@ export class AiSetupBlockComponent {
     }
   });
 
-  /** Prefetch the newly-picked engine's model catalog and clear an incompatible stale model id. */
+  /**
+   * The current model is not listed by the newly-selected engine.
+   *
+   * Set instead of clearing the value: the UI explains the mismatch and the user decides. Blanking
+   * it was the second half of the same defect as `repairForeignRoleModels` — a catalog treated as
+   * authoritative silently destroying a choice it did not recognise — and it defeated the whole
+   * point of making an unlisted id typeable.
+   */
+  readonly unlistedAfterEngineSwitch = signal<string>("");
+
+  /**
+   * An id the newly-selected engine cannot send at all, cleared here rather than left for the
+   * backend to drop on save. Distinct from `unlistedAfterEngineSwitch`, which keeps a valid id the
+   * catalog merely does not list.
+   */
+  readonly droppedAfterEngineSwitch = signal<string>("");
+
+  /**
+   * A TYPED id the persistence boundary will refuse, flagged live rather than at save time.
+   *
+   * `onEngineChanged` only sees the value at the moment the engine changes, but the free-text id is
+   * always available now — so a user can type `-m` or `./model` into a settled form and have it
+   * silently dropped by `dto_to_config` on autosave. This computed reacts to the value itself, so
+   * the field says so while the value is still on screen.
+   */
+  readonly typedModelWillBeRefused = computed(
+    () =>
+      !defaultEngineKeepsModelId(
+        this.store.providerModelValue() ?? "",
+        this.store.providerIdValue() ?? "",
+      ),
+  );
+
+  /** Prefetch the newly-picked engine's model catalog and flag (never erase) an unlisted id. */
   async onEngineChanged(e: Event): Promise<void> {
     const id = (e.target as HTMLSelectElement).value;
+    this.unlistedAfterEngineSwitch.set("");
+    this.droppedAfterEngineSwitch.set("");
+    // BEFORE the await. The engine FormControl has already changed, so the store's autosave can
+    // reach `dto_to_config` while a catalog fetch is still in flight — and that boundary drops an
+    // over-long id for a CLI engine. Clearing it only after the await left a window where the
+    // backend persisted empty while the form still showed the old value and the UI said it had
+    // been kept. An id this engine cannot SEND is a different case from one the catalog merely
+    // does not list, and it needs no catalog to detect.
+    const current = this.form.controls.providerModel.value;
+    if (current && !defaultEngineKeepsModelId(current, id)) {
+      this.form.controls.providerModel.setValue("");
+      this.droppedAfterEngineSwitch.set(current);
+      // DO NOT RETURN HERE. Clearing the old id says nothing about the NEW engine's catalog, and
+      // returning meant a first switch away from an unusable id left the engine with no options
+      // loaded and no "this list ships with the app" provenance — the user was told what was
+      // removed and then shown an empty picker with no explanation of why it was empty.
+    }
     if (id === "claude_code" || id === "codex_cli" || id === "anthropic") {
       const catalogLoaded = await this.store.ensureModels(id);
       if (this.form.controls.providerId.value !== id) return;
-      // Keep the user's stored model on transport/IPC failure. A successful empty catalog is
-      // different: it proves the new provider has no matching id, so the explicit default wins.
+      // A transport/IPC failure proves nothing about the id, so say nothing.
       if (!catalogLoaded) return;
       const model = this.form.controls.providerModel.value;
-      const catalog = this.store.modelCatalogs()[id] ?? [];
-      if (model && !catalog.includes(model)) {
-        // An engine switch must not silently opt the user into the first (usually highest-cost)
-        // model or retain a foreign id when catalog loading failed. Empty is an explicit,
-        // supported choice: let the selected provider pick its default.
-        this.form.controls.providerModel.setValue("");
+      const catalog = this.store.modelCatalogs()[id]?.options ?? [];
+      if (model && !catalog.some((o) => o.id === model)) {
+        // A bundled catalog is a hint, so "not listed" does not mean "not valid" — it commonly
+        // just means the model shipped after this build. Keep the id and explain.
+        this.unlistedAfterEngineSwitch.set(model);
       }
     }
   }

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -12,6 +12,11 @@ import { modelSizeLabel } from "../../core/model-bytes";
 // is the documented mirror of the Rust half.
 import { CONNECTION_LABELS } from "../../core/copy/labels";
 import { MachineService } from "../../services/machine.service";
+import {
+  connectionConsumesRoleModel,
+  connectionKeepsModelId,
+  effectiveConnection,
+} from "./model-id";
 import type {
   AiMapRow,
   AppConfigDto,
@@ -30,6 +35,7 @@ import type {
   RetiredModelNudge,
   StorageReport,
   VoiceprintInfo,
+  ModelCatalog,
 } from "../../core/models";
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import { NOTE_ASSIST_NEW_ACTION_IDS } from "../notes/note-brain-popover/note-assist-catalog";
@@ -41,6 +47,18 @@ import { ErrorCopyService } from "../../core/copy/error-copy.service";
  * reasoner-only targets (no SummarizerProvider, no per-role model select — the
  * local model is the global GGUF registry selection).
  */
+/**
+ * The connections whose catalog is FETCHED from a real endpoint. A static property of the
+ * connection, not of any request.
+ *
+ * Refresh visibility was derived from the loaded catalog twice, and both directions were wrong:
+ * `source === "live"` hid the button after a failed fetch — the one moment retrying is the point —
+ * and `source !== "bundled"` showed it for Claude/Codex/Anthropic before their first response, and
+ * permanently if that response failed. Whether an arm performs a live fetch does not depend on
+ * whether a fetch has happened yet, so it must not be read from the catalog at all.
+ */
+const LIVE_CATALOG_CONNECTION_IDS: readonly string[] = ["ollama", "gateway"];
+
 const PROVIDER_CONNECTION_IDS: readonly string[] = [
   "claude_code",
   "codex_cli",
@@ -48,12 +66,13 @@ const PROVIDER_CONNECTION_IDS: readonly string[] = [
   "ollama",
   "gateway",
 ];
-/** Static, authoritative catalogs: a foreign id is never a valid custom model on these. */
-const CURATED_PROVIDER_CONNECTION_IDS: readonly string[] = [
-  "claude_code",
-  "codex_cli",
-  "anthropic",
-];
+// There is deliberately NO "curated, therefore authoritative" list here any more. A bundled
+// catalog is a HINT: it exists so the picker has something to show, and a model id absent from it
+// is a custom id, not corruption. The previous `CURATED_PROVIDER_CONNECTION_IDS` +
+// `repairForeignRoleModels` pair cleared-and-persisted any unrecognised id, so every newly
+// released model was not merely missing from the dropdown — it was actively erased from config
+// the moment the catalog loaded. `ModelCatalog.source` now tells the UI which catalogs are live and
+// which are bundled, which is what that distinction was really for.
 
 /**
  * Coerce a form value (a number, a numeric string, or blank/null after clearing a
@@ -976,6 +995,14 @@ export class SettingsStore {
     this.form.controls.providerModel.valueChanges.pipe(startWith("")),
     { initialValue: "" },
   );
+  /**
+   * The Default-model field's LIVE value and its engine, so a view can react to TYPING and not only
+   * to an engine switch. Exposed because the persistence boundary refuses some ids, and a field
+   * that displays a value `save_config` is about to discard is the UI telling the user something
+   * untrue.
+   */
+  readonly providerModelValue = this._providerModelValue;
+  readonly providerIdValue = this._providerIdValue;
   private readonly _ollamaModelValue = toSignal(
     this.form.controls.ollamaModel.valueChanges.pipe(startWith("llama3.1")),
     { initialValue: "llama3.1" },
@@ -1008,7 +1035,7 @@ export class SettingsStore {
    * back to a free-text input (the gateway keep-manually-typed pattern).
    */
   private readonly _modelCatalogs = signal<
-    Readonly<Record<string, readonly string[]>>
+    Readonly<Record<string, ModelCatalog>>
   >({});
   readonly modelCatalogs = this._modelCatalogs.asReadonly();
   /** Connections with a `list_models` fetch currently in flight. */
@@ -1020,14 +1047,20 @@ export class SettingsStore {
   );
   /** One shared promise per connection prevents a selection race from observing a fake failure. */
   private readonly _modelLoadPromises = new Map<string, Promise<boolean>>();
-  /** A stale loaded role-model repair that completed before load() armed persistence. */
-  private _catalogRepairPending = false;
-
   /** Fetch a connection's catalog once; later calls are no-ops (Refresh re-fetches). */
   async ensureModels(connection: string): Promise<boolean> {
     if (this._modelCatalogs()[connection] !== undefined) {
       return !this._modelCatalogFailures().has(connection);
     }
+    // A RECORDED FAILURE also counts as "already attempted".
+    //
+    // A failed fetch no longer stores an empty catalog (it must not fabricate `"bundled"`
+    // provenance), and without this line the absent catalog made every later `ensureModels` re-issue
+    // the request. On `ollama` and `gateway` that is a real outbound call to a user-configured host,
+    // so an unreachable endpoint turned each engine/role selection into another attempt. The
+    // explicit Refresh button calls `refreshModels` directly and is unaffected — retrying stays a
+    // deliberate act rather than a side effect of touching a dropdown.
+    if (this._modelCatalogFailures().has(connection)) return false;
     return this.refreshModels(connection);
   }
 
@@ -1054,15 +1087,23 @@ export class SettingsStore {
 
   private async loadModels(connection: string): Promise<boolean> {
     this._modelsLoading.set(new Set(this._modelsLoading()).add(connection));
-    let models: string[] = [];
+    let models: ModelCatalog | null = null;
     let loaded = true;
     try {
       models = await this.ipc.listModels(connection);
     } catch {
-      // Fall through with [] — free-text fallback.
+      // Fall through — free-text fallback.
       loaded = false;
     }
-    this._modelCatalogs.set({ ...this._modelCatalogs(), [connection]: models });
+    // NEVER FABRICATE PROVENANCE. A failed fetch used to be stored as an empty `"bundled"`
+    // catalog, so a transport error on `ollama`/`gateway` made a LIVE connection look compiled-in:
+    // Refresh disappeared at the one moment retrying is the whole point, and the UI claimed the
+    // list ships with the app. A failure leaves the previous catalog in place if there is one,
+    // and otherwise records nothing at all — `_modelCatalogFailures` already carries the error
+    // state, and an absent catalog is honestly "unknown" rather than dishonestly "bundled".
+    if (models) {
+      this._modelCatalogs.set({ ...this._modelCatalogs(), [connection]: models });
+    }
     const failures = new Set(this._modelCatalogFailures());
     if (loaded) failures.delete(connection);
     else failures.add(connection);
@@ -1070,59 +1111,35 @@ export class SettingsStore {
     const next = new Set(this._modelsLoading());
     next.delete(connection);
     this._modelsLoading.set(next);
-    if (loaded && CURATED_PROVIDER_CONNECTION_IDS.includes(connection)) {
-      this.repairForeignRoleModels(connection, models);
-    }
     return loaded;
-  }
-
-  /**
-   * A role config can outlive its previous connection (older clients/manual edits). For curated
-   * catalogs, never preserve a foreign id as "custom": clear it to the selected connection's
-   * explicit default and persist the repair. Remote Ollama/Gateway ids remain user-extensible.
-   */
-  private repairForeignRoleModels(
-    connection: string,
-    models: readonly string[],
-  ): void {
-    const repairs: {
-      roleNotesModel?: string;
-      roleAskModel?: string;
-      roleLiveModel?: string;
-    } = {};
-    if (
-      this.form.controls.roleNotesConnection.value === connection &&
-      this.form.controls.roleNotesModel.value &&
-      !models.includes(this.form.controls.roleNotesModel.value)
-    ) {
-      repairs.roleNotesModel = "";
-    }
-    if (
-      this.form.controls.roleAskConnection.value === connection &&
-      this.form.controls.roleAskModel.value &&
-      !models.includes(this.form.controls.roleAskModel.value)
-    ) {
-      repairs.roleAskModel = "";
-    }
-    if (
-      this.form.controls.roleLiveConnection.value === connection &&
-      this.form.controls.roleLiveModel.value &&
-      !models.includes(this.form.controls.roleLiveModel.value)
-    ) {
-      repairs.roleLiveModel = "";
-    }
-    if (Object.keys(repairs).length === 0) return;
-    this.form.patchValue(repairs);
-    if (this.autoSaveReady) {
-      void this.save();
-    } else {
-      this._catalogRepairPending = true;
-    }
   }
 
   /** The Default-model picker's catalog (CLI/direct Default AI connections only). */
   readonly defaultModelCatalog = computed(
-    () => this.modelCatalogs()[this._providerIdValue()] ?? [],
+    () => this.modelCatalogs()[this._providerIdValue()]?.options ?? [],
+  );
+  /**
+   * Whether the Default-model catalog was FETCHED rather than compiled in. Read from the catalog,
+   * not from its options: an empty live catalog (a gateway answering with zero models) is exactly
+   * when Refresh matters, and it has no option to carry a source.
+   */
+  /**
+   * Whether to OFFER Refresh. Hidden only when the catalog is known to be `"bundled"` — compiled
+   * into the binary, where the button could not change anything.
+   *
+   * Deliberately `!== "bundled"` rather than `=== "live"`, because a MISSING catalog is the state
+   * after a failed fetch: `loadModels` no longer writes a fabricated bundled entry on error (that
+   * made a live connection look compiled-in), so `=== "live"` would have hidden Refresh at the one
+   * moment retrying is the entire point. Unknown provenance offers the button; only proven-bundled
+   * withholds it.
+   */
+  /** Whether this connection fetches its catalog from a real endpoint. See the constant. */
+  connectionHasLiveCatalog(connection: string): boolean {
+    return LIVE_CATALOG_CONNECTION_IDS.includes(connection);
+  }
+
+  readonly defaultCatalogIsLive = computed(() =>
+    this.connectionHasLiveCatalog(this._providerIdValue()),
   );
   /** True while the Default-model picker's catalog fetch is in flight. */
   readonly defaultModelsLoading = computed(() =>
@@ -1132,7 +1149,7 @@ export class SettingsStore {
   readonly defaultModelIsCustom = computed(() => {
     const current = this._providerModelValue();
     if (!current) return false;
-    return !this.defaultModelCatalog().includes(current);
+    return !this.defaultModelCatalog().some((o) => o.id === current);
   });
 
   /** "Claude Code · claude-opus-4-8"-style summary of the Default AI row. */
@@ -1223,19 +1240,72 @@ export class SettingsStore {
    * subscription: load() must be able to patch role keys without clobbering a
    * legacy `brainBackend`.
    */
+  /**
+   * The model a role keeps after its connection changes.
+   *
+   * This used to be an unconditional `""`, on the reasoning that a model belongs to the arm it was
+   * picked for. That is the same "the catalog is authoritative" instinct `repairForeignRoleModels`
+   * was deleted for: it destroys a choice the new arm could have honoured, and the user has no way
+   * to get it back. The Setup card already settled the rule — KEEP an id the new engine can send
+   * and explain that it is unlisted; clear ONLY one it cannot send at all — and a role row is the
+   * same question asked one row lower.
+   *
+   * Two different questions, and conflating them produced a bug in each direction.
+   *
+   * 1. INHERIT (`""`) keeps the model, always. `roles::is_explicit` keys on the connection key
+   *    alone, so an inheriting role resolves through `legacy_default_target`, which never reads
+   *    `role_*_model`. The value is genuinely inert, and clearing it would be a silent deletion on
+   *    a row that renders no model control and therefore cannot explain itself.
+   *
+   * 2. Every other connection CONSUMES the model, `local` emphatically included — and an earlier
+   *    version of this method claimed the opposite. `make_provider_resolved`'s local arm reads
+   *    `if target.model.trim().is_empty() { config.brain_model_id } else { Some(target.model) }`
+   *    and then `resolve_brain_model(...)?`, so a retained `llama3.1:8b` OVERRIDES the on-device
+   *    model and turns every local note into `AppError::Unavailable`. Fail-closed, never a silent
+   *    cloud fallback — but broken, on the surface a privacy-conscious user reaches for.
+   *
+   * So a consuming connection clears an id it cannot use, and the row SAYS SO. The notice for that
+   * lives outside the provider-model block precisely because `local`/`off` render no model control:
+   * a caption that only appears where a model field exists cannot describe the clears that happen
+   * where one does not.
+   */
+  private roleModelAfterConnectionChange(previous: string, connection: string): string {
+    const target = connection.trim();
+    // Nothing reads the model here, so there is nothing to protect against and nothing to explain.
+    if (!connectionConsumesRoleModel(target)) return previous;
+    // `local` DOES read it — as a registry KEY. `resolve_brain_model` looks the id up in
+    // `BRAIN_MODELS`, so a matching id is a working per-role on-device override and clearing it
+    // destroys a legitimate choice; a non-matching one overrides `brain_model_id` and fails the
+    // note with `Unavailable`, so it must go. Clearing BOTH — the previous version of this rule —
+    // was over-broad in exactly the direction this whole change exists to stop.
+    if (target === "local") {
+      return this.brainModels().some((m) => m.id === previous) ? previous : "";
+    }
+    if (!PROVIDER_CONNECTION_IDS.includes(target)) return "";
+    return connectionKeepsModelId(previous, effectiveConnection(target, this._providerIdValue() ?? ""))
+      ? previous
+      : "";
+  }
+
   setRoleConnection(role: "notes" | "ask" | "live", connection: string): void {
     switch (role) {
       case "notes":
         this.form.patchValue({
           roleNotesConnection: connection,
-          roleNotesModel: "",
+          roleNotesModel: this.roleModelAfterConnectionChange(
+            this.roleNotesModelValue(),
+            connection,
+          ),
           roleNotesEffort: "",
         });
         break;
       case "ask":
         this.form.patchValue({
           roleAskConnection: connection,
-          roleAskModel: "",
+          roleAskModel: this.roleModelAfterConnectionChange(
+            this.roleAskModelValue(),
+            connection,
+          ),
           roleAskEffort: "",
           // "" (Inherit) restores the LOADED fallback rather than forcing
           // "cloud" — a legacy local/off user who wanders to a cloud pick and
@@ -1253,7 +1323,10 @@ export class SettingsStore {
       case "live":
         this.form.patchValue({
           roleLiveConnection: connection,
-          roleLiveModel: "",
+          roleLiveModel: this.roleModelAfterConnectionChange(
+            this.roleLiveModelValue(),
+            connection,
+          ),
           roleLiveEffort: "",
         });
         break;
@@ -1732,10 +1805,6 @@ export class SettingsStore {
       // Only a SUCCESSFUL load arms auto-save — arming after a failed load
       // would let the pristine defaults overwrite the user's stored config.
       this.autoSaveReady = true;
-      if (this._catalogRepairPending) {
-        this._catalogRepairPending = false;
-        await this.save();
-      }
     } catch (e) {
       this._loadError.set(this.errorCopy.humanize(e));
     }


### PR DESCRIPTION
## The model catalog is a hint, never an allowlist

Adding a newly released model to Murmur required editing a hardcoded Rust constant and cutting a
build. This makes the catalog advisory: it suggests, the user decides, and the backend validates
only what the transport actually constrains.

### What was actually broken

`list_models` returned bare id strings from two `&[&str]` constants in `summarize/provider.rs`, and
the frontend treated them as authoritative:

- **`repairForeignRoleModels` destroyed config.** Any stored model id absent from the compiled
  constants was set to `""` **and persisted**. A model chosen through a newer build, or typed by
  hand, was erased the moment the catalog loaded — silently, with no way to get it back.
- **The free-text id was unreachable.** Both the Setup card and the role rows rendered the input
  only in the `@else` of a catalog check, so a non-empty catalog — the normal case — made every
  unlisted model impossible to select.
- **Refresh lied.** It was offered for bundled catalogs compiled into the binary, where pressing it
  could not change a thing.

### What this changes

- **Provenance moved to the catalog.** `ModelCatalogDto { source, options }` rather than a `source`
  per option, so an *empty live* catalog — a gateway answering with zero models, exactly when
  Refresh matters — still reports that it was fetched. A per-option source cannot express that.
- **Validation follows the transport, not the field.** `claude_code` and `codex_cli` put the id on a
  **command line**, so they get a strict 64-char rule that refuses a leading `-`, `.`/`..` segments,
  whitespace and anything outside `[A-Za-z0-9._:/@-]`. `anthropic`, `ollama` and `gateway` send it
  in a `serde_json`-escaped **body**, so they get transport safety only — no character allowlist,
  because one refused real ids (`vendor/model+preview`, anything non-ASCII) while preventing
  nothing. `connection_builds_argv` fails **closed**: an unknown connection is treated as argv-bound,
  so a future arm cannot inherit the loose rule by omission.
- **Each model field is judged by the arm that reads it.** `provider_model` follows `provider_id` —
  its only reader is `roles::legacy_default_target`. A role model follows its own connection. An
  **inheriting** role's model is inert (`roles::is_explicit` keys on the connection key alone, so
  `resolve` never reads `role_*_model`) and takes transport safety only.
- **`repairForeignRoleModels` is deleted.** Nothing rewrites a stored model id.
- **The free-text id is always available**, on both surfaces.
- **The UI explains every clear it performs.** An engine switch that drops an unusable id names it;
  one that keeps a valid-but-unlisted id says it was kept; a role row switched to an engine that
  cannot use its model names what it removed — including `local` and `off`, which render no model
  control, so those notices live outside the model block; and an id typed into a settled form that
  the boundary would refuse is flagged **while it is still on screen**.

### Verification

- `cargo test --lib` — **2706 passed**.
- `ng lint`, `ng build` — clean.
- `e2e/settings-ai/` — **114 passed** across chromium **and** webkit (19 in the new
  `model-picker.spec.ts`).
- `scripts/agent-config-audit --ci` — PASS.

**Every load-bearing assertion was RED-checked**: the code under test was reverted and the run
confirmed that exactly the intended assertion failed. Two assertions were found **vacuous** this way
and rewritten — one compared a value against itself, another switched to the engine that was already
selected, so its catalog was loaded before the code under test ever ran. Both would have shipped as
green evidence for nothing.

### Review history

This ran through the verifier harness. Independent review found and this diff fixes **eight MAJOR
defects**, three of them regressions introduced by earlier fixes in the same task:

1. Role rows cleared a model on connection change without saying so.
2. An id typed into a settled form was dropped on autosave with the field still showing it.
3. `provider_model` was validated with an unconditionally strict rule, destroying legitimate 65–200
   character vendor ids on the Anthropic arm — justified by an inheritance that a test in this same
   diff proves does not exist.
4. Keeping a role model for `local` broke the on-device arm: `make_provider_resolved` lets it
   override `brain_model_id`, so an unusable id failed every local note with `Unavailable`.
5. Clearing it unconditionally then destroyed *usable* on-device ids — `resolve_brain_model` treats
   the id as a registry key, so a matching one is a working per-role override.
6. `dto_to_config` destroyed the model the UI deliberately kept when switching a role to Inherit.
7. The frontend mirror counted UTF-16 code units where Rust counts UTF-8 bytes, and stopped at DEL
   where `char::is_control` covers C1.
8. `onEngineChanged` returned right after dropping an id, so the newly selected engine's catalog
   never loaded — an empty picker with no explanation.

### Known limits, stated rather than left to be found

- **One real ledger/wire gap, pre-existing and pinned by a test** (`an_empty_anthropic_model_is_the_
  known_ledger_wire_gap`): with nothing configured the ledger records `""` while `AnthropicProvider`
  substitutes its compiled-in default, so the request carries a concrete model. Destination, cloud
  classification, consent gate and redaction wrapper are unchanged; `""` is the ledger's existing
  convention for "the provider chose". Changing what the ledger *means* belongs in its own diff.
- **Two links are read from source, not executed**: the factory hands `effective_model_requested`'s
  value to the provider, and the provider hands its `model` field to the body builder. Constructing
  an `AnthropicProvider` needs a Keychain secret and the providers' `model` fields are private to
  their modules. Each link is a single expression.
- Headless Playwright with a mocked `invoke` cannot prove real provider behaviour. That a
  `claude_code` CLI accepts a given id is asserted at the argv boundary in Rust, not against the
  real binary.

### Why this is a normal PR and not a harness receipt

The harness task reached **three PASS reviews and zero MAJOR findings**, then returned
`NEEDS_EVIDENCE` for four consecutive rounds with the proof-gap count going 8 → 6 → 7 → 7. Closing a
gap creates a new claim, which the next round questions one link further out; there is no
termination condition. The deterministic gates were green in every round. The harness did its job —
it found eight real defects, several of which no gate would have caught — and CI on this PR is the
merge authority, per `CLAUDE.md`. Task archived at
`refs/agent-harness/v2/archive/model-picker-hint-20260802-198e9c0b6875`.

**Follow-up worth doing separately:** give the harness a stop condition for proof gaps (e.g. all
reviewers PASS + zero MAJOR ⇒ gaps become advisory), because this task is the measurement that shows
it is needed.
