### PR TITLE
refactor(settings): one mur-model-picker, and no engine that sends you elsewhere

### DIFF
--- a/e2e/settings-ai/codex-provider.spec.ts
+++ b/e2e/settings-ai/codex-provider.spec.ts
@@ -70,7 +70,7 @@ test("Codex can be selected globally and per feature with its catalog and brande
   await expect(engine.locator('option[value="codex_cli"]')).toHaveText("Codex");
   await engine.selectOption("codex_cli");
 
-  const defaultModel = setup.locator('select[formcontrolname="providerModel"]');
+  const defaultModel = setup.locator('mur-model-picker[formcontrolname="providerModel"] select.model-select');
   await expect(defaultModel.locator("[data-provider-default]")).toHaveText(
     "Default (provider's pick)",
   );
@@ -79,7 +79,7 @@ test("Codex can be selected globally and per feature with its catalog and brande
   // did not recognise. The UI now keeps the value and explains the mismatch instead.
   await expect(defaultModel.locator("[data-provider-default]")).toBeAttached();
   await expect(
-    setup.locator('input[formcontrolname="providerModel"]'),
+    setup.locator('mur-model-picker[formcontrolname="providerModel"] input.model-input'),
   ).toHaveValue("claude-opus-4-8");
   await expect(setup.locator("[data-unlisted-model]")).toContainText(
     "claude-opus-4-8",
@@ -275,7 +275,7 @@ test("a delayed Codex catalog cannot overwrite a newer engine selection", async 
   await engine.selectOption("codex_cli");
   await engine.selectOption("anthropic");
 
-  const model = setup.locator('select[formcontrolname="providerModel"]');
+  const model = setup.locator('mur-model-picker[formcontrolname="providerModel"] select.model-select');
   // The property under test is that a LATE catalog response cannot overwrite a NEWER engine
   // selection. Comparing the value against itself would detect the late write but pin nothing, so
   // name the value that must be there: the SEEDED id. It survives both engine switches because a
@@ -311,7 +311,7 @@ test("an empty Codex catalog KEEPS a foreign default-engine model", async ({
   // An EMPTY catalog proves nothing about the id either — a bundled list that happens to be empty
   // is still just a hint, so the stored value is kept rather than blanked.
   await expect(
-    setup.locator('input[formcontrolname="providerModel"]'),
+    setup.locator('mur-model-picker[formcontrolname="providerModel"] input.model-input'),
   ).toHaveValue("claude-opus-4-8");
 });
 
@@ -338,7 +338,7 @@ test("a failed Codex catalog request preserves the stored model id", async ({
     .locator('select[formcontrolname="providerId"]')
     .selectOption("codex_cli");
   await expect(
-    setup.locator('input[formcontrolname="providerModel"]'),
+    setup.locator('mur-model-picker[formcontrolname="providerModel"] input.model-input'),
   ).toHaveValue("claude-opus-4-8");
 });
 

--- a/e2e/settings-ai/model-picker.spec.ts
+++ b/e2e/settings-ai/model-picker.spec.ts
@@ -128,7 +128,7 @@ test("an id the boundary would refuse is cleared visibly, not silently", async (
 
   // claude_code puts the id on a command line, so this one cannot be sent. The UI clears it in the
   // same interaction and says so, rather than leaving it on screen for autosave to drop.
-  await expect(page.locator("[data-dropped-model]")).toContainText(tooLong);
+  await expect(page.locator("app-ai-setup-block [data-dropped-model]")).toContainText(tooLong);
   await expect(
     page.locator(".model-row input.model-input").first(),
     "the field must not still show a value the backend will not keep",
@@ -157,13 +157,13 @@ test("dropping an unusable model does not cancel the new engine's catalog fetch"
     .first()
     .selectOption("codex_cli");
 
-  await expect(page.locator("[data-dropped-model]")).toContainText(tooLong);
+  await expect(page.locator("app-ai-setup-block [data-dropped-model]")).toContainText(tooLong);
   await expect(
     page.locator(".model-row select.model-select option", { hasText: "Claude Sonnet 5" }),
     "the new engine's catalog must load even when the switch dropped the previous model",
   ).toHaveCount(1);
   await expect(
-    page.locator("[data-bundled-catalog]"),
+    page.locator("app-ai-setup-block [data-bundled-catalog]"),
     "a bundled catalog must still say so; silence reads as 'this list is current'",
   ).toBeVisible();
 
@@ -192,7 +192,7 @@ test("a SHAPE the boundary refuses is cleared too, not only an over-long one", a
     .first()
     .selectOption("claude_code");
 
-  await expect(page.locator("[data-dropped-model]")).toContainText("./model");
+  await expect(page.locator("app-ai-setup-block [data-dropped-model]")).toContainText("./model");
   await expect(
     page.locator(".model-row input.model-input").first(),
   ).toHaveValue("");
@@ -212,7 +212,7 @@ test("refresh button tracks the ENGINE, not the mocked catalog source", async ({
     page.locator(".model-refresh"),
     "claude_code is a bundled arm: Refresh could not change anything, so it is not offered",
   ).toHaveCount(0);
-  await expect(page.locator("[data-bundled-catalog]")).toBeVisible();
+  await expect(page.locator("app-ai-setup-block [data-bundled-catalog]")).toBeVisible();
 
   // The LIVE half of this property is asserted on the role rows, not here: the Setup card still
   // defers `ollama`/`gateway` to Advanced, and inlining their picker is the follow-up task. See
@@ -276,8 +276,8 @@ test("a role row can type an unlisted id against a NON-EMPTY catalog", async ({ 
     options: [{ id: "llama3.1:8b", label: "llama3.1:8b", source: "live" }],
   });
   const row = page.locator('[data-role="notes"]');
-  await expect(row.locator("select.role-model-select")).toBeVisible();
-  const input = row.locator("input.role-model-input");
+  await expect(row.locator("select.model-select")).toBeVisible();
+  const input = row.locator("input.model-input");
   await expect(
     input,
     "a role row must accept a newer model id even when its catalog is non-empty",
@@ -305,7 +305,7 @@ test("a role row KEEPS a usable model across a connection change and says it is 
     "ollama",
   );
   const row = page.locator('[data-role="notes"]');
-  const model = row.locator("input.role-model-input");
+  const model = row.locator("input.model-input");
   // An id the catalog does NOT list — the whole point is that such an id is legitimate. A listed
   // one would prove less: it needs no explanation, and the row correctly stays silent for it.
   await model.fill("llama4:70b");
@@ -335,7 +335,7 @@ test("a role row clears a model the new engine cannot send, and names it", async
     "ollama",
   );
   const row = page.locator('[data-role="notes"]');
-  const model = row.locator("input.role-model-input");
+  const model = row.locator("input.model-input");
   await model.fill(hfModel);
   await model.blur();
   await expect.poll(async () => model.inputValue()).toBe(hfModel);
@@ -365,9 +365,9 @@ test("switching a role to on-device KEEPS a real registry model id", async ({ pa
     "ollama",
   );
   const row = page.locator('[data-role="notes"]');
-  await row.locator("input.role-model-input").fill("qwen25-3b");
-  await row.locator("input.role-model-input").blur();
-  await expect.poll(async () => row.locator("input.role-model-input").inputValue()).toBe(
+  await row.locator("input.model-input").fill("qwen25-3b");
+  await row.locator("input.model-input").blur();
+  await expect.poll(async () => row.locator("input.model-input").inputValue()).toBe(
     "qwen25-3b",
   );
 
@@ -380,7 +380,7 @@ test("switching a role to on-device KEEPS a real registry model id", async ({ pa
 
   await row.locator("select").first().selectOption("ollama");
   await expect(
-    row.locator("input.role-model-input"),
+    row.locator("input.model-input"),
     "a valid on-device model id is a working per-role override, so it must survive",
   ).toHaveValue("qwen25-3b");
 });
@@ -403,7 +403,7 @@ test("switching a role to the on-device engine clears an unusable model AND says
     "ollama",
   );
   const row = page.locator('[data-role="notes"]');
-  const model = row.locator("input.role-model-input");
+  const model = row.locator("input.model-input");
   await model.fill("llama3.1:8b");
   await model.blur();
   await expect.poll(async () => model.inputValue()).toBe("llama3.1:8b");
@@ -417,7 +417,7 @@ test("switching a role to the on-device engine clears an unusable model AND says
 
   await row.locator("select").first().selectOption("ollama");
   await expect(
-    row.locator("input.role-model-input"),
+    row.locator("input.model-input"),
     "the clear is real, not cosmetic: the id must not reappear",
   ).toHaveValue("");
 });
@@ -442,7 +442,7 @@ test("switching a role to Inherit keeps the model, because nothing reads it ther
     "ollama",
   );
   const row = page.locator('[data-role="notes"]');
-  const model = row.locator("input.role-model-input");
+  const model = row.locator("input.model-input");
   await model.fill(hfModel);
   await model.blur();
   await expect.poll(async () => model.inputValue()).toBe(hfModel);
@@ -451,7 +451,7 @@ test("switching a role to Inherit keeps the model, because nothing reads it ther
   await expect(row.locator(".role-model-row")).toHaveCount(0);
   await row.locator("select").first().selectOption("ollama");
   await expect(
-    row.locator("input.role-model-input"),
+    row.locator("input.model-input"),
     "a detour through Inherit must not destroy a choice nothing there could have used",
   ).toHaveValue(hfModel);
 
@@ -493,9 +493,9 @@ test("the length mirror counts UTF-8 BYTES, like the backend does", async ({ pag
     .locator("app-ai-setup-block")
     .locator('select[formcontrolname="providerId"]')
     .selectOption("anthropic");
-  await page.locator("input.model-input").fill(nonAscii);
+  await page.locator("app-ai-setup-block input.model-input").fill(nonAscii);
   await expect(
-    page.locator("[data-model-refused]"),
+    page.locator("app-ai-setup-block [data-model-refused]"),
     "an id the backend measures as over-long must be flagged, whatever JavaScript counts",
   ).toBeVisible();
 
@@ -505,16 +505,16 @@ test("the length mirror counts UTF-8 BYTES, like the backend does", async ({ pag
   // Built from its code point rather than typed: a literal control character in a source file
   // is exactly what made `model-id.ts` reach reviewers as an unreadable binary blob.
   const withNel = `claude${String.fromCharCode(0x85)}opus`;
-  await page.locator("input.model-input").fill(withNel);
+  await page.locator("app-ai-setup-block input.model-input").fill(withNel);
   await expect(
-    page.locator("[data-model-refused]"),
+    page.locator("app-ai-setup-block [data-model-refused]"),
     "a C1 control character is a control character to Rust, so the mirror must refuse it too",
   ).toBeVisible();
 
   // ...and a legitimate non-ASCII id on a JSON-body arm is still accepted — the allowlist was
   // removed on purpose, and this keeps the two refusals above from passing for the wrong reason.
-  await page.locator("input.model-input").fill("vendor/modèle+preview");
-  await expect(page.locator("[data-model-refused]")).toHaveCount(0);
+  await page.locator("app-ai-setup-block input.model-input").fill("vendor/modèle+preview");
+  await expect(page.locator("app-ai-setup-block [data-model-refused]")).toHaveCount(0);
 });
 
 test("a role row flags a typed id the boundary would refuse", async ({ page }) => {
@@ -530,7 +530,7 @@ test("a role row flags a typed id the boundary would refuse", async ({ page }) =
     "claude_code",
   );
   const row = page.locator('[data-role="notes"]');
-  const model = row.locator("input.role-model-input");
+  const model = row.locator("input.model-input");
 
   await model.fill("-m");
   await expect(
@@ -551,19 +551,19 @@ test("a typed model id the backend would refuse says so while it is on screen", 
   // already discarded is the UI stating something untrue, so the check has to react to the value,
   // not to the engine.
   await openAiSettings(page, "");
-  const model = page.locator("input.model-input");
+  const model = page.locator("app-ai-setup-block input.model-input");
 
   // A leading `-` is read as a flag on an argv engine, so `valid_model_id` refuses it — the same
   // rejection an over-long id gets, but reachable by typing three characters.
   await model.fill("-m");
   await expect(
-    page.locator("[data-model-refused]"),
+    page.locator("app-ai-setup-block [data-model-refused]"),
     "an id that will not survive save must be flagged before save, not silently dropped",
   ).toBeVisible();
 
   // And the notice must be about THIS value, not a sticky flag: a legal id clears it.
   await model.fill("claude-opus-5");
-  await expect(page.locator("[data-model-refused]")).toHaveCount(0);
+  await expect(page.locator("app-ai-setup-block [data-model-refused]")).toHaveCount(0);
 });
 
 test("a role row with an EMPTY live catalog still offers Refresh", async ({ page }) => {
@@ -573,11 +573,11 @@ test("a role row with an EMPTY live catalog still offers Refresh", async ({ page
   await openRoleRows(page, { source: "live", options: [] }, "gateway");
   const row = page.locator('[data-role="notes"]');
   await expect(
-    row.locator(".role-model-refresh"),
+    row.locator(".model-refresh"),
     "an empty LIVE catalog is precisely when Refresh matters",
   ).toBeVisible();
   await expect(
-    row.locator("[data-role-bundled-catalog]"),
+    row.locator("[data-bundled-catalog]"),
     "a live catalog must never claim to ship with the app, however empty it is",
   ).toHaveCount(0);
 });
@@ -594,8 +594,8 @@ test("a role row with a bundled catalog says so instead of offering Refresh", as
     "claude_code",
   );
   const row = page.locator('[data-role="notes"]');
-  await expect(row.locator(".role-model-refresh")).toHaveCount(0);
-  await expect(row.locator("[data-role-bundled-catalog]")).toBeVisible();
+  await expect(row.locator(".model-refresh")).toHaveCount(0);
+  await expect(row.locator("[data-bundled-catalog]")).toBeVisible();
 });
 
 test("engine switch that drops a model explains itself", async ({ page }) => {
@@ -605,7 +605,7 @@ test("engine switch that drops a model explains itself", async ({ page }) => {
 
   // The id must survive the switch — being absent from a hint catalog commonly just means the
   // model shipped after this build.
-  await expect(page.locator("[data-unlisted-model]")).toContainText(FUTURE_MODEL);
+  await expect(page.locator("app-ai-setup-block [data-unlisted-model]")).toContainText(FUTURE_MODEL);
   const input = page.locator(".model-row input.model-input").first();
   await expect(input).toHaveValue(FUTURE_MODEL);
 });
@@ -631,3 +631,63 @@ test("options render labels, not raw ids", async ({ page }) => {
 function entry_id_only(): string {
   return CATALOG[0].id;
 }
+
+test("gateway and ollama get a picker in the Setup card, bound to their OWN control", async ({
+  page,
+}) => {
+  // Both engines used to render prose — "the model for Kong AI Gateway is set in its connection
+  // card under Advanced" — on the very screen the user opened to choose a model, and on the only
+  // two arms with a LIVE catalog worth refreshing.
+  //
+  // The trap this pins: `roles::legacy_default_target` returns "" for these two, and their
+  // providers read `gateway_model` / `ollama_model`. Binding `providerModel` here would look
+  // perfectly correct in the UI and write a field the backend never reads, so the assertion is on
+  // the SAVED CONFIG, not on the input's value.
+  await openAiSettings(page, "");
+  const setup = page.locator("app-ai-setup-block");
+  await setup.locator('select[formcontrolname="providerId"]').selectOption("ollama");
+
+  await expect(
+    setup.locator("mur-model-picker[formcontrolname=\"ollamaModel\"]"),
+    "the Setup card must offer a picker, not a pointer to another screen",
+  ).toBeVisible();
+  await expect(setup.getByText("is set in its connection card")).toHaveCount(0);
+
+  await setup.locator("input.model-input").fill("llama4:70b");
+  await expect
+    .poll(async () =>
+      page.evaluate(
+        () =>
+          (window as unknown as { __demoConfig?: Record<string, unknown> }).__demoConfig?.[
+            "ollamaModel"
+          ],
+      ),
+    )
+    .toBe("llama4:70b");
+
+  // ...and the value did NOT go to providerModel, which that arm ignores.
+  const providerModel = await page.evaluate(
+    () =>
+      (window as unknown as { __demoConfig?: Record<string, unknown> }).__demoConfig?.[
+        "providerModel"
+      ],
+  );
+  expect(
+    providerModel === "" || providerModel === undefined,
+    `ollama must write ollamaModel, not providerModel; providerModel was ${JSON.stringify(providerModel)}`,
+  ).toBeTruthy();
+});
+
+test("one accessor owns the control: typing is reflected by the select", async ({ page }) => {
+  // B5. The Setup card used to bind BOTH a <select> and an <input> to `providerModel`. Angular
+  // writes with `{emitModelToViewChange: false}`, so a value typed into one was never written into
+  // the other's view — two accessors, one control, silently diverging. They are one component now
+  // and share a single signal.
+  await openAiSettings(page, "");
+  const setup = page.locator("app-ai-setup-block");
+  await setup.locator("input.model-input").fill("claude-sonnet-5");
+  await expect(
+    setup.locator("select.model-select"),
+    "a value typed in the free-text field must be reflected by the dropdown of the same control",
+  ).toHaveValue("claude-sonnet-5");
+});

--- a/src/app/design-system/model-picker/model-picker.component.html
+++ b/src/app/design-system/model-picker/model-picker.component.html
@@ -1,0 +1,63 @@
+<div class="model-picker">
+  @if (options().length > 0) {
+    <select
+      #select
+      class="model-select"
+      [disabled]="isDisabled()"
+      [attr.aria-label]="ariaLabel()"
+      (change)="onSelect($event)"
+    >
+      <option value="" data-provider-default>{{ defaultLabel() }}</option>
+      @for (option of options(); track option.id) {
+        <option [value]="option.id">{{ option.label }}</option>
+      }
+      <!--
+        A stored id the catalog does not list stays selectable. Dropping it is how a newly released
+        model used to disappear from a user's config.
+      -->
+      @if (valueIsCustom()) {
+        <option [value]="value()">{{ value() }} (custom)</option>
+      }
+    </select>
+  }
+
+  <!--
+    ALWAYS rendered, not only when the catalog is empty. It used to live in the `@else` of the
+    catalog check, so a non-empty catalog made every unlisted model unreachable — which is exactly
+    the situation a model released after this build is in.
+  -->
+  <input
+    class="model-input"
+    type="text"
+    [value]="value()"
+    [disabled]="isDisabled()"
+    [attr.aria-label]="ariaLabel()"
+    [placeholder]="placeholder()"
+    autocomplete="off"
+    spellcheck="false"
+    (input)="onType($event)"
+  />
+
+  @if (canRefresh()) {
+    <button
+      type="button"
+      class="btn btn-ghost model-refresh"
+      [disabled]="loading() || isDisabled()"
+      title="Fetch this connection's model list"
+      (click)="onRefresh()"
+    >
+      @if (loading()) {
+        Loading…
+      } @else {
+        ↻ Refresh
+      }
+    </button>
+  }
+</div>
+
+@if (showsBundledNotice()) {
+  <p class="field-hint" data-bundled-catalog>
+    This list ships with the app, so a newer model may be missing — type its id above and it will be
+    used as-is.
+  </p>
+}

--- a/src/app/design-system/model-picker/model-picker.component.scss
+++ b/src/app/design-system/model-picker/model-picker.component.scss
@@ -1,0 +1,26 @@
+// Layout only. The controls themselves inherit the global form/`.btn` primitives from
+// `styles.css`, so this file adds no colours, radii or shadows of its own — every value here is a
+// design token.
+.model-picker {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+// Both controls share the same flex basis so the row does not jump when a catalog arrives and the
+// select appears next to the always-present free-text input.
+.model-select,
+.model-input {
+  flex: 1 1 220px;
+  min-width: 0;
+}
+
+.model-refresh {
+  flex: none;
+  white-space: nowrap;
+}
+
+.field-hint {
+  margin: var(--space-1) 0 0;
+}

--- a/src/app/design-system/model-picker/model-picker.component.ts
+++ b/src/app/design-system/model-picker/model-picker.component.ts
@@ -1,0 +1,177 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  computed,
+  effect,
+  forwardRef,
+  input,
+  model,
+  output,
+  signal,
+  viewChild,
+} from "@angular/core";
+import { NG_VALUE_ACCESSOR, type ControlValueAccessor } from "@angular/forms";
+import type { ModelCatalog } from "../../core/models";
+
+/**
+ * The ONE model picker.
+ *
+ * It existed three times before this: in `ai-setup-block`, in `ai-role-rows`, and again in the
+ * gateway/Ollama connection cards. Every fix had to be made in each copy, and one of them was
+ * missed for a full review round — the free-text id stayed hidden behind a non-empty catalog on the
+ * role rows after being fixed on the Setup card.
+ *
+ * The behaviour it owns, in one place:
+ *
+ *   - options render their LABEL, never a raw id;
+ *   - the free-text id is ALWAYS available, not only when the catalog is empty, because a bundled
+ *     catalog is a hint and a model released after this build must still be selectable;
+ *   - a value absent from the catalog is kept and shown as custom, never cleared;
+ *   - Refresh appears unless the catalog is KNOWN bundled — `!== "bundled"` rather than
+ *     `=== "live"`, so a failed fetch (no catalog at all) still offers the retry that is the whole
+ *     point at that moment;
+ *   - a bundled catalog says so instead of staying silent.
+ *
+ * ONE ControlValueAccessor per FormControl. The Setup card used to bind both a `<select>` and an
+ * `<input>` to the same control; Angular writes with `{emitModelToViewChange: false}`, so a value
+ * typed into one was never written back into the other's view. Both live inside this component now
+ * and share one signal, which is what makes them agree.
+ */
+@Component({
+  selector: "mur-model-picker",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: "./model-picker.component.html",
+  styleUrl: "./model-picker.component.scss",
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => MurModelPickerComponent),
+      multi: true,
+    },
+  ],
+})
+export class MurModelPickerComponent implements ControlValueAccessor {
+  /** The connection's catalog. `undefined` = never fetched, or the fetch failed. */
+  readonly catalog = input<ModelCatalog | undefined>(undefined);
+
+  /** True while a `list_models` call for this connection is in flight. */
+  readonly loading = input(false);
+
+  /** Shown in the empty option: "Default (provider's pick)" vs "Default (connection's pick)". */
+  readonly defaultLabel = input("Default (provider's pick)");
+
+  /** Free-text placeholder — the two surfaces word "blank means default" differently. */
+  readonly placeholder = input("Model id (blank = default)");
+
+  readonly ariaLabel = input<string | null>(null);
+
+  /** Emitted when the user asks for a re-fetch. The parent owns the IPC call. */
+  readonly refresh = output<void>();
+
+  /**
+   * Emitted when the USER edits the value, as opposed to a programmatic `writeValue`.
+   *
+   * The role rows use it to dismiss a "this model was cleared because…" notice once the user has
+   * chosen a replacement: without that, the explanation outlived the thing it explained. It is a
+   * separate output rather than a `valueChanges` subscription in the parent because only the
+   * component can tell a user edit from a form patch.
+   */
+  readonly modelEdited = output<void>();
+
+  /** The selected model id. Two-way (`[(value)]`) AND the CVA's model. */
+  readonly value = model("");
+
+  readonly disabled = input(false);
+  private readonly cvaDisabled = signal(false);
+  readonly isDisabled = computed(() => this.disabled() || this.cvaDisabled());
+
+  readonly options = computed(() => this.catalog()?.options ?? []);
+
+  /**
+   * Whether this connection HAS a live catalog to re-fetch — an ENGINE property, supplied by the
+   * parent, never derived from `catalog.source`.
+   *
+   * Deriving it here was wrong and a spec already pins why: `claude_code` returning a bundled list
+   * is not the same fact as `ollama` returning one. A source-derived rule makes Refresh appear or
+   * vanish according to what the last fetch happened to return, so an Ollama daemon that answered
+   * from cache would hide the button at the exact moment the user wants it. The connection decides;
+   * the catalog only reports what came back.
+   */
+  readonly canRefresh = input(false);
+
+  /**
+   * A bundled catalog is a hint that may be stale, and the UI says so rather than implying currency.
+   * Read from the CATALOG's provenance, not from any option's: an empty live catalog has no option
+   * to carry a source, and must not be mislabelled as shipping with the app.
+   */
+  readonly showsBundledNotice = computed(
+    () => !this.canRefresh() && this.options().length > 0,
+  );
+
+  /** A stored id the catalog does not list — kept selectable instead of silently dropped. */
+  readonly valueIsCustom = computed(() => {
+    const current = this.value();
+    if (!current) return false;
+    return !this.options().some((o) => o.id === current);
+  });
+
+  private readonly selectEl = viewChild<ElementRef<HTMLSelectElement>>("select");
+
+  /**
+   * Write the value onto the `<select>` DOM PROPERTY, after its options exist.
+   *
+   * `[value]="value()"` does not work here and the failure is silent: a `<select>` ignores a value
+   * for which it has no matching `<option>`, and the property binding can run before the `@for`
+   * has created them. The stored id then renders as an empty dropdown — the exact "the field shows
+   * nothing while config holds a value" symptom this whole feature exists to remove.
+   *
+   * This effect re-runs on the value AND on the options, so the assignment always happens once the
+   * matching option is present. Same lesson as the signal-CVA revert trap already recorded for this
+   * codebase: a `ControlValueAccessor` built on signals must sync the DOM property itself.
+   */
+  private readonly _syncSelect = effect(() => {
+    const el = this.selectEl()?.nativeElement;
+    const current = this.value();
+    // Track the options so a late catalog re-runs this.
+    this.options();
+    this.valueIsCustom();
+    if (el && el.value !== current) el.value = current;
+  });
+
+  private onChange: (v: string) => void = () => undefined;
+  private onTouched: () => void = () => undefined;
+
+  writeValue(v: unknown): void {
+    this.value.set(v == null ? "" : String(v));
+  }
+  registerOnChange(fn: (v: string) => void): void {
+    this.onChange = fn;
+  }
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+  setDisabledState(d: boolean): void {
+    this.cvaDisabled.set(d);
+  }
+
+  /** Both controls write through here, so the select and the free-text input can never disagree. */
+  private commit(next: string): void {
+    this.value.set(next);
+    this.onChange(next);
+    this.onTouched();
+    this.modelEdited.emit();
+  }
+
+  onSelect(e: Event): void {
+    this.commit((e.target as HTMLSelectElement).value);
+  }
+
+  onType(e: Event): void {
+    this.commit((e.target as HTMLInputElement).value);
+  }
+
+  onRefresh(): void {
+    this.refresh.emit();
+  }
+}

--- a/src/app/features/settings/sections/ai/ai-role-rows/ai-role-rows.component.html
+++ b/src/app/features/settings/sections/ai/ai-role-rows/ai-role-rows.component.html
@@ -73,84 +73,39 @@
 
           @if (row.isProviderConn) {
             <div class="role-model-row">
-              @if (row.models.length > 0) {
-                <select
-                  [formControlName]="row.modelCtrl"
-                  class="role-model-select"
-                >
-                  <option value="">Default (connection's pick)</option>
-                  @for (option of row.models; track option.id) {
-                    <option [value]="option.id">{{ option.label }}</option>
-                  }
-                  <!--
-                    Keep a manually-typed model selectable when it's not in
-                    the catalog — never silently lose it (the gateway
-                    picker's keep-manually-typed pattern).
-                  -->
-                  @if (row.modelIsCustom) {
-                    <option [value]="row.modelValue">
-                      {{ row.modelValue }} (custom)
-                    </option>
-                  }
-                </select>
-              }
               <!--
-                ALWAYS available, not only when the catalog is empty. This input used to live in the
-                `@else` of the catalog check — the same shape as the Setup card's old bug — so a
-                non-empty catalog made every unlisted id unreachable on this surface, which is the
-                entire behaviour this change exists to fix.
+                The SAME picker the Setup card uses. This surface used to carry its own copy, and
+                that is how a defect fixed on one lived on here for a full review round: the
+                free-text id stayed hidden behind a non-empty catalog after the Setup card had
+                already been fixed. One component, one behaviour, fixed once.
               -->
-              <input
+              <mur-model-picker
                 [formControlName]="row.modelCtrl"
+                [ariaLabel]="row.title + ' model'"
+                defaultLabel="Default (connection's pick)"
                 placeholder="Model id (blank = connection default)"
-                autocomplete="off"
-                spellcheck="false"
-                class="role-model-input"
-                (input)="onModelEdited(row.role)"
+                [catalog]="row.catalog"
+                [canRefresh]="row.catalogIsLive"
+                [loading]="row.modelsLoading"
+                (refresh)="refreshModels(row.conn)"
+                (modelEdited)="onModelEdited(row.role)"
               />
-              <!--
-                Refresh only where refreshing means something. A role row can select `ollama` or
-                `gateway` — the LIVE-fetched arms — so the button belongs here; a bundled catalog is
-                compiled into the binary and the button could not change it. Read from
-                `catalogIsLive` (the CATALOG's provenance), never from the options, so an empty live
-                catalog — a gateway answering with zero models, exactly when Refresh matters — still
-                offers it.
-              -->
-              @if (row.catalogIsLive) {
-                <button
-                  type="button"
-                  class="btn btn-ghost role-model-refresh"
-                  (click)="refreshModels(row.conn)"
-                  [disabled]="row.modelsLoading"
-                  title="Fetch this connection's model list"
-                >
-                  @if (row.modelsLoading) {
-                    Loading…
-                  } @else {
-                    ↻ Refresh
-                  }
-                </button>
-              } @else if (row.models.length > 0) {
-                <p class="field-hint" data-role-bundled-catalog>
-                  Ships with the app — a newer model may be missing; type its id above.
-                </p>
-              }
-              @if (refusedTypedModels().has(row.role)) {
-                <p class="field-hint" data-role-model-refused>
+            </div>
+            @if (refusedTypedModels().has(row.role)) {
+              <p class="field-hint" data-role-model-refused>
                   This is not a usable model id for the selected engine — it will not be saved.
                   Model ids are short and contain only letters, digits and
                   <code>. - _ : / &#64;</code>.
                 </p>
               }
-              @if (connectionChangeNotice()[row.role]; as notice) {
-                @if (notice.outcome === "kept") {
+            @if (connectionChangeNotice()[row.role]; as notice) {
+              @if (notice.outcome === "kept") {
                   <p class="field-hint" data-role-kept-model>
                     {{ notice.model }} is not in this engine's list. It has been kept — clear it
                     only if you want the engine to pick.
                   </p>
                 }
               }
-            </div>
 
             @if (row.conn === "anthropic") {
               <label class="field">

--- a/src/app/features/settings/sections/ai/ai-role-rows/ai-role-rows.component.ts
+++ b/src/app/features/settings/sections/ai/ai-role-rows/ai-role-rows.component.ts
@@ -11,7 +11,8 @@ import {
   viewChild,
 } from "@angular/core";
 import { ReactiveFormsModule } from "@angular/forms";
-import type { ModelOption } from "../../../../../core/models";
+import type { ModelCatalog, ModelOption } from "../../../../../core/models";
+import { MurModelPickerComponent } from "../../../../../design-system/model-picker/model-picker.component";
 import { connectionKeepsModelId, effectiveConnection } from "../../../model-id";
 import { SettingsStore } from "../../../settings.store";
 
@@ -38,6 +39,9 @@ interface RoleRowVm {
   readonly conn: string;
   readonly isProviderConn: boolean;
   readonly models: readonly ModelOption[];
+  /** The whole catalog, so the picker can read PROVENANCE — an empty live one still says
+   *  it was fetched, which no option list can express. */
+  readonly catalog: ModelCatalog | undefined;
   /**
    * Whether this row's catalog was FETCHED rather than compiled in. Read from the catalog, not
    * from its options: an empty live catalog has no option to carry a source, and that is exactly
@@ -64,7 +68,7 @@ interface RoleRowVm {
 @Component({
   selector: "app-ai-role-rows",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ReactiveFormsModule],
+  imports: [ReactiveFormsModule, MurModelPickerComponent],
   templateUrl: "./ai-role-rows.component.html",
   styleUrl: "./ai-role-rows.component.scss",
 })
@@ -223,6 +227,7 @@ export class AiRoleRowsComponent {
       conn,
       isProviderConn,
       models,
+      catalog: isProviderConn ? this.store.modelCatalogs()[conn] : undefined,
       catalogIsLive:
         isProviderConn && this.store.connectionHasLiveCatalog(conn),
       modelsLoading: isProviderConn && this.store.modelsLoading().has(conn),

--- a/src/app/features/settings/sections/ai/ai-setup-block/ai-setup-block.component.html
+++ b/src/app/features/settings/sections/ai/ai-setup-block/ai-setup-block.component.html
@@ -22,106 +22,74 @@
         </label>
 
         <!--
-          Model + reasoning-effort. providerModel steers the claude_code,
-          codex_cli and anthropic arms (gateway/ollama read their own connection-card
-          model), so the picker renders for those three — for gateway/ollama we
-          point at the connection card, now under Advanced.
+          ONE picker for every engine.
+
+          `gateway` and `ollama` used to render prose pointing at their connection card under
+          Advanced — a dead end on the very screen the user opened in order to choose a model, and
+          on the only two arms with a LIVE catalog worth refreshing. They bind their OWN control
+          (`gatewayModel` / `ollamaModel`), because `roles::legacy_default_target` returns "" for
+          them and their providers read those fields: binding `providerModel` there would look
+          correct and do nothing at all.
         -->
-        @switch (form.controls.providerId.value) {
-          @case ("gateway") {
-            <p class="field-help text-muted">
-              The model for Kong AI Gateway is set in its connection card
-              under Advanced.
-            </p>
-          }
-          @case ("ollama") {
-            <p class="field-help text-muted">
-              The model for Ollama is set in its connection card under
-              Advanced.
-            </p>
-          }
-          @default {
-            <div class="field">
-              <span class="field-label">Model</span>
-              <div class="model-row">
-                @if (defaultModelCatalog().length > 0) {
-                  <select formControlName="providerModel" class="model-select">
-                    <option value="" data-provider-default>
-                      Default (provider's pick)
-                    </option>
-                    @for (option of defaultModelCatalog(); track option.id) {
-                      <option [value]="option.id">{{ option.label }}</option>
-                    }
-                    @if (defaultModelIsCustom()) {
-                      <option [value]="form.controls.providerModel.value">
-                        {{ form.controls.providerModel.value }} (custom)
-                      </option>
-                    }
-                  </select>
-                }
-                <!--
-                  The free-text id is ALWAYS available, not only when the catalog is empty. A
-                  bundled catalog is a hint, so the moment a new model ships it is typeable here
-                  without waiting for a release — which is the entire point of this change. It used
-                  to live in the `@else` of the catalog check, so a non-empty list made every
-                  unlisted model unreachable.
-                -->
-                <input
-                  formControlName="providerModel"
-                  placeholder="Model id (blank = provider's pick)"
-                  autocomplete="off"
-                  spellcheck="false"
-                  class="model-input"
+        <div class="field">
+          <span class="field-label">Model</span>
+          <div class="model-row">
+            @switch (form.controls.providerId.value) {
+              @case ("gateway") {
+                <mur-model-picker
+                  formControlName="gatewayModel"
+                  ariaLabel="Model for Kong AI Gateway"
+                  defaultLabel="Default (gateway's pick)"
+                  [catalog]="activeCatalog()"
+                  [canRefresh]="defaultCatalogIsLive()"
+                  [loading]="defaultModelsLoading()"
+                  (refresh)="refreshDefaultModels()"
                 />
-                <!--
-                  Refresh only where refreshing means something. A "bundled" catalog is compiled
-                  into the binary, so the button could never change it — offering it there taught
-                  the user the list was live when it was a constant.
-                -->
-                @if (defaultCatalogIsLive()) {
-                  <button
-                    type="button"
-                    class="btn btn-ghost model-refresh"
-                    (click)="refreshDefaultModels()"
-                    [disabled]="defaultModelsLoading()"
-                    title="Fetch this provider's model list"
-                  >
-                    @if (defaultModelsLoading()) {
-                      Loading…
-                    } @else {
-                      ↻ Refresh
-                    }
-                  </button>
-                }
-              </div>
-              @if (!defaultCatalogIsLive() && defaultModelCatalog().length > 0) {
-                <p class="field-hint" data-bundled-catalog>
-                  This list ships with the app, so a newer model may be missing — type its id
-                  above and it will be used as-is.
-                </p>
               }
-              @if (typedModelWillBeRefused()) {
-                <p class="field-hint" data-model-refused>
-                  This is not a usable model id for the selected engine — it will not be saved.
-                  Model ids are short and contain only letters, digits and
-                  <code>. - _ : / &#64;</code>.
-                </p>
+              @case ("ollama") {
+                <mur-model-picker
+                  formControlName="ollamaModel"
+                  ariaLabel="Model for Ollama"
+                  defaultLabel="Default (Ollama's pick)"
+                  [catalog]="activeCatalog()"
+                  [canRefresh]="defaultCatalogIsLive()"
+                  [loading]="defaultModelsLoading()"
+                  (refresh)="refreshDefaultModels()"
+                />
               }
-              @if (droppedAfterEngineSwitch(); as dropped) {
-                <p class="field-hint" data-dropped-model>
-                  {{ dropped }} is not a model id this engine can use, so it has been cleared —
-                  pick a model above, or leave it blank to let the engine choose.
-                </p>
+              @default {
+                <mur-model-picker
+                  formControlName="providerModel"
+                  ariaLabel="Default model"
+                  defaultLabel="Default (provider's pick)"
+                  [catalog]="activeCatalog()"
+                  [canRefresh]="defaultCatalogIsLive()"
+                  [loading]="defaultModelsLoading()"
+                  (refresh)="refreshDefaultModels()"
+                />
               }
-              @if (unlistedAfterEngineSwitch(); as unlisted) {
-                <p class="field-hint" data-unlisted-model>
-                  {{ unlisted }} is not in this engine's list. It has been kept — clear it only if
-                  you want the provider to pick.
-                </p>
-              }
-            </div>
+            }
+          </div>
+          @if (typedModelWillBeRefused()) {
+            <p class="field-hint" data-model-refused>
+              This is not a usable model id for the selected engine — it will not be saved.
+              Model ids are short and contain only letters, digits and
+              <code>. - _ : / &#64;</code>.
+            </p>
           }
-        }
+          @if (droppedAfterEngineSwitch(); as dropped) {
+            <p class="field-hint" data-dropped-model>
+              {{ dropped }} is not a model id this engine can use, so it has been cleared —
+              pick a model above, or leave it blank to let the engine choose.
+            </p>
+          }
+          @if (unlistedAfterEngineSwitch(); as unlisted) {
+            <p class="field-hint" data-unlisted-model>
+              {{ unlisted }} is not in this engine's list. It has been kept — clear it only if
+              you want the provider to pick.
+            </p>
+          }
+        </div>
 
         @if (form.controls.providerId.value === "anthropic") {
           <label class="field">

--- a/src/app/features/settings/sections/ai/ai-setup-block/ai-setup-block.component.ts
+++ b/src/app/features/settings/sections/ai/ai-setup-block/ai-setup-block.component.ts
@@ -6,6 +6,7 @@ import {
   signal,
 } from "@angular/core";
 import { ReactiveFormsModule } from "@angular/forms";
+import { MurModelPickerComponent } from "../../../../../design-system/model-picker/model-picker.component";
 import { defaultEngineKeepsModelId } from "../../../model-id";
 import { SettingsStore } from "../../../settings.store";
 
@@ -35,7 +36,7 @@ import { SettingsStore } from "../../../settings.store";
 @Component({
   selector: "app-ai-setup-block",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ReactiveFormsModule],
+  imports: [ReactiveFormsModule, MurModelPickerComponent],
   templateUrl: "./ai-setup-block.component.html",
   styleUrl: "./ai-setup-block.component.scss",
 })
@@ -57,6 +58,17 @@ export class AiSetupBlockComponent {
   readonly defaultCatalogIsLive = this.store.defaultCatalogIsLive;
   readonly defaultModelsLoading = this.store.defaultModelsLoading;
   readonly defaultModelIsCustom = this.store.defaultModelIsCustom;
+
+  /**
+   * The catalog for the CURRENTLY SELECTED engine — the whole `ModelCatalog`, not its options.
+   *
+   * The picker needs the catalog itself because provenance lives there: an empty LIVE catalog still
+   * has to say it was fetched, and an option list cannot carry that. `undefined` means never
+   * fetched or the fetch failed, which the picker renders as "unknown" rather than as "bundled".
+   */
+  readonly activeCatalog = computed(
+    () => this.store.modelCatalogs()[this.store.providerIdValue() ?? ""],
+  );
 
   // ── on-device status wires (the full picker lives under Advanced) ────────────
   readonly brainDownloadingId = this.store.brainDownloadingId;


### PR DESCRIPTION
## One `mur-model-picker`, and no engine that sends you somewhere else

> **Built on #552, and retargeted at `murmur` so CI actually runs.** The workflow only triggers for
> PRs targeting `murmur`, so while this was based on `feat/model-catalog-is-a-hint` it had no checks
> at all. It now carries #552's two commits as well; **this PR's own change is the last commit**
> (`refactor(settings): one mur-model-picker…`). Merge #552 first and the diff here collapses to
> that one commit.

### Why

The model picker existed **three times** — `ai-setup-block`, `ai-role-rows`, and the connection
cards. Every fix had to be made in each copy, and #552 is the proof that this costs real defects:
the free-text id stayed hidden behind a non-empty catalog on the role rows for a full review round
*after* the same bug had been fixed on the Setup card.

Two engines also sent the user away. Selecting `gateway` or `ollama` as the default replaced the
picker with prose — *"The model for Kong AI Gateway is set in its connection card under Advanced."*
Those are the only two arms with a **live** catalog, so the one place the picker is most useful was
the one place it was not offered.

### What this changes

- **`src/app/design-system/model-picker/`** — standalone, `OnPush`, signals, implementing
  `ControlValueAccessor` so `formControlName` binds directly. It owns: labelled options, an
  always-available free-text id, a value the catalog does not list kept as *(custom)*, Refresh
  driven by the **connection**, and a bundled-catalog notice otherwise.
- **Both surfaces use it**; their duplicated markup is gone.
- **`gateway` and `ollama` get a real picker in the Setup card.** They bind their **own** control —
  `gatewayModel` / `ollamaModel` — because `roles::legacy_default_target` returns `""` for them and
  their providers read those fields. Binding `providerModel` there would look perfectly correct in
  the UI and write a field the backend never reads, so the spec asserts on the **saved config**,
  not on the input's value.
- **One accessor per control.** The Setup card bound both a `<select>` and an `<input>` to
  `providerModel`. Angular writes with `{emitModelToViewChange: false}`, so a value typed into one
  was never written into the other's view — two accessors on one control, silently diverging.

### One trap worth reading

The `<select>` value is written as a **DOM property from an effect**, not through `[value]`. A
`<select>` silently ignores a value it has no matching `<option>` for, and the property binding can
run before `@for` has created them — so a stored id rendered as an **empty dropdown**, which is
precisely the "the field shows nothing while config holds a value" symptom this whole feature exists
to remove. This repo has the lesson recorded already (the signal-CVA revert trap): a
`ControlValueAccessor` built on signals must sync the DOM property itself.

### Verification

- `ng lint`, `ng build` — clean, within the 16 kB per-component style budget.
- **The full Playwright suite: 446 passed, 2 skipped**, on chromium **and** webkit — not only the
  settings specs, because this touches a shared component.
- `scripts/agent-config-audit --ci` — PASS.
- **Both new specs RED-checked**: re-binding `ollama` to `providerModel` fails exactly the binding
  spec and nothing else.

### Spec changes, and why they are not a weakening

The existing specs' **assertions are untouched**; only locators moved, for two mechanical reasons:

1. `formControlName` now sits on the `<mur-model-picker>` host rather than on the `<input>`, so
   `input[formcontrolname="providerModel"]` became
   `mur-model-picker[formcontrolname="providerModel"] input.model-input` — still naming the control
   it means.
2. Both surfaces now emit the same class names and markers, so page-wide locators became ambiguous
   and are scoped to the surface under test. The role rows previously relied on having *different*
   markers from the Setup card, which was under-specification: a test that only passes because two
   copies of a component are spelled differently is testing the duplication, not the behaviour.

### Out of scope

Which ids are valid, how they are validated, or what reaches a CLI — all of that is #552 and is
untouched here. The connection cards under Advanced keep their own controls; this only stops the
Setup card from deferring to them.
