### PR TITLE
fix(harness): make the isolated worktree the default, and guard the primary checkout

### DIFF
--- a/.agents/harness/hook_guard.py
+++ b/.agents/harness/hook_guard.py
@@ -594,13 +594,48 @@ def _primary_branch_surgery_reason(invocation: GitInvocation) -> Optional[str]:
         else (top / common_raw).resolve()
     )
     live = _live_harness_task_ids(common)
-    if not live:
+    if live:
+        preview = ", ".join(live[:3]) + ("…" if len(live) > 3 else "")
+        return (
+            f"primary-checkout branch surgery is blocked while Harness task(s) "
+            f"are live or state-unknown ({preview}); continue from the isolated task/driver worktree "
+            "and use server-side PR merge"
+        )
+
+    # A live Harness task is not the only way the primary checkout is occupied.
+    # An ordinary concurrent session — another agent, or the operator — leaves no
+    # task record at all, so keying solely on `live` made the guard weakest
+    # exactly when the neighbour was least formal. `git checkout -b` in that
+    # window moves HEAD under their feet and re-attributes their uncommitted work
+    # to the new branch. That is the incident this arm exists for; the recovery
+    # (switching back) is what the override below is for.
+    #
+    # Scoped to branch selection only. merge/rebase/reset/cherry-pick/pull stay on
+    # the harness-task arm above: Git already refuses those when they would clobber
+    # a dirty tree, and `git reset` on dirty state is ordinary, intended work.
+    if invocation.subcommand not in {"checkout", "switch"}:
         return None
-    preview = ", ".join(live[:3]) + ("…" if len(live) > 3 else "")
+    if os.environ.get("MURMUR_ALLOW_PRIMARY_BRANCH_SURGERY") == "1":
+        return None
+    # TRACKED modifications only (`--untracked-files=no`). Untracked files are the
+    # loud majority of a working repo's `--porcelain` output and are precisely the
+    # entries branch selection CANNOT mis-attribute: they belong to no branch, they
+    # carry over untouched, and Git refuses on its own when a target branch would
+    # overwrite one. Counting them would fire this guard on a tree full of stray
+    # scratch docs — and an over-eager guard gets routed around, which is strictly
+    # worse than no guard. Staged and unstaged edits to tracked files are the ones
+    # that follow HEAD onto the new branch, so they are what this measures.
+    dirty = _git_text(top, "status", "--porcelain", "--untracked-files=no", check=False)
+    entries = [line for line in dirty.splitlines() if line.strip()]
+    if not entries:
+        return None
     return (
-        f"primary-checkout branch surgery is blocked while Harness task(s) "
-        f"are live or state-unknown ({preview}); continue from the isolated task/driver worktree "
-        "and use server-side PR merge"
+        f"primary-checkout branch selection is blocked while its working tree has "
+        f"{len(entries)} uncommitted tracked change(s) that may belong to a "
+        "concurrent session; create an isolated checkout with `git worktree add "
+        "<path> origin/murmur` instead. If the tree is provably yours (or you are "
+        "restoring the branch you moved off), re-run with "
+        "MURMUR_ALLOW_PRIMARY_BRANCH_SURGERY=1"
     )
 
 
@@ -2122,6 +2157,82 @@ def _run_selftest() -> int:
         for label, cmd in anti_bypass_dev:
             got = "DEV" if resource_policy.command_is_dev_in(cmd, SOURCE_ROOT) else "NOT-DEV"
             test.result(f"anti-bypass classifier: {label}", got, "DEV")
+
+    print("-- primary-checkout branch selection vs a concurrent session --")
+    # RED-before-GREEN oracle for the 2026-08-03 incident: `git checkout -b` was
+    # run in the primary checkout while another session held `feat/dashboards`
+    # with 29 uncommitted entries. The guard existed but keyed solely on live
+    # Harness tasks, so an ordinary concurrent session — which registers no task —
+    # left it silent. These cases FAIL on the pre-fix guard and pass after it.
+    for vendor in ("codex", "claude"):
+        with tempfile.TemporaryDirectory(prefix="murmur-hook-branch-") as temp:
+            repo = Path(temp) / "repo"
+            _init_repo(repo)  # already leaves a committed, CLEAN tree
+
+            # Clean primary checkout: branch selection stays allowed.
+            test.expect(
+                "clean primary: checkout -b", vendor, "block-bash",
+                "git checkout -b feature/y", repo, "ALLOW",
+            )
+            test.expect(
+                "clean primary: switch -c", vendor, "block-bash",
+                "git switch -c feature/z", repo, "ALLOW",
+            )
+
+            # Untracked scratch files alone must NOT trip the guard: branch
+            # selection cannot mis-attribute them, and a working repo is full of
+            # them. This is the false-positive floor.
+            (repo / "scratch.txt").write_text("stray\n", encoding="utf-8")
+            test.expect(
+                "untracked-only primary: checkout -b", vendor, "block-bash",
+                "git checkout -b feature/y", repo, "ALLOW",
+            )
+
+            # Someone else's uncommitted work to a TRACKED file — this is what
+            # follows HEAD onto the new branch.
+            (repo / "base.txt").write_text("concurrent edit\n", encoding="utf-8")
+
+            test.expect(
+                "dirty primary: checkout -b", vendor, "block-bash",
+                "git checkout -b feature/y", repo, "BLOCK",
+            )
+            test.expect(
+                "dirty primary: switch -c", vendor, "block-bash",
+                "git switch -c feature/z", repo, "BLOCK",
+            )
+            test.expect(
+                "dirty primary: plain branch switch", vendor, "block-bash",
+                "git checkout feature/other", repo, "BLOCK",
+            )
+            # Scoped to branch selection — `git reset` on a dirty tree is ordinary
+            # intended work and must stay allowed (Git refuses the clobbering cases
+            # on its own).
+            test.expect(
+                "dirty primary: reset stays allowed", vendor, "block-bash",
+                "git reset HEAD~1", repo, "ALLOW",
+            )
+            # Creating the isolated checkout is the prescribed escape and must
+            # never be blocked.
+            test.expect(
+                "dirty primary: worktree add", vendor, "block-bash",
+                "git worktree add ../wt origin/murmur", repo, "ALLOW",
+            )
+            # Deliberate override for "the tree is provably mine" / recovery.
+            got, _ = test.invoke(
+                vendor, "block-bash", "git checkout -b feature/y", repo,
+                extra_env={"MURMUR_ALLOW_PRIMARY_BRANCH_SURGERY": "1"},
+            )
+            test.result(f"{vendor}: dirty primary: explicit override", got, "ALLOW")
+
+            # A LINKED worktree is the sanctioned place to work; its own dirty
+            # state must not trip the primary-checkout arm.
+            linked = Path(temp) / "linked"
+            _run(["git", "worktree", "add", "-q", "-b", "wt/branch", str(linked)], repo)
+            (linked / "mine.txt").write_text("mine\n", encoding="utf-8")
+            test.expect(
+                "linked worktree: dirty checkout -b", vendor, "block-bash",
+                "git checkout -b feature/in-worktree", linked, "ALLOW",
+            )
 
     print("-- staged secret scan (no path exclusions) --")
     for vendor in ("codex", "claude"):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,13 +133,32 @@ to implement.** Splitting those two loses every implicit decision made while exp
 by context boundary, not by task type.
 
 ```bash
-git checkout -b <slug>
+# ISOLATED CHECKOUT FIRST — never `git checkout -b` in the primary checkout.
+git worktree add -b <slug> ../.murmur-agent-tasks/<slug> origin/murmur
+cd ../.murmur-agent-tasks/<slug>
 # plan AND implement here
 scripts/agent-config-audit --ci                        # 0.1s — run it every time
 (cd src-tauri && cargo test --lib) && npx ng lint && npx ng build
 git commit && gh pr create -R murmur-io/murmur
 # CI red? ANOTHER COMMIT ON THE SAME BRANCH — never a new task id.
+# After the PR merges:  git worktree remove ../.murmur-agent-tasks/<slug>
 ```
+
+**Why a worktree and not `git checkout -b`.** This block used to say `git checkout -b <slug>`,
+which contradicted `ship-feature`'s own "ordinary low-risk fixes keep the normal isolated-worktree
+route" — and since THIS file is the one loaded into every session, the unsafe half won by default.
+The primary checkout is routinely shared: another agent session or the operator can be mid-change on
+their own branch, with uncommitted work in the tree. `git checkout -b` there moves HEAD under them
+and re-attributes their work to your new branch. That is not hypothetical — it happened on
+2026-08-03, branching off a live `feat/dashboards` with 29 uncommitted entries in the tree
+(recovered, nothing lost, because `checkout -b` commits nothing). `hook_guard.py`
+`_primary_branch_surgery_reason` now refuses branch selection in a dirty primary checkout;
+`MURMUR_ALLOW_PRIMARY_BRANCH_SURGERY=1` is the deliberate override for when the tree is provably
+yours or you are restoring the branch you moved off.
+
+Control-plane changes (`.claude/**`, `.codex/**`, `.agents/**`, `CLAUDE.md`, `AGENTS.md`, reviewer
+prompts) cannot be certified by the Harness and go in a worktree **outside** the runner-owned
+`../.murmur-agent-tasks` root — for example `../.murmur-control-plane/<slug>`.
 
 `agent-config-audit` is first because it is the cheapest check in the repo and the only one that
 sees a whole class of defect the others cannot. Measured on PR #535: `cargo test --lib`, `ng lint`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,13 +133,32 @@ to implement.** Splitting those two loses every implicit decision made while exp
 by context boundary, not by task type.
 
 ```bash
-git checkout -b <slug>
+# ISOLATED CHECKOUT FIRST — never `git checkout -b` in the primary checkout.
+git worktree add -b <slug> ../.murmur-agent-tasks/<slug> origin/murmur
+cd ../.murmur-agent-tasks/<slug>
 # plan AND implement here
 scripts/agent-config-audit --ci                        # 0.1s — run it every time
 (cd src-tauri && cargo test --lib) && npx ng lint && npx ng build
 git commit && gh pr create -R murmur-io/murmur
 # CI red? ANOTHER COMMIT ON THE SAME BRANCH — never a new task id.
+# After the PR merges:  git worktree remove ../.murmur-agent-tasks/<slug>
 ```
+
+**Why a worktree and not `git checkout -b`.** This block used to say `git checkout -b <slug>`,
+which contradicted `ship-feature`'s own "ordinary low-risk fixes keep the normal isolated-worktree
+route" — and since THIS file is the one loaded into every session, the unsafe half won by default.
+The primary checkout is routinely shared: another agent session or the operator can be mid-change on
+their own branch, with uncommitted work in the tree. `git checkout -b` there moves HEAD under them
+and re-attributes their work to your new branch. That is not hypothetical — it happened on
+2026-08-03, branching off a live `feat/dashboards` with 29 uncommitted entries in the tree
+(recovered, nothing lost, because `checkout -b` commits nothing). `hook_guard.py`
+`_primary_branch_surgery_reason` now refuses branch selection in a dirty primary checkout;
+`MURMUR_ALLOW_PRIMARY_BRANCH_SURGERY=1` is the deliberate override for when the tree is provably
+yours or you are restoring the branch you moved off.
+
+Control-plane changes (`.claude/**`, `.codex/**`, `.agents/**`, `CLAUDE.md`, `AGENTS.md`, reviewer
+prompts) cannot be certified by the Harness and go in a worktree **outside** the runner-owned
+`../.murmur-agent-tasks` root — for example `../.murmur-control-plane/<slug>`.
 
 `agent-config-audit` is first because it is the cheapest check in the repo and the only one that
 sees a whole class of defect the others cannot. Measured on PR #535: `cargo test --lib`, `ng lint`


### PR DESCRIPTION
## What broke

The binding development loop in `CLAUDE.md` / `AGENTS.md` told every session to start with:

```bash
git checkout -b <slug>
```

…in the **primary checkout**. Meanwhile `.claude/skills/ship-feature/SKILL.md:3` says *"ordinary
low-risk fixes keep the normal **isolated-worktree** route."* Two binding documents, opposite
instructions — and the one that loads into every session unprompted carried the unsafe half, so it
won by default.

On 2026-08-03 that fired: a session branched off a live `feat/dashboards` that held **11 uncommitted
tracked changes** belonging to a concurrent session, moving HEAD under it. Nothing was lost —
`checkout -b` commits nothing, so switching back restored everything — but the recovery was manual
and no part of the scaffold objected.

## Why the existing guard stayed silent

`hook_guard.py::_primary_branch_surgery_reason` already blocked `checkout`/`switch`/`merge`/
`rebase`/`reset`/`cherry-pick`/`pull` in the primary checkout. Its shape was right. Its trigger was
one line:

```python
live = _live_harness_task_ids(common)
if not live:
    return None          # no live Harness task -> allow anything
```

It keyed exclusively on **live Harness tasks**. An ordinary concurrent session registers no task, so
the protection was weakest exactly when the neighbour was least formal.

## The fix

**Docs (`CLAUDE.md`, `AGENTS.md`)** — Track A now prescribes `git worktree add`, with the rationale
and the control-plane exception recorded inline. Both files carry byte-identical blocks (verified by
diff), so this specific drift cannot silently reopen.

**Guard (`hook_guard.py`)** — the harness-task arm is untouched. A second arm refuses
`checkout`/`switch` when the primary checkout has uncommitted **tracked** changes.

Two scoping decisions worth reviewing:

- **Untracked files are excluded** (`--untracked-files=no`). They are the loud majority of a working
  repo's `--porcelain` output and are precisely what branch selection *cannot* mis-attribute: they
  belong to no branch, carry over untouched, and Git refuses on its own if a target branch would
  overwrite one. Counting them would fire the guard on a tree full of scratch docs, and an
  over-eager guard gets routed around — strictly worse than no guard.
- **Only `checkout`/`switch`.** `merge`/`rebase`/`reset`/`cherry-pick`/`pull` stay on the first arm:
  Git already refuses those when they would clobber a dirty tree, and `git reset` on dirty state is
  ordinary intended work.

`MURMUR_ALLOW_PRIMARY_BRANCH_SURGERY=1` is the deliberate override (house convention, matching
`MURMUR_ALLOW_SECRET`). It is also the documented recovery path — restoring the branch you moved off
is itself a `checkout` into a dirty tree.

## Oracle — RED before GREEN

20 new assertions across both vendors in `hook_guard.py selftest`.

Neutralising the new arm (`return None` at its head) and re-running produces **exactly** this:

```
[PASS] codex: clean primary: checkout -b: ALLOW
[FAIL] codex: dirty primary: checkout -b: ALLOW
[FAIL] codex: dirty primary: switch -c: ALLOW
[FAIL] codex: dirty primary: plain branch switch: ALLOW
[PASS] codex: dirty primary: reset stays allowed: ALLOW
[PASS] codex: dirty primary: worktree add: ALLOW
[PASS] codex: dirty primary: explicit override: ALLOW
[PASS] codex: linked worktree: dirty checkout -b: ALLOW
```

The three BLOCK cases fail before the fix and pass after it; every ALLOW case — clean tree,
untracked-only, `reset`, `worktree add`, explicit override, and a dirty **linked** worktree — stays
green in both states. So the oracle discriminates rather than being vacuously true.

## Verification

| Gate | Result |
| --- | --- |
| `hook_guard.py selftest` | PASS — 265 assertions |
| `scripts/agent-config-audit --ci` | PASS — 152 checks, 0 warnings |
| `scripts/agent-harness selftest` | PASS |
| v2 fault selftest | PASS — 39 assertions |
| metrics-selftest | PASS — 70 assertions |
| `CLAUDE.md` ↔ `AGENTS.md` block parity | identical (diff clean) |

Live probe against the **real** dirty primary checkout, without executing the command:

```
$ echo '{"tool_input":{"command":"git checkout -b probe-branch"}, ...}' | hook_guard.py block-bash
BLOCK: primary-checkout branch selection is blocked while its working tree has 11 uncommitted
tracked change(s) ... create an isolated checkout with `git worktree add <path> origin/murmur`
exit=2
```

`git worktree add` → exit 0. Override → exit 0.

## Track C — measurement, honestly

`CLAUDE.md` requires the `eval/agents/matrix.py` comparison for any diff touching `CLAUDE.md` /
`AGENTS.md`. **I did not run it, because it cannot measure this edit.** All eight eval tasks score
*code-correctness knowledge* — `angular22-noop`, `lock-masked-dto`, `seal-verify-before-destroy`,
`secret-sk-proj`, `analysis-only`, `csp-style-src-nonce`, `overlay-opaque-surface`,
`additive-migration`. None exercises "do you create a worktree before branching", so the run would
produce a definitionally-zero delta on unrelated tasks.

CLAUDE.md's own honesty clause covers this: *"A delta of zero across ceiling tasks says nothing
about the edit; say so rather than reporting it as evidence the rule works."* The real instrument
for this change is the RED-before-GREEN selftest above, which is deterministic and runs in CI.

If a reviewer wants Track C satisfied literally, the honest way is a **new** eval task
("a concurrent session holds the primary checkout; make a change") — worth doing, but it is its own
PR, not a rubber stamp on this one.

## Review notes

- Control-plane paths cannot be certified by the Harness, so this was authored in a dedicated
  worktree outside the runner-owned root (`../.murmur-control-plane/scaffold-guard`), per
  `CLAUDE.md`.
- The release flow's `git checkout murmur && git pull` (`release-murmur/SKILL.md:116`) runs on a
  clean tree at that point, so it is unaffected. If it ever runs dirty, the override is the escape.
