### PR TITLE
feat(dashboards): boards become context — reachable from Ask, MCP and every source picker

### DIFF
--- a/docs/dreams/2026-08-03-dashboards.md
+++ b/docs/dreams/2026-08-03-dashboards.md
@@ -91,6 +91,32 @@ needs `lock-security-reviewer` before merge. Tile *quality* (are the "open quest
 can't be judged headlessly — real vault, real Mac. And the moment a board can be shared, the redaction
 story has to hold on the *server* side too (`../murmur-server/`), not just in the UI.
 
-## Verdict  (accepted / rejected / iterate — filled after the user disposes)
+## Verdict
 
-_pending — awaiting the user's call._
+**ACCEPTED → BUILT → MERGED (2026-08-03, PR #562, trunk `85afce8`).**
+
+Shipped scope: the `/dashboards` tab + one-board view, 10 tile kinds (note, meeting,
+document, person, reminders, drift, numbers, pulse, promises, living answer), the tile palette,
+and board-scoped Ask that cites the tiles it used. Board Ask reuses the shipped
+`ask_vault(explicit_sources)` seam, so the feature adds no new AI path and no new egress surface.
+
+**Three independent reviews, three FAILs, all fixed before merge — this is the part worth keeping.**
+Every review ran while all gates were green, and each found something the other two did not:
+
+| Review | Found |
+| --- | --- |
+| codex (cross-vendor) | 3 blockers + 5 more, incl. the flattened-DTO title leak |
+| lock-security | confirmed 2, found the sharper variant: entity tiles never resolve to `Locked`, so a stored entity NAME kept rendering after sealing |
+| adversarial verifier | the answer-cache gate was both INCOMPLETE (Ask expands into linked neighbours no source list records) and UNFALSIFIABLE (disabling it left all 2732 tests green) |
+
+Two lessons generalised beyond this feature:
+1. **A UI mask is not a gate.** `#[serde(flatten)]` ships every column of the stored row; the FE
+   declining to render one is not protection. Assert the SERIALIZED wire form, not the DOM.
+2. **A cached AI answer cannot be gated on a source list** when retrieval expands beyond the
+   sources the caller passed. Gate it on the readable-FOLDER set at answer time — that bounds
+   whatever the answer saw, however retrieval got there.
+
+Still not built (unchanged from the plan above): open-questions tiles, drag-to-reorder, `.canvas`
+export of a board. Tile quality against a real vault, Touch-ID unlock behaviour around a live
+board, and screen-share auto-relock re-masking are asserted from code, not executed on a signed
+build.

--- a/e2e/dashboards/dashboards-context.spec.ts
+++ b/e2e/dashboards/dashboards-context.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * Dashboards as CONTEXT — the half that makes a board more than a view.
+ *
+ * A board is offered as a scope in the shared source picker, so every surface
+ * that picks sources (Ask, note chat, reminders) can scope to one. Picking a
+ * board expands it into the board's own VISIBLE sources — the backend drops
+ * sealed ones, so this can never widen scope past what the session may read.
+ */
+
+const BOARDS = [
+  {
+    id: "b-atlas",
+    title: "Atlas GA",
+    emoji: "🚀",
+    tint: "indigo",
+    pinned: true,
+    position: 0,
+    createdAt: "2026-08-01T09:00:00Z",
+    updatedAt: "2026-08-03T09:00:00Z",
+    tileCount: 3,
+    tileKinds: [
+      { kind: "meeting", span: 5 },
+      { kind: "note", span: 4 },
+      { kind: "drift", span: 3 },
+    ],
+  },
+  {
+    id: "b-empty",
+    title: "Nothing on it yet",
+    emoji: null,
+    tint: null,
+    pinned: false,
+    position: 1,
+    createdAt: "2026-08-01T09:00:00Z",
+    updatedAt: "2026-08-01T09:00:00Z",
+    tileCount: 0,
+    tileKinds: [],
+  },
+];
+
+test("Ask: a dashboard can be picked as scope and expands to its visible sources", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {},
+    {
+      list_dashboards: BOARDS,
+      // Two visible sources; a sealed third is already filtered out backend-side.
+      get_dashboard_sources: [
+        { kind: "meeting", id: "m-1" },
+        { kind: "note", id: "n-1" },
+      ],
+    },
+  );
+
+  await page.goto("/ask");
+  await page.getByRole("button", { name: /Source/ }).first().click();
+
+  // Boards are offered ABOVE notes/meetings — the user's own declaration of scope.
+  const picker = page.locator(".sp-list");
+  await expect(picker.getByText("Dashboards")).toBeVisible();
+  await expect(picker.getByText("Atlas GA")).toBeVisible();
+  // A board with no tiles is not a usable scope, so it is not offered.
+  await expect(picker.getByText("Nothing on it yet")).toHaveCount(0);
+
+  await picker.getByRole("option", { name: /Atlas GA/ }).click();
+
+  // Picking the board added BOTH of its visible sources as chips.
+  await expect(page.locator(".sp-chip, .sp .pill")).toHaveCount(2, { timeout: 5000 });
+});
+
+test("Dashboards: Arrange mode makes tiles draggable and persists a reorder", async ({
+  page,
+}) => {
+  const tiles = [
+    {
+      id: "t-a", dashboardId: "b-atlas", kind: "note", refId: "n-1", title: null,
+      span: 4, position: 0, config: null, createdAt: "2026-08-01T09:00:00Z",
+      data: { kind: "note", id: "n-1", title: "FIRST TILE", snippet: "a", updatedAt: 1 },
+    },
+    {
+      id: "t-b", dashboardId: "b-atlas", kind: "note", refId: "n-2", title: null,
+      span: 4, position: 1, config: null, createdAt: "2026-08-01T09:00:00Z",
+      data: { kind: "note", id: "n-2", title: "SECOND TILE", snippet: "b", updatedAt: 1 },
+    },
+  ];
+
+  await mockTauri(
+    page,
+    {
+      reorder_dashboard_tiles: (args: { tileIds?: string[] }) => {
+        (window as unknown as { __reorder?: string[] }).__reorder = args?.tileIds;
+        return null;
+      },
+    },
+    {
+      list_dashboards: BOARDS,
+      get_dashboard: { ...BOARDS[0], tiles },
+      get_dashboard_sources: [],
+    },
+  );
+
+  await page.goto("/dashboards/b-atlas");
+  await expect(page.getByText("FIRST TILE")).toBeVisible();
+
+  // Not draggable until Arrange mode is on — a board is read-first.
+  await expect(page.locator("app-dashboard-tile").first()).not.toHaveAttribute(
+    "draggable",
+    "true",
+  );
+
+  await page.getByRole("button", { name: "Arrange" }).click();
+  await expect(page.getByText(/drag tiles to reorder/)).toBeVisible();
+  await expect(page.locator("app-dashboard-tile").first()).toHaveAttribute(
+    "draggable",
+    "true",
+  );
+
+  // Drag the second tile onto the first.
+  const source = page.locator("app-dashboard-tile").nth(1);
+  const target = page.locator("app-dashboard-tile").nth(0);
+  await source.dragTo(target);
+
+  // The backend was asked for the NEW order, second tile first.
+  await expect
+    .poll(() =>
+      page.evaluate(() => (window as unknown as { __reorder?: string[] }).__reorder),
+    )
+    .toEqual(["t-b", "t-a"]);
+});

--- a/src-tauri/src/commands/dashboards.rs
+++ b/src-tauri/src/commands/dashboards.rs
@@ -617,7 +617,7 @@ pub fn get_dashboard(
 ///
 /// `ref_id`, `span` and `position` stay: pure layout, no content, and the FE needs them to keep the
 /// board's shape stable while a folder is sealed.
-fn redact_tile_chrome(mut tile: DashboardTile, data: &TileData) -> DashboardTile {
+pub(crate) fn redact_tile_chrome(mut tile: DashboardTile, data: &TileData) -> DashboardTile {
     let withheld = match data {
         TileData::Locked | TileData::Missing | TileData::Unconfigured => true,
         // `entity_name` yields the placeholder when the entity is not visible.
@@ -1061,10 +1061,13 @@ pub(crate) fn render_tile_for_agent(tile: &DashboardTile, data: &TileData) -> St
             withheld,
             ..
         } => {
-            let q = if question.trim().is_empty() {
-                heading("living answer")
-            } else {
-                question.clone()
+            // NEVER fall back to the stored title when the answer is withheld: that title is
+            // exactly the field a legacy row copied from the source. An unnamed withheld tile is
+            // anonymous, which is the correct outcome.
+            let q = match (question.trim().is_empty(), *withheld) {
+                (true, true) => "(untitled)".to_string(),
+                (true, false) => heading("living answer"),
+                _ => question.clone(),
             };
             if *withheld {
                 format!("- living answer: {q}\n    [saved answer withheld — a source is sealed]")

--- a/src-tauri/src/commands/dashboards.rs
+++ b/src-tauri/src/commands/dashboards.rs
@@ -794,12 +794,20 @@ pub(crate) fn resolve_tile(
             })
         }
         "reminders" => {
-            // Reminders are the user's OWN data (independent of any meeting), and the store
-            // already drops sealed source anchors. Show the soonest open ones.
+            // Reminders are the user's OWN data, so a reminder with no source anchor always
+            // shows. But `list_stored_reminders` is UNGATED (it takes no `unlocked` set and
+            // applies no `visibility_clause`) — an earlier comment here claimed the store drops
+            // sealed anchors, and that was simply false.
+            //
+            // That mattered little while this tile only rendered on screen; it matters now that
+            // a board is readable by agents (local MCP and the cloud-capable Ask loop). A
+            // "smart" reminder's TITLE is authored from meeting content, so a reminder whose
+            // every anchor points at a source the session cannot read is withheld here.
             let mut rows: Vec<(i64, TileRow)> = db
                 .list_stored_reminders()?
                 .into_iter()
                 .filter(|r| matches!(r.state, crate::storage::models::ReminderState::Active))
+                .filter(|r| reminder_provenance_is_readable(db, r, unlocked))
                 .map(|r| {
                     // Due in the past ⇒ "due" (needs attention), else "open".
                     let now_ms = chrono::Utc::now().timestamp_millis();
@@ -826,9 +834,17 @@ pub(crate) fn resolve_tile(
             // The bitemporal fact history for the entity, already gated by `list_facts_visible`.
             let facts = db.list_facts_visible(&ref_id, unlocked)?;
             if facts.is_empty() {
+                let entity = entity_name(db, &ref_id, unlocked)?;
                 return Ok(TileData::Drift {
-                    entity: entity_name(db, &ref_id, unlocked)?,
-                    predicate: cfg.predicate.unwrap_or_default(),
+                    // A hidden entity emits NO stored predicate either. Nothing writes
+                    // `config.predicate` today, but the day a UI lets a user pin one chosen from
+                    // an entity's facts, echoing it back for a sealed entity would be a leak.
+                    predicate: if entity == ENTITY_HIDDEN {
+                        String::new()
+                    } else {
+                        cfg.predicate.unwrap_or_default()
+                    },
+                    entity,
                     rows: vec![],
                 });
             }
@@ -1079,6 +1095,39 @@ pub(crate) fn render_tile_for_agent(tile: &DashboardTile, data: &TileData) -> St
             }
         }
     }
+}
+
+/// Is a reminder's PROVENANCE readable in this session?
+///
+/// `true` when it has no anchors at all (a hand-written reminder is the user's own data), or when
+/// at least one anchor still resolves through its gated reader. Withholding a reminder whose every
+/// anchor is sealed is what stops an agent reading a title that was authored from sealed content.
+fn reminder_provenance_is_readable(
+    db: &crate::storage::Db,
+    reminder: &crate::storage::models::StoredReminder,
+    unlocked: &std::collections::HashSet<String>,
+) -> bool {
+    if reminder.sources.is_empty() {
+        return true;
+    }
+    reminder.sources.iter().any(|anchor| {
+        let kind = match anchor.kind.as_str() {
+            "meeting" => LinkKind::Meeting,
+            "note" => LinkKind::Note,
+            "document" => LinkKind::Document,
+            // An anchor kind we do not understand cannot be proven readable ⇒ it does not count.
+            _ => return false,
+        };
+        source_is_visible(
+            db,
+            &SourceRef {
+                kind,
+                id: anchor.id.clone(),
+            },
+            unlocked,
+        )
+        .unwrap_or(false)
+    })
 }
 
 /// The placeholder an entity-anchored tile shows when its entity is not currently visible. Also

--- a/src-tauri/src/commands/dashboards.rs
+++ b/src-tauri/src/commands/dashboards.rs
@@ -589,7 +589,7 @@ pub fn get_dashboard(
     let resolved = tiles
         .into_iter()
         .map(|tile| {
-            let data = resolve_tile(state.inner(), &tile, &unlocked)?;
+            let data = resolve_tile(&state.db, &tile, &unlocked)?;
             Ok(ResolvedTileDto {
                 tile: redact_tile_chrome(tile, &data),
                 data,
@@ -690,13 +690,12 @@ fn source_is_visible(
 }
 
 /// Resolve ONE tile. Every arm reads through a gated reader; nothing here queries raw content.
-fn resolve_tile(
-    state: &AppState,
+pub(crate) fn resolve_tile(
+    db: &crate::storage::Db,
     tile: &DashboardTile,
     unlocked: &std::collections::HashSet<String>,
 ) -> Result<TileData, AppError> {
     let cfg = parse_config(tile.config.as_deref());
-    let db = &state.db;
 
     // Kinds that need an anchor.
     let needs_ref = matches!(
@@ -828,7 +827,7 @@ fn resolve_tile(
             let facts = db.list_facts_visible(&ref_id, unlocked)?;
             if facts.is_empty() {
                 return Ok(TileData::Drift {
-                    entity: entity_name(state, &ref_id, unlocked)?,
+                    entity: entity_name(db, &ref_id, unlocked)?,
                     predicate: cfg.predicate.unwrap_or_default(),
                     rows: vec![],
                 });
@@ -872,7 +871,7 @@ fn resolve_tile(
                 .rev()
                 .collect();
             Ok(TileData::Drift {
-                entity: entity_name(state, &ref_id, unlocked)?,
+                entity: entity_name(db, &ref_id, unlocked)?,
                 predicate,
                 rows,
             })
@@ -904,7 +903,7 @@ fn resolve_tile(
                 }
             }
             Ok(TileData::Numbers {
-                entity: entity_name(state, &ref_id, unlocked)?,
+                entity: entity_name(db, &ref_id, unlocked)?,
                 rows,
             })
         }
@@ -926,7 +925,7 @@ fn resolve_tile(
                 }
             }
             Ok(TileData::Pulse {
-                entity: entity_name(state, &ref_id, unlocked)?,
+                entity: entity_name(db, &ref_id, unlocked)?,
                 total: mentions.len() as i64,
                 quiet_days: newest.map(|ts| (now - ts).max(0) / 86_400),
                 weekly,
@@ -977,6 +976,108 @@ fn resolve_tile(
     }
 }
 
+/// Render ONE resolved tile as plain text for an agent (the local MCP surface and the in-app
+/// agentic Ask loop both read this).
+///
+/// It applies the SAME redaction discipline as the UI, in the same place: a withheld payload
+/// prints its state and nothing else — never the tile's stored title, never a cached answer. That
+/// is why this lives next to `redact_tile_chrome` rather than in `tools.rs`; keeping the two
+/// together is what stops the agent surface from drifting away from the screen surface.
+pub(crate) fn render_tile_for_agent(tile: &DashboardTile, data: &TileData) -> String {
+    let heading = |fallback: &str| -> String {
+        match tile.title.as_deref() {
+            Some(t) if !t.trim().is_empty() => t.to_string(),
+            _ => fallback.to_string(),
+        }
+    };
+    let rows = |rows: &[TileRow]| -> String {
+        rows.iter()
+            .map(|r| {
+                let meta = r.meta.as_deref().unwrap_or("");
+                let status = r.status.as_deref().unwrap_or("");
+                format!("    · {} {} {}", r.text, meta, status)
+                    .trim_end()
+                    .to_string()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+    match data {
+        // Withheld states print their state ONLY — no stored title, no config.
+        TileData::Locked => "- [sealed tile — redacted; unlock the source to read it]".to_string(),
+        TileData::Missing => "- [tile whose source no longer exists]".to_string(),
+        TileData::Unconfigured => "- [tile with no source configured]".to_string(),
+        TileData::Note {
+            title, snippet, id, ..
+        } => format!("- note: {title} · id:{id}\n    {snippet}"),
+        TileData::Meeting {
+            title,
+            started_at,
+            duration_s,
+            id,
+            ..
+        } => format!("- recording: {title} · id:{id} · {started_at} · {duration_s}s"),
+        TileData::Document { title, snippet, id } => {
+            format!("- document: {title} · id:{id}\n    {snippet}")
+        }
+        TileData::Person {
+            name,
+            mention_count,
+            open_commitments,
+            id,
+        } => format!(
+            "- person: {name} · id:{id} · visibleMeetings:{mention_count} · openCommitments:{open_commitments}"
+        ),
+        TileData::Reminders { rows: r, due_count } => {
+            format!("- reminders ({due_count} open)\n{}", rows(r))
+        }
+        TileData::Drift {
+            entity,
+            predicate,
+            rows: r,
+        } => format!("- drift: {entity} · {predicate}\n{}", rows(r)),
+        TileData::Numbers { entity, rows: r } => {
+            format!("- numbers: {entity}\n{}", rows(r))
+        }
+        TileData::Pulse {
+            entity,
+            total,
+            quiet_days,
+            ..
+        } => format!(
+            "- pulse: {entity} · mentions12w:{total} · quietDays:{}",
+            quiet_days.map_or("n/a".to_string(), |d| d.to_string())
+        ),
+        TileData::Promises { owner, rows: r } => format!(
+            "- promises{}\n{}",
+            owner
+                .as_deref()
+                .map_or(String::new(), |o| format!(" ({o})")),
+            rows(r)
+        ),
+        TileData::LivingAnswer {
+            question,
+            answer,
+            withheld,
+            ..
+        } => {
+            let q = if question.trim().is_empty() {
+                heading("living answer")
+            } else {
+                question.clone()
+            };
+            if *withheld {
+                format!("- living answer: {q}\n    [saved answer withheld — a source is sealed]")
+            } else {
+                format!(
+                    "- living answer: {q}\n    {}",
+                    answer.as_deref().unwrap_or("(not answered yet)")
+                )
+            }
+        }
+    }
+}
+
 /// The placeholder an entity-anchored tile shows when its entity is not currently visible. Also
 /// the signal `redact_tile_chrome` reads to strip that tile's stored chrome.
 const ENTITY_HIDDEN: &str = "—";
@@ -984,12 +1085,11 @@ const ENTITY_HIDDEN: &str = "—";
 /// The VISIBLE display name of an entity, or a neutral placeholder. Never leaks a name that only
 /// exists behind a sealed meeting (`list_entities_visible` already drops those).
 fn entity_name(
-    state: &AppState,
+    db: &crate::storage::Db,
     entity_id: &str,
     unlocked: &std::collections::HashSet<String>,
 ) -> Result<String, AppError> {
-    Ok(state
-        .db
+    Ok(db
         .list_entities_visible(unlocked)?
         .into_iter()
         .find(|e| e.id == entity_id)

--- a/src-tauri/src/commands/tests/dashboard_cmd_tests.rs
+++ b/src-tauri/src/commands/tests/dashboard_cmd_tests.rs
@@ -307,6 +307,63 @@ fn living_answer_config_round_trips_its_readable_snapshot() {
     assert!(legacy.answer.is_some());
 }
 
+/// THE AGENT-SURFACE LEAK ORACLE. `render_tile_for_agent` feeds BOTH the local MCP server and the
+/// in-app agentic Ask loop, so a withheld tile that printed its stored title there would leak to a
+/// surface the screen-side redaction never sees. Every withheld state must print its state ONLY.
+#[test]
+fn agent_rendering_of_a_withheld_tile_prints_no_stored_chrome() {
+    let tile = |kind: &str, title: &str, config: Option<&str>| {
+        crate::storage::models::DashboardTile {
+            id: "t1".into(),
+            dashboard_id: "b1".into(),
+            kind: kind.into(),
+            ref_id: Some("x".into()),
+            title: Some(title.into()),
+            span: 4,
+            position: 0,
+            config: config.map(str::to_string),
+            created_at: "2026-08-03T10:00:00Z".into(),
+        }
+    };
+
+    for data in [TileData::Locked, TileData::Missing, TileData::Unconfigured] {
+        let out = render_tile_for_agent(&tile("note", "Acme — termination terms", None), &data);
+        assert!(
+            !out.contains("termination"),
+            "a withheld tile must not print its stored title to an agent: {out}"
+        );
+    }
+
+    // A withheld living answer prints the question but never the cached text.
+    let out = render_tile_for_agent(
+        &tile(
+            "living_answer",
+            "Will they renew?",
+            Some(r#"{"answer":"No — they are churning"}"#),
+        ),
+        &TileData::LivingAnswer {
+            question: "Will they renew?".into(),
+            answer: None,
+            answered_at: None,
+            withheld: true,
+        },
+    );
+    assert!(out.contains("withheld"), "the agent is told WHY: {out}");
+    assert!(!out.contains("churning"), "cached answer leaked: {out}");
+
+    // CONTROL: a visible tile does render its content, so the assertions above are not vacuous.
+    let out = render_tile_for_agent(
+        &tile("note", "Atlas GA checklist", None),
+        &TileData::Note {
+            id: "n1".into(),
+            title: "Atlas GA checklist".into(),
+            snippet: "auth migration is the blocker".into(),
+            updated_at: 0,
+        },
+    );
+    assert!(out.contains("Atlas GA checklist") && out.contains("auth migration"));
+}
+
 #[test]
 fn snippets_are_bounded_and_ellipsized() {
     assert_eq!(snippet_of("  short  ", 10), "short");

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -1664,6 +1664,16 @@ fn tools_spec() -> Value {
             "inputSchema": { "type": "object", "properties": {} }
         },
         {
+            "name": "list_dashboards",
+            "description": "List the user's DASHBOARDS — boards they composed BY HAND out of meetings, notes, documents, people and derived views (drift lanes, promise ledgers, pulses). Returns title + id + tile kinds only, no content. A board is the user's own declaration of what belongs together, so it is better scope than a search guess: check here first for questions about a project, deal or topic they track.",
+            "inputSchema": { "type": "object", "properties": {} }
+        },
+        {
+            "name": "get_dashboard",
+            "description": "Read one dashboard by id: every tile, already resolved — the notes and recordings on it, who is on it, which values drifted over time, what was promised and whether it landed, and what has gone quiet. A tile whose source is sealed-and-not-session-unlocked comes back redacted, exactly as it renders on screen. Use it to answer from precisely the context the user curated.",
+            "inputSchema": { "type": "object", "properties": { "dashboardId": { "type": "string" } }, "required": ["dashboardId"] }
+        },
+        {
             "name": "org_search",
             "description": "Fallback for when search_meetings / search_semantic find nothing relevant in your OWN vault and you have joined an org: search the ORGANIZATION brain — notes your colleagues explicitly shared to the shared org brain (synced + decrypted locally; no data leaves this device). Results are attributed '[org · <author>]' and MUST be cited as coming from that colleague. Only meaningful when you have joined an org and consented to org sharing (otherwise returns no results). Use for 'what does the team / someone else know or decide about X' questions.",
             "inputSchema": { "type": "object", "properties": { "query": { "type": "string" } }, "required": ["query"] }
@@ -1821,6 +1831,14 @@ fn dispatch_tool(
                 .clamp(1, 100) as usize,
         },
         "list_note_folders" => ToolCall::ListNoteFolders,
+        "list_dashboards" => ToolCall::ListDashboards,
+        "get_dashboard" => ToolCall::GetDashboard {
+            dashboard_id: args
+                .get("dashboardId")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string(),
+        },
         "search_transcript" => {
             let query = args.get("query").and_then(Value::as_str).unwrap_or("");
             ToolCall::SearchTranscript {
@@ -2055,10 +2073,15 @@ mod tests {
     }
 
     #[test]
-    fn tools_list_has_fifteen_tools() {
+    fn tools_list_has_seventeen_tools() {
         let r = rpc(r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#).unwrap();
         let tools = r["result"]["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 15);
+        assert_eq!(tools.len(), 17);
+        assert!(
+            tools.iter().any(|t| t["name"] == "list_dashboards")
+                && tools.iter().any(|t| t["name"] == "get_dashboard"),
+            "the user's own curated boards must be reachable over local MCP"
+        );
         assert!(
             tools.iter().any(|t| t["name"] == "list_entities"),
             "entity discovery must be advertised on local MCP"

--- a/src-tauri/src/orchestrate.rs
+++ b/src-tauri/src/orchestrate.rs
@@ -232,6 +232,10 @@ fn tool_label(call: &ToolCall) -> &'static str {
         // labels keep the shared transport enum compile-safe without advertising either to a model.
         ToolCall::ListEntities { .. } => "Entities",
         ToolCall::ListNoteFolders => "Note folders",
+        // Dashboards — the user's own composed boards. `ListDashboards` is metadata; `GetDashboard`
+        // resolves each tile through the gated resolver, so it labels like any other vault read.
+        ToolCall::ListDashboards => "Dashboards",
+        ToolCall::GetDashboard { .. } => "Dashboard",
         // Brain v3 PR-6 — knowledge diff / decision ledger (explicit tool; label for completeness).
         ToolCall::KnowledgeDiff { .. } => "Knowledge diff",
         ToolCall::GetOpenCommitments { .. } => "Open commitments",

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -110,7 +110,12 @@ impl AssistantScope {
         ) {
             return false;
         }
-        const VAULT_READS: [&str; 9] = [
+        const VAULT_READS: [&str; 11] = [
+            // Dashboards: `list_dashboards` is metadata-only; `get_dashboard` resolves each tile
+            // through the gated readers, so it is exactly the class of `get_meeting` — an owned
+            // vault read that a sealed folder redacts.
+            "list_dashboards",
+            "get_dashboard",
             "search_meetings",
             "search_semantic",
             "get_meeting",
@@ -259,6 +264,14 @@ pub enum ToolCall {
     /// Local-MCP-only discovery of visible note folders, visible row counts, and typed columns.
     /// Intentionally absent from [`tool_specs`] and [`GatedToolExecutor`].
     ListNoteFolders,
+    /// The user's DASHBOARDS — boards they composed by hand. Metadata only (title, tile count,
+    /// tile kinds): no board reads a source here, so this carries no gated content and is safe at
+    /// every scope. It exists so an agent can DISCOVER the boards before scoping to one.
+    ListDashboards,
+    /// ONE dashboard, every tile resolved through the SAME gated resolver the UI uses
+    /// (`commands::dashboards::resolve_tile`). A sealed source yields a redacted tile, exactly as
+    /// on screen — a board is never a back door.
+    GetDashboard { dashboard_id: String },
     /// LOCAL-MCP-ONLY knowledge diff / decision ledger for one entity: what changed between two
     /// instants (`from`/`to` ISO-8601), the chronological supersession ledger, and a separate,
     /// explicitly-HISTORICAL read-time context from Decisions / Risks / Open Questions sections in
@@ -385,6 +398,33 @@ pub fn tool_specs() -> Vec<ToolSpec> {
                     "includeNote": { "type": "boolean", "description": "Include the note on the first page (default true)." }
                 },
                 "required": ["meetingId"]
+            }),
+            write: false,
+        },
+        ToolSpec {
+            name: "list_dashboards".into(),
+            description: "List the user's DASHBOARDS — boards they composed by hand out of \
+                          meetings, notes, documents, people and derived views. Returns titles + \
+                          ids only. When a question is about a project/deal/topic the user tracks, \
+                          check here first: a board is the user's OWN declaration of what belongs \
+                          together, which is better scope than a search guess."
+                .into(),
+            parameters: serde_json::json!({ "type": "object", "properties": {} }),
+            write: false,
+        },
+        ToolSpec {
+            name: "get_dashboard".into(),
+            description: "Read one dashboard by id: every tile, already resolved — the notes and \
+                          recordings on it, who is on it, what values drifted, what was promised \
+                          and whether it landed. Sealed sources come back redacted. Use it to \
+                          answer from exactly the context the user curated."
+                .into(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "dashboardId": { "type": "string", "description": "The board id from list_dashboards." }
+                },
+                "required": ["dashboardId"]
             }),
             write: false,
         },
@@ -1077,6 +1117,64 @@ pub fn execute_tool(
                 })
                 .collect::<Vec<_>>()
                 .join("\n"))
+        }
+        ToolCall::ListDashboards => {
+            let boards = db
+                .list_dashboards()
+                .map_err(|e| AppError::Storage(format!("dashboard list failed: {e}")))?;
+            if boards.is_empty() {
+                return Ok("No dashboards yet.".to_string());
+            }
+            let kinds = db
+                .dashboard_tile_kinds()
+                .map_err(|e| AppError::Storage(format!("dashboard tile kinds failed: {e}")))?;
+            Ok(boards
+                .iter()
+                .map(|b| {
+                    let mut tile_kinds: Vec<&str> = kinds
+                        .iter()
+                        .filter(|(board_id, _, _)| board_id == &b.id)
+                        .map(|(_, kind, _)| kind.as_str())
+                        .collect();
+                    tile_kinds.sort_unstable();
+                    tile_kinds.dedup();
+                    format!(
+                        "- {} · id:{} · tiles:{} · kinds:{}",
+                        b.title,
+                        b.id,
+                        kinds.iter().filter(|(bid, _, _)| bid == &b.id).count(),
+                        if tile_kinds.is_empty() {
+                            "none".to_string()
+                        } else {
+                            tile_kinds.join(",")
+                        }
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("\n"))
+        }
+        ToolCall::GetDashboard { dashboard_id } => {
+            let Some(board) = db
+                .get_dashboard(dashboard_id)
+                .map_err(|e| AppError::Storage(format!("dashboard read failed: {e}")))?
+            else {
+                return Ok(format!("No dashboard with id {dashboard_id}."));
+            };
+            let tiles = db
+                .list_dashboard_tiles(dashboard_id)
+                .map_err(|e| AppError::Storage(format!("dashboard tiles failed: {e}")))?;
+            let mut out = format!("# {} (dashboard)\n", board.title);
+            if tiles.is_empty() {
+                out.push_str("(no tiles yet)");
+                return Ok(out);
+            }
+            for tile in &tiles {
+                // The SAME gated resolver the UI uses. A sealed source renders redacted here too.
+                let data = crate::commands::resolve_tile(db, tile, unlocked)?;
+                out.push_str(&crate::commands::render_tile_for_agent(tile, &data));
+                out.push('\n');
+            }
+            Ok(out.trim_end().to_string())
         }
         ToolCall::ListNoteFolders => {
             let folders = db
@@ -3212,6 +3310,22 @@ impl crate::agent::ToolExecutor for GatedToolExecutor<'_> {
             ));
         }
         match name {
+            // Dashboards — the user's own curated scope. Same gated executor, same visibility
+            // snapshot as every other vault read here.
+            "list_dashboards" => execute_tool(
+                &ToolCall::ListDashboards,
+                self.db,
+                &unlocked,
+                self.config,
+            ),
+            "get_dashboard" => execute_tool(
+                &ToolCall::GetDashboard {
+                    dashboard_id: s("dashboardId"),
+                },
+                self.db,
+                &unlocked,
+                self.config,
+            ),
             "search_meetings" => execute_tool(
                 &ToolCall::SearchMeetings { query: s("query") },
                 self.db,

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -1171,7 +1171,12 @@ pub fn execute_tool(
             for tile in &tiles {
                 // The SAME gated resolver the UI uses. A sealed source renders redacted here too.
                 let data = crate::commands::resolve_tile(db, tile, unlocked)?;
-                out.push_str(&crate::commands::render_tile_for_agent(tile, &data));
+                // Redact BEFORE rendering, exactly as `get_dashboard` does for the UI. The agent
+                // path calls `resolve_tile` directly, so without this the renderer would still see
+                // a withheld tile's stored `title`/`config` — and a legacy row (written by a build
+                // that copied the source's title) would hand a sealed source's name to an agent.
+                let tile = crate::commands::redact_tile_chrome(tile.clone(), &data);
+                out.push_str(&crate::commands::render_tile_for_agent(&tile, &data));
                 out.push('\n');
             }
             Ok(out.trim_end().to_string())
@@ -3669,6 +3674,100 @@ mod tests {
             .build()
             .unwrap()
             .block_on(f)
+    }
+
+    /// THE AGENT-PATH LEAK ORACLE, end to end through `execute_tool`.
+    ///
+    /// The renderer is tested in isolation elsewhere, but the agent path calls `resolve_tile`
+    /// DIRECTLY — it does not go through the command layer — so the redaction has to be applied
+    /// here too. A legacy row (written by a build that copied the source's title into the tile)
+    /// plus a sealed folder is exactly the shape that would hand an agent a sealed source's name.
+    #[test]
+    fn get_dashboard_tool_redacts_a_sealed_tile_for_agents() {
+        use crate::storage::models::{Folder, MeetingStatus, NoteRecord};
+
+        let db = tmp_db();
+        db.insert_folder(&Folder {
+            id: "f-sealed".to_string(),
+            name: "Legal".to_string(),
+            path: "Legal".to_string(),
+            parent_id: None,
+            locked: true,
+            created_at: "2026-08-01T00:00:00Z".to_string(),
+        })
+        .unwrap();
+        db.insert_meeting(&crate::storage::models::Meeting {
+            id: "m-sealed".to_string(),
+            started_at: "2026-08-01T09:00:00Z".to_string(),
+            ended_at: None,
+            title: Some("Acme termination call".to_string()),
+            duration_s: 600,
+            audio_path: None,
+            status: MeetingStatus::Summarized,
+            folder_id: Some("f-sealed".to_string()),
+        })
+        .unwrap();
+        db.upsert_note(&NoteRecord {
+            meeting_id: "m-sealed".to_string(),
+            provider_id: "test".to_string(),
+            markdown: "they are not renewing".to_string(),
+            created_at: "2026-08-01T09:00:00Z".to_string(),
+            exported_path: None,
+            model_requested: None,
+            model_served: None,
+            gateway_host: None,
+        })
+        .unwrap();
+        db.set_note_folder("m-sealed", Some("f-sealed")).unwrap();
+
+        db.insert_dashboard("b1", "Deals", None, None, "2026-08-03T10:00:00Z")
+            .unwrap();
+        // The tile carries a copied source title, as an older build would have written it.
+        db.insert_dashboard_tile(
+            "t1",
+            "b1",
+            "meeting",
+            Some("m-sealed"),
+            Some("Acme termination call"),
+            4,
+            None,
+            "2026-08-03T10:00:00Z",
+        )
+        .unwrap();
+
+        let cfg = AppConfig::default();
+        let nothing_unlocked = HashSet::new();
+        let out = execute_tool(
+            &ToolCall::GetDashboard {
+                dashboard_id: "b1".to_string(),
+            },
+            &db,
+            &nothing_unlocked,
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            !out.contains("Acme termination call") && !out.contains("not renewing"),
+            "a sealed tile must reach an agent redacted: {out}"
+        );
+        assert!(out.contains("sealed"), "and it must say so: {out}");
+
+        // CONTROL: session-unlock the folder and the SAME call returns the real content, so the
+        // assertion above is not passing merely because the tool returns nothing useful.
+        let unlocked: HashSet<String> = ["f-sealed".to_string()].into_iter().collect();
+        let out = execute_tool(
+            &ToolCall::GetDashboard {
+                dashboard_id: "b1".to_string(),
+            },
+            &db,
+            &unlocked,
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            out.contains("Acme termination call"),
+            "unlocking must restore the tile for agents too: {out}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -3770,6 +3770,62 @@ mod tests {
         );
     }
 
+    /// The INVARIANT test for the agent path, on the exact shape that used to leak: a
+    /// `living_answer` tile with a cached answer, NO question and a stored title.
+    ///
+    /// HONEST LIMIT, measured rather than assumed. Two independent layers now protect this — the
+    /// `redact_tile_chrome` call in `GetDashboard`, and `render_tile_for_agent` no longer falling
+    /// back to the stored title for a withheld answer — and EITHER alone is sufficient. I neutered
+    /// the redaction call and this test still passed, so it is NOT red-before-green proof of that
+    /// layer; it pins the end-to-end invariant, which is what actually must hold.
+    ///
+    /// The layers are covered separately where each is observable in isolation:
+    /// `commands/tests/dashboard_cmd_tests.rs::agent_rendering_of_a_withheld_tile_prints_no_stored_chrome`
+    /// drives the renderer with an UNREDACTED tile (red if the renderer regresses), and
+    /// `…::locked_tile_sheds_its_user_authored_chrome` covers `redact_tile_chrome` itself.
+    #[test]
+    fn agent_path_withholds_a_living_answer_title_and_cached_text() {
+        let db = tmp_db();
+        db.insert_dashboard("b1", "Deals", None, None, "2026-08-03T10:00:00Z")
+            .unwrap();
+        // A legacy-shaped row: cached answer, no question, and a title copied from the source.
+        db.insert_dashboard_tile(
+            "t1",
+            "b1",
+            "living_answer",
+            None,
+            Some("Acme termination terms"),
+            4,
+            Some(r#"{"answer":"They are not renewing"}"#),
+            "2026-08-03T10:00:00Z",
+        )
+        .unwrap();
+
+        let cfg = AppConfig::default();
+        let nothing_unlocked = HashSet::new();
+        let out = execute_tool(
+            &ToolCall::GetDashboard {
+                dashboard_id: "b1".to_string(),
+            },
+            &db,
+            &nothing_unlocked,
+            &cfg,
+        )
+        .unwrap();
+
+        // The answer has no recorded readable-folder snapshot ⇒ un-gateable ⇒ withheld, and with
+        // it goes the stored title.
+        assert!(
+            !out.contains("Acme termination terms"),
+            "a withheld living answer must not hand an agent its stored title: {out}"
+        );
+        assert!(
+            !out.contains("not renewing"),
+            "nor the cached answer text: {out}"
+        );
+        assert!(out.contains("withheld"), "and it must say why: {out}");
+    }
+
     #[test]
     fn production_connector_builder_requires_and_retains_live_recording_identity() {
         let _serial = crate::perf::model_lifecycle_test_guard();

--- a/src/app/design-system/source-picker/source-picker.component.html
+++ b/src/app/design-system/source-picker/source-picker.component.html
@@ -156,6 +156,36 @@
         aria-label="Source candidates"
         (scroll)="onScroll()"
       >
+        <!--
+          Boards first: a dashboard is the user's OWN declaration of what belongs
+          together, so it is the strongest scope on offer. Picking one expands it
+          into its visible sources (sealed ones are dropped backend-side).
+        -->
+        @if (dashboardRows().length > 0) {
+          <p class="sp-group">Dashboards</p>
+          @for (board of dashboardRows(); track board.id) {
+            <button
+              type="button"
+              class="sp-row menu-item sp-board"
+              role="option"
+              [attr.aria-selected]="false"
+              [disabled]="disabled() || selectionLimitReached() || expandingBoard() === board.id"
+              (click)="pickDashboard(board)"
+            >
+              <span class="sp-title">
+                @if (board.emoji) {
+                  <span class="sp-emoji">{{ board.emoji }}</span>
+                }
+                {{ board.title }}
+              </span>
+              <span class="sp-kind">
+                {{ expandingBoard() === board.id ? "adding…" : board.tileCount + " tiles" }}
+              </span>
+            </button>
+          }
+          <p class="sp-group">Notes &amp; meetings</p>
+        }
+
         @for (
           r of rows();
           track r.candidate.kind + r.candidate.id;

--- a/src/app/design-system/source-picker/source-picker.component.scss
+++ b/src/app/design-system/source-picker/source-picker.component.scss
@@ -10,6 +10,35 @@
   align-items: center;
   gap: var(--space-2);
 }
+
+/* Dashboards section — boards are offered ABOVE the note/meeting rows because a
+   board is the user's own declaration of scope, which beats a search guess. */
+.sp-group {
+  margin: var(--space-2) var(--space-3) var(--space-1);
+  color: var(--text-muted);
+  font-size: 0.66rem;
+  font-weight: 680;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.sp-board {
+  .sp-title {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-weight: 560;
+  }
+
+  .sp-kind {
+    color: var(--accent-hover);
+  }
+}
+
+.sp-emoji {
+  font-size: 0.95rem;
+  line-height: 1;
+}
 /* While the popover is open the chips + trigger must stay clickable ABOVE the
    full-viewport scrim (removing a just-added source, re-toggling) — raise the
    in-flow chip strip over the scrim (z-index 40) without leaving normal flow. */

--- a/src/app/design-system/source-picker/source-picker.component.ts
+++ b/src/app/design-system/source-picker/source-picker.component.ts
@@ -14,7 +14,12 @@ import {
   viewChild,
 } from "@angular/core";
 import { IpcService } from "../../core/ipc.service";
-import type { LinkKind, NoteCitation, SourceRef } from "../../core/models";
+import type {
+  DashboardSummary,
+  LinkKind,
+  NoteCitation,
+  SourceRef,
+} from "../../core/models";
 import { DebounceService } from "../../services/debounce.service";
 import { RepositionOnScrollDirective } from "../../features/notes/note-brain-popover/reposition-on-scroll.directive";
 import { TeleportToBodyDirective } from "../teleport-to-body.directive";
@@ -87,6 +92,15 @@ export class SourcePickerComponent {
   /** Optional hard cap. Removal remains available at the cap unless disabled. */
   readonly selectionLimit = input<number | null>(null);
   /**
+   * Offer the user's DASHBOARDS as pickable scopes. Picking one expands it into
+   * the board's own VISIBLE sources (`get_dashboard_sources`, which drops sealed
+   * ones) and adds them, so a board becomes usable as context anywhere this
+   * picker is — Ask, note chat, reminders — without any command learning a new
+   * parameter. Default ON: a board is the user's own declaration of what belongs
+   * together, which is exactly what a source picker is for.
+   */
+  readonly allowDashboards = input(true);
+  /**
    * Candidate kinds this instance may expose. Defaults to the historical Brain
    * picker set; callers such as Reminders can narrow it to note + meeting.
    */
@@ -101,6 +115,19 @@ export class SourcePickerComponent {
   readonly query = signal("");
   /** The live candidate rows for the current query (already kind-filtered). */
   readonly candidates = signal<NoteCitation[]>([]);
+  /** The user's boards, loaded once when the popover first opens. */
+  private readonly _dashboards = signal<DashboardSummary[]>([]);
+  /** Boards matching the current query — shown above the note/meeting rows. */
+  readonly dashboardRows = computed(() => {
+    if (!this.allowDashboards()) return [];
+    const q = this.query().trim().toLowerCase();
+    return this._dashboards()
+      .filter((d) => d.tileCount > 0)
+      .filter((d) => !q || d.title.toLowerCase().includes(q))
+      .slice(0, 6);
+  });
+  /** Board id currently being expanded, so the row can show progress. */
+  readonly expandingBoard = signal<string | null>(null);
   /** Keyboard-highlighted row index. */
   readonly activeIndex = signal(0);
   /** True while the (debounced) fetch for the CURRENT query is in flight. */
@@ -232,6 +259,9 @@ export class SourcePickerComponent {
     this.query.set("");
     this.candidates.set([]);
     this.activeIndex.set(0);
+    // Boards are few and content-free at this level (title + tile count), so one
+    // lazy load on first open is enough — no per-keystroke fetch.
+    void this.loadDashboards();
     // Focus the search field + first fetch (empty prefix → recent candidates)
     // once the popover renders. afterNextRender is the zoneless-safe one-shot;
     // the injector is required outside field-init context.
@@ -427,6 +457,52 @@ export class SourcePickerComponent {
       },
       { injector: this.injector },
     );
+  }
+
+  /**
+   * Expand a board into its own VISIBLE sources and add them all.
+   *
+   * The board is a SCOPE, not a source: `SourceRef.kind` is a `LinkKind`
+   * (meeting/note/document), so a dashboard cannot be one. Expanding here rather
+   * than teaching every consumer a `dashboardIds` parameter is what makes boards
+   * work as context EVERYWHERE this picker is used, with no protocol change and
+   * no new backend seam. The backend drops sealed sources from that list, so
+   * picking a board can never widen scope past what the session may read.
+   */
+  async pickDashboard(board: DashboardSummary): Promise<void> {
+    if (this.disabled() || this.selectionLimitReached()) return;
+    this.expandingBoard.set(board.id);
+    try {
+      const sources = await this.ipc.getDashboardSources(board.id);
+      const allowed = this.allowedKindSet();
+      const limit = this.selectionLimit();
+      this.selected.update((list) => {
+        const seen = new Set(list.map((s) => s.kind + s.id));
+        const out = [...list];
+        for (const src of sources) {
+          if (!allowed.has(src.kind)) continue;
+          if (seen.has(src.kind + src.id)) continue;
+          if (limit !== null && Number.isInteger(limit) && out.length >= limit) {
+            break;
+          }
+          seen.add(src.kind + src.id);
+          out.push(src);
+        }
+        return out;
+      });
+    } finally {
+      this.expandingBoard.set(null);
+    }
+  }
+
+  /** Load the boards once, when the popover first opens. */
+  private async loadDashboards(): Promise<void> {
+    if (!this.allowDashboards() || this._dashboards().length > 0) return;
+    try {
+      this._dashboards.set(await this.ipc.listDashboards());
+    } catch {
+      this._dashboards.set([]);
+    }
   }
 
   remove(ref: SourceRef): void {

--- a/src/app/features/dashboards/board-card/board-card.component.scss
+++ b/src/app/features/dashboards/board-card/board-card.component.scss
@@ -53,7 +53,11 @@
   position: relative;
   display: grid;
   grid-template-columns: repeat(12, 1fr);
-  grid-auto-rows: 26px;
+  // `1fr` rows STRETCH the miniature to fill its box. With fixed-height rows a
+  // two-row board left the bottom half of every card empty, which read as an
+  // unfinished render rather than as a small board.
+  grid-auto-rows: minmax(0, 1fr);
+  align-content: stretch;
   gap: 5px;
   height: 128px;
   padding: var(--space-3);
@@ -64,7 +68,6 @@
 
   .big & {
     height: 168px;
-    grid-auto-rows: 36px;
   }
 }
 

--- a/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.scss
+++ b/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.scss
@@ -15,6 +15,24 @@
     box-shadow var(--transition);
 }
 
+// Arrange mode: the tile becomes a grab target and says so.
+:host(.is-arranging) {
+  cursor: grab;
+}
+
+:host(.is-dragging) {
+  opacity: 0.4;
+  cursor: grabbing;
+}
+
+:host(.is-drop-target) {
+  border-color: var(--accent);
+  box-shadow:
+    0 0 0 2px var(--accent-ring),
+    var(--shadow-md);
+  transform: translateY(-2px);
+}
+
 :host(.cited) {
   border-color: var(--accent);
   box-shadow:
@@ -260,10 +278,11 @@
 
 .pulse-bar {
   flex: 1;
-  min-height: 2px;
-  border-radius: var(--radius-sm);
-  background: var(--accent);
-  opacity: 0.75;
+  min-height: 3px;
+  // A pill radius on a 6px-wide bar renders as a dot; keep the bar a bar.
+  border-radius: 2px;
+  background: linear-gradient(180deg, var(--accent-hover), var(--accent));
+  opacity: 0.85;
 }
 
 // ── drift ────────────────────────────────────────────────────────────────────
@@ -327,12 +346,14 @@
 // ── numbers ──────────────────────────────────────────────────────────────────
 .numbers {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  // Two up from the narrowest tile onwards: one giant figure per row reads as a
+  // rendering accident, not as a stat block.
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--space-2);
 }
 
 .number {
-  padding: var(--space-2) var(--space-3);
+  padding: var(--space-2);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
   background: rgba(255, 255, 255, 0.03);
@@ -347,7 +368,7 @@
 .number-value {
   display: block;
   color: var(--text-primary);
-  font-size: 1.05rem;
+  font-size: 0.95rem;
   font-weight: 680;
   letter-spacing: -0.02em;
   font-variant-numeric: tabular-nums;

--- a/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.ts
+++ b/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.ts
@@ -62,6 +62,9 @@ const LIVE_KINDS = new Set<TileData["kind"]>([
     "[style.--tile-span]": "tile().span",
     "[class.cited]": "cited() > 0",
     "[class.is-locked]": "tile().data.kind === 'locked'",
+    "[class.is-arranging]": "editing()",
+    "[class.is-dragging]": "dragging()",
+    "[class.is-drop-target]": "dropTarget()",
   },
 })
 export class DashboardTileComponent {
@@ -70,6 +73,10 @@ export class DashboardTileComponent {
   readonly cited = input(0);
   /** True while the board is in layout mode (resize / remove affordances shown). */
   readonly editing = input(false);
+  /** This tile is the one being dragged. */
+  readonly dragging = input(false);
+  /** This tile is the current drop target. */
+  readonly dropTarget = input(false);
 
   readonly remove = output<void>();
   readonly widen = output<void>();

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
@@ -12,6 +12,9 @@
   <button type="button" class="btn btn-ghost" (click)="toggleEditing()">
     {{ editing() ? "Done" : "Arrange" }}
   </button>
+  @if (editing()) {
+    <span class="arrange-hint">drag tiles to reorder · ‹ › to resize</span>
+  }
   <button type="button" class="btn btn-primary" (click)="openPalette()">
     <mur-icon icon="plus" /> Add tile
   </button>
@@ -43,6 +46,13 @@
           [tile]="tile"
           [cited]="citationFor(tile)"
           [editing]="editing()"
+          [dragging]="draggingId() === tile.id"
+          [dropTarget]="dropTargetId() === tile.id"
+          [attr.draggable]="editing() ? 'true' : null"
+          (dragstart)="onDragStart(tile, $event)"
+          (dragover)="onDragOver(tile, $event)"
+          (drop)="onDrop(tile, $event)"
+          (dragend)="onDragEnd()"
           (remove)="removeTile(tile)"
           (widen)="widen(tile)"
           (narrow)="narrow(tile)"

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.scss
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.scss
@@ -45,6 +45,12 @@
   line-height: 1;
 }
 
+.arrange-hint {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  white-space: nowrap;
+}
+
 .board {
   display: flex;
   gap: var(--space-3);
@@ -227,7 +233,13 @@
 
 // Narrow windows: the Ask column drops under the canvas rather than squeezing it.
 @media (max-width: 1080px) {
-  .board {
+  .arrange-hint {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  white-space: nowrap;
+}
+
+.board {
     flex-direction: column;
   }
 

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
@@ -83,7 +83,21 @@ export class DashboardViewComponent {
   readonly loading = this.service.boardLoading;
   readonly error = this.service.error;
 
-  readonly tiles = computed<ResolvedTile[]>(() => this.board()?.tiles ?? []);
+  private readonly serverTiles = computed<ResolvedTile[]>(
+    () => this.board()?.tiles ?? [],
+  );
+  /** Server order, unless a drag is mid-flight and we are showing its result. */
+  readonly tiles = computed<ResolvedTile[]>(() => {
+    const rows = this.serverTiles();
+    const order = this.orderOverride();
+    if (!order) return rows;
+    const byId = new Map(rows.map((t) => [t.id, t]));
+    const out = order.map((id) => byId.get(id)).filter((t): t is ResolvedTile => !!t);
+    // Anything the override does not mention (a tile added meanwhile) keeps its
+    // place at the end rather than vanishing.
+    for (const t of rows) if (!order.includes(t.id)) out.push(t);
+    return out;
+  });
   readonly isEmpty = computed(() => this.tiles().length === 0);
   readonly sealedCount = computed(
     () => this.tiles().filter((t) => t.data.kind === "locked").length,
@@ -91,6 +105,59 @@ export class DashboardViewComponent {
 
   readonly paletteOpen = signal(false);
   readonly editing = signal(false);
+
+  // ── drag-to-reorder (Arrange mode) ─────────────────────────────────────────
+  //
+  // Native HTML5 drag events, deliberately: no new dependency, no DOM observer,
+  // and the drop target is the tile itself so the grid needs no hit-testing.
+  // The order is applied OPTIMISTICALLY to a local override so the board does not
+  // jump while the backend write is in flight; the reload then replaces it.
+  readonly draggingId = signal<string | null>(null);
+  readonly dropTargetId = signal<string | null>(null);
+  private readonly orderOverride = signal<string[] | null>(null);
+
+  onDragStart(tile: ResolvedTile, event: DragEvent): void {
+    if (!this.editing()) return;
+    this.draggingId.set(tile.id);
+    event.dataTransfer?.setData("text/plain", tile.id);
+    if (event.dataTransfer) event.dataTransfer.effectAllowed = "move";
+  }
+
+  onDragOver(tile: ResolvedTile, event: DragEvent): void {
+    if (!this.editing() || !this.draggingId()) return;
+    // Without preventDefault the browser refuses the drop outright.
+    event.preventDefault();
+    if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+    if (this.dropTargetId() !== tile.id) this.dropTargetId.set(tile.id);
+  }
+
+  onDragEnd(): void {
+    this.draggingId.set(null);
+    this.dropTargetId.set(null);
+  }
+
+  async onDrop(target: ResolvedTile, event: DragEvent): Promise<void> {
+    event.preventDefault();
+    const sourceId = this.draggingId();
+    this.draggingId.set(null);
+    this.dropTargetId.set(null);
+    if (!sourceId || sourceId === target.id) return;
+
+    const ids = this.tiles().map((t) => t.id);
+    const from = ids.indexOf(sourceId);
+    const to = ids.indexOf(target.id);
+    if (from < 0 || to < 0) return;
+    ids.splice(to, 0, ...ids.splice(from, 1));
+
+    this.orderOverride.set(ids);
+    try {
+      await this.service.reorderTiles(this.id(), ids);
+    } finally {
+      // The reload inside reorderTiles is authoritative; drop the override so a
+      // rejected write cannot leave the UI showing an order the backend refused.
+      this.orderOverride.set(null);
+    }
+  }
 
   // ── board Ask ──────────────────────────────────────────────────────────────
   readonly turns = signal<BoardTurn[]>([]);


### PR DESCRIPTION
## What

#562 shipped boards you can **look at**. This makes a board something the rest of the app can **think with** — which was the point of the feature.

Four things, against the stated requirements:

| Requirement | This PR |
| --- | --- |
| editable board of meetings/notes/reminders/other entities | **drag-to-reorder** in Arrange mode (resize/remove/add already shipped) |
| available from Ask Brain | `list_dashboards` + `get_dashboard` in `AssistantScope::VAULT_READS` |
| available from MCP | the same two tools on the local MCP server (15 → 17) |
| selectable in select-sources **everywhere** | boards offered in `mur-source-picker`, so Ask / note chat / reminders all get them at once |
| looks the part | miniature fills its card; numbers 2-up; pulse renders as bars, not dots |

## One implementation, two agent surfaces

`tools.rs::execute_tool` backs **both** the local MCP server and the in-app agentic loop, so the two new `ToolCall` variants land on both at once — there is no second implementation to drift.

To make that safe, `resolve_tile` was decoupled from `AppState` (it takes `&Db` now), so an agent resolves each tile through the **exact same gated resolver the UI uses**. A sealed source renders redacted for an agent exactly as it does on screen.

`render_tile_for_agent` deliberately lives next to `redact_tile_chrome` rather than in `tools.rs`: keeping the agent renderer beside the screen redaction is what stops the two surfaces drifting apart. Its oracle (`agent_rendering_of_a_withheld_tile_prints_no_stored_chrome`) asserts a withheld tile prints its state and **nothing else** — never the stored title, never a cached answer — with a control proving a visible tile does render content.

`list_dashboards` is metadata-only (title, id, tile kinds — no board reads a source), so it carries no gated content at any scope. `get_dashboard` is exactly the class of the already-cloud-capable `get_meeting`.

## Why the picker expands boards instead of a `dashboardIds` parameter

`SourceRef.kind` is a `LinkKind` (meeting/note/document), so a dashboard cannot *be* a source without changing the wire format everywhere it appears. Expanding in the **picker** means every surface that already uses `mur-source-picker` gains boards with **no protocol change and no new backend seam** — and because the expansion goes through `get_dashboard_sources`, which drops sealed sources, picking a board can never widen scope past what the session may read.

Trade-off, stated plainly: the chips show the board's N sources rather than one "board" chip. That is the cost of not touching the wire format, and it keeps the scope the user ends up with fully visible to them.

## Drag-to-reorder

Native HTML5 drag events — no dependency, no DOM observer. The new order applies optimistically to a local override so the grid does not jump mid-write, and the override is dropped once the reload lands, so a rejected write cannot leave the UI showing an order the backend refused. `reorder_dashboard_tiles` already produced a total order from a possibly-partial list (#562).

## Visual

- The list miniature now **stretches to fill its card** (`1fr` rows). With fixed-row heights a two-row board left the bottom half of every card empty and read as an unfinished render.
- Numbers are a 2-up grid instead of one giant figure per row.
- Pulse bars use a 2px radius (a pill radius on a 6px-wide bar renders as a **dot**) and a gradient fill.

Verified by rendering the real app against a mocked IPC and reading the screenshots, not by eyeballing CSS.

## Gates

29/29 dashboard Rust tests · MCP suite 76/76 · `clippy --lib --tests -D warnings` clean · `ng lint` clean · `ng build` clean · **e2e/dashboards 9/9 on chromium AND webkit** · `agent-config-audit --ci` PASS.

## Not covered

The agent surfaces are exercised through unit tests and the MCP suite, not against a live model — whether an agent actually *chooses* `list_dashboards` for a board-shaped question is a prompt-quality question this PR does not measure. Tile quality on a real vault and Touch-ID/screen-share behaviour around a live board still need a signed build.
