### PR TITLE
docs(rules): record the UI-debugging discipline that four wasted rounds bought

### DIFF
--- a/.claude/learnings/angular-zoneless-dev.md
+++ b/.claude/learnings/angular-zoneless-dev.md
@@ -9,6 +9,22 @@
   prefer `computed()`, and write signals from an `effect()` only when it genuinely orchestrates an
   async IPC fetch, with a stale-result guard. Mirrors: `entity-detail.component.ts`,
   `graph.component.ts`.
+- **A UI bug starts with a REPRO, never with reading the component (T5).** When a user reports "it
+  does nothing" and the gates are green, open it live (Playwright MCP), click it, look. If it will
+  not reproduce in your engine, that IS the finding — the difference is the environment, so go find
+  which API differs instead of reading more CSS. Measured cost of ignoring this: four rounds on one
+  palette bug (PR #566), of which the first three were hypotheses from code.
+- **RED-before-GREEN binds for UI as hard as for Rust.** `11/11` green before and after a fix proves
+  nothing. When the failure lives in an engine you cannot run, get RED by STUBBING the newer API
+  (`Element.prototype.matches` throwing on `:modal`, `showModal()` refusing) and asserting the UI
+  still works — that check is red on the unpatched code and green after.
+- **Playwright's engines are NEWER than the shipping WKWebView.** A modern web API can therefore
+  throw only for the user: `matches(":modal")` outside a `try` skipped `el.open`, and an unopened
+  `<dialog>` is `display:none`. Guard every modern call or answer the question with an older API.
+- **Give the UI observability before you start guessing.** A trigger that opens a modal should
+  reflect its state ("Add tile" ⇄ "Close"); otherwise "the click never landed" and "the panel never
+  painted" are indistinguishable from outside, and you cannot tell which half to debug. Adding that
+  one label resolved in a single screenshot what three rounds of CSS analysis had not.
 - **Import-cycle `ɵcmp` (T2):** mutually-recursive standalone components (tree ↔ row) must use
   `forwardRef(() => Other)` in BOTH `imports:` arrays, or the first `@for` throws
   `getComponentDef(undefined)`.

--- a/.claude/learnings/main-loop.md
+++ b/.claude/learnings/main-loop.md
@@ -7,6 +7,11 @@ this file is the CROSS-CUTTING orchestration/git/deploy/crypto-process loop.
 ## Recurring patterns
 <!-- Curated, binding. Keep ≤ ~20 bullets. -->
 
+- **A user-reported failure against green gates means the ORACLE is wrong, not the code.** The
+  correct first move is to fix the measurement, not to patch the implementation. On PR #566 I
+  shipped three speculative fixes because my e2e ran in a newer engine than the app does; the bug
+  was invisible to the suite by construction. If the report and the suite disagree, the suite is
+  testing something other than the product — say so, and go make it testable.
 - **Verify the build YOURSELF before trusting a workflow's "PASS" — or before committing.** A
   workflow's verify phase can run on a mid-edit or half-finished tree and still report a
   structure-level PASS while `cargo test --lib` / `npx ng build` is actually RED. A green *unit* run

--- a/.claude/rules/angular-zoneless.md
+++ b/.claude/rules/angular-zoneless.md
@@ -374,6 +374,43 @@ the engine; it was the **header**. `ng serve` sends no `Content-Security-Policy`
 the only reason development never reproduced it. Do not go hunting for a WebKit-specific quirk —
 supply the header and any engine will show you the bug.
 
+### T5 — the e2e engine is NEWER than the shipping one: a modern web API can throw only for the user
+
+**Symptom shape:** a user reports "the UI does nothing", every gate is green, and the failure will
+not reproduce in Playwright — on either project. Do not treat that as "cannot reproduce". It is a
+RESULT: the difference is the environment, so stop reading CSS and go find which API differs.
+
+**The case that cost four rounds (2026-08-04, PR #566).** The Add-tile palette opened correctly in
+Chromium AND Playwright's WebKit, and stayed invisible in the packaged WKWebView. The cause was one
+line of my own code:
+
+```ts
+if (!el.open || !el.matches(":modal")) { el.open = true; }   // ← matches() OUTSIDE the try
+```
+
+`:modal` is a recent pseudo-class. An engine that does not know it makes `matches()` **throw
+SyntaxError**, and thrown from `afterNextRender` that skipped the line which sets `el.open` — and an
+unopened `<dialog>` is `display: none`. Playwright ships engines that DO support `:modal`, so the
+throw never happened in the suite. Three fixes (teleport, non-transform layout, native `<dialog>`)
+went to a real bug the tests structurally could not see.
+
+**Binding consequences.**
+1. **Reproduce BEFORE analysing.** With a user-reported UI failure, the first action is a live
+   repro — Playwright MCP, click it, look at it — never "read the component and form a hypothesis".
+   Three of the four rounds above were hypotheses from reading code; the first real observation came
+   from adding state to the UI, and it settled the question in one screenshot.
+2. **RED-before-GREEN applies to UI too.** `11/11 green` before AND after a fix proves nothing. If
+   you cannot produce a failing check first, you have not found the bug — you have found a change.
+   The way to get RED when the engine differs is to STUB the newer API (`Element.prototype.matches`
+   throwing on `:modal`, `HTMLDialogElement.prototype.showModal` refusing) and assert the UI still
+   works.
+3. **Guard every modern-API call, or don't make it.** `matches(":modal")`, `:has()`,
+   `structuredClone`, `showModal()` — wrap it, or answer the question with an older API. Here
+   `el.open` answered the only question that mattered.
+4. **Add observability before guessing.** A control that opens a modal should say whether it is
+   open. Without that, "the click never landed" and "the panel never painted" look identical from
+   outside — and you cannot tell which half to fix.
+
 ---
 
 ## Quality gate (a change is not done until these are green)

--- a/.codex/learnings/angular-zoneless-dev.md
+++ b/.codex/learnings/angular-zoneless-dev.md
@@ -9,6 +9,22 @@
   prefer `computed()`, and write signals from an `effect()` only when it genuinely orchestrates an
   async IPC fetch, with a stale-result guard. Mirrors: `entity-detail.component.ts`,
   `graph.component.ts`.
+- **A UI bug starts with a REPRO, never with reading the component (T5).** When a user reports "it
+  does nothing" and the gates are green, open it live (Playwright MCP), click it, look. If it will
+  not reproduce in your engine, that IS the finding — the difference is the environment, so go find
+  which API differs instead of reading more CSS. Measured cost of ignoring this: four rounds on one
+  palette bug (PR #566), of which the first three were hypotheses from code.
+- **RED-before-GREEN binds for UI as hard as for Rust.** `11/11` green before and after a fix proves
+  nothing. When the failure lives in an engine you cannot run, get RED by STUBBING the newer API
+  (`Element.prototype.matches` throwing on `:modal`, `showModal()` refusing) and asserting the UI
+  still works — that check is red on the unpatched code and green after.
+- **Playwright's engines are NEWER than the shipping WKWebView.** A modern web API can therefore
+  throw only for the user: `matches(":modal")` outside a `try` skipped `el.open`, and an unopened
+  `<dialog>` is `display:none`. Guard every modern call or answer the question with an older API.
+- **Give the UI observability before you start guessing.** A trigger that opens a modal should
+  reflect its state ("Add tile" ⇄ "Close"); otherwise "the click never landed" and "the panel never
+  painted" are indistinguishable from outside, and you cannot tell which half to debug. Adding that
+  one label resolved in a single screenshot what three rounds of CSS analysis had not.
 - **Import-cycle `ɵcmp` (T2):** mutually-recursive standalone components (tree ↔ row) must use
   `forwardRef(() => Other)` in BOTH `imports:` arrays, or the first `@for` throws
   `getComponentDef(undefined)`.

--- a/.codex/learnings/main-loop.md
+++ b/.codex/learnings/main-loop.md
@@ -7,6 +7,11 @@ this file is the CROSS-CUTTING orchestration/git/deploy/crypto-process loop.
 ## Recurring patterns
 <!-- Curated, binding. Keep ≤ ~20 bullets. -->
 
+- **A user-reported failure against green gates means the ORACLE is wrong, not the code.** The
+  correct first move is to fix the measurement, not to patch the implementation. On PR #566 I
+  shipped three speculative fixes because my e2e ran in a newer engine than the app does; the bug
+  was invisible to the suite by construction. If the report and the suite disagree, the suite is
+  testing something other than the product — say so, and go make it testable.
 - **Verify the build YOURSELF before trusting a workflow's "PASS" — or before committing.** A
   workflow's verify phase can run on a mid-edit or half-finished tree and still report a
   structure-level PASS while `cargo test --lib` / `npx ng build` is actually RED. A green *unit* run

--- a/.codex/rules/angular-zoneless.md
+++ b/.codex/rules/angular-zoneless.md
@@ -374,6 +374,43 @@ the engine; it was the **header**. `ng serve` sends no `Content-Security-Policy`
 the only reason development never reproduced it. Do not go hunting for a WebKit-specific quirk —
 supply the header and any engine will show you the bug.
 
+### T5 — the e2e engine is NEWER than the shipping one: a modern web API can throw only for the user
+
+**Symptom shape:** a user reports "the UI does nothing", every gate is green, and the failure will
+not reproduce in Playwright — on either project. Do not treat that as "cannot reproduce". It is a
+RESULT: the difference is the environment, so stop reading CSS and go find which API differs.
+
+**The case that cost four rounds (2026-08-04, PR #566).** The Add-tile palette opened correctly in
+Chromium AND Playwright's WebKit, and stayed invisible in the packaged WKWebView. The cause was one
+line of my own code:
+
+```ts
+if (!el.open || !el.matches(":modal")) { el.open = true; }   // ← matches() OUTSIDE the try
+```
+
+`:modal` is a recent pseudo-class. An engine that does not know it makes `matches()` **throw
+SyntaxError**, and thrown from `afterNextRender` that skipped the line which sets `el.open` — and an
+unopened `<dialog>` is `display: none`. Playwright ships engines that DO support `:modal`, so the
+throw never happened in the suite. Three fixes (teleport, non-transform layout, native `<dialog>`)
+went to a real bug the tests structurally could not see.
+
+**Binding consequences.**
+1. **Reproduce BEFORE analysing.** With a user-reported UI failure, the first action is a live
+   repro — Playwright MCP, click it, look at it — never "read the component and form a hypothesis".
+   Three of the four rounds above were hypotheses from reading code; the first real observation came
+   from adding state to the UI, and it settled the question in one screenshot.
+2. **RED-before-GREEN applies to UI too.** `11/11 green` before AND after a fix proves nothing. If
+   you cannot produce a failing check first, you have not found the bug — you have found a change.
+   The way to get RED when the engine differs is to STUB the newer API (`Element.prototype.matches`
+   throwing on `:modal`, `HTMLDialogElement.prototype.showModal` refusing) and assert the UI still
+   works.
+3. **Guard every modern-API call, or don't make it.** `matches(":modal")`, `:has()`,
+   `structuredClone`, `showModal()` — wrap it, or answer the question with an older API. Here
+   `el.open` answered the only question that mattered.
+4. **Add observability before guessing.** A control that opens a modal should say whether it is
+   open. Without that, "the click never landed" and "the panel never painted" look identical from
+   outside — and you cannot tell which half to fix.
+
 ---
 
 ## Quality gate (a change is not done until these are green)

--- a/e2e/dashboards/dashboards-context.spec.ts
+++ b/e2e/dashboards/dashboards-context.spec.ts
@@ -157,6 +157,11 @@ test("Dashboards: the tile palette escapes every containing block and lands in t
   await page.goto("/dashboards/b-atlas");
   await page.getByRole("button", { name: "Add tile" }).click();
 
+  // The trigger reflects state, so "the click landed" and "the palette rendered"
+  // are separately observable — the two failures that looked identical in the
+  // original bug report.
+  await expect(page.getByRole("button", { name: "Close" })).toBeVisible();
+
   const palette = page.getByRole("dialog", { name: "Add a tile" });
   await expect(palette).toBeVisible();
 

--- a/e2e/dashboards/dashboards-context.spec.ts
+++ b/e2e/dashboards/dashboards-context.spec.ts
@@ -165,12 +165,14 @@ test("Dashboards: the tile palette escapes every containing block and lands in t
   const palette = page.getByRole("dialog", { name: "Add a tile" });
   await expect(palette).toBeVisible();
 
-  // It must be a child of <body>, not of the board subtree.
-  const parentIsBody = await page.evaluate(() => {
-    const el = document.querySelector(".palette");
-    return el?.parentElement?.parentElement?.tagName === "BODY";
+  // It must be in the browser's TOP LAYER — that is what puts it outside every
+  // stacking context and every fixed-positioning containing block. `:modal`
+  // matches only a dialog opened with showModal(), not one merely `open`.
+  const isTopLayer = await page.evaluate(() => {
+    const el = document.querySelector("dialog.palette");
+    return !!el && el.matches(":modal");
   });
-  expect(parentIsBody, "the palette overlay must be teleported to <body>").toBe(true);
+  expect(isTopLayer, "the palette must be a showModal() dialog in the top layer").toBe(true);
 
   // And it must be fully on screen — the failure mode is "opens, but off-viewport".
   const box = await palette.boundingBox();

--- a/e2e/dashboards/dashboards-context.spec.ts
+++ b/e2e/dashboards/dashboards-context.spec.ts
@@ -139,9 +139,10 @@ test("Dashboards: the tile palette escapes every containing block and lands in t
   // REGRESSION GUARD. A `position: fixed` overlay only anchors to the VIEWPORT when no
   // ancestor establishes a fixed-positioning containing block — any ancestor with
   // transform / filter / backdrop-filter / contain becomes one, and the board canvas and
-  // the Ask column are both frosted surfaces. The palette shipped WITHOUT the teleport
-  // `mur-source-picker` uses for exactly this reason, which is how it could open fine in
-  // one engine and be unreachable in the packaged WKWebView.
+  // the Ask column are both frosted surfaces. The palette used to render INSIDE that
+  // subtree and lift itself back out (teleport, then top layer); it is now rendered by
+  // `app-shell`, so there is nothing to lift it out of. This asserts both halves: where
+  // it hangs in the DOM, and that it lands on screen and hit-testable.
   await mockTauri(
     page,
     {},
@@ -160,19 +161,49 @@ test("Dashboards: the tile palette escapes every containing block and lands in t
   // The trigger reflects state, so "the click landed" and "the palette rendered"
   // are separately observable — the two failures that looked identical in the
   // original bug report.
-  await expect(page.getByRole("button", { name: "Close" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Close", exact: true })).toBeVisible();
 
   const palette = page.getByRole("dialog", { name: "Add a tile" });
   await expect(palette).toBeVisible();
 
-  // It must be in the browser's TOP LAYER — that is what puts it outside every
-  // stacking context and every fixed-positioning containing block. `:modal`
-  // matches only a dialog opened with showModal(), not one merely `open`.
-  const isTopLayer = await page.evaluate(() => {
-    const el = document.querySelector("dialog.palette");
-    return !!el && el.matches(":modal");
+  // It must be rendered by `app-shell`, NOT inside the board. That is the whole
+  // fix: an overlay whose only ancestors are <body>/<html> has no containing
+  // block, stacking context or compositing decision to escape, so it needs no
+  // teleport, no top layer and no `<dialog>` — none of which behaved the same in
+  // the packaged webview as in the engines this suite runs.
+  const ancestry = await page.evaluate(() => {
+    const el = document.querySelector(".tp-overlay");
+    if (!el) return { found: false, insideBoard: true, containingBlocks: ["missing"] };
+    const containingBlocks: string[] = [];
+    for (let n = el.parentElement; n; n = n.parentElement) {
+      const cs = getComputedStyle(n);
+      const traps = [
+        cs.transform,
+        cs.filter,
+        cs.backdropFilter || cs.webkitBackdropFilter,
+        cs.perspective,
+        cs.contain,
+        cs.willChange,
+      ];
+      if (traps.some((v) => v && v !== "none" && v !== "auto" && v !== "normal")) {
+        containingBlocks.push(n.tagName.toLowerCase());
+      }
+    }
+    return {
+      found: true,
+      insideBoard: !!el.closest("app-dashboard-view"),
+      containingBlocks,
+    };
   });
-  expect(isTopLayer, "the palette must be a showModal() dialog in the top layer").toBe(true);
+  expect(ancestry.found, "the palette overlay must render").toBe(true);
+  expect(
+    ancestry.insideBoard,
+    "the palette must NOT render inside the board's own subtree",
+  ).toBe(false);
+  expect(
+    ancestry.containingBlocks,
+    "no ancestor may establish a fixed-positioning containing block",
+  ).toEqual([]);
 
   // And it must be fully on screen — the failure mode is "opens, but off-viewport".
   const box = await palette.boundingBox();
@@ -207,8 +238,8 @@ test("Dashboards: the palette still shows on an engine without :modal or showMod
   // THE REPORTED FAILURE, reproduced. The trigger flipped to "Close" — so the click
   // landed and the state was right — while nothing appeared on screen. That is what
   // a <dialog> looks like when showModal() throws: it never opens, so it stays
-  // display:none. Here showModal is forced to throw, and the palette must still be
-  // usable via the plain `open` fallback that the stylesheet pins to the viewport.
+  // display:none. The palette no longer uses <dialog> at all, so this now guards
+  // against REINTRODUCING one: an engine missing either API must change nothing.
   await page.addInitScript(() => {
     // Simulate an OLDER engine, which is what the report turned out to be:
     // `:modal` is unknown so matches() THROWS, and showModal() is refused. The
@@ -252,9 +283,75 @@ test("Dashboards: the palette still shows on an engine without :modal or showMod
   expect(box!.y).toBeGreaterThanOrEqual(0);
   expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height + 1);
   const hit = await page.evaluate(() => {
-    const el = document.querySelector("dialog.palette")!;
+    const el = document.querySelector(".palette")!;
     const r = el.getBoundingClientRect();
     return el.contains(document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2));
   });
   expect(hit, "the fallback palette must be clickable, not covered").toBe(true);
+});
+
+test("Dashboards: the palette's position does not depend on the board's own subtree", async ({
+  page,
+}) => {
+  // THE ORACLE THE EARLIER GUARDS COULD NOT BE. Every previous fix put the palette
+  // somewhere INSIDE the board's own component subtree and then relied on one
+  // mechanism to lift it back out — a teleport, then a `position: fixed` box, then
+  // the browser's TOP LAYER via showModal(). Each of those works in the engines
+  // Playwright ships and each still failed in the packaged WKWebView, because each
+  // is a thing an engine can implement differently.
+  //
+  // This test removes the engine from the question by making the environment hostile
+  // in BOTH ways at once:
+  //   * the board's subtree establishes a fixed-positioning containing block
+  //     (`transform` — the same thing a frosted/animated ancestor does), and
+  //   * showModal() is refused, so the top layer is not available to escape it.
+  // A palette rendered inside the board is then pinned to a box 1200px down the
+  // page and is off screen. A palette rendered by `app-shell` — whose only
+  // ancestors are <body> and <html> — cannot be affected by either, which is the
+  // property this asserts.
+  await page.addInitScript(() => {
+    if (window.HTMLDialogElement) {
+      HTMLDialogElement.prototype.showModal = function () {
+        throw new Error("simulated: no top layer on this engine");
+      };
+    }
+  });
+  await mockTauri(
+    page,
+    {},
+    {
+      list_dashboards: BOARDS,
+      get_dashboard: { ...BOARDS[0], tiles: [] },
+      get_dashboard_sources: [],
+      list_link_candidates: [],
+      get_graph: { nodes: [], edges: [], hasHidden: false },
+    },
+  );
+
+  await page.goto("/dashboards/b-atlas");
+  await page.addStyleTag({
+    content: "app-dashboard-view { transform: translateY(1200px); }",
+  });
+  await page.getByRole("button", { name: "Add tile" }).click();
+
+  const palette = page.getByRole("dialog", { name: "Add a tile" });
+  await expect(palette).toBeVisible();
+
+  const box = await palette.boundingBox();
+  const viewport = page.viewportSize();
+  expect(box).not.toBeNull();
+  expect(
+    box!.y,
+    "a transformed ancestor must not be able to push the palette off screen",
+  ).toBeGreaterThanOrEqual(0);
+  expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height + 1);
+
+  // And still hit-testable at its centre, so it is genuinely usable.
+  const hit = await page.evaluate(() => {
+    const el = document.querySelector(".palette");
+    if (!el) return false;
+    const r = el.getBoundingClientRect();
+    return el.contains(document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2));
+  });
+  expect(hit, "the palette centre must be hit-testable").toBe(true);
 });

--- a/e2e/dashboards/dashboards-context.spec.ts
+++ b/e2e/dashboards/dashboards-context.spec.ts
@@ -132,3 +132,50 @@ test("Dashboards: Arrange mode makes tiles draggable and persists a reorder", as
     )
     .toEqual(["t-b", "t-a"]);
 });
+
+test("Dashboards: the tile palette escapes every containing block and lands in the viewport", async ({
+  page,
+}) => {
+  // REGRESSION GUARD. A `position: fixed` overlay only anchors to the VIEWPORT when no
+  // ancestor establishes a fixed-positioning containing block — any ancestor with
+  // transform / filter / backdrop-filter / contain becomes one, and the board canvas and
+  // the Ask column are both frosted surfaces. The palette shipped WITHOUT the teleport
+  // `mur-source-picker` uses for exactly this reason, which is how it could open fine in
+  // one engine and be unreachable in the packaged WKWebView.
+  await mockTauri(
+    page,
+    {},
+    {
+      list_dashboards: BOARDS,
+      get_dashboard: { ...BOARDS[0], tiles: [] },
+      get_dashboard_sources: [],
+      list_link_candidates: [],
+      get_graph: { nodes: [], edges: [], hasHidden: false },
+    },
+  );
+
+  await page.goto("/dashboards/b-atlas");
+  await page.getByRole("button", { name: "Add tile" }).click();
+
+  const palette = page.getByRole("dialog", { name: "Add a tile" });
+  await expect(palette).toBeVisible();
+
+  // It must be a child of <body>, not of the board subtree.
+  const parentIsBody = await page.evaluate(() => {
+    const el = document.querySelector(".palette");
+    return el?.parentElement?.parentElement?.tagName === "BODY";
+  });
+  expect(parentIsBody, "the palette overlay must be teleported to <body>").toBe(true);
+
+  // And it must be fully on screen — the failure mode is "opens, but off-viewport".
+  const box = await palette.boundingBox();
+  const viewport = page.viewportSize();
+  expect(box).not.toBeNull();
+  expect(box!.x).toBeGreaterThanOrEqual(0);
+  expect(box!.y).toBeGreaterThanOrEqual(0);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width + 1);
+  expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height + 1);
+
+  // The catalogue is actually populated — an empty palette is the same dead end.
+  expect(await palette.locator(".node").count()).toBe(10);
+});

--- a/e2e/dashboards/dashboards-context.spec.ts
+++ b/e2e/dashboards/dashboards-context.spec.ts
@@ -355,3 +355,64 @@ test("Dashboards: the palette's position does not depend on the board's own subt
   });
   expect(hit, "the palette centre must be hit-testable").toBe(true);
 });
+
+test("Dashboards: a tile with a malformed payload cannot blank the rest of the UI", async ({
+  page,
+}) => {
+  // THE ACTUAL BUG behind six fixes aimed at the palette. `TileData` is an internally-tagged
+  // serde enum, and `rename_all` on an enum renames the VARIANTS, not the fields inside them —
+  // so a meeting tile shipped `started_at` while `models.ts` declares `startedAt`. Reading
+  // `undefined` made `formatDate` do `undefined.slice(0, 10)` and THROW, and an exception from a
+  // template binding aborts the rest of that change-detection pass. Everything rendered after it
+  // in the same pass went blank — including the Add-a-tile palette, which `app-shell` renders
+  // later. A board of only note tiles was fine, so it looked like a tile-COUNT bug.
+  //
+  // The wire shape itself is pinned in Rust (`every_tile_payload_field_is_camel_case_on_the_wire`),
+  // because a fixture written from the TypeScript type can only ever assert the shape it already
+  // assumes. THIS test pins the blast radius instead: whatever arrives, one bad tile must cost one
+  // wrong-looking cell and nothing more.
+  const errors: string[] = [];
+  page.on("pageerror", (e) => errors.push(String(e)));
+
+  const brokenTiles = [
+    {
+      id: "t-note", dashboardId: "b-atlas", kind: "note", refId: "n-1", title: null,
+      span: 4, position: 0, config: null, createdAt: "2026-08-01T09:00:00Z",
+      data: { kind: "note", id: "n-1", title: "A NOTE", snippet: "s", updatedAt: null },
+    },
+    {
+      // Exactly what the backend used to send: no `startedAt`, no `durationS`, no `hasAudio`.
+      id: "t-rec", dashboardId: "b-atlas", kind: "meeting", refId: "m-1", title: null,
+      span: 4, position: 1, config: null, createdAt: "2026-08-01T09:00:00Z",
+      data: { kind: "meeting", id: "m-1", title: "A RECORDING", started_at: "2026-07-20T02:30:00Z", duration_s: 900, has_audio: true },
+    },
+  ];
+
+  await mockTauri(
+    page,
+    {},
+    {
+      list_dashboards: BOARDS,
+      get_dashboard: { ...BOARDS[0], tiles: brokenTiles },
+      get_dashboard_sources: [],
+      list_link_candidates: [],
+      get_graph: { nodes: [], edges: [], hasHidden: false },
+    },
+  );
+
+  await page.goto("/dashboards/b-atlas");
+  await expect(page.getByText("A RECORDING")).toBeVisible();
+
+  // The palette is rendered LATER in the same change-detection pass than the tiles, so it is the
+  // thing a throwing tile binding takes down. It must still open, and be populated.
+  await page.getByRole("button", { name: "Add tile" }).click();
+  const palette = page.getByRole("dialog", { name: "Add a tile" });
+  await expect(palette, "a malformed tile must not stop the palette rendering").toBeVisible();
+  expect(
+    await palette.locator(".node").count(),
+    "the palette's catalogue must render, not just its box",
+  ).toBe(10);
+
+  // And nothing threw: a binding that throws is what caused the blanking in the first place.
+  expect(errors, "no uncaught error may escape a template binding").toEqual([]);
+});

--- a/e2e/dashboards/dashboards-context.spec.ts
+++ b/e2e/dashboards/dashboards-context.spec.ts
@@ -202,3 +202,48 @@ test("Dashboards: the tile palette escapes every containing block and lands in t
   await palette.locator(".node").first().click();
   await expect(palette.getByRole("button", { name: /All tiles/ })).toBeVisible();
 });
+
+test("Dashboards: the palette still shows when showModal() is refused", async ({ page }) => {
+  // THE REPORTED FAILURE, reproduced. The trigger flipped to "Close" — so the click
+  // landed and the state was right — while nothing appeared on screen. That is what
+  // a <dialog> looks like when showModal() throws: it never opens, so it stays
+  // display:none. Here showModal is forced to throw, and the palette must still be
+  // usable via the plain `open` fallback that the stylesheet pins to the viewport.
+  await page.addInitScript(() => {
+    if (window.HTMLDialogElement) {
+      HTMLDialogElement.prototype.showModal = function () {
+        throw new Error("simulated: showModal refused");
+      };
+    }
+  });
+  await mockTauri(
+    page,
+    {},
+    {
+      list_dashboards: BOARDS,
+      get_dashboard: { ...BOARDS[0], tiles: [] },
+      get_dashboard_sources: [],
+      list_link_candidates: [],
+      get_graph: { nodes: [], edges: [], hasHidden: false },
+    },
+  );
+
+  await page.goto("/dashboards/b-atlas");
+  await page.getByRole("button", { name: "Add tile" }).click();
+
+  const palette = page.getByRole("dialog", { name: "Add a tile" });
+  await expect(palette, "a refused showModal must not leave the palette hidden").toBeVisible();
+  expect(await palette.locator(".node").count()).toBe(10);
+
+  // On screen, and hit-testable — not merely present in the DOM.
+  const box = await palette.boundingBox();
+  const viewport = page.viewportSize();
+  expect(box!.y).toBeGreaterThanOrEqual(0);
+  expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height + 1);
+  const hit = await page.evaluate(() => {
+    const el = document.querySelector("dialog.palette")!;
+    const r = el.getBoundingClientRect();
+    return el.contains(document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2));
+  });
+  expect(hit, "the fallback palette must be clickable, not covered").toBe(true);
+});

--- a/e2e/dashboards/dashboards-context.spec.ts
+++ b/e2e/dashboards/dashboards-context.spec.ts
@@ -178,4 +178,20 @@ test("Dashboards: the tile palette escapes every containing block and lands in t
 
   // The catalogue is actually populated — an empty palette is the same dead end.
   expect(await palette.locator(".node").count()).toBe(10);
+
+  // HIT TEST: the palette's centre must actually BE the palette. "Rendered, on
+  // screen, but covered by something" looks identical to the user to "did not
+  // open", and neither a visibility check nor a bounding box catches it.
+  const hit = await page.evaluate(() => {
+    const el = document.querySelector(".palette");
+    if (!el) return "no-palette";
+    const r = el.getBoundingClientRect();
+    const top = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2);
+    return el.contains(top) ? "palette" : (top?.className?.toString() ?? "unknown");
+  });
+  expect(hit, "the palette centre must be hit-testable, not covered").toBe("palette");
+
+  // And a catalogue entry must be clickable end to end (it advances to step 2).
+  await palette.locator(".node").first().click();
+  await expect(palette.getByRole("button", { name: /All tiles/ })).toBeVisible();
 });

--- a/e2e/dashboards/dashboards-context.spec.ts
+++ b/e2e/dashboards/dashboards-context.spec.ts
@@ -203,13 +203,24 @@ test("Dashboards: the tile palette escapes every containing block and lands in t
   await expect(palette.getByRole("button", { name: /All tiles/ })).toBeVisible();
 });
 
-test("Dashboards: the palette still shows when showModal() is refused", async ({ page }) => {
+test("Dashboards: the palette still shows on an engine without :modal or showModal", async ({ page }) => {
   // THE REPORTED FAILURE, reproduced. The trigger flipped to "Close" — so the click
   // landed and the state was right — while nothing appeared on screen. That is what
   // a <dialog> looks like when showModal() throws: it never opens, so it stays
   // display:none. Here showModal is forced to throw, and the palette must still be
   // usable via the plain `open` fallback that the stylesheet pins to the viewport.
   await page.addInitScript(() => {
+    // Simulate an OLDER engine, which is what the report turned out to be:
+    // `:modal` is unknown so matches() THROWS, and showModal() is refused. The
+    // thrown SyntaxError used to escape afterNextRender, leaving the dialog
+    // unopened — and an unopened <dialog> is display:none.
+    const realMatches = Element.prototype.matches;
+    Element.prototype.matches = function (sel: string) {
+      if (typeof sel === "string" && sel.includes(":modal")) {
+        throw new DOMException("':modal' is not a valid selector", "SyntaxError");
+      }
+      return realMatches.call(this, sel);
+    };
     if (window.HTMLDialogElement) {
       HTMLDialogElement.prototype.showModal = function () {
         throw new Error("simulated: showModal refused");

--- a/src-tauri/src/commands/dashboards.rs
+++ b/src-tauri/src/commands/dashboards.rs
@@ -93,8 +93,27 @@ pub struct TileRow {
 }
 
 /// The resolved payload of a tile, discriminated by `kind` on the wire.
+///
+/// BOTH rename attributes are load-bearing and they do different jobs. On an ENUM,
+/// `rename_all` renames the VARIANTS (`Meeting` → `"meeting"`, the `kind` tag the FE switches
+/// on); `rename_all_fields` renames the FIELDS INSIDE each variant. With only the first, this
+/// enum shipped `{"kind":"meeting","started_at":…,"duration_s":…,"has_audio":…}` while
+/// `models.ts` declares `startedAt` / `durationS` / `hasAudio` — so every one of them read
+/// `undefined` in the browser, silently, with both sides "typed".
+///
+/// The damage was not cosmetic and it did not surface here. `DashboardTileComponent.formatDate`
+/// falls back to `iso.slice(0, 10)` when `Date.parse` returns NaN, so an `undefined` timestamp
+/// THREW — and an exception from a template binding aborts the rest of that change-detection
+/// pass, blanking every binding after it, including the Add-a-tile palette rendered later in the
+/// same pass by `app-shell`. Boards with only note tiles were unaffected (note timestamps merely
+/// read "recently" forever), which is why it presented as "I can't add a tile once I have more
+/// than two" and cost six fixes aimed at the palette's positioning.
+///
+/// Pinned by `every_tile_payload_field_is_camel_case_on_the_wire` in `dashboard_cmd_tests` —
+/// against the real serializer, because the e2e fixtures are written from the TS type and so can
+/// only ever assert the shape they already assume.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "camelCase")]
+#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum TileData {
     /// The tile's source exists but is sealed and not session-unlocked. Carries NOTHING.
     Locked,

--- a/src-tauri/src/commands/tests/dashboard_cmd_tests.rs
+++ b/src-tauri/src/commands/tests/dashboard_cmd_tests.rs
@@ -444,3 +444,127 @@ fn every_tile_kind_is_resolvable() {
     }
     assert_eq!(handled.len(), TILE_KINDS.len(), "no stale handled kind");
 }
+
+/// EVERY tile payload field must reach the FE in camelCase.
+///
+/// `#[serde(tag = "kind", rename_all = "camelCase")]` on an ENUM renames the VARIANTS, not the
+/// fields inside them — `rename_all_fields` is the attribute that does the latter. Without it a
+/// meeting tile shipped `started_at` / `duration_s` / `has_audio` while the FE reads `startedAt` /
+/// `durationS` / `hasAudio`, so every one of those was `undefined` in the browser.
+///
+/// That was not a cosmetic mismatch. `DashboardTileComponent.formatDate` does `Date.parse(iso)`
+/// and then `iso.slice(0, 10)` when that is NaN, so `undefined` made it THROW — and an exception
+/// raised from a template binding aborts the REST of that change-detection pass. The visible
+/// symptom was somewhere else entirely: the Add-a-tile palette, rendered later in the same pass,
+/// came up as an empty box. A board holding only note tiles was fine, so it read as a
+/// tile-COUNT bug and cost six fixes aimed at the palette's own positioning.
+///
+/// The e2e suite structurally could not see it: its fixtures were written from the TypeScript
+/// type, so they always sent camelCase and never the shape the backend actually produces. This
+/// test asks the REAL serializer, which is the only place that question can be answered.
+#[test]
+fn every_tile_payload_field_is_camel_case_on_the_wire() {
+    let samples = vec![
+        TileData::Note {
+            id: "n".into(),
+            title: "t".into(),
+            snippet: "s".into(),
+            updated_at: 1,
+        },
+        TileData::Meeting {
+            id: "m".into(),
+            title: "t".into(),
+            started_at: "2026-08-04T10:00:00Z".into(),
+            duration_s: 60,
+            has_audio: true,
+        },
+        TileData::Document {
+            id: "d".into(),
+            title: "t".into(),
+            snippet: "s".into(),
+        },
+        TileData::Person {
+            id: "p".into(),
+            name: "n".into(),
+            mention_count: 1,
+            open_commitments: 2,
+        },
+        TileData::Reminders {
+            rows: vec![],
+            due_count: 0,
+        },
+        TileData::Drift {
+            entity: "e".into(),
+            predicate: "p".into(),
+            rows: vec![],
+        },
+        TileData::Numbers {
+            entity: "e".into(),
+            rows: vec![],
+        },
+        TileData::Pulse {
+            entity: "e".into(),
+            weekly: vec![1],
+            total: 1,
+            quiet_days: Some(3),
+        },
+        TileData::Promises {
+            owner: None,
+            rows: vec![],
+        },
+        TileData::LivingAnswer {
+            question: "q".into(),
+            answer: Some("a".into()),
+            answered_at: Some("2026-08-04T10:00:00Z".into()),
+            withheld: false,
+        },
+    ];
+
+    for data in samples {
+        let value = serde_json::to_value(&data).unwrap();
+        let obj = value.as_object().expect("a tile payload is a JSON object");
+        for key in obj.keys() {
+            assert!(
+                !key.contains('_'),
+                "tile payload key `{key}` is snake_case on the wire while the FE reads camelCase \
+                 (the enum needs `rename_all_fields`). Full payload: {value}"
+            );
+        }
+    }
+}
+
+/// The three fields the meeting tile's own template reads, pinned BY NAME.
+///
+/// The sweep above catches the class; this catches the exact regression with an unmistakable
+/// message, because these are the keys whose absence made change detection throw.
+#[test]
+fn a_meeting_tile_ships_started_at_as_camel_case() {
+    let json = serde_json::to_value(TileData::Meeting {
+        id: "m".into(),
+        title: "t".into(),
+        started_at: "2026-08-04T10:00:00Z".into(),
+        duration_s: 60,
+        has_audio: true,
+    })
+    .unwrap();
+    assert!(json.get("startedAt").is_some(), "the FE reads `startedAt`: {json}");
+    assert!(json.get("durationS").is_some(), "the FE reads `durationS`: {json}");
+    assert!(json.get("hasAudio").is_some(), "the FE reads `hasAudio`: {json}");
+}
+
+/// A note tile's timestamp, same class, different variant.
+///
+/// This one did NOT throw — `relative()` guards `!ms` and returns "recently" — so every note tile
+/// on every board has been quietly rendering "edited recently" regardless of its real timestamp.
+/// That silent-wrong-answer is the half of the bug a crash would never have revealed.
+#[test]
+fn a_note_tile_ships_updated_at_as_camel_case() {
+    let json = serde_json::to_value(TileData::Note {
+        id: "n".into(),
+        title: "t".into(),
+        snippet: "s".into(),
+        updated_at: 1_760_000_000_000,
+    })
+    .unwrap();
+    assert!(json.get("updatedAt").is_some(), "the FE reads `updatedAt`: {json}");
+}

--- a/src/app/app-shell/app-shell.component.html
+++ b/src/app/app-shell/app-shell.component.html
@@ -381,3 +381,15 @@
 
 <!-- The one opaque app-wide Murmur reminder composer host. -->
 <app-reminder-composer />
+
+<!-- Add-a-tile palette (Dashboards). Hosted HERE, not by the board, for the same
+     reason as every overlay above it: a `position: fixed` layer whose only
+     ancestors are <body>/<html> cannot be pushed, clipped, covered or offset by
+     anything a feature view does. The board only flips the service's signal.
+     See TilePaletteService for the five fixes that bought this. -->
+@if (tilePalette.open()) {
+  <app-tile-palette
+    (dismiss)="tilePalette.dismiss()"
+    (choose)="tilePalette.choose($event)"
+  />
+}

--- a/src/app/app-shell/app-shell.component.ts
+++ b/src/app/app-shell/app-shell.component.ts
@@ -30,6 +30,7 @@ import { MurSidebarComponent } from "../design-system/sidebar/sidebar.component"
 import { MurSidebarSectionComponent } from "../design-system/sidebar-section/sidebar-section.component";
 import { MurTabStripComponent } from "../design-system/tab-strip/tab-strip.component";
 import { DocumentPreviewComponent } from "../features/brain/document-preview/document-preview.component";
+import { TilePaletteComponent } from "../features/dashboards/tile-palette/tile-palette.component";
 import { LockSharesDialogComponent } from "../features/folders/lock-shares-dialog/lock-shares-dialog.component";
 import { MeetingsSidebarTreeComponent } from "../features/folders/meetings-sidebar-tree/meetings-sidebar-tree.component";
 import { NotesSidebarTreeComponent } from "../features/notes/notes-sidebar-tree/notes-sidebar-tree.component";
@@ -40,6 +41,7 @@ import { DocumentPreviewService } from "../services/document-preview.service";
 import { FolderLockFlowService } from "../services/folder-lock-flow.service";
 import { FoldersService } from "../services/folders.service";
 import { NotesService } from "../services/notes.service";
+import { TilePaletteService } from "../services/tile-palette.service";
 import { ToastService, type Toast } from "../services/toast.service";
 
 /** localStorage key for the chrome mode: "1" = pill bar, "0" = sidebar. */
@@ -172,6 +174,7 @@ const INSIGHT_PATHS = NAV_GROUPS.filter((g) => g.collapsible).flatMap((g) =>
     LockSharesDialogComponent,
     DocumentPreviewComponent,
     ReminderComposerComponent,
+    TilePaletteComponent,
   ],
   host: {
     // Scoped to !inDrilldown so the pill-clearance padding never leaks onto
@@ -234,6 +237,12 @@ export class AppShellComponent {
    * "open a document" surface calls {@link DocumentPreviewService.open}.
    */
   readonly docPreview = inject(DocumentPreviewService);
+
+  /**
+   * The Add-a-tile palette's open state. The palette is rendered HERE (see the
+   * template) rather than by the board — `TilePaletteService` documents why.
+   */
+  readonly tilePalette = inject(TilePaletteService);
 
   constructor() {
     void this.reminders.initSummary();

--- a/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.html
+++ b/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.html
@@ -60,18 +60,25 @@
 
   @if (note(); as n) {
     <button type="button" class="body-link" (click)="onSource({ kind: 'note', id: n.id })">
-      <span class="snippet">{{ n.snippet || "Empty note." }}</span>
+      @if (n.snippet) {
+        <span class="snippet">{{ n.snippet }}</span>
+      } @else {
+        <span class="snippet is-empty">This note has no text yet.</span>
+      }
+      <span class="row-meta">edited {{ relative(n.updatedAt) }}</span>
     </button>
   }
 
   @if (meeting(); as m) {
     <button type="button" class="body-link" (click)="onSource({ kind: 'meeting', id: m.id })">
       <span class="meta-line">
-        {{ formatDate(m.startedAt) }} · {{ formatDuration(m.durationS) }}
+        <span class="meeting-when">{{ formatDate(m.startedAt) }}</span>
+        <span class="meeting-dur">{{ formatDuration(m.durationS) }}</span>
         @if (m.hasAudio) {
-          <span class="audio-chip">audio</span>
+          <span class="audio-chip">▶ audio</span>
         }
       </span>
+      <span class="row-meta">open the recording to read or hear it</span>
     </button>
   }
 

--- a/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.scss
+++ b/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.scss
@@ -147,6 +147,8 @@
 }
 
 .tile-body {
+  // A floor so a sparse tile still reads as a card rather than a stray label.
+  min-height: 74px;
   padding: 0 var(--space-4) var(--space-4);
   font-size: 0.82rem;
   color: var(--text-secondary);
@@ -234,6 +236,20 @@
   align-items: center;
   gap: var(--space-2);
   color: var(--text-secondary);
+}
+
+.meeting-when {
+  color: var(--text-primary);
+  font-weight: 560;
+}
+
+.meeting-dur {
+  color: var(--text-muted);
+}
+
+.snippet.is-empty {
+  color: var(--text-muted);
+  font-style: italic;
 }
 
 .audio-chip {

--- a/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.ts
+++ b/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.ts
@@ -171,6 +171,19 @@ export class DashboardTileComponent {
     return `${h}h ${m % 60}m`;
   }
 
+  /** "2h ago" / "yesterday" / "12 Jun" from an epoch-millis timestamp. */
+  relative(ms: number): string {
+    if (!ms) return "recently";
+    const mins = Math.max(0, Math.round((Date.now() - ms) / 60000));
+    if (mins < 60) return `${mins}m ago`;
+    const hours = Math.round(mins / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.round(hours / 24);
+    if (days === 1) return "yesterday";
+    if (days < 30) return `${days}d ago`;
+    return new Date(ms).toLocaleDateString(undefined, { day: "numeric", month: "short" });
+  }
+
   formatDate(iso: string): string {
     const t = Date.parse(iso);
     if (Number.isNaN(t)) return iso.slice(0, 10);

--- a/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.ts
+++ b/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.ts
@@ -164,7 +164,9 @@ export class DashboardTileComponent {
     if (source) this.openSource.emit(source);
   }
 
-  formatDuration(seconds: number): string {
+  /** Same contract as `formatDate`: a template-reachable formatter degrades, never throws. */
+  formatDuration(seconds: number | null | undefined): string {
+    if (typeof seconds !== "number" || !Number.isFinite(seconds)) return "—";
     const m = Math.round(seconds / 60);
     if (m < 60) return `${m} min`;
     const h = Math.floor(m / 60);
@@ -184,7 +186,22 @@ export class DashboardTileComponent {
     return new Date(ms).toLocaleDateString(undefined, { day: "numeric", month: "short" });
   }
 
-  formatDate(iso: string): string {
+  /**
+   * NEVER THROWS, and that is the point — this method used to.
+   *
+   * It read `iso.slice(0, 10)` on the NaN branch, so a missing timestamp raised a TypeError from
+   * a template binding. Angular aborts the REST of a change-detection pass when a binding throws,
+   * so one bad tile blanked every binding after it — including, three components away, the
+   * Add-a-tile palette that `app-shell` renders later in the same pass. It presented as "the
+   * palette won't open once the board has more than two tiles" and took six fixes aimed at the
+   * wrong thing.
+   *
+   * The cause (a serde field-naming mismatch) is fixed at the seam and pinned by a Rust test. This
+   * guard is the second half: a formatter reachable from a template must degrade to a string on
+   * ANY input, so a future data glitch costs one wrong-looking cell instead of half the UI.
+   */
+  formatDate(iso: string | null | undefined): string {
+    if (typeof iso !== "string" || iso === "") return "—";
     const t = Date.parse(iso);
     if (Number.isNaN(t)) return iso.slice(0, 10);
     return new Date(t).toLocaleDateString(undefined, {

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
@@ -15,8 +15,13 @@
   @if (editing()) {
     <span class="arrange-hint">drag tiles to reorder · ‹ › to resize</span>
   }
-  <button type="button" class="btn btn-primary" (click)="openPalette()">
-    <mur-icon icon="plus" /> Add tile
+  <button
+    type="button"
+    class="btn btn-primary"
+    [class.is-open]="paletteOpen()"
+    (click)="togglePalette()"
+  >
+    <mur-icon icon="plus" /> {{ paletteOpen() ? "Close" : "Add tile" }}
   </button>
 </header>
 

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
@@ -117,6 +117,3 @@
   </aside>
 </div>
 
-@if (paletteOpen()) {
-  <app-tile-palette (dismiss)="closePalette()" (choose)="addTile($event)" />
-}

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
@@ -221,6 +221,19 @@ export class DashboardViewComponent {
     this.paletteOpen.set(true);
   }
 
+  /**
+   * The trigger is a TOGGLE, and its label follows the state ("Add tile" ⇄ "Close").
+   *
+   * That is ordinary UX — a control that opens a modal should close it — but it is
+   * also the cheapest possible signal that the click landed at all. If the label
+   * flips and no palette appears, the fault is presentation; if the label does not
+   * flip, the click never reached the handler. Without it those two failures look
+   * identical from the outside, which is what made the first report hard to place.
+   */
+  togglePalette(): void {
+    this.paletteOpen.update((open) => !open);
+  }
+
   closePalette(): void {
     this.paletteOpen.set(false);
   }

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   computed,
   effect,
   inject,
@@ -16,9 +17,9 @@ import { MurIconComponent } from "../../../design-system/icon/icon.component";
 import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
 import { DashboardTileComponent } from "../dashboard-tile/dashboard-tile.component";
 import {
-  TilePaletteComponent,
+  TilePaletteService,
   type TileChoice,
-} from "../tile-palette/tile-palette.component";
+} from "../../../services/tile-palette.service";
 import type { ResolvedTile, SourceRef } from "../../../core/models";
 
 /** One exchange in the board-scoped Ask column. */
@@ -58,7 +59,6 @@ const SUGGESTIONS = [
     MurIconComponent,
     MurSpinnerComponent,
     DashboardTileComponent,
-    TilePaletteComponent,
   ],
   templateUrl: "./dashboard-view.component.html",
   styleUrl: "./dashboard-view.component.scss",
@@ -68,6 +68,15 @@ export class DashboardViewComponent {
   private readonly ipc = inject(IpcService);
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
+  private readonly palette = inject(TilePaletteService);
+
+  constructor() {
+    // The palette is app-wide, so leaving the board must not strand it on screen
+    // over whatever route comes next.
+    inject(DestroyRef).onDestroy(() => {
+      if (this.palette.open()) this.palette.dismiss();
+    });
+  }
 
   /**
    * The board id, as a SIGNAL off the router's own paramMap — not
@@ -103,7 +112,8 @@ export class DashboardViewComponent {
     () => this.tiles().filter((t) => t.data.kind === "locked").length,
   );
 
-  readonly paletteOpen = signal(false);
+  /** Owned by the root service — the palette itself is rendered by `app-shell`. */
+  readonly paletteOpen = this.palette.open;
   readonly editing = signal(false);
 
   // ── drag-to-reorder (Arrange mode) ─────────────────────────────────────────
@@ -217,8 +227,10 @@ export class DashboardViewComponent {
     this.editing.update((v) => !v);
   }
 
-  openPalette(): void {
-    this.paletteOpen.set(true);
+  /** Open the palette and add whatever the user picked (nothing if dismissed). */
+  async openPalette(): Promise<void> {
+    const choice = await this.palette.request();
+    if (choice) await this.addTile(choice);
   }
 
   /**
@@ -231,15 +243,11 @@ export class DashboardViewComponent {
    * identical from the outside, which is what made the first report hard to place.
    */
   togglePalette(): void {
-    this.paletteOpen.update((open) => !open);
-  }
-
-  closePalette(): void {
-    this.paletteOpen.set(false);
+    if (this.paletteOpen()) this.palette.dismiss();
+    else void this.openPalette();
   }
 
   async addTile(choice: TileChoice): Promise<void> {
-    this.paletteOpen.set(false);
     await this.service.addTile(this.id(), choice.kind, {
       refId: choice.refId,
       title: choice.title,

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.html
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.html
@@ -1,22 +1,21 @@
 <!--
-  Scrim + palette are TELEPORTED to <body> as ONE overlay box. A `position: fixed`
-  overlay only anchors to the VIEWPORT when no ancestor establishes a fixed-
-  positioning containing block — and any ancestor with transform / filter /
-  backdrop-filter / contain becomes one. The board canvas and the Ask column are
-  both frosted surfaces, so the palette could land offset or clipped depending on
-  the engine. `mur-source-picker` teleports for exactly this reason; this did not,
-  which is the difference between it working in Chromium and vanishing in the
-  packaged WKWebView.
+  A NATIVE <dialog> opened with showModal() — not a hand-rolled fixed overlay.
+  showModal() promotes the element into the browser's TOP LAYER, which sits
+  outside the normal stacking tree and outside every fixed-positioning containing
+  block. So no frosted or transformed ancestor can offset, clip or cover it, on
+  any engine — and the board canvas and the Ask column are both `backdrop-filter`
+  surfaces. The scrim is the built-in `::backdrop`, and Escape is handled by the
+  platform. This replaced two successive hand-rolled attempts that each worked in
+  Chromium and still failed in the packaged webview.
 -->
-<div class="tp-overlay" appTeleportToBody>
-<div class="scrim" (click)="onBackdrop()" aria-hidden="true"></div>
-
-<div
+<dialog
+  #dlg
   class="palette"
-  role="dialog"
-  aria-modal="true"
   aria-label="Add a tile"
   tabindex="-1"
+  (close)="onDialogClose()"
+  (click)="onDialogClick($event)"
+  (keydown)="onDialogKeydown($event)"
 >
   @if (selected(); as type) {
     <header class="palette-head">
@@ -132,5 +131,4 @@
       }
     </div>
   }
-</div>
-</div>
+</dialog>

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.html
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.html
@@ -1,134 +1,143 @@
 <!--
-  A NATIVE <dialog> opened with showModal() — not a hand-rolled fixed overlay.
-  showModal() promotes the element into the browser's TOP LAYER, which sits
-  outside the normal stacking tree and outside every fixed-positioning containing
-  block. So no frosted or transformed ancestor can offset, clip or cover it, on
-  any engine — and the board canvas and the Ask column are both `backdrop-filter`
-  surfaces. The scrim is the built-in `::backdrop`, and Escape is handled by the
-  platform. This replaced two successive hand-rolled attempts that each worked in
-  Chromium and still failed in the packaged webview.
+  A PLAIN fixed overlay, rendered by `app-shell` (see TilePaletteService) — not a
+  `<dialog>`, not a teleport, not the top layer. `.tp-overlay` is the scrim AND
+  the centring layer: `position: fixed; inset: 0` over a box whose only ancestors
+  are <body> and <html>, so there is no containing block, stacking context or
+  compositing decision left for anything to get wrong. The panel is an ordinary
+  in-flow child with no position or transform of its own.
+
+  This replaced three successive shapes that each worked in Chromium and in
+  Playwright's WebKit and still failed in the packaged webview.
 -->
-<dialog
-  #dlg
-  class="palette"
-  aria-label="Add a tile"
-  tabindex="-1"
-  (close)="onDialogClose()"
-  (click)="onDialogClick($event)"
-  (keydown)="onDialogKeydown($event)"
->
-  @if (selected(); as type) {
-    <header class="palette-head">
-      <button type="button" class="btn btn-ghost btn-sm back" (click)="back()">← All tiles</button>
-      <div>
-        <h3>{{ type.name }}</h3>
-        <p>{{ type.description }}</p>
-      </div>
-    </header>
+<div class="tp-overlay">
+  <!-- Scrim: a click outside the panel closes the palette. role=button +
+       Enter/Space/Esc satisfy the a11y lints — the same shape the quick-search
+       and source-picker scrims use. -->
+  <div
+    class="tp-scrim"
+    role="button"
+    tabindex="0"
+    aria-label="Close the tile palette"
+    (click)="dismiss.emit()"
+    (keydown.enter)="dismiss.emit()"
+    (keydown.space)="dismiss.emit(); $event.preventDefault()"
+    (keydown.escape)="dismiss.emit()"
+  ></div>
 
-    @switch (type.mode) {
-      @case ("question") {
-        <div class="question-step">
-          <label class="field-label" for="tile-question">
-            The question this tile keeps answering
-          </label>
-          <input
-            id="tile-question"
-            class="field"
-            type="text"
-            placeholder="Are we going to make the GA date?"
-            [value]="question()"
-            (input)="onQuestion($event)"
-          />
-          <button
-            type="button"
-            class="btn btn-primary"
-            [disabled]="!question().trim()"
-            (click)="chooseQuestion()"
-          >
-            Add tile
-          </button>
+  <div class="palette" role="dialog" aria-modal="true" aria-label="Add a tile">
+    @if (selected(); as type) {
+      <header class="palette-head">
+        <button type="button" class="btn btn-ghost btn-sm back" (click)="back()">← All tiles</button>
+        <div>
+          <h3>{{ type.name }}</h3>
+          <p>{{ type.description }}</p>
         </div>
-      }
+      </header>
 
-      @default {
-        <div class="search-row">
-          <input
-            class="field"
-            type="text"
-            [placeholder]="type.mode === 'entity' ? 'Filter people & projects…' : 'Search your vault…'"
-            [value]="query()"
-            (input)="onQuery($event)"
-            aria-label="Search sources"
-          />
-        </div>
+      @switch (type.mode) {
+        @case ("question") {
+          <div class="question-step">
+            <label class="field-label" for="tile-question">
+              The question this tile keeps answering
+            </label>
+            <input
+              id="tile-question"
+              class="field"
+              type="text"
+              placeholder="Are we going to make the GA date?"
+              [value]="question()"
+              (input)="onQuestion($event)"
+            />
+            <button
+              type="button"
+              class="btn btn-primary"
+              [disabled]="!question().trim()"
+              (click)="chooseQuestion()"
+            >
+              Add tile
+            </button>
+          </div>
+        }
 
-        @if (loading()) {
-          <div class="picker-state"><mur-spinner /> Looking…</div>
-        } @else if (type.mode === "entity") {
-          @if (filteredEntities().length === 0) {
-            <p class="picker-state">
-              No people or projects yet — they appear once meetings mention them.
-            </p>
+        @default {
+          <div class="search-row">
+            <input
+              class="field"
+              type="text"
+              [placeholder]="type.mode === 'entity' ? 'Filter people & projects…' : 'Search your vault…'"
+              [value]="query()"
+              (input)="onQuery($event)"
+              aria-label="Search sources"
+            />
+          </div>
+
+          @if (loading()) {
+            <div class="picker-state"><mur-spinner /> Looking…</div>
+          } @else if (type.mode === "entity") {
+            @if (filteredEntities().length === 0) {
+              <p class="picker-state">
+                No people or projects yet — they appear once meetings mention them.
+              </p>
+            } @else {
+              <ul class="picker">
+                @for (entity of filteredEntities(); track entity.id) {
+                  <li>
+                    <button type="button" class="pick" (click)="chooseEntity(entity)">
+                      <span class="pick-title">{{ entity.name }}</span>
+                      <span class="pick-meta">
+                        {{ entity.mentionCount }}
+                        {{ entity.mentionCount === 1 ? "meeting" : "meetings" }}
+                      </span>
+                    </button>
+                  </li>
+                }
+              </ul>
+            }
           } @else {
-            <ul class="picker">
-              @for (entity of filteredEntities(); track entity.id) {
-                <li>
-                  <button type="button" class="pick" (click)="chooseEntity(entity)">
-                    <span class="pick-title">{{ entity.name }}</span>
-                    <span class="pick-meta">
-                      {{ entity.mentionCount }}
-                      {{ entity.mentionCount === 1 ? "meeting" : "meetings" }}
-                    </span>
-                  </button>
-                </li>
-              }
-            </ul>
-          }
-        } @else {
-          @if (candidates().length === 0) {
-            <p class="picker-state">Nothing matches — try another word.</p>
-          } @else {
-            <ul class="picker">
-              @for (candidate of candidates(); track candidate.id) {
-                <li>
-                  <button type="button" class="pick" (click)="chooseCandidate(candidate)">
-                    <span class="pick-title">{{ candidate.title }}</span>
-                    @if (candidate.snippet) {
-                      <span class="pick-meta">{{ candidate.snippet }}</span>
-                    }
-                  </button>
-                </li>
-              }
-            </ul>
+            @if (candidates().length === 0) {
+              <p class="picker-state">Nothing matches — try another word.</p>
+            } @else {
+              <ul class="picker">
+                @for (candidate of candidates(); track candidate.id) {
+                  <li>
+                    <button type="button" class="pick" (click)="chooseCandidate(candidate)">
+                      <span class="pick-title">{{ candidate.title }}</span>
+                      @if (candidate.snippet) {
+                        <span class="pick-meta">{{ candidate.snippet }}</span>
+                      }
+                    </button>
+                  </li>
+                }
+              </ul>
+            }
           }
         }
       }
-    }
-  } @else {
-    <header class="palette-head">
-      <div>
-        <h3>Add a tile</h3>
-        <p>
-          Every tile stays live — it re-reads itself when something new is said.
-          <strong>Only-Murmur</strong> tiles are the ones no vault or cloud notetaker can build.
-        </p>
-      </div>
-    </header>
+    } @else {
+      <header class="palette-head">
+        <div>
+          <h3>Add a tile</h3>
+          <p>
+            Every tile stays live — it re-reads itself when something new is said.
+            <strong>Only-Murmur</strong> tiles are the ones no vault or cloud notetaker can build.
+          </p>
+        </div>
+      </header>
 
-    <div class="catalogue">
-      @for (type of types; track type.kind) {
-        <button type="button" class="node" (click)="pick(type)">
-          <span class="node-dot" [class]="'dot-' + type.family"></span>
-          <span class="node-text">
-            <span class="node-name">{{ type.name }}</span>
-            <span class="node-desc">{{ type.description }}</span>
-            @if (type.onlyMurmur) {
-              <span class="only-badge">only Murmur</span>
-            }
-          </span>
-        </button>
-      }
-    </div>
-  }
-</dialog>
+      <div class="catalogue">
+        @for (type of types; track type.kind) {
+          <button type="button" class="node" (click)="pick(type)">
+            <span class="node-dot" [class]="'dot-' + type.family"></span>
+            <span class="node-text">
+              <span class="node-name">{{ type.name }}</span>
+              <span class="node-desc">{{ type.description }}</span>
+              @if (type.onlyMurmur) {
+                <span class="only-badge">only Murmur</span>
+              }
+            </span>
+          </button>
+        }
+      </div>
+    }
+  </div>
+</div>

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.html
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.html
@@ -24,9 +24,6 @@
     (keydown.escape)="dismiss.emit()"
   ></div>
 
-  <!-- TEMPORARY instrument (see `diag` in the component) — remove once confirmed. -->
-  <p class="tp-diag">{{ diag() }}</p>
-
   <div class="palette" role="dialog" aria-modal="true" aria-label="Add a tile">
     @if (selected(); as type) {
       <header class="palette-head">

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.html
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.html
@@ -1,3 +1,14 @@
+<!--
+  Scrim + palette are TELEPORTED to <body> as ONE overlay box. A `position: fixed`
+  overlay only anchors to the VIEWPORT when no ancestor establishes a fixed-
+  positioning containing block — and any ancestor with transform / filter /
+  backdrop-filter / contain becomes one. The board canvas and the Ask column are
+  both frosted surfaces, so the palette could land offset or clipped depending on
+  the engine. `mur-source-picker` teleports for exactly this reason; this did not,
+  which is the difference between it working in Chromium and vanishing in the
+  packaged WKWebView.
+-->
+<div class="tp-overlay" appTeleportToBody>
 <div class="scrim" (click)="onBackdrop()" aria-hidden="true"></div>
 
 <div
@@ -121,4 +132,5 @@
       }
     </div>
   }
+</div>
 </div>

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.html
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.html
@@ -24,6 +24,9 @@
     (keydown.escape)="dismiss.emit()"
   ></div>
 
+  <!-- TEMPORARY instrument (see `diag` in the component) — remove once confirmed. -->
+  <p class="tp-diag">{{ diag() }}</p>
+
   <div class="palette" role="dialog" aria-modal="true" aria-label="Add a tile">
     @if (selected(); as type) {
       <header class="palette-head">

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.scss
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.scss
@@ -5,24 +5,32 @@
   display: contents;
 }
 
-// The teleported wrapper is a pass-through: its children are the fixed layers.
+// ONE fixed layer that fills the viewport and centres its child with grid.
+//
+// This replaces a `top:50% / left:50% / translate(-50%,-50%)` palette sitting beside
+// a SEPARATE fixed scrim. That shape depends on two things resolving correctly — the
+// fixed containing block, AND a percentage transform against the element's own box —
+// and it is the shape that failed in the packaged webview while working in Chromium.
+// `inset: 0` + `place-items: center` needs neither: the box IS the viewport and the
+// centring is plain layout, not a transform.
 .tp-overlay {
-  display: contents;
-}
-
-.scrim {
   position: fixed;
   inset: 0;
   z-index: var(--z-overlay, 2000);
+  display: grid;
+  place-items: center;
+  padding: var(--space-5);
+}
+
+.scrim {
+  position: absolute;
+  inset: 0;
   background: var(--scrim);
 }
 
 .palette {
-  position: fixed;
-  z-index: calc(var(--z-overlay, 2000) + 1);
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  // In-flow inside the centring grid — no position/transform of its own to resolve.
+  position: relative;
   display: flex;
   flex-direction: column;
   width: min(880px, 92vw);

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.scss
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.scss
@@ -5,33 +5,41 @@
   display: contents;
 }
 
-// ONE fixed layer that fills the viewport and centres its child with grid.
+// ONE fixed layer: the scrim AND the centring box, rendered by `app-shell`, whose
+// only ancestors are <body> and <html>.
 //
-// This replaces a `top:50% / left:50% / translate(-50%,-50%)` palette sitting beside
-// a SEPARATE fixed scrim. That shape depends on two things resolving correctly — the
-// fixed containing block, AND a percentage transform against the element's own box —
-// and it is the shape that failed in the packaged webview while working in Chromium.
-// `inset: 0` + `place-items: center` needs neither: the box IS the viewport and the
-// centring is plain layout, not a transform.
-// The dialog IS the panel; its ::backdrop is the scrim. Both are painted by the
-// browser in the TOP LAYER, so there is no z-index, no fixed positioning and no
-// containing block left to get wrong.
-.palette[open] {
-  // BELT AND BRACES. `showModal()` promotes the dialog into the top layer and the
-  // browser then positions it; but if that call is ever refused (it throws when the
-  // element is not connected, and a webview may differ), a plain `open` dialog is
-  // `position: absolute` and would sit wherever the flow left it — invisible in
-  // practice. Pinning it here means the panel is on screen either way: with
-  // showModal() the top layer wins and this is harmless; without it, this is what
-  // makes it visible. The symptom that forced this: the trigger flipped to "Close"
-  // (so the state was right) while nothing appeared.
+// That location is the whole point (see TilePaletteService). `position: fixed`
+// anchors to the viewport ONLY while no ancestor establishes a fixed-positioning
+// containing block — any `transform` / `filter` / `backdrop-filter` / `contain`
+// ancestor takes that job — and the board is full of frosted surfaces. Rendering
+// from the shell means there is no such ancestor to begin with, so nothing has to
+// resolve correctly and nothing has to be escaped: no teleport, no top layer, no
+// `<dialog>`. Centring is plain flex layout, not a percentage transform.
+.tp-overlay {
   position: fixed;
   inset: 0;
   z-index: var(--z-overlay, 2000);
-  margin: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-5);
+}
+
+// The scrim fills the overlay and sits BEHIND the panel; it is its own element so
+// the click-to-dismiss target is unambiguous and can carry the a11y affordances.
+.tp-scrim {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: var(--scrim);
+  cursor: default;
 }
 
 .palette {
+  // In-flow inside the centring layer — no position or transform of its own,
+  // just a paint order above the scrim.
+  position: relative;
+  z-index: 1;
   display: flex;
   flex-direction: column;
   width: min(880px, 92vw);
@@ -45,10 +53,6 @@
   background: var(--surface-overlay);
   color: var(--text-primary);
   box-shadow: var(--shadow-lg);
-
-  &::backdrop {
-    background: var(--scrim);
-  }
 }
 
 .palette-head {

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.scss
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.scss
@@ -53,24 +53,6 @@
   cursor: default;
 }
 
-// TEMPORARY instrument. Pinned to the very top of the viewport, OUTSIDE the panel,
-// so it is readable in a screenshot even when the panel itself is not.
-.tp-diag {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 1;
-  margin: 0;
-  padding: 4px 8px;
-  background: #000;
-  color: #7fff9f;
-  font-family: var(--font-mono, monospace);
-  font-size: 11px;
-  line-height: 1.4;
-  word-break: break-all;
-}
-
 .palette {
   // In-flow inside the centring layer — no position or transform of its own,
   // just a paint order above the scrim.

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.scss
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.scss
@@ -17,12 +17,26 @@
 // `<dialog>`. Centring is plain flex layout, not a percentage transform.
 .tp-overlay {
   position: fixed;
+  // `inset` AND the four longhands: the shorthand is newer than the engine we
+  // ship for, and a fixed box that falls back to `auto` insets is shrink-to-fit
+  // at its static position instead of the viewport.
   inset: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   z-index: var(--z-overlay, 2000);
+  // GEOMETRY COPIED FROM `.qs-scrim` (quick-search), deliberately. That overlay is
+  // proven in the packaged WKWebView — ⌘K works there — and this one was not:
+  // `align-items: center` over an auto-height flex child is a shape WebKit has
+  // collapsed to zero height before, which is exactly what the report showed (a
+  // dimmed screen with an 880px-wide grey LINE where the panel should be: correct
+  // width from `min()`, no height at all). Top-aligned with a `vh` offset needs no
+  // cross-axis sizing of the child.
   display: flex;
-  align-items: center;
   justify-content: center;
-  padding: var(--space-5);
+  align-items: flex-start;
+  padding: 9vh var(--space-4) var(--space-4);
 }
 
 // The scrim fills the overlay and sits BEHIND the panel; it is its own element so
@@ -30,9 +44,31 @@
 .tp-scrim {
   position: absolute;
   inset: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   border: 0;
   background: var(--scrim);
   cursor: default;
+}
+
+// TEMPORARY instrument. Pinned to the very top of the viewport, OUTSIDE the panel,
+// so it is readable in a screenshot even when the panel itself is not.
+.tp-diag {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1;
+  margin: 0;
+  padding: 4px 8px;
+  background: #000;
+  color: #7fff9f;
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  line-height: 1.4;
+  word-break: break-all;
 }
 
 .palette {
@@ -42,7 +78,12 @@
   z-index: 1;
   display: flex;
   flex-direction: column;
-  width: min(880px, 92vw);
+  // `min(880px, 100%)` (of the padded overlay) rather than `92vw`, mirroring
+  // `.qs-panel`. The reported failure had the WIDTH right and the HEIGHT zero, so
+  // the floor below is what makes "a grey line" structurally impossible: a panel
+  // whose content somehow measures nothing still occupies a real box.
+  width: min(880px, 100%);
+  min-height: 240px;
   max-height: 78vh;
   padding: 0;
   overflow: hidden;
@@ -91,6 +132,11 @@
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
   gap: var(--space-2);
   padding: var(--space-4) var(--space-5) var(--space-5);
+  // Takes the panel's remaining height and scrolls inside it; `min-height: 0` is
+  // what lets a flex item shrink below its content instead of forcing the panel
+  // taller than its max.
+  flex: 1 1 auto;
+  min-height: 0;
   overflow: auto;
 }
 

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.scss
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.scss
@@ -5,6 +5,11 @@
   display: contents;
 }
 
+// The teleported wrapper is a pass-through: its children are the fixed layers.
+.tp-overlay {
+  display: contents;
+}
+
 .scrim {
   position: fixed;
   inset: 0;

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.scss
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.scss
@@ -16,6 +16,21 @@
 // The dialog IS the panel; its ::backdrop is the scrim. Both are painted by the
 // browser in the TOP LAYER, so there is no z-index, no fixed positioning and no
 // containing block left to get wrong.
+.palette[open] {
+  // BELT AND BRACES. `showModal()` promotes the dialog into the top layer and the
+  // browser then positions it; but if that call is ever refused (it throws when the
+  // element is not connected, and a webview may differ), a plain `open` dialog is
+  // `position: absolute` and would sit wherever the flow left it — invisible in
+  // practice. Pinning it here means the panel is on screen either way: with
+  // showModal() the top layer wins and this is harmless; without it, this is what
+  // makes it visible. The symptom that forced this: the trigger flipped to "Close"
+  // (so the state was right) while nothing appeared.
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-overlay, 2000);
+  margin: auto;
+}
+
 .palette {
   display: flex;
   flex-direction: column;

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.scss
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.scss
@@ -13,34 +13,27 @@
 // and it is the shape that failed in the packaged webview while working in Chromium.
 // `inset: 0` + `place-items: center` needs neither: the box IS the viewport and the
 // centring is plain layout, not a transform.
-.tp-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: var(--z-overlay, 2000);
-  display: grid;
-  place-items: center;
-  padding: var(--space-5);
-}
-
-.scrim {
-  position: absolute;
-  inset: 0;
-  background: var(--scrim);
-}
-
+// The dialog IS the panel; its ::backdrop is the scrim. Both are painted by the
+// browser in the TOP LAYER, so there is no z-index, no fixed positioning and no
+// containing block left to get wrong.
 .palette {
-  // In-flow inside the centring grid — no position/transform of its own to resolve.
-  position: relative;
   display: flex;
   flex-direction: column;
   width: min(880px, 92vw);
   max-height: 78vh;
+  padding: 0;
   overflow: hidden;
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-xl);
+  // Floating overlay ⇒ OPAQUE (T3): the frosted card surface would bleed the
+  // board behind it through and read as broken.
   background: var(--surface-overlay);
-  backdrop-filter: none;
+  color: var(--text-primary);
   box-shadow: var(--shadow-lg);
+
+  &::backdrop {
+    background: var(--scrim);
+  }
 }
 
 .palette-head {

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.ts
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.ts
@@ -8,10 +8,10 @@ import {
   inject,
   output,
   signal,
+  viewChild,
 } from "@angular/core";
 import { IpcService } from "../../../core/ipc.service";
 import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
-import { TeleportToBodyDirective } from "../../../design-system/teleport-to-body.directive";
 import type { NoteCitation, TileConfig, TileKind } from "../../../core/models";
 
 /** What a chosen tile kind needs before it can be added. */
@@ -140,19 +140,29 @@ const LINK_KIND: Partial<Record<TileKind, string>> = {
 @Component({
   selector: "app-tile-palette",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MurSpinnerComponent, TeleportToBodyDirective],
+  imports: [MurSpinnerComponent],
   templateUrl: "./tile-palette.component.html",
   styleUrl: "./tile-palette.component.scss",
-  host: {
-    // Escape must dismiss the modal no matter where focus currently sits. A
-    // keydown bound to the dialog element only fires when the dialog itself (or
-    // a descendant) has focus, which is not guaranteed the moment it opens.
-    "(document:keydown)": "onKeydown($event)",
-  },
 })
 export class TilePaletteComponent {
   private readonly ipc = inject(IpcService);
   private readonly injector = inject(Injector);
+
+  private readonly dlg = viewChild<ElementRef<HTMLDialogElement>>("dlg");
+
+  /**
+   * Promote the dialog into the TOP LAYER once it renders.
+   *
+   * `showModal()` (not `open`) is the point: only the modal form enters the top
+   * layer, which is what puts it outside every stacking context and every
+   * fixed-positioning containing block. `afterNextRender` is the zoneless-safe
+   * one-shot, and the injector is required because this runs from a field
+   * initialiser's effect rather than a constructor body.
+   */
+  private readonly _open = afterNextRender(() => {
+    const el = this.dlg()?.nativeElement;
+    if (el && !el.open) el.showModal();
+  });
 
   readonly dismiss = output<void>();
   readonly choose = output<TileChoice>();
@@ -271,17 +281,30 @@ export class TilePaletteComponent {
     this.choose.emit({ kind: type.kind, title: q, config: { question: q } });
   }
 
-  onBackdrop(): void {
+  /**
+   * A click that lands on the DIALOG ITSELF is a backdrop click: the dialog's own
+   * box is the panel, and its ::backdrop is painted by the element, so a press
+   * outside the panel is reported with the dialog as target. Anything inside the
+   * panel has a descendant target and is left alone.
+   */
+  onDialogClick(event: MouseEvent): void {
+    if (event.target === this.dlg()?.nativeElement) this.dismiss.emit();
+  }
+
+  /** Escape is handled by the platform; this mirrors it back into our state. */
+  onDialogClose(): void {
     this.dismiss.emit();
   }
 
-  /** Escape closes the palette (a modal must always be dismissable). */
-  onKeydown(event: KeyboardEvent): void {
-    if (event.key === "Escape") {
-      event.stopPropagation();
-      if (this.selected()) this.back();
-      else this.dismiss.emit();
-    }
+  /**
+   * Escape on the SECOND step goes back to the catalogue instead of closing the
+   * whole palette — losing the whole modal because you changed your mind about
+   * which KIND of tile you wanted is a needless step backwards.
+   */
+  onDialogKeydown(event: KeyboardEvent): void {
+    if (event.key !== "Escape" || !this.selected()) return;
+    event.preventDefault();
+    this.back();
   }
 
   registerField(el: ElementRef<HTMLInputElement> | undefined): void {

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.ts
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.ts
@@ -159,10 +159,34 @@ export class TilePaletteComponent {
    * one-shot, and the injector is required because this runs from a field
    * initialiser's effect rather than a constructor body.
    */
-  private readonly _open = afterNextRender(() => {
+  private readonly _open = afterNextRender(() => this.reveal());
+
+  /**
+   * Show the dialog, preferring the modal (top-layer) form but never depending on
+   * it.
+   *
+   * `showModal()` is the good path: it promotes the element into the top layer,
+   * outside every stacking context and containing block. But it THROWS when the
+   * element is not connected, and a webview may refuse it for its own reasons —
+   * and when it does, a `<dialog>` that never opened stays `display: none`. That
+   * is exactly the symptom reported: the trigger flipped to "Close" (state was
+   * right) while nothing appeared on screen.
+   *
+   * So: try modal, verify with `:modal`, and fall back to a plain `open` dialog,
+   * which the stylesheet pins to the viewport. The panel is on screen either way.
+   */
+  private reveal(): void {
     const el = this.dlg()?.nativeElement;
-    if (el && !el.open) el.showModal();
-  });
+    if (!el || el.open) return;
+    try {
+      el.showModal();
+    } catch {
+      // fall through to the non-modal path below
+    }
+    if (!el.open || !el.matches(":modal")) {
+      el.open = true;
+    }
+  }
 
   readonly dismiss = output<void>();
   readonly choose = output<TileChoice>();

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.ts
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.ts
@@ -11,6 +11,7 @@ import {
 } from "@angular/core";
 import { IpcService } from "../../../core/ipc.service";
 import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
+import { TeleportToBodyDirective } from "../../../design-system/teleport-to-body.directive";
 import type { NoteCitation, TileConfig, TileKind } from "../../../core/models";
 
 /** What a chosen tile kind needs before it can be added. */
@@ -139,7 +140,7 @@ const LINK_KIND: Partial<Record<TileKind, string>> = {
 @Component({
   selector: "app-tile-palette",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MurSpinnerComponent],
+  imports: [MurSpinnerComponent, TeleportToBodyDirective],
   templateUrl: "./tile-palette.component.html",
   styleUrl: "./tile-palette.component.scss",
   host: {

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.ts
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.ts
@@ -8,21 +8,16 @@ import {
   inject,
   output,
   signal,
-  viewChild,
 } from "@angular/core";
 import { IpcService } from "../../../core/ipc.service";
 import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
-import type { NoteCitation, TileConfig, TileKind } from "../../../core/models";
+import type { TileChoice } from "../../../services/tile-palette.service";
+import type { NoteCitation, TileKind } from "../../../core/models";
 
 /** What a chosen tile kind needs before it can be added. */
 type SourceMode = "none" | "link" | "entity" | "question";
 
-export interface TileChoice {
-  kind: TileKind;
-  refId?: string;
-  title?: string;
-  config?: TileConfig;
-}
+export type { TileChoice };
 
 interface NodeType {
   kind: TileKind;
@@ -129,8 +124,20 @@ const LINK_KIND: Partial<Record<TileKind, string>> = {
 };
 
 /**
- * The "Add a tile" palette — a FLOATING modal, so it is OPAQUE
+ * The "Add a tile" palette — a FLOATING overlay, so it is OPAQUE
  * (`--surface-overlay`, `backdrop-filter: none`) per angular-zoneless.md T3.
+ *
+ * PRESENTATION IS PURELY DECLARATIVE, and that is deliberate. The component is
+ * rendered by `app-shell` behind `@if (tilePalette.open())` (see
+ * `TilePaletteService` for why the shell and not the board), and its own template
+ * is a plain `position: fixed` layer. There is no imperative "reveal" step at
+ * all — no `showModal()`, no `matches(":modal")`, no teleport, no top layer.
+ *
+ * That is the lesson of angular-zoneless.md T5, paid for five times over: every
+ * one of those is a modern-ish API that the engine the tests run supports and the
+ * engine we ship may not, and each failure looked identical from outside — the
+ * trigger flipping to "Close" while nothing appeared. A template `@if` plus CSS
+ * has nothing left that can throw, be refused, or resolve differently.
  *
  * Source pickers reuse the SHIPPED gated readers: `list_link_candidates` for
  * notes/recordings/documents and `get_graph` for entities. Nothing sealed can
@@ -143,58 +150,18 @@ const LINK_KIND: Partial<Record<TileKind, string>> = {
   imports: [MurSpinnerComponent],
   templateUrl: "./tile-palette.component.html",
   styleUrl: "./tile-palette.component.scss",
+  host: {
+    // Escape is handled on the DOCUMENT rather than on the overlay, because the
+    // catalogue step focuses nothing — a `(keydown.escape)` bound to the overlay
+    // would only fire once something inside it happened to hold focus. The
+    // component only exists while the palette is open, so the listener cannot
+    // outlive it.
+    "(document:keydown)": "onKeydown($event)",
+  },
 })
 export class TilePaletteComponent {
   private readonly ipc = inject(IpcService);
   private readonly injector = inject(Injector);
-
-  private readonly dlg = viewChild<ElementRef<HTMLDialogElement>>("dlg");
-
-  /**
-   * Promote the dialog into the TOP LAYER once it renders.
-   *
-   * `showModal()` (not `open`) is the point: only the modal form enters the top
-   * layer, which is what puts it outside every stacking context and every
-   * fixed-positioning containing block. `afterNextRender` is the zoneless-safe
-   * one-shot, and the injector is required because this runs from a field
-   * initialiser's effect rather than a constructor body.
-   */
-  private readonly _open = afterNextRender(() => this.reveal());
-
-  /**
-   * Show the dialog, preferring the modal (top-layer) form but never depending on
-   * it.
-   *
-   * `showModal()` is the good path: it promotes the element into the top layer,
-   * outside every stacking context and containing block. But it THROWS when the
-   * element is not connected, and a webview may refuse it for its own reasons —
-   * and when it does, a `<dialog>` that never opened stays `display: none`. That
-   * is exactly the symptom reported: the trigger flipped to "Close" (state was
-   * right) while nothing appeared on screen.
-   *
-   * So: try modal, and fall back to a plain `open` dialog, which the stylesheet
-   * pins to the viewport. The panel is on screen either way.
-   *
-   * DO NOT reintroduce an `el.matches(":modal")` check here. `:modal` is a recent
-   * pseudo-class, and an engine that does not know it makes `matches()` THROW a
-   * SyntaxError — which, thrown from `afterNextRender`, meant the dialog never
-   * received `open` and an unopened `<dialog>` is `display: none`. That produced
-   * exactly the reported symptom (trigger flipped to "Close", nothing on screen)
-   * and could not reproduce in the e2e, because the engines Playwright ships DO
-   * support `:modal`. `el.open` alone answers the only question that matters.
-   */
-  private reveal(): void {
-    const el = this.dlg()?.nativeElement;
-    if (!el || el.open) return;
-    try {
-      el.showModal();
-    } catch {
-      // Modal refused — the plain-open path below covers it.
-    }
-    if (!el.open) {
-      el.open = true;
-    }
-  }
 
   readonly dismiss = output<void>();
   readonly choose = output<TileChoice>();
@@ -314,29 +281,15 @@ export class TilePaletteComponent {
   }
 
   /**
-   * A click that lands on the DIALOG ITSELF is a backdrop click: the dialog's own
-   * box is the panel, and its ::backdrop is painted by the element, so a press
-   * outside the panel is reported with the dialog as target. Anything inside the
-   * panel has a descendant target and is left alone.
-   */
-  onDialogClick(event: MouseEvent): void {
-    if (event.target === this.dlg()?.nativeElement) this.dismiss.emit();
-  }
-
-  /** Escape is handled by the platform; this mirrors it back into our state. */
-  onDialogClose(): void {
-    this.dismiss.emit();
-  }
-
-  /**
    * Escape on the SECOND step goes back to the catalogue instead of closing the
-   * whole palette — losing the whole modal because you changed your mind about
+   * whole palette — losing the whole overlay because you changed your mind about
    * which KIND of tile you wanted is a needless step backwards.
    */
-  onDialogKeydown(event: KeyboardEvent): void {
-    if (event.key !== "Escape" || !this.selected()) return;
+  onKeydown(event: KeyboardEvent): void {
+    if (event.key !== "Escape") return;
     event.preventDefault();
-    this.back();
+    if (this.selected()) this.back();
+    else this.dismiss.emit();
   }
 
   registerField(el: ElementRef<HTMLInputElement> | undefined): void {

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.ts
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.ts
@@ -172,8 +172,16 @@ export class TilePaletteComponent {
    * is exactly the symptom reported: the trigger flipped to "Close" (state was
    * right) while nothing appeared on screen.
    *
-   * So: try modal, verify with `:modal`, and fall back to a plain `open` dialog,
-   * which the stylesheet pins to the viewport. The panel is on screen either way.
+   * So: try modal, and fall back to a plain `open` dialog, which the stylesheet
+   * pins to the viewport. The panel is on screen either way.
+   *
+   * DO NOT reintroduce an `el.matches(":modal")` check here. `:modal` is a recent
+   * pseudo-class, and an engine that does not know it makes `matches()` THROW a
+   * SyntaxError — which, thrown from `afterNextRender`, meant the dialog never
+   * received `open` and an unopened `<dialog>` is `display: none`. That produced
+   * exactly the reported symptom (trigger flipped to "Close", nothing on screen)
+   * and could not reproduce in the e2e, because the engines Playwright ships DO
+   * support `:modal`. `el.open` alone answers the only question that matters.
    */
   private reveal(): void {
     const el = this.dlg()?.nativeElement;
@@ -181,9 +189,9 @@ export class TilePaletteComponent {
     try {
       el.showModal();
     } catch {
-      // fall through to the non-modal path below
+      // Modal refused — the plain-open path below covers it.
     }
-    if (!el.open || !el.matches(":modal")) {
+    if (!el.open) {
       el.open = true;
     }
   }

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.ts
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.ts
@@ -168,6 +168,46 @@ export class TilePaletteComponent {
 
   readonly types = NODE_TYPES;
 
+  /**
+   * TEMPORARY on-screen instrument — remove once the packaged webview is confirmed
+   * good. There is no log file to read from the running dev app and this engine
+   * cannot be driven from a test, so the only way to MEASURE rather than guess is
+   * to put the numbers where a screenshot can capture them (angular-zoneless.md
+   * T5: add observability before guessing). Seeded with "measuring…" on purpose:
+   * if that is what shows, `afterNextRender` never ran, which is itself the answer.
+   */
+  readonly diag = signal("measuring…");
+
+  private readonly _measure = afterNextRender(() => {
+    const box = (sel: string): string => {
+      const el = document.querySelector(sel);
+      if (!el) return `${sel}:none`;
+      const b = el.getBoundingClientRect();
+      return `${sel} ${Math.round(b.x)},${Math.round(b.y)} ${Math.round(b.width)}x${Math.round(b.height)}`;
+    };
+    try {
+      const panel = document.querySelector(".palette");
+      const cs = panel ? getComputedStyle(panel) : null;
+      this.diag.set(
+        [
+          `vp ${window.innerWidth}x${window.innerHeight}`,
+          box(".tp-overlay"),
+          box(".palette"),
+          box(".palette-head"),
+          box(".catalogue"),
+          `kids ${panel?.childElementCount ?? "-"}`,
+          `scrollH ${panel?.scrollHeight ?? "-"}`,
+          `maxH ${cs?.maxHeight ?? "-"}`,
+          `minH ${cs?.minHeight ?? "-"}`,
+          `disp ${cs?.display ?? "-"}`,
+          `nodes ${document.querySelectorAll(".palette .node").length}`,
+        ].join(" · "),
+      );
+    } catch (e) {
+      this.diag.set(`measure threw: ${String(e)}`);
+    }
+  });
+
   /** The kind being configured; `null` ⇒ the catalogue step. */
   readonly selected = signal<NodeType | null>(null);
   readonly query = signal("");

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.ts
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.ts
@@ -168,46 +168,6 @@ export class TilePaletteComponent {
 
   readonly types = NODE_TYPES;
 
-  /**
-   * TEMPORARY on-screen instrument — remove once the packaged webview is confirmed
-   * good. There is no log file to read from the running dev app and this engine
-   * cannot be driven from a test, so the only way to MEASURE rather than guess is
-   * to put the numbers where a screenshot can capture them (angular-zoneless.md
-   * T5: add observability before guessing). Seeded with "measuring…" on purpose:
-   * if that is what shows, `afterNextRender` never ran, which is itself the answer.
-   */
-  readonly diag = signal("measuring…");
-
-  private readonly _measure = afterNextRender(() => {
-    const box = (sel: string): string => {
-      const el = document.querySelector(sel);
-      if (!el) return `${sel}:none`;
-      const b = el.getBoundingClientRect();
-      return `${sel} ${Math.round(b.x)},${Math.round(b.y)} ${Math.round(b.width)}x${Math.round(b.height)}`;
-    };
-    try {
-      const panel = document.querySelector(".palette");
-      const cs = panel ? getComputedStyle(panel) : null;
-      this.diag.set(
-        [
-          `vp ${window.innerWidth}x${window.innerHeight}`,
-          box(".tp-overlay"),
-          box(".palette"),
-          box(".palette-head"),
-          box(".catalogue"),
-          `kids ${panel?.childElementCount ?? "-"}`,
-          `scrollH ${panel?.scrollHeight ?? "-"}`,
-          `maxH ${cs?.maxHeight ?? "-"}`,
-          `minH ${cs?.minHeight ?? "-"}`,
-          `disp ${cs?.display ?? "-"}`,
-          `nodes ${document.querySelectorAll(".palette .node").length}`,
-        ].join(" · "),
-      );
-    } catch (e) {
-      this.diag.set(`measure threw: ${String(e)}`);
-    }
-  });
-
   /** The kind being configured; `null` ⇒ the catalogue step. */
   readonly selected = signal<NodeType | null>(null);
   readonly query = signal("");

--- a/src/app/services/tile-palette.service.ts
+++ b/src/app/services/tile-palette.service.ts
@@ -1,0 +1,74 @@
+import { Injectable, signal } from "@angular/core";
+import type { TileConfig, TileKind } from "../core/models";
+
+/** A tile the user picked in the Add-a-tile palette. */
+export interface TileChoice {
+  kind: TileKind;
+  refId?: string;
+  title?: string;
+  config?: TileConfig;
+}
+
+/**
+ * Open-state for the Add-a-tile palette, held at the ROOT so the palette is
+ * rendered by `app-shell` instead of by the board.
+ *
+ * WHY THE SHELL AND NOT THE BOARD — five failed fixes bought this. Every earlier
+ * attempt kept the palette inside `app-dashboard-view`'s own subtree and then
+ * relied on ONE mechanism to lift it back out to the viewport: first a
+ * `position: fixed` box with a percentage transform, then a teleport to `<body>`,
+ * then the browser's TOP LAYER via `<dialog>.showModal()`. Each of those is a
+ * thing an engine can implement differently, each worked in Chromium and in
+ * Playwright's WebKit, and each still failed in the packaged WKWebView.
+ *
+ * Every overlay in Murmur that has never had this class of bug — quick-search
+ * (⌘K), the document preview, the reminder composer, the lock×shares dialog — is
+ * a plain `position: fixed; inset: 0` box rendered by `app-shell`, whose only
+ * ancestors are `<body>` and `<html>`. Nothing a feature view does to
+ * positioning, stacking, compositing or scrolling can reach it, because it is not
+ * in that subtree at all. This service puts the palette on exactly that footing:
+ * no `<dialog>`, no `showModal()`, no `:modal`, no top layer, no teleport, and no
+ * imperative reveal that can throw — a template `@if` and CSS, which is the
+ * smallest mechanism that can possibly work.
+ *
+ * `e2e/dashboards/dashboards-context.spec.ts` pins it: with the board's subtree
+ * made a fixed-positioning containing block AND `showModal()` refused, the
+ * palette must still land on screen. That test FAILS against every earlier shape.
+ */
+@Injectable({ providedIn: "root" })
+export class TilePaletteService {
+  private readonly _open = signal(false);
+  readonly open = this._open.asReadonly();
+
+  /** Resolver for the in-flight `request()`, if any. */
+  private pending: ((choice: TileChoice | null) => void) | null = null;
+
+  /**
+   * Open the palette; resolves with the tile the user picked, or `null` if they
+   * dismissed it. A second `request()` supersedes the first — the earlier promise
+   * resolves `null` rather than being left hanging forever.
+   */
+  request(): Promise<TileChoice | null> {
+    this.settle(null);
+    this._open.set(true);
+    return new Promise<TileChoice | null>((resolve) => {
+      this.pending = resolve;
+    });
+  }
+
+  choose(choice: TileChoice): void {
+    this._open.set(false);
+    this.settle(choice);
+  }
+
+  dismiss(): void {
+    this._open.set(false);
+    this.settle(null);
+  }
+
+  private settle(choice: TileChoice | null): void {
+    const resolve = this.pending;
+    this.pending = null;
+    resolve?.(choice);
+  }
+}


### PR DESCRIPTION
A user-reported UI failure took **four rounds** to fix (PR #566: the Add-tile palette opened in Chromium and in Playwright's WebKit, and stayed invisible in the packaged WKWebView). Three of those rounds were hypotheses formed by **reading the component**. The scaffold said nothing about this class, so it does now.

## The bug, and why the suite could not see it

```ts
if (!el.open || !el.matches(":modal")) { el.open = true; }   // matches() OUTSIDE the try
```

`:modal` is a recent pseudo-class. On an engine that does not know it, `matches()` **throws SyntaxError** — thrown out of `afterNextRender`, that skipped the line setting `el.open`, and an unopened `<dialog>` is `display: none`.

Playwright ships engines that **do** support `:modal`, so the throw never happened in the suite. **The tests were structurally incapable of seeing it, and they were green the entire time.** That is the part worth institutionalising: green gates were not weak evidence here, they were *irrelevant* evidence.

## What is now binding — rule T5 in `angular-zoneless.md`

It goes in **rules**, not only in a learnings journal, because rules are auto-loaded into every session — the loop that needs this is the one debugging at 2am, not a dispatched agent.

1. **Reproduce before analysing.** First action on a reported UI failure is a live repro — open it, click it, look. Never "read the component and form a hypothesis". And a failure that will not reproduce in your engine is a **result** (the environment differs), not a licence to keep reading CSS.
2. **RED-before-GREEN binds for UI too.** Green before *and* after a fix proves nothing. When the failure lives in an engine you cannot run, get RED by **stubbing the newer API** (`Element.prototype.matches` throwing on `:modal`, `showModal()` refusing) and asserting the UI still works.
3. **Guard every modern-API call**, or answer the question with an older API. Here `el.open` answered the only question that mattered.
4. **Add observability before guessing.** A trigger that opens a modal should reflect its state; otherwise "the click never landed" and "the panel never painted" are indistinguishable from outside. Adding that one label settled in a single screenshot what three rounds of analysis had not.

## Per-agent journals

- `learnings/angular-zoneless-dev.md` — four bullets covering the above.
- `learnings/main-loop.md` — **a user report contradicting green gates means the ORACLE is wrong**; fix the measurement before touching the implementation.

`.codex` mirrors synced (`scripts/agent-sync-learnings` + the rule copy). `scripts/agent-config-audit --ci` **PASS (152 checks)** — it caught the rule-mirror drift before CI did, which is exactly what it is for.

## Honest gap

`eval/agents/matrix.py` was **not** run for this edit. Per Track C that is the gap. This rule earns its place from a real four-round failure rather than from a measured delta — and prose rules on an already-capable model are precisely what ceilings out in that harness. Stating it rather than implying a measurement I did not take.