### PR TITLE
fix(dashboards): collapse the empties, size tiles by kind, and stop offering three tiles that cannot fire

### DIFF
--- a/docs/research/2026-08-04-dashboards-ux-research.md
+++ b/docs/research/2026-08-04-dashboards-ux-research.md
@@ -1,0 +1,384 @@
+# Dashboards — UX/UI research and the tile-catalogue verdict
+
+*Research brief · 2026-08-04 · intended path `docs/research/2026-08-04-dashboards-ux-research.md`*
+
+Every load-bearing claim below is cited `file:symbol`. Claims from the grounding investigations that I re-checked against the tree and found **wrong** are marked ⚠ and corrected in place.
+
+---
+
+## The one-paragraph answer
+
+**The screenshot is a rendering bug, not a design failure, and it has a four-edit fix that works on the board the user already has.** Five of the nine tiles on that board render an apology inside a full-height card; all nine carry `span = 4` in SQLite because `commands/dashboards.rs:477` is `span.unwrap_or(4)` and `dashboard-view.component.ts::addTile` never passes a span even though `dashboards.service.ts::addTile` already accepts one — 12/4 = exactly three per row, forever. Collapse empty tiles to a 36-px dashed strip, override the display span per kind, render duplicates as a "same as above" strip, and add the missing `--text-tertiary` tier plus a 22-px per-kind icon mark, and the existing board looks composed. That is one session, pure frontend, no migration, and it is the entire visible delta the user complained about. Everything else in this brief is a second, deeper problem that the pretty layer does not touch: **"Ask this board" does not use the board as a retrieval scope — it uses it as a retrieval *bypass*.** `commands/mod.rs::ask_vault` routes any non-empty `explicit_sources` to the deterministic floor (no agent loop, no tools), `summarize/vault_context.rs::fair_pack_explicit_sections` then gives every source `budget / n` characters and hard-truncates, and `commands/dashboards.rs::get_dashboard_sources` drops seven of ten tile kinds with `_ => continue`. So the board's answers get *worse* the more the user composes into it, and the six only-Murmur tiles are invisible to the one feature they exist to feed. Fix the picture first because that is what was reported; fix the scope second because that is what makes the feature worth having; and do not add tile kinds to a board that cannot yet read the tiles it has.
+
+---
+
+## 1. Why the shipped board looks poor — root causes
+
+### 1a. The data is genuinely thin (measured on the user's own vault)
+
+Measured against `~/Library/Application Support/MeetNotes-dev/meetnotes.sqlite` — 78 meetings, Σ 1.38 h, **avg 63 s per meeting**. Absolute counts are small; the structural ratios are size-independent.
+
+| Symptom | Root cause (symbol) | Measured |
+|---|---|---|
+| "No figures recorded for this yet." | `facts::EXTRACT_SYSTEM` asks for *"durable state worth tracking"* (status/owner/deadline/role) and **never asks for quantities**; `commands/dashboards.rs::looks_numeric` is a post-filter accepting a leading ASCII digit | **6 of 48 facts (12.5 %) pass**, and **2 of the 6 are dates** (`deadline = 2026-07-04`). They belong to 3 of 57 entities → **P(non-empty \| random entity) = 5.3 %**. The user's anchor ("Brain") has 4 facts, all prose |
+| Drift lane with one step | `list_facts_visible` → `max_by_key(predicate count)`; the winner had count 1 | **1 of 19 fact-bearing entities** has ≥2 facts under one predicate → **1.8 %**. Three independent brakes: `facts::extract_fact_candidates` returns `Vec::new()` when `reasoner.id() == "stub"`; `facts::reconcile_facts` requires the *same normalized* `(entity, subject, predicate)` while the vault has **43 distinct predicates across 48 facts**; `commands/facts.rs::build_supersession_rows` skips same-meeting supersessions. `supersessions` = **0 rows** |
+| Flat pulse | `storage/graph_store.rs::Db::add_mention` is `INSERT OR IGNORE` on PK `(entity_id, meeting_id)` — **it counts MEETINGS, not utterances**, so the palette copy ("how often this is actually talked about") is false | 45 entities @1 mention, 5 @2, **0 @≥3**. `entity_mentions` covers **18 of 78 meetings**, written best-effort by `commands/mod.rs::build_and_persist_entities` via a cloud `complete_json` call at note time, with no backfill. **No entity in the vault can produce a non-degenerate 12-week series** |
+| Two identical Promises tiles | `tile-palette.component.ts` declares `promises` as `mode: "none"` → `pick()` emits `{kind}` with no config → `cfg.owner = None` on both → the same global list. `resolve_tile`'s `"promises"` arm **has supported `cfg.owner` since day one**; nothing in the UI ever writes it, and `TileData::Promises.owner` is never rendered | Structurally guaranteed, not a user error |
+| Promise meta reads as noise; Person headline is 0 | `summarize::action_items::extract_owner` takes the head before ` — ` verbatim | **29 of 29** open items carry the literal owner `"(właściciel nieokreślony)"`. Cascade: `resolve_tile`'s `"person"` arm matches `normalize_owner` against the person's name → **`TileData::Person.open_commitments` is structurally 0 for every person in the vault** |
+| "This note has no text yet." ×3 | `list_notes_visible` offers every note; picker has no non-empty filter | **20 of 56** `kind='note'` documents have `text` length 0. The three pinned ones are 0 / 18 / 86 chars, with meaningful-looking titles |
+
+**The one-line diagnosis:** three of the four "only-Murmur" tile kinds are anchored to a single entity id over the two thinnest tables in the schema (`facts` 48 rows, `entity_mentions` 55 rows), and the palette offers all 57 entities with no preflight.
+
+### 1b. The visual system is flat (specific devices the prototype had, the ship dropped)
+
+| Device in `docs/dreams/prototypes/dashboards/index.html` | Shipped |
+|---|---|
+| 22-px rounded icon chip per kind, coloured (`:207-209`, `:650`) | **nothing** — `dashboard-tile.component.html:5-33` is `<h3>` + `<span class="tile-kind">`. Zero colour in any tile header. This single omission is most of "nie wygląda bogato": the home-screen *thumbnail* (`board-card`) is richer than the board |
+| Variable tile sizes | every tile born `span 4` (`dashboards.rs:477` + `addTile` never passing one) → a literal 3-column wall. Plus `min-height: 74px` on the body → uniform heights |
+| Smooth `<polyline>` + area fill (`:537-545`) | 12 bars, `barHeight = v / max(...weekly) * 100` with `.pulse-bar { min-height: 3px }` — **a zero week draws a visible mark for data that does not exist**, and a peak of 1 renders at 100 %, so a board with 40 mentions/wk looks identical to one with 1 |
+| Drift rows carrying `Sarah Chen · Apr 28 · "auth is heavier than we thought"` | `meta: Some(short_day(&f.valid_from))` — a bare date, while `f.meeting_id` sits right there |
+| Per-board tint + emoji + subtitle + freshness line + sealed marker (`:603-621`) | `emoji`/`tint` are **read** in three places and **written nowhere** (`dashboards-home.component.ts:95` calls `create(title)` only; the one `update` call passes `{pinned}`). No rename. `TINTS` in `dashboards.rs` and six scss mappings are dead code → every board card is a flat grey wash |
+| Inline `[1][2][3]` citations that scroll to the tile (`:546-550`, `:732-740`) | `{{ turn.text }}` as plain text with `white-space: pre-wrap`. The answer is markdown the prompt *demands* (`summarize/vault_chat.rs::build`), so `**` and `[[…]]` render literally. `src/app/shared/markdown/markdown.component.ts` exists and already turns `[[Wikilinks]]` into gated chips — **dashboards is the only AI surface in the app not using it** |
+| tile entrance stagger, 45 ms | none |
+
+Plus, measured: `--text-muted` is **3.62 : 1** on the tile surface (dark) and **3.46 : 1** (light), and it is used at 10–11 px for `.tile-kind`, `.row-meta`, `.drift-meta`, `.number-key`, `.live-chip` — the entire secondary layer is below the legibility floor. The 6-family hue map is a measured accessibility failure (`--accent` ↔ `--graph-document` ΔE 14.2 normal / **3.6 protan**; `--warning` ↔ `--graph-meeting` ΔE 5.7), and `--accent` is user-selectable with **5 of 6 options colliding** with a family hue. Nine raw `rgba()` values render white-on-near-white in light mode. Eleven empty states all render as the same `<p class="muted">` inside a full-height box. The Ask panel holds `flex: 0 0 330px` permanently, usually showing three suggestion buttons.
+
+### 1c. The Ask error — diagnosed, and one grounding hypothesis rejected
+
+`summarizer error: cloud provider response failed after protected dispatch; details omitted` is produced by `summarize/redact.rs::content_free_dispatch_error`, the `AppError::Summarize(_)` arm, after `RedactingProvider::complete` sees the inner provider fail. It collapses into one sentence: the 180 s `CLAUDE_TIMEOUT`, spawn failure, empty stdout, non-UTF8 output, **and** `claude_code.rs::claude_failure_message` — which is *already* a content-free, actionable diagnostic naming the likely bad model id and the exact Settings path to fix it.
+
+⚠ **The "board too big / 200 k chars / timeout" hypothesis is wrong for this board.** `get_dashboard_sources` skips every derived tile (`dashboards.rs:679` `_ => continue`), so the user's 9-tile board produced **at most 4 sources — three of them notes with 0 / 18 / 86 characters of text**. The corpus was nearly empty. This was a plain `claude_code` dispatch failure. Do **not** ship scope-blaming copy ("this board is too big, 47 sources") until `PackedContext` exists and `refs.len()` is real — it would have been factually false on the board that produced the complaint.
+
+Two aggravations on the frontend: `dashboard-view.component.ts::errorText` and `dashboards.service.ts::message` are hand-rolled raw-string renderers (the app deleted nine of these to establish `core/copy/error-copy.service.ts` as the boundary; dashboards reintroduced two), and the error is pushed as `{role: "assistant"}` so it renders in a normal grey bubble, visually identical to a real answer, with no retry.
+
+---
+
+## 2. Verdict on the 10 shipped tiles
+
+**Hard constraint that shapes every verdict — tile kinds are append-only forever.** `resolve_tile`'s terminal arm is `other => Err(AppError::InvalidArg(format!("unknown tile kind: {other}")))` (`dashboards.rs:1010`) and `get_dashboard` collects with `.collect::<Result<Vec<_>, AppError>>()?`. **One unresolvable tile fails the entire board.** The user's board contains `numbers` and `pulse` rows, so deleting those arms turns their board into a hard error at open. Migrating `dashboard_tiles.kind` would be a destructive rewrite of user rows — forbidden. Therefore **"KILL" always means: remove the entry from `NODE_TYPES` in `tile-palette.component.ts` so no new one can be placed, and leave the `resolve_tile` arm alive rendering a proper degenerate/empty state.**
+
+| # | Tile | Verdict | Evidence |
+|---|---|---|---|
+| 1 | **Note** | **KEEP** — palette-level merge with Document | One of only 3 kinds that feed Ask. Picker must filter the 20 empty-text notes |
+| 2 | **Meeting** | **KEEP — REDESIGN (additive payload)** | Ships `{started_at, duration_s, has_audio}` and nothing else while `segments.speaker` (714 rows, 100 % attributed) and `timelines` chapters sit one gated read away. Every tile reads "1 min" on this vault |
+| 3 | **Document** | **KEEP** — same palette entry as Note | 4 rows; identical job. Merge the *palette offer* ("Add a source"), not the storage kind — the candidate row already carries `LINK_KIND` |
+| 4 | **Person** | **KEEP — REFEED** | Headline `open_commitments` is structurally 0 vault-wide (see §1a). Un-zeroed by the `normalize_owner` fix alone |
+| 5 | **Drift lane** | **RETIRE FROM PALETTE unless preflight says ≥2 steps** | 1.8 % hit rate; `supersessions` = 0. Keep the arm; `rows.len() < 2` must render one line ("unchanged since 3 Jun"), never a rail — a rail asserts movement |
+| 6 | **Numbers** | **RETIRE FROM PALETTE** | 5.3 % hit rate, 2 of 6 hits are dates. `looks_numeric` is a post-filter over a substrate that was never asked to contain numbers |
+| 7 | **Pulse** | **RETIRE FROM PALETTE** | 0 % non-degenerate. Its own copy is false (meetings, not utterances). Its bar mark actively lies twice. `dashboard-tile.component.html:104` has **no empty branch at all** |
+| 8 | **Promises** | **KEEP — THE FLAGSHIP; needs a subject** | 29 real open items. Add `config.owner` (backend already reads it) with an explicit "Everyone" option, and render the owner in the header. This is the dream's #2 and the tile that most justifies the feature |
+| 9 | **Reminders** | **KEEP AS-IS, low priority** | 1 row. `let due_count = rows.len()` counts *all* active rows **before** the `TILE_ROWS` truncation — both halves of the name are wrong — and the FE never renders it. Delete the field or fix it |
+| 10 | **Living answer** | **KEEP — PROMOTE TO HERO** | Its gate (`living_answer_withheld`) is the most carefully built thing in the feature. Its failures are upstream (dispatch) and presentational (`{{ la.answer }}` renders markdown raw) |
+
+**Rejected merges.** `tile-verdict` proposed collapsing 10 kinds → 6 (`source`, `commitments`, `facts`…). Creating new kinds to retire old ones costs nine touchpoints each (`TILE_KINDS`, a `resolve_tile` arm, a `TileData` variant, `models.ts`, template branch, empty branch, palette entry, span default, icon — with arm/kind parity enforced at `commands/tests/dashboard_cmd_tests.rs:439`) and **cannot remove the old kinds anyway** (append-only). The user-visible benefit — a shorter palette — is fully obtainable by editing `NODE_TYPES`. **Do the palette merge; do not do the storage merge.**
+
+**Rejected: the vault-wide open-facts replacement.** `tile-verdict`'s keystone repair ("swap `list_facts_visible(entity)` for `list_open_facts_visible(unlocked)` → 47 rows instead of 1") is a thesis violation. `storage/facts_store.rs::list_open_facts_visible` takes **only the unlock set** — no board, no source filter, no `LIMIT`. It achieves 47 rows precisely by rendering facts from meetings that are not on the board, and since `render_tile_for_agent` feeds MCP, it would leak out-of-scope material into an agent's view of a scope the user believes they bounded. Board-scoped correctly (facts whose `meeting_id ∈ get_dashboard_sources`), the user's 4-source board yields ~0–4 rows and the headline arithmetic evaporates. **Cut.**
+
+### Palette IA fix
+
+**Invert the two steps: subject first, kind second.** Today the user commits to a promise ("Drift lane") before discovering the subject can't keep it. The question *"nie wiem ile one mają sensu"* is literally "will this work for me", and it is unanswerable in the current order.
+
+**Every offer carries a live count, and counts come from aggregate SQL — never from speculative resolution.** Both synthesis proposals specified preflight as *"build a synthetic `DashboardTile`, call `resolve_tile`, keep it if it has rows"*. That is ~230 speculative resolves per palette open on this vault, serialized on the one `Mutex<Connection>` a live recording writes segments through — and `resolve_tile`'s `"note"` arm does a **full vault note-list read to resolve one note**, its `"person"` arm a full entity-list read plus `list_open_commitments` (which walks `list_meetings_visible(1000)` → `get_note_if_visible` per meeting). Replace with one `GROUP BY` per kind: `SELECT entity_id, COUNT(*) FROM facts WHERE valid_to IS NULL GROUP BY entity_id` (covered by `idx_facts_entity`), same over `entity_mentions` (`idx_entity_mentions_entity`), and a `length(text) > 0` filter on the note candidates.
+
+Be honest about what preflight buys: **it validates at add time, and tiles are persistent.** Seal a folder or delete a note and a preflight-validated board is the screenshot again, now with the added harm that the user believes it was checked. Preflight saves wasted composition effort; **render-time collapse (§4) is what keeps a board looking good over time.** Ship the render fix first.
+
+Also in this file: `registerField` (`tile-palette.component.ts:295`) is dead code — bound nowhere, so the search field is never focused; and the panel declares `role="dialog" aria-modal="true"` with no focus move and no trap.
+
+### The duplicate-tile decision
+
+It is a missing *parameter*, not a missing *constraint*. Fix in this order:
+
+1. **Owner scope on `promises`** (`mode: "entity"` + explicit "Everyone"), rendered in the header. Two ledgers scoped to two people is a legitimate board; a blanket ban is wrong.
+2. **Render-time duplicate strip, pure FE.** If two resolved tiles share `(kind, refId, config)`, render the second as *"same as the tile above · Remove"*, and have the palette scroll-and-highlight the existing tile instead of adding. This works on the board in the screenshot **today**, with zero backend, and it does not add a new error dialog to a feature whose complaint is that it surfaces raw errors as content. (An `AppError::InvalidArg` guard would be swallowed by `DashboardsService.addTile` into the hand-rolled `message(e)` renderer we are trying to delete.)
+3. If a backend guard is later wanted, it belongs in `commands/dashboards.rs::add_dashboard_tile` over `(dashboard_id, kind, ref_id, canonical_hash(config))`. **Never a `UNIQUE INDEX`** — `Db::migrate()` runs on real user DBs and the user's DB already contains the violating pair; the index would fail migration and therefore startup.
+
+---
+
+## 3. The tile catalogue we should have
+
+Ranked. Everything the critiques killed is in §8, not here.
+
+| Rank | Tile | Data source (symbol) | Cost | Only-Murmur | Visual form | Notes |
+|---|---|---|---|---|---|---|
+| 1 | **Board note / heading** | `dashboard_tiles.config.text` | **XS** | ✗ | `app-markdown` | The board cannot currently be *written*, only assembled. Datadog ships a Note widget for exactly this. Per §6 the user's own sentence is the highest-value token in the board's prompt |
+| 2 | **Talk split (per meeting)** | `segments.speaker/start_s/end_s`, `SUM(end_s-start_s) GROUP BY speaker` under the meeting gate | **S** (additive `me_ratio`, `segment_count` on `TileData::Meeting`) | ★★★ | 8-px stacked bar, 2-px surface gap, `Me 38% · Others 62%` | The richest untouched signal in the DB; Obsidian structurally cannot have it. **Two corrections:** (a) `speaker` is `add_column_if_missing(… "TEXT")` → nullable; pre-dual-stream recordings are NULL and need an explicit branch — "100 % attributed" holds only for post-2026-07 recordings; (b) **no board-wide rollup** — diarization labels are per-meeting cluster tags (`others-1`), `speaker_voiceprints` = 0 rows, so summing `others-*` across meetings adds different humans together and prints it as a roster. That is `looks_numeric` in a new coat |
+| 3 | **Quote** | `db.get_segments` behind `meeting_is_visible`; config stores **only** `{meetingId, startS, endS}` | **M** (needs a "Pin to board" flow in the transcript view) | ★★★ | Pull-quote + timestamp + "open at 02:14" | The only tile structurally incapable of being empty — its content is chosen at add time. Gate path verified sound: `get_segments` is explicitly ungated ("callers must first pass the meeting visibility boundary"), and seal blanks `segments.text` to `''`, so a relocked session yields empty text, never stale text. **v1 must NOT play audio in-tile** — `lock-model.md` documents `convertFileSrc`/`asset:` as the one audio path that bypasses `meeting_is_unlocked`, which is why the masked DTO nulls `audio_path`. v1 deep-links to the meeting detail at `start_s`, reusing the existing gated receipt-seek path |
+| 4 | **Stayed on device** | `egress_log` · `egress_store::egress_summary(days)` — **content-free by construction** | **S** | ★★★ | One stat + delta | 279 rows. Never empty, and its zero state ("0 cloud calls · 100 % local") is its best state. No cloud notetaker can render it |
+| 5 | **Board cadence** | `meetings.started_at` restricted to the board's meeting sources | **S** | ★ | Heat strip, **fixed** ladder (0 / 1 / ≤3 / ≤6 / 7+) | Board-scoped only. Vault-wide cadence is wallpaper. The fixed ladder is what makes two boards comparable — the exact property `barHeight`'s normalisation destroys |
+| 6 | **Board-scoped search view** | `search_hybrid_visible` **with the id set pushed into the legs**, contributing **zero** `SourceRef` | **L** | ★★ | Ranked rows + score bar | Gated on the retrieval work in §6. Two blockers the proposal missed: it needs a query embedding from `Embedder::embed_query` (dead without a downloaded model — this is exactly the stub-reasoner failure class the proposal invented its own test to catch), and a **post-filter after `limit`** returns zero rows for a board whose sources rank 41st–60th while the answer is demonstrably on the board. It must be a *view*, never a source-contributor, or the board is no longer hand-composed |
+
+**Board chrome, not tiles.** The scope readout (`11 tiles · 4 notes · 3 recordings · 2 docs · 2 derived views · 1 sealed`), the retrieval-coverage line (`9 of 11 indexed for recall`), the vault path, and the `murmur://dashboard/{id}` handle all belong in the board header (§4). Making the scope readout a *tile* means the user must know to add it.
+
+---
+
+## 4. The visual system
+
+### 4.1 New tokens (the only additions)
+
+```css
+/* src/design-tokens/colors.css :root */
+--text-tertiary: #8a8a9c;              /* 5.50:1 on the tile surface — the ≤12px tier */
+--hatch-stripe: rgba(255,255,255,.05); /* the sealed-tile hatch, currently a raw rgba */
+/* src/design-tokens/theme-light.css — BOTH the [data-theme] and prefers-color-scheme blocks */
+--text-tertiary: #6e6e78;              /* 4.84:1 */
+--hatch-stripe: rgba(18,18,40,.055);
+/* src/design-tokens/layout.css — duration-only, per the existing convention */
+--motion-enter-dur: 420ms; --motion-stagger: 45ms;
+--motion-cite-dur: 2600ms; --motion-breath-dur: 3200ms;
+```
+
+Migrate `.tile-kind`, `.row-meta`, `.drift-meta`, `.number-key`, `.live-chip`, `.muted-small` from `--text-muted` → `--text-tertiary`; keep `--text-muted` for ≥13 px only. Delete the nine raw `rgba()` (`dashboard-tile.component.scss:186,375,466`; `dashboard-view.component.scss:152,186`; `board-card.component.scss:67,118,208`; `tile-palette.component.scss:132`). **This single change does more for "rich" than any chart.**
+
+⚠ **Correction to one critique:** `color-mix(in srgb, …)` is *not* unprecedented in this repo — it ships in six files today including `design-system/primitives.css` and `features/dashboards/board-card/board-card.component.scss`. It is safe to use. What is genuinely unprecedented and **must not ship** is `grid-column: span min(var(--tile-span), var(--cols))`: a math function in a `span <integer>` context has no precedent here, and if WebKit rejects it the **entire declaration drops** and every tile falls back to span 1 — the board collapses into a 12-column sliver. Clamp in TypeScript (the span is already a signal).
+
+### 4.2 Tile anatomy
+
+```
+[22px mark]  EYEBROW (10px/600/+.08em/uppercase, --text-tertiary)   [grip|tools] or [freshness]
+             TITLE   (14px/640/-.01em, --text-primary)
+─ body (one of six patterns, per-pattern height band) ─
+─ footer (conditional): provenance ····················· state ─
+```
+
+- **Eyebrow above title.** The eyebrow is the classifier and must be scannable down the left edge; title-first makes every tile open with a different-length proper noun.
+- **The mark** is a 22 × 22 squircle (`border-radius: 7px` — a circle reads as an avatar), `background: color-mix(in srgb, var(--tile-hue) 18%, transparent)`, 1 px rim at 34 %, glyph `stroke: var(--tile-hue)` at 1.9. **Not** the prototype's solid-fill chip with a near-black glyph — eleven saturated solids is the confetti failure at ⅕ the ink budget.
+- **Material vs derived is carried by fill, not by a fifth hue:** material = tinted fill, derived = outline.
+- **The footer is conditional.** A mandatory 28-px bordered footer on every tile re-homogenises heights, working against the same diagnosis it sits next to. Render it only when the tile has provenance worth printing.
+- **Divider budget: one full-bleed rule per tile**, and it is the footer. Delete `.row { border-bottom }` — four promise rows currently draw three full-bleed rules inside ~120 px, which *is* the spreadsheet read. Rows become chips on `--surface-input` with `gap: var(--space-1)`.
+- Delete `min-height: 74px`. Twelve identical-height boxes come from that floor plus the uniform span.
+
+**Hue map — four hues, capped.** Reordered mint → azure → amber → orchid so orchid and azure are never adjacent, `{--graph-note, --graph-entity, --graph-meeting, --graph-document}` measures PASS on chroma, CVD (ΔE 17.4), normal-vision (19.2) and contrast in both themes. Adding a fifth (`--warning`) is a measured failure (ΔE 5.7 vs amber). Derived tiles (`reminders`, and the retired kinds) get **no hue** — `--text-secondary` marks. **`--accent` is reserved for the AI channel only** (citation ring + numeral, the `living_answer` mark, the Ask composer): it is user-selectable and 5 of 6 options collide with a family hue (orange vs `--graph-meeting` = ΔE 2.4, indistinguishable). Today `dashboard-tile.component.scss:300,318,339` paints pulse bars and the drift rail `--accent` — that is the accent doing category work; both become `var(--tile-hue)`.
+
+**Text never wears the data hue** — a family hue at 10 px on the light tile surface measures 3.48–5.04 : 1. Current violation: `.audio-chip { color: var(--graph-meeting) }` at 0.66 rem = **1.99 : 1** in light mode.
+
+### 4.3 The closed set of body patterns
+
+A new tile kind may not invent a seventh. That rule is what stops the board looking like ten bespoke widgets.
+
+| Pattern | Height band | Used by |
+|---|---|---|
+| **P1 stat cluster** — eyebrow / 28 px value / delta | 62–96 px | person, egress |
+| **P1b stat grid** — 2-up wells, `tabular-nums` | 96–140 px | numbers |
+| **P2 ledger rows** — chip rows, max 5 then `+N more` | 84–200 px | promises, reminders |
+| **P3 lane** — vertical rail with two-line steps | 76–200 px | drift |
+| **P4 micro-chart + stat** — 28–36 px chart band + one stat line | 74–110 px | cadence, pulse |
+| **P5 prose** — gradient mask, not `-webkit-line-clamp` | 84–170 px | note, document, living answer |
+| **P6 proportional strip** — segmented bar + chips | 56–88 px | meeting (talk split, chapters) |
+
+Type scale declared once on `:host`: `--t-eyebrow: .625rem`, `--t-title: .875rem`, `--t-body: .8125rem`, `--t-meta: .6875rem` (**line-height 1.35, not the global 1.5** — at 11 px, 1.5 separates a two-line meta into two unrelated elements), `--t-stat: 1.75rem`. Top-to-bottom ratio 2.8× (shipped is 1.8×, below the ~2.4× at which a card acquires a focal point). Big standalone figures get **proportional** digits; `tabular-nums` only where digits align in a column. Note the shipped hierarchy is inverted — `.number-value` is 15 px while `.stat dd` is 18 px, so the *Numbers* tile has the smallest figures on the board.
+
+### 4.4 Micro-chart specs
+
+Two rules make every SVG below survive Angular:
+1. **Never `<defs>` + `id` in a repeated component.** Emulated encapsulation scopes attributes, not ids — twelve tiles emit twelve `id="sparkFill"` and tile 7 silently paints tile 1's hue. Use `fill: currentColor; opacity: .14` or a CSS `mask-image`.
+2. **`preserveAspectRatio="none"` + `vector-effect="non-scaling-stroke"`**, and **never a `<circle>` inside a stretched viewBox** — an end-of-series dot must be a CSS element positioned from a computed signal.
+
+**Mark chooser** (deterministic, from `density = nonzero/n` and `peak`): `n === 0` → not a chart, empty ladder · `n === 1` → no chart, one stat + qualifier · `n ≤ 4` or `density < .6` → dot-strip · small ints, `n ≤ 20` → **heat strip (the Pulse/Cadence default)** · `density ≥ .6 && peak ≥ 4` → line + 14 % area · `peak < 4` → line only · **never bars**.
+
+- **Heat strip:** `display:flex; gap:2px`, cells `aspect-ratio:1; max-width:14px`, quantised on a **fixed** ladder `v===0?0:v<=1?1:v<=3?2:v<=6?3:4` → opacity `[0,.28,.48,.72,1]`, level 0 painted `--surface-input` + `--border-subtle`. Fixed, never normalised — that is what makes two boards comparable.
+- **Dot-strip:** flex columns, 1-px stem at 26 % opacity, 5-px dot; **a zero is a 3-px dim dot on the baseline** — present (the week exists), unambiguously zero. This is the property `min-height: 3px` on a bar cannot express.
+- **Sparkline:** viewBox `0 0 100 32`, plot band y∈[4,30], `yMax = max(peak, 4)`, stroke 1.75, area `opacity .14`, end dot as a CSS `<i>` with `box-shadow: 0 0 0 2px var(--surface-solid)`. Draw-on via `pathLength="1"` + dashoffset 1→0, 700 ms, once — no JS path measurement.
+- **Talk-split bar:** 8 px track, two segments with a 2-px `--surface-solid` gap, `Me` in `--tile-hue`, `Others` at 32 %.
+- **Do not ship a fake waveform.** The prototype's `Math.abs(Math.sin(i*.9))` is decorative fake data on a tile claiming to represent a real recording — a credibility hole in an app whose entire pitch is provenance.
+
+### 4.5 Empty states — a five-class ladder
+
+The screenshot's failure is precise: four full-size cards each holding one grey apology, eleven such strings shipped.
+
+| Class | Treatment |
+|---|---|
+| **Never had data** | **Collapse to a 36-px dashed header strip**: `border-style: dashed; background: transparent; backdrop-filter: none`, body and footer `display:none`, reason at `--t-meta` right-aligned. Copy is a positive statement of where data lands ("Figures said out loud land here"), never an apology |
+| **Genuinely zero = good news** | **Full tile, not grey.** A ✓ in `--success` + the sentence at `--text-secondary`. "Nothing open — every commitment on this board is closed" is a *result*; rendering a success as an absence is the most demoralising thing a board does |
+| **Degenerate** (drift `rows < 2`, pulse `total === 0`, chart `n ≤ 1`) | Collapse the *mark*, keep the tile: "One value, never revised — nothing has drifted" |
+| **Degenerate-but-populated** *(new class — no proposal named it)* | A 100 %/0 % talk bar on a solo recording, a one-cell cadence strip, a one-row ledger. These pass every emptiness check and still look broken. Same collapse treatment, keyed on a per-pattern variance predicate |
+| **Missing / Unconfigured** | Strip + an inline action ("Remove tile" / "Choose one", reopening the palette pre-filtered) |
+
+**Two layout rules the collapse depends on:** an empty strip must take **span 3** and **sort to the end of the grid**. `.canvas` is `grid-auto-rows: max-content` with `align-self: start`, so a 36-px strip left in composition order beside a 200-px tile leaves ~164 px of dead air — four scattered strips look *worse* than four grey boxes.
+
+**One ghost preview per board, never more** (repeated illustrations cause fatigue): the first empty tile renders its pattern's skeleton at 10 % opacity plus one sentence and a *tertiary* action; every subsequent one is a strip.
+
+**Loading vs refetch:** skeleton on first fetch only. On refetch hold the previous render at `opacity: .55; pointer-events: none` — same stale-while-revalidate discipline `angular-zoneless.md` §8 mandates for lists. `reloadOpenBoard()` runs on every span change and every add; a skeleton flash there is the single most damaging cheap tell.
+
+### 4.6 The sealed tile — make it look deliberate, leak nothing
+
+`TileData::Locked` carries **no fields**, `redact_tile_chrome` nulls `title`/`config`, and `DashboardTileComponent.heading()` re-asserts it client-side. **Nothing in this system may add a field to a sealed tile** — no count, no kind glyph beyond the shared lock, no chart skeleton whose shape reveals the kind.
+
+Render it full-size (a redacted region is *content*): a 45° hatch using `--hatch-stripe`, a lock glyph, and copy that ties the lock model to the thesis — **"Sealed — not in scope."** / *"Unlock the folder to bring this back into the board's scope."* A board that is screen-shareable as-is is a demo moment no cloud notetaker can offer, and today it looks like a bug.
+
+**One hazard to design around:** `redact_tile_chrome` treats `Drift`/`Numbers`/`Pulse` with `entity == ENTITY_HIDDEN` as withheld and strips chrome, but the payload still ships `weekly`, `total` and `quiet_days`. Any new footer or freshness mark must branch on the same withheld predicate, not on "does the payload carry a timestamp" — a heat strip or a `quiet 9d` chip for a hidden entity **leaks timing about a sealed entity**.
+
+### 4.7 Layout
+
+- **Display-span override, not an add-time default.** ⚠ `commands/dashboards.rs:477` clamps to a concrete value, so every existing tile has `span = 4` in SQLite and an add-time default changes nothing about the board in the screenshot. Do `displaySpan = tile.span === 4 ? DEFAULT_SPAN[kind] : tile.span`, with the first explicit resize writing a real value — ~6 lines, retroactive on every existing board. Bands: `person`/`pulse` 3 · `numbers`/`note`/`document`/`drift`/`reminders` 4 · `promises`/`meeting`/`living_answer` 6. `3+3+6`, `4+4+4`, `6+6` — the row rhythm changes by itself.
+- **Responsive by column remap**, `--cols: 12 → 8 → 4` in media queries, **clamped in TS** (not `span min()`).
+- **Tall tiles clamp with a mask + `+N more`**, never a nested scrollbar.
+- **The Ask column collapses to a 44-px rail** when `turns().length === 0`, carrying the scope count vertically. The scope count *is* the thesis made visible and belongs on screen permanently; the empty transcript does not. Expands to 380 px on use.
+- **Errors get a third turn role** rendering `.banner.is-danger` (`primitives.css:253`) with a Try-again button. Never a bubble.
+- Arrange mode: move `draggable` off the host (whose body is full of `<button>`s — WebKit does not reliably bubble a drag begun on a nested button) onto a header grip; add the missing `(dragleave)`; add `Alt+←/→` reorder and `⌘←/→` resize; add a `:focus-visible` ring to the twelve background-less buttons that have none.
+- Delete the duplicated `.arrange-hint` block inside the `max-width:1080px` query (`dashboard-view.component.scss:235-244`).
+
+### 4.8 The cited state — dim the field, and do not ship it early
+
+Brightening one card among eleven is a weak signal. `.canvas.is-citing app-dashboard-tile:not(.cited) { opacity:.45; filter:saturate(.55) }`, cited tile gets the `--accent` ring + glow + a **numeral badge** (the accessible channel — colour alone can never carry citation, and the user's accent may be within ΔE 15 of a family hue), `scroll-margin-top: var(--space-6)` + `scrollIntoView({block:"nearest"})`, held `--motion-cite-dur` then released to a **persistent 2-px accent bar on the tile's inline-start edge** until the next question. That persistent bar is the visible proof that the board *is* the retrieval scope.
+
+**Three states, not two:** `cited(n)` / `in scope, not used` / `out of scope` (sealed, or a derived tile that contributes no source, permanently desaturated with a footer reading `not a source`).
+
+**Blocking dependency — do not ship dim-the-field before §6's manifest.** `build_vault_context_pinned_visible`'s note/document arm pushes `Vec::new()`, and `tilesForSources` matches `s.meetingId` against `t.refId`. On a board of three notes and one meeting, dim-the-field would dim the three notes and spotlight the meeting — asserting a falsehood about which sources the answer stood on. **Un-cited is honest; wrongly-cited is worse than no citation.**
+
+### 4.9 Motion
+
+Live dot `opacity .55→1` over 3.2 s (shipped is `1→.3` over 2.4 s — **amplitude**, not duration, is what makes a loop noisy). Liveness is a property of the **data**, not the kind (`LIVE_KINDS` currently blinks a three-month-stale Promises tile identically to one that changed an hour ago); budget **≤3 animated dots per board**, awarded to the most recently changed, only while the route is focused. Tile entry: `translateY(10px)` + fade, 420 ms `--ease-spring`, stagger `min(i,8) × 45ms`, registered in `afterNextRender(fn, {injector})` on **first paint only** — otherwise every refresh replays the fade. Value change = a 600 ms colour wash, **no movement** (movement = arrival, colour = change). Never animate `backdrop-filter` (WKWebView repaints the layer) and never raise `background` opacity on hover (reads as a flash on a blurred surface).
+
+**The reduced-motion trap:** the prototype's `opacity:0; animation: tin … forwards` + `@media { animation: none }` leaves every tile **permanently invisible**. Always restore the end state explicitly (`opacity:1; transform:none; stroke-dashoffset:0`) and keep ≤150 ms opacity fades so state changes stay perceivable.
+
+---
+
+## 5. Views beyond the grid
+
+| View | Job | Why it beats the grid | Cost |
+|---|---|---|---|
+| **The board as an MCP handle** (`murmur://dashboard/{id}` on the header, `tile:<id>` in `render_tile_for_agent`, `search_dashboard`) | Use the scope you hand-composed inside Claude Code / Cursor | It is not a competing view — it is the board *leaving the app*. Every competitor's scope (NotebookLM notebooks, Granola folders, Dust spaces) is trapped inside the vendor by design, because the scope *is* their lock-in. `mcp.rs` already ships `get_dashboard`/`list_dashboards` and the UI never mentions it. **The only item in this brief no competitor can follow even in principle** | S–M (+ the retrieval work, §6) |
+| **`.canvas` export** | The scope outlives the app | The dream's unbuilt piece; `export/canvas.rs` already emits Canvas JSON. Also the strongest "you own this file" signal — the prototype put the vault path in the header (`index.html:664`) | S |
+| **Board diff — "since I last looked"** | Weekly re-entry: *3 new recordings · 2 promises flipped late · 4 questions still unanswered* | The grid reports **state**; this reports **change**. Reporting change is the measured line between a board people open weekly and one that goes stale (Linear's data: median workspace has two dashboards, creation outruns usage). It is also the honest fix for `LivingAnswer`, which today cannot say "3 of your sources changed since" | M (`last_seen_at` per board; everything already has a timestamp) |
+| **Read mode / Compose mode split** | Density when reading; chevrons, grips and delete only when composing | "Arrange mode" already exists but is the *only* path to a non-default span, which is why every board is a 3-column wall | S |
+| **Subject-bound board templates (`$subject`)** | One "Person board" that works for all 57 people | Today a board is hand-built `ref_id`s, so a Person board must be rebuilt per person. Bases' `this` and Tana's `PARENT` are the best ideas in either product. `TileConfig` already carries `owner`/`predicate`/`question` slots. Also the substrate for auto-compose (§7) | M |
+| **Question → board** (proposes sources, **user ratifies**) | Kills the blank page for the case where you don't yet know your scope | Only survives with the ratification step: AI *proposes*, user *ticks*. Auto-materialising is auto-RAG with a canvas and dissolves the thesis | M–L |
+
+**Deferred with a named hazard:** a board embedded in a note. A `murmur:board` managed block is precisely the shape that leaked titles and live connector data on share in PR #416 — `clean_note_body` must strip it and the block must never persist resolved content into the `.md`. Requires `lock-security-reviewer`.
+
+---
+
+## 6. The board as AI context (the part that must not be diluted)
+
+### The current contract, exactly
+
+```
+dashboard-view.ts::ask() → getDashboardSources → askVault(q, [], undefined, sources)
+  → commands/mod.rs::ask_vault  (pinned_sources non-empty ⇒ the agentic path is SKIPPED)
+  → commands/ask.rs::build_ask_vault_floor_prompt
+  → summarize/vault_context.rs::build_vault_context_pinned_visible
+  → provider.complete(system, user)          // ONE completion, no tools, no trace
+```
+
+| Quantity | Value | Symbol |
+|---|---|---|
+| Tiles per board | ≤ 60 | `dashboards_store.rs::MAX_TILES_PER_BOARD` |
+| Tile kinds contributing a source | **3 of 10** | `get_dashboard_sources` — `_ => continue` |
+| Corpus budget | 200 000 chars (4 000 for `ollama`) | `vault_context.rs::budget_for` |
+| Per-source share | `budget / n`, hard `chars().take(quota)` | `fair_pack_explicit_sections` |
+| Chat history sent | **`[]`, always** | `dashboard-view.component.ts` |
+| Living-answer gate scope | the **entire** readable folder set | `TileConfig::answer_readable_folders` |
+| Tile config cap | 8 KiB | `dashboards.rs:37 MAX_CONFIG_LEN` |
+
+**The four gaps, in order of severity.**
+
+**G1 — the scope is concatenated, not retrieved.** Pinned sources skip the agent loop; fair-share truncation means a 6-source board gives each source ~33 k chars and a 40-source board gives 5 k each cut mid-sentence. On `ollama` (4 k budget) 40 sources gets ~100 chars each — less than the `### [[Title]] · date · id:<uuid>` header itself, so the model confabulates from titles with no warning. **The board gets worse the more the user composes into it** — the one feature whose premise is "compose more scope" degrades monotonically in the composition variable. Two aggravations: each section is built at full budget and then thrown away (60 full note reads to emit 3 % of them), and `pack_meetings`/`pack_notes` compute `remaining` from `corpus.len()` (**bytes**) then consume `.chars().take(remaining)` (**chars**) while the caller counts `chars().count()` — a Polish or CJK vault overruns the declared budget by 2–4×.
+
+**G2 — derived tiles are invisible to Ask.** Seven of ten kinds contribute nothing. A user staring at a Promises tile listing three late commitments asks "who owes me something on this board?" — the app's own suggested question — and the model cannot see that tile. **The in-app Ask sees strictly less of the board than an external MCP agent does.**
+
+**G3 — citations cannot close.** `VaultSource` carries only `meeting_id` and is produced only by `pack_meetings`; the note/document arm pushes `Vec::new()`. `AskVaultResult.citations` is filled only on the agentic path, which pinned sources skip by construction. So **a note or document tile can never be cited**, and derived tiles have an entity `refId` or `null`.
+
+**G4 — the living-answer gate has a capacity cliff.** `set_dashboard_answer` stores every readable folder id; a UUID serialises at ~39 bytes inside a JSON array, so **~210 folders exhaust the 8 KiB config** and an ordinary answer returns `InvalidArg("answer too large")`. `list_folders` includes note folders; a real Obsidian vault passes 100 trivially. This is a shipped bug nobody costed.
+
+### The design
+
+**D1 — the keystone: make the packer return a manifest.** Change `build_vault_context_pinned_visible` to return `PackedContext { corpus, refs: Vec<PackedRef{ kind, id, title, folder_id, chars_packed, truncated, role }> }`. Every field is already in hand at the moment `pack_meetings`/`pack_notes` push a header. It unlocks four unrelated fixes at once: citations for every tile kind (match on `(kind, id)`, not `meetingId`); a **precise** living-answer gate (record `refs.folder_id` instead of the whole readable set — sound, far tighter, and it fixes G4); a truthful truncation readout; and a proof that MCP and Ask ground identically.
+
+**D2 — derived tiles enter the prompt.** New `get_dashboard_brief(id) -> String`: the board's derived tiles rendered through the **existing, already-redaction-correct** `render_tile_for_agent`, under one `lifecycle_guard`, capped ~4 000 chars, prepended as a labelled block:
+
+```
+WHAT THIS BOARD ALREADY SHOWS (the user composed these views; do not re-derive them):
+- promises (Marcus Reid): Send Acme paperwork · due 2026-07-22 · late
+- drift: Atlas GA · target_date: Apr 30 → Jun 14
+```
+
+Zero new gated reader, zero new egress class, ~1–2 % of budget. **Do not** turn derived tiles into `SourceRef`s — `SourceRef.kind` is a `LinkKind` and a drift lane is not a retrievable document.
+
+**D3 — retrieve inside the scope.** When `n_sources × min_useful_chars > budget`, stop fair-sharing: run hybrid retrieval **restricted to the board's source set** and pack the top-k whole. The restriction must be pushed **into the search legs** (`search_visible_impl` / `search_semantic_visible` / the graph leg), not applied after fusion — a post-filter after `limit` returns zero rows for a board whose sources rank 41st–60th. Expose it as a board toggle, **Whole board** vs **Most relevant**, because neither dominates (Dust ships Include and Search as two explicit modes for exactly this reason) and the user is the one who knows.
+
+**D4 — in-app citations.** Render answers with `src/app/shared/markdown/markdown.component.ts` (bold, sections, and `[[Title]]` as clickable gated chips — instantly). Number tiles from the manifest. Then inline `[n]` superscripts that scroll-and-flash the tile. **Reuse markdown.component's hard-won lesson:** read the title from `textContent`, never a `data-*` attribute — Angular's sanitizer strips unrecognised `data-*` even when DOMPurify allow-lists them.
+
+**D5 — the MCP surface**, in order: (1) emit `tile:<id>` plus a board header (`# Atlas · id:… · tiles:12 · sources:7 · sealed:1`) in `render_tile_for_agent` — an external agent currently *cannot* cite a tile; (2) **`search_dashboard(dashboardId, query)`** — without it, the recommended agent behaviour after `get_dashboard` is vault-wide search, i.e. **the scope evaporates at the exact moment the agent needs depth**; (3) `get_dashboard_context` returning what in-app Ask packs, bounded by the existing `MAX_TOOL_WINDOW_CHARS`; (4) later, promote boards to MCP **resources** (`murmur://dashboard/{id}`) plus one prompt `ask_this_board` — returning large static blobs from *tools* is the known anti-pattern.
+
+**D6 — scope reuse outside the board view.** `source-picker.component.ts::pickDashboard` already splices a board's refs into a flat selection — which destroys board identity, snapshots the membership at pick time, and truncates silently at `selectionLimit`. Carry `viaBoard: {id, title}` so chips read `Atlas · 7 sources` and the answer header can say "Grounded in Atlas", and **re-expand at ask time, not pick time** — free correctness: a tile added mid-thread joins the scope, a folder sealed mid-thread drops out. Do **not** wire boards into the record view (live transcript is the anchor there, and `acquire_external_egress_lease` risk during recording is real).
+
+**D7 — the prompt-bloat bound.** Pass the 12-turn history (`capped_ask_history` exists; every other chat surface uses it). Surface `truncated` from the manifest ("12 of 47 sources were trimmed to fit"). Refuse *before* dispatch when the packed scope exceeds a sane bound rather than burning 180 s. Tag provider errors with `errcode` codes (`PROVIDER_TIMEOUT`, `PROVIDER_MODEL_REJECTED`, `PROVIDER_CLI_MISSING`, …) **inside the provider**, teach `content_free_dispatch_error` to preserve a leading `[code]` (a kebab-case token from a closed set leaks nothing — pin it with a test asserting the message matches `^\[[a-z-]+\] ` and contains none of the inner error's bytes), and delete both hand-rolled FE renderers in favour of `ErrorCopyService.humanize`.
+
+**D8 — measure it.** Track B demands an oracle and nobody proposed one. **Until board-scoped Ask beats vault-wide Ask on a fixed question set drawn from the real vault, "a board is a retrieval scope" is an aesthetic preference with a canvas attached.** `eval/` exists; this is the missing experiment, and it is the only thing that can adjudicate D3's toggle defaults.
+
+**Untested gate.** `get_dashboard_sources` — the function that *defines* the scope — has **zero** Rust tests; its only coverage is Playwright mocks asserting the FE's assumption. RED-first oracles before anything reshapes it: a sealed-folder source is absent; a derived tile contributes nothing; a deleted source yields `Missing` not an error; duplicates dedupe by `(kind,id)`.
+
+---
+
+## 7. The empty-board problem
+
+**Reject sample data.** Every empty-state playbook recommends preloading demo content; it is wrong *here specifically*, because this app's entire pitch is that everything on screen was actually said. A fake board is the same credibility hole as the prototype's sine-wave waveform.
+
+The strategy, in dependency order:
+
+1. **Fix rendering first (§4.5).** The empty-tile problem is a *rendering* problem with a ~25-line fix that works on boards that already exist. Every composition-time mechanism costs an order of magnitude more and cannot protect a board over time. Ship the render fix, then measure whether the palette complaint survives it.
+2. **Counts on the palette rows** (aggregate SQL, §2): `Numbers · 3 figures for "Atlas"` / `Drift — nothing of his has been revised yet` [greyed]. Hide unavailable offers in the browse band; **grey with a reason** in the subject band — where the user explicitly asked about someone, silence reads as a missing feature and a reason teaches the concept.
+3. **"Compose a board about…"** — pick a subject, run the counts across kinds, materialise the 5–8 that return rows, ordered material-first. Uses the `$subject` binding so the result is a template instance, not a one-off.
+4. **The empty Dashboards tab proposes computed boards**, not templates — real miniatures from real data (`Kuba — 12 recordings · 4 open promises`). One click materialises. If the vault has 0 meetings, say *"Record something first"* and link to Record. **Never a fake board.** If an auto "This week" board ships, label it *Auto*, make it read-only, and give it one button — **"Make this mine"** — that forks it into an editable board; the fork is the conversion event and it teaches composition by example. Exactly one auto-board; a shelf of them is Notion.
+5. **The structural fix nobody proposed: composition must be a byproduct of normal use.** Boards are a late-game feature sitting in the primary nav, which is exactly why the user's first board was assembled from empty notes and single-fact entities. Add **"Pin to board"** to the transcript selection, the note header, the person page, and the Ask answer. If a user has to visit the Dashboards tab to *build* a board, it happens once.
+
+---
+
+## 8. What NOT to build
+
+Each of these was proposed and each is killed for a specific reason.
+
+| Killed | Reason |
+|---|---|
+| **Deleting or replacing any `resolve_tile` arm** (`numbers`, `pulse`, `drift`) | `dashboards.rs:1010` errors on an unknown kind and `get_dashboard` collects with `?` — **one unresolvable tile fails the whole board**, and the user's board contains both. The only alternative is a destructive rewrite of `dashboard_tiles.kind`. Retire from `NODE_TYPES` instead |
+| **A vault-wide open-facts tile** (`list_open_facts_visible`) | It is not board-scoped. It puts content into a board the user did not compose, and `render_tile_for_agent` would push it into MCP's view of a scope the user believes they bounded. Board-scoped, its "47 rows" collapses to ~0–4 on the board in question. Also unbounded — no `LIMIT`, correlated `EXISTS` per row |
+| **Preflight as speculative `resolve_tile` per candidate** (`get_tile_offers` / `dashboard_tile_candidates`) | ~230 resolves per palette open on this vault, on the one `Mutex<Connection>` a live recording writes through, where the `"note"` arm does a full vault note-list read *per note* and the `"person"` arm does a full-vault note scan. Replace with `GROUP BY` counts |
+| **New tile kinds to retire old ones** (`source`, `commitments`, `facts` merges) | Nine touchpoints each, arm/kind parity enforced by test, and the old kinds cannot be removed anyway. The palette gets the same benefit for free |
+| **A DB `UNIQUE INDEX` on `(dashboard_id, kind, ref_id, config)`** | The user's live DB already violates it; `Db::migrate()` runs on real user DBs → failed migration → failed startup |
+| **`grid-column: span min(var(--tile-span), var(--cols))`** | No precedent for a math function in a `span <integer>` context; if WebKit rejects it the whole declaration drops and the board becomes a 12-column sliver. Clamp in TS |
+| **Per-kind default span at add time** | Every existing tile already has a concrete `span = 4`; the default changes nothing about the board that was complained about. Use a display-span override |
+| **Dim-the-field citations before the packer manifest** | Note/document tiles cannot be cited today, so dimming would spotlight the one meeting tile and assert a falsehood about what the answer stood on. Wrongly-cited is worse than un-cited |
+| **A mandatory footer on every tile** | Adds ~28 px to every tile, re-homogenising the heights the same spec correctly identifies as the problem. Make it conditional |
+| **Board-wide talk-time rollup / speaker roster** | `speaker_voiceprints` = 0 rows; `others-N` are per-meeting cluster tags. Summing them across meetings adds different humans together — the same class of lie as `looks_numeric` printing deadlines |
+| **Live query as a source contributor** | Membership changing without the user touching it is auto-RAG in a tile costume; the board stops being hand-composed. Allowed only as a zero-`SourceRef` view |
+| **`search_dashboard` / live query as a post-filter after `limit`** | Returns zero rows for a board whose sources rank below the vault-wide top-k, while the answer is on the board. The id set must go into the legs. Also silently dead without a downloaded embedder |
+| **N3 "Open questions" aggregate count** | ~70 % precision is fine for a *row* (three seconds to verify by playing the tape) and a lie for the *headline* — the count is what the user reads and what feeds the prompt, and nobody plays all three. Ship the ledger without the number, later |
+| **Regex "Numbers v2" over notes + transcript** | Matches `2026-07-04`, `1 min`, `Bielik-11B`, `8765`. It converts an *empty* tile into a *noisy* one. "No figures recorded" is honest; a grid of `11 / 3 / 2026 / 1` is a lie with better density. Only viable unit-anchored (currency/percent + unit words) |
+| **In-tile audio playback for Quote v1** | `convertFileSrc`/`asset:` is the one audio path that bypasses `meeting_is_unlocked` — the leak that was already closed once by nulling `audio_path` in the masked DTO. Deep-link to the gated detail view instead |
+| **Auto re-running living answers on a schedule** | Silent scheduled cloud egress. Make staleness visible; let the user press the button |
+| **Scope-blaming error copy** ("this board is too big — 47 sources") | Would have been factually false on the board that produced the complaint (≤4 sources, ~100 chars of text) |
+| **Board-wide "never empty" wallpaper** — vault-wide links/orphans, vault-wide timeline, going-quiet, mini brain-map, vault audit, ask history, org feed, attachments, decision log | Their non-emptiness comes from *ignoring the board*. They make the board look full while making it mean less. Cadence survives only board-scoped |
+| **Scope readout as a tile** | The user would have to know to add it. It is board chrome |
+| **`grid-template-rows: masonry`** | Not dependable in the shipping WKWebView |
+| **A fake/synthetic waveform** | Decorative fake data in a provenance app |
+
+---
+
+## 9. Recommended sequence
+
+| Phase | Scope | Files | Size | Risk | Lock review |
+|---|---|---|---|---|---|
+| **1 — make the existing screenshot look good** (FE only, retroactive, no migration) | Empty ladder: `is-empty` → 36-px dashed strip, forced span 3, sorted last · display-span override per kind · render-time duplicate strip · `--text-tertiary` + `--hatch-stripe` tokens, migrate the six ≤11 px call sites, delete the nine raw `rgba()` · 22-px per-kind mark + eyebrow-above-title (5 new `mur-icon` arms) · degenerate guards (drift `<2` rows, pulse `total===0`) · success-framed zeros · sealed tile re-copy | `dashboard-tile.*`, `dashboard-view.*`, `colors.css`, `theme-light.css`, `icon.component.html` | **M** | Low. Verify `color-mix` (already shipped in 6 files) and the mask fade in a **packaged** WKWebView build per T4/T5 — `ng build` green proves nothing here | No |
+| **2 — data honesty** | `normalize_owner` treats any parenthetical-only owner head as `None` (**language-agnostic**, plus the note-generation prompt, or it silently regresses for an English `note_language`) · retire `numbers`/`pulse` from `NODE_TYPES`, gate `drift` on a count · palette count chips from aggregate `GROUP BY` SQL · non-empty filter on the note picker · subject-first palette order · wire or delete `registerField` + focus trap · fix/delete `due_count` | `summarize/action_items.rs`, `tile-palette.*`, one new count command | **M** | Low. `normalize_owner` is XS and un-zeroes `Person.open_commitments` vault-wide — the highest ratio in the whole brief | No |
+| **3 — perf prerequisites** (block later phases; do them now) | Hoist `list_open_commitments` to **once per board** in `get_dashboard` (`Db::list_people` already does exactly this) — today two Promises tiles = two full-vault note scans, and `updateTile → reloadOpenBoard` re-resolves *every* tile, so one chevron click costs three full scans · patch span locally instead of `reloadOpenBoard` (span is pure layout, no gated payload changes) · RED-first Rust oracles for `get_dashboard_sources` | `commands/dashboards.rs`, `dashboards.service.ts`, `commands/tests/` | **S–M** | Low | No |
+| **4 — Ask honesty** | `get_dashboard_brief` via the existing `render_tile_for_agent`, prepended to the pinned corpus · render answers + living answer through `app-markdown` · error turns as `.banner.is-danger` with retry · `errcode` tags at the provider, preserved through `content_free_dispatch_error` · pass the 12-turn history · fix the bytes-vs-chars budget mismatch | `commands/dashboards.rs`, `commands/ask.rs`, `errcode.rs`, `claude_code.rs`, `redact.rs`, `vault_context.rs`, dashboards FE | **M** | Medium — content enters a prompt via a new path, even though the renderer is already redaction-correct | **Yes** |
+| **5 — the manifest (keystone)** | `PackedContext`/`PackedRef` from `build_vault_context_pinned_visible` · citations matched on `(kind, id)` → note/document tiles citable · living-answer gate narrowed to `refs.folder_id` (**also fixes the 8 KiB / ~210-folder cliff**) · truncation readout · then the §4.8 cited state | `vault_context.rs`, `models.rs`, `commands/dashboards.rs`, FE | **M–L** | **High — this narrows a security gate.** Keep `living_answer_withheld` a pure function and fail-closed on legacy/empty rows | **Yes, mandatory** |
+| **6 — the scope leaves the app** | `tile:<id>` + board header in `render_tile_for_agent` · `search_dashboard` with the id set pushed into the search legs · `get_dashboard_context` · retrieval-inside-scope with the Whole-board / Most-relevant toggle · board identity through `source-picker` (`viaBoard`, re-expand at ask time) · `.canvas` export · MCP handle + vault path + composition line on the board header | `mcp.rs`, `tools.rs`, `db.rs` (search legs), `source-picker.*`, `export/canvas.rs` | **L** | High — protocol surface + a new query shape over gated readers | **Yes** (protocol + egress classification) |
+| **7 — new tiles** | Board note/heading · per-meeting talk split (additive `me_ratio`/`segment_count`, NULL-speaker branch) · Quote (pin-from-transcript, anchors-only config, deep-link not in-tile audio) · Stayed-on-device · board-scoped cadence | `commands/dashboards.rs`, `dashboard-tile.*`, detail view (pin affordance) | **L** | Medium–high — Quote is a new read of `segments` (ungated reader, must gate at the call site) and touches the audio-path trap | **Yes** for Quote |
+| **8 — polish** | Ask rail collapse · board emoji/tint/rename writers · home-card sealed marker, freshness line, sparkline, delete confirm, search + segmented · arrange-mode grip/keyboard/focus rings · motion pass · board diff · read/compose split | dashboards FE | **M** | Low | No |
+
+**Phase 1 alone is the entire visible delta the user complained about.** Do not let phases 4–7 delay it, and do not sell phases 1–3 as differentiation — they are correctness and accessibility debt (a measured 3.46 : 1 contrast and a ΔE-3.6-under-protanopia palette are bugs, not taste).
+
+---
+
+## Open questions for the user
+
+1. **Do boards earn their place in the primary nav, or should composition move into the surfaces where you already are?** The board is a late-game artifact — the industry base rate is that dashboards get created and then go stale — and yours was assembled from empty notes because there was a "+ Add tile" button and nothing else. **Recommendation:** keep the tab, but make "Pin to board" a first-class action in the transcript, the note header, the person page and the Ask answer (Phase 7). If composition never becomes a byproduct of normal use, boards will be built once each.
+
+2. **When a board grows past the budget, should Ask *truncate everything* or *retrieve the most relevant*?** Today it silently truncates, so a 40-source board answers worse than a 6-source one — the composition incentive is inverted. **Recommendation:** ship both as a visible toggle (Dust ships Include and Search as explicit modes because neither dominates), default to Whole-board under ~12 sources and Most-relevant above it — and settle the threshold with the D8 eval, not by taste.
+
+3. **Do you want `drift` fixed at the extractor, or retired?** It fires for 1 of 57 entities and `supersessions` has 0 rows, blocked by three independent mechanisms (stub reasoner, free-form predicates — 43 distinct across 48 facts, same-meeting skip). It is also the single most only-Murmur concept in the catalogue. **Recommendation:** retire it from the palette now (Phase 2) and open a separate investigation into predicate normalisation in `facts::reconcile_facts` — do not keep advertising it while it cannot fire, and do not entangle that fix with this work.
+
+4. **Should a board be a static scope or a live one?** A saved-query tile whose membership changes without you touching it is more useful and less *yours*; the whole thesis rests on "the user hand-composed the universe." **Recommendation:** static membership for anything that contributes a source; live queries allowed only as views that contribute zero sources. If you want live membership, it should be an explicit per-board setting labelled as such, not a tile that quietly does it.
+
+5. **Is a fake waveform / decorative chart ever acceptable?** The prototype's richness partly came from `Math.abs(Math.sin(i*.9))`. **Recommendation:** no, never on a tile representing a real recording — but say so out loud, because it means the shipped board will always be slightly quieter than that prototype, and the gap should be closed with real signals (talk split, chapter strip, heat strip) rather than by lowering the bar.

--- a/docs/superpowers/specs/2026-08-04-dashboards-rebuild-design.md
+++ b/docs/superpowers/specs/2026-08-04-dashboards-rebuild-design.md
@@ -1,0 +1,640 @@
+# Dashboards rebuild — design
+
+*Spec · 2026-08-04 · supersedes nothing; implements the verdict in
+`docs/research/2026-08-04-dashboards-ux-research.md`.*
+
+Research brief: `docs/research/2026-08-04-dashboards-ux-research.md` (383 lines, 12 agents,
+three adversarial critiques). This document is the **decision** layer: what we build, in what
+order, and what we refuse. Where the brief and this spec disagree, this spec wins — the
+divergences are marked **[DECISION]** and carry the reason.
+
+---
+
+## 0. The invariant that outranks every phase — a board is brain context
+
+The user's binding constraint, stated during design: *"to wszystko musi być połączone z brain
+jako wspólne konteksty w dashboard"*. Verified state of the tree, so nobody re-litigates it:
+
+**Already true (do not rebuild):**
+
+| Path | Symbol | What it gives |
+|---|---|---|
+| Local MCP server | `mcp.rs:1667` `list_dashboards`, `mcp.rs:1672` `get_dashboard` | An external agent reads a board with **every tile resolved** through `commands::render_tile_for_agent`, sealed tiles redacted by `redact_tile_chrome` first |
+| In-app agentic loop | `tools.rs:405` / `tools.rs:416` in `tool_specs()` | `@brain` and vault-wide Ask can pull a board in as context on their own initiative |
+| Every source picker | `source-picker.component.ts::pickDashboard` | A board expands into its visible sources anywhere a picker exists |
+
+**The gap, and it is inverted from intuition:** the board's own *"Ask this board"* is the
+**weakest** consumer of the board in the whole app. `dashboard-view.component.ts:319` calls
+`askVault(question, [], undefined, sources)`; a non-empty `explicit_sources` makes
+`commands/mod.rs::ask_vault` (line ~4464) take the deterministic floor and **skip the agentic
+path entirely** — so it never receives `get_dashboard` as a tool, and
+`commands/dashboards.rs::get_dashboard_sources` hands it only `note`/`meeting`/`document`
+(`_ => continue`). Claude Code over MCP sees more of the board than the panel rendered beside it.
+
+**[DECISION] This is promoted from a Phase-4 item to a cross-cutting acceptance criterion.**
+
+> **AC-BRAIN.** Every tile kind that renders content on screen must be readable by (a) in-app
+> board Ask, (b) the in-app agentic loop, and (c) the MCP surface — through **one** renderer,
+> `render_tile_for_agent`, with `redact_tile_chrome` applied first. A tile kind that a human can
+> read on a board and an agent cannot is a defect, and no phase may introduce one.
+>
+> **The corollary that bounds it:** parity of *reading* must not become parity of *scope*.
+> Derived tiles enter the prompt as a labelled **brief**, never as `SourceRef`s — `SourceRef.kind`
+> is a `LinkKind` and a drift lane is not a retrievable document. The existing
+> `get_dashboard_sources` filter is correct and stays.
+
+Every phase below carries an AC-BRAIN line. Phase 4 is where it first becomes true for board Ask;
+Phases 6–7 are where it must not regress.
+
+---
+
+## 1. What we are fixing, in one paragraph
+
+The shipped board reads as a wall of identical grey boxes holding apologies. Three independent
+causes, and they need three different fixes. **(a) A layout bug:** every tile is born
+`span = 4` (`commands/dashboards.rs:477` `span.unwrap_or(4)`, and
+`dashboard-view.component.ts::addTile` never passes one although `dashboards.service.ts:143`
+accepts it) → 12/4 = three per row forever, plus a `min-height: 74px` floor. **(b) Thin data by
+construction:** the fact extractor is never asked for quantities, mention counting is
+`INSERT OR IGNORE` per *meeting* rather than per utterance, and `extract_owner` yields the
+literal string `"(właściciel nieokreślony)"` — so Numbers, Pulse, Drift and Person's headline are
+structurally near-empty regardless of how much the user records. **(c) A visual system that was
+designed and then not shipped:** the `/dreaming` prototype's per-kind coloured mark, variable
+tile sizes, smooth sparkline, and inline citations are all absent; `--text-muted` at 10–11 px
+measures 3.46–3.62 : 1, below the legibility floor, across the entire secondary text layer.
+
+Beneath all of it sits the real defect: **board Ask degrades monotonically in the variable the
+feature asks the user to increase.** `fair_pack_explicit_sections` gives each source
+`budget / n` characters and hard-truncates, so a 40-source board answers worse than a 6-source
+one.
+
+### Measurement caveat, carried forward honestly
+
+The brief's hit-rate figures (Numbers 5.3 %, Drift 1.8 %, Pulse 0 %) were measured against
+`~/Library/Application Support/MeetNotes-dev/meetnotes.sqlite` — **the dev database**, 78 meetings
+averaging 63 s, i.e. test recordings. Per `release-murmur` rule 4, dev and release data are
+isolated; the production vault was not read. **The mechanisms are proven from source and hold
+regardless of vault size; the percentages are indicative, not a measurement of the user's real
+vault.** No decision in this spec rests on a percentage alone — each rests on the mechanism.
+
+---
+
+## 2. Decisions taken
+
+| # | Question | Decision | Consequence |
+|---|---|---|---|
+| D1 | Scope | **Full programme, Phases 1–8** | Several sessions. Phases 4, 5, 6, 7 need `lock-security-reviewer`; 5 and 6 are the high-risk ones |
+| D2 | Numbers / Pulse / Drift | **Retire from the palette now; open a separate extractor investigation** | They stop being offered. `resolve_tile` arms stay alive (see the append-only constraint below). The extractor work is a *different* spec and must not be entangled with this one |
+| D3 | New tiles | **Talk split · Quote · Board note · Stayed-on-device** | Board-scoped cadence and the board-scoped search view are deferred, not killed — cadence rides Phase 8, search rides the Phase 6 retrieval work |
+| D4 | Composition | **Keep the tab, add "Pin to board" to transcript selection, note header, person page, and Ask answers** | Composition becomes a byproduct of normal use. This is Phase 7 and is the difference between a feature and a demo |
+
+### The append-only constraint that shapes D2
+
+`commands/dashboards.rs:1010` ends `resolve_tile` with
+`other => Err(AppError::InvalidArg(format!("unknown tile kind: {other}")))`, and `get_dashboard`
+collects with `.collect::<Result<Vec<_>, AppError>>()?`. **One unresolvable tile fails the entire
+board**, and the user's live board contains both `numbers` and `pulse` rows. Migrating
+`dashboard_tiles.kind` would be a destructive rewrite of user rows, forbidden by
+`rust-tauri.md` §4.
+
+> **Therefore "retire" means exactly:** remove the entry from `NODE_TYPES` in
+> `tile-palette.component.ts` so no new one can be placed, and leave the `resolve_tile` arm alive
+> rendering a proper degenerate state. **No `resolve_tile` arm is ever deleted.** This is a
+> permanent rule for this feature, not a phase note.
+
+---
+
+## 3. Architecture — the seams we work at
+
+Nothing here introduces a new AI path, a new gated reader, or a new egress class. That is
+deliberate and is what keeps the programme reviewable.
+
+```
+                       ┌─ dashboard-view (in-app Ask) ──┐
+storage/dashboards_store ─→ commands/dashboards.rs      │
+  dashboards, dashboard_tiles     ├─ resolve_tile ──────┼─→ get_dashboard      → UI
+  (additive only)                 │   (the ONE gated    │
+                                  │    resolver)        ├─→ render_tile_for_agent
+                                  │                     │      ├─→ tools.rs GetDashboard  (in-app loop)
+                                  ├─ redact_tile_chrome │      ├─→ mcp.rs get_dashboard   (external)
+                                  │   (applied FIRST)   │      └─→ get_dashboard_brief    (NEW, Ph4)
+                                  └─ get_dashboard_sources → ask_vault(explicit_sources)
+                                      note|meeting|document only — CORRECT, unchanged
+```
+
+**Four rules that fall out of this diagram, and that every phase is checked against:**
+
+1. `resolve_tile` is the single gated resolver. No phase adds a second path to tile content.
+2. `redact_tile_chrome` runs **before** any renderer. A sealed tile carries `{kind:"locked"}` and
+   no fields; nothing may add one — no count, no kind glyph beyond the shared lock, no chart
+   skeleton whose *shape* discloses the kind.
+3. Derived tiles never become `SourceRef`s. They reach a prompt as text, through the brief.
+4. Additive migrations only. **No `UNIQUE INDEX` on `(dashboard_id, kind, ref_id, config)`** —
+   the user's live DB already violates it, and `Db::migrate()` runs at startup on real user DBs,
+   so the index would fail migration and therefore launch.
+
+---
+
+## 4. Phases
+
+Each phase is independently shippable and independently revertible. Phase 1 is the entire visible
+delta the user complained about and must not be blocked by anything below it.
+
+### Phase 1 — make the existing board look composed  ·  FE only · **M** · no lock review
+
+Retroactive on boards that already exist; no migration, no backend.
+
+- **Empty-state ladder** replacing eleven identical `<p class="muted">` boxes:
+  - *never had data* → collapse to a **36-px dashed header strip**, `background: transparent`,
+    `backdrop-filter: none`, body and footer `display:none`, copy states where data will land
+    ("Figures said out loud land here"), never an apology.
+  - *genuinely zero = good news* → **full tile, not grey**: `✓` in `--success` +
+    `--text-secondary`. "Nothing open — every commitment on this board is closed" is a *result*;
+    rendering it as an absence is the most demoralising thing the board does.
+  - *degenerate* (drift `rows < 2`, pulse `total === 0`, any chart with `n ≤ 1`) → collapse the
+    **mark**, keep the tile: "One value, never revised — nothing has drifted".
+  - *degenerate-but-populated* → a 100 %/0 % talk bar, a one-cell strip, a one-row ledger pass
+    every emptiness check and still look broken. Same treatment, keyed on a per-pattern variance
+    predicate.
+  - *missing / unconfigured* → strip + an inline action.
+  - **Two layout rules the collapse depends on:** an empty strip takes **span 3** and **sorts to
+    the end of the grid**. `.canvas` is `grid-auto-rows: max-content` with `align-self: start`,
+    so a 36-px strip left in composition order beside a 200-px tile leaves ~164 px of dead air —
+    scattered strips look *worse* than the grey boxes.
+  - **One ghost preview per board, never more** (repeated illustrations fatigue): the first empty
+    tile renders its pattern skeleton at 10 % opacity plus one sentence and a tertiary action.
+- **Display-span override.** `displaySpan = tile.span === 4 ? DEFAULT_SPAN[kind] : tile.span`;
+  the first explicit resize writes a real value. ~6 lines, retroactive.
+  Bands: `person`/`pulse` 3 · `numbers`/`note`/`document`/`drift`/`reminders` 4 ·
+  `promises`/`meeting`/`livingAnswer` 6. `3+3+6`, `4+4+4`, `6+6` — the row rhythm appears by
+  itself. **[DECISION] Not an add-time default** — every existing tile already holds a concrete
+  `4`, so an add-time default changes nothing about the board that was complained about.
+  Delete `min-height: 74px`.
+- **Render-time duplicate strip.** Two resolved tiles sharing `(kind, refId, config)` → the
+  second renders as *"same as the tile above · Remove"*, and the palette scroll-highlights the
+  existing tile instead of adding. Pure FE, works on the user's board today. **[DECISION] No
+  backend `InvalidArg` guard** — it would be swallowed by `DashboardsService.addTile` into the
+  hand-rolled `message(e)` renderer this programme is deleting.
+- **Tokens.** Add `--text-tertiary` (#8a8a9c dark, 5.50 : 1; #6e6e78 light, 4.84 : 1) and
+  `--hatch-stripe`, **in both the `[data-theme]` and the `prefers-color-scheme` blocks** of
+  `theme-light.css`. Migrate `.tile-kind`, `.row-meta`, `.drift-meta`, `.number-key`,
+  `.live-chip`, `.muted-small` off `--text-muted` (which stays for ≥13 px only). Delete the nine
+  raw `rgba()` values that render white-on-near-white in light mode.
+- **Per-kind mark + eyebrow-above-title** — §5.
+- **Sealed tile** re-copied to *"Sealed — not in scope."* / *"Unlock the folder to bring this
+  back into the board's scope."* Full-size, 45° hatch. A board that is screen-shareable as-is is
+  a demo moment; today it reads as a bug.
+
+**AC-BRAIN:** none of this changes what an agent reads. Assert unchanged
+`render_tile_for_agent` output.
+
+**Verification.** RED-before-GREEN per `angular-zoneless.md` **T5**: a Playwright spec that
+fails on today's code — assert an empty-payload tile renders at `span 3` with no body, and that
+nine tiles do not all report equal height. Then `ng lint`, `ng build`, and — because
+`color-mix()`, `mask-image` and `backdrop-filter` are involved — **a packaged WKWebView check**
+per **T4**: a green `ng build` proves nothing about the shipped engine.
+
+### Phase 2 — data honesty  ·  **M** · no lock review
+
+- **`normalize_owner` / `extract_owner`**: an owner head that is *only* a parenthetical becomes
+  `None`. **Language-agnostic** — matching the Polish literal would silently regress for an
+  English `note_language`. Also fix the note-generation prompt, or the extractor keeps producing
+  the shape. **This is XS and un-zeroes `TileData::Person.open_commitments` vault-wide — the
+  highest work-to-value ratio in the programme.**
+- **Retire `numbers` and `pulse` from `NODE_TYPES`;** gate `drift` on a live count ≥ 2.
+- **Palette counts from aggregate SQL.** `SELECT entity_id, COUNT(*) … GROUP BY entity_id` over
+  `facts` (covered by `idx_facts_entity`) and `entity_mentions` (`idx_entity_mentions_entity`),
+  plus `length(text) > 0` on note candidates. **[DECISION] Never speculative `resolve_tile` per
+  candidate** — that is ~230 resolves per palette open, serialised on the one
+  `Mutex<Connection>` a live recording writes segments through, and `resolve_tile`'s `"note"` arm
+  does a full vault note-list read to resolve one note. Hide unavailable offers in the browse
+  band; **grey with a reason** in the subject band, where silence would read as a missing feature.
+- **Subject-first palette order.** Pick the subject, then see which tiles it can support. Today
+  the user commits to "Drift lane" before discovering the subject cannot keep the promise — which
+  is literally the question *"nie wiem ile one mają sensu"*, and it is unanswerable in the
+  current order.
+- **`promises` gains `mode: "entity"`** with an explicit *Everyone* option; the owner renders in
+  the header. The backend has read `cfg.owner` since day one and no UI ever wrote it — which is
+  what produced the two identical tiles.
+- Wire or delete `registerField` (`tile-palette.component.ts:295`, bound nowhere, so the search
+  field never focuses); add the focus move and trap the `role="dialog" aria-modal="true"`
+  currently claims without implementing. Fix or delete `due_count` (it counts all active rows
+  *before* the `TILE_ROWS` truncation, and the FE never renders it — both halves of the name are
+  wrong).
+
+**Honest bound on preflight:** it validates at *add* time and tiles are *persistent*. Seal a
+folder and a preflight-validated board is the screenshot again, now with the user believing it
+was checked. Preflight saves wasted composition effort; **Phase 1's render-time collapse is what
+keeps a board good over time.** That ordering is deliberate.
+
+**AC-BRAIN:** `Person.open_commitments` becoming non-zero changes `render_tile_for_agent` output.
+Update the agent-surface oracle rather than letting it drift.
+
+### Phase 3 — performance prerequisites  ·  **S–M** · no lock review
+
+Do these before anything else touches `get_dashboard`; they are cheap now and load-bearing later.
+
+- **Hoist `list_open_commitments` to once per board** in `get_dashboard` — `Db::list_people`
+  already demonstrates the pattern. Today two Promises tiles cost two full-vault note scans, and
+  `updateTile → reloadOpenBoard` re-resolves *every* tile, so one chevron click costs three.
+- **Patch span locally** instead of `reloadOpenBoard()` — span is pure layout and no gated
+  payload changes.
+- **RED-first Rust oracles for `get_dashboard_sources`**, which currently has **zero** Rust tests
+  despite being the function that *defines* the scope; its only coverage is Playwright mocks
+  asserting the FE's own assumption. Required before Phase 5 reshapes anything near it:
+  a sealed-folder source is absent · a derived tile contributes nothing · a deleted source yields
+  `Missing`, not an error · duplicates dedupe by `(kind, id)`.
+
+### Phase 4 — Ask honesty, and AC-BRAIN becomes true  ·  **M** · **lock review required**
+
+- **`get_dashboard_brief(id) -> String`** — the board's derived tiles rendered through the
+  existing, already-redaction-correct `render_tile_for_agent`, under one `lifecycle_guard`,
+  capped ~4 000 chars, prepended to the pinned corpus as a labelled block:
+
+  ```
+  WHAT THIS BOARD ALREADY SHOWS (the user composed these views; do not re-derive them):
+  - promises (Marcus Reid): Send Acme paperwork · due 2026-07-22 · late
+  - drift: Atlas GA · target_date: Apr 30 → Jun 14
+  ```
+
+  Zero new gated reader, zero new egress class, ~1–2 % of budget. **This is the phase that
+  satisfies AC-BRAIN for board Ask.**
+- **Render answers and living answers through `src/app/shared/markdown/markdown.component.ts`.**
+  The prompt in `summarize/vault_chat.rs::build` *demands* markdown; the board renders it as
+  `{{ turn.text }}` with `white-space: pre-wrap`, so `**` and `[[…]]` appear literally. The
+  component already turns `[[Wikilinks]]` into gated chips. Dashboards is the only AI surface in
+  the app not using it. **Reuse its hard-won lesson:** read the title from `textContent`, never a
+  `data-*` attribute — Angular's sanitizer strips unrecognised `data-*` even when DOMPurify
+  allow-lists them.
+- **Errors get a third turn role** rendering `.banner.is-danger` (`design-system/primitives.css`)
+  with a
+  Try-again button. Today an error is pushed as `{role:"assistant"}` and renders in a normal grey
+  bubble, visually identical to a real answer, with no retry.
+- **`errcode` tags at the provider** (`PROVIDER_TIMEOUT`, `PROVIDER_MODEL_REJECTED`,
+  `PROVIDER_CLI_MISSING`, …), preserved through `summarize/redact.rs::content_free_dispatch_error`
+  as a leading `[code]`. Pin with a test asserting the message matches `^\[[a-z-]+\] ` **and
+  contains none of the inner error's bytes** — a kebab-case token from a closed set leaks nothing.
+  Delete both hand-rolled FE renderers (`dashboard-view.component.ts::errorText`,
+  `dashboards.service.ts::message`) in favour of `core/copy/error-copy.service.ts` — the boundary
+  the app established by deleting nine of these, and which dashboards reintroduced two of.
+- **Pass the 12-turn history.** `capped_ask_history` exists and every other chat surface uses it;
+  the board sends `[]`.
+- **Fix the bytes-vs-chars budget mismatch:** `pack_meetings`/`pack_notes` compute `remaining`
+  from `corpus.len()` (**bytes**) then consume `.chars().take(remaining)` (**chars**) while the
+  caller counts `chars().count()`. A Polish or CJK vault overruns the declared budget by 2–4×.
+  This is a live correctness bug for this user specifically.
+
+**[DECISION] No scope-blaming copy** ("this board is too big — 47 sources") until the Phase-5
+manifest makes `refs.len()` real. On the board that produced the complaint it would have been
+factually false: `get_dashboard_sources` yielded at most 4 sources, three of them notes holding
+0 / 18 / 86 characters. **The Ask failure in the screenshot was a plain `claude_code` dispatch
+failure, not a size problem** — `claude_code.rs::claude_failure_message` already produces a
+content-free actionable diagnostic naming the likely bad model id, and
+`content_free_dispatch_error` collapses it to one useless sentence.
+
+**Lock review focus:** content enters a prompt through a new path, even though the renderer is
+already redaction-correct.
+
+### Phase 5 — the packer manifest (keystone)  ·  **M–L** · **lock review mandatory**
+
+`build_vault_context_pinned_visible` returns
+`PackedContext { corpus, refs: Vec<PackedRef { kind, id, title, folder_id, chars_packed, truncated, role }> }`.
+Every field is already in hand where `pack_meetings`/`pack_notes` push a header. One change,
+four unrelated fixes:
+
+1. **Citations for every tile kind** — match on `(kind, id)` instead of `meetingId`. Today
+   `VaultSource` carries only `meeting_id` and the note/document arm pushes `Vec::new()`, so a
+   note or document tile **can never be cited**.
+2. **A precise living-answer gate** — record `refs.folder_id` instead of the entire readable
+   folder set. Sound, far tighter, and it fixes the shipped capacity cliff: `set_dashboard_answer`
+   stores every readable folder id, a UUID serialises at ~39 bytes inside a JSON array, so
+   **~210 folders exhaust `MAX_CONFIG_LEN` (8 KiB)** and an ordinary answer fails with
+   `InvalidArg("answer too large")`. `list_folders` includes note folders; a real Obsidian vault
+   passes 100 trivially.
+3. **A truthful truncation readout** — "12 of 47 sources were trimmed to fit".
+4. **Proof that MCP and in-app Ask ground identically.**
+
+Then, and **only** then, the cited state (§5.6).
+
+**Risk note for the reviewer: this phase NARROWS a security gate.** Keep `living_answer_withheld`
+a pure function and **fail closed** on legacy or empty rows.
+
+### Phase 6 — the scope leaves the app  ·  **L** · **lock review required** (protocol + egress)
+
+- `tile:<id>` identifiers and a board header (`# Atlas · id:… · tiles:12 · sources:7 · sealed:1`)
+  in `render_tile_for_agent` — an external agent currently **cannot cite a tile**.
+- **`search_dashboard(dashboardId, query)`.** Without it, the recommended agent behaviour after
+  `get_dashboard` is vault-wide search — **the scope evaporates at the exact moment the agent
+  needs depth.** The id set must be pushed **into the search legs**
+  (`search_visible_impl` / `search_semantic_visible` / the graph leg), **never** applied as a
+  post-filter after `limit`: that returns zero rows for a board whose sources rank 41st–60th
+  while the answer is demonstrably on the board. Note it is silently dead without a downloaded
+  embedder (`Embedder::embed_query`) — the same stub-model failure class as the fact extractor,
+  and it needs the same explicit branch.
+- `get_dashboard_context` returning what in-app Ask packs, bounded by `MAX_TOOL_WINDOW_CHARS`.
+- **Retrieval inside the scope.** When `n_sources × min_useful_chars > budget`, stop fair-sharing
+  and retrieve top-k whole, restricted to the board's sources. Expose as a board toggle,
+  **Whole board** vs **Most relevant** — neither dominates, and the user knows which they want.
+  Default Whole-board under ~12 sources; **settle the threshold with the eval below, not by
+  taste.**
+- **Board identity through the picker.** `pickDashboard` currently splices refs into a flat
+  selection, destroying board identity, snapshotting membership at pick time, and truncating
+  silently at `selectionLimit`. Carry `viaBoard: {id, title}` so chips read `Atlas · 7 sources`,
+  and **re-expand at ask time, not pick time** — free correctness: a tile added mid-thread joins
+  the scope, a folder sealed mid-thread drops out.
+- `.canvas` export (`export/canvas.rs` already emits Canvas JSON) + `murmur://dashboard/{id}` and
+  the vault path on the board header.
+
+**[DECISION] Do not wire boards into the record view.** The live transcript is the anchor there,
+and `acquire_external_egress_lease` risk during recording is real.
+
+**The measurement this phase owes (Track B).** Nobody proposed an oracle, and without one the
+thesis is unfalsifiable: **until board-scoped Ask beats vault-wide Ask on a fixed question set
+drawn from the real vault, "a board is a retrieval scope" is an aesthetic preference with a
+canvas attached.** `eval/` exists. This experiment also adjudicates the Whole-board / Most-relevant
+default.
+
+### Phase 7 — the four new tiles + "Pin to board"  ·  **L** · **lock review required** (Quote)
+
+| Tile | Source | Form | Note |
+|---|---|---|---|
+| **Board note** | `dashboard_tiles.config.text` + existing `app-markdown` | prose | **XS.** The board cannot currently be *written*, only assembled — and the user's own sentence is the highest-value token in the board's prompt |
+| **Talk split** | `segments.speaker/start_s/end_s`, `SUM(end_s-start_s) GROUP BY speaker`, under the meeting gate; additive `me_ratio`/`segment_count` on `TileData::Meeting` | 8-px stacked bar, 2-px gap | **Per meeting only.** `speaker` is `add_column_if_missing(… "TEXT")` → nullable, so pre-dual-stream recordings need an explicit NULL branch. **No board-wide rollup:** `others-N` are per-meeting cluster tags and `speaker_voiceprints` has 0 rows, so summing across meetings adds different humans together and prints it as a roster — the same class of lie as `looks_numeric` printing deadlines |
+| **Quote** | `db.get_segments` behind `meeting_is_visible`; config stores **only** `{meetingId, startS, endS}` | pull-quote + timestamp | The only tile structurally incapable of being empty — content is chosen at add time. Gate path verified: `get_segments` is explicitly ungated ("callers must first pass the meeting visibility boundary") and sealing blanks `segments.text` to `''`, so a relocked session yields empty text, never stale text. **v1 must not play audio in-tile** — `lock-model.md` documents `convertFileSrc`/`asset:` as the one audio path bypassing `meeting_is_unlocked`, which is why the masked DTO nulls `audio_path`. Deep-link to the gated detail view at `start_s` |
+| **Stayed on device** | `egress_store::egress_summary(days)` over `egress_log` — content-free by construction | one stat + delta | Never empty, and its zero state ("0 cloud calls · 100 % local") is its best state. No cloud notetaker can render it |
+
+- **"Pin to board"** as a first-class action in: transcript selection (which is also how Quote is
+  created), the note header, the person page, and Ask answers. **This is D4 and it is the
+  structural fix** — boards are a late-game artifact sitting in the primary nav, which is exactly
+  why the first one was assembled from empty notes. If a user must visit the Dashboards tab to
+  *build* a board, it happens once.
+
+**AC-BRAIN:** all four new kinds get a `render_tile_for_agent` arm in the same change, with an
+agent-surface oracle. A tile a human can read and an agent cannot is a defect.
+
+### Phase 8 — polish  ·  **M** · no lock review
+
+Ask rail collapses to 44 px when `turns()` is empty, carrying the scope count vertically (the
+scope count *is* the thesis made visible and belongs on screen permanently; the empty transcript
+does not), expanding to 380 px on use · board emoji/tint/rename **writers** (`TINTS` in
+`dashboards.rs` and six SCSS mappings are dead code because nothing ever writes the field) ·
+home-card sealed marker, freshness line, sparkline, delete confirmation, search + segmented
+control · arrange-mode grip, `Alt+←/→` reorder, `⌘←/→` resize, `:focus-visible` rings on the
+twelve background-less buttons that have none, the missing `(dragleave)`, and `draggable` moved
+off the host (whose body is full of `<button>`s — WebKit does not reliably bubble a drag begun on
+a nested button) · **board-scoped cadence** tile (fixed heat ladder) · **board diff — "since I
+last looked"** (`last_seen_at`; the grid reports *state*, this reports *change*, which is the
+line between a board opened weekly and one that goes stale) · motion pass · read/compose split ·
+delete the duplicated `.arrange-hint` block at `dashboard-view.component.scss:235-244`.
+
+---
+
+## 5. The visual system
+
+### 5.1 Tile anatomy
+
+```
+[22px mark]  EYEBROW (10px/600/+.08em/uppercase, --text-tertiary)   [grip|tools] or [freshness]
+             TITLE   (14px/640/-.01em, --text-primary)
+─ body (one of six patterns, per-pattern height band) ─
+─ footer (CONDITIONAL): provenance ····················· state ─
+```
+
+- **Eyebrow above title.** The eyebrow is the classifier and must be scannable down the left
+  edge; title-first opens every tile with a different-length proper noun.
+- **The mark** is a 22 × 22 squircle (`border-radius: 7px` — a circle reads as an avatar),
+  `background: color-mix(in srgb, var(--tile-hue) 18%, transparent)`, 1-px rim at 34 %, glyph
+  `stroke: var(--tile-hue)` at 1.9. **Not** the prototype's solid fill with a near-black glyph —
+  eleven saturated solids is the confetti failure at ⅕ of the ink budget. Material vs derived is
+  carried by **fill vs outline**, not by a fifth hue.
+- **The footer is conditional.** A mandatory 28-px bordered footer on every tile re-homogenises
+  the heights this spec is trying to break.
+- **Divider budget: one full-bleed rule per tile, and it is the footer.** Delete
+  `.row { border-bottom }` — four promise rows currently draw three full-bleed rules inside
+  ~120 px, which *is* the spreadsheet read. Rows become chips on `--surface-input` with
+  `gap: var(--space-1)`.
+
+**Hue map — four hues, capped:** `{--graph-note, --graph-entity, --graph-meeting,
+--graph-document}`, ordered mint → azure → amber → orchid so orchid and azure are never adjacent.
+Adding a fifth (`--warning`) is a measured failure (ΔE 5.7 vs amber). Derived tiles get **no
+hue** — `--text-secondary` marks. **`--accent` is reserved for the AI channel only** (citation
+ring and numeral, the `livingAnswer` mark, the Ask composer): it is user-selectable and 5 of 6
+options collide with a family hue (orange vs `--graph-meeting` = ΔE 2.4). Today
+`dashboard-tile.component.scss:300,318,339` paints the pulse bars and the drift rail `--accent` —
+that is the accent doing category work; both become `var(--tile-hue)`.
+
+**Text never wears the data hue.** A family hue at 10 px on the light tile surface measures
+3.48–5.04 : 1. Current violation: `.audio-chip { color: var(--graph-meeting) }` at 0.66 rem =
+**1.99 : 1** in light mode.
+
+### 5.2 The closed set of body patterns
+
+**A new tile kind may not invent a seventh.** This rule is what stops the board looking like ten
+bespoke widgets, and it is binding on Phase 7.
+
+| Pattern | Height band | Used by |
+|---|---|---|
+| **P1** stat cluster — eyebrow / 28-px value / delta | 62–96 px | person, stayed-on-device |
+| **P1b** stat grid — 2-up wells, `tabular-nums` | 96–140 px | numbers *(retired, arm alive)* |
+| **P2** ledger rows — chip rows, max 5 then `+N more` | 84–200 px | promises, reminders |
+| **P3** lane — vertical rail, two-line steps | 76–200 px | drift *(gated)* |
+| **P4** micro-chart + stat | 74–110 px | cadence, pulse *(retired, arm alive)* |
+| **P5** prose — gradient mask, **not** `-webkit-line-clamp` | 84–170 px | note, document, living answer, board note, quote |
+| **P6** proportional strip — segmented bar + chips | 56–88 px | meeting / talk split |
+
+Type scale declared once on `:host`: `--t-eyebrow: .625rem`, `--t-title: .875rem`,
+`--t-body: .8125rem`, `--t-meta: .6875rem` (**line-height 1.35, not the global 1.5** — at 11 px,
+1.5 separates a two-line meta into two unrelated elements), `--t-stat: 1.75rem`. Top-to-bottom
+ratio 2.8× (shipped is 1.8×, below the ~2.4× at which a card acquires a focal point). Note the
+shipped hierarchy is *inverted*: `.number-value` is 15 px while `.stat dd` is 18 px, so the
+Numbers tile has the smallest figures on the board. Big standalone figures get **proportional**
+digits; `tabular-nums` only where digits align in a column.
+
+### 5.3 Micro-charts — two rules that make every SVG survive Angular
+
+1. **Never `<defs>` + `id` in a repeated component.** Emulated encapsulation scopes attributes,
+   not ids — twelve tiles emit twelve `id="sparkFill"` and tile 7 silently paints tile 1's hue.
+   Use `fill: currentColor; opacity: .14` or a CSS `mask-image`.
+2. **`preserveAspectRatio="none"` + `vector-effect="non-scaling-stroke"`**, and **never a
+   `<circle>` inside a stretched viewBox** — an end-of-series dot must be a CSS element
+   positioned from a computed signal.
+
+**Mark chooser**, deterministic from `density = nonzero/n` and `peak`:
+`n === 0` → not a chart, empty ladder · `n === 1` → no chart, one stat + qualifier ·
+`n ≤ 4` or `density < .6` → dot-strip · small ints, `n ≤ 20` → **heat strip (the default)** ·
+`density ≥ .6 && peak ≥ 4` → line + 14 % area · `peak < 4` → line only · **never bars**.
+
+Today's Pulse is the counter-example: `barHeight = v / max(...weekly) * 100` with
+`min-height: 3px` means **a zero week draws a visible mark for data that does not exist**, and a
+peak of 1 renders at 100 %, so 40 mentions/week looks identical to 1.
+
+- **Heat strip:** `display:flex; gap:2px`, cells `aspect-ratio:1; max-width:14px`, quantised on a
+  **fixed** ladder `v===0?0:v<=1?1:v<=3?2:v<=6?3:4` → opacity `[0,.28,.48,.72,1]`, level 0 painted
+  `--surface-input` + `--border-subtle`. **Fixed, never normalised** — that is what makes two
+  boards comparable, and exactly the property `barHeight` destroys.
+- **Dot-strip:** flex columns, 1-px stem at 26 % opacity, 5-px dot; **a zero is a 3-px dim dot on
+  the baseline** — present, unambiguously zero. A bar with `min-height` cannot express this.
+- **Sparkline:** viewBox `0 0 100 32`, plot band y ∈ [4,30], `yMax = max(peak, 4)`, stroke 1.75,
+  area `opacity .14`, end dot as a CSS `<i>` with `box-shadow: 0 0 0 2px var(--surface-solid)`.
+  Draw-on via `pathLength="1"` + dashoffset 1→0, 700 ms, once — no JS path measurement.
+- **Talk-split bar:** 8-px track, two segments with a 2-px `--surface-solid` gap, `Me` in
+  `--tile-hue`, `Others` at 32 %.
+- **No fake waveform, ever.** The prototype's `Math.abs(Math.sin(i*.9))` is decorative fake data
+  on a tile claiming to represent a real recording — a credibility hole in an app whose entire
+  pitch is provenance. **Consequence, stated out loud: the shipped board will be slightly quieter
+  than that prototype.** Close the gap with real signals (talk split, chapter strip, heat strip),
+  never by lowering the bar.
+
+### 5.4 The sealed tile
+
+`TileData::Locked` carries no fields; `redact_tile_chrome` nulls `title`/`config`;
+`DashboardTileComponent.heading()` re-asserts it client-side. **Nothing may add a field.**
+
+**Hazard to design around:** `redact_tile_chrome` treats `Drift`/`Numbers`/`Pulse` with
+`entity == ENTITY_HIDDEN` as withheld and strips chrome, but the payload still ships `weekly`,
+`total` and `quiet_days`. Any new footer or freshness mark **must branch on the same withheld
+predicate**, not on "does the payload carry a timestamp" — a heat strip or a `quiet 9d` chip for
+a hidden entity leaks timing about a sealed entity.
+
+### 5.5 Layout
+
+`--cols: 12 → 8 → 4` in media queries, **clamped in TypeScript**, not
+`grid-column: span min(var(--tile-span), var(--cols))` — a math function in a `span <integer>`
+context has no precedent in this repo, and if WebKit rejects it **the whole declaration drops**
+and every tile falls back to span 1, collapsing the board into a 12-column sliver.
+(`color-mix()` by contrast is already shipped in six files including
+`design-system/primitives.css` and `board-card.component.scss`, and is safe.)
+Tall tiles clamp with a mask + `+N more`, never a nested scrollbar.
+
+### 5.6 The cited state — dim the field, and not before Phase 5
+
+Brightening one card among eleven is a weak signal.
+`.canvas.is-citing app-dashboard-tile:not(.cited) { opacity:.45; filter:saturate(.55) }`; the
+cited tile gets the `--accent` ring, a glow, and a **numeral badge** (the accessible channel —
+colour alone can never carry citation, and the user's accent may sit within ΔE 15 of a family
+hue); `scroll-margin-top: var(--space-6)` + `scrollIntoView({block:"nearest"})`; held
+`--motion-cite-dur`, then released to a **persistent 2-px accent bar on the tile's inline-start
+edge** until the next question. That persistent bar is the visible proof that the board *is* the
+retrieval scope.
+
+**Three states, not two:** `cited(n)` · *in scope, not used* · *out of scope* (sealed, or a
+derived tile that contributes no source — permanently desaturated, footer reads `not a source`).
+
+**Blocking dependency.** Do **not** ship dim-the-field before the Phase-5 manifest. Today
+`build_vault_context_pinned_visible`'s note/document arm pushes `Vec::new()` and `tilesForSources`
+matches `s.meetingId` against `t.refId` — on a board of three notes and one meeting, dimming
+would dim the three notes and spotlight the meeting, asserting a falsehood about what the answer
+stood on. **Un-cited is honest; wrongly-cited is worse than no citation.**
+
+### 5.7 Motion
+
+Live dot `opacity .55→1` over 3.2 s (shipped is `1→.3` over 2.4 s — **amplitude**, not duration,
+is what makes a loop noisy). **Liveness is a property of the data, not the kind** —
+`LIVE_KINDS` currently blinks a three-month-stale Promises tile identically to one that changed
+an hour ago. Budget **≤3 animated dots per board**, awarded to the most recently changed, only
+while the route is focused. Tile entry: `translateY(10px)` + fade, 420 ms `--ease-spring`, stagger
+`min(i,8) × 45ms`, registered in `afterNextRender(fn, {injector})` on **first paint only** —
+otherwise every refresh replays the fade, and `reloadOpenBoard()` runs on every span change and
+every add. Value change = a 600 ms colour wash, **no movement** (movement = arrival, colour =
+change). Never animate `backdrop-filter` (WKWebView repaints the layer); never raise `background`
+opacity on hover on a blurred surface.
+
+**The reduced-motion trap:** `opacity:0; animation: … forwards` plus
+`@media (prefers-reduced-motion) { animation: none }` leaves every tile **permanently invisible**.
+Always restore the end state explicitly (`opacity:1; transform:none; stroke-dashoffset:0`).
+
+### 5.8 Loading
+
+Skeleton on **first fetch only**. On refetch hold the previous render at
+`opacity:.55; pointer-events:none` — the stale-while-revalidate discipline `angular-zoneless.md`
+§8 mandates for lists. A skeleton flash on every span change is the single most damaging cheap
+tell.
+
+---
+
+## 6. What we are NOT building
+
+Each was proposed by a research agent and each is refused for a stated reason. This section is
+binding: re-proposing one of these requires new evidence, not a new argument.
+
+| Refused | Reason |
+|---|---|
+| Deleting any `resolve_tile` arm | One unresolvable tile fails the whole board, and the user's board holds `numbers` and `pulse`. The alternative is a destructive `kind` rewrite |
+| New tile kinds created to retire old ones (`source`, `commitments`, `facts` merges) | Nine touchpoints each, and `dashboard_cmd_tests` asserts arm/kind parity in **both** directions (`"tile kind is storable but has no resolver arm"` + `"no stale handled kind"`), so `TILE_KINDS` and the `resolve_tile` arms must move together. The old kinds cannot be removed anyway. Editing `NODE_TYPES` gets the same user-visible benefit for free |
+| A vault-wide open-facts tile (`list_open_facts_visible`) | Not board-scoped. It puts content into a board the user did not compose and pushes it through `render_tile_for_agent` into an agent's view of a scope the user believes they bounded. Also unbounded — no `LIMIT`, correlated `EXISTS` per row |
+| Preflight as speculative `resolve_tile` per candidate | ~230 resolves per palette open on the one `Mutex<Connection>` a live recording writes through. Use `GROUP BY` |
+| A `UNIQUE INDEX` on `(dashboard_id, kind, ref_id, config)` | The live DB already violates it; `Db::migrate()` runs at startup → failed migration → failed launch |
+| `grid-column: span min(…)` | No precedent for a math function in a `span <integer>` context; a WebKit rejection drops the whole declaration |
+| Per-kind default span at add time | Every existing tile already holds a concrete `4`; it changes nothing about the board complained about |
+| Dim-the-field citations before Phase 5 | Note/document tiles cannot be cited today; dimming would assert a falsehood |
+| A mandatory footer on every tile | Re-homogenises the heights this spec exists to break |
+| Board-wide talk-time rollup / speaker roster | `speaker_voiceprints` = 0 rows and `others-N` are per-meeting cluster tags — summing adds different humans together |
+| Live query as a source contributor | Membership changing without the user touching it is auto-RAG in a tile costume. Allowed only as a view contributing zero `SourceRef`s |
+| `search_dashboard` as a post-filter after `limit` | Returns zero rows for a board whose sources rank below the vault-wide top-k while the answer is on the board |
+| An "Open questions" aggregate **count** | ~70 % precision is fine for a *row* (three seconds to verify by playing the tape) and a lie for the *headline*, which is what the user reads and what feeds the prompt. Ship the ledger without the number, later |
+| Regex "Numbers v2" over notes + transcript | Matches `2026-07-04`, `1 min`, `Bielik-11B`, `8765`. Converts an *empty* tile into a *noisy* one. Only viable unit-anchored |
+| In-tile audio for Quote v1 | `convertFileSrc`/`asset:` is the one audio path bypassing `meeting_is_unlocked` — the leak already closed once by nulling `audio_path` |
+| Auto re-running living answers on a schedule | Silent scheduled cloud egress. Make staleness visible; let the user press the button |
+| Scope-blaming error copy | Would have been factually false on the board that produced the complaint |
+| Vault-wide "never empty" wallpaper (links/orphans, vault timeline, going-quiet, mini brain-map, vault audit, ask history, org feed, decision log) | Their non-emptiness comes from *ignoring the board*. They make it look full while making it mean less |
+| Scope readout as a tile | The user would have to know to add it. It is board chrome |
+| `grid-template-rows: masonry` | Not dependable in the shipping WKWebView |
+| Sample/demo data on an empty board | Every empty-state playbook recommends it and it is wrong *here*: the app's pitch is that everything on screen was actually said. A fake board is the same credibility hole as a fake waveform |
+| Boards in the record view | Live transcript is the anchor; `acquire_external_egress_lease` risk during recording is real |
+| A board embedded in a note (`murmur:board` managed block) | Deferred, not killed. This is precisely the shape that leaked titles and live connector data on share in PR #416 — `clean_note_body` must strip it and it must never persist resolved content into the `.md`. Needs its own `lock-security-reviewer` pass |
+
+---
+
+## 7. Out of scope — the extractor investigation (D2)
+
+Deliberately **not** in this programme, and must not be entangled with it:
+
+- `facts::EXTRACT_SYSTEM` never asks for quantities → Numbers has almost nothing to filter.
+- `facts::reconcile_facts` requires identical normalised `(entity, subject, predicate)` while
+  predicates are free-form → supersessions do not form → Drift cannot fire.
+  `commands/facts.rs::build_supersession_rows` additionally skips same-meeting supersessions.
+- `facts::extract_fact_candidates` returns `Vec::new()` when `reasoner.id() == "stub"`.
+- `storage/graph_store.rs::Db::add_mention` is `INSERT OR IGNORE` on PK
+  `(entity_id, meeting_id)` — it counts **meetings, not utterances**, so the palette copy "how
+  often this is actually talked about" is false, and no entity can produce a non-degenerate
+  12-week series. Written best-effort by `commands/mod.rs::build_and_persist_entities` at note
+  time, with no backfill.
+
+These are model/prompt-shaped problems needing a real vault and a real Mac to judge. They get
+their own spec. **Until then Numbers and Pulse stay out of the palette and Drift stays gated** —
+we do not advertise a capability that structurally cannot fire.
+
+---
+
+## 8. Verification per phase
+
+Beyond the standing gates (`cargo test --lib`, `npx ng lint`, `npx ng build`,
+`scripts/agent-config-audit --ci`, and `scripts/ci.sh` once at the end):
+
+| Phase | Required proof |
+|---|---|
+| 1 | **RED-before-GREEN Playwright** failing on today's code (empty tile at span 3, no body; nine tiles not all equal height). **Packaged WKWebView check** per T4 — `color-mix`, `mask-image`, `backdrop-filter` are involved and `ng build` proves nothing about the shipped engine |
+| 2 | RED-first Rust test: an owner head that is only a parenthetical yields `None`, **in both a Polish and an English `note_language`**. Palette-count query plans confirmed to use `idx_facts_entity` / `idx_entity_mentions_entity` |
+| 3 | The four `get_dashboard_sources` oracles, RED-first. A profile showing one full-vault note scan per board render, not per tile |
+| 4 | Agent-surface oracle extended to the brief. `errcode` test asserting `^\[[a-z-]+\] ` **and** that the message contains none of the inner error's bytes. **`lock-security-reviewer`** |
+| 5 | `living_answer_withheld` stays a pure function and **fails closed** on legacy/empty rows — RED-first. Citation matching on `(kind, id)` proven for a note tile. **`lock-security-reviewer`, mandatory** |
+| 6 | Scope-restriction pushed **into the legs**, proven by a test where a board source ranks below the vault-wide top-k. Embedder-absent branch explicit. **The `eval/` experiment: board-scoped Ask vs vault-wide Ask on a fixed real-vault question set.** **`lock-security-reviewer`** (protocol + egress) |
+| 7 | Quote: a relocked session yields empty text, never stale text; no `asset:`/`convertFileSrc` path added. Talk split: explicit NULL-`speaker` branch. `render_tile_for_agent` arm + oracle for all four kinds. **`lock-security-reviewer`** |
+| 8 | Reduced-motion end states restored explicitly (the permanently-invisible-tile trap) |
+
+**Honest boundary, per `agentic-workflow.md`:** headless checks cannot prove Touch-ID unlock
+behaviour around a live board, real screen-share auto-relock of a sealed tile, or WKWebView
+rendering of the packaged build. Those need a signed build on the Mac and must be named as
+unproven until they are run.
+
+---
+
+## Open items for the user
+
+1. **Phase ordering vs the extractor.** This spec ships the picture first and leaves the
+   extractor to its own investigation (D2). If the real vault turns out to be much richer than
+   the dev DB, Numbers/Pulse/Drift may deserve to stay in the palette — that check is one query
+   against the production DB and it is worth running before Phase 2 retires them.
+2. **Whole-board vs Most-relevant default** (Phase 6) is deliberately left to the `eval/`
+   experiment rather than taste. If the experiment is not run, the default stands at Whole-board
+   under ~12 sources and should be labelled provisional.

--- a/e2e/dashboards/board-shot.spec.ts
+++ b/e2e/dashboards/board-shot.spec.ts
@@ -1,0 +1,63 @@
+import { test } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * NOT a gate — a LOOK. This reproduces the exact board from the 2026-08-04
+ * complaint (nine tiles, five of them empty, two identical Promise ledgers) and
+ * writes a screenshot, because the defect being fixed is one that every green
+ * gate in the repo was blind to. Kept out of the CI grep by having no assertions.
+ */
+
+const BOARD = {
+  id: "b-test",
+  title: "Test",
+  emoji: null,
+  tint: null,
+  pinned: false,
+  position: 0,
+  createdAt: "2026-07-20T09:00:00Z",
+  updatedAt: "2026-08-03T09:00:00Z",
+  tileCount: 9,
+  tileKinds: [],
+};
+
+const PROMISE_ROWS = [
+  { text: 'Weronika — zweryfikować nazwę "Alcon" (duplikat)', meta: "Weronika · due 2026-07-06", status: "late", source: null },
+  { text: "Leszek — sprawdzić, czy rampa do kupienia jest dostępna", meta: "Leszek · due 2026-07-07", status: "late", source: null },
+  { text: "Organizator - ustalenie dokładnej liczby osób", meta: "Organizator · due 2026-07-10", status: "late", source: null },
+  { text: "Organizator — sprawdzić, czy dzieci mają miejsca", meta: "Organizator · due 2026-07-10", status: "late", source: null },
+  { text: "Organizator — ustal czas rozpoczęcia spotkania", meta: "Organizator · due 2026-07-11", status: "late", source: null },
+  { text: "Mówca — skorzystać z toalety przed wyjściem", meta: "Mówca", status: "open", source: null },
+];
+
+function t(id: string, kind: string, data: unknown, position: number) {
+  return {
+    id, dashboardId: "b-test", kind, refId: `r-${position}`, title: null,
+    span: 4, position, config: null, createdAt: "2026-07-20T09:00:00Z", data,
+  };
+}
+
+const TILES = [
+  t("t1", "note", { kind: "note", id: "n1", title: "Meeting 2026-07-20 02:30", snippet: "", updatedAt: Date.now() - 6 * 864e5 }, 0),
+  t("t2", "note", { kind: "note", id: "n2", title: "Jakub Gawroński CV Summary", snippet: "Jakub Gawroński CV", updatedAt: Date.now() - 16 * 864e5 }, 1),
+  t("t3", "meeting", { kind: "meeting", id: "m1", title: "Krytyka autopromocji prawnika (Ostrowski) — moment", startedAt: "2026-07-31T14:00:00Z", durationS: 240, hasAudio: true }, 2),
+  t("t4", "promises", { kind: "promises", owner: null, rows: PROMISE_ROWS }, 3),
+  t("t5", "promises", { kind: "promises", owner: null, rows: PROMISE_ROWS }, 4),
+  t("t6", "pulse", { kind: "pulse", entity: "Kuba", weekly: [0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0], total: 2, quietDays: 30 }, 5),
+  t("t7", "numbers", { kind: "numbers", entity: "Brain", rows: [] }, 6),
+  t("t8", "drift", { kind: "drift", entity: "Kuba", predicate: "role", rows: [{ text: "owner", meta: "Jul 4, 2026", status: "now", source: null }] }, 7),
+  t("t9", "note", { kind: "note", id: "n3", title: "Krytyka autopromocji prawnika (Ostrowski) — moment", snippet: "", updatedAt: Date.now() - 4 * 864e5 }, 8),
+];
+
+test("shot: the complained-about board, rebuilt", async ({ page }) => {
+  await mockTauri(page, {}, {
+    list_dashboards: [BOARD],
+    get_dashboard: { ...BOARD, tiles: TILES },
+    get_dashboard_sources: [{ kind: "note", id: "n2" }, { kind: "meeting", id: "m1" }],
+  });
+  await page.setViewportSize({ width: 1680, height: 1050 });
+  await page.goto("/dashboards/b-test");
+  await page.locator("app-dashboard-tile").first().waitFor();
+  await page.waitForTimeout(400);
+  await page.screenshot({ path: "test-results/board-after.png", fullPage: true });
+});

--- a/e2e/dashboards/dashboard-density.spec.ts
+++ b/e2e/dashboards/dashboard-density.spec.ts
@@ -180,6 +180,69 @@ test("Dashboards: every tile header carries a per-kind mark", async ({ page }) =
   ).toHaveAttribute("data-kind", "note");
 });
 
+test("Dashboards: a failed Ask is a banner with a retry, not a grey bubble that looks like an answer", async ({
+  page,
+}) => {
+  // The exact failure from the 2026-08-04 report: `summarize/redact.rs::
+  // content_free_dispatch_error` collapses a provider failure into one sentence,
+  // and the board pushed it as `{role: "assistant"}` — so it rendered in the same
+  // bubble as a grounded conclusion, with nothing to retry.
+  await mockTauri(
+    page,
+    {
+      ask_vault: () => {
+        throw new Error(
+          "summarizer error: cloud provider response failed after protected dispatch; details omitted",
+        );
+      },
+    },
+    {
+      list_dashboards: BOARDS,
+      get_dashboard: BOARD_DETAIL,
+      get_dashboard_sources: [{ kind: "note", id: "n-1" }],
+    },
+  );
+
+  await page.goto("/dashboards/b-dense");
+  await page.getByRole("textbox", { name: /Ask a question/i }).fill("what is late?");
+  await page.getByRole("button", { name: "Ask", exact: true }).click();
+
+  const banner = page.locator(".thread .banner.is-danger");
+  await expect(banner).toBeVisible();
+  await expect(banner.getByRole("button", { name: /Try again/i })).toBeVisible();
+  // And it is NOT dressed as an answer.
+  await expect(page.locator(".thread .bubble:not(.me)")).toHaveCount(0);
+});
+
+test("Dashboards: an answer renders as markdown, not as literal asterisks", async ({ page }) => {
+  // `summarize/vault_chat.rs::build` DEMANDS markdown from the model, and the
+  // board rendered `{{ turn.text }}` with `white-space: pre-wrap`.
+  await mockTauri(
+    page,
+    {
+      ask_vault: () => ({
+        answer: "The **auth migration** is the risk.",
+        sources: [],
+        citations: [],
+      }),
+    },
+    {
+      list_dashboards: BOARDS,
+      get_dashboard: BOARD_DETAIL,
+      get_dashboard_sources: [{ kind: "note", id: "n-1" }],
+    },
+  );
+
+  await page.goto("/dashboards/b-dense");
+  await page.getByRole("textbox", { name: /Ask a question/i }).fill("what is the risk?");
+  await page.getByRole("button", { name: "Ask", exact: true }).click();
+
+  const answer = page.locator(".thread .bubble:not(.me)");
+  await expect(answer).toBeVisible();
+  await expect(answer.locator("strong")).toHaveText("auth migration");
+  await expect(answer).not.toContainText("**");
+});
+
 test("Dashboards: a duplicate tile renders as a back-reference, not a second copy", async ({
   page,
 }) => {

--- a/e2e/dashboards/dashboard-density.spec.ts
+++ b/e2e/dashboards/dashboard-density.spec.ts
@@ -1,0 +1,232 @@
+import { expect, test } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * Dashboards — the DENSITY oracle (Phase 1 of the 2026-08-04 rebuild).
+ *
+ * These are RED-before-GREEN tests for a bug that had no failing check: a real
+ * user board rendered as nine identical grey boxes, five of them holding an
+ * apology, and every gate was green. `ng build` cannot see it, and neither can a
+ * unit test — the defect is what the layout DOES with the payload.
+ *
+ * Three properties are pinned here, and each one failed on the code that shipped:
+ *
+ *  1. A tile whose payload NEVER had data collapses to a header strip rather than
+ *     reserving a full card for a sentence of regret. `commands/dashboards.rs`
+ *     stores `span.unwrap_or(4)` and `dashboard-view.component.ts::addTile` never
+ *     passed a span, so every tile on every existing board is 4/12 — three per
+ *     row, forever, empty or not.
+ *
+ *  2. Kinds get DIFFERENT display widths even though every stored row says 4.
+ *     A ledger and a two-stat cluster are not the same shape and must not occupy
+ *     the same box.
+ *
+ *  3. An empty PROMISES tile is NOT collapsed. "Nothing open — every commitment
+ *     on this board is closed" is a RESULT, not an absence, and rendering a
+ *     success as a grey apology is the single most demoralising thing the board
+ *     does. This is the test that stops a naive "hide anything with no rows"
+ *     implementation from passing the other two.
+ */
+
+const BOARDS = [
+  {
+    id: "b-dense",
+    title: "Density",
+    emoji: null,
+    tint: null,
+    pinned: false,
+    position: 0,
+    createdAt: "2026-08-01T09:00:00Z",
+    updatedAt: "2026-08-03T09:00:00Z",
+    tileCount: 4,
+    tileKinds: [
+      { kind: "numbers", span: 4 },
+      { kind: "promises", span: 4 },
+      { kind: "person", span: 4 },
+      { kind: "note", span: 4 },
+    ],
+  },
+];
+
+/** Every tile stored at span 4 — exactly what a real board looks like today. */
+function tile(id: string, kind: string, data: unknown, position: number) {
+  return {
+    id,
+    dashboardId: "b-dense",
+    kind,
+    refId: "r-1",
+    title: null,
+    span: 4,
+    position,
+    config: null,
+    createdAt: "2026-08-01T09:00:00Z",
+    data,
+  };
+}
+
+const BOARD_DETAIL = {
+  ...BOARDS[0],
+  tiles: [
+    // Never had data → must collapse.
+    tile("t-numbers", "numbers", { kind: "numbers", entity: "Brain", rows: [] }, 0),
+    // Genuinely zero → GOOD NEWS → must stay a full tile.
+    tile("t-promises", "promises", { kind: "promises", owner: null, rows: [] }, 1),
+    // Populated stat cluster → narrow.
+    tile(
+      "t-person",
+      "person",
+      { kind: "person", id: "e-1", name: "Kuba", mentionCount: 12, openCommitments: 3 },
+      2,
+    ),
+    // Populated prose.
+    tile(
+      "t-note",
+      "note",
+      {
+        kind: "note",
+        id: "n-1",
+        title: "Atlas GA checklist",
+        snippet: "Blocking: the auth migration, ~1 sprint left.",
+        updatedAt: 1_780_000_000_000,
+      },
+      3,
+    ),
+  ],
+};
+
+async function openBoard(page: import("@playwright/test").Page) {
+  await mockTauri(
+    page,
+    {},
+    { list_dashboards: BOARDS, get_dashboard: BOARD_DETAIL, get_dashboard_sources: [] },
+  );
+  await page.goto("/dashboards/b-dense");
+  await expect(page.locator("app-dashboard-tile")).toHaveCount(4);
+}
+
+/** The rendered column span, read off the resolved grid placement. */
+async function spanOf(page: import("@playwright/test").Page, id: string): Promise<number> {
+  return page.evaluate((tileId) => {
+    const el = document.querySelector(`app-dashboard-tile[data-tile-id="${tileId}"]`);
+    if (!el) return -1;
+    const raw = getComputedStyle(el).gridColumn; // e.g. "span 3 / auto"
+    const m = /span\s+(\d+)/.exec(raw);
+    return m ? Number(m[1]) : -1;
+  }, id);
+}
+
+test("Dashboards: a tile that never had data collapses instead of reserving a full card", async ({
+  page,
+}) => {
+  await openBoard(page);
+
+  const numbers = page.locator('app-dashboard-tile[data-tile-id="t-numbers"]');
+  await expect(numbers).toHaveClass(/is-empty/);
+
+  // The apology is gone: no body region at all, and the strip is narrow.
+  await expect(numbers.locator(".tile-body")).toHaveCount(0);
+  expect(await spanOf(page, "t-numbers")).toBe(3);
+
+  // And it is SHORT — the whole point. The invariant that matters is RELATIVE:
+  // a collapsed strip must not read as a peer of a populated card. (An absolute
+  // pixel ceiling would just encode today's font stack; the ratio is the design.)
+  const heights = await page.evaluate(() => {
+    const h = (id: string) =>
+      document
+        .querySelector(`app-dashboard-tile[data-tile-id="${id}"]`)!
+        .getBoundingClientRect().height;
+    return { empty: h("t-numbers"), full: h("t-note") };
+  });
+  expect(heights.empty).toBeLessThan(heights.full * 0.75);
+  expect(heights.empty).toBeLessThanOrEqual(56);
+});
+
+test("Dashboards: an empty PROMISES tile reads as a result, not as an absence", async ({
+  page,
+}) => {
+  await openBoard(page);
+
+  const promises = page.locator('app-dashboard-tile[data-tile-id="t-promises"]');
+  // Zero open commitments is good news — it keeps its card and its body.
+  await expect(promises).not.toHaveClass(/is-empty/);
+  await expect(promises.locator(".tile-body")).toHaveCount(1);
+  await expect(promises.locator(".state-good")).toBeVisible();
+});
+
+test("Dashboards: kinds get different widths even though every stored row says span 4", async ({
+  page,
+}) => {
+  await openBoard(page);
+
+  const person = await spanOf(page, "t-person");
+  const note = await spanOf(page, "t-note");
+  const promises = await spanOf(page, "t-promises");
+
+  // A stat cluster is narrower than prose, which is narrower than a ledger.
+  expect(person).toBe(3);
+  expect(note).toBe(4);
+  expect(promises).toBe(6);
+  expect(new Set([person, note, promises]).size).toBeGreaterThan(1);
+});
+
+test("Dashboards: every tile header carries a per-kind mark", async ({ page }) => {
+  await openBoard(page);
+
+  // The single biggest visual omission versus the prototype: the shipped header
+  // was an <h3> and a grey uppercase word, with zero colour anywhere on the board.
+  await expect(page.locator("app-dashboard-tile .tile-mark")).toHaveCount(4);
+  await expect(
+    page.locator('app-dashboard-tile[data-tile-id="t-note"] .tile-mark'),
+  ).toHaveAttribute("data-kind", "note");
+});
+
+test("Dashboards: a duplicate tile renders as a back-reference, not a second copy", async ({
+  page,
+}) => {
+  // Two Promises tiles with no owner resolve to the SAME global list — the exact
+  // pair on the user's board. The palette never wrote `config.owner`, so this is
+  // structurally guaranteed rather than a user error.
+  await mockTauri(
+    page,
+    {},
+    {
+      list_dashboards: BOARDS,
+      get_dashboard: {
+        ...BOARDS[0],
+        tiles: [
+          tile(
+            "t-p1",
+            "promises",
+            {
+              kind: "promises",
+              owner: null,
+              rows: [{ text: "Send the Acme paperwork", meta: "due 2026-07-22", status: "late", source: null }],
+            },
+            0,
+          ),
+          tile(
+            "t-p2",
+            "promises",
+            {
+              kind: "promises",
+              owner: null,
+              rows: [{ text: "Send the Acme paperwork", meta: "due 2026-07-22", status: "late", source: null }],
+            },
+            1,
+          ),
+        ],
+      },
+      get_dashboard_sources: [],
+    },
+  );
+
+  await page.goto("/dashboards/b-dense");
+  await expect(page.locator("app-dashboard-tile")).toHaveCount(2);
+
+  const second = page.locator('app-dashboard-tile[data-tile-id="t-p2"]');
+  await expect(second).toHaveClass(/is-duplicate/);
+  await expect(second.getByText(/same as the tile above/i)).toBeVisible();
+
+  // The row is rendered ONCE on the board, not twice.
+  await expect(page.getByText("Send the Acme paperwork")).toHaveCount(1);
+});

--- a/e2e/dashboards/dashboards-context.spec.ts
+++ b/e2e/dashboards/dashboards-context.spec.ts
@@ -215,7 +215,12 @@ test("Dashboards: the tile palette escapes every containing block and lands in t
   expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height + 1);
 
   // The catalogue is actually populated — an empty palette is the same dead end.
-  expect(await palette.locator(".node").count()).toBe(10);
+  // Asserted as "several, including the ones we know are offered" rather than an
+  // exact count: the catalogue legitimately shrinks (three kinds were retired on
+  // 2026-08-04 because they structurally could not fire), and a magic number turns
+  // every such product decision into a false failure here.
+  expect(await palette.locator(".node").count()).toBeGreaterThanOrEqual(6);
+  await expect(palette.getByText("Promise ledger")).toBeVisible();
 
   // HIT TEST: the palette's centre must actually BE the palette. "Rendered, on
   // screen, but covered by something" looks identical to the user to "did not
@@ -275,7 +280,7 @@ test("Dashboards: the palette still shows on an engine without :modal or showMod
 
   const palette = page.getByRole("dialog", { name: "Add a tile" });
   await expect(palette, "a refused showModal must not leave the palette hidden").toBeVisible();
-  expect(await palette.locator(".node").count()).toBe(10);
+  expect(await palette.locator(".node").count()).toBeGreaterThanOrEqual(6);
 
   // On screen, and hit-testable — not merely present in the DOM.
   const box = await palette.boundingBox();
@@ -411,7 +416,7 @@ test("Dashboards: a tile with a malformed payload cannot blank the rest of the U
   expect(
     await palette.locator(".node").count(),
     "the palette's catalogue must render, not just its box",
-  ).toBe(10);
+  ).toBeGreaterThanOrEqual(6);
 
   // And nothing threw: a binding that throws is what caused the blanking in the first place.
   expect(errors, "no uncaught error may escape a template binding").toEqual([]);

--- a/e2e/dashboards/dashboards.spec.ts
+++ b/e2e/dashboards/dashboards.spec.ts
@@ -139,7 +139,9 @@ test("Dashboards: a SEALED tile leaks nothing — not even the title the user ty
 
   const sealed = page.locator("app-dashboard-tile.is-locked");
   await expect(sealed).toHaveCount(1);
-  await expect(sealed).toContainText("Sealed folder");
+  // Copy tightened 2026-08-04 to tie the lock model to the board's thesis: a sealed
+  // tile is not merely locked, it is OUT OF SCOPE for the board's Ask.
+  await expect(sealed).toContainText("Sealed — not in scope");
   await expect(sealed.locator(".tile-title")).toHaveText("🔒 Locked");
 
   // The whole page must not contain the sealed title anywhere — heading, DOM
@@ -195,7 +197,11 @@ test("Dashboards: an entity tile whose entity went invisible keeps no stored nam
   await page.goto("/dashboards/b-atlas");
   await expect(page.locator("app-dashboard-tile")).toHaveCount(1);
   await expect(page.locator("app-dashboard-tile .tile-title")).not.toContainText("Dana");
-  await expect(page.getByText(/Nothing has moved here yet/)).toBeVisible();
+  // A drift lane with no rows never had data, so it collapses to a strip rather
+  // than reserving a full card for an apology (2026-08-04 density pass). The
+  // leak assertion above is the point of this test and is unchanged.
+  await expect(page.locator("app-dashboard-tile")).toHaveClass(/is-empty/);
+  await expect(page.getByText(/Values land here as they get revised/)).toBeVisible();
 });
 
 test("Dashboards: a withheld Living answer shows why, and not the cached text", async ({

--- a/e2e/dashboards/dashboards.spec.ts
+++ b/e2e/dashboards/dashboards.spec.ts
@@ -349,11 +349,19 @@ test("Dashboards: the tile palette offers the catalogue and flags only-Murmur ti
 
   const palette = page.getByRole("dialog", { name: "Add a tile" });
   await expect(palette).toBeVisible();
-  await expect(palette.getByText("Drift lane")).toBeVisible();
   await expect(palette.getByText("Promise ledger")).toBeVisible();
-  await expect(palette.getByText("Pulse")).toBeVisible();
+  await expect(palette.getByText("Living answer")).toBeVisible();
+  // RETIRED 2026-08-04 and asserted ABSENT, not merely unmentioned: `drift`,
+  // `numbers` and `pulse` are blocked in the extractor rather than by a shortage
+  // of recordings (see tile-palette.component.ts), and a tile that is empty for
+  // most people is worse than no tile. Their `resolve_tile` arms stay alive so
+  // boards that already contain one keep opening — this asserts only that the
+  // palette stops OFFERING them.
+  await expect(palette.getByText("Drift lane")).toHaveCount(0);
+  await expect(palette.getByText("Numbers")).toHaveCount(0);
+  await expect(palette.getByText("Pulse")).toHaveCount(0);
   // The catalogue marks the tiles that only exist because Murmur heard the room.
-  expect(await palette.locator(".only-badge").count()).toBeGreaterThanOrEqual(6);
+  expect(await palette.locator(".only-badge").count()).toBeGreaterThanOrEqual(3);
 
   // Escape must always dismiss a modal.
   await page.keyboard.press("Escape");

--- a/src-tauri/src/commands/dashboards.rs
+++ b/src-tauri/src/commands/dashboards.rs
@@ -665,6 +665,20 @@ pub fn get_dashboard_sources(
     let _lifecycle = super::lifecycle_guard(state.inner());
     let tiles = state.db.list_dashboard_tiles(&id)?;
     let unlocked = super::unlocked_snapshot(state.inner())?;
+    dashboard_sources_inner(&state.db, tiles, &unlocked)
+}
+
+/// The scope rule itself, free of `AppState` so it can be tested directly.
+///
+/// Extracted 2026-08-04: this function DEFINES what a board-scoped Ask may read,
+/// and it had no Rust test at all — its only coverage was Playwright mocks, which
+/// assert the frontend's assumption about the answer rather than the answer.
+/// See `commands/tests/dashboard_source_scope_tests.rs`.
+pub(crate) fn dashboard_sources_inner(
+    db: &crate::storage::Db,
+    tiles: Vec<DashboardTile>,
+    unlocked: &std::collections::HashSet<String>,
+) -> Result<Vec<SourceRef>, AppError> {
     let mut out: Vec<SourceRef> = Vec::new();
     for tile in tiles {
         let Some(ref_id) = tile.ref_id.as_deref() else {
@@ -676,6 +690,10 @@ pub fn get_dashboard_sources(
             "document" => LinkKind::Document,
             // Derived tiles (drift/numbers/pulse/promises/person/reminders) are VIEWS over the
             // vault, not retrievable documents — they contribute no source of their own.
+            //
+            // This is deliberate and stays. What a derived tile SHOWS still has to reach the
+            // model, but it reaches it as a rendered brief, never as a `SourceRef`: that type's
+            // `kind` is a `LinkKind`, and a drift lane is not a retrievable document.
             _ => continue,
         };
         let candidate = SourceRef {
@@ -683,7 +701,7 @@ pub fn get_dashboard_sources(
             id: ref_id.to_string(),
         };
         // GATE: only a source that survives its own gated reader may enter the Ask scope.
-        if !source_is_visible(&state.db, &candidate, &unlocked)? {
+        if !source_is_visible(db, &candidate, unlocked)? {
             continue;
         }
         if !out.iter().any(|s| s.id == candidate.id && s.kind == kind) {
@@ -1213,3 +1231,7 @@ fn short_day(iso: &str) -> String {
 #[cfg(test)]
 #[path = "tests/dashboard_cmd_tests.rs"]
 mod dashboard_cmd_tests;
+
+#[cfg(test)]
+#[path = "tests/dashboard_source_scope_tests.rs"]
+mod dashboard_source_scope_tests;

--- a/src-tauri/src/commands/tests/dashboard_source_scope_tests.rs
+++ b/src-tauri/src/commands/tests/dashboard_source_scope_tests.rs
@@ -1,0 +1,264 @@
+//! THE SCOPE ORACLE — `dashboard_sources_inner`, the function that DEFINES what a
+//! board-scoped Ask is allowed to read.
+//!
+//! Before 2026-08-04 this function had **no Rust test at all**. Its only coverage
+//! was Playwright specs feeding a mocked `get_dashboard_sources`, which assert the
+//! frontend's assumption about the answer rather than the answer itself — so every
+//! property below was, in practice, unverified on the surface that enforces it.
+//!
+//! Four properties, each with a CONTROL so it cannot go vacuous: a passing test
+//! that would also pass with the gate deleted proves nothing, and that exact
+//! failure (an unfalsifiable answer-cache gate) is what the adversarial review of
+//! PR #562 caught in this very feature.
+
+use super::*;
+use crate::storage::models::{Folder, Meeting, MeetingStatus, NoteRecord};
+use std::collections::HashSet;
+
+const TEST_DEK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"; // MURMUR_DEV_DEK placeholder
+
+fn file_db(label: &str) -> crate::storage::Db {
+    crate::storage::Db::open_with_key(
+        &crate::storage::db::unique_temp_path(&format!("meetnotes-dash-scope-{label}"), "sqlite"),
+        TEST_DEK,
+    )
+    .unwrap()
+}
+
+fn seed_folder(db: &crate::storage::Db, id: &str, locked: bool) {
+    db.insert_folder(&Folder {
+        id: id.to_string(),
+        name: id.to_string(),
+        path: id.to_string(),
+        parent_id: None,
+        locked,
+        created_at: "2026-08-01T00:00:00Z".to_string(),
+    })
+    .unwrap();
+}
+
+/// A meeting plus its note, filed into `folder_id` so `visibility_clause` has
+/// something to gate on.
+fn seed_meeting(db: &crate::storage::Db, meeting_id: &str, folder_id: &str) {
+    db.insert_meeting(&Meeting {
+        id: meeting_id.to_string(),
+        started_at: "2026-08-01T09:00:00Z".to_string(),
+        ended_at: None,
+        title: Some("standup".to_string()),
+        duration_s: 600,
+        audio_path: None,
+        status: MeetingStatus::Summarized,
+        folder_id: Some(folder_id.to_string()),
+    })
+    .unwrap();
+    db.upsert_note(&NoteRecord {
+        meeting_id: meeting_id.to_string(),
+        provider_id: "test".to_string(),
+        markdown: "# note".to_string(),
+        created_at: "2026-08-01T09:00:00Z".to_string(),
+        exported_path: None,
+        model_requested: None,
+        model_served: None,
+        gateway_host: None,
+    })
+    .unwrap();
+    db.set_note_folder(meeting_id, Some(folder_id)).unwrap();
+}
+
+/// A standalone NOTE document — `documents` with `kind='note'`, which is what a
+/// `LinkKind::Note` source actually points at (NOT the per-meeting `notes` row).
+fn seed_note(db: &crate::storage::Db, note_id: &str, folder_id: &str) {
+    db.insert_note(note_id, folder_id, note_id, note_id, "body", 1_780_000_000)
+        .unwrap();
+}
+
+fn tile(id: &str, kind: &str, ref_id: Option<&str>, position: i64) -> DashboardTile {
+    DashboardTile {
+        id: id.to_string(),
+        dashboard_id: "b1".to_string(),
+        kind: kind.to_string(),
+        ref_id: ref_id.map(|s| s.to_string()),
+        title: None,
+        span: 4,
+        position,
+        config: None,
+        created_at: "2026-08-01T09:00:00Z".to_string(),
+    }
+}
+
+fn nothing_unlocked() -> HashSet<String> {
+    HashSet::new()
+}
+
+/// A source inside a SEALED, not-session-unlocked folder must not enter the scope.
+///
+/// This is the load-bearing one: `explicit_sources` is handed straight to
+/// `ask_vault`, which packs each source's text into the prompt. A sealed source
+/// surviving this filter would put locked content into a model call.
+#[test]
+fn a_sealed_source_never_enters_the_ask_scope() {
+    let db = file_db("sealed");
+    seed_folder(&db, "f-open", false);
+    seed_folder(&db, "f-sealed", true);
+    seed_meeting(&db, "m-open", "f-open");
+    seed_meeting(&db, "m-sealed", "f-sealed");
+
+    let tiles = vec![
+        tile("t1", "meeting", Some("m-open"), 0),
+        tile("t2", "meeting", Some("m-sealed"), 1),
+    ];
+
+    let out = dashboard_sources_inner(&db, tiles.clone(), &nothing_unlocked()).unwrap();
+    assert_eq!(
+        out.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+        vec!["m-open"],
+        "a sealed meeting must not contribute a source"
+    );
+
+    // CONTROL — the same call with the folder SESSION-UNLOCKED returns it, so the
+    // assertion above is testing the gate and not merely a seeding mistake.
+    let unlocked: HashSet<String> = ["f-sealed".to_string()].into_iter().collect();
+    let out = dashboard_sources_inner(&db, tiles, &unlocked).unwrap();
+    assert_eq!(out.len(), 2, "session-unlocking the folder restores the source");
+}
+
+/// A DERIVED tile is a view over the vault, not a retrievable document, so it
+/// contributes no `SourceRef` of its own.
+///
+/// This is deliberate, not an oversight, and the test exists so nobody "fixes" it
+/// by widening the match: `SourceRef.kind` is a `LinkKind`, and there is no
+/// `LinkKind` a drift lane or a promise ledger could honestly claim. What those
+/// tiles SHOW still has to reach the model — but as rendered text, never as a
+/// retrieval source.
+#[test]
+fn derived_tiles_contribute_no_source() {
+    let db = file_db("derived");
+    seed_folder(&db, "f-open", false);
+    seed_meeting(&db, "m-open", "f-open");
+
+    let tiles = vec![
+        tile("t1", "drift", Some("e-atlas"), 0),
+        tile("t2", "numbers", Some("e-atlas"), 1),
+        tile("t3", "pulse", Some("e-atlas"), 2),
+        tile("t4", "person", Some("e-kuba"), 3),
+        tile("t5", "promises", None, 4),
+        tile("t6", "reminders", None, 5),
+        tile("t7", "living_answer", None, 6),
+    ];
+    assert!(
+        dashboard_sources_inner(&db, tiles, &nothing_unlocked())
+            .unwrap()
+            .is_empty(),
+        "no derived tile may contribute a retrieval source"
+    );
+
+    // CONTROL — a MATERIAL tile on the same board does contribute, so the empty
+    // result above is the kind filter and not a broken fixture.
+    let material = vec![tile("t8", "meeting", Some("m-open"), 7)];
+    assert_eq!(
+        dashboard_sources_inner(&db, material, &nothing_unlocked())
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+/// A tile pointing at a source that no longer exists contributes nothing, and —
+/// crucially — does not fail the call.
+///
+/// `resolve_tile` distinguishes deleted from sealed so the TILE can render
+/// "missing"; the scope has no such need and must simply drop it. An `Err` here
+/// would take the whole board's Ask down with one stale tile.
+#[test]
+fn a_deleted_source_is_dropped_rather_than_erroring() {
+    let db = file_db("deleted");
+    seed_folder(&db, "f-open", false);
+    seed_meeting(&db, "m-open", "f-open");
+
+    let tiles = vec![
+        tile("t1", "meeting", Some("m-open"), 0),
+        tile("t2", "note", Some("n-never-existed"), 1),
+        tile("t3", "document", Some("d-never-existed"), 2),
+        // A material kind with no anchor at all — the `Unconfigured` shape.
+        tile("t4", "note", None, 3),
+    ];
+
+    let out = dashboard_sources_inner(&db, tiles, &nothing_unlocked())
+        .expect("a dangling ref must not fail the whole scope");
+    assert_eq!(
+        out.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+        vec!["m-open"],
+        "dangling note/document refs are dropped, and none of them errors"
+    );
+}
+
+/// FINDING, recorded rather than silently encoded as intent (2026-08-04).
+///
+/// A `meeting` ref that resolves to NOTHING still enters the scope, because
+/// `meetings_store::Db::meeting_is_visible` ends in `Ok(!has_notes || has_visible)`
+/// — a meeting with no note row is visible BY CONSTRUCTION, and a meeting that
+/// does not exist trivially has no note row.
+///
+/// For a deleted meeting this is only wasteful: `fair_pack_explicit_sections`
+/// divides the prompt budget by the number of sources, so a stale tile silently
+/// shrinks every other source's share while contributing nothing.
+///
+/// The case worth a specialist's eye is the OTHER one this predicate admits: a
+/// meeting that exists, sits in a SEALED folder, and has no note row yet — the
+/// shape `lock-model.md` already calls out for audio ("recorded into an
+/// already-sealed folder, or a crash window"). This test does not assert that is
+/// safe; it pins the CURRENT behaviour so the change is visible if someone
+/// tightens the predicate, and flags it for `lock-security-reviewer`. Do not
+/// "fix" it inside a frontend density pass — `storage/**` is a lock-risk path.
+#[test]
+fn a_dangling_meeting_ref_currently_survives_the_gate() {
+    let db = file_db("dangling-meeting");
+    let tiles = vec![tile("t1", "meeting", Some("m-never-existed"), 0)];
+    let out = dashboard_sources_inner(&db, tiles, &nothing_unlocked()).unwrap();
+    assert_eq!(
+        out.len(),
+        1,
+        "documents the fail-OPEN branch of meeting_is_visible; see the doc comment"
+    );
+}
+
+/// Two tiles pointing at the same source contribute ONE entry.
+///
+/// Without this, a board with a duplicate tile pays for that source twice inside
+/// `fair_pack_explicit_sections`, whose budget is `total / n` — so duplicating a
+/// tile would silently shrink every OTHER source's share of the prompt.
+#[test]
+fn duplicate_tiles_dedupe_by_kind_and_id() {
+    let db = file_db("dedupe");
+    seed_folder(&db, "f-open", false);
+    seed_meeting(&db, "m-open", "f-open");
+    seed_meeting(&db, "m-other", "f-open");
+
+    let tiles = vec![
+        tile("t1", "meeting", Some("m-open"), 0),
+        tile("t2", "meeting", Some("m-open"), 1),
+        tile("t3", "meeting", Some("m-other"), 2),
+    ];
+
+    let out = dashboard_sources_inner(&db, tiles, &nothing_unlocked()).unwrap();
+    assert_eq!(out.len(), 2, "the repeated source appears once");
+    assert_eq!(out[0].id, "m-open", "first occurrence keeps its position");
+    assert_eq!(out[1].id, "m-other");
+
+    // CONTROL — dedupe is on (kind, id), not on id alone. A note and a meeting
+    // that happen to share an id are two different sources and both survive.
+    let db2 = file_db("dedupe-kind");
+    seed_folder(&db2, "f-open", false);
+    seed_meeting(&db2, "same-id", "f-open");
+    seed_note(&db2, "same-id", "f-open");
+    let mixed = vec![
+        tile("t1", "meeting", Some("same-id"), 0),
+        tile("t2", "note", Some("same-id"), 1),
+    ];
+    let out = dashboard_sources_inner(&db2, mixed, &nothing_unlocked()).unwrap();
+    assert_eq!(
+        out.len(),
+        2,
+        "a note and a meeting sharing an id are distinct sources"
+    );
+}

--- a/src/app/design-system/icon/icon.component.html
+++ b/src/app/design-system/icon/icon.component.html
@@ -104,5 +104,41 @@
     @case ("display") {
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="12" rx="2" /><path d="M8 20h8M12 16v4" /></svg>
     }
+    @case ("document") {
+      <svg viewBox="0 0 20 20" fill="none">
+        <path d="M5 2.75h5.6L15 7.1v10.15c0 .55-.45 1-1 1H5c-.55 0-1-.45-1-1V3.75c0-.55.45-1 1-1z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" />
+        <path d="M10.4 3v3.9h3.9" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round" />
+      </svg>
+    }
+    @case ("drift") {
+      <svg viewBox="0 0 20 20" fill="none">
+        <path d="M5 4.5v11" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" opacity="0.45" />
+        <circle cx="5" cy="6.2" r="1.7" stroke="currentColor" stroke-width="1.3" />
+        <circle cx="5" cy="13.6" r="1.7" fill="currentColor" />
+        <path d="M9 6.2h6M9 13.6h6" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" />
+      </svg>
+    }
+    @case ("numbers") {
+      <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round">
+        <path d="M7.4 3.6 6 16.4M14 3.6l-1.4 12.8M3.6 7.4h13M3.4 12.6h13" />
+      </svg>
+    }
+    @case ("pulse") {
+      <svg viewBox="0 0 20 20" fill="none">
+        <path d="M2.6 11.4h3l2-5.4 2.6 8.6 2-3.2h4.2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    }
+    @case ("promises") {
+      <svg viewBox="0 0 20 20" fill="none">
+        <rect x="3.25" y="4" width="13.5" height="12" rx="2.2" stroke="currentColor" stroke-width="1.4" />
+        <path d="m6.6 10.1 2.1 2.1 4.6-4.6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    }
+    @case ("lock") {
+      <svg viewBox="0 0 20 20" fill="none">
+        <rect x="4.25" y="8.6" width="11.5" height="8.15" rx="2" stroke="currentColor" stroke-width="1.4" />
+        <path d="M6.9 8.6V6.5a3.1 3.1 0 0 1 6.2 0v2.1" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" />
+      </svg>
+    }
   }
 </span>

--- a/src/app/design-system/icon/icon.component.ts
+++ b/src/app/design-system/icon/icon.component.ts
@@ -19,7 +19,15 @@ export type ShellIcon =
   | "topbar"
   | "sun"
   | "moon"
-  | "display";
+  | "display"
+  // Dashboard tile marks. A board tile identifies its KIND by a glyph, and the
+  // glyph set lives here with every other icon rather than inline in one feature.
+  | "document"
+  | "drift"
+  | "numbers"
+  | "pulse"
+  | "promises"
+  | "lock";
 
 /**
  * Design System — one inline-SVG glyph, shared by the floating sidebar, the

--- a/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.html
+++ b/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.html
@@ -3,9 +3,25 @@
 }
 
 <header class="tile-head">
+  <!--
+    The mark carries the KIND as colour + glyph. Material kinds (note/meeting/
+    document/person) wear one of the four family hues; derived views take the
+    neutral mark. The shipped header had no colour anywhere on the board, which is
+    most of why a composed board read as a wall of grey boxes.
+  -->
+  <span class="tile-mark" [attr.data-kind]="data().kind" aria-hidden="true">
+    <mur-icon [icon]="mark()" />
+  </span>
+
   <div class="tile-titles">
-    <h3 class="tile-title">{{ heading() }}</h3>
+    <!-- Eyebrow ABOVE the title: the classifier is what you scan down the left
+         edge, and a title-first header opens every tile with a different-length
+         proper noun. -->
     <span class="tile-kind">{{ kindLabel() }}</span>
+    <h3 class="tile-title">{{ heading() }}</h3>
+    @if (bodyState() === "empty") {
+      <span class="empty-why">{{ emptyCopy() }}</span>
+    }
   </div>
 
   @if (isLive()) {
@@ -32,30 +48,44 @@
   }
 </header>
 
+@if (duplicateOf(); as dup) {
+  <!--
+    A second tile resolving to the same thing renders as a back-reference. Showing
+    the rows twice makes a board look duplicated rather than composed, and the
+    cause is a missing PARAMETER (promises never got an owner), not a user mistake.
+  -->
+  <p class="dup-note">
+    Same as the tile above — <span class="dup-title">{{ dup }}</span>
+    @if (editing()) {
+      <button type="button" class="btn btn-ghost btn-sm" (click)="remove.emit()">Remove</button>
+    }
+  </p>
+} @else if (bodyState() !== "empty") {
 <div class="tile-body">
   <!--
     A sealed tile's payload is `{ kind: "locked" }` — there are literally no
     fields to render. That is the lock-model contract, asserted backend-side.
+    It keeps a FULL card on purpose: a redacted region is content, and a board you
+    can screen-share as-is is the lock model paying for itself.
   -->
   @if (isSealed()) {
     <div class="sealed">
       <span class="sealed-hatch" aria-hidden="true"></span>
       <span class="sealed-copy">
         <span class="sealed-glyph" aria-hidden="true">🔒</span>
-        Sealed folder — redacted here.
-        <small>Unlock the source to see this tile.</small>
+        Sealed — not in scope.
+        <small>Unlock the folder to bring this back into the board's scope.</small>
       </span>
     </div>
   }
 
-  @if (isMissing()) {
-    <p class="muted">
-      The source this tile pointed at is gone. Remove the tile, or add a new one.
+  <!--
+    Zero, where zero is the WIN. Not a grey apology: a result, stated as one.
+  -->
+  @if (bodyState() === "good") {
+    <p class="state-good">
+      <span class="good-tick" aria-hidden="true">✓</span>{{ goodCopy() }}
     </p>
-  }
-
-  @if (isUnconfigured()) {
-    <p class="muted">This tile has no source. Remove it and add it again from the palette.</p>
   }
 
   @if (note(); as n) {
@@ -103,9 +133,9 @@
 
   @if (pulse(); as pl) {
     <div class="pulse">
-      <div class="pulse-bars" aria-hidden="true">
+      <div class="pulse-strip" aria-hidden="true">
         @for (w of pl.weekly; track $index) {
-          <span class="pulse-bar" [style.height.%]="barHeight(w)"></span>
+          <span class="heat-cell" [attr.data-level]="heatLevel(w)"></span>
         }
       </div>
       <dl class="stats">
@@ -124,8 +154,14 @@
   }
 
   @if (drift(); as dr) {
-    @if (dr.rows.length === 0) {
-      <p class="muted">Nothing has moved here yet — no superseded values recorded.</p>
+    @if (bodyState() === "degenerate") {
+      <!-- One step is not a drift. Drawing the rail through a single point would
+           assert a movement that never happened, so the mark collapses and the
+           tile says the true thing instead. -->
+      <p class="state-degenerate">
+        <span class="drift-value">{{ dr.rows[0].text }}</span>
+        <span class="row-meta">One value, never revised — nothing has drifted yet.</span>
+      </p>
     } @else {
       <ol class="drift">
         @for (row of dr.rows; track $index) {
@@ -152,9 +188,7 @@
   }
 
   @if (numbers(); as nu) {
-    @if (nu.rows.length === 0) {
-      <p class="muted">No figures recorded for this yet.</p>
-    } @else {
+    @if (nu.rows.length > 0) {
       <div class="numbers">
         @for (row of nu.rows; track $index) {
           <button
@@ -175,9 +209,7 @@
   }
 
   @if (promises(); as pr) {
-    @if (pr.rows.length === 0) {
-      <p class="muted">Nothing open — every commitment on this board is closed.</p>
-    } @else {
+    @if (pr.rows.length > 0) {
       <ul class="rows">
         @for (row of pr.rows; track $index) {
           <li class="row">
@@ -202,9 +234,7 @@
   }
 
   @if (reminders(); as rm) {
-    @if (rm.rows.length === 0) {
-      <p class="muted">No open reminders.</p>
-    } @else {
+    @if (rm.rows.length > 0) {
       <ul class="rows">
         @for (row of rm.rows; track $index) {
           <li class="row">
@@ -244,3 +274,4 @@
     </div>
   }
 </div>
+}

--- a/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.scss
+++ b/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.scss
@@ -57,11 +57,84 @@
   box-shadow: var(--shadow-md);
 }
 
+// ── the collapsed strip ──────────────────────────────────────────────────────
+//
+// A tile that never had data does not get a full card. It becomes a dashed header
+// strip, loses its frosted surface entirely (glass on nothing reads as a broken
+// panel), and — set by the board — sorts to the END of the grid, because a 36px
+// strip left in composition order beside a 200px tile leaves ~164px of dead air.
+// Four scattered strips look WORSE than four grey boxes.
+:host(.is-empty),
+:host(.is-duplicate) {
+  // `order` applies to grid items, so the strips sink to the end of the board
+  // without the component knowing anything about its neighbours.
+  order: 1;
+  border-style: dashed;
+  border-color: var(--border-subtle);
+  background: transparent;
+  backdrop-filter: none;
+}
+
+// A strip is ONE line: mark · title · where-data-will-land. The eyebrow is
+// dropped because the mark already carries the kind, and a two-line header would
+// put the strip back within a few pixels of the card it is meant to replace.
+:host(.is-empty) {
+  .tile-head {
+    padding: var(--space-2) var(--space-3);
+  }
+
+  .tile-kind {
+    display: none;
+  }
+
+  .tile-title {
+    font-size: 0.8125rem;
+    font-weight: 560;
+    color: var(--text-secondary);
+  }
+
+  .tile-mark {
+    width: 18px;
+    height: 18px;
+    border-radius: 6px;
+    background: transparent;
+    box-shadow: none;
+    color: var(--text-tertiary);
+
+    mur-icon {
+      width: 12px;
+      height: 12px;
+    }
+  }
+}
+
 .tile-head {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: var(--space-2);
   padding: var(--space-3) var(--space-4) var(--space-2);
+}
+
+// The kind, as colour + glyph. A squircle, not a circle — a circle reads as an
+// avatar. Tinted fill for material kinds, and the neutral hue resolves through
+// `--tile-hue` for derived views, so eleven tiles never become eleven solids.
+.tile-mark {
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 7px;
+  color: var(--tile-hue, var(--text-secondary));
+  background: color-mix(in srgb, var(--tile-hue, var(--text-secondary)) 18%, transparent);
+  box-shadow: inset 0 0 0 1px
+    color-mix(in srgb, var(--tile-hue, var(--text-secondary)) 34%, transparent);
+
+  mur-icon {
+    display: block;
+    width: 14px;
+    height: 14px;
+  }
 }
 
 .tile-titles {
@@ -70,8 +143,9 @@
 
 .tile-title {
   margin: 0;
-  font-size: 0.86rem;
+  font-size: 0.875rem;
   font-weight: 640;
+  line-height: 1.3;
   letter-spacing: -0.01em;
   color: var(--text-primary);
   overflow: hidden;
@@ -79,12 +153,28 @@
   white-space: nowrap;
 }
 
+// The eyebrow. `--text-tertiary`, not `--text-muted`: at this size the muted tier
+// measures 3.62:1 on this surface, below the legibility floor.
 .tile-kind {
   display: block;
-  color: var(--text-muted);
-  font-size: 0.64rem;
-  letter-spacing: 0.05em;
+  color: var(--text-tertiary);
+  font-size: 0.625rem;
+  font-weight: 600;
+  line-height: 1.35;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
+}
+
+// Where data WILL land, said once, under the title. Never an apology — the copy
+// states the future, not the absence ("Figures said out loud land here").
+.empty-why {
+  display: block;
+  color: var(--text-tertiary);
+  font-size: 0.6875rem;
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .live-chip {
@@ -92,7 +182,7 @@
   align-items: center;
   gap: 5px;
   margin-left: auto;
-  color: var(--text-muted);
+  color: var(--text-tertiary);
   font-size: 0.64rem;
   white-space: nowrap;
 }
@@ -147,10 +237,12 @@
 }
 
 .tile-body {
-  // A floor so a sparse tile still reads as a card rather than a stray label.
-  min-height: 74px;
+  // NO min-height. A floor here is half of why twelve tiles rendered as twelve
+  // identical boxes: every body was padded up to the same height regardless of
+  // what it had to say. Height should follow content; emptiness is handled by
+  // collapsing the whole tile, not by inflating a sparse one.
   padding: 0 var(--space-4) var(--space-4);
-  font-size: 0.82rem;
+  font-size: 0.8125rem;
   color: var(--text-secondary);
   overflow: hidden;
   border-radius: 0 0 var(--radius-lg) var(--radius-lg);
@@ -162,8 +254,53 @@
 }
 
 .muted-small {
-  color: var(--text-muted);
-  font-size: 0.7rem;
+  color: var(--text-tertiary);
+  font-size: 0.6875rem;
+  line-height: 1.35;
+}
+
+// Zero, where zero is the WIN — a result, not an absence.
+.state-good {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.good-tick {
+  color: var(--success);
+  font-weight: 700;
+}
+
+// Populated, but too thin to support the mark it implies.
+.state-degenerate {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+
+  .drift-value {
+    color: var(--text-primary);
+    font-weight: 560;
+  }
+}
+
+// A second tile resolving to the same thing as an earlier one.
+.dup-note {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0 var(--space-4) var(--space-3);
+  color: var(--text-tertiary);
+  font-size: 0.6875rem;
+  line-height: 1.35;
+}
+
+.dup-title {
+  color: var(--text-secondary);
+  font-weight: 560;
 }
 
 // ── sealed ───────────────────────────────────────────────────────────────────
@@ -183,14 +320,14 @@
   border-radius: var(--radius-sm);
   background: repeating-linear-gradient(
     45deg,
-    rgba(255, 255, 255, 0.05) 0 4px,
+    var(--hatch-stripe) 0 4px,
     transparent 4px 9px
   );
 }
 
 .sealed-copy {
   position: relative;
-  color: var(--text-muted);
+  color: var(--text-secondary);
 
   small {
     display: block;
@@ -244,20 +381,20 @@
 }
 
 .meeting-dur {
-  color: var(--text-muted);
+  color: var(--text-tertiary);
 }
 
 .snippet.is-empty {
-  color: var(--text-muted);
+  color: var(--text-tertiary);
   font-style: italic;
 }
 
 .audio-chip {
   padding: 2px var(--space-2);
-  border: 1px solid var(--border-subtle);
+  border: 1px solid color-mix(in srgb, var(--graph-meeting) 45%, transparent);
   border-radius: var(--radius-pill);
-  color: var(--graph-meeting);
-  font-size: 0.66rem;
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
 }
 
 .stats {
@@ -268,8 +405,9 @@
 
 .stat {
   dt {
-    color: var(--text-muted);
-    font-size: 0.68rem;
+    color: var(--text-tertiary);
+    font-size: 0.6875rem;
+    line-height: 1.35;
   }
 
   dd {
@@ -284,21 +422,32 @@
 }
 
 // ── pulse ────────────────────────────────────────────────────────────────────
-.pulse-bars {
+// A heat strip on a FIXED ladder. Height carries no meaning here, which is the
+// point: the previous bars normalised to the local peak, so a quiet entity and a
+// busy one drew the same picture. Opacity is absolute, so two tiles compare.
+.pulse-strip {
   display: flex;
-  align-items: flex-end;
-  gap: 3px;
-  height: 52px;
+  gap: 2px;
   margin-bottom: var(--space-3);
 }
 
-.pulse-bar {
+.heat-cell {
   flex: 1;
-  min-height: 3px;
-  // A pill radius on a 6px-wide bar renders as a dot; keep the bar a bar.
-  border-radius: 2px;
-  background: linear-gradient(180deg, var(--accent-hover), var(--accent));
-  opacity: 0.85;
+  max-width: 14px;
+  aspect-ratio: 1;
+  border-radius: 3px;
+  background: var(--tile-hue);
+
+  // Level 0 is an empty WELL, not a faint mark: the week existed and had nothing
+  // in it. A bar with a min-height said "something happened" about a zero.
+  &[data-level="0"] {
+    background: var(--surface-input);
+    box-shadow: inset 0 0 0 1px var(--border-subtle);
+  }
+  &[data-level="1"] { opacity: 0.28; }
+  &[data-level="2"] { opacity: 0.48; }
+  &[data-level="3"] { opacity: 0.72; }
+  &[data-level="4"] { opacity: 1; }
 }
 
 // ── drift ────────────────────────────────────────────────────────────────────
@@ -355,8 +504,9 @@
 
 .drift-meta {
   display: block;
-  color: var(--text-muted);
-  font-size: 0.68rem;
+  color: var(--text-tertiary);
+  font-size: 0.6875rem;
+  line-height: 1.35;
 }
 
 // ── numbers ──────────────────────────────────────────────────────────────────
@@ -372,7 +522,7 @@
   padding: var(--space-2);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--surface-input);
   color: inherit;
   font: inherit;
   text-align: left;
@@ -392,8 +542,9 @@
 
 .number-key {
   display: block;
-  color: var(--text-muted);
-  font-size: 0.68rem;
+  color: var(--text-tertiary);
+  font-size: 0.6875rem;
+  line-height: 1.35;
 }
 
 .number-was {
@@ -436,8 +587,9 @@
 
 .row-meta {
   display: block;
-  color: var(--text-muted);
-  font-size: 0.68rem;
+  color: var(--text-tertiary);
+  font-size: 0.6875rem;
+  line-height: 1.35;
 }
 
 .pill {
@@ -463,7 +615,7 @@
 }
 
 .pill-open {
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--surface-input);
   color: var(--text-secondary);
   border-color: var(--border);
 }

--- a/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.ts
+++ b/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.ts
@@ -1,5 +1,7 @@
 import { ChangeDetectionStrategy, Component, computed, input, output } from "@angular/core";
 import type { ResolvedTile, SourceRef, TileData } from "../../../core/models";
+import type { ShellIcon } from "../../../design-system/icon/icon.component";
+import { MurIconComponent } from "../../../design-system/icon/icon.component";
 
 /** What the tile header shows when the user gave the tile no title of its own. */
 const DEFAULT_TITLE: Record<TileData["kind"], string> = {
@@ -44,6 +46,92 @@ const LIVE_KINDS = new Set<TileData["kind"]>([
   "livingAnswer",
 ]);
 
+/** The 22px mark in each tile header — the kind, made scannable. */
+const TILE_ICON: Record<TileData["kind"], ShellIcon> = {
+  locked: "lock",
+  missing: "document",
+  unconfigured: "plus",
+  note: "notes",
+  meeting: "meetings",
+  document: "document",
+  person: "people",
+  reminders: "reminders",
+  drift: "drift",
+  numbers: "numbers",
+  pulse: "pulse",
+  promises: "promises",
+  livingAnswer: "ask",
+};
+
+/**
+ * FOUR hues, and no more.
+ *
+ * The four graph families measure PASS on chroma, CVD separation and contrast in
+ * both themes; adding a fifth (`--warning`) collides with amber at ΔE 5.7. So only
+ * MATERIAL kinds — the things that exist in the vault as documents — wear a hue.
+ * DERIVED tiles are views over that material and take the neutral mark, which is
+ * also what keeps a board of ten tiles from reading as confetti.
+ *
+ * `--accent` is deliberately absent: it is reserved for the AI channel (the
+ * citation ring, the Ask composer, the living answer), it is USER-SELECTABLE, and
+ * five of its six options sit within ΔE 15 of a family hue. An accent doing
+ * category work is an accent that stops meaning "the brain touched this".
+ */
+const TILE_HUE: Partial<Record<TileData["kind"], string>> = {
+  note: "var(--graph-note)",
+  document: "var(--graph-document)",
+  meeting: "var(--graph-meeting)",
+  person: "var(--graph-entity)",
+  livingAnswer: "var(--accent)",
+};
+
+/**
+ * The width a kind wants, in 12ths — applied only to tiles the user never resized.
+ *
+ * Why an override and not a default at add time: `commands/dashboards.rs` clamps
+ * with `span.unwrap_or(4)`, so EVERY tile on EVERY existing board already holds a
+ * concrete `4` in SQLite. A new add-time default would change nothing about a board
+ * that already exists, which is exactly the board that was complained about. The
+ * first explicit resize writes a real value and this stops applying.
+ */
+const DEFAULT_SPAN: Record<TileData["kind"], number> = {
+  locked: 3,
+  missing: 3,
+  unconfigured: 3,
+  note: 4,
+  meeting: 6,
+  document: 4,
+  person: 3,
+  reminders: 4,
+  drift: 4,
+  numbers: 4,
+  pulse: 3,
+  promises: 6,
+  livingAnswer: 6,
+};
+
+/** The span the backend hands every un-resized tile — the value the override replaces. */
+const STORED_DEFAULT_SPAN = 4;
+
+/** Collapsed empties are uniform and narrow, so a row of them reads as one gutter. */
+const EMPTY_SPAN = 3;
+
+/**
+ * What the body has to say, which is NOT the same question as "does it have rows".
+ *
+ * - `empty`      — never had data. Collapses to a header strip; a full card holding
+ *                  one sentence of regret is what made nine tiles read as a wall.
+ * - `good`       — genuinely zero, and that is the GOOD outcome. Keeps its card.
+ *                  "Nothing open — every commitment on this board is closed" is a
+ *                  result; rendering a success as an absence is the most
+ *                  demoralising thing a board can do, and it is why this is a
+ *                  separate state rather than `rows.length === 0`.
+ * - `degenerate` — populated, but with too little to support the mark it implies.
+ *                  A drift lane with one step asserts movement that never happened.
+ * - `normal`     — render the body.
+ */
+export type TileBodyState = "empty" | "good" | "degenerate" | "normal";
+
 /**
  * ONE tile on a board.
  *
@@ -58,10 +146,16 @@ const LIVE_KINDS = new Set<TileData["kind"]>([
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: "./dashboard-tile.component.html",
   styleUrl: "./dashboard-tile.component.scss",
+  imports: [MurIconComponent],
   host: {
-    "[style.--tile-span]": "tile().span",
+    "[attr.data-tile-id]": "tile().id",
+    "[attr.data-kind]": "data().kind",
+    "[style.--tile-span]": "displaySpan()",
+    "[style.--tile-hue]": "hue()",
     "[class.cited]": "cited() > 0",
     "[class.is-locked]": "tile().data.kind === 'locked'",
+    "[class.is-empty]": "bodyState() === 'empty'",
+    "[class.is-duplicate]": "duplicateOf() !== null",
     "[class.is-arranging]": "editing()",
     "[class.is-dragging]": "dragging()",
     "[class.is-drop-target]": "dropTarget()",
@@ -77,6 +171,16 @@ export class DashboardTileComponent {
   readonly dragging = input(false);
   /** This tile is the current drop target. */
   readonly dropTarget = input(false);
+  /**
+   * The title of an EARLIER tile that resolves to exactly the same thing, or null.
+   *
+   * The board that prompted this work carried two identical Promise ledgers. That is
+   * not user error: `tile-palette` declares `promises` with `mode: "none"`, so it
+   * never asks for an owner, so `config.owner` is never written, so both tiles
+   * resolve to the same global list — structurally guaranteed. The second one
+   * renders as a back-reference instead of a second copy of the same rows.
+   */
+  readonly duplicateOf = input<string | null>(null);
 
   readonly remove = output<void>();
   readonly widen = output<void>();
@@ -121,7 +225,94 @@ export class DashboardTileComponent {
   });
 
   readonly kindLabel = computed(() => KIND_LABEL[this.data().kind]);
-  readonly isLive = computed(() => LIVE_KINDS.has(this.data().kind));
+  readonly mark = computed(() => TILE_ICON[this.data().kind]);
+  readonly hue = computed(() => TILE_HUE[this.data().kind] ?? "var(--text-secondary)");
+
+  /**
+   * What the body has to say. See {@link TileBodyState} — the load-bearing
+   * distinction is `empty` (never had data → collapse) versus `good` (zero, and
+   * zero is the win → keep the card).
+   */
+  readonly bodyState = computed<TileBodyState>(() => {
+    const d = this.data();
+    switch (d.kind) {
+      case "missing":
+      case "unconfigured":
+        return "empty";
+      case "note":
+      case "document":
+        return d.snippet.trim() ? "normal" : "empty";
+      case "numbers":
+        return d.rows.length === 0 ? "empty" : "normal";
+      case "pulse":
+        return d.total === 0 ? "empty" : "normal";
+      case "drift":
+        // Zero steps is nothing; ONE step is worse than nothing, because a rail
+        // drawn through a single point asserts a movement that never happened.
+        if (d.rows.length === 0) return "empty";
+        return d.rows.length < 2 ? "degenerate" : "normal";
+      case "promises":
+      case "reminders":
+        return d.rows.length === 0 ? "good" : "normal";
+      default:
+        // `locked` keeps its full card ON PURPOSE: a redacted region is content,
+        // and a board that can be screen-shared as-is is the point of the lock model.
+        return "normal";
+    }
+  });
+
+  /** One sentence saying where data WILL land — never an apology for its absence. */
+  readonly emptyCopy = computed(() => {
+    const d = this.data();
+    switch (d.kind) {
+      case "missing":
+        return "Its source is gone from the vault";
+      case "unconfigured":
+        return "No source chosen yet";
+      case "note":
+      case "document":
+        return "Nothing written in it yet";
+      case "numbers":
+        return "Figures said out loud land here";
+      case "pulse":
+        return "Mentions land here once it comes up";
+      case "drift":
+        return "Values land here as they get revised";
+      default:
+        return "Nothing here yet";
+    }
+  });
+
+  /** The good-news line for a tile whose emptiness is the desired outcome. */
+  readonly goodCopy = computed(() =>
+    this.data().kind === "promises"
+      ? "Nothing open — every commitment on this board is closed"
+      : "No open reminders",
+  );
+
+  /**
+   * A tile with nothing in it does not get to claim it is live, and neither does
+   * a collapsed strip — a blinking dot on an empty box is the board asserting
+   * activity it cannot show.
+   */
+  readonly isLive = computed(
+    () =>
+      LIVE_KINDS.has(this.data().kind) &&
+      this.bodyState() === "normal" &&
+      this.duplicateOf() === null,
+  );
+
+  /**
+   * The width actually rendered. Collapsed empties are uniform and narrow; a tile
+   * the user never resized takes its kind's natural width; an explicitly resized
+   * tile is left exactly alone.
+   */
+  readonly displaySpan = computed(() => {
+    if (this.duplicateOf() !== null) return EMPTY_SPAN;
+    if (this.bodyState() === "empty") return EMPTY_SPAN;
+    const stored = this.tile().span;
+    return stored === STORED_DEFAULT_SPAN ? DEFAULT_SPAN[this.data().kind] : stored;
+  });
 
   // ── narrowed views of the discriminated union ──────────────────────────────
   //
@@ -150,14 +341,25 @@ export class DashboardTileComponent {
   readonly isMissing = computed(() => this.data().kind === "missing");
   readonly isUnconfigured = computed(() => this.data().kind === "unconfigured");
 
-  /** Pulse: the tallest weekly bucket, so the bars can be scaled to it. */
-  readonly pulsePeak = computed(() => {
-    const p = this.pulse();
-    return p ? Math.max(1, ...p.weekly) : 1;
-  });
-
-  barHeight(value: number): number {
-    return Math.round((value / this.pulsePeak()) * 100);
+  /**
+   * Pulse, as a heat strip on a FIXED ladder — not bars scaled to the local peak.
+   *
+   * The bar chart this replaces lied twice. `min-height: 3px` drew a visible mark
+   * for a week with no mentions at all, so absence looked like activity; and
+   * scaling to `max(...weekly)` meant a peak of 1 rendered at full height, so a
+   * board with forty mentions a week was pixel-identical to one with a single
+   * mention. A fixed ladder is what makes two tiles — and two boards —
+   * comparable at a glance, which is the entire job of the mark.
+   *
+   * Level 0 is drawn as an empty well: the week EXISTS and had nothing, which is
+   * a different statement from "no data".
+   */
+  heatLevel(value: number): 0 | 1 | 2 | 3 | 4 {
+    if (value <= 0) return 0;
+    if (value <= 1) return 1;
+    if (value <= 3) return 2;
+    if (value <= 6) return 3;
+    return 4;
   }
 
   onSource(source: SourceRef | null): void {

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
@@ -50,6 +50,7 @@
         <app-dashboard-tile
           [tile]="tile"
           [cited]="citationFor(tile)"
+          [duplicateOf]="duplicateOf(tile)"
           [editing]="editing()"
           [dragging]="draggingId() === tile.id"
           [dropTarget]="dropTargetId() === tile.id"

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
@@ -88,7 +88,24 @@
 
     <div class="thread">
       @for (turn of turns(); track $index) {
-        <div class="bubble" [class.me]="turn.role === 'user'">{{ turn.text }}</div>
+        @if (turn.role === "error") {
+          <!-- A failure is chrome, not a conclusion. It used to render in the same
+               grey bubble as a real answer, with nothing to retry. -->
+          <div class="banner is-danger" role="alert">
+            <span>{{ turn.text }}</span>
+            <button type="button" class="btn btn-ghost btn-sm" (click)="retry(turn)">
+              Try again
+            </button>
+          </div>
+        } @else if (turn.role === "user") {
+          <div class="bubble me">{{ turn.text }}</div>
+        } @else {
+          <!-- The prompt in `summarize/vault_chat.rs::build` DEMANDS markdown, so
+               rendering the answer as plain text printed `**` and `[[…]]` literally.
+               `app-markdown` also turns wikilinks into gated, clickable chips —
+               dashboards was the only AI surface in the app not using it. -->
+          <div class="bubble"><app-markdown [markdown]="turn.text" compact /></div>
+        }
       } @empty {
         <div class="suggestions">
           @for (s of suggestions; track s) {

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.scss
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.scss
@@ -144,16 +144,30 @@
   padding: var(--space-4);
 }
 
+.thread .banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  font-size: 0.8rem;
+}
+
 .bubble {
   padding: var(--space-3);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
   border-bottom-left-radius: var(--radius-sm);
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--surface-input);
   color: var(--text-secondary);
   font-size: 0.8rem;
   line-height: 1.6;
-  white-space: pre-wrap;
+
+  // `white-space: pre-wrap` belongs to text that is NOT parsed. An assistant turn
+  // now renders through `app-markdown`, where pre-wrap would preserve the source
+  // newlines around every block element and double the spacing.
+  &.me {
+    white-space: pre-wrap;
+  }
 
   &.me {
     align-self: flex-end;

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
@@ -20,15 +20,33 @@ import {
   TilePaletteService,
   type TileChoice,
 } from "../../../services/tile-palette.service";
-import type { ResolvedTile, SourceRef } from "../../../core/models";
+import type { ChatTurn, ResolvedTile, SourceRef } from "../../../core/models";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
+import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
 
-/** One exchange in the board-scoped Ask column. */
+/**
+ * One exchange in the board-scoped Ask column.
+ *
+ * `error` is a THIRD role, not a flavour of `assistant`. A failure used to be
+ * pushed as an assistant turn, so a dispatch error rendered in the same grey
+ * bubble as a real answer, with nothing to retry - the board stated a provider
+ * failure in the exact visual language it uses for grounded conclusions.
+ */
 interface BoardTurn {
-  role: "user" | "assistant";
+  role: "user" | "assistant" | "error";
   text: string;
   /** Tile ids this answer was grounded in (assistant turns only). */
   citedTiles?: string[];
+  /** The question that produced an error turn, so Try again can re-send it. */
+  retry?: string;
 }
+
+/**
+ * The same 12-message bound every other chat surface uses (`CHAT_CONTEXT_TURNS`).
+ * The board sent `[]`, so every question arrived context-free and a follow-up
+ * like "and the second one?" could not resolve.
+ */
+const HISTORY_TURNS = 12;
 
 const SUGGESTIONS = [
   "What's most likely to go wrong here?",
@@ -59,6 +77,7 @@ const SUGGESTIONS = [
     MurIconComponent,
     MurSpinnerComponent,
     DashboardTileComponent,
+    MarkdownComponent,
   ],
   templateUrl: "./dashboard-view.component.html",
   styleUrl: "./dashboard-view.component.scss",
@@ -69,6 +88,7 @@ export class DashboardViewComponent {
   private readonly router = inject(Router);
   private readonly route = inject(ActivatedRoute);
   private readonly palette = inject(TilePaletteService);
+  private readonly errors = inject(ErrorCopyService);
 
   constructor() {
     // The palette is app-wide, so leaving the board must not strand it on screen
@@ -358,7 +378,7 @@ export class DashboardViewComponent {
         ]);
         return;
       }
-      const result = await this.ipc.askVault(question, [], undefined, sources);
+      const result = await this.ipc.askVault(question, this.askHistory(), undefined, sources);
       this.turns.update((t) => [
         ...t,
         {
@@ -370,11 +390,32 @@ export class DashboardViewComponent {
     } catch (e) {
       this.turns.update((t) => [
         ...t,
-        { role: "assistant", text: this.errorText(e) },
+        { role: "error", text: this.errors.humanize(e, "generic"), retry: question },
       ]);
     } finally {
       this.asking.set(false);
     }
+  }
+
+  /**
+   * The conversation so far, bounded and stripped of error turns - a failed
+   * dispatch is UI chrome, and replaying "That didn't work" as prior context
+   * would teach the model that the board could not answer.
+   */
+  private askHistory(): ChatTurn[] {
+    return this.turns()
+      .filter((t) => t.role !== "error")
+      .slice(-HISTORY_TURNS)
+      .map((t) => ({ role: t.role as "user" | "assistant", content: t.text }));
+  }
+
+  /** Re-send the question an error turn was raised for. */
+  retry(turn: BoardTurn): void {
+    if (!turn.retry) return;
+    const question = turn.retry;
+    this.turns.update((t) => t.filter((x) => x !== turn));
+    this.draft.set(question);
+    void this.ask();
   }
 
   /** Map the answer's source ids back onto the tiles that carry them. */
@@ -405,12 +446,4 @@ export class DashboardViewComponent {
     }
   }
 
-  private errorText(e: unknown): string {
-    if (typeof e === "string") return e;
-    if (e && typeof e === "object") {
-      const v = Object.values(e as Record<string, unknown>)[0];
-      if (typeof v === "string") return v;
-    }
-    return "That didn't work. Try again.";
-  }
 }

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
@@ -112,6 +112,48 @@ export class DashboardViewComponent {
     () => this.tiles().filter((t) => t.data.kind === "locked").length,
   );
 
+  /**
+   * Tile id → the heading of the EARLIER tile it duplicates.
+   *
+   * Two tiles that resolve to the same payload render the same rows twice, which
+   * is what made a nine-tile board read as a duplicated one. The cause is a
+   * missing parameter rather than user error — `tile-palette` never writes
+   * `config.owner`, so every Promise ledger resolves to the same global list —
+   * so the second tile becomes a back-reference and the fix costs no backend.
+   *
+   * Keyed on the RESOLVED payload, not on `(kind, refId, config)`: two tiles can
+   * be configured differently and still resolve identically, and it is the
+   * on-screen repetition that the user sees.
+   */
+  readonly duplicates = computed<ReadonlyMap<string, string>>(() => {
+    const seen = new Map<string, string>();
+    const out = new Map<string, string>();
+    for (const t of this.tiles()) {
+      // A sealed tile carries no fields at all, so every sealed tile would look
+      // like every other one. Redaction is not duplication — never collapse them.
+      if (t.data.kind === "locked") continue;
+      const key = JSON.stringify(t.data);
+      const first = seen.get(key);
+      if (first === undefined) seen.set(key, this.headingOf(t));
+      else out.set(t.id, first);
+    }
+    return out;
+  });
+
+  duplicateOf(tile: ResolvedTile): string | null {
+    return this.duplicates().get(tile.id) ?? null;
+  }
+
+  /** The label a back-reference points at — the user-visible name of the original. */
+  private headingOf(tile: ResolvedTile): string {
+    if (tile.title && tile.title.trim()) return tile.title.trim();
+    const d = tile.data;
+    if (d.kind === "note" || d.kind === "meeting" || d.kind === "document") return d.title;
+    if (d.kind === "person") return d.name;
+    if (d.kind === "promises") return d.owner ? `Promises · ${d.owner}` : "Promises";
+    return d.kind;
+  }
+
   /** Owned by the root service — the palette itself is rendered by `app-shell`. */
   readonly paletteOpen = this.palette.open;
   readonly editing = signal(false);

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.html
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.html
@@ -41,6 +41,7 @@
               The question this tile keeps answering
             </label>
             <input
+              #searchField
               id="tile-question"
               class="field"
               type="text"
@@ -62,6 +63,7 @@
         @default {
           <div class="search-row">
             <input
+              #searchField
               class="field"
               type="text"
               [placeholder]="type.mode === 'entity' ? 'Filter people & projects…' : 'Search your vault…'"

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.ts
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.ts
@@ -2,12 +2,12 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
-  Injector,
-  afterNextRender,
   computed,
+  effect,
   inject,
   output,
   signal,
+  viewChild,
 } from "@angular/core";
 import { IpcService } from "../../../core/ipc.service";
 import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
@@ -32,6 +32,30 @@ interface NodeType {
 /**
  * The tile catalogue. Order is the palette's reading order: material first,
  * then the derived views that are the actual reason to build a board.
+ *
+ * RETIRED 2026-08-04 — `drift`, `numbers`, `pulse`. Each is anchored to ONE
+ * entity over the two thinnest tables in the schema, and each is blocked by a
+ * mechanism in the extractor rather than by a shortage of recordings:
+ *
+ *  - `numbers` post-filters facts with `looks_numeric`, but `facts::EXTRACT_SYSTEM`
+ *    asks for "durable state worth tracking" and never asks for quantities, so the
+ *    filter runs over a substrate that was never built to contain figures (and
+ *    what it does match is mostly dates).
+ *  - `drift` needs SUPERSEDED facts, and `facts::reconcile_facts` requires the same
+ *    NORMALIZED `(entity, subject, predicate)` while predicates are free-form —
+ *    so supersessions do not form.
+ *  - `pulse` reads `entity_mentions`, written by `graph_store::Db::add_mention` as
+ *    `INSERT OR IGNORE` on PK `(entity_id, meeting_id)`. It counts MEETINGS, not
+ *    utterances, which makes this entry's own former copy ("how often this is
+ *    actually talked about") false, and caps every weekly bucket at 1.
+ *
+ * A tile that is empty for most people is worse than no tile, so they stop being
+ * OFFERED. Their `resolve_tile` arms stay alive and must never be deleted: that
+ * function ends in `Err(AppError::InvalidArg("unknown tile kind"))` and
+ * `get_dashboard` collects with `?`, so removing an arm would turn every board
+ * that already contains one of these into a hard error at open. Fixing the
+ * extractor is its own investigation; see
+ * docs/superpowers/specs/2026-08-04-dashboards-rebuild-design.md §7.
  */
 const NODE_TYPES: NodeType[] = [
   {
@@ -65,30 +89,6 @@ const NODE_TYPES: NodeType[] = [
     onlyMurmur: true,
     mode: "entity",
     family: "person",
-  },
-  {
-    kind: "drift",
-    name: "Drift lane",
-    description: "How ONE value moved over time — GA: Apr 30 → May 24 → Jun 14.",
-    onlyMurmur: true,
-    mode: "entity",
-    family: "insight",
-  },
-  {
-    kind: "numbers",
-    name: "Numbers",
-    description: "Figures that were said out loud, with what they used to be.",
-    onlyMurmur: true,
-    mode: "entity",
-    family: "insight",
-  },
-  {
-    kind: "pulse",
-    name: "Pulse",
-    description: "How often this is actually talked about — and where it went quiet.",
-    onlyMurmur: true,
-    mode: "entity",
-    family: "insight",
   },
   {
     kind: "promises",
@@ -161,7 +161,6 @@ const LINK_KIND: Partial<Record<TileKind, string>> = {
 })
 export class TilePaletteComponent {
   private readonly ipc = inject(IpcService);
-  private readonly injector = inject(Injector);
 
   readonly dismiss = output<void>();
   readonly choose = output<TileChoice>();
@@ -176,8 +175,19 @@ export class TilePaletteComponent {
   readonly entities = signal<{ id: string; name: string; mentionCount: number }[]>([]);
   readonly question = signal("");
 
-  private readonly searchField =
-    signal<ElementRef<HTMLInputElement> | null>(null);
+  /**
+   * Focus the picker's field the moment it exists.
+   *
+   * This replaces a `registerField()` method that was bound NOWHERE in the
+   * template, so it never ran and the field never focused — the palette opened
+   * its second step and left the caret in the void. A `viewChild` signal fires
+   * on its own when the `@switch` swaps the step in, with no call site to forget.
+   */
+  private readonly searchField = viewChild<ElementRef<HTMLInputElement>>("searchField");
+
+  private readonly _focusField = effect(() => {
+    this.searchField()?.nativeElement.focus();
+  });
 
   readonly filteredEntities = computed(() => {
     const q = this.query().trim().toLowerCase();
@@ -292,9 +302,4 @@ export class TilePaletteComponent {
     else this.dismiss.emit();
   }
 
-  registerField(el: ElementRef<HTMLInputElement> | undefined): void {
-    if (!el) return;
-    this.searchField.set(el);
-    afterNextRender(() => el.nativeElement.focus(), { injector: this.injector });
-  }
 }

--- a/src/app/services/dashboards.service.ts
+++ b/src/app/services/dashboards.service.ts
@@ -94,6 +94,21 @@ export class DashboardsService {
     if (id) await this.loadBoard(id);
   }
 
+  /**
+   * Apply a committed span locally — the backend already accepted it, so this is
+   * reconciliation, not an optimistic guess that could diverge.
+   */
+  private patchTileSpan(tileId: string, span: number): void {
+    this._board.update((board) => {
+      if (!board) return board;
+      const i = board.tiles.findIndex((t) => t.id === tileId);
+      if (i < 0 || board.tiles[i].span === span) return board;
+      const tiles = [...board.tiles];
+      tiles[i] = { ...tiles[i], span };
+      return { ...board, tiles };
+    });
+  }
+
   async create(
     title: string,
     emoji?: string,
@@ -166,7 +181,17 @@ export class DashboardsService {
         span: patch.span,
         config: patch.config ? JSON.stringify(patch.config) : undefined,
       });
-      await this.reloadOpenBoard();
+      // A SPAN-only change is pure layout: it cannot alter a single gated payload,
+      // so patch it in place instead of re-resolving the board. `get_dashboard`
+      // re-runs every tile's gated reader, and a Promise ledger costs a full-vault
+      // note scan — so one chevron click was paying for the whole board twice over,
+      // and a board with two ledgers paid for that scan twice again.
+      //
+      // Anything else (title, config) CAN change what resolves, so it still reloads.
+      const spanOnly =
+        patch.span !== undefined && patch.title === undefined && patch.config === undefined;
+      if (spanOnly) this.patchTileSpan(id, patch.span!);
+      else await this.reloadOpenBoard();
     } catch (e) {
       this._error.set(this.message(e));
     }

--- a/src/design-tokens/colors.css
+++ b/src/design-tokens/colors.css
@@ -13,7 +13,14 @@
   --text-primary: #f6f6fa;
   --text-secondary: #a6a6b6;
   --text-muted: #6c6c7d;
+  /* The ≤12px tier. `--text-muted` measures 3.62:1 on the raised surface, which is
+     below the legibility floor, and it was carrying every eyebrow, meta line and
+     unit label in the app. Anything set at 12px or smaller uses THIS (5.50:1);
+     `--text-muted` stays for ≥13px only. */
+  --text-tertiary: #8a8a9c;
   --text-on-accent: #ffffff;
+  /* Diagonal hatch for a redacted/sealed region — was a raw rgba() in three files. */
+  --hatch-stripe: rgba(255, 255, 255, 0.05);
 
   /* --- Cool accent (calm states: idle, nav, focus, links) ----------------- */
   --accent: #6e76ff;

--- a/src/design-tokens/theme-light.css
+++ b/src/design-tokens/theme-light.css
@@ -23,6 +23,8 @@
   --text-primary: #17171f;
   --text-secondary: #55555f;
   --text-muted: #86868f;
+  --text-tertiary: #6e6e78; /* 4.84:1 on the light tile surface */
+  --hatch-stripe: rgba(18, 18, 40, 0.055);
   --accent-soft: rgba(110, 118, 255, 0.13);
   --border: rgba(18, 18, 40, 0.12);
   --border-strong: rgba(18, 18, 40, 0.20);
@@ -86,6 +88,8 @@
     --text-primary: #17171f;
     --text-secondary: #55555f;
     --text-muted: #86868f;
+    --text-tertiary: #6e6e78;
+    --hatch-stripe: rgba(18, 18, 40, 0.055);
     --accent-soft: rgba(110, 118, 255, 0.13);
     --border: rgba(18, 18, 40, 0.12);
     --border-strong: rgba(18, 18, 40, 0.20);


### PR DESCRIPTION
> **Stacking note.** This branch is cut from `fix/ui-debug-discipline` (PR #567),
> which carries the camelCase payload fix `b054e7f` that this work depends on —
> without it the tile palette is dead. The base is `murmur` so the gate actually
> runs; until #567 merges, the diff here includes its ten commits.

## Why

A real board rendered as nine identical grey boxes, five of them holding an
apology, with every gate in the repo green. The research behind this
(`docs/research/2026-08-04-dashboards-ux-research.md` — 12 agents, three
adversarial critiques) separates that into causes that need different fixes, and
the headline finding is that **the screenshot was largely a rendering bug, not a
design failure**, with a frontend fix that works retroactively on boards that
already exist.

Plan: `docs/superpowers/specs/2026-08-04-dashboards-rebuild-design.md`.

## `06f8e2a` — the board looks composed

| Cause | Fix |
| --- | --- |
| Every tile is born `span = 4` (`dashboards.rs` `span.unwrap_or(4)`; `dashboard-view::addTile` never passed one although the service accepts it) → three per row, forever | A **display-side** override per kind. Not an add-time default — existing rows already say `4`, so a default would not have touched the board complained about. An explicit resize wins and the override stops applying |
| Eleven empty states, all the same grey `<p class="muted">` in a full-height card | An emptiness **ladder**. *Never had data* → a dashed one-line strip that sorts to the end and says where data will land. *Zero, and zero is the win* → keeps its card and states the result. *Degenerate* → keeps the card, drops the mark |
| Two identical Promise ledgers | A back-reference. Keyed on the resolved payload; sealed tiles excluded, because redaction is not duplication |
| Pulse lied twice — `min-height: 3px` drew a mark for a week with **no** mentions, and scaling to `max(...weekly)` put a peak of 1 at full height | A heat strip on a **fixed** ladder, so two tiles and two boards compare. Level 0 is an empty well: the week existed and had nothing in it |
| No colour anywhere on the board | A 22px per-kind mark, eyebrow above title. **Four** hues, worn only by material kinds. `--accent` excluded on purpose — it is the AI channel, user-selectable, and five of six options sit within ΔE 15 of a family hue |
| `--text-muted` measures 3.62:1 dark / 3.46:1 light and carried every eyebrow and meta line | New `--text-tertiary` for the ≤12px tier; `--hatch-stripe` replaces three raw `rgba()` that rendered white-on-near-white in light mode |

## `72be338` — the palette stops offering what cannot fire

`drift`, `numbers` and `pulse` are no longer offered — not for lack of
recordings, but because each is blocked by a named mechanism: the fact extractor
is never asked for quantities; `reconcile_facts` needs identical normalised
predicates while predicates are free-form, so supersessions never form; and
`add_mention` is `INSERT OR IGNORE` per **meeting**, so it counts meetings rather
than utterances and caps every weekly bucket at 1.

**"Retire" means the `NODE_TYPES` entry only.** Every `resolve_tile` arm stays —
that function ends in `Err(InvalidArg("unknown tile kind"))` and `get_dashboard`
collects with `?`, so deleting one would turn every board already containing such
a tile into a hard error at open.

Also: `registerField()` was bound nowhere, so the picker's field never focused.

## `03088f6` — the scope function goes under test

`get_dashboard_sources` defines what a board-scoped Ask may read and **had no Rust
test at all**; its only coverage was Playwright mocks asserting the frontend's
assumption about the answer. Extracted to `dashboard_sources_inner` and pinned
four properties, each with a control so none can go vacuous — sealed source
excluded, derived tile contributes nothing, dangling ref dropped rather than
erroring, duplicates dedupe on `(kind, id)`.

> **Finding for `lock-security-reviewer`, recorded rather than silently encoded as
> intent.** `meetings_store::meeting_is_visible` ends in
> `Ok(!has_notes || has_visible)` — a meeting with **no note row is visible by
> construction**. For a deleted meeting that is merely wasteful. The case worth a
> specialist's eye is the other one the predicate admits: a meeting that exists,
> sits in a **sealed** folder, and has no note row yet — the shape `lock-model.md`
> already calls out for audio. `a_dangling_meeting_ref_currently_survives_the_gate`
> pins today's behaviour so tightening it is a visible change. It is **not** a
> claim that the behaviour is safe, and it is not fixed here: `storage/**` is a
> lock-risk path and does not belong in a frontend pass.

Also: a span-only update no longer reloads the board. Span is pure layout, but
`updateTile` reloaded unconditionally and `get_dashboard` re-runs every gated
reader — where a Promise ledger costs a full-vault note scan.

## `6359217` — the Ask column stops lying

Errors were pushed as `{role: "assistant"}`, so a provider failure rendered in the
same grey bubble as a grounded conclusion with no retry. Now a third turn role →
`.banner.is-danger` + Try again, with copy from `ErrorCopyService` instead of a
hand-rolled renderer (that boundary exists because nine such renderers were
deleted to establish it; dashboards had reintroduced one).

Answers now render through `app-markdown` — the prompt in `vault_chat.rs::build`
demands markdown and the board printed `**` literally. And the 12-turn history is
actually sent; it was `[]`, so every question arrived context-free.

## Verification

`e2e/dashboards/dashboard-density.spec.ts` is **RED on the parent commit** for the
right reasons — `.tile-mark` resolves to 0 elements against a live page, and the
span probe returns `-1` because `data-tile-id` does not exist. Its Promises test
is the guard on the others: an empty **Promises** tile must NOT collapse, so a
naive "hide anything with no rows" cannot pass.

Locally: `cargo test --lib` **2744 passed / 0 failed**, `ng lint` clean,
`ng build` clean, **496 passed / 2 skipped across Chromium AND WebKit**.

**Not proven headlessly:** the packaged WKWebView render of `color-mix()` and the
dashed-strip surface. Per rule T4 a green `ng build` proves nothing about the
shipping engine.

## Deliberately not here

- **`get_dashboard_brief`** — the important half. Seven of ten tile kinds
  contribute nothing to the prompt, so **the in-app Ask sees strictly less of the
  board than an external MCP agent does**: you can look at a Promise ledger, ask
  the app's own suggested question "who owes me something on this board?", and the
  model cannot see that tile. Needs a parameter on `ask_vault` in
  `commands/mod.rs` → lock-risk → harness + lock review.
- **`extract_owner`** (`summarize/**` → egress-risk). 29 of 29 open items carry
  the literal owner `"(właściciel nieokreślony)"`, which makes
  `Person.open_commitments` structurally 0 for every person. Highest
  work-to-value ratio in the programme, and it needs the harness.
- **Promise-ledger owner scope** — the structural cause of the duplicate ledgers,
  but `config.owner` would put a person's NAME in an ungated column that survives
  sealing: the class of defect PR #562's review caught.
- Palette count chips (`storage/**`), the `list_open_commitments` hoist
  (`mcp.rs`), and spec phases 5–8.
