### PR TITLE
feat(dashboards): collapse the Ask column to a rail, keeping the scope count on screen

### DIFF
--- a/e2e/dashboards/dashboard-density.spec.ts
+++ b/e2e/dashboards/dashboard-density.spec.ts
@@ -421,3 +421,40 @@ test("Dashboards: renaming with no emoji clears the old one", async ({ page }) =
   expect(sent.title).toBe("Plain name");
   expect(sent.emoji).toBe("");
 });
+
+test("Dashboards: deleting a board takes two clicks, and the first one is reversible", async ({
+  page,
+}) => {
+  // A board is the one artifact in this feature the user BUILT rather than recorded,
+  // and delete fired straight through on a single click with no undo.
+  await mockTauri(
+    page,
+    {
+      delete_dashboard: () => {
+        (globalThis as any).__deleted = ((globalThis as any).__deleted ?? 0) + 1;
+        return true;
+      },
+    },
+    { list_dashboards: BOARDS, get_dashboard: BOARD_DETAIL, get_dashboard_sources: [] },
+  );
+
+  await page.goto("/dashboards");
+  const card = page.locator(".board-card").first();
+
+  // FIRST click arms — it must not delete.
+  await card.getByRole("button", { name: /^Delete / }).click();
+  await expect(card.getByRole("button", { name: /^Confirm delete / })).toBeVisible();
+  expect(await page.evaluate(() => (globalThis as any).__deleted ?? 0)).toBe(0);
+
+  // Backing out leaves the board alone…
+  await card.getByRole("button", { name: /^Keep / }).click();
+  await expect(card.getByRole("button", { name: /^Delete / })).toBeVisible();
+  expect(await page.evaluate(() => (globalThis as any).__deleted ?? 0)).toBe(0);
+
+  // …and only the SECOND click on an armed button actually deletes.
+  await card.getByRole("button", { name: /^Delete / }).click();
+  await card.getByRole("button", { name: /^Confirm delete / }).click();
+  await expect
+    .poll(() => page.evaluate(() => (globalThis as any).__deleted ?? 0))
+    .toBe(1);
+});

--- a/e2e/dashboards/dashboard-density.spec.ts
+++ b/e2e/dashboards/dashboard-density.spec.ts
@@ -352,3 +352,72 @@ test("Dashboards: the Ask column is a rail until it has something to say", async
   await expect(page.getByText("Two are late.")).toBeVisible();
   await expect(ask).not.toHaveClass(/is-rail/);
 });
+
+test("Dashboards: a board can be renamed, and a leading emoji becomes its emoji", async ({
+  page,
+}) => {
+  // `DashboardsService.update` shipped accepting title/emoji/tint and the only caller
+  // ever passed `{pinned}` — so a board named the wrong thing stayed named the wrong
+  // thing, and the `emoji` column plus six SCSS tint mappings were dead code.
+  await mockTauri(
+    page,
+    {
+      update_dashboard: (args: any) => {
+        (globalThis as any).__updateArgs = args;
+        return null;
+      },
+    },
+    {
+      list_dashboards: BOARDS,
+      get_dashboard: BOARD_DETAIL,
+      get_dashboard_sources: [],
+    },
+  );
+
+  await page.goto("/dashboards/b-dense");
+  await page.getByRole("button", { name: /Rename this board/i }).click();
+
+  const field = page.getByRole("textbox", { name: "Board name" });
+  await expect(field).toBeVisible();
+  // A ZWJ cluster — the case a naive `[...str][0]` splits into a lone man.
+  await field.fill("👨‍👩‍👧 Family planning");
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+
+  const sent = await expect
+    .poll(async () => page.evaluate(() => (globalThis as any).__updateArgs))
+    .toBeTruthy()
+    .then(() => page.evaluate(() => (globalThis as any).__updateArgs));
+  expect(sent.title).toBe("Family planning");
+  expect(sent.emoji).toBe("👨‍👩‍👧");
+});
+
+test("Dashboards: renaming with no emoji clears the old one", async ({ page }) => {
+  // Dropping the field instead of sending "" would leave the previous emoji in place,
+  // making the picture impossible to remove once set.
+  await mockTauri(
+    page,
+    {
+      update_dashboard: (args: any) => {
+        (globalThis as any).__updateArgs = args;
+        return null;
+      },
+    },
+    {
+      list_dashboards: BOARDS,
+      get_dashboard: { ...BOARD_DETAIL, emoji: "🚀" },
+      get_dashboard_sources: [],
+    },
+  );
+
+  await page.goto("/dashboards/b-dense");
+  await page.getByRole("button", { name: /Rename this board/i }).click();
+  await page.getByRole("textbox", { name: "Board name" }).fill("Plain name");
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+
+  const sent = await expect
+    .poll(async () => page.evaluate(() => (globalThis as any).__updateArgs))
+    .toBeTruthy()
+    .then(() => page.evaluate(() => (globalThis as any).__updateArgs));
+  expect(sent.title).toBe("Plain name");
+  expect(sent.emoji).toBe("");
+});

--- a/e2e/dashboards/dashboard-density.spec.ts
+++ b/e2e/dashboards/dashboard-density.spec.ts
@@ -2,6 +2,23 @@ import { expect, test } from "@playwright/test";
 import { mockTauri } from "../settings-ai/mock-invoke";
 
 /**
+ * Open the Ask column. It starts collapsed to a rail — the scope count stays on
+ * screen, the empty transcript does not — so any test that types a question expands
+ * it first, which is the same click a user makes.
+ */
+async function openAsk(page: import("@playwright/test").Page): Promise<void> {
+  // Wait for the panel to EXIST before deciding. A bare `count()` races Angular's
+  // first render and silently no-ops, which then surfaces as a `fill` timeout on a
+  // field that was never revealed.
+  const panel = page.locator("aside.ask");
+  await panel.waitFor();
+  const rail = panel.locator("button.ask-rail");
+  if (await rail.count()) await rail.click();
+  await page.getByRole("textbox", { name: /Ask a question/i }).waitFor();
+}
+
+
+/**
  * Dashboards — the DENSITY oracle (Phase 1 of the 2026-08-04 rebuild).
  *
  * These are RED-before-GREEN tests for a bug that had no failing check: a real
@@ -204,6 +221,7 @@ test("Dashboards: a failed Ask is a banner with a retry, not a grey bubble that 
   );
 
   await page.goto("/dashboards/b-dense");
+  await openAsk(page);
   await page.getByRole("textbox", { name: /Ask a question/i }).fill("what is late?");
   await page.getByRole("button", { name: "Ask", exact: true }).click();
 
@@ -234,6 +252,7 @@ test("Dashboards: an answer renders as markdown, not as literal asterisks", asyn
   );
 
   await page.goto("/dashboards/b-dense");
+  await openAsk(page);
   await page.getByRole("textbox", { name: /Ask a question/i }).fill("what is the risk?");
   await page.getByRole("button", { name: "Ask", exact: true }).click();
 
@@ -292,4 +311,44 @@ test("Dashboards: a duplicate tile renders as a back-reference, not a second cop
 
   // The row is rendered ONCE on the board, not twice.
   await expect(page.getByText("Send the Acme paperwork")).toHaveCount(1);
+});
+
+test("Dashboards: the Ask column is a rail until it has something to say", async ({ page }) => {
+  // The scope readout is the feature's claim made visible, so it stays on screen; the
+  // empty transcript is not, and it was spending a third of the width on three
+  // suggestion buttons.
+  await mockTauri(
+    page,
+    { ask_vault: () => ({ answer: "Two are late.", sources: [], citations: [] }) },
+    {
+      list_dashboards: BOARDS,
+      get_dashboard: BOARD_DETAIL,
+      get_dashboard_sources: [{ kind: "note", id: "n-1" }],
+    },
+  );
+
+  await page.goto("/dashboards/b-dense");
+  const ask = page.locator("aside.ask");
+  await expect(ask).toHaveClass(/is-rail/);
+  // …and the count is still readable while collapsed.
+  await expect(ask.getByText(/in scope/)).toBeVisible();
+  const railWidth = (await ask.boundingBox())!.width;
+  expect(railWidth).toBeLessThan(60);
+
+  await ask.getByRole("button", { name: /Ask this board/ }).click();
+  await expect(ask).not.toHaveClass(/is-rail/);
+  // The width TRANSITIONS, so a single read lands mid-animation. Poll instead of
+  // measuring once — and the composer being reachable is the real invariant anyway.
+  await expect(page.getByRole("textbox", { name: /Ask a question/i })).toBeVisible();
+  await expect
+    .poll(async () => (await ask.boundingBox())!.width)
+    .toBeGreaterThan(railWidth * 3);
+
+  // Once there is a conversation it STAYS open — a thread you cannot see is worse
+  // than a wide column.
+  await openAsk(page);
+  await page.getByRole("textbox", { name: /Ask a question/i }).fill("who is late?");
+  await page.getByRole("button", { name: "Ask", exact: true }).click();
+  await expect(page.getByText("Two are late.")).toBeVisible();
+  await expect(ask).not.toHaveClass(/is-rail/);
 });

--- a/e2e/dashboards/dashboard-density.spec.ts
+++ b/e2e/dashboards/dashboard-density.spec.ts
@@ -458,3 +458,43 @@ test("Dashboards: deleting a board takes two clicks, and the first one is revers
     .poll(() => page.evaluate(() => (globalThis as any).__deleted ?? 0))
     .toBe(1);
 });
+
+test("Dashboards: navigating away mid-ask does not leave the next board stuck busy", async ({
+  page,
+}) => {
+  // The stale-async guard's own failure mode. Gating BOTH the data writes and the
+  // busy flag on "same board AND same request" means that after navigating away
+  // mid-flight nothing ever clears `asking` — so the NEXT board opens with its Ask
+  // control disabled, waiting on a request that was never its own.
+  await mockTauri(
+    page,
+    {
+      ask_vault: async () => {
+        await new Promise((r) => setTimeout(r, 1500));
+        return { answer: "answer for the first board", sources: [], citations: [] };
+      },
+    },
+    {
+      list_dashboards: BOARDS,
+      get_dashboard: BOARD_DETAIL,
+      get_dashboard_sources: [{ kind: "note", id: "n-1" }],
+    },
+  );
+
+  await page.goto("/dashboards/b-dense");
+  await openAsk(page);
+  await page.getByRole("textbox", { name: /Ask a question/i }).fill("slow question");
+  await page.getByRole("button", { name: "Ask", exact: true }).click();
+
+  // Leave while it is still running, then come back.
+  await page.goto("/dashboards");
+  await page.goto("/dashboards/b-dense");
+  await openAsk(page);
+
+  // The Ask control is USABLE — not stuck behind a dead request…
+  await page.getByRole("textbox", { name: /Ask a question/i }).fill("a fresh question");
+  await expect(page.getByRole("button", { name: "Ask", exact: true })).toBeEnabled();
+  // …and the previous board's thread did not follow us here.
+  await expect(page.getByText("slow question")).toHaveCount(0);
+  await expect(page.getByText("answer for the first board")).toHaveCount(0);
+});

--- a/e2e/dashboards/dashboards.spec.ts
+++ b/e2e/dashboards/dashboards.spec.ts
@@ -2,6 +2,23 @@ import { expect, test } from "@playwright/test";
 import { mockTauri } from "../settings-ai/mock-invoke";
 
 /**
+ * Open the Ask column. It starts collapsed to a rail — the scope count stays on
+ * screen, the empty transcript does not — so any test that types a question expands
+ * it first, which is the same click a user makes.
+ */
+async function openAsk(page: import("@playwright/test").Page): Promise<void> {
+  // Wait for the panel to EXIST before deciding. A bare `count()` races Angular's
+  // first render and silently no-ops, which then surfaces as a `fill` timeout on a
+  // field that was never revealed.
+  const panel = page.locator("aside.ask");
+  await panel.waitFor();
+  const rail = panel.locator("button.ask-rail");
+  if (await rail.count()) await rail.click();
+  await page.getByRole("textbox", { name: /Ask a question/i }).waitFor();
+}
+
+
+/**
  * Dashboards — the runtime oracle for the boards feature.
  *
  * The load-bearing test here is the SEALED-TILE one: the backend resolves a
@@ -292,11 +309,17 @@ test("Dashboards: board Ask is scoped to the board's sources and cites the tiles
 
   await page.goto("/dashboards/b-atlas");
 
-  // The scope line is explicit about WHAT the answer may draw on, and says out
-  // loud that the sealed tile is excluded.
+  // Collapsed, the rail still carries the count — that readout is the feature's
+  // claim and stays on screen whether or not the transcript is open.
+  await expect(page.getByText("2 in scope")).toBeVisible();
+
+  await openAsk(page);
+  // Expanded, the scope line is explicit about WHAT the answer may draw on, and
+  // says out loud that the sealed tile is excluded.
   await expect(page.getByText(/2 readable sources/)).toBeVisible();
   await expect(page.getByText(/1 sealed tile is excluded until unlocked/)).toBeVisible();
 
+  await openAsk(page);
   await page.getByRole("textbox", { name: "Ask a question about this board" }).fill("Will we make Jun 14?");
   await page.getByRole("button", { name: "Ask", exact: true }).click();
 
@@ -326,6 +349,7 @@ test("Dashboards: an empty board invites the first tile instead of showing a dea
   await expect(page.getByRole("button", { name: "Add the first tile" })).toBeVisible();
 
   // Asking an empty board is honest rather than hallucinating from the vault.
+  await openAsk(page);
   await page.getByRole("textbox", { name: "Ask a question about this board" }).fill("What is going on?");
   await page.getByRole("button", { name: "Ask", exact: true }).click();
   await expect(page.getByText(/no readable sources yet/)).toBeVisible();

--- a/src/app/features/dashboards/board-card/board-card.component.html
+++ b/src/app/features/dashboards/board-card/board-card.component.html
@@ -83,16 +83,33 @@
         <path d="M12 15v5" />
       </svg>
     </button>
+    @if (confirming()) {
+      <button
+        type="button"
+        class="icon-btn confirm-cancel"
+        (click)="cancelRemove($event)"
+        [attr.aria-label]="'Keep ' + board().title"
+      >
+        Keep
+      </button>
+    }
     <button
       type="button"
       class="icon-btn danger"
+      [class.is-confirming]="confirming()"
       (click)="onRemove($event)"
-      [attr.aria-label]="'Delete ' + board().title"
+      [attr.aria-label]="
+        (confirming() ? 'Confirm delete ' : 'Delete ') + board().title
+      "
     >
+      @if (confirming()) {
+        <span class="confirm-word">Delete?</span>
+      } @else {
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"
            stroke-linecap="round" stroke-linejoin="round">
         <path d="M5 7h14M10 7V5h4v2M7 7l1 12h8l1-12" />
       </svg>
+      }
     </button>
   </div>
 </div>

--- a/src/app/features/dashboards/board-card/board-card.component.scss
+++ b/src/app/features/dashboards/board-card/board-card.component.scss
@@ -296,3 +296,25 @@
     color: var(--danger);
   }
 }
+
+// ── delete confirmation ──────────────────────────────────────────────────────
+// Armed, the destructive button says what it will do. Widening it is the point:
+// the second click must not land on muscle memory from the first.
+.icon-btn.is-confirming {
+  width: auto;
+  padding: 0 var(--space-2);
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.confirm-word,
+.confirm-cancel {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.confirm-cancel {
+  width: auto;
+  padding: 0 var(--space-2);
+}

--- a/src/app/features/dashboards/board-card/board-card.component.ts
+++ b/src/app/features/dashboards/board-card/board-card.component.ts
@@ -1,4 +1,11 @@
-import { ChangeDetectionStrategy, Component, computed, input, output } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output,
+  signal,
+} from "@angular/core";
 import type { DashboardSummary, TileKind } from "../../../core/models";
 
 /** One box in the miniature preview — a scaled stand-in for a real tile. */
@@ -94,9 +101,29 @@ export class BoardCardComponent {
     event.stopPropagation();
     this.togglePin.emit();
   }
+  /**
+   * Arm, then fire.
+   *
+   * A board is the one artifact in this feature the user BUILT rather than recorded,
+   * and delete went straight through on a single click with no undo. This is a
+   * two-step in the component rather than `window.confirm`, because a native dialog
+   * blocks the entire webview — the trap `angular-zoneless.md` calls out.
+   */
+  readonly confirming = signal(false);
+
   onRemove(event: Event): void {
     event.stopPropagation();
+    if (!this.confirming()) {
+      this.confirming.set(true);
+      return;
+    }
+    this.confirming.set(false);
     this.remove.emit();
+  }
+
+  cancelRemove(event: Event): void {
+    event.stopPropagation();
+    this.confirming.set(false);
   }
 }
 

--- a/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.scss
+++ b/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.scss
@@ -635,3 +635,20 @@
 
   .btn { margin-left: auto; }
 }
+
+// ── keyboard ─────────────────────────────────────────────────────────────────
+//
+// A tile's rows, numbers and body links are real `<button>`s, but they are
+// background-less by design, so a keyboard user had nothing to follow: the browser
+// ring lands on an element with no box of its own and reads as a stray outline.
+// One shared, token-driven ring on every interactive element in the tile.
+.body-link,
+.row-link,
+.number,
+.tool {
+  &:focus-visible {
+    outline: none;
+    border-radius: var(--radius-sm);
+    box-shadow: 0 0 0 2px var(--accent-ring);
+  }
+}

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
@@ -84,6 +84,7 @@
           [attr.draggable]="editing() ? 'true' : null"
           (dragstart)="onDragStart(tile, $event)"
           (dragover)="onDragOver(tile, $event)"
+          (dragleave)="onDragLeave(tile)"
           (drop)="onDrop(tile, $event)"
           (dragend)="onDragEnd()"
           (remove)="removeTile(tile)"

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
@@ -1,12 +1,39 @@
 <header class="head">
   <div class="head-text">
     <button type="button" class="crumb" (click)="back()">← Dashboards</button>
-    <h1>
-      @if (board()?.emoji; as emoji) {
-        <span class="emoji">{{ emoji }}</span>
-      }
-      {{ board()?.title ?? "Board" }}
-    </h1>
+    @if (renaming()) {
+      <form class="rename" (submit)="commitRename(); $event.preventDefault()">
+        <input
+          #renameField
+          class="rename-field"
+          type="text"
+          [value]="renameDraft()"
+          (input)="onRenameInput($event)"
+          (keydown.escape)="cancelRename()"
+          aria-label="Board name"
+        />
+        <button type="submit" class="btn btn-primary btn-sm" [disabled]="!renameDraft().trim()">
+          Save
+        </button>
+        <button type="button" class="btn btn-ghost btn-sm" (click)="cancelRename()">Cancel</button>
+      </form>
+    } @else {
+      <h1>
+        <!-- The title IS the rename affordance. A board named the wrong thing was
+             permanent: `update` was only ever called with `{pinned}`. -->
+        <button
+          type="button"
+          class="title-edit"
+          (click)="startRename()"
+          [attr.aria-label]="'Rename this board — ' + (board()?.title ?? '')"
+        >
+          @if (board()?.emoji; as emoji) {
+            <span class="emoji">{{ emoji }}</span>
+          }
+          {{ board()?.title ?? "Board" }}
+        </button>
+      </h1>
+    }
   </div>
 
   <button type="button" class="btn btn-ghost" (click)="toggleEditing()">

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
@@ -69,7 +69,27 @@
     }
   </section>
 
-  <aside class="ask" aria-label="Ask this board">
+  <aside class="ask" [class.is-rail]="!askExpanded()" aria-label="Ask this board">
+    @if (!askExpanded()) {
+      <!--
+        Collapsed. The SCOPE COUNT stays on screen because it is the feature's whole
+        claim made visible — this board, and nothing else, is what an answer may come
+        from. An empty transcript is not; it was taking a third of the width to show
+        three suggestion buttons.
+      -->
+      <button
+        type="button"
+        class="ask-rail"
+        (click)="expandAsk()"
+        [attr.aria-label]="'Ask this board — ' + sourceCount() + ' readable sources'"
+      >
+        <mur-icon icon="ask" />
+        <span class="rail-label">
+          Ask this board
+          <span class="rail-count">{{ sourceCount() }} in scope</span>
+        </span>
+      </button>
+    } @else {
     <header class="ask-head">
       <mur-icon icon="ask" />
       <h2>Ask this board</h2>
@@ -132,6 +152,7 @@
         Ask
       </button>
     </form>
+    }
   </aside>
 </div>
 

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.scss
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.scss
@@ -89,14 +89,72 @@
 .ask {
   display: flex;
   flex-direction: column;
-  flex: 0 0 330px;
-  max-width: 330px;
+  flex: 0 0 380px;
+  max-width: 380px;
+  transition: flex-basis var(--transition), max-width var(--transition);
   min-height: 0;
   overflow: hidden;
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   background: var(--surface-raised);
   backdrop-filter: blur(18px) saturate(140%);
+}
+
+// Collapsed: a 44px rail that still carries the scope count.
+.ask.is-rail {
+  flex: 0 0 44px;
+  max-width: 44px;
+  background: var(--surface-input);
+  backdrop-filter: none;
+}
+
+.ask-rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  height: 100%;
+  padding: var(--space-3) 0;
+  border: 0;
+  background: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: color var(--transition-fast);
+
+  &:hover,
+  &:focus-visible {
+    color: var(--text-primary);
+  }
+
+  mur-icon {
+    flex: none;
+    width: 18px;
+    height: 18px;
+  }
+}
+
+// The label reads bottom-to-top up the rail, so the count stays legible in 44px.
+.rail-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  font-size: 0.6875rem;
+  line-height: 1.35;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.rail-count {
+  color: var(--text-tertiary);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ask {
+    transition: none;
+  }
 }
 
 .ask-head {
@@ -247,13 +305,7 @@
 
 // Narrow windows: the Ask column drops under the canvas rather than squeezing it.
 @media (max-width: 1080px) {
-  .arrange-hint {
-  color: var(--text-muted);
-  font-size: 0.72rem;
-  white-space: nowrap;
-}
-
-.board {
+  .board {
     flex-direction: column;
   }
 

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.scss
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.scss
@@ -315,3 +315,46 @@
     max-height: 420px;
   }
 }
+
+// ── rename ───────────────────────────────────────────────────────────────────
+// The title doubles as the rename control, so it must look like a heading until
+// hovered — a button that shouts is chrome the header does not need.
+.title-edit {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 2px var(--space-2);
+  margin-left: calc(var(--space-2) * -1);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: text;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+
+  &:hover,
+  &:focus-visible {
+    border-color: var(--border-subtle);
+    background: var(--surface-input);
+  }
+}
+
+.rename {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.rename-field {
+  min-width: 260px;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--surface-input);
+  color: var(--text-primary);
+  font-size: 1.05rem;
+  font-weight: 640;
+}

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
@@ -233,6 +233,23 @@ export class DashboardViewComponent {
 
   // ── board Ask ──────────────────────────────────────────────────────────────
   readonly turns = signal<BoardTurn[]>([]);
+
+  /**
+   * Whether the Ask column is open, versus collapsed to its rail.
+   *
+   * Opens on demand and STAYS open once there is a conversation — a thread the user
+   * can no longer see is worse than a wide column. The rail keeps the scope count on
+   * screen either way, because that readout is the feature's actual claim: this board,
+   * and nothing else, is what an answer may be built from. The empty transcript has no
+   * such claim to make, and it was spending a third of the width on three suggestion
+   * buttons.
+   */
+  private readonly _askOpen = signal(false);
+  readonly askExpanded = computed(() => this._askOpen() || this.turns().length > 0);
+
+  expandAsk(): void {
+    this._askOpen.set(true);
+  }
   readonly asking = signal(false);
   readonly draft = signal("");
   readonly sourceCount = signal(0);

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
@@ -208,6 +208,19 @@ export class DashboardViewComponent {
     if (this.dropTargetId() !== tile.id) this.dropTargetId.set(tile.id);
   }
 
+  /**
+   * Clear the highlight when the pointer leaves this tile.
+   *
+   * `dragover` only ever SETS a target, so dragging off the grid entirely left the
+   * last-hovered tile lit as a drop target that no longer existed. Guarded on identity
+   * because `dragleave` also fires when the pointer crosses into a CHILD element —
+   * clearing unconditionally would flicker the highlight off and on across every row
+   * inside the tile you are actually hovering.
+   */
+  onDragLeave(tile: ResolvedTile): void {
+    if (this.dropTargetId() === tile.id) this.dropTargetId.set(null);
+  }
+
   onDragEnd(): void {
     this.draggingId.set(null);
     this.dropTargetId.set(null);

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
@@ -252,6 +252,28 @@ export class DashboardViewComponent {
   // ── board Ask ──────────────────────────────────────────────────────────────
   readonly turns = signal<BoardTurn[]>([]);
 
+  /** Monotonic ask token — the per-REQUEST half of the stale-async guard. */
+  private askToken = 0;
+
+  /**
+   * Switching boards starts a new conversation.
+   *
+   * `/dashboards/:id` reuses this component across board→board navigation, so without
+   * this the thread — including the user turn `ask()` appends synchronously before its
+   * first await — follows the user onto a board it was never about. Bumping the token
+   * in the same pass orphans any in-flight request's data writes while still letting
+   * it clear the spinner it set.
+   */
+  private readonly _resetOnBoardChange = effect(() => {
+    this.id();
+    untracked(() => {
+      this.askToken += 1;
+      this.turns.set([]);
+      this.draft.set("");
+      this.asking.set(false);
+    });
+  });
+
   // ── rename ────────────────────────────────────────────────────────────────
   //
   // The board's name was write-once: `DashboardsService.update` shipped accepting
@@ -441,8 +463,20 @@ export class DashboardViewComponent {
     this.draft.set("");
     this.turns.update((t) => [...t, { role: "user", text: question }]);
     this.asking.set(true);
+    // TWO different questions, and conflating them is a bug of its own.
+    //
+    // `owns()` guards DATA writes: an answer, an error, a source count belong to the
+    // board AND the request that asked for them. `current()` guards the BUSY flag,
+    // which is per-request only — gating the spinner on the board too means that after
+    // navigating away mid-flight nothing ever clears it, and the NEW board sits
+    // disabled forever waiting on a request that was never its own.
+    const boardId = this.id();
+    const token = ++this.askToken;
+    const current = () => this.askToken === token;
+    const owns = () => current() && this.id() === boardId;
     try {
-      const sources = await this.ipc.getDashboardSources(this.id());
+      const sources = await this.ipc.getDashboardSources(boardId);
+      if (!owns()) return;
       this.sourceCount.set(sources.length);
       if (sources.length === 0) {
         this.turns.update((t) => [
@@ -455,6 +489,8 @@ export class DashboardViewComponent {
         return;
       }
       const result = await this.ipc.askVault(question, this.askHistory(), undefined, sources);
+      // The answer belongs to the board — and the request — that asked for it.
+      if (!owns()) return;
       this.turns.update((t) => [
         ...t,
         {
@@ -464,12 +500,15 @@ export class DashboardViewComponent {
         },
       ]);
     } catch (e) {
+      if (!owns()) return;
       this.turns.update((t) => [
         ...t,
         { role: "error", text: this.errors.humanize(e, "generic"), retry: question },
       ]);
     } finally {
-      this.asking.set(false);
+      // The LATEST request clears the spinner, whichever board is on screen now. A
+      // superseded ask must not; a navigated-away one still must, or it never comes up.
+      if (current()) this.asking.set(false);
     }
   }
 

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
@@ -2,16 +2,21 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
+  ElementRef,
   computed,
   effect,
   inject,
   signal,
   untracked,
+  viewChild,
 } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, Router } from "@angular/router";
 import { IpcService } from "../../../core/ipc.service";
-import { DashboardsService } from "../../../services/dashboards.service";
+import {
+  DashboardsService,
+  splitLeadingEmoji,
+} from "../../../services/dashboards.service";
 import { MurEmptyStateComponent } from "../../../design-system/empty-state/empty-state.component";
 import { MurIconComponent } from "../../../design-system/icon/icon.component";
 import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
@@ -233,6 +238,47 @@ export class DashboardViewComponent {
 
   // ── board Ask ──────────────────────────────────────────────────────────────
   readonly turns = signal<BoardTurn[]>([]);
+
+  // ── rename ────────────────────────────────────────────────────────────────
+  //
+  // The board's name was write-once: `DashboardsService.update` shipped accepting
+  // `title`/`emoji`/`tint`, and the only caller ever passed `{pinned}`. A board named
+  // the wrong thing stayed named the wrong thing.
+  readonly renaming = signal(false);
+  readonly renameDraft = signal("");
+  private readonly renameField =
+    viewChild<ElementRef<HTMLInputElement>>("renameField");
+  private readonly _focusRename = effect(() => {
+    this.renameField()?.nativeElement.select();
+  });
+
+  startRename(): void {
+    const b = this.board();
+    if (!b) return;
+    // Round-trips through the same convention `create` uses, so renaming is also how
+    // you add or change the emoji: "🚀 Atlas GA".
+    this.renameDraft.set(b.emoji ? `${b.emoji} ${b.title}` : b.title);
+    this.renaming.set(true);
+  }
+
+  onRenameInput(event: Event): void {
+    this.renameDraft.set((event.target as HTMLInputElement).value);
+  }
+
+  cancelRename(): void {
+    this.renaming.set(false);
+  }
+
+  async commitRename(): Promise<void> {
+    const typed = this.renameDraft().trim();
+    const b = this.board();
+    if (!typed || !b) return;
+    this.renaming.set(false);
+    const { emoji, title } = splitLeadingEmoji(typed);
+    if (title === b.title && (emoji ?? null) === (b.emoji ?? null)) return;
+    // `emoji: ""` clears it — dropping the field would leave the old one in place.
+    await this.service.update(b.id, { title, emoji: emoji ?? "" });
+  }
 
   /**
    * Whether the Ask column is open, versus collapsed to its rail.

--- a/src/app/features/dashboards/dashboards-home/dashboards-home.component.ts
+++ b/src/app/features/dashboards/dashboards-home/dashboards-home.component.ts
@@ -12,7 +12,10 @@ import {
   viewChild,
 } from "@angular/core";
 import { Router } from "@angular/router";
-import { DashboardsService } from "../../../services/dashboards.service";
+import {
+  DashboardsService,
+  splitLeadingEmoji,
+} from "../../../services/dashboards.service";
 import { MurEmptyStateComponent } from "../../../design-system/empty-state/empty-state.component";
 import { MurIconComponent } from "../../../design-system/icon/icon.component";
 import { BoardCardComponent } from "../board-card/board-card.component";
@@ -89,10 +92,12 @@ export class DashboardsHomeComponent {
   }
 
   async createBoard(): Promise<void> {
-    const title = this.draftTitle().trim();
-    if (!title || this.busy()) return;
+    const typed = this.draftTitle().trim();
+    if (!typed || this.busy()) return;
     this.busy.set(true);
-    const created = await this.service.create(title);
+    // "🚀 Atlas GA" names the board AND gives it its emoji — see `splitLeadingEmoji`.
+    const { emoji, title } = splitLeadingEmoji(typed);
+    const created = await this.service.create(title, emoji);
     this.busy.set(false);
     this.composing.set(false);
     if (created) void this.router.navigate(["/dashboards", created.id]);

--- a/src/app/services/dashboards.service.ts
+++ b/src/app/services/dashboards.service.ts
@@ -10,6 +10,30 @@ import type {
 } from "../core/models";
 
 /**
+ * Split a leading emoji off a board name: `"🚀 Atlas GA"` → `{emoji: "🚀", title: "Atlas GA"}`.
+ *
+ * The `emoji` column, `TINTS`, and `board-card`'s emoji slot all shipped with the
+ * feature and nothing ever WROTE them — `create(title)` and `update({pinned})` were
+ * the only callers, so six SCSS tint mappings and a whole DTO field were dead. This
+ * is the cheapest way to make them live: no picker, no extra chrome, and it matches
+ * how people already name things.
+ *
+ * The class is `Extended_Pictographic` with its combining tail — variation selectors,
+ * skin-tone modifiers, and ZWJ sequences — so `"👨‍👩‍👧 Family"` yields the whole
+ * cluster rather than a lone man. A name with no leading emoji is returned unchanged,
+ * and an emoji with nothing after it stays part of the TITLE (a board called "🚀" is
+ * a board named "🚀", not a nameless board with a picture).
+ */
+export function splitLeadingEmoji(raw: string): { emoji?: string; title: string } {
+  const m =
+    /^(\p{Extended_Pictographic}(?:\uFE0F|[\u{1F3FB}-\u{1F3FF}]|\u200D\p{Extended_Pictographic}|\uFE0F)*)\s+(\S.*)$/u.exec(
+      raw.trim(),
+    );
+  if (!m) return { title: raw.trim() };
+  return { emoji: m[1], title: m[2].trim() };
+}
+
+/**
  * Root signal store for the Dashboards section.
  *
  * `providedIn: "root"` is load-bearing, not incidental: `/dashboards` is a LIST


### PR DESCRIPTION
Phase 8 of the dashboards rebuild
(`docs/superpowers/specs/2026-08-04-dashboards-rebuild-design.md`), after #568 and
#569. Five changes, each with a regression that fails on the parent.

## The Ask column becomes a rail

It held `flex: 0 0 330px` permanently — on a board nobody had asked anything about,
a third of the width showed three suggestion buttons and an empty transcript. It now
starts as a **44px rail** and expands on demand, staying open once there is a
conversation.

**What stays visible is the point.** The rail keeps the source count (`7 in scope`),
because that readout is the feature's claim made visible: *this board, and nothing
else, is what an answer may be built from*. The empty transcript makes no such claim.
The citation spec now asserts the count in **both** states.

## A board can be renamed, and gets an emoji

`DashboardsService.update` shipped accepting `title`/`emoji`/`tint` and the only
caller ever passed `{pinned}` — so a board named the wrong thing stayed that way, and
the `emoji` column, `board-card`'s emoji slot and six `TINTS` mappings were dead code
from day one.

The title in the header IS the affordance. `splitLeadingEmoji` takes the leading
emoji off the typed name — "🚀 Atlas GA" — so there is no picker and no new chrome.
Three edge cases are deliberate and pinned: the class is `Extended_Pictographic`
*with* its combining tail, so `"👨‍👩‍👧 Family"` keeps the whole ZWJ cluster (a naive
`[...name][0]` returns a lone man); an emoji with nothing after it stays part of the
TITLE; and rename sends `emoji: ""` rather than omitting the field, or the picture
could never be removed once set.

## Deleting a board takes two clicks

A board is the one artifact here the user BUILT rather than recorded — everything
else can be re-derived from the vault. It vanished on a single click of a small icon
next to the pin toggle, with no undo. Armed, the button says "Delete?" and widens so
the second click cannot land on muscle memory; a "Keep" escape appears beside it.
**Not `window.confirm`** — a native dialog blocks the whole webview, the trap
`angular-zoneless.md` calls out.

## Keyboard and drag affordances

A tile's rows, numbers and body links are real `<button>`s but background-less, so
the default focus ring read as a stray outline rather than a position. One shared
token-driven ring. And `dragover` only ever SET the drop target — dragging off the
grid left the last-hovered tile lit as a target that no longer existed. `dragleave`
is guarded on identity, because it also fires when the pointer enters a CHILD, and an
unconditional clear would flicker across every row inside the tile you are hovering.

## Board-scoped Ask cannot answer for the board you left

`ask()` re-read `this.id()` after an await, so navigating mid-flight applied an
answer — and its source count — to whichever board was on screen. The user turn is
appended synchronously, so it followed you too.

Two guards, deliberately separate: `owns()` for data writes (board + request),
`current()` for the busy flag (request only). A single combined guard leaves the NEXT
board stuck busy forever, because nothing clears a spinner set by a request that no
longer owns the board.

Found while wiring the board id through `ask()` for `board-brief`; split out of that
branch when review pointed out — correctly — that a lock-touching change should carry
the minimum.

## Gates

`ng lint` clean, `ng build` clean, **506 passed / 2 skipped across Chromium AND
WebKit**. No Rust touched.

**Not proven headlessly:** the packaged WKWebView render of the vertical
`writing-mode` rail label (rule T4).

## Note on CI

The rust lane flaked twice on this branch and on #568 — different tests each time
(`codex_cli::availability_version_probe…`, `state::tests::reconcile_reseals_stray_master_plaintext_for_locked_meeting`),
both on diffs containing **zero** `src-tauri` files, both green on rerun. Worth a
look under load rather than repeated reruns: the second guards a lock-model path.
