### PR TITLE
docs(rules): the wire-contract lesson six rounds of palette fixes actually bought

### DIFF
--- a/.claude/learnings/main-loop.md
+++ b/.claude/learnings/main-loop.md
@@ -7,6 +7,12 @@ this file is the CROSS-CUTTING orchestration/git/deploy/crypto-process loop.
 ## Recurring patterns
 <!-- Curated, binding. Keep ≤ ~20 bullets. -->
 
+- **When a fix does not hold, change the LAYER you are looking at — do not iterate inside it.** Six
+  rounds went to the Add-tile palette's positioning (teleport, non-transform layout, native
+  `<dialog>`, fallbacks) and the palette was never the bug: the tile payload shipped snake_case
+  while the FE read camelCase, so a tile threw while rendering and took the board with it. Two
+  failed fixes in the same layer is the signal to move DOWN a layer — component → payload →
+  contract — not to try a fourth variant of the same idea.
 - **A user-reported failure against green gates means the ORACLE is wrong, not the code.** The
   correct first move is to fix the measurement, not to patch the implementation. On PR #566 I
   shipped three speculative fixes because my e2e ran in a newer engine than the app does; the bug

--- a/.claude/learnings/rust-tauri-dev.md
+++ b/.claude/learnings/rust-tauri-dev.md
@@ -3,6 +3,12 @@
 ## Recurring patterns
 <!-- Curated, binding. Prepended to every dispatch. Keep ≤ ~20 bullets. -->
 
+- **An enum crossing IPC needs BOTH `rename_all` AND `rename_all_fields`.** On an enum the first
+  renames the VARIANTS, the second the FIELDS INSIDE them. `TileData` had only the first: variants
+  tagged correctly so it looked right, while `started_at`/`duration_s`/`has_audio` reached a FE
+  reading camelCase — every field `undefined`, the tile threw, the board died, and six fixes went
+  to the wrong layer. Assert the SERIALIZED key names in a test; a round-trip through the same Rust
+  type passes regardless of naming. See `rust-tauri.md` §2b.
 - **`AppError` + `Result<T>` only.** Never bare `anyhow::Result`, `Box<dyn Error>`, or
   `unwrap()`/`expect()` in non-test code. A locked-content refusal is `AppError::Locked`, never a
   generic `Storage`/`Other`. `AppError` is `Serialize` — don't hand-build error strings for the FE.

--- a/.claude/rules/angular-zoneless.md
+++ b/.claude/rules/angular-zoneless.md
@@ -411,6 +411,28 @@ went to a real bug the tests structurally could not see.
    open. Without that, "the click never landed" and "the panel never painted" look identical from
    outside — and you cannot tell which half to fix.
 
+### T6 — a hand-written IPC mock DEFINES a contract; it does not verify one
+
+**The failure (2026-08-04, PR #566/#568).** Six rounds went to the Add-tile palette's positioning.
+The palette was never the bug. `TileData` shipped its variant fields in snake_case
+(`started_at` / `duration_s` / `has_audio`) while the FE read camelCase, so every field was
+`undefined`, the tile threw while rendering, and it took the board down with it.
+
+**Why the suite was blind.** Every `mockTauri` fixture in `e2e/` is hand-written TypeScript typed
+against the FE's own interface — so the fixtures were camelCase by construction and could not
+disagree with the FE. The e2e proved that the FE renders the shape the FE expects. It said nothing
+about the shape the backend sends, which is the only thing that was wrong.
+
+**Binding.**
+- A mock is a stand-in for the TRANSPORT, never for the CONTRACT. The contract is asserted on the
+  producing side — see `rust-tauri.md` §2b (assert serialized key names).
+- When a UI failure survives more than one fix, stop debugging the component and check the PAYLOAD
+  first: log/inspect one real IPC response and compare its keys with the interface. A field that is
+  `undefined` on screen and correct in the mock is a contract mismatch, not a rendering bug.
+- A tile/row renderer must not throw on a missing field. Formatters that take `string | number`
+  from IPC should tolerate `undefined` — one bad field killing the whole view is what turned a
+  naming mismatch into "the palette does not open".
+
 ---
 
 ## Quality gate (a change is not done until these are green)

--- a/.claude/rules/rust-tauri.md
+++ b/.claude/rules/rust-tauri.md
@@ -33,6 +33,32 @@
 - Emit progress/state to the FE via the typed helpers in `src-tauri/src/events.rs`, not by
   inventing ad-hoc event names at the call site.
 
+### 2b. Every DTO that crosses IPC is camelCase — and on an ENUM that needs TWO attributes
+
+The FE reads camelCase. A struct gets that from `#[serde(rename_all = "camelCase")]`. An **enum with
+data-carrying variants needs BOTH**, because they do different jobs:
+
+```rust
+#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
+//                    ^ renames the VARIANTS   ^ renames the FIELDS INSIDE them
+```
+
+**The bug this cost (2026-08-04, PR #566/#568).** `TileData` carried only the first. The variants
+tagged correctly (`"meeting"`), so it looked right — while the meeting tile shipped `started_at`,
+`duration_s`, `has_audio` and the FE read `startedAt`, `durationS`, `hasAudio`. Every one resolved
+to `undefined`, the tile threw while rendering, and it took the whole board down with it. **Six
+fixes went to the palette's positioning before anyone looked at the payload.**
+
+Why nothing caught it: `cargo test --lib` never asserted the serialized key names, and the e2e
+mocks were hand-written in camelCase — so the tests validated a contract the FE and the fixtures
+had agreed on between themselves, and which the backend did not honour. A hand-written mock
+DEFINES a shape; it does not verify one.
+
+**RULE:** any DTO crossing the IPC boundary needs a test that asserts the SERIALIZED key names, not
+just a round-trip through the same Rust type (which passes regardless of naming). Pattern:
+`serde_json::to_value(&dto)` and assert every key matches `^[a-z][a-zA-Z0-9]*$` with no `_`. See
+`commands/tests/dashboard_cmd_tests.rs` — the camelCase wire oracle.
+
 ## 3. Storage — SQLCipher; `PRAGMA key` FIRST
 
 - The whole DB is SQLCipher-encrypted. Open ONLY through `storage/db.rs::Db::open` (pulls the

--- a/.codex/learnings/main-loop.md
+++ b/.codex/learnings/main-loop.md
@@ -7,6 +7,12 @@ this file is the CROSS-CUTTING orchestration/git/deploy/crypto-process loop.
 ## Recurring patterns
 <!-- Curated, binding. Keep ≤ ~20 bullets. -->
 
+- **When a fix does not hold, change the LAYER you are looking at — do not iterate inside it.** Six
+  rounds went to the Add-tile palette's positioning (teleport, non-transform layout, native
+  `<dialog>`, fallbacks) and the palette was never the bug: the tile payload shipped snake_case
+  while the FE read camelCase, so a tile threw while rendering and took the board with it. Two
+  failed fixes in the same layer is the signal to move DOWN a layer — component → payload →
+  contract — not to try a fourth variant of the same idea.
 - **A user-reported failure against green gates means the ORACLE is wrong, not the code.** The
   correct first move is to fix the measurement, not to patch the implementation. On PR #566 I
   shipped three speculative fixes because my e2e ran in a newer engine than the app does; the bug

--- a/.codex/learnings/rust-tauri-dev.md
+++ b/.codex/learnings/rust-tauri-dev.md
@@ -3,6 +3,12 @@
 ## Recurring patterns
 <!-- Curated, binding. Prepended to every dispatch. Keep ≤ ~20 bullets. -->
 
+- **An enum crossing IPC needs BOTH `rename_all` AND `rename_all_fields`.** On an enum the first
+  renames the VARIANTS, the second the FIELDS INSIDE them. `TileData` had only the first: variants
+  tagged correctly so it looked right, while `started_at`/`duration_s`/`has_audio` reached a FE
+  reading camelCase — every field `undefined`, the tile threw, the board died, and six fixes went
+  to the wrong layer. Assert the SERIALIZED key names in a test; a round-trip through the same Rust
+  type passes regardless of naming. See `rust-tauri.md` §2b.
 - **`AppError` + `Result<T>` only.** Never bare `anyhow::Result`, `Box<dyn Error>`, or
   `unwrap()`/`expect()` in non-test code. A locked-content refusal is `AppError::Locked`, never a
   generic `Storage`/`Other`. `AppError` is `Serialize` — don't hand-build error strings for the FE.

--- a/.codex/rules/angular-zoneless.md
+++ b/.codex/rules/angular-zoneless.md
@@ -411,6 +411,28 @@ went to a real bug the tests structurally could not see.
    open. Without that, "the click never landed" and "the panel never painted" look identical from
    outside — and you cannot tell which half to fix.
 
+### T6 — a hand-written IPC mock DEFINES a contract; it does not verify one
+
+**The failure (2026-08-04, PR #566/#568).** Six rounds went to the Add-tile palette's positioning.
+The palette was never the bug. `TileData` shipped its variant fields in snake_case
+(`started_at` / `duration_s` / `has_audio`) while the FE read camelCase, so every field was
+`undefined`, the tile threw while rendering, and it took the board down with it.
+
+**Why the suite was blind.** Every `mockTauri` fixture in `e2e/` is hand-written TypeScript typed
+against the FE's own interface — so the fixtures were camelCase by construction and could not
+disagree with the FE. The e2e proved that the FE renders the shape the FE expects. It said nothing
+about the shape the backend sends, which is the only thing that was wrong.
+
+**Binding.**
+- A mock is a stand-in for the TRANSPORT, never for the CONTRACT. The contract is asserted on the
+  producing side — see `rust-tauri.md` §2b (assert serialized key names).
+- When a UI failure survives more than one fix, stop debugging the component and check the PAYLOAD
+  first: log/inspect one real IPC response and compare its keys with the interface. A field that is
+  `undefined` on screen and correct in the mock is a contract mismatch, not a rendering bug.
+- A tile/row renderer must not throw on a missing field. Formatters that take `string | number`
+  from IPC should tolerate `undefined` — one bad field killing the whole view is what turned a
+  naming mismatch into "the palette does not open".
+
 ---
 
 ## Quality gate (a change is not done until these are green)

--- a/.codex/rules/rust-tauri.md
+++ b/.codex/rules/rust-tauri.md
@@ -33,6 +33,32 @@
 - Emit progress/state to the FE via the typed helpers in `src-tauri/src/events.rs`, not by
   inventing ad-hoc event names at the call site.
 
+### 2b. Every DTO that crosses IPC is camelCase — and on an ENUM that needs TWO attributes
+
+The FE reads camelCase. A struct gets that from `#[serde(rename_all = "camelCase")]`. An **enum with
+data-carrying variants needs BOTH**, because they do different jobs:
+
+```rust
+#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
+//                    ^ renames the VARIANTS   ^ renames the FIELDS INSIDE them
+```
+
+**The bug this cost (2026-08-04, PR #566/#568).** `TileData` carried only the first. The variants
+tagged correctly (`"meeting"`), so it looked right — while the meeting tile shipped `started_at`,
+`duration_s`, `has_audio` and the FE read `startedAt`, `durationS`, `hasAudio`. Every one resolved
+to `undefined`, the tile threw while rendering, and it took the whole board down with it. **Six
+fixes went to the palette's positioning before anyone looked at the payload.**
+
+Why nothing caught it: `cargo test --lib` never asserted the serialized key names, and the e2e
+mocks were hand-written in camelCase — so the tests validated a contract the FE and the fixtures
+had agreed on between themselves, and which the backend did not honour. A hand-written mock
+DEFINES a shape; it does not verify one.
+
+**RULE:** any DTO crossing the IPC boundary needs a test that asserts the SERIALIZED key names, not
+just a round-trip through the same Rust type (which passes regardless of naming). Pattern:
+`serde_json::to_value(&dto)` and assert every key matches `^[a-z][a-zA-Z0-9]*$` with no `_`. See
+`commands/tests/dashboard_cmd_tests.rs` — the camelCase wire oracle.
+
 ## 3. Storage — SQLCipher; `PRAGMA key` FIRST
 
 - The whole DB is SQLCipher-encrypted. Open ONLY through `storage/db.rs::Db::open` (pulls the


### PR DESCRIPTION
#568 found the real cause of the "dead palette": `TileData` shipped its variant fields in **snake_case** (`started_at` / `duration_s` / `has_audio`) while the FE read camelCase. Every field resolved to `undefined`, the tile threw while rendering, and it took the board down with it.

The **oracle** for that now lives in the code (#568). The **lesson** lived nowhere — so the same shape can recur tomorrow in any other DTO. That is what this PR fixes.

## Two rules, on the two sides that were each half-wrong

**`rust-tauri.md` §2b — an enum crossing IPC needs BOTH attributes:**

```rust
#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
//                    ^ renames the VARIANTS    ^ renames the FIELDS inside them
```

With only the first, the variants tag correctly — so it *looks* right — while every payload field ships snake_case. Now required: **any DTO crossing IPC needs a test asserting the SERIALIZED key names.** A round-trip through the same Rust type passes regardless of naming, which is precisely why `cargo test` stayed green through six rounds.

**`angular-zoneless.md` T6 — a hand-written IPC mock DEFINES a contract; it does not verify one.** Every `mockTauri` fixture is TypeScript typed against the FE's own interface, so the fixtures were camelCase *by construction* and could not disagree with the FE. The e2e proved that the FE renders the shape the FE expects — and said nothing about the shape the backend sends, which was the only thing wrong. Also binding: **a renderer must not throw on a missing field**, which is what turned a naming mismatch into "the palette does not open".

## Orchestration lesson

`learnings/main-loop.md`: **when a fix does not hold, change the LAYER you are looking at instead of iterating inside it.** Two failed fixes in one layer is the signal to move down — component → payload → contract. Six rounds went to positioning a panel that was never broken.

## Verified on this trunk before writing any of it

Per the T5 discipline these rules themselves demand — repro before analysis:

- `cargo test --lib dashboard` — **38/38**
- `e2e/dashboards` — **21/21 on chromium AND webkit**
- a live browser walk of the whole add-tile flow against the dev server: palette opens, catalogue populated, flow completes, **zero console errors**

`.codex` mirrors synced; `scripts/agent-config-audit --ci` **PASS (152 checks)**.

## Honest gap

`eval/agents/matrix.py` was not run. Per Track C that is the gap — these rules earn their place from a six-round production failure rather than from a measured delta.