### PR TITLE
fix(state): give the reconcile tests a directory they own

### DIFF
--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -782,6 +782,20 @@ mod tests {
         p
     }
 
+    /// A private DIRECTORY for a test that writes locked-audio fixtures.
+    ///
+    /// `repair_and_finalize_locked_at_rest` scans the PARENT of each locked audio path and refuses
+    /// any staging artifact it cannot account for. With fixtures written straight into
+    /// `std::env::temp_dir()`, that parent is the shared temp root, so a concurrently-running test's
+    /// artifact fails this one — intermittently, and with whichever test happens to lose the race.
+    /// Owning the directory is what makes the scan see only this test's own files.
+    fn tmp_audio_dir(tag: &str) -> PathBuf {
+        let dir = crate::storage::db::unique_temp_path(&format!("murmur-state-{tag}-dir"), "d");
+        let _ = std::fs::remove_file(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
     /// Build a real SQLCipher-encrypted DB (keyed with `GOOD_KEY`) by seeding a plaintext DB and
     /// running the production encrypt-in-place path.
     fn seed_encrypted_db(path: &std::path::Path) {
@@ -1178,7 +1192,11 @@ mod tests {
         mark_folder_locked_recoverable(&db, "f1");
 
         // Sibling files derived from the unique db path so concurrent test runs never collide.
-        let base = p.to_string_lossy().to_string();
+        // Fixtures live in a directory this test OWNS — see `tmp_audio_dir`.
+        let base = tmp_audio_dir("reconcile")
+            .join("audio")
+            .to_string_lossy()
+            .to_string();
         let mic_plain = format!("{base}.m1.mic.wav");
         let mic_enc = format!("{base}.m1.mic.wav.enc");
         let sys_plain = format!("{base}.m1.sys.wav");
@@ -1291,7 +1309,11 @@ mod tests {
         .unwrap();
         db.seal_note("m1", "claude_code", &note_blob).unwrap();
 
-        let base = p.to_string_lossy().to_string();
+        // Fixtures live in a directory this test OWNS — see `tmp_audio_dir`.
+        let base = tmp_audio_dir("reconcile")
+            .join("audio")
+            .to_string_lossy()
+            .to_string();
         let mic_enc = format!("{base}.m1.mic.wav.enc");
         let mic_source = format!("{base}.m1.mic.source.wav");
         std::fs::write(&mic_source, b"MIC-MASTER").unwrap();


### PR DESCRIPTION
fix(state): give the reconcile tests a directory they own

CI failed twice on an unrelated diff (a package-lock bump), with a DIFFERENT
victim each time: first `reconcile_reseals_stray_master_plaintext_for_locked_
meeting`, then `reconcile_leaves_already_sealed_masters_untouched` while the
first one passed. Both died on the same error —
`Storage("audio crypto staging artifact has no matching locked-audio target")`.

`repair_and_finalize_locked_at_rest` scans the PARENT of every locked audio path
and hard-errors on a staging artifact whose target it cannot account for. That
strictness is correct and stays: an unexplained `.<target><MARKER><uuid>.part`
beside locked audio is crash residue that must never be silently deleted.

The defect is that these two tests wrote their fixtures straight into
`std::env::temp_dir()`, so the scanned parent was the SHARED TEMP ROOT of the
whole machine. `cargo nextest` runs tests in parallel, so one test's staging
artifact failed the other — intermittently, and with whichever test lost the
race. Production is unaffected: masters live in the app's audio directory.

Test-only change. Each test now roots its fixtures in a directory returned by the
new `tmp_audio_dir`, so the scan sees only its own files.

RED-checked by making the race deterministic instead of waiting to be unlucky: a
foreign `.part` artifact planted in the shared temp root fails BOTH tests on the
old layout with the exact CI error, and neither on the new one with the same
artifact still present.

`cargo test --lib`: 2733 passed.
