### PR TITLE
feat(scripts): wkwebview-probe — run JS in the engine we actually ship

### DIFF
--- a/.claude/learnings/main-loop.md
+++ b/.claude/learnings/main-loop.md
@@ -7,6 +7,12 @@ this file is the CROSS-CUTTING orchestration/git/deploy/crypto-process loop.
 ## Recurring patterns
 <!-- Curated, binding. Keep ≤ ~20 bullets. -->
 
+- **A hypothesis you cannot falsify is not a diagnosis — build the instrument first.** Three of six
+  palette fixes rested on "`:modal` throws in the shipping WKWebView". Nobody could check, because
+  nothing here could run JS in that engine. `scripts/wkwebview-probe` now can, and the first thing
+  it did was DISPROVE that hypothesis in ten seconds (`:modal` does not throw; the cause was the
+  wire contract). When a report will not reproduce in your tools, the next move is to get a tool
+  that can see it — not a fourth variant of the same guess.
 - **When a fix does not hold, change the LAYER you are looking at — do not iterate inside it.** Six
   rounds went to the Add-tile palette's positioning (teleport, non-transform layout, native
   `<dialog>`, fallbacks) and the palette was never the bug: the tile payload shipped snake_case

--- a/.claude/rules/angular-zoneless.md
+++ b/.claude/rules/angular-zoneless.md
@@ -411,6 +411,31 @@ went to a real bug the tests structurally could not see.
    open. Without that, "the click never landed" and "the panel never painted" look identical from
    outside — and you cannot tell which half to fix.
 
+**CORRECTION (2026-08-05, measured with `scripts/wkwebview-probe`).** The diagnosis above was
+WRONG, and it is left standing only so the correction is legible. `:modal` was never the cause.
+Executing JS inside the real shipping WKWebView returns:
+
+    matches(":modal") threw: null      // it does not throw
+    showModal() threw:     null        // it is not refused
+    :modal after showModal: true       // it works correctly
+
+The actual cause was the wire contract — snake_case payload fields against a camelCase FE (T6
+below), found by inspecting the payload rather than the component. Three of the six fixes were
+built on a hypothesis nobody could falsify, because until now nothing in this repo could run a
+line of JavaScript in the engine we ship.
+
+**The discipline in T5 stands; only its example was false.** Reproduce first. Get a RED check. Do
+not depend on an API you have not verified *in the shipping engine* — and now you can:
+
+```bash
+swiftc -O -o /tmp/wkprobe scripts/wkwebview-probe/main.swift
+/tmp/wkprobe --url http://localhost:1420/ --eval 'return CSS.supports("color","color-mix(in srgb, red, blue)")'
+```
+
+No accessibility grant, no signing, no GUI. When a UI failure will not reproduce in Playwright,
+that is the tool that tells you whether the engine is actually the difference — in seconds, instead
+of three speculative rounds.
+
 ### T6 — a hand-written IPC mock DEFINES a contract; it does not verify one
 
 **The failure (2026-08-04, PR #566/#568).** Six rounds went to the Add-tile palette's positioning.

--- a/.codex/learnings/main-loop.md
+++ b/.codex/learnings/main-loop.md
@@ -7,6 +7,12 @@ this file is the CROSS-CUTTING orchestration/git/deploy/crypto-process loop.
 ## Recurring patterns
 <!-- Curated, binding. Keep ≤ ~20 bullets. -->
 
+- **A hypothesis you cannot falsify is not a diagnosis — build the instrument first.** Three of six
+  palette fixes rested on "`:modal` throws in the shipping WKWebView". Nobody could check, because
+  nothing here could run JS in that engine. `scripts/wkwebview-probe` now can, and the first thing
+  it did was DISPROVE that hypothesis in ten seconds (`:modal` does not throw; the cause was the
+  wire contract). When a report will not reproduce in your tools, the next move is to get a tool
+  that can see it — not a fourth variant of the same guess.
 - **When a fix does not hold, change the LAYER you are looking at — do not iterate inside it.** Six
   rounds went to the Add-tile palette's positioning (teleport, non-transform layout, native
   `<dialog>`, fallbacks) and the palette was never the bug: the tile payload shipped snake_case

--- a/.codex/rules/angular-zoneless.md
+++ b/.codex/rules/angular-zoneless.md
@@ -411,6 +411,31 @@ went to a real bug the tests structurally could not see.
    open. Without that, "the click never landed" and "the panel never painted" look identical from
    outside — and you cannot tell which half to fix.
 
+**CORRECTION (2026-08-05, measured with `scripts/wkwebview-probe`).** The diagnosis above was
+WRONG, and it is left standing only so the correction is legible. `:modal` was never the cause.
+Executing JS inside the real shipping WKWebView returns:
+
+    matches(":modal") threw: null      // it does not throw
+    showModal() threw:     null        // it is not refused
+    :modal after showModal: true       // it works correctly
+
+The actual cause was the wire contract — snake_case payload fields against a camelCase FE (T6
+below), found by inspecting the payload rather than the component. Three of the six fixes were
+built on a hypothesis nobody could falsify, because until now nothing in this repo could run a
+line of JavaScript in the engine we ship.
+
+**The discipline in T5 stands; only its example was false.** Reproduce first. Get a RED check. Do
+not depend on an API you have not verified *in the shipping engine* — and now you can:
+
+```bash
+swiftc -O -o /tmp/wkprobe scripts/wkwebview-probe/main.swift
+/tmp/wkprobe --url http://localhost:1420/ --eval 'return CSS.supports("color","color-mix(in srgb, red, blue)")'
+```
+
+No accessibility grant, no signing, no GUI. When a UI failure will not reproduce in Playwright,
+that is the tool that tells you whether the engine is actually the difference — in seconds, instead
+of three speculative rounds.
+
 ### T6 — a hand-written IPC mock DEFINES a contract; it does not verify one
 
 **The failure (2026-08-04, PR #566/#568).** Six rounds went to the Add-tile palette's positioning.

--- a/scripts/wkwebview-probe/README.md
+++ b/scripts/wkwebview-probe/README.md
@@ -1,0 +1,57 @@
+# wkwebview-probe
+
+Run JavaScript inside the **real** WKWebView Murmur ships in, from the command line.
+
+```bash
+swiftc -O -o /tmp/wkprobe scripts/wkwebview-probe/main.swift
+
+# is an API actually available in the engine we ship?
+/tmp/wkprobe --url http://localhost:1420/ \
+  --eval 'return { colorMix: CSS.supports("color","color-mix(in srgb, red, blue)"),
+                   has: CSS.supports("selector(:has(*))") }'
+
+# does a page render without throwing?
+/tmp/wkprobe --url http://localhost:1420/dashboards --settle 3 \
+  --eval-file probe.js --timeout 30
+```
+
+Output is a single JSON object on stdout (`{"value": …}`); diagnostics go to stderr.
+Exit codes: `0` ok · `1` bad args · `2` navigation failed · `3` the expression threw · `4` timeout.
+
+## Why this exists
+
+The e2e suite runs in Playwright's Chromium and WebKit. Those are **newer** than the WKWebView on a
+given macOS, so a modern web API can pass every gate and still fail for the user — and nothing in
+this repo could execute a line of JS in the engine that actually ships.
+
+That gap cost six rounds on 2026-08-04 (PR #566/#568). The palette "did not open"; three of the
+fixes were built on the hypothesis that `matches(":modal")` was throwing on the shipping engine.
+Nobody could check. The first thing this probe did, once it existed, was **falsify that hypothesis
+in ten seconds**:
+
+```
+matches(":modal") threw: null      # it does not throw
+showModal() threw:     null        # it is not refused
+:modal after showModal: true       # it works correctly
+```
+
+The real cause was the wire contract (snake_case payload vs camelCase FE). See
+`.claude/rules/angular-zoneless.md` T5 (corrected) and T6.
+
+## What it does and does not prove
+
+**Proves:** whether a JS/CSS API exists and behaves in the shipping engine; whether a page
+bootstraps and renders there without throwing.
+
+**Does not prove:** anything requiring Tauri itself — `window.__TAURI_INTERNALS__` is absent, so the
+app runs without IPC. Use it for engine-capability and render questions, not for data flows. It also
+says nothing about a signed build, Touch ID, ScreenCaptureKit or the lock model; those still need a
+real notarized run on a real Mac.
+
+## Notes
+
+- No accessibility grant needed. Driving the packaged app with AppleScript requires one, and the
+  permission dialog **hangs a non-interactive shell** — the same trap as the `security` CLI.
+- Headless: the web view is never attached to a window.
+- `--settle` (default 2s) is the pause after load before evaluating; an Angular app needs a beat to
+  bootstrap or the probe reads an empty `<app-root>`.

--- a/scripts/wkwebview-probe/main.swift
+++ b/scripts/wkwebview-probe/main.swift
@@ -1,0 +1,158 @@
+// wkwebview-probe — run JavaScript inside a REAL WKWebView and print the result.
+//
+// WHY THIS EXISTS
+// ---------------
+// Murmur's UI ships inside Tauri's WKWebView. The e2e suite runs in Playwright's
+// Chromium and WebKit, and those are NEWER than the WKWebView on a given macOS.
+// A modern web API can therefore work in every gate and still throw for the user.
+//
+// That is not hypothetical. 2026-08-04, PR #566/#568: `el.matches(":modal")` sat
+// outside a `try`. `:modal` is a recent pseudo-class, so on the shipping engine
+// `matches()` threw SyntaxError, the dialog never received `open`, and an
+// unopened <dialog> is display:none. Six rounds of fixes went to the wrong layer
+// because nothing could execute JS in the engine that was actually failing.
+//
+// This closes that hole. It needs no accessibility grant (unlike driving the app
+// with AppleScript, which hangs the shell on a permission dialog), no signing,
+// and no GUI: it is a plain command-line binary that loads a URL, waits for the
+// page, evaluates an expression, and prints the JSON result.
+//
+// USAGE
+//   wkwebview-probe --url http://localhost:1420/dashboards --eval 'document.title'
+//   wkwebview-probe --url … --eval-file probe.js --timeout 30 --settle 2
+//
+// EXIT CODES
+//   0  the expression evaluated; its JSON value is on stdout
+//   1  bad arguments
+//   2  navigation failed
+//   3  the expression threw (the JS error text is on stderr)
+//   4  timed out
+//
+// The probe deliberately prints ONLY the evaluated value on stdout, so callers
+// can pipe it into jq. Diagnostics go to stderr.
+
+import Foundation
+import WebKit
+
+// ── arguments ────────────────────────────────────────────────────────────────
+
+func argValue(_ name: String) -> String? {
+    let args = CommandLine.arguments
+    guard let i = args.firstIndex(of: name), i + 1 < args.count else { return nil }
+    return args[i + 1]
+}
+
+func fail(_ message: String, code: Int32) -> Never {
+    FileHandle.standardError.write(Data(("wkwebview-probe: " + message + "\n").utf8))
+    exit(code)
+}
+
+guard let urlString = argValue("--url"), let url = URL(string: urlString) else {
+    fail("--url <URL> is required", code: 1)
+}
+
+var script: String
+if let inline = argValue("--eval") {
+    script = inline
+} else if let path = argValue("--eval-file") {
+    guard let body = try? String(contentsOfFile: path, encoding: .utf8) else {
+        fail("cannot read --eval-file \(path)", code: 1)
+    }
+    script = body
+} else {
+    fail("one of --eval <expr> or --eval-file <path> is required", code: 1)
+}
+
+let timeout = Double(argValue("--timeout") ?? "30") ?? 30
+// Seconds to wait AFTER load before evaluating. An Angular app needs a beat to
+// bootstrap and render; without it the probe reads an empty <app-root>.
+let settle = Double(argValue("--settle") ?? "2") ?? 2
+
+// ── the probe ────────────────────────────────────────────────────────────────
+
+final class Probe: NSObject, WKNavigationDelegate {
+    let webView: WKWebView
+    private let script: String
+    private let settle: Double
+
+    init(script: String, settle: Double) {
+        let config = WKWebViewConfiguration()
+        // Match the app: Tauri serves the dev app over http on localhost.
+        config.preferences.setValue(true, forKey: "allowFileAccessFromFileURLs")
+        self.webView = WKWebView(frame: .init(x: 0, y: 0, width: 1440, height: 900),
+                                 configuration: config)
+        self.script = script
+        self.settle = settle
+        super.init()
+        webView.navigationDelegate = self
+    }
+
+    func load(_ url: URL) {
+        webView.load(URLRequest(url: url))
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        // Give the SPA time to bootstrap, then evaluate.
+        DispatchQueue.main.asyncAfter(deadline: .now() + settle) { [weak self] in
+            self?.evaluate()
+        }
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        fail("navigation failed: \(error.localizedDescription)", code: 2)
+    }
+
+    func webView(_ webView: WKWebView,
+                 didFailProvisionalNavigation navigation: WKNavigation!,
+                 withError error: Error) {
+        fail("navigation failed: \(error.localizedDescription)", code: 2)
+    }
+
+    private func evaluate() {
+        // Wrap in an async IIFE so callers may use `await`, and JSON-encode the
+        // result so structured values survive the bridge (WKWebView only returns
+        // a small set of primitive types directly).
+        // NOTE the leading `return`: callAsyncJavaScript treats the string as the
+        // BODY of an async function, so an expression alone evaluates to undefined.
+        let wrapped = """
+        try {
+          const value = await (async () => { \(script) })();
+          return JSON.stringify({ ok: true, value: value === undefined ? null : value });
+        } catch (e) {
+          return JSON.stringify({ ok: false, error: String((e && e.stack) || e) });
+        }
+        """
+        webView.callAsyncJavaScript(wrapped, in: nil, in: .page) { result in
+            switch result {
+            case .success(let value):
+                guard let json = value as? String,
+                      let data = json.data(using: .utf8),
+                      let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+                else {
+                    fail("could not decode the probe result", code: 3)
+                }
+                if let ok = obj["ok"] as? Bool, ok {
+                    let payload = obj["value"] ?? NSNull()
+                    let out = (try? JSONSerialization.data(withJSONObject: ["value": payload]))
+                        .flatMap { String(data: $0, encoding: .utf8) } ?? "{\"value\":null}"
+                    print(out)
+                    exit(0)
+                } else {
+                    fail("evaluation threw: \(obj["error"] as? String ?? "unknown")", code: 3)
+                }
+            case .failure(let error):
+                fail("evaluation failed: \(error.localizedDescription)", code: 3)
+            }
+        }
+    }
+}
+
+let probe = Probe(script: script, settle: settle)
+probe.load(url)
+
+DispatchQueue.main.asyncAfter(deadline: .now() + timeout) {
+    fail("timed out after \(Int(timeout))s", code: 4)
+}
+
+// WKWebView needs a run loop; there is no window, so nothing is shown.
+RunLoop.main.run()


### PR DESCRIPTION
**And the first thing it did was prove one of my own rules wrong.**

## The gap

The e2e suite runs in Playwright's Chromium and WebKit. Those are **newer** than the WKWebView on a given macOS, so a modern web API can pass every gate and still fail for the user — and nothing in this repo could execute a line of JS in the engine that actually ships. That is the hole six rounds fell through on 2026-08-04 (#566/#568).

## The tool

A ~150-line Swift binary: loads a URL in a headless WKWebView, waits for the SPA to bootstrap, evaluates an expression, prints JSON on stdout.

```bash
swiftc -O -o /tmp/wkprobe scripts/wkwebview-probe/main.swift
/tmp/wkprobe --url http://localhost:1420/ --eval 'return CSS.supports("color","color-mix(in srgb, red, blue)")'
```

No accessibility grant — driving the packaged app with AppleScript needs one, and that permission dialog **hangs a non-interactive shell**, the same trap as the `security` CLI. No signing, no GUI.

## The correction it forced

T5 (merged in #567) states that `matches(":modal")` threw on the shipping engine and that this broke the palette. **Measured, that is false:**

```
matches(":modal") threw: null      # does not throw
showModal() threw:     null        # not refused
:modal after showModal: true       # works correctly
```

Three of the six fixes rested on a hypothesis **nobody could falsify**. The real cause was the wire contract — snake_case payload against a camelCase FE (T6).

T5's **discipline stands** (reproduce first, get a RED check, don't depend on an unverified API); only its example was wrong. It is corrected in place with the measurement, in the same shape as the existing T4 correction — the false claim left visible so the correction is legible. A scaffold carrying a confident wrong diagnosis is worse than one carrying none.

## Orchestration lesson

`learnings/main-loop.md`: **a hypothesis you cannot falsify is not a diagnosis.** When a report will not reproduce in your tools, get a tool that can see it — rather than trying a fourth variant of the same guess.

## Verified

Against the running dev server, the probe returns a capability map for the shipping engine: `color-mix`, `:has`, `place-items`, `grid max-content`, `backdrop-filter`, `structuredClone`, `dialog`/`showModal` — all supported here. `agent-config-audit --ci` **PASS (152)**.

## Honest boundary (also in the README)

Proves engine capability and render behaviour. **Cannot** prove anything needing Tauri itself — `window.__TAURI_INTERNALS__` is absent, so no IPC — and nothing about a signed build, Touch ID, ScreenCaptureKit or the lock model. Those still need a notarized run on a real Mac.