### PR TITLE
feat(dashboards): add focused workspace views

### DIFF
--- a/e2e/dashboards/board-shot.spec.ts
+++ b/e2e/dashboards/board-shot.spec.ts
@@ -22,42 +22,158 @@ const BOARD = {
 };
 
 const PROMISE_ROWS = [
-  { text: 'Weronika — zweryfikować nazwę "Alcon" (duplikat)', meta: "Weronika · due 2026-07-06", status: "late", source: null },
-  { text: "Leszek — sprawdzić, czy rampa do kupienia jest dostępna", meta: "Leszek · due 2026-07-07", status: "late", source: null },
-  { text: "Organizator - ustalenie dokładnej liczby osób", meta: "Organizator · due 2026-07-10", status: "late", source: null },
-  { text: "Organizator — sprawdzić, czy dzieci mają miejsca", meta: "Organizator · due 2026-07-10", status: "late", source: null },
-  { text: "Organizator — ustal czas rozpoczęcia spotkania", meta: "Organizator · due 2026-07-11", status: "late", source: null },
-  { text: "Mówca — skorzystać z toalety przed wyjściem", meta: "Mówca", status: "open", source: null },
+  {
+    text: 'Weronika — zweryfikować nazwę "Alcon" (duplikat)',
+    meta: "Weronika · due 2026-07-06",
+    status: "late",
+    source: null,
+  },
+  {
+    text: "Leszek — sprawdzić, czy rampa do kupienia jest dostępna",
+    meta: "Leszek · due 2026-07-07",
+    status: "late",
+    source: null,
+  },
+  {
+    text: "Organizator - ustalenie dokładnej liczby osób",
+    meta: "Organizator · due 2026-07-10",
+    status: "late",
+    source: null,
+  },
+  {
+    text: "Organizator — sprawdzić, czy dzieci mają miejsca",
+    meta: "Organizator · due 2026-07-10",
+    status: "late",
+    source: null,
+  },
+  {
+    text: "Organizator — ustal czas rozpoczęcia spotkania",
+    meta: "Organizator · due 2026-07-11",
+    status: "late",
+    source: null,
+  },
+  {
+    text: "Mówca — skorzystać z toalety przed wyjściem",
+    meta: "Mówca",
+    status: "open",
+    source: null,
+  },
 ];
 
 function t(id: string, kind: string, data: unknown, position: number) {
   return {
-    id, dashboardId: "b-test", kind, refId: `r-${position}`, title: null,
-    span: 4, position, config: null, createdAt: "2026-07-20T09:00:00Z", data,
+    id,
+    dashboardId: "b-test",
+    kind,
+    refId: `r-${position}`,
+    title: null,
+    span: 4,
+    position,
+    config: null,
+    createdAt: "2026-07-20T09:00:00Z",
+    data,
   };
 }
 
 const TILES = [
-  t("t1", "note", { kind: "note", id: "n1", title: "Meeting 2026-07-20 02:30", snippet: "", updatedAt: Date.now() - 6 * 864e5 }, 0),
-  t("t2", "note", { kind: "note", id: "n2", title: "Jakub Gawroński CV Summary", snippet: "Jakub Gawroński CV", updatedAt: Date.now() - 16 * 864e5 }, 1),
-  t("t3", "meeting", { kind: "meeting", id: "m1", title: "Krytyka autopromocji prawnika (Ostrowski) — moment", startedAt: "2026-07-31T14:00:00Z", durationS: 240, hasAudio: true }, 2),
+  t(
+    "t1",
+    "note",
+    {
+      kind: "note",
+      id: "n1",
+      title: "Meeting 2026-07-20 02:30",
+      snippet: "",
+      updatedAt: Date.now() - 6 * 864e5,
+    },
+    0,
+  ),
+  t(
+    "t2",
+    "note",
+    {
+      kind: "note",
+      id: "n2",
+      title: "Jakub Gawroński CV Summary",
+      snippet: "Jakub Gawroński CV",
+      updatedAt: Date.now() - 16 * 864e5,
+    },
+    1,
+  ),
+  t(
+    "t3",
+    "meeting",
+    {
+      kind: "meeting",
+      id: "m1",
+      title: "Krytyka autopromocji prawnika (Ostrowski) — moment",
+      startedAt: "2026-07-31T14:00:00Z",
+      durationS: 240,
+      hasAudio: true,
+    },
+    2,
+  ),
   t("t4", "promises", { kind: "promises", owner: null, rows: PROMISE_ROWS }, 3),
   t("t5", "promises", { kind: "promises", owner: null, rows: PROMISE_ROWS }, 4),
-  t("t6", "pulse", { kind: "pulse", entity: "Kuba", weekly: [0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0], total: 2, quietDays: 30 }, 5),
+  t(
+    "t6",
+    "pulse",
+    {
+      kind: "pulse",
+      entity: "Kuba",
+      weekly: [0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0],
+      total: 2,
+      quietDays: 30,
+    },
+    5,
+  ),
   t("t7", "numbers", { kind: "numbers", entity: "Brain", rows: [] }, 6),
-  t("t8", "drift", { kind: "drift", entity: "Kuba", predicate: "role", rows: [{ text: "owner", meta: "Jul 4, 2026", status: "now", source: null }] }, 7),
-  t("t9", "note", { kind: "note", id: "n3", title: "Krytyka autopromocji prawnika (Ostrowski) — moment", snippet: "", updatedAt: Date.now() - 4 * 864e5 }, 8),
+  t(
+    "t8",
+    "drift",
+    {
+      kind: "drift",
+      entity: "Kuba",
+      predicate: "role",
+      rows: [
+        { text: "owner", meta: "Jul 4, 2026", status: "now", source: null },
+      ],
+    },
+    7,
+  ),
+  t(
+    "t9",
+    "note",
+    {
+      kind: "note",
+      id: "n3",
+      title: "Krytyka autopromocji prawnika (Ostrowski) — moment",
+      snippet: "",
+      updatedAt: Date.now() - 4 * 864e5,
+    },
+    8,
+  ),
 ];
 
 test("shot: the complained-about board, rebuilt", async ({ page }) => {
-  await mockTauri(page, {}, {
-    list_dashboards: [BOARD],
-    get_dashboard: { ...BOARD, tiles: TILES },
-    get_dashboard_sources: [{ kind: "note", id: "n2" }, { kind: "meeting", id: "m1" }],
-  });
+  await mockTauri(
+    page,
+    {},
+    {
+      list_dashboards: [BOARD],
+      get_dashboard: { ...BOARD, tiles: TILES },
+      get_dashboard_sources: [
+        { kind: "note", id: "n2" },
+        { kind: "meeting", id: "m1" },
+      ],
+    },
+  );
   await page.setViewportSize({ width: 1680, height: 1050 });
   await page.goto("/dashboards/b-test");
-  await page.locator("app-dashboard-tile").first().waitFor();
+  await page.locator('section[aria-label="Board brief"]').waitFor();
   await page.waitForTimeout(400);
-  await page.screenshot({ path: "test-results/board-after.png", fullPage: true });
+  await page.screenshot({
+    path: "test-results/board-after.png",
+    fullPage: true,
+  });
 });

--- a/e2e/dashboards/dashboard-density.spec.ts
+++ b/e2e/dashboards/dashboard-density.spec.ts
@@ -1,22 +1,32 @@
 import { expect, test } from "@playwright/test";
 import { mockTauri } from "../settings-ai/mock-invoke";
 
-/**
- * Open the Ask column. It starts collapsed to a rail — the scope count stays on
- * screen, the empty transcript does not — so any test that types a question expands
- * it first, which is the same click a user makes.
- */
+/** Open the board's on-demand Ask surface if it is not already present. */
 async function openAsk(page: import("@playwright/test").Page): Promise<void> {
-  // Wait for the panel to EXIST before deciding. A bare `count()` races Angular's
-  // first render and silently no-ops, which then surfaces as a `fill` timeout on a
-  // field that was never revealed.
   const panel = page.locator("aside.ask");
-  await panel.waitFor();
-  const rail = panel.locator("button.ask-rail");
-  if (await rail.count()) await rail.click();
+  if (!(await panel.count())) {
+    await page.getByRole("button", { name: "Ask", exact: true }).click();
+  }
   await page.getByRole("textbox", { name: /Ask a question/i }).waitFor();
 }
 
+async function submitAsk(page: import("@playwright/test").Page): Promise<void> {
+  await page
+    .getByLabel("Ask this board")
+    .getByRole("button", { name: "Ask", exact: true })
+    .click();
+}
+
+async function enterCompose(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  if (
+    !(await page.locator('section[aria-label="Compose board tiles"]').count())
+  ) {
+    await page.getByRole("button", { name: "Compose", exact: true }).click();
+  }
+  await page.locator('section[aria-label="Compose board tiles"]').waitFor();
+}
 
 /**
  * Dashboards — the DENSITY oracle (Phase 1 of the 2026-08-04 rebuild).
@@ -85,14 +95,30 @@ const BOARD_DETAIL = {
   ...BOARDS[0],
   tiles: [
     // Never had data → must collapse.
-    tile("t-numbers", "numbers", { kind: "numbers", entity: "Brain", rows: [] }, 0),
+    tile(
+      "t-numbers",
+      "numbers",
+      { kind: "numbers", entity: "Brain", rows: [] },
+      0,
+    ),
     // Genuinely zero → GOOD NEWS → must stay a full tile.
-    tile("t-promises", "promises", { kind: "promises", owner: null, rows: [] }, 1),
+    tile(
+      "t-promises",
+      "promises",
+      { kind: "promises", owner: null, rows: [] },
+      1,
+    ),
     // Populated stat cluster → narrow.
     tile(
       "t-person",
       "person",
-      { kind: "person", id: "e-1", name: "Kuba", mentionCount: 12, openCommitments: 3 },
+      {
+        kind: "person",
+        id: "e-1",
+        name: "Kuba",
+        mentionCount: 12,
+        openCommitments: 3,
+      },
       2,
     ),
     // Populated prose.
@@ -115,16 +141,26 @@ async function openBoard(page: import("@playwright/test").Page) {
   await mockTauri(
     page,
     {},
-    { list_dashboards: BOARDS, get_dashboard: BOARD_DETAIL, get_dashboard_sources: [] },
+    {
+      list_dashboards: BOARDS,
+      get_dashboard: BOARD_DETAIL,
+      get_dashboard_sources: [],
+    },
   );
   await page.goto("/dashboards/b-dense");
+  await enterCompose(page);
   await expect(page.locator("app-dashboard-tile")).toHaveCount(4);
 }
 
 /** The rendered column span, read off the resolved grid placement. */
-async function spanOf(page: import("@playwright/test").Page, id: string): Promise<number> {
+async function spanOf(
+  page: import("@playwright/test").Page,
+  id: string,
+): Promise<number> {
   return page.evaluate((tileId) => {
-    const el = document.querySelector(`app-dashboard-tile[data-tile-id="${tileId}"]`);
+    const el = document.querySelector(
+      `app-dashboard-tile[data-tile-id="${tileId}"]`,
+    );
     if (!el) return -1;
     const raw = getComputedStyle(el).gridColumn; // e.g. "span 3 / auto"
     const m = /span\s+(\d+)/.exec(raw);
@@ -155,7 +191,9 @@ test("Dashboards: a tile that never had data collapses instead of reserving a fu
     return { empty: h("t-numbers"), full: h("t-note") };
   });
   expect(heights.empty).toBeLessThan(heights.full * 0.75);
-  expect(heights.empty).toBeLessThanOrEqual(56);
+  // Compose's explicit move controls add one compact toolbar row, but an empty
+  // strip must remain materially shorter than a populated card.
+  expect(heights.empty).toBeLessThanOrEqual(88);
 });
 
 test("Dashboards: an empty PROMISES tile reads as a result, not as an absence", async ({
@@ -163,7 +201,9 @@ test("Dashboards: an empty PROMISES tile reads as a result, not as an absence", 
 }) => {
   await openBoard(page);
 
-  const promises = page.locator('app-dashboard-tile[data-tile-id="t-promises"]');
+  const promises = page.locator(
+    'app-dashboard-tile[data-tile-id="t-promises"]',
+  );
   // Zero open commitments is good news — it keeps its card and its body.
   await expect(promises).not.toHaveClass(/is-empty/);
   await expect(promises.locator(".tile-body")).toHaveCount(1);
@@ -186,7 +226,9 @@ test("Dashboards: kinds get different widths even though every stored row says s
   expect(new Set([person, note, promises]).size).toBeGreaterThan(1);
 });
 
-test("Dashboards: every tile header carries a per-kind mark", async ({ page }) => {
+test("Dashboards: every tile header carries a per-kind mark", async ({
+  page,
+}) => {
   await openBoard(page);
 
   // The single biggest visual omission versus the prototype: the shipped header
@@ -222,17 +264,23 @@ test("Dashboards: a failed Ask is a banner with a retry, not a grey bubble that 
 
   await page.goto("/dashboards/b-dense");
   await openAsk(page);
-  await page.getByRole("textbox", { name: /Ask a question/i }).fill("what is late?");
-  await page.getByRole("button", { name: "Ask", exact: true }).click();
+  await page
+    .getByRole("textbox", { name: /Ask a question/i })
+    .fill("what is late?");
+  await submitAsk(page);
 
   const banner = page.locator(".thread .banner.is-danger");
   await expect(banner).toBeVisible();
-  await expect(banner.getByRole("button", { name: /Try again/i })).toBeVisible();
+  await expect(
+    banner.getByRole("button", { name: /Try again/i }),
+  ).toBeVisible();
   // And it is NOT dressed as an answer.
   await expect(page.locator(".thread .bubble:not(.me)")).toHaveCount(0);
 });
 
-test("Dashboards: an answer renders as markdown, not as literal asterisks", async ({ page }) => {
+test("Dashboards: an answer renders as markdown, not as literal asterisks", async ({
+  page,
+}) => {
   // `summarize/vault_chat.rs::build` DEMANDS markdown from the model, and the
   // board rendered `{{ turn.text }}` with `white-space: pre-wrap`.
   await mockTauri(
@@ -253,8 +301,10 @@ test("Dashboards: an answer renders as markdown, not as literal asterisks", asyn
 
   await page.goto("/dashboards/b-dense");
   await openAsk(page);
-  await page.getByRole("textbox", { name: /Ask a question/i }).fill("what is the risk?");
-  await page.getByRole("button", { name: "Ask", exact: true }).click();
+  await page
+    .getByRole("textbox", { name: /Ask a question/i })
+    .fill("what is the risk?");
+  await submitAsk(page);
 
   const answer = page.locator(".thread .bubble:not(.me)");
   await expect(answer).toBeVisible();
@@ -282,7 +332,14 @@ test("Dashboards: a duplicate tile renders as a back-reference, not a second cop
             {
               kind: "promises",
               owner: null,
-              rows: [{ text: "Send the Acme paperwork", meta: "due 2026-07-22", status: "late", source: null }],
+              rows: [
+                {
+                  text: "Send the Acme paperwork",
+                  meta: "due 2026-07-22",
+                  status: "late",
+                  source: null,
+                },
+              ],
             },
             0,
           ),
@@ -292,7 +349,14 @@ test("Dashboards: a duplicate tile renders as a back-reference, not a second cop
             {
               kind: "promises",
               owner: null,
-              rows: [{ text: "Send the Acme paperwork", meta: "due 2026-07-22", status: "late", source: null }],
+              rows: [
+                {
+                  text: "Send the Acme paperwork",
+                  meta: "due 2026-07-22",
+                  status: "late",
+                  source: null,
+                },
+              ],
             },
             1,
           ),
@@ -303,6 +367,7 @@ test("Dashboards: a duplicate tile renders as a back-reference, not a second cop
   );
 
   await page.goto("/dashboards/b-dense");
+  await enterCompose(page);
   await expect(page.locator("app-dashboard-tile")).toHaveCount(2);
 
   const second = page.locator('app-dashboard-tile[data-tile-id="t-p2"]');
@@ -313,13 +378,18 @@ test("Dashboards: a duplicate tile renders as a back-reference, not a second cop
   await expect(page.getByText("Send the Acme paperwork")).toHaveCount(1);
 });
 
-test("Dashboards: the Ask column is a rail until it has something to say", async ({ page }) => {
-  // The scope readout is the feature's claim made visible, so it stays on screen; the
-  // empty transcript is not, and it was spending a third of the width on three
-  // suggestion buttons.
+test("Dashboards: Ask is on demand and closing it preserves the in-memory thread", async ({
+  page,
+}) => {
   await mockTauri(
     page,
-    { ask_vault: () => ({ answer: "Two are late.", sources: [], citations: [] }) },
+    {
+      ask_vault: () => ({
+        answer: "Two are late.",
+        sources: [],
+        citations: [],
+      }),
+    },
     {
       list_dashboards: BOARDS,
       get_dashboard: BOARD_DETAIL,
@@ -328,29 +398,21 @@ test("Dashboards: the Ask column is a rail until it has something to say", async
   );
 
   await page.goto("/dashboards/b-dense");
-  const ask = page.locator("aside.ask");
-  await expect(ask).toHaveClass(/is-rail/);
-  // …and the count is still readable while collapsed.
-  await expect(ask.getByText(/in scope/)).toBeVisible();
-  const railWidth = (await ask.boundingBox())!.width;
-  expect(railWidth).toBeLessThan(60);
-
-  await ask.getByRole("button", { name: /Ask this board/ }).click();
-  await expect(ask).not.toHaveClass(/is-rail/);
-  // The width TRANSITIONS, so a single read lands mid-animation. Poll instead of
-  // measuring once — and the composer being reachable is the real invariant anyway.
-  await expect(page.getByRole("textbox", { name: /Ask a question/i })).toBeVisible();
-  await expect
-    .poll(async () => (await ask.boundingBox())!.width)
-    .toBeGreaterThan(railWidth * 3);
-
-  // Once there is a conversation it STAYS open — a thread you cannot see is worse
-  // than a wide column.
+  await expect(page.locator("aside.ask")).toHaveCount(0);
   await openAsk(page);
-  await page.getByRole("textbox", { name: /Ask a question/i }).fill("who is late?");
-  await page.getByRole("button", { name: "Ask", exact: true }).click();
+  const ask = page.locator("aside.ask");
+  await expect(ask).toBeVisible();
+  await page
+    .getByRole("textbox", { name: /Ask a question/i })
+    .fill("who is late?");
+  await submitAsk(page);
   await expect(page.getByText("Two are late.")).toBeVisible();
-  await expect(ask).not.toHaveClass(/is-rail/);
+
+  await ask.getByRole("button", { name: "Close Ask" }).click();
+  await expect(ask).toHaveCount(0);
+  await openAsk(page);
+  await expect(page.getByText("who is late?")).toBeVisible();
+  await expect(page.getByText("Two are late.")).toBeVisible();
 });
 
 test("Dashboards: a board can be renamed, and a leading emoji becomes its emoji", async ({
@@ -391,7 +453,9 @@ test("Dashboards: a board can be renamed, and a leading emoji becomes its emoji"
   expect(sent.emoji).toBe("👨‍👩‍👧");
 });
 
-test("Dashboards: renaming with no emoji clears the old one", async ({ page }) => {
+test("Dashboards: renaming with no emoji clears the old one", async ({
+  page,
+}) => {
   // Dropping the field instead of sending "" would leave the previous emoji in place,
   // making the picture impossible to remove once set.
   await mockTauri(
@@ -431,11 +495,16 @@ test("Dashboards: deleting a board takes two clicks, and the first one is revers
     page,
     {
       delete_dashboard: () => {
-        (globalThis as any).__deleted = ((globalThis as any).__deleted ?? 0) + 1;
+        (globalThis as any).__deleted =
+          ((globalThis as any).__deleted ?? 0) + 1;
         return true;
       },
     },
-    { list_dashboards: BOARDS, get_dashboard: BOARD_DETAIL, get_dashboard_sources: [] },
+    {
+      list_dashboards: BOARDS,
+      get_dashboard: BOARD_DETAIL,
+      get_dashboard_sources: [],
+    },
   );
 
   await page.goto("/dashboards");
@@ -443,7 +512,9 @@ test("Dashboards: deleting a board takes two clicks, and the first one is revers
 
   // FIRST click arms — it must not delete.
   await card.getByRole("button", { name: /^Delete / }).click();
-  await expect(card.getByRole("button", { name: /^Confirm delete / })).toBeVisible();
+  await expect(
+    card.getByRole("button", { name: /^Confirm delete / }),
+  ).toBeVisible();
   expect(await page.evaluate(() => (globalThis as any).__deleted ?? 0)).toBe(0);
 
   // Backing out leaves the board alone…
@@ -471,7 +542,11 @@ test("Dashboards: navigating away mid-ask does not leave the next board stuck bu
     {
       ask_vault: async () => {
         await new Promise((r) => setTimeout(r, 1500));
-        return { answer: "answer for the first board", sources: [], citations: [] };
+        return {
+          answer: "answer for the first board",
+          sources: [],
+          citations: [],
+        };
       },
     },
     {
@@ -483,8 +558,10 @@ test("Dashboards: navigating away mid-ask does not leave the next board stuck bu
 
   await page.goto("/dashboards/b-dense");
   await openAsk(page);
-  await page.getByRole("textbox", { name: /Ask a question/i }).fill("slow question");
-  await page.getByRole("button", { name: "Ask", exact: true }).click();
+  await page
+    .getByRole("textbox", { name: /Ask a question/i })
+    .fill("slow question");
+  await submitAsk(page);
 
   // Leave while it is still running, then come back.
   await page.goto("/dashboards");
@@ -492,13 +569,21 @@ test("Dashboards: navigating away mid-ask does not leave the next board stuck bu
   await openAsk(page);
 
   // The Ask control is USABLE — not stuck behind a dead request…
-  await page.getByRole("textbox", { name: /Ask a question/i }).fill("a fresh question");
-  await expect(page.getByRole("button", { name: "Ask", exact: true })).toBeEnabled();
+  await page
+    .getByRole("textbox", { name: /Ask a question/i })
+    .fill("a fresh question");
+  await expect(
+    page
+      .getByLabel("Ask this board")
+      .getByRole("button", { name: "Ask", exact: true }),
+  ).toBeEnabled();
   // …and the previous board's thread did not follow us here.
   await expect(page.getByText("slow question")).toHaveCount(0);
   await expect(page.getByText("answer for the first board")).toHaveCount(0);
 });
-test("Dashboards: sealed material-only board still asks with its board id", async ({ page }) => {
+test("Dashboards: sealed material-only board still asks with its board id", async ({
+  page,
+}) => {
   // The board scopes the ask even when it has nothing readable to SHOW. Deciding on
   // the resolved payload made this unreachable: every tile resolves to `locked`, the
   // old count was zero, and the UI told the user to add tiles to a board that has
@@ -522,12 +607,9 @@ test("Dashboards: sealed material-only board still asks with its board id", asyn
         };
       },
       // A board-scoped answer may contain DERIVED-tile material — rows the board
-      // composed, not documents the user pinned. Nothing may persist it: the
-      // living-answer cache is gated by a stamp of readable folders, and only
-      // `refreshAnswer` writes that cache — deliberately calling `askVault` with FOUR
-      // arguments, so `dashboardId` stays `undefined` and no brief is rendered into a
-      // stored answer. That property is implicit; it survives only while nobody adds a
-      // sixth argument there, which is why it is pinned rather than left to a comment.
+      // composed, not documents the user pinned. Board Ask deliberately keeps
+      // persistence disabled; pin the absence of `set_dashboard_answer` calls so
+      // a future refactor cannot silently turn an ephemeral answer into a cache.
       set_dashboard_answer: () => {
         (globalThis as any).__setDashboardAnswerCalls =
           ((globalThis as any).__setDashboardAnswerCalls ?? 0) + 1;
@@ -549,16 +631,22 @@ test("Dashboards: sealed material-only board still asks with its board id", asyn
   );
 
   await page.goto("/dashboards/b-dense");
+  await enterCompose(page);
   await expect(page.locator("app-dashboard-tile")).toHaveCount(3);
+  await page.getByRole("button", { name: "Done", exact: true }).click();
 
-  // The Ask column starts collapsed to its rail, so expand it the way a user does.
+  // Ask is not mounted until explicitly opened.
   await openAsk(page);
-  await page.getByRole("textbox", { name: /Ask a question/i }).fill("who owes me?");
-  await page.getByRole("button", { name: "Ask", exact: true }).click();
+  await page
+    .getByRole("textbox", { name: /Ask a question/i })
+    .fill("who owes me?");
+  await submitAsk(page);
 
   // It ASKED — no dead end, and the answer names the real situation (locked tiles)
   // rather than telling the user to go record a meeting.
-  await expect(page.getByText(/Nothing on this board is readable/)).toBeVisible();
+  await expect(
+    page.getByText(/Nothing on this board is readable/),
+  ).toBeVisible();
   // …and it sent the board id, which is what makes the backend scope the request
   // instead of falling through to a vault-wide search.
   const sent = await page.evaluate(() => (globalThis as any).__askArgs);

--- a/e2e/dashboards/dashboard-workspace.spec.ts
+++ b/e2e/dashboards/dashboard-workspace.spec.ts
@@ -1,0 +1,1016 @@
+import { expect, test } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+const SEALED_SECRET = "Project Nightjar confidential acquisition";
+
+const BOARD = {
+  id: "b-workspace",
+  title: "Atlas workspace",
+  emoji: "🧭",
+  tint: "indigo",
+  pinned: true,
+  position: 0,
+  createdAt: "2026-08-01T09:00:00Z",
+  updatedAt: "2026-08-11T09:00:00Z",
+  tileCount: 9,
+  tileKinds: [],
+};
+
+function tile(
+  id: string,
+  kind: string,
+  refId: string | null,
+  data: unknown,
+  position: number,
+) {
+  return {
+    id,
+    dashboardId: BOARD.id,
+    kind,
+    refId,
+    title: null,
+    span: 4,
+    position,
+    config: null,
+    createdAt: "2026-08-01T09:00:00Z",
+    data,
+  };
+}
+
+const TILES = [
+  tile(
+    "t-note",
+    "note",
+    "n-plan",
+    {
+      kind: "note",
+      id: "n-plan",
+      title: "Atlas launch plan",
+      snippet: "The rollout starts with the private beta and support handoff.",
+      updatedAt: 1_786_400_000_000,
+    },
+    0,
+  ),
+  tile(
+    "t-recording",
+    "meeting",
+    "m-review",
+    {
+      kind: "meeting",
+      id: "m-review",
+      title: "Atlas launch review",
+      startedAt: "2026-08-10T09:00:00Z",
+      durationS: 1860,
+      hasAudio: true,
+    },
+    1,
+  ),
+  tile(
+    "t-document",
+    "document",
+    "d-prd",
+    {
+      kind: "document",
+      id: "d-prd",
+      title: "Atlas PRD",
+      snippet: "Success criteria, rollout risks and the launch checklist.",
+    },
+    2,
+  ),
+  tile(
+    "t-promises",
+    "promises",
+    null,
+    {
+      kind: "promises",
+      owner: null,
+      rows: [
+        {
+          text: "Kuba — confirm the release checklist",
+          meta: "due 2026-08-11",
+          status: "late",
+          source: { kind: "meeting", id: "m-review" },
+        },
+        {
+          text: "Marta — send the support handoff",
+          meta: "open",
+          status: "open",
+          source: null,
+        },
+      ],
+    },
+    3,
+  ),
+  tile(
+    "t-reminders",
+    "reminders",
+    null,
+    {
+      kind: "reminders",
+      dueCount: 1,
+      rows: [
+        {
+          text: "Review the launch risk register",
+          meta: "today",
+          status: "due",
+          source: { kind: "note", id: "n-plan" },
+        },
+      ],
+    },
+    4,
+  ),
+  tile(
+    "t-good-zero",
+    "promises",
+    "owner-closed",
+    { kind: "promises", owner: "Closed team", rows: [] },
+    5,
+  ),
+  tile(
+    "t-person",
+    "person",
+    "person-kuba",
+    {
+      kind: "person",
+      id: "person-kuba",
+      name: "Kuba",
+      mentionCount: 12,
+      openCommitments: 2,
+    },
+    6,
+  ),
+  tile(
+    "t-answer",
+    "living_answer",
+    null,
+    {
+      kind: "livingAnswer",
+      question: "Are we ready to launch Atlas?",
+      answer: "The launch is viable once the overdue checklist is confirmed.",
+      answeredAt: "2026-08-11T09:00:00Z",
+      withheld: false,
+    },
+    7,
+  ),
+  {
+    ...tile("t-locked", "note", "n-locked", { kind: "locked" }, 8),
+    title: SEALED_SECRET,
+    config: JSON.stringify({ legacyTitle: SEALED_SECRET }),
+  },
+];
+
+const DETAIL = { ...BOARD, tiles: TILES };
+const SOURCES = [
+  { kind: "note", id: "n-plan" },
+  { kind: "meeting", id: "m-review" },
+  { kind: "document", id: "d-prd" },
+];
+
+async function openBoard(page: import("@playwright/test").Page): Promise<void> {
+  await mockTauri(
+    page,
+    {},
+    {
+      list_dashboards: [BOARD],
+      get_dashboard: DETAIL,
+      get_dashboard_sources: SOURCES,
+    },
+  );
+  await page.goto(`/dashboards/${BOARD.id}`);
+  await page.locator('section[aria-label="Board brief"]').waitFor();
+}
+
+async function enterCompose(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  await page.getByRole("button", { name: "Compose", exact: true }).click();
+  await page.locator('section[aria-label="Compose board tiles"]').waitFor();
+}
+
+async function assertNoSealedSecret(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  expect(
+    await page.evaluate(
+      (secret) => document.documentElement.outerHTML.includes(secret),
+      SEALED_SECRET,
+    ),
+    "a resolved locked tile must not restore legacy content-shaped chrome",
+  ).toBe(false);
+}
+
+test("Dashboard workspace: Brief is the calm default and every lens represents the same board", async ({
+  page,
+}) => {
+  await openBoard(page);
+
+  const read = page.locator('section[aria-label="Board brief"]');
+  await expect(read.locator(".dominant")).toHaveCount(1);
+  await expect(read.getByText("Are we ready to launch Atlas?")).toBeVisible();
+  await expect(
+    read.getByRole("heading", { name: "Needs attention" }),
+  ).toBeVisible();
+  await expect(
+    read.getByText("Kuba — confirm the release checklist"),
+  ).toBeVisible();
+  await expect(
+    read.getByRole("heading", { name: "Recent evidence" }),
+  ).toBeVisible();
+  await expect(read.getByText("Atlas launch plan")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Brief", exact: true }),
+  ).toHaveAttribute("aria-current", "page");
+  await assertNoSealedSecret(page);
+
+  await page.getByRole("button", { name: "Overview", exact: true }).click();
+  await expect(
+    page.getByRole("heading", { name: "The board at a glance" }),
+  ).toBeVisible();
+  await expect(page.getByText("Readable sources")).toBeVisible();
+  await expect(page.getByText("3", { exact: true }).first()).toBeVisible();
+  await assertNoSealedSecret(page);
+
+  await page.getByRole("button", { name: "Commitments", exact: true }).click();
+  await expect(
+    page.getByRole("heading", { name: "Promises and reminders" }),
+  ).toBeVisible();
+  await expect(page.getByText("Review the launch risk register")).toBeVisible();
+  await assertNoSealedSecret(page);
+
+  await page.getByRole("button", { name: "Sources", exact: true }).click();
+  await expect(
+    page.getByRole("heading", { name: "Material in this board" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Atlas launch review/ }),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: /Atlas PRD/ })).toBeVisible();
+  await assertNoSealedSecret(page);
+
+  await page.getByRole("button", { name: "People", exact: true }).click();
+  await expect(
+    page.getByRole("heading", { name: "Explicit people views" }),
+  ).toBeVisible();
+  await expect(page.getByText("Kuba", { exact: true })).toBeVisible();
+  await expect(page.getByText("12 meetings")).toBeVisible();
+  await assertNoSealedSecret(page);
+});
+
+test("Dashboard workspace: superseded drift history is explicit and distinct from unavailable states", async ({
+  page,
+}) => {
+  const history = {
+    ...BOARD,
+    tiles: [
+      tile(
+        "t-superseded-history",
+        "drift",
+        "entity-atlas",
+        {
+          kind: "drift",
+          entity: "Project Atlas",
+          predicate: "launch date",
+          rows: [
+            {
+              text: "30 April",
+              meta: "recorded 12 March",
+              status: "old",
+              source: { kind: "meeting", id: "m-history" },
+            },
+            {
+              text: "14 June",
+              meta: "recorded 3 June",
+              status: "now",
+              source: { kind: "meeting", id: "m-current" },
+            },
+          ],
+        },
+        0,
+      ),
+      tile("t-missing-history", "note", "n-missing", { kind: "missing" }, 1),
+      tile("t-locked-history", "note", "n-locked", { kind: "locked" }, 2),
+    ],
+  };
+  await mockTauri(
+    page,
+    {},
+    {
+      list_dashboards: [BOARD],
+      get_dashboard: history,
+      get_dashboard_sources: [],
+    },
+  );
+
+  await page.goto(`/dashboards/${BOARD.id}`);
+  const boundary = page.locator('footer[aria-label="Board boundary"]');
+  await expect(boundary).toContainText("1 superseded past-state value");
+  await expect(boundary).toContainText("1 missing or not configured");
+  await expect(boundary).toContainText("1 sealed and excluded");
+
+  await page.getByRole("button", { name: "Overview", exact: true }).click();
+  const overview = page.getByRole("region", { name: "overview lens" });
+  await expect(overview.getByText("Superseded values")).toBeVisible();
+  await expect(overview.getByText("Superseded past state")).toBeVisible();
+  await expect(
+    overview.getByText("Project Atlas · launch date: 30 April"),
+  ).toBeVisible();
+  await expect(overview.getByText("past state", { exact: true })).toBeVisible();
+  const superseded = overview.locator(
+    'section[aria-labelledby="superseded-title"]',
+  );
+  await expect(superseded).not.toContainText("14 June");
+  await expect(superseded).not.toContainText(/empty|stale|sealed|missing/i);
+});
+
+test("Dashboard workspace: Note and Recording additions persist ref ids only and restore focus", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {
+      add_dashboard_tile: (args: unknown) => {
+        const root = globalThis as { __dashboardAddCalls?: unknown[] };
+        root.__dashboardAddCalls = [...(root.__dashboardAddCalls ?? []), args];
+        return null;
+      },
+    },
+    {
+      list_dashboards: [BOARD],
+      get_dashboard: DETAIL,
+      get_dashboard_sources: SOURCES,
+      list_link_candidates: [
+        {
+          kind: "note",
+          id: "n-candidate",
+          title: "Sensitive candidate note title",
+          snippet: "Sensitive candidate note content",
+        },
+        {
+          kind: "meeting",
+          id: "m-candidate",
+          title: "Private recording title",
+          snippet: "Private recording transcript excerpt",
+        },
+        {
+          kind: "document",
+          id: "d-candidate",
+          title: "Private strategy deck",
+          snippet: "Private document extract",
+        },
+      ],
+    },
+  );
+  await page.goto(`/dashboards/${BOARD.id}`);
+  await enterCompose(page);
+
+  const invoker = page.getByRole("button", { name: "Add to board" });
+  await invoker.click();
+  let palette = page.getByRole("dialog", { name: "Add to board" });
+  await expect(palette).toBeVisible();
+  await expect(palette.getByRole("heading", { name: "Sources" })).toBeVisible();
+  await expect(palette.getByRole("heading", { name: "Views" })).toBeVisible();
+  await expect(palette.getByRole("button", { name: /^Note/ })).toBeFocused();
+
+  // Shift+Tab from the first choice wraps to the last, and Tab wraps back. Focus
+  // cannot escape to the board beneath the opaque overlay.
+  await page.keyboard.press("Shift+Tab");
+  await expect(palette.locator(".node").last()).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(palette.getByRole("button", { name: /^Note/ })).toBeFocused();
+
+  await palette.getByRole("button", { name: /^Note/ }).click();
+  await expect(
+    palette.getByRole("textbox", { name: "Search sources" }),
+  ).toBeFocused();
+  await expect(
+    palette.getByText("Sensitive candidate note title"),
+  ).toBeVisible();
+  await expect(palette.getByText("Private recording title")).toHaveCount(0);
+
+  // Escape backs out one level, keeping the overlay open; a second selection can
+  // then complete the flow without losing the original trigger.
+  await page.keyboard.press("Escape");
+  await expect(palette.getByRole("heading", { name: "Sources" })).toBeVisible();
+  await expect(palette.getByRole("button", { name: /^Note/ })).toBeFocused();
+  await palette.getByRole("button", { name: /^Note/ }).click();
+  await palette
+    .getByRole("button", { name: /Sensitive candidate note title/ })
+    .click();
+  await expect(palette).toHaveCount(0);
+  await expect(invoker).toBeFocused();
+
+  await invoker.click();
+  palette = page.getByRole("dialog", { name: "Add to board" });
+  await palette.getByRole("button", { name: /^Recording/ }).click();
+  await expect(
+    palette.getByRole("textbox", { name: "Search sources" }),
+  ).toBeFocused();
+  await expect(palette.getByText("Private recording title")).toBeVisible();
+  await expect(palette.getByText("Sensitive candidate note title")).toHaveCount(
+    0,
+  );
+  await palette
+    .getByRole("button", { name: /Private recording title/ })
+    .click();
+  await expect(palette).toHaveCount(0);
+  await expect(invoker).toBeFocused();
+
+  const calls = (await page.evaluate(
+    () =>
+      (globalThis as { __dashboardAddCalls?: unknown[] }).__dashboardAddCalls ??
+      [],
+  )) as Array<Record<string, unknown>>;
+  expect(
+    calls.map(({ dashboardId, kind, refId }) => ({ dashboardId, kind, refId })),
+  ).toEqual([
+    { dashboardId: BOARD.id, kind: "note", refId: "n-candidate" },
+    { dashboardId: BOARD.id, kind: "meeting", refId: "m-candidate" },
+  ]);
+  for (const call of calls) {
+    expect(Object.keys(JSON.parse(JSON.stringify(call))).sort()).toEqual([
+      "dashboardId",
+      "kind",
+      "refId",
+    ]);
+    expect(call["title"]).toBeUndefined();
+    expect(call["config"]).toBeUndefined();
+  }
+  const wire = JSON.stringify(calls);
+  expect(wire).not.toContain("Sensitive candidate note title");
+  expect(wire).not.toContain("Sensitive candidate note content");
+  expect(wire).not.toContain("Private recording title");
+  expect(wire).not.toContain("Private recording transcript excerpt");
+});
+
+test("Dashboard workspace: keyboard tile movement persists the same order shown in Compose", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {
+      reorder_dashboard_tiles: async (args: unknown) => {
+        (globalThis as { __dashboardReorder?: unknown }).__dashboardReorder =
+          args;
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        return null;
+      },
+    },
+    {
+      list_dashboards: [BOARD],
+      get_dashboard: DETAIL,
+      get_dashboard_sources: SOURCES,
+    },
+  );
+  await page.goto(`/dashboards/${BOARD.id}`);
+  await enterCompose(page);
+
+  const first = page.locator("app-dashboard-tile").first();
+  await expect(first).toHaveAttribute("data-tile-id", "t-note");
+  await first.getByRole("button", { name: "Move tile later" }).click();
+  await expect(page.locator("app-dashboard-tile").first()).toHaveAttribute(
+    "data-tile-id",
+    "t-recording",
+  );
+  await expect(page.locator("app-dashboard-tile").nth(1)).toHaveAttribute(
+    "data-tile-id",
+    "t-note",
+  );
+
+  const sent = (await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (globalThis as { __dashboardReorder?: unknown }).__dashboardReorder,
+      ),
+    )
+    .toBeTruthy()
+    .then(() =>
+      page.evaluate(
+        () =>
+          (globalThis as { __dashboardReorder?: unknown }).__dashboardReorder,
+      ),
+    )) as { dashboardId?: string; tileIds?: string[] };
+  expect(sent.dashboardId).toBe(BOARD.id);
+  expect(sent.tileIds?.slice(0, 2)).toEqual(["t-recording", "t-note"]);
+});
+
+test("Dashboard workspace: 900x680 keeps primary actions and overlays usable without horizontal overflow", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 900, height: 680 });
+  await openBoard(page);
+
+  await expect(
+    page.getByRole("button", { name: "Ask", exact: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Compose", exact: true }),
+  ).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(() => document.documentElement.scrollWidth <= innerWidth),
+    )
+    .toBe(true);
+
+  const cards = await page
+    .locator(".brief-grid .read-card")
+    .evaluateAll((elements) =>
+      elements.map((element) => {
+        const rect = element.getBoundingClientRect();
+        return {
+          left: rect.left,
+          right: rect.right,
+          top: rect.top,
+          bottom: rect.bottom,
+        };
+      }),
+    );
+  expect(cards).toHaveLength(2);
+  const overlaps =
+    cards[0].left < cards[1].right &&
+    cards[0].right > cards[1].left &&
+    cards[0].top < cards[1].bottom &&
+    cards[0].bottom > cards[1].top;
+  expect(
+    overlaps,
+    "Brief cards must not overlap at the default Murmur window",
+  ).toBe(false);
+
+  await page.getByRole("button", { name: "Ask", exact: true }).click();
+  await expect(page.locator("aside.ask")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Close Ask" })).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(() => document.documentElement.scrollWidth <= innerWidth),
+    )
+    .toBe(true);
+  await page.getByRole("button", { name: "Close Ask" }).click();
+
+  await enterCompose(page);
+  await page.getByRole("button", { name: "Add to board" }).click();
+  const palette = page.getByRole("dialog", { name: "Add to board" });
+  const box = await palette.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.x).toBeGreaterThanOrEqual(8);
+  expect(box!.y).toBeGreaterThanOrEqual(8);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(892);
+  expect(box!.y + box!.height).toBeLessThanOrEqual(672);
+  await palette.getByRole("button", { name: /^Note/ }).scrollIntoViewIfNeeded();
+  await expect(palette.getByRole("button", { name: /^Note/ })).toBeVisible();
+  await palette
+    .getByRole("button", { name: /^Recording/ })
+    .scrollIntoViewIfNeeded();
+  await expect(
+    palette.getByRole("button", { name: /^Recording/ }),
+  ).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(() => document.documentElement.scrollWidth <= innerWidth),
+    )
+    .toBe(true);
+});
+
+test("Dashboard workspace: a null board is unavailable, never misrepresented as empty", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {},
+    {
+      list_dashboards: [BOARD],
+      get_dashboard: null,
+      get_dashboard_sources: [],
+    },
+  );
+  await page.goto(`/dashboards/${BOARD.id}`);
+
+  await expect(page.getByText("Board unavailable.")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Try again" })).toBeVisible();
+  await expect(
+    page.getByText("Start with material for this board."),
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Add a Note, Recording or Document" }),
+  ).toHaveCount(0);
+});
+
+test("Dashboard workspace: relock wins over an older same-board readable response", async ({
+  page,
+}) => {
+  const READABLE_SECRET = "Redwood signing terms and private valuation";
+  const readable = {
+    ...BOARD,
+    tiles: [
+      {
+        ...tile(
+          "t-race",
+          "note",
+          "n-race",
+          {
+            kind: "note",
+            id: "n-race",
+            title: READABLE_SECRET,
+            snippet: "Never re-admit this after relock.",
+            updatedAt: 1_786_400_000_000,
+          },
+          0,
+        ),
+        title: READABLE_SECRET,
+      },
+    ],
+  };
+  const locked = {
+    ...BOARD,
+    tiles: [
+      {
+        ...tile("t-race", "note", "n-race", { kind: "locked" }, 0),
+        title: READABLE_SECRET,
+      },
+    ],
+  };
+
+  await mockTauri(
+    page,
+    {
+      get_dashboard: async () => {
+        const root = globalThis as {
+          __boardReads?: number;
+          __releaseOldBoard?: () => void;
+          __readableBoard: unknown;
+          __lockedBoard: unknown;
+        };
+        root.__boardReads = (root.__boardReads ?? 0) + 1;
+        if (root.__boardReads === 1) {
+          await new Promise<void>((resolve) => {
+            root.__releaseOldBoard = resolve;
+          });
+          return root.__readableBoard;
+        }
+        return root.__lockedBoard;
+      },
+      list_folders: () => {
+        const root = globalThis as { __foldersRead?: number };
+        root.__foldersRead = (root.__foldersRead ?? 0) + 1;
+        const exposed = root.__foldersRead === 1;
+        return [
+          {
+            id: "f-race",
+            name: "Race folder",
+            parentId: null,
+            noteCount: 1,
+            locked: true,
+            unlocked: exposed,
+            kind: "meeting",
+            children: [],
+          },
+        ];
+      },
+      relock_all: () => null,
+    },
+    {
+      list_dashboards: [BOARD],
+      get_dashboard_sources: [],
+    },
+  );
+  await page.addInitScript(
+    ({ readableBoard, lockedBoard }) => {
+      (globalThis as { __readableBoard: unknown }).__readableBoard =
+        readableBoard;
+      (globalThis as { __lockedBoard: unknown }).__lockedBoard = lockedBoard;
+    },
+    { readableBoard: readable, lockedBoard: locked },
+  );
+  await page.goto(`/dashboards/${BOARD.id}`);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (globalThis as { __boardReads?: number }).__boardReads ?? 0,
+      ),
+    )
+    .toBe(1);
+
+  // This is the real app-shell action. FoldersService.relockAll publishes the
+  // fresh locked tree, and DashboardView must synchronously discard the old
+  // content before issuing its newer same-id gated read.
+  await page
+    .getByRole("button", { name: "Re-seal all 1 unlocked folder now" })
+    .click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (globalThis as { __boardReads?: number }).__boardReads ?? 0,
+      ),
+    )
+    .toBe(2);
+  await page.evaluate(() =>
+    (globalThis as { __releaseOldBoard?: () => void }).__releaseOldBoard?.(),
+  );
+
+  await expect(page.getByText("1 sealed and excluded")).toBeVisible();
+  await expect(page.locator("body")).not.toContainText(READABLE_SECRET);
+  expect(
+    await page.evaluate(
+      (secret) => document.documentElement.outerHTML.includes(secret),
+      READABLE_SECRET,
+    ),
+  ).toBe(false);
+});
+
+test("Dashboard workspace: relock scrubs mounted plaintext even when the folder refresh fails", async ({
+  page,
+}) => {
+  const BOARD_SECRET = "Nightjar board valuation and signing date";
+  const ASK_SECRET = "Nightjar assistant-only risk summary";
+  const PALETTE_SECRET = "Nightjar private candidate title";
+  const readable = {
+    ...BOARD,
+    tiles: [
+      {
+        ...tile(
+          "t-relock-failure",
+          "note",
+          "n-relock-failure",
+          {
+            kind: "note",
+            id: "n-relock-failure",
+            title: BOARD_SECRET,
+            snippet: "Readable before the folder is re-sealed.",
+            updatedAt: 1_786_400_000_000,
+          },
+          0,
+        ),
+        title: BOARD_SECRET,
+      },
+    ],
+  };
+  const locked = {
+    ...BOARD,
+    tiles: [
+      {
+        ...tile(
+          "t-relock-failure",
+          "note",
+          "n-relock-failure",
+          { kind: "locked" },
+          0,
+        ),
+        title: BOARD_SECRET,
+      },
+    ],
+  };
+
+  await mockTauri(
+    page,
+    {
+      get_dashboard: () => {
+        const root = globalThis as {
+          __dashboardLocked?: boolean;
+          __dashboardReads?: number;
+          __readableBoard: unknown;
+          __lockedBoard: unknown;
+        };
+        root.__dashboardReads = (root.__dashboardReads ?? 0) + 1;
+        return root.__dashboardLocked
+          ? root.__lockedBoard
+          : root.__readableBoard;
+      },
+      get_dashboard_sources: () =>
+        (globalThis as { __dashboardLocked?: boolean }).__dashboardLocked
+          ? []
+          : [{ kind: "note", id: "n-relock-failure" }],
+      ask_vault: () => ({
+        answer: "Nightjar assistant-only risk summary",
+        sources: [],
+        citations: [],
+      }),
+      list_link_candidates: () => [
+        {
+          kind: "note",
+          id: "n-private-candidate",
+          title: "Nightjar private candidate title",
+          snippet: "Candidate plaintext must leave the DOM on relock.",
+        },
+      ],
+      list_folders: () => {
+        const root = globalThis as { __foldersRead?: number };
+        root.__foldersRead = (root.__foldersRead ?? 0) + 1;
+        if (root.__foldersRead > 1) {
+          throw new Error("simulated post-relock folder refresh failure");
+        }
+        return [
+          {
+            id: "f-relock-failure",
+            name: "Relock failure folder",
+            parentId: null,
+            noteCount: 1,
+            locked: true,
+            unlocked: true,
+            kind: "meeting",
+            children: [],
+          },
+        ];
+      },
+      relock_all: () => {
+        const root = globalThis as {
+          __dashboardLocked?: boolean;
+          __relockCalls?: number;
+          __demoEmit?: (event: string, payload: unknown) => void;
+        };
+        root.__relockCalls = (root.__relockCalls ?? 0) + 1;
+        root.__dashboardLocked = true;
+        root.__demoEmit?.("murmur://ask-history-invalidated", null);
+        return null;
+      },
+    },
+    {
+      list_dashboards: [BOARD],
+    },
+  );
+  await page.addInitScript(
+    ({ readableBoard, lockedBoard }) => {
+      (globalThis as { __readableBoard: unknown }).__readableBoard =
+        readableBoard;
+      (globalThis as { __lockedBoard: unknown }).__lockedBoard = lockedBoard;
+      (globalThis as { __dashboardLocked?: boolean }).__dashboardLocked = false;
+    },
+    { readableBoard: readable, lockedBoard: locked },
+  );
+  await page.goto(`/dashboards/${BOARD.id}`);
+  await expect(page.getByRole("heading", { name: BOARD_SECRET })).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        (
+          globalThis as {
+            __demoEventListenerRegistrationCount: (event: string) => number;
+          }
+        ).__demoEventListenerRegistrationCount(
+          "murmur://ask-history-invalidated",
+        ),
+      ),
+    )
+    .toBe(1);
+
+  // Mount an Ask answer and a source candidate at the same time. Both are
+  // ephemeral plaintext surfaces that must be destroyed on the earliest privacy
+  // boundary, regardless of whether the folder tree can publish a new stamp.
+  await page.getByRole("button", { name: "Ask", exact: true }).click();
+  await page
+    .getByRole("textbox", { name: "Ask a question about this board" })
+    .fill("What is the hidden risk?");
+  await page
+    .getByLabel("Ask this board")
+    .getByRole("button", { name: "Ask", exact: true })
+    .click();
+  await expect(page.getByText(ASK_SECRET)).toBeVisible();
+  await page.getByRole("button", { name: "Compose", exact: true }).click();
+  const addInvoker = page.getByRole("button", { name: "Add to board" });
+  await addInvoker.focus();
+  await page.keyboard.press("Enter");
+  const palette = page.getByRole("dialog", { name: "Add to board" });
+  await palette.getByRole("button", { name: /^Note/ }).click();
+  await expect(palette.getByText(PALETTE_SECRET)).toBeVisible();
+
+  // The opaque scrim correctly makes shell chrome pointer-inert. A backend
+  // privacy boundary can still arrive while the palette is mounted (for example
+  // from another window or screen-share auto-lock), so invoke the real shell
+  // handler's native button activation without weakening production hit-testing.
+  await page
+    .getByRole("button", { name: "Re-seal all 1 unlocked folder now" })
+    .evaluate((button) => (button as HTMLButtonElement).click());
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (globalThis as { __relockCalls?: number }).__relockCalls ?? 0,
+      ),
+    )
+    .toBe(1);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (globalThis as { __dashboardReads?: number }).__dashboardReads ?? 0,
+      ),
+    )
+    .toBe(2);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (globalThis as { __foldersRead?: number }).__foldersRead ?? 0,
+      ),
+    )
+    .toBe(2);
+
+  // `list_folders` rejected, so FoldersService retained the old unlocked tree.
+  // The process-wide privacy event must nevertheless close/scrub every surface
+  // and trigger a fresh gated board read, which now resolves generically locked.
+  await expect(palette).toHaveCount(0);
+  await expect(page.locator("aside.ask")).toHaveCount(0);
+  await expect(page.getByText("1 sealed and excluded")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Re-seal all 1 unlocked folder now" }),
+  ).toBeVisible();
+
+  // Compose had unmounted Ask before relock. Reopening it proves that the old
+  // in-memory turn was destroyed rather than merely hidden with the surface.
+  await page.getByRole("button", { name: "Ask", exact: true }).click();
+  await expect(page.locator("aside.ask")).toBeVisible();
+  await expect(page.locator("aside.ask")).not.toContainText(ASK_SECRET);
+
+  for (const secret of [BOARD_SECRET, ASK_SECRET, PALETTE_SECRET]) {
+    await expect(page.locator("body")).not.toContainText(secret);
+    expect(
+      await page.evaluate(
+        (value) => document.documentElement.outerHTML.includes(value),
+        secret,
+      ),
+      `${secret} must not survive a relock whose folder refresh failed`,
+    ).toBe(false);
+  }
+});
+
+test("Dashboard workspace: a privacy-listener failure blocks every board read and retry", async ({
+  page,
+}) => {
+  const BLOCKED_SECRET = "Nightjar must never cross a missing privacy listener";
+  const readable = {
+    ...BOARD,
+    tiles: [
+      tile(
+        "t-listener-failure",
+        "note",
+        "n-listener-failure",
+        {
+          kind: "note",
+          id: "n-listener-failure",
+          title: BLOCKED_SECRET,
+          snippet: "This fixture would leak if get_dashboard were called.",
+          updatedAt: 1_786_400_000_000,
+        },
+        0,
+      ),
+    ],
+  };
+
+  await mockTauri(
+    page,
+    {
+      get_dashboard: () => {
+        const root = globalThis as {
+          __privacyBlockedReads?: number;
+          __privacyBlockedBoard: unknown;
+        };
+        root.__privacyBlockedReads = (root.__privacyBlockedReads ?? 0) + 1;
+        return root.__privacyBlockedBoard;
+      },
+    },
+    {
+      list_dashboards: [BOARD],
+      get_dashboard_sources: [{ kind: "note", id: "n-listener-failure" }],
+    },
+    ["murmur://ask-history-invalidated"],
+  );
+  await page.addInitScript((board) => {
+    (globalThis as { __privacyBlockedBoard: unknown }).__privacyBlockedBoard =
+      board;
+  }, readable);
+
+  await page.goto(`/dashboards/${BOARD.id}`);
+  await expect(page.getByText("Board unavailable.")).toBeVisible();
+  await expect(
+    page.getByText(/isn.t available securely right now/),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "Try again" })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Add a Note, Recording or Document" }),
+  ).toHaveCount(0);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (globalThis as { __privacyBlockedReads?: number })
+            .__privacyBlockedReads ?? 0,
+      ),
+    )
+    .toBe(0);
+
+  await page.getByRole("button", { name: "Try again" }).click();
+  await expect(page.getByText("Board unavailable.")).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (globalThis as { __privacyBlockedReads?: number })
+            .__privacyBlockedReads ?? 0,
+      ),
+    )
+    .toBe(0);
+  await expect(page.locator("body")).not.toContainText(BLOCKED_SECRET);
+  expect(
+    await page.evaluate(
+      (secret) => document.documentElement.outerHTML.includes(secret),
+      BLOCKED_SECRET,
+    ),
+  ).toBe(false);
+});

--- a/e2e/dashboards/dashboards-context.spec.ts
+++ b/e2e/dashboards/dashboards-context.spec.ts
@@ -41,6 +41,41 @@ const BOARDS = [
   },
 ];
 
+async function enterCompose(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  if (
+    !(await page.locator('section[aria-label="Compose board tiles"]').count())
+  ) {
+    await page.getByRole("button", { name: "Compose", exact: true }).click();
+  }
+  await page.locator('section[aria-label="Compose board tiles"]').waitFor();
+}
+
+async function openPalette(page: import("@playwright/test").Page) {
+  // Board resolution is asynchronous. Waiting for either stable entry action
+  // avoids racing the loading state and then committing to a Compose button
+  // that cannot exist on an empty board.
+  await page
+    .locator(
+      'button:has-text("Add a Note, Recording or Document"), button:has-text("Compose")',
+    )
+    .first()
+    .waitFor();
+  const emptyAction = page.getByRole("button", {
+    name: "Add a Note, Recording or Document",
+  });
+  if (await emptyAction.isVisible()) {
+    await emptyAction.click();
+  } else {
+    await enterCompose(page);
+    await page.getByRole("button", { name: "Add to board" }).click();
+  }
+  const palette = page.getByRole("dialog", { name: "Add to board" });
+  await palette.waitFor();
+  return palette;
+}
+
 test("Ask: a dashboard can be picked as scope and expands to its visible sources", async ({
   page,
 }) => {
@@ -58,7 +93,10 @@ test("Ask: a dashboard can be picked as scope and expands to its visible sources
   );
 
   await page.goto("/ask");
-  await page.getByRole("button", { name: /Source/ }).first().click();
+  await page
+    .getByRole("button", { name: /Source/ })
+    .first()
+    .click();
 
   // Boards are offered ABOVE notes/meetings — the user's own declaration of scope.
   const picker = page.locator(".sp-list");
@@ -70,22 +108,50 @@ test("Ask: a dashboard can be picked as scope and expands to its visible sources
   await picker.getByRole("option", { name: /Atlas GA/ }).click();
 
   // Picking the board added BOTH of its visible sources as chips.
-  await expect(page.locator(".sp-chip, .sp .pill")).toHaveCount(2, { timeout: 5000 });
+  await expect(page.locator(".sp-chip, .sp .pill")).toHaveCount(2, {
+    timeout: 5000,
+  });
 });
 
-test("Dashboards: Arrange mode makes tiles draggable and persists a reorder", async ({
+test("Dashboards: Compose makes tiles draggable and persists a reorder", async ({
   page,
 }) => {
   const tiles = [
     {
-      id: "t-a", dashboardId: "b-atlas", kind: "note", refId: "n-1", title: null,
-      span: 4, position: 0, config: null, createdAt: "2026-08-01T09:00:00Z",
-      data: { kind: "note", id: "n-1", title: "FIRST TILE", snippet: "a", updatedAt: 1 },
+      id: "t-a",
+      dashboardId: "b-atlas",
+      kind: "note",
+      refId: "n-1",
+      title: null,
+      span: 4,
+      position: 0,
+      config: null,
+      createdAt: "2026-08-01T09:00:00Z",
+      data: {
+        kind: "note",
+        id: "n-1",
+        title: "FIRST TILE",
+        snippet: "a",
+        updatedAt: 1,
+      },
     },
     {
-      id: "t-b", dashboardId: "b-atlas", kind: "note", refId: "n-2", title: null,
-      span: 4, position: 1, config: null, createdAt: "2026-08-01T09:00:00Z",
-      data: { kind: "note", id: "n-2", title: "SECOND TILE", snippet: "b", updatedAt: 1 },
+      id: "t-b",
+      dashboardId: "b-atlas",
+      kind: "note",
+      refId: "n-2",
+      title: null,
+      span: 4,
+      position: 1,
+      config: null,
+      createdAt: "2026-08-01T09:00:00Z",
+      data: {
+        kind: "note",
+        id: "n-2",
+        title: "SECOND TILE",
+        snippet: "b",
+        updatedAt: 1,
+      },
     },
   ];
 
@@ -93,7 +159,8 @@ test("Dashboards: Arrange mode makes tiles draggable and persists a reorder", as
     page,
     {
       reorder_dashboard_tiles: (args: { tileIds?: string[] }) => {
-        (window as unknown as { __reorder?: string[] }).__reorder = args?.tileIds;
+        (window as unknown as { __reorder?: string[] }).__reorder =
+          args?.tileIds;
         return null;
       },
     },
@@ -105,16 +172,12 @@ test("Dashboards: Arrange mode makes tiles draggable and persists a reorder", as
   );
 
   await page.goto("/dashboards/b-atlas");
-  await expect(page.getByText("FIRST TILE")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "FIRST TILE" })).toBeVisible();
 
-  // Not draggable until Arrange mode is on — a board is read-first.
-  await expect(page.locator("app-dashboard-tile").first()).not.toHaveAttribute(
-    "draggable",
-    "true",
-  );
-
-  await page.getByRole("button", { name: "Arrange" }).click();
-  await expect(page.getByText(/drag tiles to reorder/)).toBeVisible();
+  // The peer-card grid does not exist until the explicit Compose mode is entered.
+  await expect(page.locator("app-dashboard-tile")).toHaveCount(0);
+  await enterCompose(page);
+  await expect(page.getByText(/Drag or use Move earlier/)).toBeVisible();
   await expect(page.locator("app-dashboard-tile").first()).toHaveAttribute(
     "draggable",
     "true",
@@ -128,7 +191,9 @@ test("Dashboards: Arrange mode makes tiles draggable and persists a reorder", as
   // The backend was asked for the NEW order, second tile first.
   await expect
     .poll(() =>
-      page.evaluate(() => (window as unknown as { __reorder?: string[] }).__reorder),
+      page.evaluate(
+        () => (window as unknown as { __reorder?: string[] }).__reorder,
+      ),
     )
     .toEqual(["t-b", "t-a"]);
 });
@@ -156,15 +221,7 @@ test("Dashboards: the tile palette escapes every containing block and lands in t
   );
 
   await page.goto("/dashboards/b-atlas");
-  await page.getByRole("button", { name: "Add tile" }).click();
-
-  // The trigger reflects state, so "the click landed" and "the palette rendered"
-  // are separately observable — the two failures that looked identical in the
-  // original bug report.
-  await expect(page.getByRole("button", { name: "Close", exact: true })).toBeVisible();
-
-  const palette = page.getByRole("dialog", { name: "Add a tile" });
-  await expect(palette).toBeVisible();
+  const palette = await openPalette(page);
 
   // It must be rendered by `app-shell`, NOT inside the board. That is the whole
   // fix: an overlay whose only ancestors are <body>/<html> has no containing
@@ -173,7 +230,8 @@ test("Dashboards: the tile palette escapes every containing block and lands in t
   // the packaged webview as in the engines this suite runs.
   const ancestry = await page.evaluate(() => {
     const el = document.querySelector(".tp-overlay");
-    if (!el) return { found: false, insideBoard: true, containingBlocks: ["missing"] };
+    if (!el)
+      return { found: false, insideBoard: true, containingBlocks: ["missing"] };
     const containingBlocks: string[] = [];
     for (let n = el.parentElement; n; n = n.parentElement) {
       const cs = getComputedStyle(n);
@@ -185,7 +243,9 @@ test("Dashboards: the tile palette escapes every containing block and lands in t
         cs.contain,
         cs.willChange,
       ];
-      if (traps.some((v) => v && v !== "none" && v !== "auto" && v !== "normal")) {
+      if (
+        traps.some((v) => v && v !== "none" && v !== "auto" && v !== "normal")
+      ) {
         containingBlocks.push(n.tagName.toLowerCase());
       }
     }
@@ -229,17 +289,28 @@ test("Dashboards: the tile palette escapes every containing block and lands in t
     const el = document.querySelector(".palette");
     if (!el) return "no-palette";
     const r = el.getBoundingClientRect();
-    const top = document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2);
-    return el.contains(top) ? "palette" : (top?.className?.toString() ?? "unknown");
+    const top = document.elementFromPoint(
+      r.x + r.width / 2,
+      r.y + r.height / 2,
+    );
+    return el.contains(top)
+      ? "palette"
+      : (top?.className?.toString() ?? "unknown");
   });
-  expect(hit, "the palette centre must be hit-testable, not covered").toBe("palette");
+  expect(hit, "the palette centre must be hit-testable, not covered").toBe(
+    "palette",
+  );
 
   // And a catalogue entry must be clickable end to end (it advances to step 2).
   await palette.locator(".node").first().click();
-  await expect(palette.getByRole("button", { name: /All tiles/ })).toBeVisible();
+  await expect(
+    palette.getByRole("button", { name: /All tiles/ }),
+  ).toBeVisible();
 });
 
-test("Dashboards: the palette still shows on an engine without :modal or showModal", async ({ page }) => {
+test("Dashboards: the palette still shows on an engine without :modal or showModal", async ({
+  page,
+}) => {
   // THE REPORTED FAILURE, reproduced. The trigger flipped to "Close" — so the click
   // landed and the state was right — while nothing appeared on screen. That is what
   // a <dialog> looks like when showModal() throws: it never opens, so it stays
@@ -253,7 +324,10 @@ test("Dashboards: the palette still shows on an engine without :modal or showMod
     const realMatches = Element.prototype.matches;
     Element.prototype.matches = function (sel: string) {
       if (typeof sel === "string" && sel.includes(":modal")) {
-        throw new DOMException("':modal' is not a valid selector", "SyntaxError");
+        throw new DOMException(
+          "':modal' is not a valid selector",
+          "SyntaxError",
+        );
       }
       return realMatches.call(this, sel);
     };
@@ -276,10 +350,11 @@ test("Dashboards: the palette still shows on an engine without :modal or showMod
   );
 
   await page.goto("/dashboards/b-atlas");
-  await page.getByRole("button", { name: "Add tile" }).click();
-
-  const palette = page.getByRole("dialog", { name: "Add a tile" });
-  await expect(palette, "a refused showModal must not leave the palette hidden").toBeVisible();
+  const palette = await openPalette(page);
+  await expect(
+    palette,
+    "a refused showModal must not leave the palette hidden",
+  ).toBeVisible();
   expect(await palette.locator(".node").count()).toBeGreaterThanOrEqual(6);
 
   // On screen, and hit-testable — not merely present in the DOM.
@@ -290,7 +365,9 @@ test("Dashboards: the palette still shows on an engine without :modal or showMod
   const hit = await page.evaluate(() => {
     const el = document.querySelector(".palette")!;
     const r = el.getBoundingClientRect();
-    return el.contains(document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2));
+    return el.contains(
+      document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2),
+    );
   });
   expect(hit, "the fallback palette must be clickable, not covered").toBe(true);
 });
@@ -337,9 +414,7 @@ test("Dashboards: the palette's position does not depend on the board's own subt
   await page.addStyleTag({
     content: "app-dashboard-view { transform: translateY(1200px); }",
   });
-  await page.getByRole("button", { name: "Add tile" }).click();
-
-  const palette = page.getByRole("dialog", { name: "Add a tile" });
+  const palette = await openPalette(page);
   await expect(palette).toBeVisible();
 
   const box = await palette.boundingBox();
@@ -356,7 +431,9 @@ test("Dashboards: the palette's position does not depend on the board's own subt
     const el = document.querySelector(".palette");
     if (!el) return false;
     const r = el.getBoundingClientRect();
-    return el.contains(document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2));
+    return el.contains(
+      document.elementFromPoint(r.x + r.width / 2, r.y + r.height / 2),
+    );
   });
   expect(hit, "the palette centre must be hit-testable").toBe(true);
 });
@@ -381,15 +458,42 @@ test("Dashboards: a tile with a malformed payload cannot blank the rest of the U
 
   const brokenTiles = [
     {
-      id: "t-note", dashboardId: "b-atlas", kind: "note", refId: "n-1", title: null,
-      span: 4, position: 0, config: null, createdAt: "2026-08-01T09:00:00Z",
-      data: { kind: "note", id: "n-1", title: "A NOTE", snippet: "s", updatedAt: null },
+      id: "t-note",
+      dashboardId: "b-atlas",
+      kind: "note",
+      refId: "n-1",
+      title: null,
+      span: 4,
+      position: 0,
+      config: null,
+      createdAt: "2026-08-01T09:00:00Z",
+      data: {
+        kind: "note",
+        id: "n-1",
+        title: "A NOTE",
+        snippet: "s",
+        updatedAt: null,
+      },
     },
     {
       // Exactly what the backend used to send: no `startedAt`, no `durationS`, no `hasAudio`.
-      id: "t-rec", dashboardId: "b-atlas", kind: "meeting", refId: "m-1", title: null,
-      span: 4, position: 1, config: null, createdAt: "2026-08-01T09:00:00Z",
-      data: { kind: "meeting", id: "m-1", title: "A RECORDING", started_at: "2026-07-20T02:30:00Z", duration_s: 900, has_audio: true },
+      id: "t-rec",
+      dashboardId: "b-atlas",
+      kind: "meeting",
+      refId: "m-1",
+      title: null,
+      span: 4,
+      position: 1,
+      config: null,
+      createdAt: "2026-08-01T09:00:00Z",
+      data: {
+        kind: "meeting",
+        id: "m-1",
+        title: "A RECORDING",
+        started_at: "2026-07-20T02:30:00Z",
+        duration_s: 900,
+        has_audio: true,
+      },
     },
   ];
 
@@ -410,9 +514,11 @@ test("Dashboards: a tile with a malformed payload cannot blank the rest of the U
 
   // The palette is rendered LATER in the same change-detection pass than the tiles, so it is the
   // thing a throwing tile binding takes down. It must still open, and be populated.
-  await page.getByRole("button", { name: "Add tile" }).click();
-  const palette = page.getByRole("dialog", { name: "Add a tile" });
-  await expect(palette, "a malformed tile must not stop the palette rendering").toBeVisible();
+  const palette = await openPalette(page);
+  await expect(
+    palette,
+    "a malformed tile must not stop the palette rendering",
+  ).toBeVisible();
   expect(
     await palette.locator(".node").count(),
     "the palette's catalogue must render, not just its box",

--- a/e2e/dashboards/dashboards.spec.ts
+++ b/e2e/dashboards/dashboards.spec.ts
@@ -1,22 +1,32 @@
 import { expect, test } from "@playwright/test";
 import { mockTauri } from "../settings-ai/mock-invoke";
 
-/**
- * Open the Ask column. It starts collapsed to a rail — the scope count stays on
- * screen, the empty transcript does not — so any test that types a question expands
- * it first, which is the same click a user makes.
- */
+/** Open the board's on-demand Ask surface if it is not already present. */
 async function openAsk(page: import("@playwright/test").Page): Promise<void> {
-  // Wait for the panel to EXIST before deciding. A bare `count()` races Angular's
-  // first render and silently no-ops, which then surfaces as a `fill` timeout on a
-  // field that was never revealed.
   const panel = page.locator("aside.ask");
-  await panel.waitFor();
-  const rail = panel.locator("button.ask-rail");
-  if (await rail.count()) await rail.click();
+  if (!(await panel.count())) {
+    await page.getByRole("button", { name: "Ask", exact: true }).click();
+  }
   await page.getByRole("textbox", { name: /Ask a question/i }).waitFor();
 }
 
+async function submitAsk(page: import("@playwright/test").Page): Promise<void> {
+  await page
+    .getByLabel("Ask this board")
+    .getByRole("button", { name: "Ask", exact: true })
+    .click();
+}
+
+async function enterCompose(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  if (
+    !(await page.locator('section[aria-label="Compose board tiles"]').count())
+  ) {
+    await page.getByRole("button", { name: "Compose", exact: true }).click();
+  }
+  await page.locator('section[aria-label="Compose board tiles"]').waitFor();
+}
 
 /**
  * Dashboards — the runtime oracle for the boards feature.
@@ -127,10 +137,16 @@ const BOARD_DETAIL = {
 test("Dashboards: the list renders boards with their miniature, and opens one", async ({
   page,
 }) => {
-  await mockTauri(page, {}, { list_dashboards: BOARDS, get_dashboard: BOARD_DETAIL });
+  await mockTauri(
+    page,
+    {},
+    { list_dashboards: BOARDS, get_dashboard: BOARD_DETAIL },
+  );
 
   await page.goto("/dashboards");
-  await expect(page.getByRole("heading", { name: "Dashboards", level: 1 })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Dashboards", level: 1 }),
+  ).toBeVisible();
 
   // Pinned first, and the card carries its source-mix chips.
   await expect(page.getByText("Atlas GA")).toBeVisible();
@@ -139,36 +155,60 @@ test("Dashboards: the list renders boards with their miniature, and opens one", 
   await expect(page.getByText("1 insight")).toBeVisible();
 
   // The miniature draws one box per tile — layout metadata, never a payload.
-  await expect(page.locator(".board-card").first().locator(".mt")).toHaveCount(3);
+  await expect(page.locator(".board-card").first().locator(".mt")).toHaveCount(
+    3,
+  );
 
   await page.getByRole("button", { name: "Open Atlas GA" }).click();
-  await expect(page.getByRole("heading", { name: /Atlas GA/, level: 1 })).toBeVisible();
-  await expect(page.getByText("Atlas GA checklist")).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: /Atlas GA/, level: 1 }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Atlas GA checklist" }),
+  ).toBeVisible();
 });
 
 test("Dashboards: a SEALED tile leaks nothing — not even the title the user typed", async ({
   page,
 }) => {
-  await mockTauri(page, {}, { list_dashboards: BOARDS, get_dashboard: BOARD_DETAIL });
+  await mockTauri(
+    page,
+    {},
+    { list_dashboards: BOARDS, get_dashboard: BOARD_DETAIL },
+  );
 
   await page.goto("/dashboards/b-atlas");
-  await expect(page.getByText("Atlas GA checklist")).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Atlas GA checklist" }),
+  ).toBeVisible();
 
+  const assertSecretAbsent = async () => {
+    await expect(page.locator("body")).not.toContainText(SEALED_SECRET);
+    expect(
+      await page.evaluate(
+        (secret) => document.documentElement.outerHTML.includes(secret),
+        SEALED_SECRET,
+      ),
+      "the sealed title must not appear anywhere in the DOM",
+    ).toBe(false);
+  };
+
+  // Read mode must stay generic in the Brief and in every alternate lens.
+  await expect(page.getByText("1 sealed and excluded")).toBeVisible();
+  await assertSecretAbsent();
+  for (const lens of ["Overview", "Commitments", "Sources", "People"]) {
+    await page.getByRole("button", { name: lens, exact: true }).click();
+    await assertSecretAbsent();
+  }
+
+  // Compose may render the legacy tile row, but only from its resolved locked
+  // payload. Stored kind/title/config remain forbidden as fallback chrome.
+  await enterCompose(page);
   const sealed = page.locator("app-dashboard-tile.is-locked");
   await expect(sealed).toHaveCount(1);
-  // Copy tightened 2026-08-04 to tie the lock model to the board's thesis: a sealed
-  // tile is not merely locked, it is OUT OF SCOPE for the board's Ask.
   await expect(sealed).toContainText("Sealed — not in scope");
   await expect(sealed.locator(".tile-title")).toHaveText("🔒 Locked");
-
-  // The whole page must not contain the sealed title anywhere — heading, DOM
-  // attribute, tooltip or otherwise.
-  await expect(page.locator("body")).not.toContainText(SEALED_SECRET);
-  const anywhere = await page.evaluate(
-    (secret) => document.documentElement.outerHTML.includes(secret),
-    SEALED_SECRET,
-  );
-  expect(anywhere, "the sealed title must not appear in the DOM at all").toBe(false);
+  await assertSecretAbsent();
 
   // CONTROL: the same assertion catches a leak when one exists — an unsealed
   // tile's title IS in the DOM, so the check above is not vacuous.
@@ -212,13 +252,18 @@ test("Dashboards: an entity tile whose entity went invisible keeps no stored nam
   );
 
   await page.goto("/dashboards/b-atlas");
+  await enterCompose(page);
   await expect(page.locator("app-dashboard-tile")).toHaveCount(1);
-  await expect(page.locator("app-dashboard-tile .tile-title")).not.toContainText("Dana");
+  await expect(
+    page.locator("app-dashboard-tile .tile-title"),
+  ).not.toContainText("Dana");
   // A drift lane with no rows never had data, so it collapses to a strip rather
   // than reserving a full card for an apology (2026-08-04 density pass). The
   // leak assertion above is the point of this test and is unchanged.
   await expect(page.locator("app-dashboard-tile")).toHaveClass(/is-empty/);
-  await expect(page.getByText(/Values land here as they get revised/)).toBeVisible();
+  await expect(
+    page.getByText(/Values land here as they get revised/),
+  ).toBeVisible();
 });
 
 test("Dashboards: a withheld Living answer shows why, and not the cached text", async ({
@@ -257,21 +302,97 @@ test("Dashboards: a withheld Living answer shows why, and not the cached text", 
   );
 
   await page.goto("/dashboards/b-atlas");
+  await enterCompose(page);
   await expect(page.getByText(/The saved answer is hidden/)).toBeVisible();
-  await expect(page.getByText(/one of the sources it was built from is sealed/)).toBeVisible();
+  await expect(
+    page.getByText(/one of the sources it was built from is sealed/),
+  ).toBeVisible();
 });
 
-test("Dashboards: board Ask is scoped to the board's sources and cites the tiles it used", async ({
+test("Dashboards: Read exposes Living Answer answered-at without inventing a stale verdict", async ({
   page,
 }) => {
   await mockTauri(
     page,
     {
-      ask_vault: () => ({
-        answer: "Jun 14 is at risk — the migration still has a sprint left.",
-        sources: [{ meetingId: "m-1", title: "Atlas weekly", startedAt: "2026-06-03T09:00:00Z" }],
-        citations: [],
-      }),
+      set_dashboard_answer: () => {
+        const root = globalThis as { __readAnswerWrites?: number };
+        root.__readAnswerWrites = (root.__readAnswerWrites ?? 0) + 1;
+        return null;
+      },
+    },
+    {
+      list_dashboards: BOARDS,
+      get_dashboard: {
+        ...BOARDS[0],
+        tiles: [
+          {
+            id: "t-cached-answer",
+            dashboardId: "b-atlas",
+            kind: "living_answer",
+            refId: null,
+            title: null,
+            span: 5,
+            position: 0,
+            config: JSON.stringify({ question: "Will Atlas launch?" }),
+            createdAt: "2026-01-01T09:00:00Z",
+            data: {
+              kind: "livingAnswer",
+              question: "Will Atlas launch?",
+              answer: "The launch remains on track.",
+              answeredAt: "2026-01-02T09:00:00Z",
+              withheld: false,
+            },
+          },
+        ],
+      },
+      get_dashboard_sources: [],
+    },
+  );
+
+  await page.goto("/dashboards/b-atlas");
+  const brief = page.getByRole("region", { name: "Board brief" });
+  await expect(
+    brief.getByText("Cached answer", { exact: false }),
+  ).toBeVisible();
+  await expect(brief.getByText(/answered .+2026/i)).toBeVisible();
+  await expect(brief).not.toContainText(/stale|fresh/i);
+
+  await page.getByRole("button", { name: "Compose", exact: true }).click();
+  const tile = page.locator(
+    'app-dashboard-tile[data-tile-id="t-cached-answer"]',
+  );
+  await expect(tile).toBeVisible();
+  await expect(tile.getByRole("button", { name: "Re-answer" })).toHaveCount(0);
+  expect(
+    await page.evaluate(
+      () =>
+        (globalThis as { __readAnswerWrites?: number }).__readAnswerWrites ?? 0,
+    ),
+  ).toBe(0);
+});
+
+test("Dashboards: board Ask sends readable sources and the board id", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {
+      ask_vault: (args: unknown) => {
+        (globalThis as { __dashboardAskArgs?: unknown }).__dashboardAskArgs =
+          args;
+        return {
+          answer: "Jun 14 is at risk — the migration still has a sprint left.",
+          sources: [
+            {
+              meetingId: "m-1",
+              title: "Atlas weekly",
+              startedAt: "2026-06-03T09:00:00Z",
+            },
+          ],
+          citations: [],
+        };
+      },
     },
     {
       list_dashboards: BOARDS,
@@ -309,26 +430,29 @@ test("Dashboards: board Ask is scoped to the board's sources and cites the tiles
 
   await page.goto("/dashboards/b-atlas");
 
-  // Collapsed, the rail still carries the count — that readout is the feature's
-  // claim and stays on screen whether or not the transcript is open.
-  await expect(page.getByText("2 in scope")).toBeVisible();
+  await expect(page.locator("aside.ask")).toHaveCount(0);
 
   await openAsk(page);
-  // Expanded, the scope line is explicit about WHAT the answer may draw on, and
-  // says out loud that the sealed tile is excluded.
-  await expect(page.getByText(/2 readable sources/)).toBeVisible();
-  await expect(page.getByText(/1 sealed tile is excluded until unlocked/)).toBeVisible();
+  await expect(
+    page.getByText(/2 currently readable material sources/),
+  ).toBeVisible();
+  await expect(page.getByText(/1 sealed item is excluded/)).toBeVisible();
 
   await openAsk(page);
-  await page.getByRole("textbox", { name: "Ask a question about this board" }).fill("Will we make Jun 14?");
-  await page.getByRole("button", { name: "Ask", exact: true }).click();
+  await page
+    .getByRole("textbox", { name: "Ask a question about this board" })
+    .fill("Will we make Jun 14?");
+  await submitAsk(page);
 
   await expect(page.getByText(/Jun 14 is at risk/)).toBeVisible();
-
-  // The tile whose source grounded the answer lights up and numbers itself.
-  const cited = page.locator("app-dashboard-tile.cited");
-  await expect(cited).toHaveCount(1);
-  await expect(cited.locator(".cite-n")).toHaveText("1");
+  const sent = (await page.evaluate(
+    () => (globalThis as { __dashboardAskArgs?: unknown }).__dashboardAskArgs,
+  )) as { dashboardId?: string; explicitSources?: unknown[] };
+  expect(sent.dashboardId).toBe("b-atlas");
+  expect(sent.explicitSources).toEqual([
+    { kind: "meeting", id: "m-1" },
+    { kind: "note", id: "n-1" },
+  ]);
 });
 
 test("Dashboards: an empty board invites the first tile instead of showing a dead grid", async ({
@@ -345,22 +469,39 @@ test("Dashboards: an empty board invites the first tile instead of showing a dea
   );
 
   await page.goto("/dashboards/b-acme");
-  await expect(page.getByText("This board is empty.")).toBeVisible();
-  await expect(page.getByRole("button", { name: "Add the first tile" })).toBeVisible();
+  await expect(
+    page.getByText("Start with material for this board."),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Add a Note, Recording or Document" }),
+  ).toBeVisible();
 
   // Asking an empty board is honest rather than hallucinating from the vault.
   await openAsk(page);
-  await page.getByRole("textbox", { name: "Ask a question about this board" }).fill("What is going on?");
-  await page.getByRole("button", { name: "Ask", exact: true }).click();
+  await page
+    .getByRole("textbox", { name: "Ask a question about this board" })
+    .fill("What is going on?");
+  await submitAsk(page);
   await expect(page.getByText(/no readable sources yet/)).toBeVisible();
 });
 
-test("Dashboards: the tile palette offers the catalogue and flags only-Murmur tiles", async ({
+test("Dashboards: Living Answer creation stores its question config but never an answer", async ({
   page,
 }) => {
   await mockTauri(
     page,
-    {},
+    {
+      add_dashboard_tile: (args: unknown) => {
+        (globalThis as { __livingAnswerAdd?: unknown }).__livingAnswerAdd =
+          args;
+        return null;
+      },
+      set_dashboard_answer: () => {
+        const root = globalThis as { __livingAnswerWrites?: number };
+        root.__livingAnswerWrites = (root.__livingAnswerWrites ?? 0) + 1;
+        return null;
+      },
+    },
     {
       list_dashboards: BOARDS,
       get_dashboard: BOARD_DETAIL,
@@ -369,25 +510,50 @@ test("Dashboards: the tile palette offers the catalogue and flags only-Murmur ti
   );
 
   await page.goto("/dashboards/b-atlas");
-  await page.getByRole("button", { name: "Add tile" }).click();
+  await enterCompose(page);
+  await page.getByRole("button", { name: "Add to board" }).click();
 
-  const palette = page.getByRole("dialog", { name: "Add a tile" });
+  const palette = page.getByRole("dialog", { name: "Add to board" });
   await expect(palette).toBeVisible();
+  await expect(palette.getByRole("heading", { name: "Sources" })).toBeVisible();
+  await expect(palette.getByRole("heading", { name: "Views" })).toBeVisible();
+  await expect(palette.getByRole("button", { name: /^Note/ })).toBeVisible();
+  await expect(
+    palette.getByRole("button", { name: /^Recording/ }),
+  ).toBeVisible();
+  await expect(
+    palette.getByRole("button", { name: /^Document/ }),
+  ).toBeVisible();
   await expect(palette.getByText("Promise ledger")).toBeVisible();
-  await expect(palette.getByText("Living answer")).toBeVisible();
-  // RETIRED 2026-08-04 and asserted ABSENT, not merely unmentioned: `drift`,
-  // `numbers` and `pulse` are blocked in the extractor rather than by a shortage
-  // of recordings (see tile-palette.component.ts), and a tile that is empty for
-  // most people is worse than no tile. Their `resolve_tile` arms stay alive so
-  // boards that already contain one keep opening — this asserts only that the
-  // palette stops OFFERING them.
+  // Retired extractor views stay absent; Living Answer remains a supported View.
   await expect(palette.getByText("Drift lane")).toHaveCount(0);
   await expect(palette.getByText("Numbers")).toHaveCount(0);
   await expect(palette.getByText("Pulse")).toHaveCount(0);
-  // The catalogue marks the tiles that only exist because Murmur heard the room.
-  expect(await palette.locator(".only-badge").count()).toBeGreaterThanOrEqual(3);
+  expect(await palette.locator(".only-badge").count()).toBeGreaterThanOrEqual(
+    3,
+  );
 
-  // Escape must always dismiss a modal.
-  await page.keyboard.press("Escape");
-  await expect(palette).toBeHidden();
+  await palette.getByRole("button", { name: /^Living answer/ }).click();
+  const question = palette.getByLabel("The question this tile keeps answering");
+  await expect(question).toBeFocused();
+  await question.fill("  Will Atlas ship safely?  ");
+  await palette.getByRole("button", { name: "Add tile" }).click();
+  await expect(palette).toHaveCount(0);
+
+  const added = await page.evaluate(
+    () => (globalThis as { __livingAnswerAdd?: unknown }).__livingAnswerAdd,
+  );
+  expect(JSON.parse(JSON.stringify(added))).toEqual({
+    dashboardId: "b-atlas",
+    kind: "living_answer",
+    title: "Will Atlas ship safely?",
+    config: JSON.stringify({ question: "Will Atlas ship safely?" }),
+  });
+  expect(
+    await page.evaluate(
+      () =>
+        (globalThis as { __livingAnswerWrites?: number })
+          .__livingAnswerWrites ?? 0,
+    ),
+  ).toBe(0);
 });

--- a/src/app/features/dashboards/dashboard-projection.ts
+++ b/src/app/features/dashboards/dashboard-projection.ts
@@ -1,0 +1,282 @@
+import type { ResolvedTile, SourceRef, TileRow } from "../../core/models";
+
+export type DashboardLens =
+  | "brief"
+  | "overview"
+  | "commitments"
+  | "sources"
+  | "people";
+
+export interface MaterialSourceView {
+  id: string;
+  kind: "note" | "meeting" | "document";
+  label: "Note" | "Recording" | "Document";
+  title: string;
+  detail: string;
+  source: SourceRef;
+  sortAt: number | null;
+}
+
+export interface CommitmentView {
+  id: string;
+  text: string;
+  meta: string | null;
+  status: string | null;
+  source: SourceRef | null;
+  category: "Promise" | "Reminder";
+}
+
+export interface PersonView {
+  id: string;
+  name: string;
+  mentionCount: number;
+  openCommitments: number;
+}
+
+export interface SupersededStateView {
+  id: string;
+  entity: string;
+  predicate: string;
+  value: string;
+  meta: string | null;
+  source: SourceRef | null;
+}
+
+export interface BoardProjection {
+  dominant: {
+    label: string;
+    title: string;
+    detail: string;
+    answeredAt: string | null;
+    source: SourceRef | null;
+  };
+  attention: CommitmentView[];
+  evidence: MaterialSourceView[];
+  commitments: CommitmentView[];
+  sources: MaterialSourceView[];
+  people: PersonView[];
+  supersededStates: SupersededStateView[];
+  readableMaterialCount: number;
+  derivedViewCount: number;
+  sealedCount: number;
+  missingCount: number;
+  hasGoodZero: boolean;
+}
+
+const MATERIAL_KINDS = new Set(["note", "meeting", "document"]);
+const ATTENTION_STATUSES = new Set(["late", "due"]);
+
+function safeText(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function sourceFromTile(tile: ResolvedTile): MaterialSourceView | null {
+  const data = tile.data;
+  switch (data.kind) {
+    case "note":
+      if (typeof data.id !== "string" || data.id === "") return null;
+      return {
+        id: `${data.kind}:${data.id}`,
+        kind: data.kind,
+        label: "Note",
+        title: safeText(data.title, "Untitled note"),
+        detail: safeText(data.snippet, "No note text yet."),
+        source: { kind: "note", id: data.id },
+        sortAt: Number.isFinite(data.updatedAt) ? data.updatedAt : null,
+      };
+    case "meeting":
+      if (typeof data.id !== "string" || data.id === "") return null;
+      return {
+        id: `${data.kind}:${data.id}`,
+        kind: data.kind,
+        label: "Recording",
+        title: safeText(data.title, "Untitled recording"),
+        detail: data.hasAudio
+          ? "Audio is available."
+          : "Audio is unavailable.",
+        source: { kind: "meeting", id: data.id },
+        sortAt:
+          typeof data.startedAt === "string" && Number.isFinite(Date.parse(data.startedAt))
+            ? Date.parse(data.startedAt)
+            : null,
+      };
+    case "document":
+      if (typeof data.id !== "string" || data.id === "") return null;
+      return {
+        id: `${data.kind}:${data.id}`,
+        kind: data.kind,
+        label: "Document",
+        title: safeText(data.title, "Untitled document"),
+        detail: safeText(data.snippet, "No extractable text."),
+        source: { kind: "document", id: data.id },
+        sortAt: null,
+      };
+    default:
+      return null;
+  }
+}
+
+function rowViews(
+  tile: ResolvedTile,
+  rows: TileRow[],
+  category: CommitmentView["category"],
+): CommitmentView[] {
+  return rows.map((row, index) => ({
+    id: `${tile.id}:${index}`,
+    text: row.text,
+    meta: row.meta,
+    status: row.status,
+    source: row.source,
+    category,
+  }));
+}
+
+/**
+ * Build every Read lens from the already-resolved, already-gated board payload.
+ * A locked tile contributes one number only; no stored chrome or source metadata
+ * is copied into the projection, which keeps every Read representation generic.
+ */
+export function projectDashboard(tiles: readonly ResolvedTile[]): BoardProjection {
+  const sources: MaterialSourceView[] = [];
+  const seenSources = new Set<string>();
+  const commitments: CommitmentView[] = [];
+  const people: PersonView[] = [];
+  const supersededStates: SupersededStateView[] = [];
+  let sealedCount = 0;
+  let missingCount = 0;
+  let derivedViewCount = 0;
+  let hasGoodZero = false;
+  let livingAnswer: { title: string; detail: string; answeredAt: string | null } | null = null;
+
+  for (const tile of tiles) {
+    const data = tile.data;
+    if (data.kind === "locked") {
+      sealedCount += 1;
+      continue;
+    }
+    if (data.kind === "missing" || data.kind === "unconfigured") {
+      missingCount += 1;
+      continue;
+    }
+
+    const material = sourceFromTile(tile);
+    if (material) {
+      if (!seenSources.has(material.id)) {
+        seenSources.add(material.id);
+        sources.push(material);
+      }
+      continue;
+    }
+
+    derivedViewCount += 1;
+    switch (data.kind) {
+      case "promises":
+        commitments.push(...rowViews(tile, data.rows, "Promise"));
+        hasGoodZero ||= data.rows.length === 0;
+        break;
+      case "reminders":
+        commitments.push(...rowViews(tile, data.rows, "Reminder"));
+        hasGoodZero ||= data.rows.length === 0;
+        break;
+      case "person":
+        people.push({
+          id: data.id,
+          name: data.name,
+          mentionCount: data.mentionCount,
+          openCommitments: data.openCommitments,
+        });
+        break;
+      case "livingAnswer":
+        if (!livingAnswer && !data.withheld && data.answer) {
+          livingAnswer = {
+            title: data.question,
+            detail: data.answer,
+            answeredAt: data.answeredAt,
+          };
+        }
+        break;
+      case "drift":
+        for (const [index, row] of data.rows.entries()) {
+          // `old` is an explicit backend-resolved bitemporal state: this value
+          // was superseded. It is the wire's honest past-state signal, distinct from
+          // a missing source, sealed payload, or useful zero.
+          if (row.status === "old") {
+            supersededStates.push({
+              id: `${tile.id}:${index}`,
+              entity: data.entity,
+              predicate: data.predicate,
+              value: row.text,
+              meta: row.meta,
+              source: row.source,
+            });
+          }
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  const attention = commitments
+    .filter((row) => row.status !== null && ATTENTION_STATUSES.has(row.status))
+    .slice(0, 5);
+  const evidence = [...sources]
+    .sort((a, b) => {
+      if (a.sortAt === null && b.sortAt === null) return 0;
+      if (a.sortAt === null) return 1;
+      if (b.sortAt === null) return -1;
+      return b.sortAt - a.sortAt;
+    })
+    .slice(0, 4);
+  const firstSource = sources[0] ?? null;
+  const dominant = livingAnswer
+    ? {
+        label: "Cached answer",
+        title: livingAnswer.title || "Living answer",
+        detail: livingAnswer.detail,
+        answeredAt: livingAnswer.answeredAt,
+        source: null,
+      }
+    : firstSource
+      ? {
+          label: "Current source",
+          title: firstSource.title,
+          detail: firstSource.detail,
+          answeredAt: null,
+          source: firstSource.source,
+        }
+      : commitments.length === 0 && hasGoodZero
+        ? {
+            label: "Current state",
+            title: "Nothing open",
+            detail: "The board's configured commitment views have no open items.",
+            answeredAt: null,
+            source: null,
+          }
+        : {
+            label: "Current state",
+            title: "No readable material yet",
+            detail: "Add a note, recording or document, or unlock a sealed source.",
+            answeredAt: null,
+            source: null,
+          };
+
+  return {
+    dominant,
+    attention,
+    evidence,
+    commitments,
+    sources,
+    people,
+    supersededStates,
+    readableMaterialCount: sources.length,
+    derivedViewCount,
+    sealedCount,
+    missingCount,
+    hasGoodZero,
+  };
+}
+
+export function isMaterialTile(tile: ResolvedTile): boolean {
+  return MATERIAL_KINDS.has(tile.data.kind);
+}

--- a/src/app/features/dashboards/dashboard-read/dashboard-read.component.html
+++ b/src/app/features/dashboards/dashboard-read/dashboard-read.component.html
@@ -1,0 +1,171 @@
+<section class="read" [attr.aria-label]="lens() === 'brief' ? 'Board brief' : lens() + ' lens'">
+  @switch (lens()) {
+    @case ("brief") {
+      <div class="dominant">
+        <span class="eyebrow">{{ projection().dominant.label }}</span>
+        <h2>{{ projection().dominant.title }}</h2>
+        <p>{{ projection().dominant.detail }}</p>
+        @if (projection().dominant.answeredAt; as answeredAt) {
+          <p class="answer-age">Answered {{ formatDate(answeredAt) }}</p>
+        }
+        @if (projection().dominant.source; as source) {
+          <button type="button" class="source-action" (click)="open(source)">
+            Open source <span aria-hidden="true">→</span>
+          </button>
+        }
+      </div>
+
+      <div class="brief-grid">
+        <section class="read-card" aria-labelledby="attention-title">
+          <header class="section-head">
+            <h3 id="attention-title">Needs attention</h3>
+            <span>{{ projection().attention.length }}</span>
+          </header>
+          @if (projection().attention.length === 0) {
+            <p class="good"><span aria-hidden="true">✓</span> No due or overdue items</p>
+          } @else {
+            <ul class="read-list">
+              @for (row of projection().attention; track row.id) {
+                <li>
+                  <button type="button" class="read-row" [disabled]="!row.source" (click)="open(row.source)">
+                    <span class="row-title">{{ row.text }}</span>
+                    <span class="row-meta">{{ row.category }}@if (row.meta) { · {{ row.meta }}}</span>
+                  </button>
+                  <span class="status">{{ row.status }}</span>
+                </li>
+              }
+            </ul>
+          }
+        </section>
+
+        <section class="read-card" aria-labelledby="evidence-title">
+          <header class="section-head">
+            <h3 id="evidence-title">Recent evidence</h3>
+            <span>{{ projection().evidence.length }}</span>
+          </header>
+          @if (projection().evidence.length === 0) {
+            <p class="muted">No readable material sources on this board.</p>
+          } @else {
+            <ul class="read-list">
+              @for (source of projection().evidence; track source.id) {
+                <li>
+                  <button type="button" class="read-row" (click)="open(source.source)">
+                    <span class="row-title">{{ source.title }}</span>
+                    <span class="row-meta">{{ source.label }} · {{ source.detail }}</span>
+                  </button>
+                </li>
+              }
+            </ul>
+          }
+        </section>
+      </div>
+    }
+
+    @case ("overview") {
+      <div class="lens-head">
+        <span class="eyebrow">Overview</span>
+        <h2>The board at a glance</h2>
+        <p>Counts describe the readable board payload plus history the backend explicitly marks as superseded.</p>
+      </div>
+      <dl class="metrics">
+        <div><dt>Readable sources</dt><dd>{{ projection().readableMaterialCount }}</dd></div>
+        <div><dt>Derived views</dt><dd>{{ projection().derivedViewCount }}</dd></div>
+        <div><dt>People</dt><dd>{{ projection().people.length }}</dd></div>
+        <div><dt>Open items</dt><dd>{{ projection().commitments.length }}</dd></div>
+        <div><dt>Superseded values</dt><dd>{{ projection().supersededStates.length }}</dd></div>
+      </dl>
+      @if (projection().supersededStates.length > 0) {
+        <section class="read-card" aria-labelledby="superseded-title">
+          <header class="section-head">
+            <h3 id="superseded-title">Superseded past state</h3>
+            <span>{{ projection().supersededStates.length }}</span>
+          </header>
+          <ul class="read-list">
+            @for (state of projection().supersededStates; track state.id) {
+              <li>
+                <button type="button" class="read-row" [disabled]="!state.source" (click)="open(state.source)">
+                  <span class="row-title">{{ state.entity }} · {{ state.predicate || "history" }}: {{ state.value }}</span>
+                  <span class="row-meta">Superseded@if (state.meta) { · {{ state.meta }}}</span>
+                </button>
+                <span class="past-status">past state</span>
+              </li>
+            }
+          </ul>
+        </section>
+      }
+    }
+
+    @case ("commitments") {
+      <div class="lens-head">
+        <span class="eyebrow">Commitments</span>
+        <h2>Promises and reminders</h2>
+        <p>Only rows already resolved by this board are shown.</p>
+      </div>
+      @if (projection().commitments.length === 0) {
+        @if (projection().hasGoodZero) {
+          <div class="positive-zero"><span aria-hidden="true">✓</span><strong>Nothing open</strong><p>Configured commitment views currently have no rows.</p></div>
+        } @else {
+          <p class="muted">No commitment or reminder view is configured on this board.</p>
+        }
+      } @else {
+        <ul class="read-list lens-list">
+          @for (row of projection().commitments; track row.id) {
+            <li>
+              <button type="button" class="read-row" [disabled]="!row.source" (click)="open(row.source)">
+                <span class="row-title">{{ row.text }}</span>
+                <span class="row-meta">{{ row.category }}@if (row.meta) { · {{ row.meta }}}</span>
+              </button>
+              @if (row.status) { <span class="status">{{ row.status }}</span> }
+            </li>
+          }
+        </ul>
+      }
+    }
+
+    @case ("sources") {
+      <div class="lens-head">
+        <span class="eyebrow">Sources</span>
+        <h2>Material in this board</h2>
+        <p>Notes, recordings and documents are distinct from derived board views.</p>
+      </div>
+      <ul class="source-list">
+        @for (source of projection().sources; track source.id) {
+          <li>
+            <button type="button" (click)="open(source.source)">
+              <span class="source-mark" [attr.data-kind]="source.kind"><mur-icon [icon]="source.kind === 'meeting' ? 'meetings' : source.kind === 'note' ? 'notes' : 'document'" /></span>
+              <span><strong>{{ source.title }}</strong><small>{{ source.label }} · {{ source.detail }}</small></span>
+              <span aria-hidden="true">→</span>
+            </button>
+          </li>
+        }
+      </ul>
+      @if (projection().sources.length === 0) { <p class="muted">No readable material sources.</p> }
+    }
+
+    @case ("people") {
+      <div class="lens-head">
+        <span class="eyebrow">People</span>
+        <h2>Explicit people views</h2>
+        <p>People are not inferred from source titles or commitment text.</p>
+      </div>
+      @if (projection().people.length === 0) {
+        <p class="muted">No Person view is configured on this board.</p>
+      } @else {
+        <ul class="people-list">
+          @for (person of projection().people; track person.id) {
+            <li><strong>{{ person.name }}</strong><span>{{ person.mentionCount }} meetings</span><span>{{ person.openCommitments }} open promises</span></li>
+          }
+        </ul>
+      }
+    }
+  }
+
+  <footer class="boundary" aria-label="Board boundary">
+    <strong>Board boundary</strong>
+    <span>{{ projection().readableMaterialCount }} readable material sources</span>
+    <span>{{ projection().derivedViewCount }} derived views</span>
+    @if (projection().sealedCount > 0) { <span>{{ projection().sealedCount }} sealed and excluded</span> }
+    @if (projection().missingCount > 0) { <span>{{ projection().missingCount }} missing or not configured</span> }
+    @if (projection().supersededStates.length > 0) { <span>{{ projection().supersededStates.length }} superseded past-state {{ projection().supersededStates.length === 1 ? "value" : "values" }}</span> }
+  </footer>
+</section>

--- a/src/app/features/dashboards/dashboard-read/dashboard-read.component.scss
+++ b/src/app/features/dashboards/dashboard-read/dashboard-read.component.scss
@@ -1,0 +1,66 @@
+:host { display: block; min-width: 0; }
+
+.read { display: flex; flex-direction: column; gap: var(--space-4); min-width: 0; }
+
+.dominant,
+.lens-head {
+  padding: var(--space-6);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  background: var(--surface-raised);
+  backdrop-filter: blur(var(--shell-glass-blur)) saturate(var(--shell-glass-saturate));
+
+  h2 { margin: var(--space-1) 0 var(--space-2); font-size: 1.45rem; letter-spacing: -0.03em; }
+  p { max-width: 68ch; margin: 0; color: var(--text-secondary); line-height: 1.6; }
+}
+
+.dominant { border-color: var(--border-strong); box-shadow: var(--shadow-md); }
+.dominant .answer-age { margin-top: var(--space-3); color: var(--text-tertiary); font-size: 0.72rem; }
+.eyebrow { color: var(--text-tertiary); font-size: 0.6875rem; font-weight: 650; letter-spacing: 0.08em; text-transform: uppercase; }
+.source-action { margin-top: var(--space-4); padding: 0; border: 0; background: none; color: var(--accent-hover); font: inherit; font-weight: 600; cursor: pointer; }
+
+.brief-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-4); }
+.read-card { min-width: 0; padding: var(--space-4); border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--surface-raised); }
+.section-head { display: flex; align-items: center; justify-content: space-between; gap: var(--space-2); margin-bottom: var(--space-3); }
+.section-head h3 { margin: 0; font-size: 0.9rem; }
+.section-head span { color: var(--text-tertiary); font-size: 0.75rem; }
+.read-list, .source-list, .people-list { margin: 0; padding: 0; list-style: none; }
+.read-list li { display: flex; align-items: center; gap: var(--space-3); border-top: 1px solid var(--border-subtle); }
+.read-list li:first-child { border-top: 0; }
+.read-row { display: flex; flex: 1; flex-direction: column; min-width: 0; gap: var(--space-1); padding: var(--space-3) 0; border: 0; background: none; color: inherit; font: inherit; text-align: left; cursor: pointer; }
+.read-row:disabled { cursor: default; }
+.row-title { color: var(--text-primary); font-size: 0.82rem; font-weight: 580; }
+.row-meta { overflow: hidden; color: var(--text-tertiary); font-size: 0.7rem; text-overflow: ellipsis; white-space: nowrap; }
+.status { flex: none; padding: var(--space-1) var(--space-2); border-radius: var(--radius-pill); background: var(--warning-soft); color: var(--warning); font-size: 0.68rem; }
+.past-status { flex: none; padding: var(--space-1) var(--space-2); border-radius: var(--radius-pill); background: var(--surface-input); color: var(--text-tertiary); font-size: 0.68rem; }
+.good { display: flex; gap: var(--space-2); margin: 0; color: var(--text-secondary); }
+.good span { color: var(--success); }
+.muted { margin: 0; color: var(--text-muted); }
+
+.metrics { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: var(--space-3); margin: 0; }
+.metrics div { padding: var(--space-4); border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--surface-raised); }
+.metrics dt { color: var(--text-tertiary); font-size: 0.72rem; }
+.metrics dd { margin: var(--space-2) 0 0; color: var(--text-primary); font-size: 1.5rem; font-weight: 680; }
+.lens-list { padding: 0 var(--space-4); border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--surface-raised); }
+.positive-zero { padding: var(--space-6); border: 1px solid var(--success); border-radius: var(--radius-lg); background: var(--success-soft); }
+.positive-zero > span { float: left; margin-right: var(--space-3); color: var(--success); font-size: 1.3rem; }
+.positive-zero p { margin: var(--space-1) 0 0; color: var(--text-secondary); }
+
+.source-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-3); }
+.source-list button { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: var(--space-3); width: 100%; padding: var(--space-4); border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--surface-raised); color: var(--text-primary); font: inherit; text-align: left; cursor: pointer; }
+.source-list strong, .source-list small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.source-list small { margin-top: var(--space-1); color: var(--text-tertiary); font-size: 0.7rem; }
+.source-mark { display: grid; place-items: center; width: var(--space-6); height: var(--space-6); border-radius: var(--radius-sm); background: var(--surface-hover); }
+.source-mark mur-icon { width: var(--space-4); height: var(--space-4); }
+.people-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-3); }
+.people-list li { display: flex; flex-direction: column; gap: var(--space-1); padding: var(--space-4); border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--surface-raised); }
+.people-list span { color: var(--text-tertiary); font-size: 0.74rem; }
+
+.boundary { display: flex; flex-wrap: wrap; gap: var(--space-2) var(--space-4); padding: var(--space-3) var(--space-4); border: 1px solid var(--border-subtle); border-radius: var(--radius-md); color: var(--text-tertiary); font-size: 0.7rem; }
+.boundary strong { color: var(--text-secondary); }
+
+@media (max-width: 760px) {
+  .brief-grid, .source-list, .people-list { grid-template-columns: 1fr; }
+  .metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .dominant, .lens-head { padding: var(--space-4); }
+}

--- a/src/app/features/dashboards/dashboard-read/dashboard-read.component.ts
+++ b/src/app/features/dashboards/dashboard-read/dashboard-read.component.ts
@@ -1,0 +1,34 @@
+import { ChangeDetectionStrategy, Component, input, output } from "@angular/core";
+import type { SourceRef } from "../../../core/models";
+import { MurIconComponent } from "../../../design-system/icon/icon.component";
+import type {
+  BoardProjection,
+  DashboardLens,
+} from "../dashboard-projection";
+
+@Component({
+  selector: "app-dashboard-read",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MurIconComponent],
+  templateUrl: "./dashboard-read.component.html",
+  styleUrl: "./dashboard-read.component.scss",
+})
+export class DashboardReadComponent {
+  readonly lens = input.required<DashboardLens>();
+  readonly projection = input.required<BoardProjection>();
+  readonly openSource = output<SourceRef>();
+
+  open(source: SourceRef | null): void {
+    if (source) this.openSource.emit(source);
+  }
+
+  formatDate(iso: string): string {
+    const timestamp = Date.parse(iso);
+    if (Number.isNaN(timestamp)) return "time unavailable";
+    return new Date(timestamp).toLocaleDateString(undefined, {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    });
+  }
+}

--- a/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.html
+++ b/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.html
@@ -32,6 +32,26 @@
 
   @if (editing()) {
     <div class="tile-tools">
+      <button
+        type="button"
+        class="tool"
+        [disabled]="!canMoveEarlier()"
+        (click)="moveEarlier.emit()"
+        aria-label="Move tile earlier"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+             stroke-linecap="round"><path d="M12 19V5m-6 6 6-6 6 6" /></svg>
+      </button>
+      <button
+        type="button"
+        class="tool"
+        [disabled]="!canMoveLater()"
+        (click)="moveLater.emit()"
+        aria-label="Move tile later"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+             stroke-linecap="round"><path d="M12 5v14m6-6-6 6-6-6" /></svg>
+      </button>
       <button type="button" class="tool" (click)="narrow.emit()" aria-label="Make tile narrower">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
              stroke-linecap="round"><path d="M15 6l-6 6 6 6" /></svg>
@@ -257,21 +277,25 @@
     @if (la.withheld) {
       <p class="muted">
         🔒 The saved answer is hidden — one of the sources it was built from is sealed.
-        Unlock it and re-answer.
+        Unlock its sources to reveal it.
       </p>
     } @else if (la.answer) {
       <p class="answer">{{ la.answer }}</p>
     } @else {
-      <p class="muted">Not answered yet — ask it once and the answer lives here.</p>
+      <p class="muted">No saved answer yet.</p>
     }
+    @if (la.answeredAt || allowRefreshAnswer()) {
     <div class="answer-foot">
       @if (la.answeredAt) {
         <span class="muted-small">answered {{ formatDate(la.answeredAt) }}</span>
       }
+      @if (allowRefreshAnswer()) {
       <button type="button" class="btn btn-ghost btn-sm" (click)="refreshAnswer.emit()">
         Re-answer
       </button>
+      }
     </div>
+    }
   }
 </div>
 }

--- a/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.scss
+++ b/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.scss
@@ -18,6 +18,15 @@
 // Arrange mode: the tile becomes a grab target and says so.
 :host(.is-arranging) {
   cursor: grab;
+
+  .tile-head {
+    flex-wrap: wrap;
+  }
+
+  .tile-tools {
+    flex-basis: 100%;
+    justify-content: flex-end;
+  }
 }
 
 :host(.is-dragging) {
@@ -231,6 +240,11 @@
   &:hover {
     background: var(--surface-hover);
     color: var(--text-primary);
+  }
+
+  &:disabled {
+    opacity: 0.35;
+    cursor: default;
   }
 
   &.danger:hover { color: var(--danger); }

--- a/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.ts
+++ b/src/app/features/dashboards/dashboard-tile/dashboard-tile.component.ts
@@ -167,6 +167,10 @@ export class DashboardTileComponent {
   readonly cited = input(0);
   /** True while the board is in layout mode (resize / remove affordances shown). */
   readonly editing = input(false);
+  readonly canMoveEarlier = input(false);
+  readonly canMoveLater = input(false);
+  /** Security-sensitive persistence is opt-in; dashboards keep this disabled. */
+  readonly allowRefreshAnswer = input(false);
   /** This tile is the one being dragged. */
   readonly dragging = input(false);
   /** This tile is the current drop target. */
@@ -185,6 +189,8 @@ export class DashboardTileComponent {
   readonly remove = output<void>();
   readonly widen = output<void>();
   readonly narrow = output<void>();
+  readonly moveEarlier = output<void>();
+  readonly moveLater = output<void>();
   readonly openSource = output<SourceRef>();
   readonly refreshAnswer = output<void>();
 

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
@@ -3,184 +3,119 @@
     <button type="button" class="crumb" (click)="back()">← Dashboards</button>
     @if (renaming()) {
       <form class="rename" (submit)="commitRename(); $event.preventDefault()">
-        <input
-          #renameField
-          class="rename-field"
-          type="text"
-          [value]="renameDraft()"
-          (input)="onRenameInput($event)"
-          (keydown.escape)="cancelRename()"
-          aria-label="Board name"
-        />
-        <button type="submit" class="btn btn-primary btn-sm" [disabled]="!renameDraft().trim()">
-          Save
-        </button>
+        <input #renameField class="rename-field" type="text" [value]="renameDraft()" (input)="onRenameInput($event)" (keydown.escape)="cancelRename()" aria-label="Board name" />
+        <button type="submit" class="btn btn-primary btn-sm" [disabled]="!renameDraft().trim()">Save</button>
         <button type="button" class="btn btn-ghost btn-sm" (click)="cancelRename()">Cancel</button>
       </form>
     } @else {
       <h1>
-        <!-- The title IS the rename affordance. A board named the wrong thing was
-             permanent: `update` was only ever called with `{pinned}`. -->
-        <button
-          type="button"
-          class="title-edit"
-          (click)="startRename()"
-          [attr.aria-label]="'Rename this board — ' + (board()?.title ?? '')"
-        >
-          @if (board()?.emoji; as emoji) {
-            <span class="emoji">{{ emoji }}</span>
-          }
+        <button type="button" class="title-edit" (click)="startRename()" [attr.aria-label]="'Rename this board — ' + (board()?.title ?? '')">
+          @if (board()?.emoji; as emoji) { <span class="emoji">{{ emoji }}</span> }
           {{ board()?.title ?? "Board" }}
         </button>
       </h1>
     }
   </div>
 
-  <button type="button" class="btn btn-ghost" (click)="toggleEditing()">
-    {{ editing() ? "Done" : "Arrange" }}
-  </button>
-  @if (editing()) {
-    <span class="arrange-hint">drag tiles to reorder · ‹ › to resize</span>
+  @if (mode() === "read") {
+    <button type="button" class="btn btn-ghost secondary-action" [disabled]="!privacyReady()" (click)="openAsk()"><mur-icon icon="ask" /> Ask</button>
+    @if (!isEmpty()) { <button type="button" class="btn btn-ghost" (click)="enterCompose()">Compose</button> }
+  } @else {
+    <span class="compose-hint">Drag or use Move earlier / Move later</span>
+    <button type="button" class="btn btn-primary" [class.is-open]="paletteOpen()" (click)="togglePalette($event)">
+      <mur-icon icon="plus" /> {{ paletteOpen() ? "Close" : "Add to board" }}
+    </button>
+    <button type="button" class="btn btn-ghost" (click)="leaveCompose()">Done</button>
   }
-  <button
-    type="button"
-    class="btn btn-primary"
-    [class.is-open]="paletteOpen()"
-    (click)="togglePalette()"
-  >
-    <mur-icon icon="plus" /> {{ paletteOpen() ? "Close" : "Add tile" }}
-  </button>
 </header>
 
-@if (error(); as err) {
-  <div class="banner banner-error" role="alert">{{ err }}</div>
-}
+@if (error(); as err) { <div class="banner banner-error" role="alert">{{ err }}</div> }
 
-<div class="board">
-  <section class="canvas" aria-label="Board tiles">
-    @if (isEmpty() && loading()) {
-      <mur-empty-state>Loading this board…</mur-empty-state>
-    } @else if (isEmpty()) {
-      <mur-empty-state>
-        <strong>This board is empty.</strong>
-        <p class="empty-copy">
-          Add a note or a recording to give it something to stand on — then add a
-          drift lane, a promise ledger or a pulse, which only work because Murmur
-          heard the conversation.
-        </p>
-        <button type="button" class="btn btn-primary" (click)="openPalette()">
-          Add the first tile
-        </button>
-      </mur-empty-state>
-    } @else {
-      @for (tile of tiles(); track tile.id) {
-        <app-dashboard-tile
-          [tile]="tile"
-          [cited]="citationFor(tile)"
-          [duplicateOf]="duplicateOf(tile)"
-          [editing]="editing()"
-          [dragging]="draggingId() === tile.id"
-          [dropTarget]="dropTargetId() === tile.id"
-          [attr.draggable]="editing() ? 'true' : null"
-          (dragstart)="onDragStart(tile, $event)"
-          (dragover)="onDragOver(tile, $event)"
-          (dragleave)="onDragLeave(tile)"
-          (drop)="onDrop(tile, $event)"
-          (dragend)="onDragEnd()"
-          (remove)="removeTile(tile)"
-          (widen)="widen(tile)"
-          (narrow)="narrow(tile)"
-          (openSource)="openSource($event)"
-          (refreshAnswer)="refreshAnswer(tile)"
-        />
-      }
+@if (!privacyReady() && !privacyError()) {
+  <mur-empty-state><mur-spinner /> Establishing a secure board session…</mur-empty-state>
+} @else if (privacyRefreshing() || loading()) {
+  <mur-empty-state><mur-spinner /> Re-checking this board…</mur-empty-state>
+} @else if (boardUnavailable()) {
+  <mur-empty-state>
+    <strong>Board unavailable.</strong>
+    <p class="empty-copy">{{ privacyError() ?? "Murmur could not safely resolve this board's current readable scope." }}</p>
+    <button type="button" class="btn btn-primary" (click)="retryLoad()">Try again</button>
+  </mur-empty-state>
+} @else if (isEmpty() && !askOpen()) {
+  <mur-empty-state>
+    <strong>Start with material for this board.</strong>
+    <p class="empty-copy">Add a Note, Recording or Document. Derived views can follow once the board has something readable to work from.</p>
+    <button type="button" class="btn btn-primary" (click)="openPalette($event)">Add a Note, Recording or Document</button>
+  </mur-empty-state>
+} @else if (mode() === "compose") {
+  <section class="compose" aria-label="Compose board tiles">
+    @for (tile of tiles(); track tile.id; let first = $first; let last = $last) {
+      <app-dashboard-tile
+        [tile]="tile"
+        [editing]="true"
+        [allowRefreshAnswer]="false"
+        [duplicateOf]="duplicateOf(tile)"
+        [canMoveEarlier]="!first"
+        [canMoveLater]="!last"
+        [dragging]="draggingId() === tile.id"
+        [dropTarget]="dropTargetId() === tile.id"
+        draggable="true"
+        (dragstart)="onDragStart(tile, $event)"
+        (dragover)="onDragOver(tile, $event)"
+        (dragleave)="onDragLeave(tile)"
+        (drop)="onDrop(tile, $event)"
+        (dragend)="onDragEnd()"
+        (moveEarlier)="moveTile(tile, -1)"
+        (moveLater)="moveTile(tile, 1)"
+        (remove)="removeTile(tile)"
+        (widen)="widen(tile)"
+        (narrow)="narrow(tile)"
+        (openSource)="openSource($event)"
+      />
     }
   </section>
-
-  <aside class="ask" [class.is-rail]="!askExpanded()" aria-label="Ask this board">
-    @if (!askExpanded()) {
-      <!--
-        Collapsed. The SCOPE COUNT stays on screen because it is the feature's whole
-        claim made visible — this board, and nothing else, is what an answer may come
-        from. An empty transcript is not; it was taking a third of the width to show
-        three suggestion buttons.
-      -->
-      <button
-        type="button"
-        class="ask-rail"
-        (click)="expandAsk()"
-        [attr.aria-label]="'Ask this board — ' + sourceCount() + ' readable sources'"
-      >
-        <mur-icon icon="ask" />
-        <span class="rail-label">
-          Ask this board
-          <span class="rail-count">{{ sourceCount() }} in scope</span>
-        </span>
-      </button>
-    } @else {
-    <header class="ask-head">
-      <mur-icon icon="ask" />
-      <h2>Ask this board</h2>
-    </header>
-
-    <p class="scope">
-      Grounded in <strong>this board only</strong> — {{ sourceCount() }}
-      readable {{ sourceCount() === 1 ? "source" : "sources" }}.
-      @if (sealedCount() > 0) {
-        <span class="scope-sealed">
-          {{ sealedCount() }} sealed {{ sealedCount() === 1 ? "tile is" : "tiles are" }}
-          excluded until unlocked.
-        </span>
-      }
-    </p>
-
-    <div class="thread">
-      @for (turn of turns(); track $index) {
-        @if (turn.role === "error") {
-          <!-- A failure is chrome, not a conclusion. It used to render in the same
-               grey bubble as a real answer, with nothing to retry. -->
-          <div class="banner is-danger" role="alert">
-            <span>{{ turn.text }}</span>
-            <button type="button" class="btn btn-ghost btn-sm" (click)="retry(turn)">
-              Try again
-            </button>
-          </div>
-        } @else if (turn.role === "user") {
-          <div class="bubble me">{{ turn.text }}</div>
-        } @else {
-          <!-- The prompt in `summarize/vault_chat.rs::build` DEMANDS markdown, so
-               rendering the answer as plain text printed `**` and `[[…]]` literally.
-               `app-markdown` also turns wikilinks into gated, clickable chips —
-               dashboards was the only AI surface in the app not using it. -->
-          <div class="bubble"><app-markdown [markdown]="turn.text" compact /></div>
+} @else {
+  <div class="workspace" [class.has-ask]="askOpen()">
+    <main class="reading">
+      <nav class="lenses" aria-label="Dashboard lenses">
+        @for (item of lenses; track item.id) {
+          <button type="button" [class.active]="lens() === item.id" [attr.aria-current]="lens() === item.id ? 'page' : null" (click)="selectLens(item.id)">{{ item.label }}</button>
         }
-      } @empty {
-        <div class="suggestions">
-          @for (s of suggestions; track s) {
-            <button type="button" class="suggestion" (click)="askSuggestion(s)">{{ s }}</button>
+      </nav>
+      <app-dashboard-read [lens]="lens()" [projection]="projection()" (openSource)="openSource($event)" />
+    </main>
+
+    @if (askOpen()) {
+      <aside class="ask" aria-label="Ask this board">
+        <header class="ask-head">
+          <div><span class="eyebrow">On demand</span><h2>Ask this board</h2></div>
+          <button type="button" class="btn btn-ghost btn-sm" (click)="closeAsk()" aria-label="Close Ask">Close</button>
+        </header>
+        <p class="scope">
+          Uses {{ sourceCount() }} currently readable material {{ sourceCount() === 1 ? "source" : "sources" }}, this board's derived views, and permitted gated linked context. This is the allowed scope, not a claim that every sentence is exact cited evidence.
+          @if (projection().sealedCount > 0) { <span>{{ projection().sealedCount }} sealed {{ projection().sealedCount === 1 ? "item is" : "items are" }} excluded.</span> }
+        </p>
+        <div class="thread">
+          @for (turn of turns(); track turn.id) {
+            @if (turn.role === "error") {
+              <div class="banner is-danger" role="alert"><span>{{ turn.text }}</span><button type="button" class="btn btn-ghost btn-sm" (click)="retry(turn)">Try again</button></div>
+            } @else if (turn.role === "user") {
+              <div class="bubble me">{{ turn.text }}</div>
+            } @else {
+              <div class="bubble"><app-markdown [markdown]="turn.text" compact /></div>
+            }
+          } @empty {
+            <div class="suggestions">
+              @for (suggestion of suggestions; track suggestion) { <button type="button" class="suggestion" (click)="askSuggestion(suggestion)">{{ suggestion }}</button> }
+            </div>
           }
+          @if (asking()) { <div class="bubble thinking"><mur-spinner /> Thinking…</div> }
         </div>
-      }
-
-      @if (asking()) {
-        <div class="bubble thinking"><mur-spinner /> Thinking…</div>
-      }
-    </div>
-
-    <form class="composer" (submit)="ask(); $event.preventDefault()">
-      <input
-        class="ask-field"
-        type="text"
-        placeholder="Ask about these tiles…"
-        [value]="draft()"
-        (input)="onDraft($event)"
-        aria-label="Ask a question about this board"
-      />
-      <button type="submit" class="btn btn-primary btn-sm" [disabled]="!draft().trim() || asking()">
-        Ask
-      </button>
-    </form>
+        <form class="composer" (submit)="ask(); $event.preventDefault()">
+          <input class="ask-field" type="text" placeholder="Ask about this board…" [value]="draft()" (input)="onDraft($event)" aria-label="Ask a question about this board" />
+          <button type="submit" class="btn btn-primary btn-sm" [disabled]="!draft().trim() || asking()">Ask</button>
+        </form>
+      </aside>
     }
-  </aside>
-</div>
-
+  </div>
+}

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.scss
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.scss
@@ -1,360 +1,54 @@
-// One board: the tile canvas + the board-scoped Ask column. Tokens only.
-:host {
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  padding: 0 var(--space-2) var(--space-5);
-}
+:host { display: flex; flex-direction: column; min-width: 0; min-height: 0; padding: 0 var(--space-2) var(--space-5); }
+.head { display: flex; align-items: flex-end; gap: var(--space-2); padding: var(--space-2) 0 var(--space-4); }
+.head-text { flex: 1; min-width: 0; }
+.head h1 { margin: var(--space-1) 0 0; font-size: 1.5rem; font-weight: 680; letter-spacing: -0.035em; }
+.crumb { padding: 0; border: 0; background: none; color: var(--text-muted); font: inherit; font-size: 0.76rem; cursor: pointer; }
+.crumb:hover { color: var(--text-primary); }
+.emoji { font-size: 1.35rem; line-height: 1; }
+.title-edit { display: inline-flex; align-items: center; gap: var(--space-2); margin-left: calc(var(--space-2) * -1); padding: var(--space-1) var(--space-2); border: 1px solid transparent; border-radius: var(--radius-sm); background: none; color: inherit; font: inherit; cursor: text; }
+.title-edit:hover, .title-edit:focus-visible { border-color: var(--border-subtle); background: var(--surface-input); }
+.rename { display: flex; align-items: center; gap: var(--space-2); }
+.rename-field { min-width: 260px; padding: var(--space-1) var(--space-2); border: 1px solid var(--border-strong); border-radius: var(--radius-sm); background: var(--surface-input); color: var(--text-primary); font-size: 1.05rem; font-weight: 640; }
+.head mur-icon { width: var(--space-4); height: var(--space-4); }
+.compose-hint { color: var(--text-tertiary); font-size: 0.72rem; white-space: nowrap; }
+.banner-error { margin-bottom: var(--space-3); }
+.empty-copy { max-width: 48ch; margin: var(--space-2) auto var(--space-4); color: var(--text-muted); }
 
-.head {
-  display: flex;
-  align-items: flex-end;
-  gap: var(--space-2);
-  padding: var(--space-2) 0 var(--space-4);
+.workspace { display: grid; grid-template-columns: minmax(0, 1fr); gap: var(--space-4); min-width: 0; min-height: 0; flex: 1; }
+.workspace.has-ask { grid-template-columns: minmax(0, 1fr) minmax(300px, 360px); }
+.reading { min-width: 0; overflow: auto; padding-bottom: var(--space-5); }
+.lenses { display: flex; gap: var(--space-1); margin-bottom: var(--space-4); padding: var(--space-1); overflow-x: auto; border: 1px solid var(--border-subtle); border-radius: var(--radius-pill); background: var(--surface-input); width: max-content; max-width: 100%; }
+.lenses button { flex: none; padding: var(--space-2) var(--space-3); border: 0; border-radius: var(--radius-pill); background: none; color: var(--text-secondary); font: inherit; font-size: 0.76rem; cursor: pointer; }
+.lenses button.active { background: var(--shell-active-bg); color: var(--shell-active-text); box-shadow: var(--shell-active-shadow); }
 
-  h1 {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    margin: 2px 0 0;
-    font-size: 1.5rem;
-    font-weight: 680;
-    letter-spacing: -0.035em;
-  }
-}
+.compose { display: grid; grid-template-columns: repeat(12, minmax(0, 1fr)); grid-auto-rows: max-content; align-content: start; gap: var(--space-3); min-width: 0; overflow: auto; padding-bottom: var(--space-5); }
 
-.head-text {
-  flex: 1;
-  min-width: 0;
-}
+.ask { display: flex; flex-direction: column; min-width: 0; min-height: 0; overflow: hidden; border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--surface-raised); backdrop-filter: blur(var(--shell-glass-blur)) saturate(var(--shell-glass-saturate)); }
+.ask-head { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); padding: var(--space-3) var(--space-4); border-bottom: 1px solid var(--border-subtle); }
+.ask-head h2 { margin: var(--space-1) 0 0; font-size: 0.88rem; }
+.eyebrow { color: var(--text-tertiary); font-size: 0.64rem; font-weight: 650; letter-spacing: 0.08em; text-transform: uppercase; }
+.scope { margin: var(--space-3) var(--space-4) 0; padding: var(--space-3); border: 1px solid var(--accent-ring); border-radius: var(--radius-sm); background: var(--accent-soft); color: var(--text-secondary); font-size: 0.7rem; line-height: 1.5; }
+.scope span { display: block; margin-top: var(--space-1); color: var(--text-tertiary); }
+.thread { display: flex; flex: 1; flex-direction: column; gap: var(--space-3); min-height: 0; overflow: auto; padding: var(--space-4); }
+.thread .banner { display: flex; align-items: center; justify-content: space-between; gap: var(--space-2); font-size: 0.8rem; }
+.bubble { padding: var(--space-3); border: 1px solid var(--border-subtle); border-radius: var(--radius-md); background: var(--surface-input); color: var(--text-secondary); font-size: 0.8rem; line-height: 1.6; }
+.bubble.me { align-self: flex-end; max-width: 88%; border-color: transparent; background: var(--accent); color: var(--text-on-accent); white-space: pre-wrap; }
+.bubble.thinking { display: flex; align-items: center; gap: var(--space-2); color: var(--text-muted); }
+.suggestions { display: flex; flex-direction: column; gap: var(--space-2); }
+.suggestion { padding: var(--space-2) var(--space-3); border: 1px solid var(--border-subtle); border-radius: var(--radius-sm); background: var(--surface-input); color: var(--text-secondary); font: inherit; font-size: 0.76rem; text-align: left; cursor: pointer; }
+.suggestion:hover { background: var(--surface-hover); color: var(--text-primary); }
+.composer { display: flex; align-items: center; gap: var(--space-2); padding: var(--space-3); border-top: 1px solid var(--border-subtle); }
+.ask-field { flex: 1; min-width: 0; padding: var(--space-2) var(--space-3); border: 1px solid var(--border-subtle); border-radius: var(--radius-pill); background: var(--surface-input); color: var(--text-primary); font: inherit; font-size: 0.78rem; }
+.ask-field:focus-visible { outline: none; border-color: var(--accent-ring); box-shadow: 0 0 0 var(--space-1) var(--accent-soft); }
 
-.crumb {
-  padding: 0;
-  border: 0;
-  background: none;
-  color: var(--text-muted);
-  font: inherit;
-  font-size: 0.76rem;
-  cursor: pointer;
-
-  &:hover { color: var(--text-primary); }
-}
-
-.emoji {
-  font-size: 1.35rem;
-  line-height: 1;
-}
-
-.arrange-hint {
-  color: var(--text-muted);
-  font-size: 0.72rem;
-  white-space: nowrap;
-}
-
-.board {
-  display: flex;
-  gap: var(--space-3);
-  min-height: 0;
-  flex: 1;
-}
-
-// The 12-column grid the tile spans map onto. `grid-auto-rows: max-content` is
-// load-bearing: with `auto` rows the browser distributes the container height
-// evenly and every tile clips its own content.
-.canvas {
-  display: grid;
-  grid-template-columns: repeat(12, 1fr);
-  grid-auto-rows: max-content;
-  align-content: start;
-  gap: var(--space-3);
-  flex: 1;
-  min-width: 0;
-  overflow: auto;
-  padding-bottom: var(--space-5);
-}
-
-.canvas mur-empty-state {
-  grid-column: span 12;
-}
-
-.empty-copy {
-  max-width: 46ch;
-  margin: var(--space-2) auto var(--space-4);
-  color: var(--text-muted);
-}
-
-// ── Ask column ───────────────────────────────────────────────────────────────
-// In-flow panel ⇒ the frosted card surface is correct here (T3 applies to
-// FLOATING overlays only).
-.ask {
-  display: flex;
-  flex-direction: column;
-  flex: 0 0 380px;
-  max-width: 380px;
-  transition: flex-basis var(--transition), max-width var(--transition);
-  min-height: 0;
-  overflow: hidden;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  background: var(--surface-raised);
-  backdrop-filter: blur(18px) saturate(140%);
-}
-
-// Collapsed: a 44px rail that still carries the scope count.
-.ask.is-rail {
-  flex: 0 0 44px;
-  max-width: 44px;
-  background: var(--surface-input);
-  backdrop-filter: none;
-}
-
-.ask-rail {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-3);
-  width: 100%;
-  height: 100%;
-  padding: var(--space-3) 0;
-  border: 0;
-  background: none;
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition: color var(--transition-fast);
-
-  &:hover,
-  &:focus-visible {
-    color: var(--text-primary);
-  }
-
-  mur-icon {
-    flex: none;
-    width: 18px;
-    height: 18px;
-  }
-}
-
-// The label reads bottom-to-top up the rail, so the count stays legible in 44px.
-.rail-label {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  writing-mode: vertical-rl;
-  transform: rotate(180deg);
-  font-size: 0.6875rem;
-  line-height: 1.35;
-  letter-spacing: 0.02em;
-  white-space: nowrap;
-}
-
-.rail-count {
-  color: var(--text-tertiary);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .ask {
-    transition: none;
-  }
-}
-
-.ask-head {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-3) var(--space-4);
-  border-bottom: 1px solid var(--border-subtle);
-  color: var(--text-secondary);
-
-  h2 {
-    margin: 0;
-    font-size: 0.82rem;
-    font-weight: 640;
-    color: var(--text-primary);
-  }
-}
-
-.scope {
-  margin: var(--space-3) var(--space-4) 0;
-  padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--accent-ring);
-  border-radius: var(--radius-sm);
-  background: var(--accent-soft);
-  color: var(--text-secondary);
-  font-size: 0.72rem;
-  line-height: 1.5;
-
-  strong { color: var(--text-primary); }
-}
-
-.scope-sealed {
-  display: block;
-  margin-top: 2px;
-  color: var(--text-muted);
-}
-
-.thread {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3);
-  flex: 1;
-  min-height: 0;
-  overflow: auto;
-  padding: var(--space-4);
-}
-
-.thread .banner {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2);
-  font-size: 0.8rem;
-}
-
-.bubble {
-  padding: var(--space-3);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-md);
-  border-bottom-left-radius: var(--radius-sm);
-  background: var(--surface-input);
-  color: var(--text-secondary);
-  font-size: 0.8rem;
-  line-height: 1.6;
-
-  // `white-space: pre-wrap` belongs to text that is NOT parsed. An assistant turn
-  // now renders through `app-markdown`, where pre-wrap would preserve the source
-  // newlines around every block element and double the spacing.
-  &.me {
-    white-space: pre-wrap;
-  }
-
-  &.me {
-    align-self: flex-end;
-    max-width: 88%;
-    border-color: transparent;
-    border-radius: var(--radius-md);
-    border-bottom-right-radius: var(--radius-sm);
-    background: var(--accent);
-    color: var(--text-on-accent);
-  }
-
-  &.thinking {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    color: var(--text-muted);
-  }
-}
-
-.suggestions {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-}
-
-.suggestion {
-  padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-sm);
-  background: rgba(255, 255, 255, 0.028);
-  color: var(--text-secondary);
-  font: inherit;
-  font-size: 0.76rem;
-  text-align: left;
-  cursor: pointer;
-  transition:
-    background var(--transition-fast),
-    color var(--transition-fast);
-
-  &:hover {
-    background: var(--surface-hover);
-    color: var(--text-primary);
-  }
-}
-
-.composer {
-  display: flex;
-  gap: var(--space-2);
-  align-items: center;
-  padding: var(--space-3);
-  border-top: 1px solid var(--border-subtle);
-}
-
-.ask-field {
-  flex: 1;
-  min-width: 0;
-  padding: var(--space-2) var(--space-3);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-pill);
-  background: var(--surface-input);
-  color: var(--text-primary);
-  font: inherit;
-  font-size: 0.78rem;
-
-  &::placeholder { color: var(--text-muted); }
-
-  &:focus-visible {
-    outline: none;
-    border-color: var(--accent-ring);
-    box-shadow: 0 0 0 3px var(--accent-soft);
-  }
-}
-
-.banner-error {
-  margin-bottom: var(--space-3);
-}
-
-// Narrow windows: the Ask column drops under the canvas rather than squeezing it.
 @media (max-width: 1080px) {
-  .board {
-    flex-direction: column;
-  }
-
-  .ask {
-    flex: 1 1 auto;
-    max-width: none;
-    max-height: 420px;
-  }
+  .workspace.has-ask { grid-template-columns: minmax(0, 1fr); }
+  .ask { max-height: 360px; }
+  .secondary-action { margin-left: auto; }
 }
-
-// ── rename ───────────────────────────────────────────────────────────────────
-// The title doubles as the rename control, so it must look like a heading until
-// hovered — a button that shouts is chrome the header does not need.
-.title-edit {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-  padding: 2px var(--space-2);
-  margin-left: calc(var(--space-2) * -1);
-  border: 1px solid transparent;
-  border-radius: var(--radius-sm);
-  background: none;
-  color: inherit;
-  font: inherit;
-  cursor: text;
-  transition:
-    background var(--transition-fast),
-    border-color var(--transition-fast);
-
-  &:hover,
-  &:focus-visible {
-    border-color: var(--border-subtle);
-    background: var(--surface-input);
-  }
+@media (max-width: 720px) {
+  .head { align-items: center; flex-wrap: wrap; }
+  .head-text { flex-basis: 100%; }
+  .compose-hint { display: none; }
 }
-
-.rename {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.rename-field {
-  min-width: 260px;
-  padding: var(--space-1) var(--space-2);
-  border: 1px solid var(--border-strong);
-  border-radius: var(--radius-sm);
-  background: var(--surface-input);
-  color: var(--text-primary);
-  font-size: 1.05rem;
-  font-weight: 640;
-}
+@media (prefers-reduced-motion: reduce) { .lenses button { transition: none; } }

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
@@ -13,67 +13,56 @@ import {
 import { toSignal } from "@angular/core/rxjs-interop";
 import { ActivatedRoute, Router } from "@angular/router";
 import { IpcService } from "../../../core/ipc.service";
+import { AskHistoryPrivacyBarrierService } from "../../../core/ask-history-privacy-barrier.service";
+import type {
+  ChatTurn,
+  DashboardDetail,
+  ResolvedTile,
+  SourceRef,
+} from "../../../core/models";
+import { ErrorCopyService } from "../../../core/copy/error-copy.service";
+import { MurEmptyStateComponent } from "../../../design-system/empty-state/empty-state.component";
+import { MurIconComponent } from "../../../design-system/icon/icon.component";
+import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
+import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
 import {
   DashboardsService,
   splitLeadingEmoji,
 } from "../../../services/dashboards.service";
-import { MurEmptyStateComponent } from "../../../design-system/empty-state/empty-state.component";
-import { MurIconComponent } from "../../../design-system/icon/icon.component";
-import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
-import { DashboardTileComponent } from "../dashboard-tile/dashboard-tile.component";
+import { FoldersService } from "../../../services/folders.service";
 import {
   TilePaletteService,
   type TileChoice,
 } from "../../../services/tile-palette.service";
-import type { ChatTurn, ResolvedTile, SourceRef } from "../../../core/models";
-import { ErrorCopyService } from "../../../core/copy/error-copy.service";
-import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
+import { DashboardTileComponent } from "../dashboard-tile/dashboard-tile.component";
+import { DashboardReadComponent } from "../dashboard-read/dashboard-read.component";
+import {
+  projectDashboard,
+  type DashboardLens,
+} from "../dashboard-projection";
 
-/**
- * One exchange in the board-scoped Ask column.
- *
- * `error` is a THIRD role, not a flavour of `assistant`. A failure used to be
- * pushed as an assistant turn, so a dispatch error rendered in the same grey
- * bubble as a real answer, with nothing to retry - the board stated a provider
- * failure in the exact visual language it uses for grounded conclusions.
- */
 interface BoardTurn {
+  id: number;
   role: "user" | "assistant" | "error";
   text: string;
-  /** Tile ids this answer was grounded in (assistant turns only). */
-  citedTiles?: string[];
-  /** The question that produced an error turn, so Try again can re-send it. */
   retry?: string;
 }
 
-/**
- * The same 12-message bound every other chat surface uses (`CHAT_CONTEXT_TURNS`).
- * The board sent `[]`, so every question arrived context-free and a follow-up
- * like "and the second one?" could not resolve.
- */
 const HISTORY_TURNS = 12;
-
 const SUGGESTIONS = [
-  "What's most likely to go wrong here?",
-  "Who owes me something on this board?",
-  "What changed since last week?",
+  "What needs attention?",
+  "Which commitments are still open?",
+  "Summarize the readable material on this board.",
 ];
 
-/**
- * `/dashboards/:id` — one board.
- *
- * Two halves: the tile canvas, and **Ask this board** — which is the whole
- * point of the feature. Ask reuses the SHIPPED `ask_vault(explicitSources: …)`
- * path with the board's own visible sources (`getDashboardSources`), so:
- *   * retrieval is pinned to exactly what the user composed (no vault-wide
- *     wandering), and
- *   * there is no new AI command, no new egress surface, and no new redaction
- *     seam — the existing consent/redaction/ledger path applies verbatim.
- *
- * Sealed sources never enter that list (the backend filters them), so a
- * board-scoped Ask can't retrieve from a locked folder even when the board
- * shows a redacted tile for it.
- */
+const LENSES: readonly { id: DashboardLens; label: string }[] = [
+  { id: "brief", label: "Brief" },
+  { id: "overview", label: "Overview" },
+  { id: "commitments", label: "Commitments" },
+  { id: "sources", label: "Sources" },
+  { id: "people", label: "People" },
+];
+
 @Component({
   selector: "app-dashboard-view",
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -82,6 +71,7 @@ const SUGGESTIONS = [
     MurIconComponent,
     MurSpinnerComponent,
     DashboardTileComponent,
+    DashboardReadComponent,
     MarkdownComponent,
   ],
   templateUrl: "./dashboard-view.component.html",
@@ -94,176 +84,95 @@ export class DashboardViewComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly palette = inject(TilePaletteService);
   private readonly errors = inject(ErrorCopyService);
+  private readonly folders = inject(FoldersService);
+  private readonly privacyBarrier = inject(AskHistoryPrivacyBarrierService);
+  private removePrivacyInvalidator: (() => void) | null = null;
 
   constructor() {
-    // The palette is app-wide, so leaving the board must not strand it on screen
-    // over whatever route comes next.
+    this.removePrivacyInvalidator = this.privacyBarrier.registerInvalidator(() =>
+      this.invalidateAndRefresh(),
+    );
+    void this.privacyBarrier.ensureReady();
     inject(DestroyRef).onDestroy(() => {
+      this.removePrivacyInvalidator?.();
+      this.removePrivacyInvalidator = null;
       if (this.palette.open()) this.palette.dismiss();
     });
   }
 
-  /**
-   * The board id, as a SIGNAL off the router's own paramMap — not
-   * `snapshot.paramMap` in `ngOnInit`. `/dashboards/:id` is not in
-   * `TabRouteReuseStrategy`'s scope today, but if it ever were, a snapshot read
-   * would silently stop re-firing when navigating board→board. Reading the
-   * observable keeps the load correct under either strategy.
-   */
   private readonly params = toSignal(this.route.paramMap);
   readonly id = computed(() => this.params()?.get("id") ?? "");
-
-  readonly board = this.service.board;
-  readonly loading = this.service.boardLoading;
+  readonly board = signal<DashboardDetail | null>(null);
+  readonly loading = signal(false);
+  readonly boardUnavailable = signal(false);
+  readonly privacyReady = this.privacyBarrier.ready;
+  readonly privacyError = this.privacyBarrier.error;
   readonly error = this.service.error;
+  readonly paletteOpen = this.palette.open;
+  readonly mode = signal<"read" | "compose">("read");
+  readonly lens = signal<DashboardLens>("brief");
+  readonly lenses = LENSES;
+  readonly privacyRefreshing = signal(false);
 
-  private readonly serverTiles = computed<ResolvedTile[]>(
-    () => this.board()?.tiles ?? [],
+  private readonly serverTiles = computed<ResolvedTile[]>(() =>
+    this.privacyRefreshing() ? [] : (this.board()?.tiles ?? []),
   );
-  /** Server order, unless a drag is mid-flight and we are showing its result. */
+  private readonly orderOverride = signal<string[] | null>(null);
   readonly tiles = computed<ResolvedTile[]>(() => {
     const rows = this.serverTiles();
     const order = this.orderOverride();
     if (!order) return rows;
-    const byId = new Map(rows.map((t) => [t.id, t]));
-    const out = order.map((id) => byId.get(id)).filter((t): t is ResolvedTile => !!t);
-    // Anything the override does not mention (a tile added meanwhile) keeps its
-    // place at the end rather than vanishing.
-    for (const t of rows) if (!order.includes(t.id)) out.push(t);
-    return out;
+    const byId = new Map(rows.map((tile) => [tile.id, tile]));
+    const ordered = order
+      .map((id) => byId.get(id))
+      .filter((tile): tile is ResolvedTile => tile !== undefined);
+    for (const tile of rows) {
+      if (!order.includes(tile.id)) ordered.push(tile);
+    }
+    return ordered;
   });
   readonly isEmpty = computed(() => this.tiles().length === 0);
-  readonly sealedCount = computed(
-    () => this.tiles().filter((t) => t.data.kind === "locked").length,
-  );
-
-  /**
-   * Tile id → the heading of the EARLIER tile it duplicates.
-   *
-   * Two tiles that resolve to the same payload render the same rows twice, which
-   * is what made a nine-tile board read as a duplicated one. The cause is a
-   * missing parameter rather than user error — `tile-palette` never writes
-   * `config.owner`, so every Promise ledger resolves to the same global list —
-   * so the second tile becomes a back-reference and the fix costs no backend.
-   *
-   * Keyed on the RESOLVED payload, not on `(kind, refId, config)`: two tiles can
-   * be configured differently and still resolve identically, and it is the
-   * on-screen repetition that the user sees.
-   */
+  readonly projection = computed(() => projectDashboard(this.tiles()));
   readonly duplicates = computed<ReadonlyMap<string, string>>(() => {
     const seen = new Map<string, string>();
-    const out = new Map<string, string>();
-    for (const t of this.tiles()) {
-      // A sealed tile carries no fields at all, so every sealed tile would look
-      // like every other one. Redaction is not duplication — never collapse them.
-      if (t.data.kind === "locked") continue;
-      const key = JSON.stringify(t.data);
+    const duplicates = new Map<string, string>();
+    for (const tile of this.tiles()) {
+      if (
+        tile.data.kind === "locked" ||
+        tile.data.kind === "missing" ||
+        tile.data.kind === "unconfigured"
+      ) {
+        continue;
+      }
+      const key = JSON.stringify(tile.data);
       const first = seen.get(key);
-      if (first === undefined) seen.set(key, this.headingOf(t));
-      else out.set(t.id, first);
+      if (first === undefined) seen.set(key, this.tileHeading(tile));
+      else duplicates.set(tile.id, first);
     }
-    return out;
+    return duplicates;
   });
 
-  duplicateOf(tile: ResolvedTile): string | null {
-    return this.duplicates().get(tile.id) ?? null;
-  }
+  readonly renaming = signal(false);
+  readonly renameDraft = signal("");
+  private readonly renameField = viewChild<ElementRef<HTMLInputElement>>("renameField");
+  private readonly _focusRename = effect(() => {
+    this.renameField()?.nativeElement.select();
+  });
 
-  /** The label a back-reference points at — the user-visible name of the original. */
-  private headingOf(tile: ResolvedTile): string {
-    if (tile.title && tile.title.trim()) return tile.title.trim();
-    const d = tile.data;
-    if (d.kind === "note" || d.kind === "meeting" || d.kind === "document") return d.title;
-    if (d.kind === "person") return d.name;
-    if (d.kind === "promises") return d.owner ? `Promises · ${d.owner}` : "Promises";
-    return d.kind;
-  }
-
-  /** Owned by the root service — the palette itself is rendered by `app-shell`. */
-  readonly paletteOpen = this.palette.open;
-  readonly editing = signal(false);
-
-  // ── drag-to-reorder (Arrange mode) ─────────────────────────────────────────
-  //
-  // Native HTML5 drag events, deliberately: no new dependency, no DOM observer,
-  // and the drop target is the tile itself so the grid needs no hit-testing.
-  // The order is applied OPTIMISTICALLY to a local override so the board does not
-  // jump while the backend write is in flight; the reload then replaces it.
   readonly draggingId = signal<string | null>(null);
   readonly dropTargetId = signal<string | null>(null);
-  private readonly orderOverride = signal<string[] | null>(null);
 
-  onDragStart(tile: ResolvedTile, event: DragEvent): void {
-    if (!this.editing()) return;
-    this.draggingId.set(tile.id);
-    event.dataTransfer?.setData("text/plain", tile.id);
-    if (event.dataTransfer) event.dataTransfer.effectAllowed = "move";
-  }
-
-  onDragOver(tile: ResolvedTile, event: DragEvent): void {
-    if (!this.editing() || !this.draggingId()) return;
-    // Without preventDefault the browser refuses the drop outright.
-    event.preventDefault();
-    if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
-    if (this.dropTargetId() !== tile.id) this.dropTargetId.set(tile.id);
-  }
-
-  /**
-   * Clear the highlight when the pointer leaves this tile.
-   *
-   * `dragover` only ever SETS a target, so dragging off the grid entirely left the
-   * last-hovered tile lit as a drop target that no longer existed. Guarded on identity
-   * because `dragleave` also fires when the pointer crosses into a CHILD element —
-   * clearing unconditionally would flicker the highlight off and on across every row
-   * inside the tile you are actually hovering.
-   */
-  onDragLeave(tile: ResolvedTile): void {
-    if (this.dropTargetId() === tile.id) this.dropTargetId.set(null);
-  }
-
-  onDragEnd(): void {
-    this.draggingId.set(null);
-    this.dropTargetId.set(null);
-  }
-
-  async onDrop(target: ResolvedTile, event: DragEvent): Promise<void> {
-    event.preventDefault();
-    const sourceId = this.draggingId();
-    this.draggingId.set(null);
-    this.dropTargetId.set(null);
-    if (!sourceId || sourceId === target.id) return;
-
-    const ids = this.tiles().map((t) => t.id);
-    const from = ids.indexOf(sourceId);
-    const to = ids.indexOf(target.id);
-    if (from < 0 || to < 0) return;
-    ids.splice(to, 0, ...ids.splice(from, 1));
-
-    this.orderOverride.set(ids);
-    try {
-      await this.service.reorderTiles(this.id(), ids);
-    } finally {
-      // The reload inside reorderTiles is authoritative; drop the override so a
-      // rejected write cannot leave the UI showing an order the backend refused.
-      this.orderOverride.set(null);
-    }
-  }
-
-  // ── board Ask ──────────────────────────────────────────────────────────────
   readonly turns = signal<BoardTurn[]>([]);
-
-  /** Monotonic ask token — the per-REQUEST half of the stale-async guard. */
+  readonly asking = signal(false);
+  readonly draft = signal("");
+  readonly sourceCount = signal(0);
+  readonly askOpen = signal(false);
+  readonly suggestions = SUGGESTIONS;
   private askToken = 0;
+  private nextTurnId = 1;
+  private refreshToken = 0;
+  private folderVisibilityStamp: string | null = null;
 
-  /**
-   * Switching boards starts a new conversation.
-   *
-   * `/dashboards/:id` reuses this component across board→board navigation, so without
-   * this the thread — including the user turn `ask()` appends synchronously before its
-   * first await — follows the user onto a board it was never about. Bumping the token
-   * in the same pass orphans any in-flight request's data writes while still letting
-   * it clear the spinner it set.
-   */
   private readonly _resetOnBoardChange = effect(() => {
     this.id();
     untracked(() => {
@@ -271,28 +180,203 @@ export class DashboardViewComponent {
       this.turns.set([]);
       this.draft.set("");
       this.asking.set(false);
+      this.askOpen.set(false);
+      this.mode.set("read");
+      this.lens.set("brief");
     });
   });
 
-  // ── rename ────────────────────────────────────────────────────────────────
-  //
-  // The board's name was write-once: `DashboardsService.update` shipped accepting
-  // `title`/`emoji`/`tint`, and the only caller ever passed `{pinned}`. A board named
-  // the wrong thing stayed named the wrong thing.
-  readonly renaming = signal(false);
-  readonly renameDraft = signal("");
-  private readonly renameField =
-    viewChild<ElementRef<HTMLInputElement>>("renameField");
-  private readonly _focusRename = effect(() => {
-    this.renameField()?.nativeElement.select();
+  private readonly _load = effect(() => {
+    const id = this.id();
+    const privacyReady = this.privacyReady();
+    const privacyError = this.privacyError();
+    if (!id) return;
+    untracked(() => {
+      if (privacyReady) {
+        void this.refresh(id);
+      } else {
+        // Listener setup can fail while an initial gated read is already in
+        // flight. Orphan it synchronously so its late plaintext response cannot
+        // become admissible after the barrier has moved to error.
+        this.refreshToken += 1;
+        this.board.set(null);
+        this.sourceCount.set(0);
+        this.loading.set(privacyError === null);
+        this.privacyRefreshing.set(privacyError === null);
+        this.boardUnavailable.set(privacyError !== null);
+      }
+    });
   });
 
+  /**
+   * The process-wide privacy barrier owns the monotonic lock-authority boundary.
+   * The tree stamp remains a secondary refresh for exposure changes such as unlock.
+   */
+  private readonly _regateOnFolderChange = effect(() => {
+    const stamp = this.folderStamp(this.folders.tree());
+    const previousStamp = this.folderVisibilityStamp;
+    this.folderVisibilityStamp = stamp;
+    if (previousStamp === null || previousStamp === stamp) return;
+
+    untracked(() => {
+      this.invalidateAndRefresh();
+    });
+  });
+
+  private invalidateAndRefresh(): void {
+    this.askToken += 1;
+    this.refreshToken += 1;
+    this.turns.set([]);
+    this.draft.set("");
+    this.asking.set(false);
+    this.askOpen.set(false);
+    this.renaming.set(false);
+    this.renameDraft.set("");
+    this.mode.set("read");
+    this.lens.set("brief");
+    this.sourceCount.set(0);
+    this.board.set(null);
+    this.orderOverride.set(null);
+    this.onDragEnd();
+    if (this.palette.open()) this.palette.dismiss();
+    const id = this.id();
+    if (id && this.privacyReady()) {
+      void this.refresh(id);
+    } else {
+      this.loading.set(false);
+      this.privacyRefreshing.set(false);
+      this.boardUnavailable.set(this.privacyError() !== null);
+    }
+  }
+
+  private folderStamp(
+    nodes: readonly {
+      id: string;
+      locked: boolean;
+      unlocked: boolean;
+      children?: unknown[];
+    }[],
+  ): string {
+    const values: string[] = [];
+    const visit = (items: typeof nodes): void => {
+      for (const node of items) {
+        values.push(`${node.id}:${node.locked ? 1 : 0}:${node.unlocked ? 1 : 0}`);
+        visit((node.children ?? []) as typeof nodes);
+      }
+    };
+    visit(nodes);
+    return values.sort().join("|");
+  }
+
+  private async refresh(id: string): Promise<void> {
+    const token = ++this.refreshToken;
+    this.board.set(null);
+    this.boardUnavailable.set(false);
+    this.privacyRefreshing.set(true);
+    this.loading.set(true);
+    try {
+      const [detail, sources] = await Promise.all([
+        this.ipc.getDashboard(id),
+        this.ipc.getDashboardSources(id),
+      ]);
+      if (
+        token !== this.refreshToken ||
+        this.id() !== id ||
+        !this.privacyReady()
+      ) {
+        return;
+      }
+      if (detail === null) {
+        this.sourceCount.set(0);
+        this.boardUnavailable.set(true);
+        return;
+      }
+      this.board.set(detail);
+      this.sourceCount.set(sources.length);
+      this.boardUnavailable.set(false);
+    } catch {
+      if (
+        token !== this.refreshToken ||
+        this.id() !== id ||
+        !this.privacyReady()
+      ) {
+        return;
+      }
+      this.board.set(null);
+      this.sourceCount.set(0);
+      this.boardUnavailable.set(true);
+    } finally {
+      if (
+        token === this.refreshToken &&
+        this.id() === id &&
+        this.privacyReady()
+      ) {
+        this.loading.set(false);
+        this.privacyRefreshing.set(false);
+      }
+    }
+  }
+
+  async retryLoad(): Promise<void> {
+    const id = this.id();
+    if (!id) return;
+    this.board.set(null);
+    this.boardUnavailable.set(false);
+    this.loading.set(true);
+    this.privacyRefreshing.set(true);
+    if (await this.privacyBarrier.ensureReady()) {
+      await this.refresh(id);
+    } else if (this.id() === id) {
+      this.loading.set(false);
+      this.privacyRefreshing.set(false);
+      this.boardUnavailable.set(true);
+    }
+  }
+
+  selectLens(lens: DashboardLens): void {
+    this.lens.set(lens);
+  }
+
+  duplicateOf(tile: ResolvedTile): string | null {
+    return this.duplicates().get(tile.id) ?? null;
+  }
+
+  private tileHeading(tile: ResolvedTile): string {
+    if (tile.title?.trim()) return tile.title.trim();
+    const data = tile.data;
+    switch (data.kind) {
+      case "note":
+      case "meeting":
+      case "document":
+        return data.title;
+      case "person":
+        return data.name;
+      case "promises":
+        return "Promises";
+      case "reminders":
+        return "Reminders";
+      case "livingAnswer":
+        return data.question || "Living answer";
+      default:
+        return "Derived view";
+    }
+  }
+
+  enterCompose(): void {
+    this.askOpen.set(false);
+    this.mode.set("compose");
+  }
+
+  leaveCompose(): void {
+    this.draggingId.set(null);
+    this.dropTargetId.set(null);
+    this.mode.set("read");
+  }
+
   startRename(): void {
-    const b = this.board();
-    if (!b) return;
-    // Round-trips through the same convention `create` uses, so renaming is also how
-    // you add or change the emoji: "🚀 Atlas GA".
-    this.renameDraft.set(b.emoji ? `${b.emoji} ${b.title}` : b.title);
+    const board = this.board();
+    if (!board) return;
+    this.renameDraft.set(board.emoji ? `${board.emoji} ${board.title}` : board.title);
     this.renaming.set(true);
   }
 
@@ -306,130 +390,116 @@ export class DashboardViewComponent {
 
   async commitRename(): Promise<void> {
     const typed = this.renameDraft().trim();
-    const b = this.board();
-    if (!typed || !b) return;
+    const board = this.board();
+    if (!typed || !board) return;
     this.renaming.set(false);
     const { emoji, title } = splitLeadingEmoji(typed);
-    if (title === b.title && (emoji ?? null) === (b.emoji ?? null)) return;
-    // `emoji: ""` clears it — dropping the field would leave the old one in place.
-    await this.service.update(b.id, { title, emoji: emoji ?? "" });
+    if (title === board.title && (emoji ?? null) === (board.emoji ?? null)) return;
+    await this.service.update(board.id, { title, emoji: emoji ?? "" });
+    await this.refresh(board.id);
   }
 
-  /**
-   * Whether the Ask column is open, versus collapsed to its rail.
-   *
-   * Opens on demand and STAYS open once there is a conversation — a thread the user
-   * can no longer see is worse than a wide column. The rail keeps the scope count on
-   * screen either way, because that readout is the feature's actual claim: this board,
-   * and nothing else, is what an answer may be built from. The empty transcript has no
-   * such claim to make, and it was spending a third of the width on three suggestion
-   * buttons.
-   */
-  private readonly _askOpen = signal(false);
-  readonly askExpanded = computed(() => this._askOpen() || this.turns().length > 0);
-
-  expandAsk(): void {
-    this._askOpen.set(true);
+  onDragStart(tile: ResolvedTile, event: DragEvent): void {
+    if (this.mode() !== "compose") return;
+    this.draggingId.set(tile.id);
+    event.dataTransfer?.setData("text/plain", tile.id);
+    if (event.dataTransfer) event.dataTransfer.effectAllowed = "move";
   }
-  readonly asking = signal(false);
-  readonly draft = signal("");
-  readonly sourceCount = signal(0);
-  readonly suggestions = SUGGESTIONS;
 
-  /** Tile id → 1-based citation index for the LAST answer. */
-  readonly citations = computed(() => {
-    const last = [...this.turns()].reverse().find((t) => t.role === "assistant");
-    const map = new Map<string, number>();
-    last?.citedTiles?.forEach((tileId, i) => map.set(tileId, i + 1));
-    return map;
-  });
+  onDragOver(tile: ResolvedTile, event: DragEvent): void {
+    if (this.mode() !== "compose" || !this.draggingId()) return;
+    event.preventDefault();
+    if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
+    this.dropTargetId.set(tile.id);
+  }
 
-  /**
-   * Load the board whenever the route id changes, and drop any previous Ask
-   * thread — a conversation scoped to one board must never carry into another.
-   */
-  private readonly _load = effect(() => {
-    const id = this.id();
-    if (!id) return;
-    // `untracked` is load-bearing, not defensive. `refresh()` runs SYNCHRONOUSLY
-    // up to its first await, and `DashboardsService.loadBoard` reads `board()`
-    // in there (to decide whether to clear the stale board). Without this the
-    // effect would take a dependency on `board`, which the same call then
-    // writes — an endless reload loop that pins the view on "Loading this
-    // board…" forever. The e2e spec for an empty board is the regression guard.
-    untracked(() => {
-      this.turns.set([]);
-      void this.refresh(id);
-    });
-  });
+  onDragLeave(tile: ResolvedTile): void {
+    if (this.dropTargetId() === tile.id) this.dropTargetId.set(null);
+  }
 
-  private async refresh(id: string): Promise<void> {
-    await this.service.loadBoard(id);
-    // Same stale-result discipline as the service: a late source-count for the
-    // board we just navigated AWAY from must not overwrite the current one.
+  onDragEnd(): void {
+    this.draggingId.set(null);
+    this.dropTargetId.set(null);
+  }
+
+  async onDrop(target: ResolvedTile, event: DragEvent): Promise<void> {
+    event.preventDefault();
+    const sourceId = this.draggingId();
+    this.onDragEnd();
+    if (!sourceId || sourceId === target.id) return;
+    await this.moveTo(sourceId, this.tiles().findIndex((tile) => tile.id === target.id));
+  }
+
+  async moveTile(tile: ResolvedTile, delta: -1 | 1): Promise<void> {
+    const index = this.tiles().findIndex((candidate) => candidate.id === tile.id);
+    await this.moveTo(tile.id, index + delta);
+  }
+
+  private async moveTo(tileId: string, destination: number): Promise<void> {
+    const ids = this.tiles().map((tile) => tile.id);
+    const from = ids.indexOf(tileId);
+    if (from < 0 || destination < 0 || destination >= ids.length || from === destination) return;
+    ids.splice(destination, 0, ...ids.splice(from, 1));
+    this.orderOverride.set(ids);
     try {
-      const count = (await this.ipc.getDashboardSources(id)).length;
-      if (this.id() === id) this.sourceCount.set(count);
-    } catch {
-      if (this.id() === id) this.sourceCount.set(0);
+      await this.service.reorderTiles(this.id(), ids);
+      await this.refresh(this.id());
+    } finally {
+      this.orderOverride.set(null);
     }
-  }
-
-  citationFor(tile: ResolvedTile): number {
-    return this.citations().get(tile.id) ?? 0;
   }
 
   back(): void {
     void this.router.navigate(["/dashboards"]);
   }
 
-  toggleEditing(): void {
-    this.editing.update((v) => !v);
-  }
-
-  /** Open the palette and add whatever the user picked (nothing if dismissed). */
-  async openPalette(): Promise<void> {
+  async openPalette(event?: Event): Promise<void> {
+    if (!this.privacyReady()) return;
+    const explicit = event?.currentTarget;
+    const invoker = explicit instanceof HTMLElement
+      ? explicit
+      : document.activeElement instanceof HTMLElement &&
+          document.activeElement !== document.body
+        ? document.activeElement
+        : null;
     const choice = await this.palette.request();
     if (choice) await this.addTile(choice);
+    if (invoker?.isConnected) invoker.focus();
   }
 
-  /**
-   * The trigger is a TOGGLE, and its label follows the state ("Add tile" ⇄ "Close").
-   *
-   * That is ordinary UX — a control that opens a modal should close it — but it is
-   * also the cheapest possible signal that the click landed at all. If the label
-   * flips and no palette appears, the fault is presentation; if the label does not
-   * flip, the click never reached the handler. Without it those two failures look
-   * identical from the outside, which is what made the first report hard to place.
-   */
-  togglePalette(): void {
+  togglePalette(event?: Event): void {
     if (this.paletteOpen()) this.palette.dismiss();
-    else void this.openPalette();
+    else void this.openPalette(event);
   }
 
   async addTile(choice: TileChoice): Promise<void> {
+    if (!this.privacyReady()) return;
     await this.service.addTile(this.id(), choice.kind, {
       refId: choice.refId,
       title: choice.title,
       config: choice.config,
     });
-    this.sourceCount.set((await this.ipc.getDashboardSources(this.id())).length);
+    await this.refresh(this.id());
   }
 
   async removeTile(tile: ResolvedTile): Promise<void> {
+    if (!this.privacyReady()) return;
     await this.service.removeTile(tile.id);
-    this.sourceCount.set((await this.ipc.getDashboardSources(this.id())).length);
+    await this.refresh(this.id());
   }
 
   async widen(tile: ResolvedTile): Promise<void> {
+    if (!this.privacyReady()) return;
     await this.service.updateTile(tile.id, { span: Math.min(12, tile.span + 1) });
+    await this.refresh(this.id());
   }
 
   async narrow(tile: ResolvedTile): Promise<void> {
+    if (!this.privacyReady()) return;
     await this.service.updateTile(tile.id, { span: Math.max(3, tile.span - 1) });
+    await this.refresh(this.id());
   }
 
-  /** Click-through from a tile row to its source. */
   openSource(source: SourceRef): void {
     switch (source.kind) {
       case "meeting":
@@ -439,9 +509,17 @@ export class DashboardViewComponent {
         void this.router.navigate(["/notes", source.id]);
         break;
       default:
-        // Documents have no dedicated route; the brain view owns them.
         void this.router.navigate(["/brain"]);
     }
+  }
+
+  openAsk(): void {
+    if (!this.privacyReady()) return;
+    this.askOpen.set(true);
+  }
+
+  closeAsk(): void {
+    this.askOpen.set(false);
   }
 
   onDraft(event: Event): void {
@@ -453,23 +531,16 @@ export class DashboardViewComponent {
     void this.ask();
   }
 
-  /**
-   * Ask the board. The answer is grounded in the board's VISIBLE sources only;
-   * tiles whose source the answer cited light up and number themselves.
-   */
   async ask(): Promise<void> {
+    if (!this.privacyReady()) return;
     const question = this.draft().trim();
     if (!question || this.asking()) return;
     this.draft.set("");
-    this.turns.update((t) => [...t, { role: "user", text: question }]);
+    this.turns.update((turns) => [
+      ...turns,
+      { id: this.nextTurnId++, role: "user", text: question },
+    ]);
     this.asking.set(true);
-    // TWO different questions, and conflating them is a bug of its own.
-    //
-    // `owns()` guards DATA writes: an answer, an error, a source count belong to the
-    // board AND the request that asked for them. `current()` guards the BUSY flag,
-    // which is per-request only — gating the spinner on the board too means that after
-    // navigating away mid-flight nothing ever clears it, and the NEW board sits
-    // disabled forever waiting on a request that was never its own.
     const boardId = this.id();
     const token = ++this.askToken;
     const current = () => this.askToken === token;
@@ -478,16 +549,13 @@ export class DashboardViewComponent {
       const sources = await this.ipc.getDashboardSources(boardId);
       if (!owns()) return;
       this.sourceCount.set(sources.length);
-      // An empty SOURCE list no longer means an empty board. Derived tiles are never
-      // `SourceRef`s, and sealed material tiles resolve to no readable source either.
-      // Presence of ANY stored tile therefore keeps the board scope alive and lets
-      // the backend's empty-but-present path prevent a vault-wide fallback.
       if (sources.length === 0 && this.tiles().length === 0) {
-        this.turns.update((t) => [
-          ...t,
+        this.turns.update((turns) => [
+          ...turns,
           {
+            id: this.nextTurnId++,
             role: "assistant",
-            text: "This board has no readable sources yet — add a note, recording or document tile (or unlock a sealed one) and ask again.",
+            text: "This board has no readable sources yet — add a note, recording or document, or unlock a sealed source, and ask again.",
           },
         ]);
         return;
@@ -498,81 +566,44 @@ export class DashboardViewComponent {
         undefined,
         sources,
         undefined,
-        // The BOARD, so the backend can render its derived tiles into the prompt.
-        // An id, never the finished text: handing the FE a string to inject would be
-        // a new injection surface and would build content outside the gate.
         boardId,
       );
-      // The answer belongs to the board — and the request — that asked for it.
       if (!owns()) return;
-      this.turns.update((t) => [
-        ...t,
+      this.turns.update((turns) => [
+        ...turns,
+        { id: this.nextTurnId++, role: "assistant", text: result.answer },
+      ]);
+    } catch (error) {
+      if (!owns()) return;
+      this.turns.update((turns) => [
+        ...turns,
         {
-          role: "assistant",
-          text: result.answer,
-          citedTiles: this.tilesForSources(result.sources.map((s) => s.meetingId)),
+          id: this.nextTurnId++,
+          role: "error",
+          text: this.errors.humanize(error, "generic"),
+          retry: question,
         },
       ]);
-    } catch (e) {
-      if (!owns()) return;
-      this.turns.update((t) => [
-        ...t,
-        { role: "error", text: this.errors.humanize(e, "generic"), retry: question },
-      ]);
     } finally {
-      // The LATEST request clears the spinner, whichever board is on screen now. A
-      // superseded ask must not; a navigated-away one still must, or it never comes up.
       if (current()) this.asking.set(false);
     }
   }
 
-  /**
-   * The conversation so far, bounded and stripped of error turns - a failed
-   * dispatch is UI chrome, and replaying "That didn't work" as prior context
-   * would teach the model that the board could not answer.
-   */
   private askHistory(): ChatTurn[] {
     return this.turns()
-      .filter((t) => t.role !== "error")
+      .filter((turn) => turn.role !== "error")
       .slice(-HISTORY_TURNS)
-      .map((t) => ({ role: t.role as "user" | "assistant", content: t.text }));
+      .map((turn) => ({
+        role: turn.role as "user" | "assistant",
+        content: turn.text,
+      }));
   }
 
-  /** Re-send the question an error turn was raised for. */
   retry(turn: BoardTurn): void {
     if (!turn.retry) return;
-    const question = turn.retry;
-    this.turns.update((t) => t.filter((x) => x !== turn));
-    this.draft.set(question);
+    this.turns.update((turns) => turns.filter((candidate) => candidate.id !== turn.id));
+    this.draft.set(turn.retry);
     void this.ask();
-  }
-
-  /** Map the answer's source ids back onto the tiles that carry them. */
-  private tilesForSources(sourceIds: string[]): string[] {
-    const wanted = new Set(sourceIds);
-    return this.tiles()
-      .filter((t) => t.refId && wanted.has(t.refId))
-      .map((t) => t.id);
-  }
-
-  /** Re-run a Living-answer tile's pinned question and persist the result. */
-  async refreshAnswer(tile: ResolvedTile): Promise<void> {
-    if (tile.data.kind !== "livingAnswer") return;
-    const question = tile.data.question.trim();
-    if (!question) return;
-    try {
-      const sources = await this.ipc.getDashboardSources(this.id());
-      if (sources.length === 0) return;
-      const result = await this.ipc.askVault(question, [], undefined, sources);
-      // The BACKEND persists this, so it can stamp the readable-folder snapshot
-      // that gates the cached answer. Writing it from here through the generic
-      // tile update is what left the cache un-gateable.
-      await this.ipc.setDashboardAnswer(tile.id, question, result.answer);
-      await this.service.loadBoard(this.id());
-    } catch {
-      // The service surfaces the error banner; a failed re-answer leaves the
-      // previous answer intact rather than blanking the tile.
-    }
   }
 
 }

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.html
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.html
@@ -24,7 +24,7 @@
     (keydown.escape)="dismiss.emit()"
   ></div>
 
-  <div class="palette" role="dialog" aria-modal="true" aria-label="Add a tile">
+  <div #panel class="palette" role="dialog" aria-modal="true" aria-label="Add to board" tabindex="-1">
     @if (selected(); as type) {
       <header class="palette-head">
         <button type="button" class="btn btn-ghost btn-sm back" (click)="back()">← All tiles</button>
@@ -118,17 +118,20 @@
     } @else {
       <header class="palette-head">
         <div>
-          <h3>Add a tile</h3>
+          <h3>Add to board</h3>
           <p>
-            Every tile stays live — it re-reads itself when something new is said.
-            <strong>Only-Murmur</strong> tiles are the ones no vault or cloud notetaker can build.
+            Add material Sources, or a derived View over the board's readable scope.
+            Source picks persist only their reference id.
           </p>
         </div>
       </header>
 
       <div class="catalogue">
-        @for (type of types; track type.kind) {
-          <button type="button" class="node" (click)="pick(type)">
+        <h4>Sources</h4>
+        <p class="group-copy">Readable material you deliberately add to this board.</p>
+        <div class="catalogue-grid source-grid">
+        @for (type of sourceTypes; track type.kind; let first = $first) {
+          <button #firstChoice type="button" class="node" (click)="pick(type)">
             <span class="node-dot" [class]="'dot-' + type.family"></span>
             <span class="node-text">
               <span class="node-name">{{ type.name }}</span>
@@ -139,6 +142,21 @@
             </span>
           </button>
         }
+        </div>
+        <h4>Views</h4>
+        <p class="group-copy">Derived representations; they do not add material to Ask scope.</p>
+        <div class="catalogue-grid">
+        @for (type of viewTypes; track type.kind) {
+          <button type="button" class="node" (click)="pick(type)">
+            <span class="node-dot" [class]="'dot-' + type.family"></span>
+            <span class="node-text">
+              <span class="node-name">{{ type.name }}</span>
+              <span class="node-desc">{{ type.description }}</span>
+              @if (type.onlyMurmur) { <span class="only-badge">only Murmur</span> }
+            </span>
+          </button>
+        }
+        </div>
       </div>
     }
   </div>

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.scss
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.scss
@@ -110,9 +110,6 @@
 }
 
 .catalogue {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-  gap: var(--space-2);
   padding: var(--space-4) var(--space-5) var(--space-5);
   // Takes the panel's remaining height and scrolls inside it; `min-height: 0` is
   // what lets a flex item shrink below its content instead of forcing the panel
@@ -120,6 +117,25 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow: auto;
+
+  h4 {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 0.84rem;
+  }
+}
+
+.group-copy {
+  margin: var(--space-1) 0 var(--space-3);
+  color: var(--text-tertiary);
+  font-size: 0.72rem;
+}
+
+.catalogue-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: var(--space-2);
+  margin-bottom: var(--space-4);
 }
 
 .node {

--- a/src/app/features/dashboards/tile-palette/tile-palette.component.ts
+++ b/src/app/features/dashboards/tile-palette/tile-palette.component.ts
@@ -29,6 +29,15 @@ interface NodeType {
   family: "note" | "rec" | "person" | "doc" | "insight" | "remind";
 }
 
+const FOCUSABLE_SELECTOR = [
+  "button:not([disabled])",
+  "a[href]",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
 /**
  * The tile catalogue. Order is the palette's reading order: material first,
  * then the derived views that are the actual reason to build a board.
@@ -109,7 +118,7 @@ const NODE_TYPES: NodeType[] = [
   {
     kind: "living_answer",
     name: "Living answer",
-    description: "A pinned question whose answer you can re-run any time.",
+    description: "A saved question with its last gated answer, when available.",
     onlyMurmur: true,
     mode: "question",
     family: "insight",
@@ -166,6 +175,8 @@ export class TilePaletteComponent {
   readonly choose = output<TileChoice>();
 
   readonly types = NODE_TYPES;
+  readonly sourceTypes = NODE_TYPES.filter((type) => type.mode === "link");
+  readonly viewTypes = NODE_TYPES.filter((type) => type.mode !== "link");
 
   /** The kind being configured; `null` ⇒ the catalogue step. */
   readonly selected = signal<NodeType | null>(null);
@@ -184,9 +195,13 @@ export class TilePaletteComponent {
    * on its own when the `@switch` swaps the step in, with no call site to forget.
    */
   private readonly searchField = viewChild<ElementRef<HTMLInputElement>>("searchField");
+  private readonly panel = viewChild<ElementRef<HTMLElement>>("panel");
+  private readonly firstChoice = viewChild<ElementRef<HTMLButtonElement>>("firstChoice");
 
   private readonly _focusField = effect(() => {
-    this.searchField()?.nativeElement.focus();
+    const field = this.searchField()?.nativeElement;
+    if (field) field.focus();
+    else this.firstChoice()?.nativeElement.focus();
   });
 
   readonly filteredEntities = computed(() => {
@@ -296,10 +311,35 @@ export class TilePaletteComponent {
    * which KIND of tile you wanted is a needless step backwards.
    */
   onKeydown(event: KeyboardEvent): void {
-    if (event.key !== "Escape") return;
-    event.preventDefault();
-    if (this.selected()) this.back();
-    else this.dismiss.emit();
+    if (event.key === "Escape") {
+      event.preventDefault();
+      if (this.selected()) this.back();
+      else this.dismiss.emit();
+      return;
+    }
+    if (event.key !== "Tab") return;
+    const panel = this.panel()?.nativeElement;
+    if (!panel) return;
+    const focusable = [...panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)]
+      .filter((element) => element.getClientRects().length > 0);
+    if (focusable.length === 0) {
+      event.preventDefault();
+      panel.focus();
+      return;
+    }
+    const active = document.activeElement;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (!focusable.includes(active as HTMLElement)) {
+      event.preventDefault();
+      first.focus();
+    } else if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
   }
 
 }


### PR DESCRIPTION
## Summary

- make dashboards open as a calm Read workspace with Brief, Overview, Commitments, Sources, and People lenses
- keep the tile grid in explicit Compose mode, with keyboard reordering and a Sources versus Views Add flow
- add Note, Recording, and Document sources by reference id only; keep board Ask on demand and scoped by dashboard id
- fail closed behind the process-wide privacy barrier, scrub mounted board, Ask, and palette state on relock, and reject stale same-board responses
- preserve Living Answer question creation, but keep Re-answer persistence disabled until the backend can validate an ask-time visibility witness

## Verification

- Harness v2 PASSED on exact diff fc60bc1dca5a6af0702c477a9c8711ae4926194f45620d82f79b56ff3c958a49
- fresh Codex combined review: PASS, 0 findings
- lock-security review: PASS
- ng lint: PASS
- ng build: PASS
- full Playwright: 574 passed, 2 skipped, 0 flaky
- dashboard Chromium: 37/37; focused WebKit: 9/9; repaired palette WebKit stress: 20/20

## Scope

Frontend and dashboard E2E only. No backend DTO, command, storage, migration, provider, egress, MCP, or Obsidian export changes.