### PR TITLE
fix(notes): dismiss transient overlays outside editor

### DIFF
--- a/e2e/notes/overlay-dismiss-escape.spec.ts
+++ b/e2e/notes/overlay-dismiss-escape.spec.ts
@@ -1,0 +1,192 @@
+import { expect, test } from "@playwright/test";
+import { mockNotes } from "./mock-invoke";
+
+async function selectBodyText(page: import("@playwright/test").Page): Promise<void> {
+  const body = page.locator(".body-area");
+  await expect(body).toBeVisible();
+  await body.evaluate((el: HTMLTextAreaElement) => {
+    const start = el.value.indexOf("body text");
+    el.focus();
+    el.setSelectionRange(start, start + "body text".length);
+    el.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+  });
+}
+
+async function expectNoTransientNoteUi(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  for (const selector of [
+    ".sel-bar",
+    ".brain-pop",
+    ".link-pop",
+    ".slash-menu",
+    ".head-menu",
+    ".menu-backdrop",
+  ]) {
+    await expect(page.locator(selector)).toHaveCount(0);
+  }
+}
+
+async function backgroundAndReturnToCachedNote(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  await page
+    .getByRole("link", { name: "Record", exact: true })
+    .dispatchEvent("click");
+  await expect(page).toHaveURL(/\/record$/);
+  await expectNoTransientNoteUi(page);
+
+  // Browser Back drives Angular's router back to the stored `/notes/:id`
+  // handle without creating a fresh page or injecting a pointer event.
+  await page.goBack();
+  await expect(page).toHaveURL(/\/notes\/n1$/);
+  await expect(page.locator(".body-area")).toBeVisible();
+  await expectNoTransientNoteUi(page);
+}
+
+test("note selection overlays stay interactive and dismiss when the pointer leaves the editor", async ({
+  page,
+}) => {
+  await mockNotes(page);
+  await page.goto("/notes/n1");
+
+  await selectBodyText(page);
+  const toolbar = page.locator(".sel-bar");
+  await expect(toolbar).toBeVisible();
+
+  // Other note chrome is outside the body selection's owning surface.
+  await page.locator(".note-title-input").click();
+  await expect(toolbar).toHaveCount(0);
+
+  await selectBodyText(page);
+  await expect(toolbar).toBeVisible();
+
+  // The teleported toolbar is part of the editor interaction even though its
+  // DOM node lives under <body>. Clicking it must not trigger click-away.
+  await toolbar.getByRole("button", { name: "Ask Brain" }).click();
+  const popover = page.locator(".brain-pop");
+  await expect(popover).toBeVisible();
+
+  await popover.getByPlaceholder("Ask Brain to edit…").click();
+  await expect(popover).toBeVisible();
+
+  await page.locator(".note-title-input").click();
+  await expect(popover).toHaveCount(0);
+  await expect(toolbar).toHaveCount(0);
+
+  await selectBodyText(page);
+  await toolbar.getByRole("button", { name: "Ask Brain" }).click();
+  await expect(popover).toBeVisible();
+
+  // Leaving the owning editor for app chrome dismisses the transient overlay.
+  await page.getByRole("link", { name: "Record", exact: true }).click();
+  await expect(page).toHaveURL(/\/record$/);
+  await expect(popover).toHaveCount(0);
+  await expect(toolbar).toHaveCount(0);
+});
+
+test("a cached note route clears every editing overlay and never resurrects it on return", async ({
+  page,
+}) => {
+  await mockNotes(page, {
+    list_link_candidates: () => [
+      { kind: "note", id: "n2", title: "Weekly plan", snippet: "" },
+    ],
+  });
+  await page.goto("/notes/n1");
+
+  // Brain is teleported to <body>; pointer-free backgrounding must detach it.
+  await selectBodyText(page);
+  await page.locator(".sel-bar").getByRole("button", { name: "Ask Brain" }).click();
+  await expect(page.locator(".brain-pop")).toBeVisible();
+  await backgroundAndReturnToCachedNote(page);
+
+  // The link picker is also teleported and carries async candidate state.
+  let body = page.locator(".body-area");
+  await body.click();
+  await body.evaluate((el: HTMLTextAreaElement) => {
+    el.setSelectionRange(el.value.length, el.value.length);
+  });
+  await body.press("Enter");
+  await body.press("/");
+  await page
+    .locator(".slash-menu")
+    .getByRole("option", { name: "Link to note" })
+    .click();
+  await expect(page.locator(".link-pop")).toBeVisible();
+  await backgroundAndReturnToCachedNote(page);
+
+  // Inline slash-menu state must be cleared even though it has no teleported node.
+  body = page.locator(".body-area");
+  await body.click();
+  await body.evaluate((el: HTMLTextAreaElement) => {
+    el.setSelectionRange(el.value.length, el.value.length);
+  });
+  await body.press("Enter");
+  await body.press("/");
+  await expect(page.locator(".slash-menu")).toBeVisible();
+  await backgroundAndReturnToCachedNote(page);
+
+  // Header menu + backdrop are cached component state too.
+  await page.getByRole("button", { name: "More actions" }).click();
+  await expect(page.locator(".head-menu")).toBeVisible();
+  await expect(page.locator(".menu-backdrop")).toBeVisible();
+  await backgroundAndReturnToCachedNote(page);
+});
+
+test("outside-dismiss pointerdown does not consume header or slash-menu actions", async ({
+  page,
+}) => {
+  await mockNotes(page, {
+    list_link_candidates: () => [
+      { kind: "note", id: "n2", title: "Weekly plan", snippet: "" },
+    ],
+  });
+  await page.goto("/notes/n1");
+
+  await page.getByRole("button", { name: "More actions" }).click();
+  await page.getByRole("menuitem", { name: /Share/ }).click();
+  await expect(page.locator(".share-modal")).toBeVisible();
+  await page.getByRole("button", { name: "Close", exact: true }).click();
+
+  const body = page.locator(".body-area");
+  await body.click();
+  await body.evaluate((el: HTMLTextAreaElement) => {
+    el.setSelectionRange(el.value.length, el.value.length);
+  });
+  await body.press("Enter");
+  await body.press("/");
+
+  const slashMenu = page.locator(".slash-menu");
+  await expect(slashMenu).toBeVisible();
+  await slashMenu.getByRole("option", { name: "Link to note" }).click();
+  const picker = page.locator(".link-pop");
+  await expect(picker).toBeVisible();
+  await picker.getByText("Weekly plan").click();
+  await expect(body).toHaveValue(/\[\[Weekly plan\]\]/);
+});
+
+test("main-shell Escape is consumed after its document-level overlay handler runs", async ({
+  page,
+}) => {
+  await mockNotes(page);
+  await page.goto("/notes/n1");
+
+  await page.getByRole("button", { name: "Search (⌘K)" }).first().click();
+  await expect(page.locator(".qs-scrim")).toBeVisible();
+
+  const prevented = await page.evaluate(() => {
+    const event = new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+      cancelable: true,
+    });
+    document.body.dispatchEvent(event);
+    return event.defaultPrevented;
+  });
+
+  // Existing document-level Escape behavior still gets first chance to close
+  // the overlay; the shell then blocks the native window fallback.
+  await expect(page.locator(".qs-scrim")).toHaveCount(0);
+  expect(prevented).toBe(true);
+});

--- a/src/app/app-shell/app-shell.component.ts
+++ b/src/app/app-shell/app-shell.component.ts
@@ -202,6 +202,7 @@ const INSIGHT_PATHS = NAV_GROUPS.filter((g) => g.collapsible).flatMap((g) =>
     // `.app-main` comment in styles.css. Views that want a narrower reading
     // column own that cap in their own component scss.)
     "(document:keydown)": "onGlobalKeydown($event)",
+    "(window:keydown.escape)": "onWindowEscape($event)",
   },
   templateUrl: "./app-shell.component.html",
   styleUrl: "./app-shell.component.scss",
@@ -617,6 +618,18 @@ export class AppShellComponent {
         void this.tabs.closeTab(activeId);
       }
     }
+  }
+
+  /**
+   * Consume Escape at the main-window shell boundary after document-level
+   * overlay handlers have run. In native macOS fullscreen, an unconsumed Escape
+   * falls through to window chrome (which can hide/minimize Murmur); the app's
+   * own transient UI still receives the event first during normal bubbling.
+   * The separate `/bar` window is outside this shell and keeps its intentional
+   * Escape-to-hide behavior.
+   */
+  onWindowEscape(event: Event): void {
+    event.preventDefault();
   }
 
   /**

--- a/src/app/features/notes/link-picker/link-picker.component.html
+++ b/src/app/features/notes/link-picker/link-picker.component.html
@@ -8,6 +8,7 @@
 <div
   #popover
   class="link-pop"
+  data-note-editor-overlay
   appTeleportToBody
   appRepositionOnScroll
   [repositionAnchor]="anchorElement()"

--- a/src/app/features/notes/link-picker/link-picker.component.ts
+++ b/src/app/features/notes/link-picker/link-picker.component.ts
@@ -126,6 +126,11 @@ export class LinkPickerComponent {
 
   private readonly popoverEl = viewChild<ElementRef<HTMLDivElement>>("popover");
 
+  /** Remove the teleported box immediately when its cached owner is detached. */
+  detachFromDocument(): void {
+    this.popoverEl()?.nativeElement.remove();
+  }
+
   /** Monotonic request token — a late reply for a superseded query is dropped (T1 stale-guard). */
   private requestSeq = 0;
   /**

--- a/src/app/features/notes/note-brain-popover/note-brain-popover.component.html
+++ b/src/app/features/notes/note-brain-popover/note-brain-popover.component.html
@@ -4,6 +4,7 @@
 <div
   #popover
   class="brain-pop"
+  data-note-editor-overlay
   appTeleportToBody
   appRepositionOnScroll
   (reposition)="reposition()"

--- a/src/app/features/notes/note-brain-popover/note-brain-popover.component.ts
+++ b/src/app/features/notes/note-brain-popover/note-brain-popover.component.ts
@@ -168,6 +168,11 @@ export class NoteBrainPopoverComponent {
   /** The popover element, positioned after render. */
   private readonly popoverEl =
     viewChild<ElementRef<HTMLDivElement>>("popover");
+
+  /** Remove the teleported box immediately when its cached owner is detached. */
+  detachFromDocument(): void {
+    this.popoverEl()?.nativeElement.remove();
+  }
   /** The command input, focused after the menu renders. */
   private readonly cmdInput =
     viewChild<ElementRef<HTMLInputElement>>("cmdInput");

--- a/src/app/features/notes/note-editor/note-editor.component.ts
+++ b/src/app/features/notes/note-editor/note-editor.component.ts
@@ -175,6 +175,9 @@ const NOTE_CHAT_OPEN_KEY = "murmur-note-chat-open";
 @Component({
   selector: "app-note-editor",
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    "(document:pointerdown)": "onDocumentPointerDown($event)",
+  },
   imports: [
     ConnectionsComponent,
     LinkPickerComponent,
@@ -426,6 +429,9 @@ export class NoteEditorComponent {
   private linkPickerRepositionQueued = false;
   private readonly tagInput =
     viewChild<ElementRef<HTMLInputElement>>("tagInput");
+  private readonly selectionToolbar = viewChild(NoteSelectionToolbarComponent);
+  private readonly brainPopover = viewChild(NoteBrainPopoverComponent);
+  private readonly linkPicker = viewChild(LinkPickerComponent);
 
   /**
    * Monotonic request token — a late `getNote` reply for a superseded id is
@@ -752,6 +758,7 @@ export class NoteEditorComponent {
       if (!doc || key !== tabKeyFor("note", doc.id)) {
         return;
       }
+      this.onTabBackgrounded();
       void this.runNoteBoundaryWork();
     });
     this.destroyRef.onDestroy(unsubDetach);
@@ -2739,6 +2746,63 @@ export class NoteEditorComponent {
   /** Dismiss the Brain popover + the bubble (Close / Discard / after Accept). */
   closePopover(): void {
     this.clearSelection();
+  }
+
+  /**
+   * Dismiss editor-owned transient UI when a pointer interaction leaves the
+   * body textarea and its teleported overlays. Other note chrome (title,
+   * properties, header) is outside the selection's owning surface and must
+   * dismiss it too. The overlay boxes live under `<body>`, so they carry an
+   * explicit marker rather than relying on component-host containment.
+   */
+  onDocumentPointerDown(event: PointerEvent): void {
+    const target = event.target;
+    if (!(target instanceof Element)) {
+      return;
+    }
+    if (
+      this.bodyArea()?.nativeElement === target ||
+      target.closest("[data-note-editor-overlay]")
+    ) {
+      return;
+    }
+
+    // A pointerdown runs before the target's click. Clear selection-owned UI
+    // immediately, but do not tear down the specific inline menu whose click
+    // still needs to run (otherwise Share / slash-menu actions disappear before
+    // Angular receives their click). Other open menus still close as click-away.
+    const insideHeaderMenu = target.closest(".head-crumb, .head-more") !== null;
+    const insideSlashMenu = target.closest(".slash-menu") !== null;
+    this.clearSelection();
+    this.closeLinkPicker();
+    if (!insideSlashMenu) {
+      this.slashOpen.set(false);
+    }
+    if (!insideHeaderMenu) {
+      this.closeMenus();
+    }
+  }
+
+  /**
+   * A cached note route is detached rather than destroyed on tab/navigation
+   * switches. Drop transient editor state explicitly so teleported boxes cannot
+   * remain visible over the newly-active route.
+   */
+  onTabBackgrounded(): void {
+    this.dismissTransientUi();
+  }
+
+  private dismissTransientUi(): void {
+    // A tab route is detached before its signal-driven template can reconcile.
+    // Remove any boxes already teleported to <body> synchronously; clearing the
+    // owning signals below keeps the cached view correct when it reattaches.
+    this.selectionToolbar()?.detachFromDocument();
+    this.brainPopover()?.detachFromDocument();
+    this.linkPicker()?.detachFromDocument();
+    this.clearSelection();
+    this.closeLinkPicker();
+    this.slashOpen.set(false);
+    this.closeMenus();
   }
 
   /** Drop the selection state (hides both the bubble and the Brain popover). */

--- a/src/app/features/notes/note-selection-toolbar/note-selection-toolbar.component.html
+++ b/src/app/features/notes/note-selection-toolbar/note-selection-toolbar.component.html
@@ -5,6 +5,7 @@
 <div
   #bar
   class="sel-bar"
+  data-note-editor-overlay
   appTeleportToBody
   appRepositionOnScroll
   (reposition)="reposition()"

--- a/src/app/features/notes/note-selection-toolbar/note-selection-toolbar.component.ts
+++ b/src/app/features/notes/note-selection-toolbar/note-selection-toolbar.component.ts
@@ -79,6 +79,11 @@ export class NoteSelectionToolbarComponent {
     this.format.emit(op);
   }
 
+  /** Remove the teleported box immediately when its cached owner is detached. */
+  detachFromDocument(): void {
+    this.barEl()?.nativeElement.remove();
+  }
+
   /** Position the bar ABOVE the selection rect (flips below when there's no room). */
   reposition(): void {
     afterNextRender(


### PR DESCRIPTION
## Summary

- dismiss the selection toolbar, Brain popover, and link picker on clicks outside their active note interaction, including title chrome and sidebar navigation
- synchronously detach teleported note overlays when a cached note route backgrounds, preventing orphaned or resurrected UI
- consume Escape in the main shell after overlay handlers run, preventing the native fullscreen fallback while preserving the separate floating recorder bar behavior
- add deterministic click-away, cached-route round-trip, and Escape regression coverage

## Verification

- Harness v2 PASS on exact diff SHA: 55a1d1b11ef418873759060be9332111800c75be5ea5d93af2853ca4bff39737
- independent Codex adversarial review: PASS
- npx ng lint
- npx ng build
- full Playwright suite
- focused Chromium + WebKit regression suite: 8/8 passed

The mocked-browser runtime pins Escape ordering and default prevention; native macOS fullscreen itself was not directly automated.