### PR TITLE
fix(ai): bound Ask history context

### DIFF
--- a/docs/research/2026-08-13-ai-context-knowledge-audit.md
+++ b/docs/research/2026-08-13-ai-context-knowledge-audit.md
@@ -2,7 +2,10 @@
 
 **Date:** 2026-08-13
 
-**Code baseline:** `518d96c1c05c97d2b513e7959555edcd6c3819cb` (`origin/murmur`)
+**Audit code baseline:** `518d96c1c05c97d2b513e7959555edcd6c3819cb` (`origin/murmur`)
+
+**Remediation:** the local-provider budget correction was independently receipted in commit
+`99324c4`; the durable-history correction is the separate Harness change that updates this report.
 
 **Scope:** engine/provider routing, retrieval, prompt/context assembly, Brain memory, links, Ask, MCP, dashboards and Living Answers, plus current external approaches.
 
@@ -12,9 +15,9 @@ Murmur already has a strong modern knowledge substrate. It combines SQLCipher-ca
 
 It is **not yet maximally efficient at context management**. Candidate discovery is fine-grained, but the deterministic Ask floor often turns those candidates back into whole-note Markdown under static character budgets. The system also loses typed provenance for note/document and derived-dashboard evidence. That prevents precise citations, exact cache dependencies, reliable freshness signals, and evidence-level quality evaluation.
 
-Two concrete resource-bound defects were confirmed. The first was small enough to fix in this change: the explicit on-device `local` connection received the cloud-sized 200,000-character Ask corpus budget because `vault_context::budget_for` recognized only `ollama`. The local sidecar plans around a roughly 4096-token window, so this mismatch could create an oversized prefill and crowd out the actual question and answer. This change makes the vault packer reuse the existing on-device/weak-provider classification and caps `local`, Apple Foundation Models, and Ollama at 4,000 characters. It does **not** claim measured latency, RAM, or answer-quality improvement; those require a real-model benchmark.
+Two concrete resource-bound defects were confirmed and corrected in separate Harness receipts. The first was the explicit on-device `local` connection receiving the cloud-sized 200,000-character Ask corpus budget because `vault_context::budget_for` recognized only `ollama`. The local sidecar plans around a roughly 4096-token window, so this mismatch could create an oversized prefill and crowd out the actual question and answer. The first correction makes the vault packer reuse the existing on-device/weak-provider classification and caps `local`, Apple Foundation Models, and Ollama at 4,000 characters. It does **not** claim measured latency, RAM, or answer-quality improvement; those require a real-model benchmark.
 
-The second defect is in durable Ask history: `capped_ask_history` retains the newest 12 turns but does not apply a character budget. Twelve pasted-document-sized turns can therefore enter both the deterministic and agentic prompt, while agent transcript compaction never trims that immutable head. This needs a separate narrow Harness receipt because it changes a different egress-bearing surface and was discovered after this task's owned-path contract was bound.
+The second defect was in durable Ask history: `capped_ask_history` retained the newest 12 turns but did not apply a character budget. Twelve pasted-document-sized turns could therefore enter both the deterministic and agentic prompt, while agent transcript compaction never trims that immutable head. The follow-up correction enforces a strict 16,000-Unicode-scalar budget at their shared renderer, including role labels and the omission marker. It retains the newest complete turns first and uses a marked, Unicode-safe suffix only when the newest prior turn alone is oversized; the current question remains separate and intact.
 
 The highest-value next investment is not another database, GraphRAG service, compression model, or reranker. It is one provider-neutral **evidence-span context compiler** that emits both prompt text and a typed dependency manifest.
 
@@ -40,7 +43,7 @@ No real-Mac local-model latency/RAM run, private-vault quality evaluation, or co
 | Retrieval | `Db::search_hybrid_visible` fuses normalized FTS, KNN, and graph scores at 0.4/0.4/0.2, redistributing weight when a leg is empty. It applies visibility and optional temporal windows. | More substantive than a cosmetic knowledge graph. **High** |
 | Reranking | Ask may pointwise-rerank the top 10 candidates with a local reasoner and a 3-second bound, degrading to the original order. | Safely bounded, but value and call cost are not currently demonstrated. **Medium** |
 | Context packing | `summarize::vault_context` selects up to 40 candidates, then packs full note Markdown and document snippets into a provider-class character budget. Pinned sources are fairly allocated; active linked neighbours are deduplicated and globally capped at eight. | Correct bounds and gates, but evidence granularity is lost after retrieval. **High** |
-| Agentic Ask | The read-only `GatedToolExecutor` exposes allowlisted tools. Ask is capped at six steps, deduplicates repeated calls, bounds gathered output, compacts the loop transcript, and falls back to the deterministic floor on ordinary non-convergence. JIT listing/retrieval remains off by default. | Sensible bounded-agent design; default-off JIT is appropriate until faithfulness is measured. **High** |
+| Agentic Ask | The read-only `GatedToolExecutor` exposes allowlisted tools. Ask is capped at six steps, deduplicates repeated calls, bounds gathered output, compacts the loop transcript, and falls back to the deterministic floor on ordinary non-convergence. Both Ask routes share a 16,000-character prior-history renderer; JIT listing/retrieval remains off by default. | Sensible bounded-agent design; default-off JIT is appropriate until faithfulness is measured. **High** |
 | Long-term memory | Entity and user facts are bitemporal: superseded facts close validity instead of being overwritten. Consolidation scores visible facts, produces entity/weekly rollups, and regenerates on source fact-set hash changes with seal-epoch protection. | Close in spirit to temporal knowledge systems such as Graphiti, without a second graph store. **High** |
 | Links and graph | Manual, wikilink, companion, semantic, entity, note, document, and meeting relationships are typed DB records. Visible readers gate both endpoints. Links influence navigation and retrieval, not only graph visualization. | Strong and correctly placed in SQLite. **High** |
 | Dashboard context | Material tiles resolve through gated readers. Derived board briefs are assembled under a lifecycle guard. Living Answer reads fail closed when their stamped readable-folder set is no longer readable. | Safe but conservative; provenance/freshness is incomplete. **High** |
@@ -85,15 +88,15 @@ At the baseline revision, `summarize::vault_context::budget_for` returned 4,000 
 
 Therefore the Ask floor could pack about 50 times more vault text for `local` than for Ollama before the prompt reached the same class of constrained on-device engine. This is a wiring defect, not a speculative optimization. **Confidence: high.**
 
-The fix reuses `related_context::is_weak_provider` in `vault_context::budget_for`. Regression coverage binds the full current on-device matrix, a representative cloud provider, and both whole-vault and pinned construction with a long multibyte corpus. Cloud budget, egress classification, redaction, consent, ledger behaviour, retrieval ranking, visibility gates, and link caps are unchanged.
+The fix reuses `related_context::is_weak_provider` in `vault_context::budget_for`. Regression coverage binds the full current on-device matrix, every current cloud-capable identifier plus an unknown future identifier, and both whole-vault and pinned construction with a long multibyte corpus. Cloud budget, egress classification, redaction, consent, ledger behaviour, retrieval ranking, visibility gates, and link caps are unchanged.
 
-### 2. Confirmed follow-up defect: durable Ask history has only a turn-count cap
+### 2. Confirmed and corrected: durable Ask history had only a turn-count cap
 
 The ordinary in-meeting chat path applies both `CHAT_CONTEXT_TURNS` and `CHAT_HISTORY_CHAR_BUDGET`. Whole-vault Ask instead passes its durable history through `capped_ask_history`, which takes only the newest 12 `ChatTurn`s. Both `vault_chat::render_conversation` and the deterministic floor render those contents in full. On the agentic route, `LoopTranscript` compaction can remove old tool-result blocks but deliberately never trims its initial head, which already contains the full rendered history.
 
-As a result, 12 legal history records can contain hundreds of thousands of characters, making the 32,000-character loop-transcript target ineffective and increasing cloud egress, local context overflow risk, latency, and failure probability. Existing tests prove only that turn 13 is dropped; they do not exercise oversized content. **Confidence: high.**
+As a result, 12 legal history records could contain hundreds of thousands of characters, making the 32,000-character loop-transcript target ineffective and increasing cloud egress, local context overflow risk, latency, and failure probability. Applying the base renderer to the focused 12-turn fixture gives a source-derived 33,280-character result, and the oversized Polish/emoji fixture exceeds 16,000. These are deterministic calculations from the base source and fixtures, not runner-owned historical RED artifacts; the Harness evidence for the landed diff is GREEN-only. **Confidence: high.**
 
-The follow-up should enforce a strict Ask-specific character budget after the 12-turn cap, retain the newest complete turns first, preserve the current question (which is a separate argument), and deterministically tail-truncate only a single oversized newest prior turn. A multibyte Polish/emoji regression must prove both the bound and newest-context retention.
+The follow-up now enforces a strict 16,000-character Ask-specific budget after the 12-turn cap at `vault_chat::render_conversation`, the shared seam for both deterministic and agentic Ask. It retains the newest complete suffix; when the newest prior turn alone cannot fit, it retains a visibly ellipsized suffix. The limit includes role labels, separators, newlines, and the omission marker. Short and exactly-on-boundary histories remain byte-identical, while the separately supplied current question keeps its existing trim-only behavior.
 
 ### 3. The main structural inefficiency is evidence packaging, not candidate discovery
 
@@ -102,13 +105,12 @@ Hybrid retrieval operates on chunks and independent score legs, yet `vault_conte
 Static provider-class character limits also do not reserve explicit space for:
 
 - system and safety instructions;
-- durable Ask history;
 - pinned/board context;
 - agent tool results;
 - the current question;
 - the completion.
 
-The agentic loop has its own 32,000-character transcript and 64,000-character gathered-result bounds. In-meeting chat has a 64,000-character history bound. Durable Ask uses a 12-turn count cap but no equivalent per-turn character budget in `capped_ask_history`. These independently reasonable limits do not form a single end-to-end context allocation.
+The agentic loop has its own 32,000-character transcript and 64,000-character gathered-result bounds. In-meeting chat has a 64,000-character history bound. Durable Ask now reserves at most 16,000 characters for rendered prior history after its 12-turn cap. These independently reasonable limits still do not form a single end-to-end allocation across corpus, instructions, tools, current question, and completion.
 
 Long contexts are not automatically better. [Lost in the Middle](https://arxiv.org/abs/2307.03172) shows position sensitivity and degradation when relevant evidence is surrounded by distractors. This supports reducing irrelevant prompt material, but the size of the Murmur-specific quality/latency effect remains unmeasured. **Confidence: high for the mismatch; medium for product impact.**
 
@@ -193,9 +195,9 @@ This audit's code change is intentionally narrow:
 - prove whole-vault and pinned packers obey it;
 - change no retrieval, prompt, lock, provider, or egress semantics.
 
-### Priority 0b — strictly bound durable Ask history
+### Priority 0b — strictly bound durable Ask history (landed in the follow-up)
 
-In a separate egress-reviewed change:
+The separate egress-reviewed change now:
 
 - apply a character budget after the 12-turn cap;
 - keep the newest complete prior turns that fit;
@@ -291,10 +293,12 @@ Do not adopt Graphiti, Letta, Neo4j/FalkorDB, or Microsoft GraphRAG as a new run
 - A 208+ unrelated-folder fixture no longer exhausts the tile config after safe dependency narrowing.
 - The control prompt remains byte-identical when the new compiler flag is off.
 - Real-corpus evaluation reports evidence coverage and final answer/citation quality, not only meeting-ID recall.
+- Prior Ask history stays at or below 16,000 Unicode scalar values at 16,000/16,001 boundaries, with newest context and the complete current question retained.
 
 ## Limitations and open questions
 
 - The corrected 4,000-character local bound is a conservative class-level guard, not full per-model token budgeting.
+- The 16,000-character history bound is likewise a deterministic scalar-value guard, not a tokenizer-aware full-prompt allocator. It does not cap the current question, corpus, system instructions, or tool output, and it does not avoid loading/cloning the newest 12 durable rows before rendering.
 - The verification host currently has Codex CLI 0.147.0 in Homebrew and the production-verified 0.146.0 binary in `~/.local/bin`. Murmur correctly fails closed on the unverified minor. Harness checks replace `HOME`, and production binary discovery deliberately ignores ambient `PATH`, so the task-private Harness home exposes a symlink to the user-owned 0.146.0 binary; the runtime tests still canonicalize, ownership-check, permission-check, version-check, and identity-pin that target. This is compatibility evidence for 0.146.0, not evidence that 0.147.0 is unsafe or incompatible.
 - No live Qwen/Apple/Ollama run was performed, so no TTFT, total latency, RAM, or quality gain is claimed for the fix.
 - The relative cost of retrieval, serial reranking, indexing, and local generation is still unprofiled on a representative vault.

--- a/src-tauri/src/commands/ask.rs
+++ b/src-tauri/src/commands/ask.rs
@@ -264,9 +264,10 @@ impl crate::reason::LocalReasoner for DurableDispatchReasoner<'_> {
     }
 }
 
-/// Cap the incoming Ask history to the last [`CHAT_CONTEXT_TURNS`] turns — the same discipline as
-/// the in-meeting chat panel, closing the unbounded-prompt-growth gap the pre-agentic `ask_vault`
-/// had (it rendered the whole history uncapped).
+/// First cap the incoming Ask history to the last [`CHAT_CONTEXT_TURNS`] turns. The shared
+/// `vault_chat::render_conversation` seam then applies the strict rendered-character budget to both
+/// the deterministic floor and agentic Ask. Keeping the count cap here still avoids cloning an
+/// unbounded number of durable rows before the render-time content bound is applied.
 pub(crate) fn capped_ask_history(history: &[ChatTurn]) -> &[ChatTurn] {
     let start = history.len().saturating_sub(CHAT_CONTEXT_TURNS);
     &history[start..]

--- a/src-tauri/src/commands/tests/ask_vault_tests.rs
+++ b/src-tauri/src/commands/tests/ask_vault_tests.rs
@@ -341,6 +341,182 @@ fn ask_floor_preserves_no_consent_error_semantics() {
     );
 }
 
+/// LOCAL_LOOPBACK authorization oracle for the exact two Ask paths that consume
+/// `vault_chat::render_conversation`: a loopback Ollama floor excludes sealed corpus rows and a
+/// stale visibility admission prevents the provider future from being constructed; the agentic
+/// loop carries the same admission through `DurableDispatchReasoner`, invokes the real
+/// provider-backed reasoner, and rejects before `provider.complete` can open a connection. This
+/// binds the history-budget change to the unchanged dispatch gate instead of treating loopback as
+/// implicitly authorized. It is the mandatory LOCAL_LOOPBACK evidence in acceptance item 6, not
+/// an assertion that production dispatch behavior changed.
+#[test]
+fn loopback_ollama_ask_paths_revalidate_visibility_before_provider_dispatch() {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let ollama_base_url = format!("http://{}", listener.local_addr().unwrap());
+    let loopback_connections = std::sync::Arc::new(AtomicUsize::new(0));
+    let loopback_connections_for_server = std::sync::Arc::clone(&loopback_connections);
+    let stop_server = std::sync::Arc::new(AtomicBool::new(false));
+    let stop_server_worker = std::sync::Arc::clone(&stop_server);
+    let server = std::thread::spawn(move || {
+        listener.set_nonblocking(true).unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while !stop_server_worker.load(Ordering::SeqCst) && std::time::Instant::now() < deadline {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    use std::io::{Read, Write};
+
+                    loopback_connections_for_server.fetch_add(1, Ordering::SeqCst);
+                    stream
+                        .set_read_timeout(Some(std::time::Duration::from_secs(1)))
+                        .unwrap();
+                    let mut request = [0_u8; 4096];
+                    let _ = stream.read(&mut request);
+                    let body = br#"{"response":"unexpected dispatch","done":true}"#;
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    );
+                    let _ = stream.write_all(response.as_bytes());
+                    let _ = stream.write_all(body);
+                    break;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                Err(error) => panic!("unexpected listener error: {error}"),
+            }
+        }
+    });
+    let db = tmp_db();
+    seed_note(&db, "open1", "Atlas Kickoff", "OPEN-ATLAS-CONTEXT", None);
+    db.insert_folder(&Folder {
+        id: "sealed-folder".into(),
+        name: "Sealed".into(),
+        path: "Sealed".into(),
+        parent_id: None,
+        locked: true,
+        created_at: "2026-06-26T00:00:00Z".into(),
+    })
+    .unwrap();
+    // Keep plaintext in this adversarial fixture so the assertion proves the read predicate, not
+    // merely the normal at-rest blanking invariant.
+    seed_note(
+        &db,
+        "sealed1",
+        "Atlas Secret",
+        "SEALED-PLAINTEXT-MUST-NOT-REACH-OLLAMA",
+        Some("sealed-folder"),
+    );
+
+    let cfg = AppConfig {
+        provider_id: crate::summarize::PROVIDER_OLLAMA.into(),
+        role_ask_connection: crate::summarize::PROVIDER_OLLAMA.into(),
+        ollama_base_url,
+        semantic_search_enabled: false,
+        ..AppConfig::default()
+    };
+    assert!(
+        !crate::summarize::egress_is_cloud(crate::summarize::PROVIDER_OLLAMA, &cfg),
+        "fixture must exercise the LOCAL_LOOPBACK row"
+    );
+
+    let unlocked = HashSet::new();
+    let history = [ChatTurn {
+        role: "user".into(),
+        content: "PRIOR-HISTORY-WOULD-REACH-THE-PROVIDER".into(),
+    }];
+    let prompt = build_ask_vault_floor_prompt(
+        &db, &cfg, &unlocked, "atlas", &history, "", None, None, None, None,
+    )
+    .unwrap();
+    let AskFloorPrompt::Ready { system, user, .. } = prompt else {
+        panic!("visible fixture must produce a provider-bound floor prompt");
+    };
+    assert!(system.contains("OPEN-ATLAS-CONTEXT"));
+    assert!(!system.contains("SEALED-PLAINTEXT-MUST-NOT-REACH-OLLAMA"));
+    assert!(user.contains("PRIOR-HISTORY-WOULD-REACH-THE-PROVIDER"));
+
+    let floor_validations = std::sync::Arc::new(AtomicUsize::new(0));
+    let floor_validation_spy = std::sync::Arc::clone(&floor_validations);
+    let floor_admission = crate::state::ContentDispatchAdmission::for_test(
+        std::sync::Arc::new(Mutex::new(())),
+        move || {
+            floor_validation_spy.fetch_add(1, Ordering::SeqCst);
+            Err(AppError::Locked(
+                "relocked before loopback floor dispatch".into(),
+            ))
+        },
+    );
+    let floor_result = block_on(ask_vault_floor_authorized(
+        &std::sync::Arc::new(db),
+        &cfg,
+        &unlocked,
+        "atlas",
+        &history,
+        "",
+        None,
+        &std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
+        None,
+        None,
+        None,
+        floor_admission,
+    ));
+    assert!(matches!(floor_result, Err(AppError::Locked(_))));
+    assert_eq!(floor_validations.load(Ordering::SeqCst), 1);
+
+    let resolved = crate::summarize::roles::resolve(crate::summarize::roles::Role::Ask, &cfg);
+    assert_eq!(resolved.connection, crate::summarize::PROVIDER_OLLAMA);
+    assert!(
+        !resolved.is_reasoner_only(),
+        "loopback Ollama must exercise the real agentic provider route"
+    );
+    let agentic = crate::reason::CloudReasoner::for_role(
+        std::sync::Arc::new(Mutex::new(cfg.clone())),
+        crate::summarize::roles::Role::Ask,
+        std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
+    );
+    assert_eq!(agentic.id(), "cloud:ollama");
+    let agentic_validations = std::sync::Arc::new(AtomicUsize::new(0));
+    let agentic_validation_spy = std::sync::Arc::clone(&agentic_validations);
+    let agentic_admission = crate::state::ContentDispatchAdmission::for_test(
+        std::sync::Arc::new(Mutex::new(())),
+        move || {
+            agentic_validation_spy.fetch_add(1, Ordering::SeqCst);
+            Err(AppError::Locked(
+                "relocked before loopback agentic dispatch".into(),
+            ))
+        },
+    );
+    let guarded_agentic = durable_dispatch_reasoner(&agentic, agentic_admission);
+    let db = tmp_db();
+    let unlocked = Mutex::new(HashSet::new());
+    let executor = ask_executor(&db, &unlocked, &cfg);
+    let agentic_result = ask_vault_loop(
+        &guarded_agentic,
+        &executor,
+        &db,
+        &unlocked,
+        "atlas",
+        &history,
+        "",
+        "",
+        false,
+        None,
+        crate::reason::GenOptions::ask_answer(),
+    );
+    assert!(matches!(agentic_result, Err(AppError::Locked(_))));
+    assert_eq!(agentic_validations.load(Ordering::SeqCst), 1);
+    stop_server.store(true, Ordering::SeqCst);
+    server.join().unwrap();
+    assert_eq!(
+        loopback_connections.load(Ordering::SeqCst),
+        0,
+        "visibility rejection must prevent every loopback Ollama connection"
+    );
+}
+
 /// The Cloud loop path: a scripted brain calls a GATED tool, answers, and the tool-derived
 /// `[[Title]]` citations flow into the DTO — verbatim in `citations` AND resolved (gated) into
 /// the structured `sources` chips.
@@ -493,6 +669,221 @@ fn ask_history_cap_enforced() {
 
     // A short history passes through untouched.
     assert_eq!(capped_ask_history(&msgs[..3]).len(), 3);
+}
+
+const ASK_HISTORY_TEST_BUDGET: usize = 16_000;
+const ASK_HISTORY_TEST_OMISSION_MARKER: &str =
+    "[Earlier Ask history omitted to fit the context budget.]\n";
+
+fn rendered_prior_history<'a>(rendered: &'a str, question: &str) -> &'a str {
+    let current_turn = format!("User: {}\nAssistant:", question.trim());
+    rendered
+        .strip_suffix(&current_turn)
+        .expect("the current question and completion cue must remain intact")
+}
+
+/// Focused resource/egress regression: a count cap alone does not bound twelve legal,
+/// pasted-document-sized turns. The shared renderer must keep a suffix of complete newest turns,
+/// disclose that older context was omitted, and leave the separately supplied question intact.
+#[test]
+fn ask_history_char_budget_bounds_many_large_turns_and_keeps_newest_context() {
+    let mut history: Vec<ChatTurn> = (0..11)
+        .map(|i| ChatTurn {
+            role: if i % 2 == 0 { "user" } else { "assistant" }.into(),
+            content: format!("OLDER-TURN-{i}-{}", "ż".repeat(3_000)),
+        })
+        .collect();
+    history.push(ChatTurn {
+        role: "assistant".into(),
+        content: "NEWEST-COMPLETE-TURN-Ω".into(),
+    });
+    let question = "CURRENT-QUESTION-zażółć-🙂";
+    let rendered =
+        crate::summarize::vault_chat::render_conversation(capped_ask_history(&history), question);
+    let prior = rendered_prior_history(&rendered, question);
+
+    assert!(
+        prior.chars().count() <= ASK_HISTORY_TEST_BUDGET,
+        "rendered prior Ask history exceeded the strict budget: {}",
+        prior.chars().count()
+    );
+    assert!(prior.starts_with(ASK_HISTORY_TEST_OMISSION_MARKER));
+    assert!(prior.contains("Assistant: NEWEST-COMPLETE-TURN-Ω\n"));
+    assert!(
+        !prior.contains("OLDER-TURN-0-"),
+        "the oldest complete turn must be dropped rather than partially packed"
+    );
+    assert!(rendered.ends_with("User: CURRENT-QUESTION-zażółć-🙂\nAssistant:"));
+}
+
+/// When even the newest prior turn cannot fit whole, preserve an honestly marked, Unicode-safe
+/// suffix. This keeps the immediate context without permitting one legal row to bypass the bound.
+#[test]
+fn ask_history_char_budget_marks_and_safely_suffixes_one_oversized_newest_turn() {
+    let history = [ChatTurn {
+        role: "assistant".into(),
+        content: format!("HEAD-SENTINEL-{}-TAIL-Ω", "ą🙂".repeat(12_000)),
+    }];
+    let question = "CURRENT-QUESTION-STAYS-WHOLE";
+    let rendered = crate::summarize::vault_chat::render_conversation(&history, question);
+    let prior = rendered_prior_history(&rendered, question);
+
+    assert!(prior.chars().count() <= ASK_HISTORY_TEST_BUDGET);
+    assert!(prior.starts_with(ASK_HISTORY_TEST_OMISSION_MARKER));
+    assert!(prior.contains("Assistant: …"));
+    assert!(!prior.contains("HEAD-SENTINEL"));
+    assert!(prior.contains("-TAIL-Ω"));
+    assert!(rendered.ends_with("User: CURRENT-QUESTION-STAYS-WHOLE\nAssistant:"));
+}
+
+/// Reserving the long omission marker must not partially truncate a newest turn that fits within
+/// the full history budget by itself. Use a shorter honest marker and retain the complete turn.
+#[test]
+fn ask_history_char_budget_keeps_a_complete_newest_turn_near_the_boundary() {
+    // "Assistant: " (11) + content (15,968) + newline (1) = 15,980 characters, leaving
+    // enough room for the compact 18-character omission marker but not the long marker.
+    let newest_content = "ż".repeat(15_968);
+    let history = [
+        ChatTurn {
+            role: "user".into(),
+            content: "older".repeat(30),
+        },
+        ChatTurn {
+            role: "assistant".into(),
+            content: newest_content.clone(),
+        },
+    ];
+    let rendered = crate::summarize::vault_chat::render_conversation(&history, "q");
+    let prior = rendered_prior_history(&rendered, "q");
+
+    assert_eq!(prior.chars().count(), 15_998);
+    assert!(prior.starts_with("[Earlier omitted]\n"));
+    assert!(prior.ends_with(&format!("Assistant: {newest_content}\n")));
+    assert!(!prior.contains("older"));
+}
+
+/// Even with zero scalar headroom, the complete newest content wins over an older turn; a leading
+/// ellipsis replaces only the normal separator space so omission remains disclosed within 16,000.
+#[test]
+fn ask_history_char_budget_keeps_exact_boundary_newest_content_with_older_omission() {
+    let newest_content = "🙂".repeat(15_988);
+    let history = [
+        ChatTurn {
+            role: "user".into(),
+            content: "older".repeat(30),
+        },
+        ChatTurn {
+            role: "assistant".into(),
+            content: newest_content.clone(),
+        },
+    ];
+    let rendered = crate::summarize::vault_chat::render_conversation(&history, "q");
+    let prior = rendered_prior_history(&rendered, "q");
+
+    assert_eq!(prior.chars().count(), ASK_HISTORY_TEST_BUDGET);
+    assert_eq!(prior, format!("…Assistant:{newest_content}\n"));
+}
+
+/// Every adaptive-marker boundary keeps the newest turn complete and never exceeds the budget.
+/// The cases exercise all marker choices: one-scalar prefix, two-scalar line marker, and compact
+/// or long labelled marker. Zero headroom is covered by the exact-boundary regression above.
+#[test]
+fn ask_history_char_budget_adapts_omission_marker_to_available_headroom() {
+    for headroom in [1usize, 2, 17, 18, 56, 57] {
+        let newest_content = "ż".repeat(15_988 - headroom);
+        let history = [
+            ChatTurn {
+                role: "user".into(),
+                content: "older".repeat(30),
+            },
+            ChatTurn {
+                role: "assistant".into(),
+                content: newest_content.clone(),
+            },
+        ];
+        let rendered = crate::summarize::vault_chat::render_conversation(&history, "q");
+        let prior = rendered_prior_history(&rendered, "q");
+
+        assert!(
+            prior.chars().count() <= ASK_HISTORY_TEST_BUDGET,
+            "headroom {headroom} exceeded the history budget"
+        );
+        assert!(
+            prior.ends_with(&format!("Assistant: {newest_content}\n")),
+            "headroom {headroom} did not preserve the complete newest turn"
+        );
+        assert!(!prior.contains("older"));
+        match headroom {
+            1 => assert!(prior.starts_with('…')),
+            2 | 17 => assert!(prior.starts_with("…\n")),
+            18 | 56 => assert!(prior.starts_with("[Earlier omitted]\n")),
+            57 => assert!(prior.starts_with(ASK_HISTORY_TEST_OMISSION_MARKER)),
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// Marker readability must not cost an adjacent complete turn. Choose the largest newest
+/// contiguous suffix first, then shorten the honest omission marker when the long label would make
+/// that suffix overflow.
+#[test]
+fn ask_history_char_budget_shortens_marker_to_keep_a_larger_complete_suffix() {
+    // Rendered costs: 100 + 30 + 15,920 = 16,050. The long 57-scalar marker can accompany only
+    // the newest turn, but the 18-scalar compact marker plus the newest two costs 15,968.
+    let dropped_content = format!("DROP-{}", "o".repeat(88));
+    let adjacent_content = format!("KEEP-{}", "a".repeat(18));
+    let newest_content = format!("NEWEST-{}", "ż".repeat(15_901));
+    let history = [
+        ChatTurn {
+            role: "user".into(),
+            content: dropped_content.clone(),
+        },
+        ChatTurn {
+            role: "user".into(),
+            content: adjacent_content.clone(),
+        },
+        ChatTurn {
+            role: "assistant".into(),
+            content: newest_content.clone(),
+        },
+    ];
+    let rendered = crate::summarize::vault_chat::render_conversation(&history, "q");
+    let prior = rendered_prior_history(&rendered, "q");
+
+    assert_eq!(prior.chars().count(), 15_968);
+    assert!(prior.starts_with("[Earlier omitted]\n"));
+    assert!(!prior.contains(&dropped_content));
+    assert!(prior.contains(&format!("User: {adjacent_content}\n")));
+    assert!(prior.ends_with(&format!("Assistant: {newest_content}\n")));
+}
+
+/// A history exactly on the scalar-value boundary remains byte-identical to the old short-history
+/// rendering. One extra scalar is what activates the explicit truncation path.
+#[test]
+fn ask_history_char_budget_preserves_the_exact_boundary() {
+    // "User: " (6) + content (15,993) + newline (1) = exactly 16,000 characters.
+    let content = "ż".repeat(15_993);
+    let history = [ChatTurn {
+        role: "user".into(),
+        content: content.clone(),
+    }];
+    let rendered = crate::summarize::vault_chat::render_conversation(&history, "q");
+    let prior = rendered_prior_history(&rendered, "q");
+    assert_eq!(prior.chars().count(), ASK_HISTORY_TEST_BUDGET);
+    assert_eq!(prior, format!("User: {content}\n"));
+    assert!(!prior.contains(ASK_HISTORY_TEST_OMISSION_MARKER));
+
+    // One additional scalar must activate the marked, bounded truncation path.
+    let over_content = "ż".repeat(15_994);
+    let over_history = [ChatTurn {
+        role: "user".into(),
+        content: over_content,
+    }];
+    let over_rendered = crate::summarize::vault_chat::render_conversation(&over_history, "q");
+    let over_prior = rendered_prior_history(&over_rendered, "q");
+    assert!(over_prior.chars().count() <= ASK_HISTORY_TEST_BUDGET);
+    assert!(over_prior.starts_with(ASK_HISTORY_TEST_OMISSION_MARKER));
+    assert!(over_prior.contains("User: …"));
 }
 
 /// SURFACE SPLIT: the vault executor must NOT advertise `propose_note` (the Ask page has no

--- a/src-tauri/src/summarize/vault_chat.rs
+++ b/src-tauri/src/summarize/vault_chat.rs
@@ -3,6 +3,15 @@
 
 use crate::storage::models::ChatTurn;
 
+/// Strict budget for rendered PRIOR Ask history. The current question is appended separately and
+/// is deliberately outside this limit. Half of the agent loop's 32k immutable-head target leaves
+/// room for that question and the surrounding protocol while keeping the deterministic floor and
+/// agentic route byte-identical through one rendering seam.
+const ASK_PRIOR_HISTORY_CHAR_BUDGET: usize = 16_000;
+const ASK_HISTORY_OMISSION_MARKER: &str =
+    "[Earlier Ask history omitted to fit the context budget.]\n";
+const ASK_HISTORY_COMPACT_OMISSION_MARKER: &str = "[Earlier omitted]\n";
+
 /// Shared coordinate/polarity discipline for both the deterministic corpus floor and the agentic
 /// Ask persona. The Qwen bake-off exposed a clause-contamination failure: an OPEN budget was used
 /// to negate a separately approved launch. Single-sourcing keeps the two Ask routes aligned.
@@ -63,20 +72,133 @@ fn memory_block(memory_brief: &str) -> String {
 }
 
 /// Render the running conversation + latest question into the user message. Shared VERBATIM by the
-/// corpus floor ([`build`]) and the agentic Ask loop, so both brains see the exact same conversation
-/// (the floor stays byte-identical to the pre-agentic implementation).
+/// corpus floor ([`build`]) and the agentic Ask loop, so both brains see the exact same bounded
+/// conversation. Prior history keeps the newest complete suffix within
+/// [`ASK_PRIOR_HISTORY_CHAR_BUDGET`]. Only when the newest prior turn alone cannot fit do we retain
+/// an honestly marked, Unicode-safe suffix of that turn. The separately supplied current question
+/// retains its existing trim-only behavior and is never consumed by the prior-history budget.
 pub fn render_conversation(history: &[ChatTurn], question: &str) -> String {
     let mut user = String::new();
-    for turn in history {
-        let who = if turn.role == "assistant" {
-            "Assistant"
-        } else {
-            "User"
-        };
-        user.push_str(&format!("{who}: {}\n", turn.content.trim()));
+
+    let complete_history_fits = history
+        .iter()
+        .try_fold(0usize, |used, turn| {
+            let next = used.saturating_add(rendered_turn_cost(turn));
+            (next <= ASK_PRIOR_HISTORY_CHAR_BUDGET).then_some(next)
+        })
+        .is_some();
+
+    if complete_history_fits {
+        for turn in history {
+            push_complete_turn(&mut user, turn);
+        }
+    } else {
+        let mut used = 0usize;
+        let mut start = history.len();
+
+        for (index, turn) in history.iter().enumerate().rev() {
+            let cost = rendered_turn_cost(turn);
+            if cost > ASK_PRIOR_HISTORY_CHAR_BUDGET.saturating_sub(used) {
+                break;
+            }
+            used = used.saturating_add(cost);
+            start = index;
+        }
+
+        if start < history.len() {
+            push_complete_suffix_with_omission(&mut user, &history[start..], used);
+        } else if let Some(newest) = history.last() {
+            let available = ASK_PRIOR_HISTORY_CHAR_BUDGET
+                .saturating_sub(ASK_HISTORY_OMISSION_MARKER.chars().count());
+            user.push_str(ASK_HISTORY_OMISSION_MARKER);
+            let prefix = format!("{}: …", role_label(newest));
+            let suffix_capacity = available.saturating_sub(prefix.chars().count() + 1);
+            user.push_str(&prefix);
+            user.push_str(suffix_chars(newest.content.trim(), suffix_capacity));
+            user.push('\n');
+        }
     }
+
     user.push_str(&format!("User: {}\nAssistant:", question.trim()));
     user
+}
+
+fn role_label(turn: &ChatTurn) -> &'static str {
+    if turn.role == "assistant" {
+        "Assistant"
+    } else {
+        "User"
+    }
+}
+
+fn rendered_turn_cost(turn: &ChatTurn) -> usize {
+    role_label(turn).chars().count() + 2 + turn.content.trim().chars().count() + 1
+}
+
+fn push_complete_turn(output: &mut String, turn: &ChatTurn) {
+    output.push_str(role_label(turn));
+    output.push_str(": ");
+    output.push_str(turn.content.trim());
+    output.push('\n');
+}
+
+/// Disclose omitted older history without sacrificing any complete turn from the largest newest
+/// contiguous suffix that fits by itself. Prefer the readable long marker, then progressively
+/// shorter honest markers. At zero headroom, replace only the normal separator space on the oldest
+/// retained turn with a leading ellipsis, so every retained role and content remains complete at
+/// exactly the same scalar cost as ordinary rendering.
+fn push_complete_suffix_with_omission(
+    output: &mut String,
+    suffix: &[ChatTurn],
+    suffix_cost: usize,
+) {
+    let headroom = ASK_PRIOR_HISTORY_CHAR_BUDGET.saturating_sub(suffix_cost);
+    let long_cost = ASK_HISTORY_OMISSION_MARKER.chars().count();
+    let compact_cost = ASK_HISTORY_COMPACT_OMISSION_MARKER.chars().count();
+
+    if headroom >= long_cost {
+        output.push_str(ASK_HISTORY_OMISSION_MARKER);
+        for turn in suffix {
+            push_complete_turn(output, turn);
+        }
+    } else if headroom >= compact_cost {
+        output.push_str(ASK_HISTORY_COMPACT_OMISSION_MARKER);
+        for turn in suffix {
+            push_complete_turn(output, turn);
+        }
+    } else if headroom >= 2 {
+        output.push_str("…\n");
+        for turn in suffix {
+            push_complete_turn(output, turn);
+        }
+    } else if headroom == 1 {
+        output.push('…');
+        for turn in suffix {
+            push_complete_turn(output, turn);
+        }
+    } else if let Some((first, rest)) = suffix.split_first() {
+        output.push('…');
+        output.push_str(role_label(first));
+        output.push(':');
+        output.push_str(first.content.trim());
+        output.push('\n');
+        for turn in rest {
+            push_complete_turn(output, turn);
+        }
+    }
+}
+
+fn suffix_chars(text: &str, max_chars: usize) -> &str {
+    if max_chars == 0 {
+        return "";
+    }
+    let start = text
+        .char_indices()
+        .rev()
+        .nth(max_chars - 1)
+        .map(|(index, _)| index)
+        .unwrap_or(0);
+    &text[start..]
 }
 
 /// The vault-QA persona for the AGENTIC Ask surface (PR G, ask-unify): the same grounded / cited /


### PR DESCRIPTION
## Summary

Durable Ask capped history at 12 turns, but each turn could still contain arbitrarily large text. Applying the base renderer to the focused 12-turn fixture yields a source-derived **33,280 prior-history characters**; this number is a deterministic source/fixture calculation, not a runner-owned historical RED artifact.

This change adds one strict bound at `vault_chat::render_conversation`, the shared seam used by deterministic-floor and agentic Ask.

## What changed

- keeps the existing newest-12-turn cap;
- limits rendered prior history to **16,000 Unicode scalar values**, including labels, separators, newlines, and the omission marker;
- retains the largest newest complete contiguous suffix before choosing the most readable omission marker that fits;
- uses an adaptive honest omission marker when a complete newest turn fits only near the boundary;
- retains a visibly marked, UTF-8-safe suffix when the newest prior turn alone is oversized;
- preserves short and exact-boundary histories byte-for-byte;
- leaves the separately supplied current question intact after its existing `trim()` behavior and outside the history budget;
- records the system audit and evidence boundary in `docs/research/2026-08-13-ai-context-knowledge-audit.md`.

No production provider selection, retrieval, corpus packing, consent, redaction, ledger, persistence, IPC, dependency, UI, or lock behavior changes.

## Security and egress oracle

The focused local-loopback oracle binds the unchanged authorization invariant for both Ask consumers:

- sealed plaintext is excluded from the deterministic corpus;
- stale visibility admission rejects deterministic-floor dispatch;
- the same admission rejects agentic dispatch through the real Ask-role `CloudReasoner` / Ollama route;
- rejection occurs before `provider.complete` can establish a loopback connection;
- the listener observes zero connections.

## Verification

- GREEN regressions cover large histories, largest-suffix selection (including rendered costs 100/30/15,920), every adaptive-marker headroom boundary (0/1/2/17/18/56/57), oversized Polish/emoji content, exact 16,000 and 16,001 boundaries, the complete current question, and existing short-history/12-turn behavior.
- Harness risk class: `egress`.
- Reviewers: **Codex combined + Codex egress-security**, with the explicit same-vendor high-risk exception requested for this task.
- Final exact-diff receipt: attempt `e17f5986894b5392dfa717f98bd736a26faeea6888ba13ea29ebd8fd4ed5382d`; diff `83dd7aabd687522e1e9b3976082f2ac4cf2650b53e48ef132e72a317b802655f`; evidence `8cf140587f7af75975609d0bcc3d1b45d9357a2ebf494d6406c2457ad8f12227`.
- Runner-owned `cargo test --lib`: PASS — 2,906 passed, 0 failed, 18 ignored.
- Runner-owned `cargo clippy --lib --tests -- -D warnings`: PASS.

## Evidence limits

This is a deterministic scalar-value bound, not a tokenizer-aware full-prompt allocator. It does not cap the current question, corpus, system instructions, or tool output, and it still loads/clones the newest 12 durable rows before rendering.

No live Ollama/Qwen/Apple model benchmark was run, so this PR makes no claim about latency, RAM, token cost, answer quality, or real-model generation behavior. The loopback oracle proves pre-dispatch authorization and absence of a network connection after relock; it is not a model-quality or performance test.
