### PR TITLE
feat: add dashboard composite context and Compose workspace

### DIFF
--- a/e2e/ask/ask-source-scope.spec.ts
+++ b/e2e/ask/ask-source-scope.spec.ts
@@ -38,6 +38,7 @@ test("Ask page threads the picked source into ask_vault's explicitSources (empty
     // The picker's candidate feed — one meeting the user can scope to.
     list_link_candidates: () => [
       { kind: "meeting", id: "m9", title: "Planning sync" },
+      { kind: "note", id: "n-new", title: "Fresh manual source" },
     ],
     ask_vault_persisted: (args: {
       conversationId?: string;
@@ -87,28 +88,155 @@ test("Ask page threads the picked source into ask_vault's explicitSources (empty
   await page.locator(".sp-scrim").click();
   await expect(page.locator(".sp-pop")).toHaveCount(0);
 
-  // Scoped turn: the picked meeting rides ask_vault as explicitSources. Click
-  // Send explicitly (deterministic) and wait for the SECOND user row to land.
+  // Changing the manual scope starts a fresh durable thread.
   await input.fill("Scoped question");
   await page.locator(".ask-send").click();
-  await expect(page.locator(".ask-row.is-user")).toHaveCount(2);
-  await expect(page.locator(".ask-row.is-user").nth(1)).toContainText(
+  await expect(page.locator(".ask-row.is-user")).toHaveCount(1);
+  await expect(page.locator(".ask-row.is-user").first()).toContainText(
     "Scoped question",
   );
 
   const calls = await page.evaluate(
     () =>
-      (window as unknown as {
-        __askCalls?: { explicitSources: { kind: string; id: string }[] | null }[];
-      }).__askCalls ?? [],
+      (
+        window as unknown as {
+          __askCalls?: {
+            explicitSources: { kind: string; id: string }[] | null;
+          }[];
+        }
+      ).__askCalls ?? [],
   );
   expect(calls.length).toBe(2);
   // First (control) call: no scope threaded.
   expect(calls[0].explicitSources).toBeNull();
   // Second (scoped) call: exactly the picked meeting as {kind, id}.
-  expect((calls[1].explicitSources ?? []).map((s) => `${s.kind}:${s.id}`)).toEqual([
-    "meeting:m9",
-  ]);
+  expect(
+    (calls[1].explicitSources ?? []).map((s) => `${s.kind}:${s.id}`),
+  ).toEqual(["meeting:m9"]);
 
   expect(consoleErrors).toEqual([]);
+});
+
+test("Ask selects one composite dashboard chip and sends its id beside manual sources", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    list_meetings: () => [
+      {
+        id: "m9",
+        title: "Planning sync",
+        startedAt: "2026-07-01T10:00:00Z",
+        endedAt: null,
+        durationS: 0,
+        audioPath: null,
+        status: "EXPORTED",
+      },
+      {
+        id: "m10",
+        title: "Fresh manual source",
+        startedAt: "2026-07-02T10:00:00Z",
+        endedAt: null,
+        durationS: 0,
+        audioPath: null,
+        status: "EXPORTED",
+      },
+    ],
+    list_notes: () => [],
+    list_link_candidates: () => [
+      { kind: "meeting", id: "m9", title: "Planning sync" },
+      { kind: "meeting", id: "m10", title: "Fresh manual source" },
+    ],
+    list_dashboards: () => [
+      {
+        id: "dashboard-test",
+        title: "Test",
+        emoji: "🧭",
+        tint: null,
+        pinned: false,
+        position: 0,
+        createdAt: "2026-08-01T00:00:00Z",
+        updatedAt: "2026-08-01T00:00:00Z",
+        tileCount: 2,
+        tileKinds: [],
+      },
+    ],
+    get_dashboard_sources: () => {
+      (
+        window as unknown as { __dashboardChildrenRead?: number }
+      ).__dashboardChildrenRead = 1;
+      return [{ kind: "note", id: "child-must-not-leak" }];
+    },
+    ask_vault_persisted: (args: Record<string, unknown>) => {
+      const target = window as unknown as { __compositeAskCalls?: unknown[] };
+      target.__compositeAskCalls = [
+        ...(target.__compositeAskCalls ?? []),
+        args,
+      ];
+      return {
+        conversationId: `composite-thread-${target.__compositeAskCalls.length}`,
+        userMessageId: crypto.randomUUID(),
+        assistantMessageId: crypto.randomUUID(),
+        answer: "Composite answer",
+        sources: [],
+        citations: [],
+      };
+    },
+  });
+  await page.goto("/ask");
+  const picker = page.locator("mur-source-picker");
+  await picker.locator(".sp-trigger").click();
+  await page.getByRole("option", { name: "Use dashboard Test" }).click();
+  await expect(
+    picker.locator('[data-testid="selected-dashboard-chip"]'),
+  ).toHaveCount(1);
+  await expect(
+    picker.locator('[data-testid="selected-dashboard-chip"]'),
+  ).toContainText("Test");
+
+  await picker.locator(".sp-trigger").click();
+  await page.getByRole("option", { name: "Planning sync" }).click();
+  await page
+    .locator(".sp-scrim")
+    .evaluate((element) => (element as HTMLElement).click());
+  await expect(page.locator(".sp-pop")).toHaveCount(0);
+  await page.locator(".ask-input").fill("Use both scopes");
+  await page.locator(".ask-input").press("Enter");
+  await expect(
+    page.getByText("Composite answer", { exact: true }),
+  ).toBeVisible();
+
+  await picker.getByRole("button", { name: "Remove Planning sync" }).click();
+  await picker.locator(".sp-trigger").click();
+  await page.getByRole("option", { name: "Fresh manual source" }).click();
+  await page
+    .locator(".sp-scrim")
+    .evaluate((element) => (element as HTMLElement).click());
+  await expect(page.locator(".sp-pop")).toHaveCount(0);
+  await expect(
+    picker.locator('[data-testid="selected-dashboard-chip"]'),
+  ).toContainText("Test");
+  await page.locator(".ask-input").fill("Use changed manual scope");
+  await page.locator(".ask-input").press("Enter");
+  await expect(page.locator(".ask-row.is-assistant")).toHaveCount(1);
+
+  const state = await page.evaluate(() => ({
+    calls:
+      (window as unknown as { __compositeAskCalls?: Record<string, unknown>[] })
+        .__compositeAskCalls ?? [],
+    childReads:
+      (window as unknown as { __dashboardChildrenRead?: number })
+        .__dashboardChildrenRead ?? 0,
+  }));
+  expect(state.calls).toHaveLength(2);
+  expect(state.childReads).toBe(0);
+  expect(state.calls[0]?.["dashboardId"]).toBe("dashboard-test");
+  expect(state.calls[0]?.["explicitSources"]).toEqual([
+    { kind: "meeting", id: "m9", title: "Planning sync" },
+  ]);
+  expect(state.calls[1]?.["conversationId"]).toBeUndefined();
+  expect(state.calls[1]?.["dashboardId"]).toBe("dashboard-test");
+  expect(state.calls[1]?.["explicitSources"]).toEqual([
+    { kind: "meeting", id: "m10", title: "Fresh manual source" },
+  ]);
+  expect(JSON.stringify(state.calls)).not.toContain("child-must-not-leak");
 });

--- a/e2e/ask/chat-history-lock.spec.ts
+++ b/e2e/ask/chat-history-lock.spec.ts
@@ -29,8 +29,9 @@ test("locking an authored-note folder evicts loaded vault Ask titles, messages, 
     },
     lock_folder: (args: { folderId: string }) => {
       if (args.folderId === "nf-history") {
-        (window as unknown as { __historyNoteLocked?: boolean })
-          .__historyNoteLocked = true;
+        (
+          window as unknown as { __historyNoteLocked?: boolean }
+        ).__historyNoteLocked = true;
       }
       return null;
     },
@@ -42,17 +43,23 @@ test("locking an authored-note folder evicts loaded vault Ask titles, messages, 
   await page.locator(".sp-scrim").click();
   await page.locator(".ask-input").fill("Sensitive Ask message");
   await page.locator(".ask-input").press("Enter");
-  await expect(page.getByText("Sensitive Ask message", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Sensitive Ask message", { exact: true }),
+  ).toBeVisible();
 
   await page.getByRole("button", { name: "Conversation history" }).click();
-  await expect(page.getByText("Sensitive Ask message", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Sensitive Ask message", { exact: true }),
+  ).toBeVisible();
 
   const lock = page.getByRole("button", { name: "Lock folder" }).first();
   await expect(lock).toBeAttached();
   await lock.click({ force: true });
 
   await expect(page.locator("mur-chat-history")).toHaveCount(0);
-  await expect(page.getByText("Sensitive Ask message", { exact: true })).toHaveCount(0);
+  await expect(
+    page.getByText("Sensitive Ask message", { exact: true }),
+  ).toHaveCount(0);
   await expect(page.locator(".ask-row")).toHaveCount(0);
   await expect(page.locator("mur-source-picker .sp-chip")).toHaveCount(0);
 });
@@ -80,8 +87,9 @@ test("locking a meeting folder evicts loaded vault Ask plaintext", async ({
     },
     lock_folder: (args: { folderId: string }) => {
       if (args.folderId === "f-history") {
-        (window as unknown as { __historyMeetingLocked?: boolean })
-          .__historyMeetingLocked = true;
+        (
+          window as unknown as { __historyMeetingLocked?: boolean }
+        ).__historyMeetingLocked = true;
       }
       return null;
     },
@@ -89,12 +97,16 @@ test("locking a meeting folder evicts loaded vault Ask plaintext", async ({
   await page.goto("/ask");
   await page.locator(".ask-input").fill("Meeting-derived secret");
   await page.locator(".ask-input").press("Enter");
-  await expect(page.getByText("Meeting-derived secret", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Meeting-derived secret", { exact: true }),
+  ).toBeVisible();
 
   const lock = page.locator("app-folder-row .lock-toggle").first();
   await expect(lock).toBeAttached();
   await lock.click({ force: true });
-  await expect(page.getByText("Meeting-derived secret", { exact: true })).toHaveCount(0);
+  await expect(
+    page.getByText("Meeting-derived secret", { exact: true }),
+  ).toHaveCount(0);
   await expect(page.locator(".ask-row")).toHaveCount(0);
 });
 
@@ -105,7 +117,9 @@ test("a content deletion event evicts the durable Ask cache immediately", async 
   await page.goto("/ask");
   await page.locator(".ask-input").fill("Deleted-source secret");
   await page.locator(".ask-input").press("Enter");
-  await expect(page.getByText("Deleted-source secret", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Deleted-source secret", { exact: true }),
+  ).toBeVisible();
 
   await page.evaluate(() => {
     (
@@ -117,7 +131,9 @@ test("a content deletion event evicts the durable Ask cache immediately", async 
       id: "n-deleted",
     });
   });
-  await expect(page.getByText("Deleted-source secret", { exact: true })).toHaveCount(0);
+  await expect(
+    page.getByText("Deleted-source secret", { exact: true }),
+  ).toHaveCount(0);
   await expect(page.locator(".ask-row")).toHaveCount(0);
 });
 
@@ -136,7 +152,9 @@ test("the canonical Ask-history purge event evicts every mounted plaintext cache
   await page.locator(".sp-scrim").click();
   await page.locator(".ask-input").fill("Moved-source secret");
   await page.locator(".ask-input").press("Enter");
-  await expect(page.getByText("Moved-source secret", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Moved-source secret", { exact: true }),
+  ).toBeVisible();
   await expect(page.locator("mur-source-picker .sp-chip")).toHaveCount(1);
 
   await page.evaluate(() => {
@@ -147,7 +165,9 @@ test("the canonical Ask-history purge event evicts every mounted plaintext cache
     ).__demoEmit("murmur://ask-history-invalidated", null);
   });
 
-  await expect(page.getByText("Moved-source secret", { exact: true })).toHaveCount(0);
+  await expect(
+    page.getByText("Moved-source secret", { exact: true }),
+  ).toHaveCount(0);
   await expect(page.locator(".ask-row")).toHaveCount(0);
   await expect(page.locator("mur-source-picker .sp-chip")).toHaveCount(0);
   await expect(page.locator("mur-chat-history")).toHaveCount(0);
@@ -157,16 +177,38 @@ test("privacy invalidation closes the source picker, scrubs cached labels, and d
   page,
 }) => {
   await mockTauri(page, {
-    list_dashboards: () => [
-      {
-        id: "dashboard-secret",
-        title: "Sealed dashboard title",
-        emoji: "🔒",
-        tileCount: 2,
-        createdAt: "2026-08-06T01:00:00Z",
-        updatedAt: "2026-08-06T01:00:00Z",
-      },
-    ],
+    list_dashboards: () => {
+      const target = window as unknown as {
+        __dashboardListCall?: number;
+        __resolveLateDashboards?: () => void;
+      };
+      target.__dashboardListCall = (target.__dashboardListCall ?? 0) + 1;
+      if (target.__dashboardListCall === 1) {
+        return [
+          {
+            id: "dashboard-secret",
+            title: "Sealed dashboard title",
+            emoji: "🔒",
+            tileCount: 2,
+            createdAt: "2026-08-06T01:00:00Z",
+            updatedAt: "2026-08-06T01:00:00Z",
+          },
+        ];
+      }
+      return new Promise((resolve) => {
+        target.__resolveLateDashboards = () =>
+          resolve([
+            {
+              id: "late-dashboard-secret",
+              title: "Late sealed dashboard title",
+              emoji: "🤫",
+              tileCount: 1,
+              createdAt: "2026-08-06T01:00:00Z",
+              updatedAt: "2026-08-06T01:00:00Z",
+            },
+          ]);
+      });
+    },
     list_link_candidates: () =>
       new Promise((resolve) => {
         (
@@ -182,13 +224,35 @@ test("privacy invalidation closes the source picker, scrubs cached labels, and d
             },
           ]);
       }),
+    ask_vault_persisted: () =>
+      new Promise((resolve) => {
+        (
+          window as unknown as {
+            __resolveLatePrivateAsk?: () => void;
+          }
+        ).__resolveLatePrivateAsk = () =>
+          resolve({
+            conversationId: "stale-private-thread",
+            userMessageId: crypto.randomUUID(),
+            assistantMessageId: crypto.randomUUID(),
+            answer: "Late sealed answer",
+            sources: [],
+            citations: [],
+          });
+      }),
   });
   await page.goto("/ask");
 
   await page.locator("mur-source-picker .sp-trigger").click();
+  await page
+    .getByRole("option", { name: "Use dashboard Sealed dashboard title" })
+    .click();
   await expect(
-    page.getByRole("option", { name: /Sealed dashboard title/ }),
-  ).toBeVisible();
+    page.locator('[data-testid="selected-dashboard-chip"]'),
+  ).toContainText("Sealed dashboard title");
+  await page.locator(".ask-input").fill("Private held question");
+  await page.locator(".ask-input").press("Enter");
+  await expect(page.locator(".ask-typing")).toBeVisible();
 
   await page.evaluate(() => {
     (
@@ -199,16 +263,56 @@ test("privacy invalidation closes the source picker, scrubs cached labels, and d
   });
 
   await expect(page.locator(".sp-pop")).toHaveCount(0);
-  await expect(page.getByText("Sealed dashboard title", { exact: true })).toHaveCount(0);
+  await expect(
+    page.getByText("Sealed dashboard title", { exact: true }),
+  ).toHaveCount(0);
+  await expect(
+    page.locator('[data-testid="selected-dashboard-chip"]'),
+  ).toHaveCount(0);
+  await expect(
+    page.getByText("Private held question", { exact: true }),
+  ).toHaveCount(0);
+
+  await page.locator("mur-source-picker .sp-trigger").click();
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        Boolean(
+          (
+            window as unknown as {
+              __resolveLateDashboards?: () => void;
+            }
+          ).__resolveLateDashboards,
+        ),
+      ),
+    )
+    .toBe(true);
   await page.evaluate(() => {
     (
       window as unknown as {
-        __resolveLatePrivateCandidates?: () => void;
+        __demoEmit: (event: string, payload: unknown) => void;
       }
-    ).__resolveLatePrivateCandidates?.();
+    ).__demoEmit("murmur://ask-history-invalidated", null);
   });
-  await page.waitForTimeout(200);
-  await expect(page.getByText("Late sealed source title", { exact: true })).toHaveCount(0);
+  await page.evaluate(() => {
+    const target = window as unknown as {
+      __resolveLatePrivateCandidates?: () => void;
+      __resolveLateDashboards?: () => void;
+      __resolveLatePrivateAsk?: () => void;
+    };
+    target.__resolveLatePrivateCandidates?.();
+    target.__resolveLateDashboards?.();
+    target.__resolveLatePrivateAsk?.();
+  });
+  await expect(
+    page.getByText("Late sealed source title", { exact: true }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByText("Late sealed dashboard title", { exact: true }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByText("Late sealed answer", { exact: true }),
+  ).toHaveCount(0);
   await expect(page.locator("mur-source-picker .sp-chip")).toHaveCount(0);
 });
 
@@ -251,7 +355,11 @@ test("meeting drawer purge clears saved titles and sources and defeats a late pr
       scope: { kind: "meeting", refId: "m-atlas-roadmap" },
       title: "Meeting history secret title",
       selectedSources: [
-        { kind: "note", id: "n-saved-secret", title: "Saved meeting secret source" },
+        {
+          kind: "note",
+          id: "n-saved-secret",
+          title: "Saved meeting secret source",
+        },
       ],
       messages: [
         {
@@ -282,12 +390,16 @@ test("meeting drawer purge clears saved titles and sources and defeats a late pr
   const chat = page.locator("app-meeting-chat");
   await chat.getByRole("button", { name: "Conversation history" }).click();
   await chat.locator(".history-row").click();
-  await expect(chat.getByText("Meeting drawer secret message", { exact: true })).toBeVisible();
+  await expect(
+    chat.getByText("Meeting drawer secret message", { exact: true }),
+  ).toBeVisible();
   await expect(chat.locator(".sp-chip-title")).toHaveText([
     "Saved meeting secret source",
   ]);
   await chat.getByRole("button", { name: "Conversation history" }).click();
-  await expect(chat.getByText("Meeting history secret title", { exact: true })).toBeVisible();
+  await expect(
+    chat.getByText("Meeting history secret title", { exact: true }),
+  ).toBeVisible();
 
   await page.evaluate(() => {
     (
@@ -297,8 +409,12 @@ test("meeting drawer purge clears saved titles and sources and defeats a late pr
     ).__demoEmit("murmur://ask-history-invalidated", null);
   });
 
-  await expect(chat.getByText("Meeting history secret title", { exact: true })).toHaveCount(0);
-  await expect(chat.getByText("Meeting drawer secret message", { exact: true })).toHaveCount(0);
+  await expect(
+    chat.getByText("Meeting history secret title", { exact: true }),
+  ).toHaveCount(0);
+  await expect(
+    chat.getByText("Meeting drawer secret message", { exact: true }),
+  ).toHaveCount(0);
   await expect(chat.locator(".sp-chip-title")).toHaveCount(0);
   await page.evaluate(() => {
     (
@@ -307,10 +423,14 @@ test("meeting drawer purge clears saved titles and sources and defeats a late pr
   });
   await page.waitForTimeout(100);
   await expect(chat.locator(".sp-chip-title")).toHaveCount(0);
-  await expect(chat.getByText("Late meeting-linked secret", { exact: true })).toHaveCount(0);
+  await expect(
+    chat.getByText("Late meeting-linked secret", { exact: true }),
+  ).toHaveCount(0);
   await chat.getByRole("button", { name: "New conversation" }).click();
   await expect(chat.locator(".sp-chip-title")).toHaveCount(0);
-  await expect(chat.getByText("Late meeting-linked secret", { exact: true })).toHaveCount(0);
+  await expect(
+    chat.getByText("Late meeting-linked secret", { exact: true }),
+  ).toHaveCount(0);
 });
 
 test("authored-note drawer purge clears saved titles and sources and defeats a late prefill", async ({
@@ -352,7 +472,11 @@ test("authored-note drawer purge clears saved titles and sources and defeats a l
       scope: { kind: "note", refId: "n1" },
       title: "Note history secret title",
       selectedSources: [
-        { kind: "meeting", id: "m-saved-secret", title: "Saved note secret source" },
+        {
+          kind: "meeting",
+          id: "m-saved-secret",
+          title: "Saved note secret source",
+        },
       ],
       messages: [
         {
@@ -383,12 +507,16 @@ test("authored-note drawer purge clears saved titles and sources and defeats a l
   const chat = page.locator(".note-chat-drawer app-note-chat");
   await chat.getByRole("button", { name: "Conversation history" }).click();
   await chat.locator(".history-row").click();
-  await expect(chat.getByText("Note drawer secret message", { exact: true })).toBeVisible();
+  await expect(
+    chat.getByText("Note drawer secret message", { exact: true }),
+  ).toBeVisible();
   await expect(chat.locator(".sp-chip-title")).toHaveText([
     "Saved note secret source",
   ]);
   await chat.getByRole("button", { name: "Conversation history" }).click();
-  await expect(chat.getByText("Note history secret title", { exact: true })).toBeVisible();
+  await expect(
+    chat.getByText("Note history secret title", { exact: true }),
+  ).toBeVisible();
 
   await page.evaluate(() => {
     (
@@ -398,8 +526,12 @@ test("authored-note drawer purge clears saved titles and sources and defeats a l
     ).__demoEmit("murmur://ask-history-invalidated", null);
   });
 
-  await expect(chat.getByText("Note history secret title", { exact: true })).toHaveCount(0);
-  await expect(chat.getByText("Note drawer secret message", { exact: true })).toHaveCount(0);
+  await expect(
+    chat.getByText("Note history secret title", { exact: true }),
+  ).toHaveCount(0);
+  await expect(
+    chat.getByText("Note drawer secret message", { exact: true }),
+  ).toHaveCount(0);
   await expect(chat.locator(".sp-chip-title")).toHaveCount(0);
   await page.evaluate(() => {
     (
@@ -408,10 +540,14 @@ test("authored-note drawer purge clears saved titles and sources and defeats a l
   });
   await page.waitForTimeout(100);
   await expect(chat.locator(".sp-chip-title")).toHaveCount(0);
-  await expect(chat.getByText("Late note-linked secret", { exact: true })).toHaveCount(0);
+  await expect(
+    chat.getByText("Late note-linked secret", { exact: true }),
+  ).toHaveCount(0);
   await chat.getByRole("button", { name: "New conversation" }).click();
   await expect(chat.locator(".sp-chip-title")).toHaveCount(0);
-  await expect(chat.getByText("Late note-linked secret", { exact: true })).toHaveCount(0);
+  await expect(
+    chat.getByText("Late note-linked secret", { exact: true }),
+  ).toHaveCount(0);
 });
 
 test("durable Ask cannot read or send before every privacy listener is acknowledged", async ({
@@ -458,10 +594,12 @@ test("durable Ask cannot read or send before every privacy listener is acknowled
   await expect(page.locator(".ask-input")).toBeDisabled();
   expect(
     await page.evaluate(() => ({
-      list: (window as unknown as { __privacyListCalls?: number })
-        .__privacyListCalls ?? 0,
-      send: (window as unknown as { __privacySendCalls?: number })
-        .__privacySendCalls ?? 0,
+      list:
+        (window as unknown as { __privacyListCalls?: number })
+          .__privacyListCalls ?? 0,
+      send:
+        (window as unknown as { __privacySendCalls?: number })
+          .__privacySendCalls ?? 0,
     })),
   ).toEqual({ list: 0, send: 0 });
 
@@ -540,12 +678,15 @@ test("privacy-listener failure is fail-closed and double Retry coalesces one rec
   await expect(page.locator(".ask-input")).toBeDisabled();
   expect(
     await page.evaluate(() => ({
-      list: (window as unknown as { __privacyRetryLists?: number })
-        .__privacyRetryLists ?? 0,
-      send: (window as unknown as { __privacyRetrySends?: number })
-        .__privacyRetrySends ?? 0,
-      sources: (window as unknown as { __privacySourceReads?: number })
-        .__privacySourceReads ?? 0,
+      list:
+        (window as unknown as { __privacyRetryLists?: number })
+          .__privacyRetryLists ?? 0,
+      send:
+        (window as unknown as { __privacyRetrySends?: number })
+          .__privacyRetrySends ?? 0,
+      sources:
+        (window as unknown as { __privacySourceReads?: number })
+          .__privacySourceReads ?? 0,
     })),
   ).toEqual({ list: 0, send: 0, sources: 0 });
 
@@ -564,10 +705,12 @@ test("privacy-listener failure is fail-closed and double Retry coalesces one rec
     },
     [askEvent, contentEvent, visibilityEvent],
   );
-  await secureAlert.getByRole("button", { name: "Retry" }).evaluate((button) => {
-    button.click();
-    button.click();
-  });
+  await secureAlert
+    .getByRole("button", { name: "Retry" })
+    .evaluate((button) => {
+      button.click();
+      button.click();
+    });
   await expect
     .poll(() =>
       page.evaluate(

--- a/e2e/ask/chat-history.spec.ts
+++ b/e2e/ask/chat-history.spec.ts
@@ -1,6 +1,96 @@
 import { expect, test } from "@playwright/test";
 import { mockTauri } from "../settings-ai/mock-invoke";
 
+test("vault history restores live dashboard metadata and a user scope change starts a new thread", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    list_ask_conversations: () => [
+      {
+        id: "saved-dashboard-thread",
+        scope: { kind: "vault" },
+        title: "Saved dashboard question",
+        createdAt: "2026-08-06T01:00:00Z",
+        updatedAt: "2026-08-06T01:01:00Z",
+        messageCount: 2,
+      },
+    ],
+    load_ask_conversation: () => ({
+      id: "saved-dashboard-thread",
+      scope: { kind: "vault" },
+      title: "Saved dashboard question",
+      selectedSources: [{ kind: "note", id: "manual", title: "Manual source" }],
+      dashboard: {
+        id: "dashboard-live",
+        title: "Live renamed dashboard",
+        emoji: "✨",
+      },
+      messages: [
+        {
+          id: "u1",
+          ordinal: 0,
+          role: "user",
+          content: "Saved dashboard question",
+          sources: [],
+          citations: [],
+          createdAt: "2026-08-06T01:00:00Z",
+        },
+        {
+          id: "a1",
+          ordinal: 1,
+          role: "assistant",
+          content: "Saved dashboard answer",
+          sources: [],
+          citations: [],
+          createdAt: "2026-08-06T01:01:00Z",
+        },
+      ],
+      createdAt: "2026-08-06T01:00:00Z",
+      updatedAt: "2026-08-06T01:01:00Z",
+    }),
+    ask_vault_persisted: (args: Record<string, unknown>) => {
+      (
+        window as unknown as { __historyDashboardSend?: unknown }
+      ).__historyDashboardSend = args;
+      return {
+        conversationId: "fresh-after-remove",
+        userMessageId: "u2",
+        assistantMessageId: "a2",
+        answer: "Fresh answer",
+        sources: [],
+        citations: [],
+      };
+    },
+  });
+  await page.goto("/ask");
+  await page.getByRole("button", { name: "Conversation history" }).click();
+  await page.getByRole("button", { name: /Saved dashboard question/ }).click();
+  const chip = page.locator('[data-testid="selected-dashboard-chip"]');
+  await expect(chip).toContainText("Live renamed dashboard");
+  await page
+    .getByRole("button", { name: "Remove dashboard Live renamed dashboard" })
+    .click();
+  await expect(page.locator(".ask-row")).toHaveCount(0);
+  await expect(page.locator("mur-source-picker .sp-chip-title")).toContainText([
+    "Manual source",
+  ]);
+  await page.locator(".ask-input").fill("Fresh scope question");
+  await page.locator(".ask-input").press("Enter");
+  const sent = await page.evaluate(
+    () =>
+      (
+        window as unknown as {
+          __historyDashboardSend?: Record<string, unknown>;
+        }
+      ).__historyDashboardSend,
+  );
+  expect(sent?.["conversationId"]).toBeUndefined();
+  expect(sent?.["dashboardId"]).toBeUndefined();
+  expect(sent?.["explicitSources"]).toEqual([
+    { kind: "note", id: "manual", title: "Manual source" },
+  ]);
+});
+
 test("vault Ask lists, resumes, continues, and starts durable conversations without duplicating rows", async ({
   page,
 }) => {
@@ -78,9 +168,9 @@ test("vault Ask lists, resumes, continues, and starts durable conversations with
   await expect(firstRow).toContainText("What was the Atlas decision?");
   await firstRow.click();
   await expect(page.locator(".ask-row")).toHaveCount(2);
-  await expect(page.locator("mur-source-picker .sp-chip-title").first()).toHaveText(
-    selectedTitle ?? "",
-  );
+  await expect(
+    page.locator("mur-source-picker .sp-chip-title").first(),
+  ).toHaveText(selectedTitle ?? "");
   await expect(
     page.locator("mur-source-picker .sp-chip-title").first(),
   ).not.toHaveText("FORGED FE TITLE");
@@ -98,7 +188,9 @@ test("vault Ask lists, resumes, continues, and starts durable conversations with
   await input.press("Enter");
   await history.click();
   await expect(page.locator("mur-chat-history .history-row")).toHaveCount(2);
-  await expect(page.getByText("Start a separate topic", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Start a separate topic", { exact: true }),
+  ).toBeVisible();
 
   expect(errors).toEqual([]);
 });
@@ -132,7 +224,9 @@ test("vault Ask history keeps the conversation during list failure and retries",
 
   // Closing history reveals the untouched conversation underneath.
   await page.getByRole("button", { name: "Conversation history" }).click();
-  await expect(page.getByText("Keep this visible conversation", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Keep this visible conversation", { exact: true }),
+  ).toBeVisible();
 });
 
 test("vault Ask exposes an explicit loading state while history is fetched", async ({
@@ -240,7 +334,9 @@ test("a failed row resume preserves the list and focus, then returns focus to th
   await expect(row).toBeFocused();
 
   await row.press("Enter");
-  await expect(page.getByText("Focusable answer", { exact: true })).toBeVisible();
+  await expect(
+    page.getByText("Focusable answer", { exact: true }),
+  ).toBeVisible();
   await expect(page.locator(".ask-input")).toBeFocused();
 });
 

--- a/e2e/ask/reminder-dashboard-expand.spec.ts
+++ b/e2e/ask/reminder-dashboard-expand.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+test("Reminders keep the picker default expand mode and persist flat dashboard sources", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    get_reminder_summary: () => ({ dueInboxCount: 0 }),
+    list_reminders: () => ({
+      inbox: [],
+      upcoming: [],
+      completed: [],
+      dueInboxCount: 0,
+    }),
+    list_dashboards: () => [
+      {
+        id: "dashboard-reminder",
+        title: "Reminder expansion board",
+        emoji: "⏰",
+        tileCount: 2,
+        createdAt: "2026-08-06T01:00:00Z",
+        updatedAt: "2026-08-06T01:00:00Z",
+      },
+    ],
+    get_dashboard_sources: (args: { id: string }) => {
+      const target = window as unknown as {
+        __reminderDashboardReads?: unknown[];
+      };
+      target.__reminderDashboardReads = [
+        ...(target.__reminderDashboardReads ?? []),
+        args,
+      ];
+      return [
+        { kind: "meeting", id: "m-dashboard-child", title: "Meeting child" },
+        { kind: "note", id: "n-dashboard-child", title: "Note child" },
+      ];
+    },
+    create_reminder: (args: unknown) => {
+      (
+        window as unknown as { __reminderCreateArgs?: unknown }
+      ).__reminderCreateArgs = args;
+      return {
+        id: "reminder-created",
+        title: "Expanded dashboard reminder",
+        details: null,
+        dueAt: Date.now() + 60_000,
+        repeatEvery: null,
+        repeatUnit: null,
+        state: "active",
+        origin: "manual",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        completedAt: null,
+        sources: [],
+      };
+    },
+  });
+
+  await page.goto("/reminders");
+  await page.getByRole("button", { name: "New reminder" }).first().click();
+  const composer = page.locator("app-reminder-composer");
+  await composer.getByLabel("Title").fill("Expanded dashboard reminder");
+  await composer.getByRole("button", { name: "+ Add source" }).click();
+  await page
+    .getByRole("option", { name: "Use dashboard Reminder expansion board" })
+    .click();
+
+  await expect(
+    composer.locator('[data-testid="selected-dashboard-chip"]'),
+  ).toHaveCount(0);
+  await expect(composer.locator(".sp-chip-title")).toHaveText([
+    "Meeting child",
+    "Note child",
+  ]);
+  if (await page.locator(".sp-pop").isVisible()) {
+    await page.locator(".sp-search").press("Escape");
+  }
+  await composer.getByRole("button", { name: "Create reminder" }).click();
+
+  const state = await page.evaluate(() => ({
+    reads:
+      (window as unknown as { __reminderDashboardReads?: unknown[] })
+        .__reminderDashboardReads ?? [],
+    args: (
+      window as unknown as { __reminderCreateArgs?: Record<string, unknown> }
+    ).__reminderCreateArgs,
+  }));
+  expect(state.reads).toEqual([{ id: "dashboard-reminder" }]);
+  expect(state.args).not.toHaveProperty("dashboardId");
+  expect(
+    (state.args?.["draft"] as Record<string, unknown>)?.["sources"],
+  ).toEqual([
+    { kind: "meeting", id: "m-dashboard-child" },
+    { kind: "note", id: "n-dashboard-child" },
+  ]);
+});

--- a/e2e/dashboards/dashboard-density.spec.ts
+++ b/e2e/dashboards/dashboard-density.spec.ts
@@ -20,12 +20,10 @@ async function submitAsk(page: import("@playwright/test").Page): Promise<void> {
 async function enterCompose(
   page: import("@playwright/test").Page,
 ): Promise<void> {
-  if (
-    !(await page.locator('section[aria-label="Compose board tiles"]').count())
-  ) {
+  if (!(await page.locator('[data-testid="dashboard-compose"]').count())) {
     await page.getByRole("button", { name: "Compose", exact: true }).click();
   }
-  await page.locator('section[aria-label="Compose board tiles"]').waitFor();
+  await page.locator('[data-testid="dashboard-compose"]').waitFor();
 }
 
 /**
@@ -149,94 +147,62 @@ async function openBoard(page: import("@playwright/test").Page) {
   );
   await page.goto("/dashboards/b-dense");
   await enterCompose(page);
-  await expect(page.locator("app-dashboard-tile")).toHaveCount(4);
+  await expect(page.locator(".compose-row")).toHaveCount(4);
 }
 
-/** The rendered column span, read off the resolved grid placement. */
-async function spanOf(
-  page: import("@playwright/test").Page,
-  id: string,
-): Promise<number> {
-  return page.evaluate((tileId) => {
-    const el = document.querySelector(
-      `app-dashboard-tile[data-tile-id="${tileId}"]`,
-    );
-    if (!el) return -1;
-    const raw = getComputedStyle(el).gridColumn; // e.g. "span 3 / auto"
-    const m = /span\s+(\d+)/.exec(raw);
-    return m ? Number(m[1]) : -1;
-  }, id);
-}
-
-test("Dashboards: a tile that never had data collapses instead of reserving a full card", async ({
+test("Dashboards: Compose renders one compact canonical row per tile with no body previews", async ({
   page,
 }) => {
   await openBoard(page);
-
-  const numbers = page.locator('app-dashboard-tile[data-tile-id="t-numbers"]');
-  await expect(numbers).toHaveClass(/is-empty/);
-
-  // The apology is gone: no body region at all, and the strip is narrow.
-  await expect(numbers.locator(".tile-body")).toHaveCount(0);
-  expect(await spanOf(page, "t-numbers")).toBe(3);
-
-  // And it is SHORT — the whole point. The invariant that matters is RELATIVE:
-  // a collapsed strip must not read as a peer of a populated card. (An absolute
-  // pixel ceiling would just encode today's font stack; the ratio is the design.)
-  const heights = await page.evaluate(() => {
-    const h = (id: string) =>
-      document
-        .querySelector(`app-dashboard-tile[data-tile-id="${id}"]`)!
-        .getBoundingClientRect().height;
-    return { empty: h("t-numbers"), full: h("t-note") };
-  });
-  expect(heights.empty).toBeLessThan(heights.full * 0.75);
-  // Compose's explicit move controls add one compact toolbar row, but an empty
-  // strip must remain materially shorter than a populated card.
-  expect(heights.empty).toBeLessThanOrEqual(88);
-});
-
-test("Dashboards: an empty PROMISES tile reads as a result, not as an absence", async ({
-  page,
-}) => {
-  await openBoard(page);
-
-  const promises = page.locator(
-    'app-dashboard-tile[data-tile-id="t-promises"]',
-  );
-  // Zero open commitments is good news — it keeps its card and its body.
-  await expect(promises).not.toHaveClass(/is-empty/);
-  await expect(promises.locator(".tile-body")).toHaveCount(1);
-  await expect(promises.locator(".state-good")).toBeVisible();
-});
-
-test("Dashboards: kinds get different widths even though every stored row says span 4", async ({
-  page,
-}) => {
-  await openBoard(page);
-
-  const person = await spanOf(page, "t-person");
-  const note = await spanOf(page, "t-note");
-  const promises = await spanOf(page, "t-promises");
-
-  // A stat cluster is narrower than prose, which is narrower than a ledger.
-  expect(person).toBe(3);
-  expect(note).toBe(4);
-  expect(promises).toBe(6);
-  expect(new Set([person, note, promises]).size).toBeGreaterThan(1);
-});
-
-test("Dashboards: every tile header carries a per-kind mark", async ({
-  page,
-}) => {
-  await openBoard(page);
-
-  // The single biggest visual omission versus the prototype: the shipped header
-  // was an <h3> and a grey uppercase word, with zero colour anywhere on the board.
-  await expect(page.locator("app-dashboard-tile .tile-mark")).toHaveCount(4);
+  expect(
+    await page
+      .locator(".compose-row")
+      .evaluateAll((rows) =>
+        rows.map((row) => row.getAttribute("data-tile-id")),
+      ),
+  ).toEqual(["t-numbers", "t-promises", "t-person", "t-note"]);
+  await expect(page.locator(".tile-body")).toHaveCount(0);
   await expect(
-    page.locator('app-dashboard-tile[data-tile-id="t-note"] .tile-mark'),
-  ).toHaveAttribute("data-kind", "note");
+    page.locator(".compose-row.is-empty, .compose-row.is-duplicate"),
+  ).toHaveCount(0);
+});
+
+test("Dashboards: empty and populated derived views remain distinct labelled rows", async ({
+  page,
+}) => {
+  await openBoard(page);
+  await expect(page.locator('[data-tile-id="t-promises"]')).toContainText(
+    "0 open promises",
+  );
+  await expect(page.locator('[data-tile-id="t-person"]')).toContainText(
+    "Live derived board view",
+  );
+});
+
+test("Dashboards: Compose has no width controls and every row uses the same list column", async ({
+  page,
+}) => {
+  await openBoard(page);
+  await expect(
+    page.getByRole("button", { name: /Make tile (wider|narrower)/i }),
+  ).toHaveCount(0);
+  const lefts = await page
+    .locator(".compose-row")
+    .evaluateAll((rows) =>
+      rows.map((row) => Math.round(row.getBoundingClientRect().left)),
+    );
+  expect(new Set(lefts).size).toBe(1);
+});
+
+test("Dashboards: every Compose row carries a per-kind label and handle", async ({
+  page,
+}) => {
+  await openBoard(page);
+  await expect(page.locator(".compose-row .kind-mark")).toHaveCount(4);
+  await expect(page.locator('.compose-row[data-kind="note"]')).toContainText(
+    "Note",
+  );
+  await expect(page.locator('.drag-handle[draggable="true"]')).toHaveCount(4);
 });
 
 test("Dashboards: a failed Ask is a banner with a retry, not a grey bubble that looks like an answer", async ({
@@ -249,7 +215,7 @@ test("Dashboards: a failed Ask is a banner with a retry, not a grey bubble that 
   await mockTauri(
     page,
     {
-      ask_vault: () => {
+      ask_vault_persisted: () => {
         throw new Error(
           "summarizer error: cloud provider response failed after protected dispatch; details omitted",
         );
@@ -286,7 +252,7 @@ test("Dashboards: an answer renders as markdown, not as literal asterisks", asyn
   await mockTauri(
     page,
     {
-      ask_vault: () => ({
+      ask_vault_persisted: () => ({
         answer: "The **auth migration** is the risk.",
         sources: [],
         citations: [],
@@ -368,14 +334,16 @@ test("Dashboards: a duplicate tile renders as a back-reference, not a second cop
 
   await page.goto("/dashboards/b-dense");
   await enterCompose(page);
-  await expect(page.locator("app-dashboard-tile")).toHaveCount(2);
-
-  const second = page.locator('app-dashboard-tile[data-tile-id="t-p2"]');
-  await expect(second).toHaveClass(/is-duplicate/);
-  await expect(second.getByText(/same as the tile above/i)).toBeVisible();
-
-  // The row is rendered ONCE on the board, not twice.
-  await expect(page.getByText("Send the Acme paperwork")).toHaveCount(1);
+  await expect(page.locator(".compose-row")).toHaveCount(2);
+  expect(
+    await page
+      .locator(".compose-row")
+      .evaluateAll((rows) =>
+        rows.map((row) => row.getAttribute("data-tile-id")),
+      ),
+  ).toEqual(["t-p1", "t-p2"]);
+  await expect(page.locator(".compose-row.is-duplicate")).toHaveCount(0);
+  await expect(page.getByText("Send the Acme paperwork")).toHaveCount(0);
 });
 
 test("Dashboards: Ask is on demand and closing it preserves the in-memory thread", async ({
@@ -384,7 +352,7 @@ test("Dashboards: Ask is on demand and closing it preserves the in-memory thread
   await mockTauri(
     page,
     {
-      ask_vault: () => ({
+      ask_vault_persisted: () => ({
         answer: "Two are late.",
         sources: [],
         citations: [],
@@ -540,7 +508,7 @@ test("Dashboards: navigating away mid-ask does not leave the next board stuck bu
   await mockTauri(
     page,
     {
-      ask_vault: async () => {
+      ask_vault_persisted: async () => {
         await new Promise((r) => setTimeout(r, 1500));
         return {
           answer: "answer for the first board",
@@ -592,7 +560,7 @@ test("Dashboards: sealed material-only board still asks with its board id", asyn
   await mockTauri(
     page,
     {
-      ask_vault: (args: any) => {
+      ask_vault_persisted: (args: any) => {
         (globalThis as any).__askArgs = args;
         // The REAL string the board-scoped empty path returns (`commands/ask.rs`,
         // pinned by `a_board_scoped_empty_ask_does_not_tell_the_user_to_record`).
@@ -632,7 +600,8 @@ test("Dashboards: sealed material-only board still asks with its board id", asyn
 
   await page.goto("/dashboards/b-dense");
   await enterCompose(page);
-  await expect(page.locator("app-dashboard-tile")).toHaveCount(3);
+  await expect(page.locator(".compose-row")).toHaveCount(3);
+  await expect(page.locator('.compose-row[data-kind="locked"]')).toHaveCount(3);
   await page.getByRole("button", { name: "Done", exact: true }).click();
 
   // Ask is not mounted until explicitly opened.

--- a/e2e/dashboards/dashboard-workspace.spec.ts
+++ b/e2e/dashboards/dashboard-workspace.spec.ts
@@ -184,7 +184,7 @@ async function enterCompose(
   page: import("@playwright/test").Page,
 ): Promise<void> {
   await page.getByRole("button", { name: "Compose", exact: true }).click();
-  await page.locator('section[aria-label="Compose board tiles"]').waitFor();
+  await page.locator('[data-testid="dashboard-compose"]').waitFor();
 }
 
 async function assertNoSealedSecret(
@@ -448,11 +448,19 @@ test("Dashboard workspace: keyboard tile movement persists the same order shown 
   await mockTauri(
     page,
     {
-      reorder_dashboard_tiles: async (args: unknown) => {
-        (globalThis as { __dashboardReorder?: unknown }).__dashboardReorder =
-          args;
-        await new Promise((resolve) => setTimeout(resolve, 250));
-        return null;
+      reorder_dashboard_tiles: (args: unknown) => {
+        const target = globalThis as {
+          __dashboardReorders?: unknown[];
+          __resolveHeldReorder?: () => void;
+        };
+        target.__dashboardReorders = [
+          ...(target.__dashboardReorders ?? []),
+          args,
+        ];
+        if (target.__dashboardReorders.length > 1) return null;
+        return new Promise((resolve) => {
+          target.__resolveHeldReorder = () => resolve(null);
+        });
       },
     },
     {
@@ -464,34 +472,261 @@ test("Dashboard workspace: keyboard tile movement persists the same order shown 
   await page.goto(`/dashboards/${BOARD.id}`);
   await enterCompose(page);
 
-  const first = page.locator("app-dashboard-tile").first();
+  const first = page.locator(".compose-row").first();
   await expect(first).toHaveAttribute("data-tile-id", "t-note");
-  await first.getByRole("button", { name: "Move tile later" }).click();
-  await expect(page.locator("app-dashboard-tile").first()).toHaveAttribute(
+  const handle = page.getByRole("button", {
+    name: /Drag to reorder Atlas launch plan/,
+  });
+  await handle.focus();
+  await handle.press("Alt+ArrowDown");
+  await expect(page.locator(".compose-row").first()).toHaveAttribute(
     "data-tile-id",
     "t-recording",
   );
-  await expect(page.locator("app-dashboard-tile").nth(1)).toHaveAttribute(
+  await expect(page.locator(".compose-row").nth(1)).toHaveAttribute(
     "data-tile-id",
     "t-note",
   );
 
-  const sent = (await expect
+  await expect
     .poll(() =>
       page.evaluate(
         () =>
-          (globalThis as { __dashboardReorder?: unknown }).__dashboardReorder,
+          (globalThis as { __dashboardReorders?: unknown[] })
+            .__dashboardReorders?.length ?? 0,
       ),
     )
-    .toBeTruthy()
-    .then(() =>
-      page.evaluate(
-        () =>
-          (globalThis as { __dashboardReorder?: unknown }).__dashboardReorder,
-      ),
-    )) as { dashboardId?: string; tileIds?: string[] };
+    .toBe(1);
+  await expect(handle).toBeFocused();
+  await expect(page.locator(".compose-row")).toHaveCount(TILES.length);
+
+  await page.evaluate(() => {
+    (
+      globalThis as { __resolveHeldReorder?: () => void }
+    ).__resolveHeldReorder?.();
+  });
+  const sent = (await page.evaluate(
+    () =>
+      (globalThis as { __dashboardReorders?: unknown[] })
+        .__dashboardReorders?.[0],
+  )) as { dashboardId?: string; tileIds?: string[] };
   expect(sent.dashboardId).toBe(BOARD.id);
   expect(sent.tileIds?.slice(0, 2)).toEqual(["t-recording", "t-note"]);
+  await expect(handle).toBeFocused();
+
+  await page
+    .getByRole("button", { name: "Move later Atlas launch plan" })
+    .click();
+  await expect(page.locator(".compose-row").nth(2)).toHaveAttribute(
+    "data-tile-id",
+    "t-note",
+  );
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (globalThis as { __dashboardReorders?: unknown[] })
+            .__dashboardReorders?.length ?? 0,
+      ),
+    )
+    .toBe(2);
+  const clickSent = (await page.evaluate(
+    () =>
+      (globalThis as { __dashboardReorders?: unknown[] })
+        .__dashboardReorders?.[1],
+  )) as { tileIds?: string[] };
+  const domOrder = await page
+    .locator(".compose-row")
+    .evaluateAll((rows) => rows.map((row) => row.getAttribute("data-tile-id")));
+  expect(clickSent.tileIds).toEqual(domOrder);
+});
+
+test("Dashboard Compose is a canonical compact list for readable, missing, sealed, and unconfigured rows", async ({
+  page,
+}) => {
+  const longTitle = `Long board title ${"without overflow ".repeat(18)}`;
+  const detail = {
+    ...BOARD,
+    tiles: [
+      {
+        ...tile(
+          "t-long",
+          "note",
+          "n-long",
+          {
+            kind: "note",
+            id: "n-long",
+            title: longTitle,
+            snippet: "Readable material",
+            updatedAt: 1_786_400_000_000,
+          },
+          0,
+        ),
+        title: longTitle,
+      },
+      {
+        ...tile("t-locked-middle", "note", "n-locked", { kind: "locked" }, 1),
+        title: "LEGACY PRIVATE LOCKED TITLE",
+        config: JSON.stringify({
+          kind: "note",
+          title: "LEGACY PRIVATE LOCKED TITLE",
+        }),
+      },
+      tile("t-missing-middle", "note", "n-gone", { kind: "missing" }, 2),
+      tile(
+        "t-unconfigured-middle",
+        "numbers",
+        null,
+        { kind: "unconfigured" },
+        3,
+      ),
+      TILES[1],
+    ],
+  };
+  await mockTauri(
+    page,
+    {},
+    {
+      list_dashboards: [BOARD],
+      get_dashboard: detail,
+      get_dashboard_sources: [],
+    },
+  );
+  await page.setViewportSize({ width: 900, height: 680 });
+  await page.goto(`/dashboards/${BOARD.id}`);
+  await enterCompose(page);
+
+  const rows = page.locator(".compose-row");
+  await expect(rows).toHaveCount(5);
+  expect(
+    await rows.evaluateAll((items) =>
+      items.map((item) => item.getAttribute("data-tile-id")),
+    ),
+  ).toEqual([
+    "t-long",
+    "t-locked-middle",
+    "t-missing-middle",
+    "t-unconfigured-middle",
+    "t-recording",
+  ]);
+  await expect(rows.nth(1)).toHaveAttribute("data-kind", "locked");
+  await expect(rows.nth(2)).toHaveAttribute("data-kind", "missing");
+  await expect(rows.nth(3)).toHaveAttribute("data-kind", "unconfigured");
+  await expect(rows.nth(1)).toContainText("Sealed item");
+  await expect(
+    page.getByText("LEGACY PRIVATE LOCKED TITLE", { exact: false }),
+  ).toHaveCount(0);
+  await expect(page.locator(".tile-body")).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: /Make tile (wider|narrower)/i }),
+  ).toHaveCount(0);
+  await expect(page.locator('[draggable="true"]')).toHaveCount(5);
+  await expect(page.locator('.compose-row[draggable="true"]')).toHaveCount(0);
+  await expect(page.locator('.drag-handle[draggable="true"]')).toHaveCount(5);
+
+  const geometry = await page.evaluate(() => {
+    const composeRows = [
+      ...document.querySelectorAll<HTMLElement>(".compose-row"),
+    ];
+    const boxes = composeRows.map((row) => row.getBoundingClientRect());
+    return {
+      overflow: document.documentElement.scrollWidth > innerWidth,
+      rowOverflow: composeRows.some((row) => row.scrollWidth > row.clientWidth),
+      overlap: boxes.some((box, index) => {
+        const next = boxes[index + 1];
+        return Boolean(next && box.bottom > next.top);
+      }),
+    };
+  });
+  expect(geometry).toEqual({
+    overflow: false,
+    rowOverflow: false,
+    overlap: false,
+  });
+  await expect(
+    page.getByRole("button", { name: "Add to board" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Done", exact: true }),
+  ).toBeVisible();
+
+  await page.setViewportSize({ width: 1500, height: 900 });
+  await expect
+    .poll(() =>
+      page.evaluate(() => document.documentElement.scrollWidth <= innerWidth),
+    )
+    .toBe(true);
+  const wideBoxes = await rows.evaluateAll((items) =>
+    items.map((item) => {
+      const box = item.getBoundingClientRect();
+      return { top: box.top, bottom: box.bottom };
+    }),
+  );
+  expect(
+    wideBoxes.some((box, index) => {
+      const next = wideBoxes[index + 1];
+      return Boolean(next && box.bottom > next.top);
+    }),
+  ).toBe(false);
+  await expect(
+    page.getByRole("button", { name: "Add to board" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Done", exact: true }),
+  ).toBeVisible();
+});
+
+test("Dashboard Compose removes optimistically and rolls back without reloading the board", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {
+      delete_dashboard_tile: (args: unknown) => {
+        const target = globalThis as {
+          __removeArgs?: unknown;
+          __rejectHeldRemove?: () => void;
+        };
+        target.__removeArgs = args;
+        return new Promise((_resolve, reject) => {
+          target.__rejectHeldRemove = () =>
+            reject(new Error("simulated remove failure"));
+        });
+      },
+    },
+    {
+      list_dashboards: [BOARD],
+      get_dashboard: DETAIL,
+      get_dashboard_sources: SOURCES,
+    },
+  );
+  await page.goto(`/dashboards/${BOARD.id}`);
+  await enterCompose(page);
+  await expect(page.locator(".compose-row")).toHaveCount(TILES.length);
+
+  await page
+    .getByRole("button", { name: "Remove Atlas launch plan from board" })
+    .click();
+  await expect(page.locator(".compose-row")).toHaveCount(TILES.length - 1);
+  await expect(page.locator('[data-tile-id="t-note"]')).toHaveCount(0);
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        Boolean(
+          (globalThis as { __rejectHeldRemove?: () => void })
+            .__rejectHeldRemove,
+        ),
+      ),
+    )
+    .toBe(true);
+  await page.evaluate(() => {
+    (globalThis as { __rejectHeldRemove?: () => void }).__rejectHeldRemove?.();
+  });
+  await expect(page.locator(".compose-row")).toHaveCount(TILES.length);
+  await expect(page.locator(".compose-row").first()).toHaveAttribute(
+    "data-tile-id",
+    "t-note",
+  );
 });
 
 test("Dashboard workspace: 900x680 keeps primary actions and overlays usable without horizontal overflow", async ({
@@ -547,6 +782,17 @@ test("Dashboard workspace: 900x680 keeps primary actions and overlays usable wit
   await page.getByRole("button", { name: "Close Ask" }).click();
 
   await enterCompose(page);
+  await expect(
+    page.getByRole("button", { name: "Add to board" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Done", exact: true }),
+  ).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(() => document.documentElement.scrollWidth <= innerWidth),
+    )
+    .toBe(true);
   await page.getByRole("button", { name: "Add to board" }).click();
   const palette = page.getByRole("dialog", { name: "Add to board" });
   const box = await palette.boundingBox();
@@ -778,7 +1024,7 @@ test("Dashboard workspace: relock scrubs mounted plaintext even when the folder 
         (globalThis as { __dashboardLocked?: boolean }).__dashboardLocked
           ? []
           : [{ kind: "note", id: "n-relock-failure" }],
-      ask_vault: () => ({
+      ask_vault_persisted: () => ({
         answer: "Nightjar assistant-only risk summary",
         sources: [],
         citations: [],

--- a/e2e/dashboards/dashboards-context.spec.ts
+++ b/e2e/dashboards/dashboards-context.spec.ts
@@ -44,12 +44,10 @@ const BOARDS = [
 async function enterCompose(
   page: import("@playwright/test").Page,
 ): Promise<void> {
-  if (
-    !(await page.locator('section[aria-label="Compose board tiles"]').count())
-  ) {
+  if (!(await page.locator('[data-testid="dashboard-compose"]').count())) {
     await page.getByRole("button", { name: "Compose", exact: true }).click();
   }
-  await page.locator('section[aria-label="Compose board tiles"]').waitFor();
+  await page.locator('[data-testid="dashboard-compose"]').waitFor();
 }
 
 async function openPalette(page: import("@playwright/test").Page) {
@@ -76,19 +74,21 @@ async function openPalette(page: import("@playwright/test").Page) {
   return palette;
 }
 
-test("Ask: a dashboard can be picked as scope and expands to its visible sources", async ({
+test("Ask: a dashboard is one composite chip and never expands in the WebView", async ({
   page,
 }) => {
   await mockTauri(
     page,
-    {},
+    {
+      get_dashboard_sources: () => {
+        (
+          window as unknown as { __contextDashboardReads?: number }
+        ).__contextDashboardReads = 1;
+        return [{ kind: "note", id: "must-not-read" }];
+      },
+    },
     {
       list_dashboards: BOARDS,
-      // Two visible sources; a sealed third is already filtered out backend-side.
-      get_dashboard_sources: [
-        { kind: "meeting", id: "m-1" },
-        { kind: "note", id: "n-1" },
-      ],
     },
   );
 
@@ -102,15 +102,24 @@ test("Ask: a dashboard can be picked as scope and expands to its visible sources
   const picker = page.locator(".sp-list");
   await expect(picker.getByText("Dashboards")).toBeVisible();
   await expect(picker.getByText("Atlas GA")).toBeVisible();
-  // A board with no tiles is not a usable scope, so it is not offered.
-  await expect(picker.getByText("Nothing on it yet")).toHaveCount(0);
+  // Composite identity remains meaningful even when the live readable corpus is empty.
+  await expect(picker.getByText("Nothing on it yet")).toBeVisible();
 
   await picker.getByRole("option", { name: /Atlas GA/ }).click();
 
-  // Picking the board added BOTH of its visible sources as chips.
-  await expect(page.locator(".sp-chip, .sp .pill")).toHaveCount(2, {
-    timeout: 5000,
-  });
+  await expect(
+    page.locator('[data-testid="selected-dashboard-chip"]'),
+  ).toHaveCount(1);
+  await expect(
+    page.locator('[data-testid="selected-dashboard-chip"]'),
+  ).toContainText("Atlas GA");
+  expect(
+    await page.evaluate(
+      () =>
+        (window as unknown as { __contextDashboardReads?: number })
+          .__contextDashboardReads ?? 0,
+    ),
+  ).toBe(0);
 });
 
 test("Dashboards: Compose makes tiles draggable and persists a reorder", async ({
@@ -175,17 +184,24 @@ test("Dashboards: Compose makes tiles draggable and persists a reorder", async (
   await expect(page.getByRole("heading", { name: "FIRST TILE" })).toBeVisible();
 
   // The peer-card grid does not exist until the explicit Compose mode is entered.
-  await expect(page.locator("app-dashboard-tile")).toHaveCount(0);
+  await expect(page.locator('[data-testid="dashboard-compose"]')).toHaveCount(
+    0,
+  );
   await enterCompose(page);
   await expect(page.getByText(/Drag or use Move earlier/)).toBeVisible();
-  await expect(page.locator("app-dashboard-tile").first()).toHaveAttribute(
+  await expect(page.locator(".compose-row")).toHaveCount(2);
+  await expect(page.locator(".compose-row").first()).not.toHaveAttribute(
+    "draggable",
+    "true",
+  );
+  await expect(page.locator(".drag-handle").first()).toHaveAttribute(
     "draggable",
     "true",
   );
 
   // Drag the second tile onto the first.
-  const source = page.locator("app-dashboard-tile").nth(1);
-  const target = page.locator("app-dashboard-tile").nth(0);
+  const source = page.locator(".drag-handle").nth(1);
+  const target = page.locator(".compose-row").nth(0);
   await source.dragTo(target);
 
   // The backend was asked for the NEW order, second tile first.

--- a/e2e/dashboards/dashboards.spec.ts
+++ b/e2e/dashboards/dashboards.spec.ts
@@ -20,12 +20,10 @@ async function submitAsk(page: import("@playwright/test").Page): Promise<void> {
 async function enterCompose(
   page: import("@playwright/test").Page,
 ): Promise<void> {
-  if (
-    !(await page.locator('section[aria-label="Compose board tiles"]').count())
-  ) {
+  if (!(await page.locator('[data-testid="dashboard-compose"]').count())) {
     await page.getByRole("button", { name: "Compose", exact: true }).click();
   }
-  await page.locator('section[aria-label="Compose board tiles"]').waitFor();
+  await page.locator('[data-testid="dashboard-compose"]').waitFor();
 }
 
 /**
@@ -201,13 +199,14 @@ test("Dashboards: a SEALED tile leaks nothing — not even the title the user ty
     await assertSecretAbsent();
   }
 
-  // Compose may render the legacy tile row, but only from its resolved locked
-  // payload. Stored kind/title/config remain forbidden as fallback chrome.
+  // Compose renders a generic compact row from the gated payload only.
   await enterCompose(page);
-  const sealed = page.locator("app-dashboard-tile.is-locked");
+  const sealed = page.locator('.compose-row[data-kind="locked"]');
   await expect(sealed).toHaveCount(1);
-  await expect(sealed).toContainText("Sealed — not in scope");
-  await expect(sealed.locator(".tile-title")).toHaveText("🔒 Locked");
+  await expect(sealed).toContainText("Sealed item");
+  await expect(sealed).toContainText(
+    "Content hidden until its folder is unlocked",
+  );
   await assertSecretAbsent();
 
   // CONTROL: the same assertion catches a leak when one exists — an unsealed
@@ -253,60 +252,116 @@ test("Dashboards: an entity tile whose entity went invisible keeps no stored nam
 
   await page.goto("/dashboards/b-atlas");
   await enterCompose(page);
-  await expect(page.locator("app-dashboard-tile")).toHaveCount(1);
-  await expect(
-    page.locator("app-dashboard-tile .tile-title"),
-  ).not.toContainText("Dana");
+  await expect(page.locator(".compose-row")).toHaveCount(1);
+  await expect(page.locator(".compose-row strong")).not.toContainText("Dana");
   // A drift lane with no rows never had data, so it collapses to a strip rather
   // than reserving a full card for an apology (2026-08-04 density pass). The
   // leak assertion above is the point of this test and is unchanged.
-  await expect(page.locator("app-dashboard-tile")).toHaveClass(/is-empty/);
-  await expect(
-    page.getByText(/Values land here as they get revised/),
-  ).toBeVisible();
+  await expect(page.locator(".compose-row")).toHaveAttribute(
+    "data-kind",
+    "drift",
+  );
 });
 
-test("Dashboards: a withheld Living answer shows why, and not the cached text", async ({
+test("Dashboards: withheld legacy Living Answer chrome never reaches Read or Compose DOM", async ({
   page,
 }) => {
+  const secret = "NIGHTJAR LEGACY LIVING ANSWER SECRET";
   await mockTauri(
     page,
-    {},
+    {
+      get_dashboard: () => {
+        // Simulate a legacy persisted row whose every content-shaped field held
+        // plaintext. The production resolver is the authority that projects it
+        // to this scrubbed wire shape before the WebView sees it.
+        const legacyStored = {
+          title: "NIGHTJAR LEGACY LIVING ANSWER SECRET",
+          config: JSON.stringify({
+            question: "NIGHTJAR LEGACY LIVING ANSWER SECRET",
+            answer: "NIGHTJAR LEGACY LIVING ANSWER SECRET",
+          }),
+          question: "NIGHTJAR LEGACY LIVING ANSWER SECRET",
+        };
+        void legacyStored;
+        return {
+          id: "b-atlas",
+          title: "Atlas GA",
+          emoji: "🚀",
+          tint: "indigo",
+          pinned: true,
+          position: 0,
+          createdAt: "2026-08-01T09:00:00Z",
+          updatedAt: "2026-08-03T09:00:00Z",
+          tileCount: 2,
+          tileKinds: [],
+          tiles: [
+            {
+              id: "t-answer-withheld",
+              dashboardId: "b-atlas",
+              kind: "living_answer",
+              refId: null,
+              title: null,
+              span: 5,
+              position: 0,
+              config: null,
+              createdAt: "2026-08-01T09:00:00Z",
+              data: {
+                kind: "livingAnswer",
+                question: "",
+                answer: null,
+                answeredAt: null,
+                withheld: true,
+              },
+            },
+            {
+              id: "t-answer-readable",
+              dashboardId: "b-atlas",
+              kind: "living_answer",
+              refId: null,
+              title: null,
+              span: 5,
+              position: 1,
+              config: null,
+              createdAt: "2026-08-01T09:00:00Z",
+              data: {
+                kind: "livingAnswer",
+                question: "Authorized gated launch question",
+                answer: "Authorized gated answer",
+                answeredAt: "2026-08-03T09:00:00Z",
+                withheld: false,
+              },
+            },
+          ],
+        };
+      },
+    },
     {
       list_dashboards: BOARDS,
-      get_dashboard: {
-        ...BOARDS[0],
-        tiles: [
-          {
-            id: "t-answer",
-            dashboardId: "b-atlas",
-            kind: "living_answer",
-            refId: null,
-            title: null,
-            span: 5,
-            position: 0,
-            config: null,
-            createdAt: "2026-08-01T09:00:00Z",
-            data: {
-              kind: "livingAnswer",
-              question: "Will Acme renew?",
-              answer: null,
-              answeredAt: null,
-              withheld: true,
-            },
-          },
-        ],
-      },
       get_dashboard_sources: [],
     },
   );
 
   await page.goto("/dashboards/b-atlas");
-  await enterCompose(page);
-  await expect(page.getByText(/The saved answer is hidden/)).toBeVisible();
   await expect(
-    page.getByText(/one of the sources it was built from is sealed/),
+    page.getByText("Authorized gated launch question", { exact: true }),
   ).toBeVisible();
+  expect(
+    await page.locator("app-root").evaluate((root) => root.outerHTML),
+  ).not.toContain(secret);
+
+  await enterCompose(page);
+  const withheld = page.locator('[data-tile-id="t-answer-withheld"]');
+  await expect(withheld).toContainText("Living answer");
+  await expect(withheld).toContainText("Waiting for an answer");
+  await expect(withheld).not.toContainText(
+    /saved answer is hidden|sources it was built from/i,
+  );
+  await expect(
+    page.locator('[data-tile-id="t-answer-readable"]'),
+  ).toContainText("Authorized gated launch question");
+  expect(
+    await page.locator("app-root").evaluate((root) => root.outerHTML),
+  ).not.toContain(secret);
 });
 
 test("Dashboards: Read exposes Living Answer answered-at without inventing a stale verdict", async ({
@@ -359,11 +414,11 @@ test("Dashboards: Read exposes Living Answer answered-at without inventing a sta
   await expect(brief).not.toContainText(/stale|fresh/i);
 
   await page.getByRole("button", { name: "Compose", exact: true }).click();
-  const tile = page.locator(
-    'app-dashboard-tile[data-tile-id="t-cached-answer"]',
-  );
+  const tile = page.locator('.compose-row[data-tile-id="t-cached-answer"]');
   await expect(tile).toBeVisible();
   await expect(tile.getByRole("button", { name: "Re-answer" })).toHaveCount(0);
+  await page.getByRole("button", { name: "Done", exact: true }).click();
+  await expect(page.getByRole("button", { name: "Re-answer" })).toBeVisible();
   expect(
     await page.evaluate(
       () =>
@@ -372,16 +427,31 @@ test("Dashboards: Read exposes Living Answer answered-at without inventing a sta
   ).toBe(0);
 });
 
-test("Dashboards: board Ask sends readable sources and the board id", async ({
+test("Dashboards: board Ask sends only board id and backend conversation id, never FE history", async ({
   page,
 }) => {
   await mockTauri(
     page,
     {
-      ask_vault: (args: unknown) => {
-        (globalThis as { __dashboardAskArgs?: unknown }).__dashboardAskArgs =
-          args;
+      get_dashboard_sources: () => {
+        (
+          globalThis as { __dashboardAskSourceReads?: number }
+        ).__dashboardAskSourceReads =
+          ((globalThis as { __dashboardAskSourceReads?: number })
+            .__dashboardAskSourceReads ?? 0) + 1;
+        return [{ kind: "note", id: "must-not-expand" }];
+      },
+      ask_vault_persisted: (args: Record<string, unknown>) => {
+        const target = globalThis as { __dashboardAskCalls?: unknown[] };
+        target.__dashboardAskCalls = [
+          ...(target.__dashboardAskCalls ?? []),
+          args,
+        ];
         return {
+          conversationId:
+            (args["conversationId"] as string | undefined) ?? "board-thread-1",
+          userMessageId: crypto.randomUUID(),
+          assistantMessageId: crypto.randomUUID(),
           answer: "Jun 14 is at risk — the migration still has a sprint left.",
           sources: [
             {
@@ -421,10 +491,6 @@ test("Dashboards: board Ask sends readable sources and the board id", async ({
           },
         ],
       },
-      get_dashboard_sources: [
-        { kind: "meeting", id: "m-1" },
-        { kind: "note", id: "n-1" },
-      ],
     },
   );
 
@@ -445,14 +511,107 @@ test("Dashboards: board Ask sends readable sources and the board id", async ({
   await submitAsk(page);
 
   await expect(page.getByText(/Jun 14 is at risk/)).toBeVisible();
-  const sent = (await page.evaluate(
-    () => (globalThis as { __dashboardAskArgs?: unknown }).__dashboardAskArgs,
-  )) as { dashboardId?: string; explicitSources?: unknown[] };
-  expect(sent.dashboardId).toBe("b-atlas");
-  expect(sent.explicitSources).toEqual([
-    { kind: "meeting", id: "m-1" },
-    { kind: "note", id: "n-1" },
-  ]);
+  await page
+    .getByRole("textbox", { name: "Ask a question about this board" })
+    .fill("What changed?");
+  await submitAsk(page);
+  const calls = (await page.evaluate(
+    () =>
+      (globalThis as { __dashboardAskCalls?: unknown[] }).__dashboardAskCalls,
+  )) as Array<{
+    dashboardId?: string;
+    conversationId?: string;
+    explicitSources?: unknown[];
+    history?: unknown[];
+  }>;
+  expect(calls).toHaveLength(2);
+  expect(calls[0].dashboardId).toBe("b-atlas");
+  expect(calls[0].conversationId).toBeUndefined();
+  expect(calls[1].dashboardId).toBe("b-atlas");
+  expect(calls[1].conversationId).toBe("board-thread-1");
+  expect(calls[0].explicitSources).toBeUndefined();
+  expect(calls[0].history).toBeUndefined();
+  expect(calls[1].history).toBeUndefined();
+  expect(
+    await page.evaluate(
+      () =>
+        (globalThis as { __dashboardAskSourceReads?: number })
+          .__dashboardAskSourceReads ?? 0,
+    ),
+  ).toBe(0);
+});
+
+test("Dashboards: a board mutation synchronously drops turns and starts a provenance-fresh Ask thread", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {
+      ask_vault_persisted: (args: Record<string, unknown>) => {
+        const target = globalThis as { __mutationAskCalls?: unknown[] };
+        target.__mutationAskCalls = [
+          ...(target.__mutationAskCalls ?? []),
+          args,
+        ];
+        const first = target.__mutationAskCalls.length === 1;
+        return {
+          conversationId: first ? "secret-old-thread" : "fresh-thread",
+          userMessageId: crypto.randomUUID(),
+          assistantMessageId: crypto.randomUUID(),
+          answer: first ? "OLD SECRET ANSWER" : "Fresh board answer",
+          sources: [],
+          citations: [],
+        };
+      },
+      reorder_dashboard_tiles: () => null,
+    },
+    {
+      list_dashboards: BOARDS,
+      get_dashboard: BOARD_DETAIL,
+      get_dashboard_sources: [],
+    },
+  );
+
+  await page.goto("/dashboards/b-atlas");
+  await openAsk(page);
+  await page
+    .getByRole("textbox", { name: "Ask a question about this board" })
+    .fill("OLD SECRET QUESTION");
+  await submitAsk(page);
+  await expect(
+    page.getByText("OLD SECRET ANSWER", { exact: true }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Compose", exact: true }).click();
+  await page
+    .getByRole("button", { name: /Move later/ })
+    .first()
+    .click();
+  await expect(
+    page.getByText("OLD SECRET QUESTION", { exact: true }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByText("OLD SECRET ANSWER", { exact: true }),
+  ).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Done", exact: true }).click();
+  await openAsk(page);
+  await page
+    .getByRole("textbox", { name: "Ask a question about this board" })
+    .fill("Question after mutation");
+  await submitAsk(page);
+  await expect(
+    page.getByText("Fresh board answer", { exact: true }),
+  ).toBeVisible();
+
+  const calls = (await page.evaluate(
+    () => (globalThis as { __mutationAskCalls?: unknown[] }).__mutationAskCalls,
+  )) as Array<Record<string, unknown>>;
+  expect(calls).toHaveLength(2);
+  expect(calls[0]["conversationId"]).toBeUndefined();
+  expect(calls[1]["conversationId"]).toBeUndefined();
+  expect(calls[1]["history"]).toBeUndefined();
+  expect(JSON.stringify(calls[1])).not.toContain("OLD SECRET");
 });
 
 test("Dashboards: an empty board invites the first tile instead of showing a dead grid", async ({
@@ -460,7 +619,13 @@ test("Dashboards: an empty board invites the first tile instead of showing a dea
 }) => {
   await mockTauri(
     page,
-    {},
+    {
+      ask_vault_persisted: () => ({
+        answer: "This board has no readable sources yet.",
+        sources: [],
+        citations: [],
+      }),
+    },
     {
       list_dashboards: BOARDS,
       get_dashboard: { ...BOARDS[1], tiles: [] },

--- a/e2e/dashboards/living-answer-refresh.spec.ts
+++ b/e2e/dashboards/living-answer-refresh.spec.ts
@@ -1,0 +1,315 @@
+import { expect, test } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+const BOARD = {
+  id: "b-living-answer",
+  title: "Atlas decisions",
+  emoji: "🧭",
+  tint: "indigo",
+  pinned: true,
+  position: 0,
+  createdAt: "2026-08-01T09:00:00Z",
+  updatedAt: "2026-08-13T09:00:00Z",
+  tileCount: 1,
+  tileKinds: [],
+};
+
+const QUESTION = "Are we ready to launch Atlas?";
+
+function livingAnswer(
+  answer: string | null,
+  answeredAt: string | null,
+  withheld = false,
+) {
+  return {
+    ...BOARD,
+    tiles: [
+      {
+        id: "t-living-answer",
+        dashboardId: BOARD.id,
+        kind: "living_answer",
+        refId: null,
+        title: null,
+        span: 5,
+        position: 0,
+        config: null,
+        createdAt: "2026-08-01T09:00:00Z",
+        data: {
+          kind: "livingAnswer",
+          question: QUESTION,
+          answer,
+          answeredAt,
+          withheld,
+        },
+      },
+    ],
+  };
+}
+
+test("Living Answer refresh sends identity and question only, then reloads the readable board", async ({
+  page,
+}) => {
+  const refreshedAnswer =
+    "Yes — the launch checklist is complete and the current board has no blockers.";
+  const initial = livingAnswer(null, null);
+  const refreshed = livingAnswer(refreshedAnswer, "2026-08-13T10:00:00Z");
+
+  await mockTauri(
+    page,
+    {
+      get_dashboard: () => {
+        const root = globalThis as {
+          __livingBoard: unknown;
+          __livingBoardReads?: number;
+        };
+        root.__livingBoardReads = (root.__livingBoardReads ?? 0) + 1;
+        return root.__livingBoard;
+      },
+      refresh_dashboard_answer: (args: unknown) => {
+        const root = globalThis as {
+          __livingRefreshArgs?: unknown;
+          __refreshedLivingBoard: {
+            tiles: Array<{ data: unknown }>;
+          };
+          __livingBoard: unknown;
+        };
+        root.__livingRefreshArgs = args;
+        root.__livingBoard = root.__refreshedLivingBoard;
+        return root.__refreshedLivingBoard.tiles[0].data;
+      },
+      set_dashboard_answer: () => {
+        const root = globalThis as { __legacyAnswerWrites?: number };
+        root.__legacyAnswerWrites = (root.__legacyAnswerWrites ?? 0) + 1;
+        return null;
+      },
+    },
+    {
+      list_dashboards: [BOARD],
+    },
+  );
+  await page.addInitScript(
+    ({ initialBoard, refreshedBoard }) => {
+      (globalThis as { __livingBoard: unknown }).__livingBoard = initialBoard;
+      (
+        globalThis as { __refreshedLivingBoard: unknown }
+      ).__refreshedLivingBoard = refreshedBoard;
+    },
+    { initialBoard: initial, refreshedBoard: refreshed },
+  );
+
+  await page.goto(`/dashboards/${BOARD.id}`);
+  await page.getByRole("button", { name: "Answer now" }).click();
+
+  await expect(page.getByText(refreshedAnswer, { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Re-answer" })).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (globalThis as { __livingBoardReads?: number }).__livingBoardReads ??
+          0,
+      ),
+    )
+    .toBe(2);
+
+  const payload = await page.evaluate(
+    () =>
+      (globalThis as { __livingRefreshArgs?: Record<string, unknown> })
+        .__livingRefreshArgs,
+  );
+  expect(Object.keys(payload ?? {}).sort()).toEqual([
+    "dashboardId",
+    "question",
+    "tileId",
+  ]);
+  expect(payload).toEqual({
+    dashboardId: BOARD.id,
+    tileId: "t-living-answer",
+    question: QUESTION,
+  });
+  expect(payload).not.toHaveProperty("answer");
+  expect(payload).not.toHaveProperty("answerSources");
+  expect(payload).not.toHaveProperty("provenance");
+  expect(
+    await page.evaluate(
+      () =>
+        (globalThis as { __legacyAnswerWrites?: number })
+          .__legacyAnswerWrites ?? 0,
+    ),
+  ).toBe(0);
+});
+
+test("Living Answer refresh cannot land after a board mutation", async ({
+  page,
+}) => {
+  const lateAnswer = "LATE MUTATION ANSWER MUST NOT LAND";
+  await mockTauri(
+    page,
+    {
+      refresh_dashboard_answer: () =>
+        new Promise((resolve) => {
+          (
+            globalThis as { __releaseMutationAnswer?: () => void }
+          ).__releaseMutationAnswer = () =>
+            resolve({
+              kind: "livingAnswer",
+              question: "Are we ready to launch Atlas?",
+              answer: "LATE MUTATION ANSWER MUST NOT LAND",
+              answeredAt: "2026-08-13T10:00:00Z",
+              withheld: false,
+            });
+        }),
+      delete_dashboard_tile: () => true,
+    },
+    {
+      list_dashboards: [BOARD],
+      get_dashboard: livingAnswer(
+        "The earlier answer.",
+        "2026-08-12T10:00:00Z",
+      ),
+    },
+  );
+
+  await page.goto(`/dashboards/${BOARD.id}`);
+  await page.getByRole("button", { name: "Re-answer" }).click();
+  await expect(page.getByRole("button", { name: "Refreshing…" })).toBeVisible();
+  await page.getByRole("button", { name: "Compose", exact: true }).click();
+  await page
+    .getByRole("button", { name: `Remove ${QUESTION} from board` })
+    .click();
+  await page.evaluate(() =>
+    (
+      globalThis as { __releaseMutationAnswer?: () => void }
+    ).__releaseMutationAnswer?.(),
+  );
+
+  await expect(page.locator("body")).not.toContainText(lateAnswer);
+  await expect(page.locator('[data-tile-id="t-living-answer"]')).toHaveCount(0);
+});
+
+test("Living Answer refresh never renders a backend-withheld payload", async ({
+  page,
+}) => {
+  const withheldSecret = "WITHHELD RESPONSE SENTINEL MUST NOT LAND";
+  await mockTauri(
+    page,
+    {
+      refresh_dashboard_answer: () => ({
+        kind: "livingAnswer",
+        question: "Are we ready to launch Atlas?",
+        answer: "WITHHELD RESPONSE SENTINEL MUST NOT LAND",
+        answeredAt: "2026-08-13T10:00:00Z",
+        withheld: true,
+      }),
+    },
+    {
+      list_dashboards: [BOARD],
+      get_dashboard: livingAnswer(
+        "The earlier answer remains readable.",
+        "2026-08-12T10:00:00Z",
+      ),
+    },
+  );
+
+  await page.goto(`/dashboards/${BOARD.id}`);
+  await page.getByRole("button", { name: "Re-answer" }).click();
+
+  await expect(
+    page.getByText("The earlier answer remains readable."),
+  ).toBeVisible();
+  await expect(page.locator("body")).not.toContainText(withheldSecret);
+  expect(
+    await page.evaluate(
+      (secret) => document.documentElement.outerHTML.includes(secret),
+      withheldSecret,
+    ),
+  ).toBe(false);
+});
+
+test("Living Answer refresh cannot cross a privacy invalidation or render a withheld response", async ({
+  page,
+}) => {
+  const withheldSecret = "WITHHELD NIGHTJAR ANSWER MUST NOT LAND";
+  const readable = livingAnswer(
+    "The earlier readable answer.",
+    "2026-08-12T10:00:00Z",
+  );
+  const locked = {
+    ...BOARD,
+    tiles: [
+      {
+        ...readable.tiles[0],
+        title: withheldSecret,
+        data: { kind: "locked" },
+      },
+    ],
+  };
+
+  await mockTauri(
+    page,
+    {
+      get_dashboard: () => {
+        const root = globalThis as {
+          __livingLocked?: boolean;
+          __readableLivingBoard: unknown;
+          __lockedLivingBoard: unknown;
+        };
+        return root.__livingLocked
+          ? root.__lockedLivingBoard
+          : root.__readableLivingBoard;
+      },
+      refresh_dashboard_answer: () =>
+        new Promise((resolve) => {
+          (
+            globalThis as { __releaseWithheldAnswer?: () => void }
+          ).__releaseWithheldAnswer = () =>
+            resolve({
+              kind: "livingAnswer",
+              question: "Are we ready to launch Atlas?",
+              answer: "WITHHELD NIGHTJAR ANSWER MUST NOT LAND",
+              answeredAt: "2026-08-13T10:00:00Z",
+              withheld: true,
+            });
+        }),
+    },
+    {
+      list_dashboards: [BOARD],
+    },
+  );
+  await page.addInitScript(
+    ({ readableBoard, lockedBoard }) => {
+      (globalThis as { __livingLocked?: boolean }).__livingLocked = false;
+      (globalThis as { __readableLivingBoard: unknown }).__readableLivingBoard =
+        readableBoard;
+      (globalThis as { __lockedLivingBoard: unknown }).__lockedLivingBoard =
+        lockedBoard;
+    },
+    { readableBoard: readable, lockedBoard: locked },
+  );
+
+  await page.goto(`/dashboards/${BOARD.id}`);
+  await page.getByRole("button", { name: "Re-answer" }).click();
+  await expect(page.getByRole("button", { name: "Refreshing…" })).toBeVisible();
+  await page.evaluate(() => {
+    const root = globalThis as {
+      __livingLocked?: boolean;
+      __demoEmit: (event: string, payload: unknown) => void;
+    };
+    root.__livingLocked = true;
+    root.__demoEmit("murmur://ask-history-invalidated", null);
+  });
+  await page.evaluate(() =>
+    (
+      globalThis as { __releaseWithheldAnswer?: () => void }
+    ).__releaseWithheldAnswer?.(),
+  );
+
+  await expect(page.getByText("1 sealed and excluded")).toBeVisible();
+  await expect(page.locator("body")).not.toContainText(withheldSecret);
+  expect(
+    await page.evaluate(
+      (secret) => document.documentElement.outerHTML.includes(secret),
+      withheldSecret,
+    ),
+  ).toBe(false);
+});

--- a/e2e/detail/meeting-chat-history.spec.ts
+++ b/e2e/detail/meeting-chat-history.spec.ts
@@ -112,8 +112,131 @@ test("a late meeting answer cannot append after canonical history invalidation",
 
   const current = page.locator("app-meeting-chat");
   await expect(current.locator(".chat-typing")).toHaveCount(0);
-  await expect(current.getByText("Held old question", { exact: true })).toHaveCount(0);
+  await expect(
+    current.getByText("Held old question", { exact: true }),
+  ).toHaveCount(0);
   await expect(
     current.getByText("STALE answer from the old meeting", { exact: true }),
   ).toHaveCount(0);
+});
+
+test("meeting history restores the live dashboard DTO and changing it starts a fresh anchored thread", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    list_ask_conversations: () => [
+      {
+        id: "saved-meeting-thread",
+        scope: { kind: "meeting", refId: "m-atlas-roadmap" },
+        title: "Saved meeting question",
+        createdAt: "2026-08-06T01:00:00Z",
+        updatedAt: "2026-08-06T01:01:00Z",
+        messageCount: 2,
+      },
+    ],
+    load_ask_conversation: () => ({
+      id: "saved-meeting-thread",
+      scope: { kind: "meeting", refId: "m-atlas-roadmap" },
+      title: "Saved meeting question",
+      selectedSources: [
+        {
+          kind: "meeting",
+          id: "m-atlas-roadmap",
+          title: "Q2 Roadmap Planning",
+        },
+        { kind: "note", id: "n-saved", title: "Saved meeting source" },
+      ],
+      dashboard: {
+        id: "dashboard-meeting-history",
+        title: "Live meeting dashboard title",
+        emoji: "📅",
+      },
+      messages: [
+        {
+          id: "00000000-0000-4000-8000-000000000501",
+          ordinal: 0,
+          role: "user",
+          content: "Saved meeting question",
+          sources: [],
+          citations: [],
+          createdAt: "2026-08-06T01:00:00Z",
+        },
+        {
+          id: "00000000-0000-4000-8000-000000000502",
+          ordinal: 1,
+          role: "assistant",
+          content: "Saved meeting answer",
+          sources: [],
+          citations: [],
+          createdAt: "2026-08-06T01:01:00Z",
+        },
+      ],
+      createdAt: "2026-08-06T01:00:00Z",
+      updatedAt: "2026-08-06T01:01:00Z",
+    }),
+    chat_meeting_persisted: (args: unknown) => {
+      (
+        window as unknown as { __freshMeetingArgs?: unknown }
+      ).__freshMeetingArgs = args;
+      return {
+        conversationId: "fresh-meeting-thread",
+        userMessageId: crypto.randomUUID(),
+        assistantMessageId: crypto.randomUUID(),
+        answer: "Fresh meeting answer",
+        sources: [],
+        citations: [],
+      };
+    },
+  });
+
+  await page.goto("/meeting/m-atlas-roadmap");
+  await page.getByRole("button", { name: /Ask/ }).click();
+  const chat = page.locator("app-meeting-chat");
+  await chat.getByRole("button", { name: "Conversation history" }).click();
+  await chat.locator(".history-row").click();
+  await expect(
+    chat.locator('[data-testid="selected-dashboard-chip"]'),
+  ).toContainText("Live meeting dashboard title");
+
+  await chat
+    .getByRole("button", {
+      name: "Remove dashboard Live meeting dashboard title",
+    })
+    .click();
+  await expect(chat.locator(".chat-row")).toHaveCount(0);
+  await expect(
+    chat.locator('[data-testid="selected-dashboard-chip"]'),
+  ).toHaveCount(0);
+  await expect(chat.locator(".sp-chip-title")).toHaveText([
+    "Q2 Roadmap Planning",
+    "Saved meeting source",
+  ]);
+
+  await chat.locator(".chat-input").fill("Fresh after dashboard removal");
+  await chat.locator(".chat-input").press("Enter");
+  await expect(
+    chat.getByText("Fresh meeting answer", { exact: true }),
+  ).toBeVisible();
+  const args = await page.evaluate(
+    () =>
+      (
+        window as unknown as {
+          __freshMeetingArgs?: {
+            conversationId?: string;
+            meetingId?: string;
+            dashboardId?: string;
+            explicitSources?: Array<{ kind: string; id: string }>;
+          };
+        }
+      ).__freshMeetingArgs,
+  );
+  expect(args?.conversationId).toBeUndefined();
+  expect(args?.meetingId).toBe("m-atlas-roadmap");
+  expect(args?.dashboardId).toBeUndefined();
+  expect(
+    (args?.explicitSources ?? []).map(({ kind, id }) => ({ kind, id })),
+  ).toEqual([
+    { kind: "meeting", id: "m-atlas-roadmap" },
+    { kind: "note", id: "n-saved" },
+  ]);
 });

--- a/e2e/detail/meeting-chat-source-scope.spec.ts
+++ b/e2e/detail/meeting-chat-source-scope.spec.ts
@@ -10,7 +10,7 @@ import { mockTauri } from "../settings-ai/mock-invoke";
  * default scope is `[{meeting m-atlas-roadmap "Q2 Roadmap Planning"}, {note nX}]`;
  * `chat_meeting` records the `explicitSources` it saw on `window`.
  */
-test("meeting chat pre-fills this meeting + its links and sends chat_meeting with explicitSources", async ({
+test("meeting chat keeps its meeting anchor, adds one dashboard scope, and sends dashboardId without expansion", async ({
   page,
 }) => {
   const consoleErrors: string[] = [];
@@ -41,9 +41,27 @@ test("meeting chat pre-fills this meeting + its links and sends chat_meeting wit
       }
       return [];
     },
-    chat_meeting_persisted: (args: { explicitSources?: unknown }) => {
-      (window as unknown as { __chatSources?: unknown }).__chatSources =
-        args.explicitSources ?? null;
+    list_dashboards: () => [
+      {
+        id: "dashboard-meeting",
+        title: "Meeting board live title",
+        emoji: "📅",
+        tileCount: 2,
+        createdAt: "2026-08-06T01:00:00Z",
+        updatedAt: "2026-08-06T01:00:00Z",
+      },
+    ],
+    get_dashboard_sources: () => {
+      (
+        window as unknown as { __meetingDashboardExpanded?: boolean }
+      ).__meetingDashboardExpanded = true;
+      return [{ kind: "meeting", id: "must-not-expand" }];
+    },
+    chat_meeting_persisted: (args: {
+      explicitSources?: unknown;
+      dashboardId?: string;
+    }) => {
+      (window as unknown as { __chatArgs?: unknown }).__chatArgs = args;
       return {
         conversationId: "meeting-conversation-1",
         userMessageId: crypto.randomUUID(),
@@ -86,6 +104,17 @@ test("meeting chat pre-fills this meeting + its links and sends chat_meeting wit
     "Companion note",
   ]);
 
+  await chat.locator("mur-source-picker .sp-trigger").click();
+  await page
+    .getByRole("option", { name: "Use dashboard Meeting board live title" })
+    .click();
+  await expect(
+    chat.locator('[data-testid="selected-dashboard-chip"]'),
+  ).toHaveCount(1);
+  await expect(
+    chat.locator('[data-testid="selected-dashboard-chip"]'),
+  ).toContainText("Meeting board live title");
+
   // Ask a question — Enter sends.
   const input = chat.locator(".chat-input");
   await input.fill("What did we decide?");
@@ -95,16 +124,25 @@ test("meeting chat pre-fills this meeting + its links and sends chat_meeting wit
   ).toContainText("Grounded meeting answer.");
 
   // chat_meeting carried the pinned scope: the meeting + its active link.
-  const sent = await page.evaluate(
-    () =>
-      (window as unknown as { __chatSources?: { kind: string; id: string }[] })
-        .__chatSources,
-  );
-  expect(sent).toBeTruthy();
-  expect((sent ?? []).map((s) => `${s.kind}:${s.id}`)).toEqual([
-    "meeting:m-atlas-roadmap",
-    "note:nX",
-  ]);
+  const sent = await page.evaluate(() => {
+    const target = window as unknown as {
+      __chatArgs?: {
+        explicitSources?: { kind: string; id: string }[];
+        dashboardId?: string;
+      };
+      __meetingDashboardExpanded?: boolean;
+    };
+    return {
+      args: target.__chatArgs,
+      expanded: target.__meetingDashboardExpanded,
+    };
+  });
+  expect(sent.args).toBeTruthy();
+  expect(
+    (sent.args?.explicitSources ?? []).map((s) => `${s.kind}:${s.id}`),
+  ).toEqual(["meeting:m-atlas-roadmap", "note:nX"]);
+  expect(sent.args?.dashboardId).toBe("dashboard-meeting");
+  expect(sent.expanded).not.toBe(true);
 
   expect(consoleErrors).toEqual([]);
 });

--- a/e2e/notes/note-chat-history.spec.ts
+++ b/e2e/notes/note-chat-history.spec.ts
@@ -88,6 +88,11 @@ test("a late default-source prefill cannot overwrite sources restored from histo
       selectedSources: [
         { kind: "note", id: "n-saved", title: "Saved source scope" },
       ],
+      dashboard: {
+        id: "dashboard-note-history",
+        title: "Live note dashboard title",
+        emoji: "📝",
+      },
       messages: [
         {
           id: "00000000-0000-4000-8000-000000000401",
@@ -111,15 +116,65 @@ test("a late default-source prefill cannot overwrite sources restored from histo
       createdAt: "2026-08-06T01:00:00Z",
       updatedAt: "2026-08-06T01:01:00Z",
     }),
+    ask_vault_persisted: (args: unknown) => {
+      (window as unknown as { __freshNoteArgs?: unknown }).__freshNoteArgs =
+        args;
+      return {
+        conversationId: "fresh-note-thread",
+        userMessageId: crypto.randomUUID(),
+        assistantMessageId: crypto.randomUUID(),
+        answer: "Fresh note answer",
+        sources: [],
+        citations: [],
+      };
+    },
   });
   await page.goto("/notes/n1");
   await page.locator(".head-chat-btn").click();
   const drawer = page.locator(".note-chat-drawer");
   await drawer.getByRole("button", { name: "Conversation history" }).click();
   await drawer.locator(".history-row").click();
-  await expect(drawer.locator(".sp-chip-title")).toHaveText([
-    "Saved source scope",
-  ]);
+  const manualChips = drawer.locator(
+    ".sp-chip:not(.sp-dashboard-chip) .sp-chip-title",
+  );
+  await expect(manualChips).toHaveText(["Saved source scope"]);
+  await expect(
+    drawer.locator('[data-testid="selected-dashboard-chip"]'),
+  ).toContainText("Live note dashboard title");
+
+  await drawer
+    .getByRole("button", { name: "Remove dashboard Live note dashboard title" })
+    .click();
+  await expect(drawer.locator(".chat-row")).toHaveCount(0);
+  await expect(
+    drawer.locator('[data-testid="selected-dashboard-chip"]'),
+  ).toHaveCount(0);
+  await expect(manualChips).toHaveText(["Saved source scope"]);
+
+  await drawer
+    .locator(".chat-input")
+    .fill("Fresh thread after dashboard removal");
+  await drawer.locator(".chat-input").press("Enter");
+  await expect(
+    drawer.getByText("Fresh note answer", { exact: true }),
+  ).toBeVisible();
+  const freshArgs = await page.evaluate(
+    () =>
+      (
+        window as unknown as {
+          __freshNoteArgs?: {
+            conversationId?: string;
+            dashboardId?: string;
+            explicitSources?: Array<{ kind: string; id: string }>;
+          };
+        }
+      ).__freshNoteArgs,
+  );
+  expect(freshArgs?.conversationId).toBeUndefined();
+  expect(freshArgs?.dashboardId).toBeUndefined();
+  expect(
+    (freshArgs?.explicitSources ?? []).map(({ kind, id }) => ({ kind, id })),
+  ).toEqual([{ kind: "note", id: "n-saved" }]);
 
   await page.evaluate(() => {
     (
@@ -166,7 +221,9 @@ test("a long authored-note history remains vertically reachable in the narrow dr
   await expect
     .poll(() => list.evaluate((element) => element.scrollTop))
     .toBeGreaterThan(0);
-  await expect(drawer.getByText("Conversation 60", { exact: true })).toBeVisible();
+  await expect(
+    drawer.getByText("Conversation 60", { exact: true }),
+  ).toBeVisible();
 });
 
 test("authored-note source titles wait for the privacy-listener barrier", async ({

--- a/e2e/notes/note-chat-source-scope.spec.ts
+++ b/e2e/notes/note-chat-source-scope.spec.ts
@@ -17,7 +17,7 @@ import { mockNotes } from "./mock-invoke";
  * scope is `[{note n1}, {meeting m9}]`; `ask_vault` records the `explicitSources`
  * it was called with on `window` so the test can assert the exact wire shape.
  */
-test("Ask-about-this-note opens in the drawer, pre-fills note + its links, and sends ask_vault with explicitSources", async ({
+test("note chat keeps its note anchor, adds one dashboard scope, and sends dashboardId without expanding it", async ({
   page,
 }) => {
   const consoleErrors: string[] = [];
@@ -63,9 +63,31 @@ test("Ask-about-this-note opens in the drawer, pre-fills note + its links, and s
       }
       return [];
     },
-    ask_vault_persisted: (args: { explicitSources?: unknown }) => {
-      (window as unknown as { __askVaultSources?: unknown }).__askVaultSources =
-        args.explicitSources ?? null;
+    list_dashboards: () => [
+      {
+        id: "dashboard-note",
+        title: "Note board live title",
+        emoji: "📝",
+        tileCount: 2,
+        createdAt: "2026-08-06T01:00:00Z",
+        updatedAt: "2026-08-06T01:00:00Z",
+      },
+    ],
+    get_dashboard_sources: () => {
+      (
+        window as unknown as { __noteDashboardExpanded?: boolean }
+      ).__noteDashboardExpanded = true;
+      return [{ kind: "note", id: "must-not-expand" }];
+    },
+    ask_vault_persisted: (args: {
+      explicitSources?: unknown;
+      dashboardId?: string;
+    }) => {
+      (
+        window as unknown as {
+          __askVaultArgs?: unknown;
+        }
+      ).__askVaultArgs = args;
       return {
         conversationId: "note-conversation-1",
         userMessageId: crypto.randomUUID(),
@@ -93,6 +115,17 @@ test("Ask-about-this-note opens in the drawer, pre-fills note + its links, and s
   const chips = chat.locator(".sp-chip-title");
   await expect(chips).toHaveText(["My First Note", "Planning sync"]);
 
+  await chat.locator("mur-source-picker .sp-trigger").click();
+  await page
+    .getByRole("option", { name: "Use dashboard Note board live title" })
+    .click();
+  await expect(
+    chat.locator('[data-testid="selected-dashboard-chip"]'),
+  ).toHaveCount(1);
+  await expect(
+    chat.locator('[data-testid="selected-dashboard-chip"]'),
+  ).toContainText("Note board live title");
+
   // Ask a question — Enter sends via the composer.
   const input = chat.locator(".chat-input");
   await input.fill("Summarize this note");
@@ -103,14 +136,26 @@ test("Ask-about-this-note opens in the drawer, pre-fills note + its links, and s
 
   // ask_vault carried the pinned scope: exactly the note + its active link,
   // each as `{kind, id}` (title is display-only; the backend ignores it).
-  const sent = await page.evaluate(
-    () =>
-      (window as unknown as { __askVaultSources?: { kind: string; id: string }[] })
-        .__askVaultSources,
+  const sent = await page.evaluate(() => {
+    const target = window as unknown as {
+      __askVaultArgs?: {
+        explicitSources?: { kind: string; id: string }[];
+        dashboardId?: string;
+      };
+      __noteDashboardExpanded?: boolean;
+    };
+    return {
+      args: target.__askVaultArgs,
+      expanded: target.__noteDashboardExpanded,
+    };
+  });
+  expect(sent.args).toBeTruthy();
+  const pairs = (sent.args?.explicitSources ?? []).map(
+    (s) => `${s.kind}:${s.id}`,
   );
-  expect(sent).toBeTruthy();
-  const pairs = (sent ?? []).map((s) => `${s.kind}:${s.id}`);
   expect(pairs).toEqual(["note:n1", "meeting:m9"]);
+  expect(sent.args?.dashboardId).toBe("dashboard-note");
+  expect(sent.expanded).not.toBe(true);
 
   expect(consoleErrors).toEqual([]);
 });

--- a/e2e/notes/notes-org.spec.ts
+++ b/e2e/notes/notes-org.spec.ts
@@ -85,7 +85,9 @@ test("All notes merges org shared items (with org-name badge) + the chip row lis
   // 2) "All notes" shows YOUR authored note AND the org shared item, merged,
   // as table rows.
   await expect(page.getByText("My First Note")).toBeVisible();
-  const orgRow = page.locator(".mur-table tbody tr", { hasText: "Team Roadmap Q3" });
+  const orgRow = page.locator(".mur-table tbody tr", {
+    hasText: "Team Roadmap Q3",
+  });
   await expect(orgRow).toHaveCount(1);
   // The org row carries the ORG-NAME badge + the author hint.
   await expect(orgRow.locator(".org-badge")).toContainText("Siema");
@@ -182,6 +184,70 @@ test("clicking an org shared item routes to the read-only /org-item viewer", asy
   expect(consoleErrors).toEqual([]);
 });
 
+test("org-item Ask never offers unsupported composite dashboard scope", async ({
+  page,
+}) => {
+  await mockNotes(page, {
+    ...ORG_MOCKS,
+    list_dashboards: () => [
+      {
+        id: "unsupported-org-dashboard",
+        title: "Must not be offered to org Ask",
+        emoji: "🚫",
+        tileCount: 1,
+        createdAt: "2026-08-06T01:00:00Z",
+        updatedAt: "2026-08-06T01:00:00Z",
+      },
+    ],
+  });
+  await page.goto("/org-item/oi1");
+  await page.evaluate(() => {
+    const target = window as unknown as {
+      __orgAskArgs?: unknown;
+      __TAURI_INTERNALS__: {
+        invoke: (
+          command: string,
+          args?: Record<string, unknown>,
+        ) => Promise<unknown>;
+      };
+    };
+    const original = target.__TAURI_INTERNALS__.invoke.bind(
+      target.__TAURI_INTERNALS__,
+    );
+    target.__TAURI_INTERNALS__.invoke = (command, args) => {
+      if (command === "ask_vault") target.__orgAskArgs = args;
+      return original(command, args);
+    };
+  });
+  await page.getByRole("button", { name: "Ask Brain" }).click();
+  const chat = page.locator("app-note-chat");
+  await chat.getByRole("button", { name: "Sources" }).click();
+  await expect(
+    page.getByRole("option", {
+      name: "Use dashboard Must not be offered to org Ask",
+    }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByText("Must not be offered to org Ask", { exact: true }),
+  ).toHaveCount(0);
+  await page.evaluate(() => {
+    const scrim = document.querySelector<HTMLElement>(".sp-scrim");
+    scrim?.click();
+  });
+  await expect(page.locator(".sp-pop")).toHaveCount(0);
+  await chat.locator(".chat-input").fill("Ask only about this org item");
+  await chat.locator(".chat-input").press("Enter");
+  await expect(chat.locator(".chat-row.is-assistant")).toHaveCount(1);
+
+  const args = await page.evaluate(
+    () =>
+      (window as unknown as { __orgAskArgs?: Record<string, unknown> })
+        .__orgAskArgs,
+  );
+  expect(args?.["pinnedOrgItemId"]).toBe("oi1");
+  expect(args).not.toHaveProperty("dashboardId");
+});
+
 test("selecting the org chip shows ONLY that org's items", async ({ page }) => {
   const consoleErrors: string[] = [];
   page.on("console", (msg) => {
@@ -243,7 +309,9 @@ test("a long org name truncates with an ellipsis, not a hard clip (matches .titl
   await page.goto("/notes");
   await expect(page.locator(".notes-content")).toBeVisible();
 
-  const orgRow = page.locator(".mur-table tbody tr", { hasText: "Team Roadmap Q3" });
+  const orgRow = page.locator(".mur-table tbody tr", {
+    hasText: "Team Roadmap Q3",
+  });
   const badge = orgRow.locator(".org-badge");
   await expect(badge).toBeVisible();
 

--- a/src-tauri/src/commands/ask.rs
+++ b/src-tauri/src/commands/ask.rs
@@ -273,6 +273,16 @@ pub(crate) fn capped_ask_history(history: &[ChatTurn]) -> &[ChatTurn] {
     &history[start..]
 }
 
+pub(crate) fn remove_duplicate_dashboard_question(history: &mut Vec<ChatTurn>, question: &str) {
+    if history
+        .last()
+        .map(|turn| turn.role == "user" && turn.content.trim() == question.trim())
+        == Some(true)
+    {
+        history.pop();
+    }
+}
+
 /// Run the vault-scoped agentic attempt for [`ask_vault`]. Returns `Some(result)` ONLY when the
 /// loop CONVERGED; `None` on non-convergence or ordinary loop errors — incl. `Unavailable` (no cloud
 /// consent) — so the caller floors to the pre-agentic path with its original semantics. A
@@ -282,19 +292,16 @@ pub(crate) fn ask_vault_agentic_attempt(
     question: &str,
     history: &[ChatTurn],
     thread_id: &str,
+    config: AppConfig,
     dispatch_admission: crate::state::ContentDispatchAdmission,
     durable_history: bool,
 ) -> Result<Option<AskVaultResult>, AppError> {
     let state = app.state::<AppState>();
-    let config = match state.config.lock() {
-        Ok(c) => c.clone(),
-        Err(_) => return Ok(None), // poisoned config ⇒ floor (which will surface its own error)
-    };
     // Re-resolved per turn (never a startup snapshot): consent/provider/backend changes apply.
     // ASK role — under the legacy fallback this dispatches exactly like the pre-role `current()`.
     let reasoner = state
         .reasoner
-        .current_for(crate::summarize::roles::Role::Ask);
+        .current_for_config(crate::summarize::roles::Role::Ask, &config);
     // VAULT-SCOPED executor: no live meeting, READ-ONLY, and NO note drafts (the Ask page has no
     // notes flow / Accept affordance, so `propose_note` is not advertised on this surface). The
     // AppHandle is present so web_search / calendar_lookup participate under their existing
@@ -510,15 +517,6 @@ pub(crate) fn build_ask_vault_floor_prompt(
     reranker: Option<&dyn crate::rerank::Reranker>,
     explicit_sources: Option<&[crate::storage::models::SourceRef]>,
     pinned_org_item_id: Option<&str>,
-    // The asking board's DERIVED tiles, already gated and rendered by
-    // `commands::dashboards::dashboard_brief_for_ask`.
-    //
-    // `None` for every non-board caller, which keeps their packed prompt
-    // byte-identical. `Some("")` is a REAL state and is NOT the same thing: a board
-    // whose tiles are all sealed or hidden has nothing to say, but it still SCOPES
-    // the ask. Inferring scope from emptiness let such a board fall through to the
-    // vault-wide search below and answer from content the user never composed.
-    board_brief: Option<&str>,
 ) -> Result<AskFloorPrompt, AppError> {
     // Budget on the ASK-role provider's RESOLVED connection — the corpus egresses to it. With
     // role keys absent this is the legacy `provider_id` for EVERY brain_backend (the pre-role
@@ -532,35 +530,13 @@ pub(crate) fn build_ask_vault_floor_prompt(
     // every search leg (a sealed source/neighbour contributes nothing). `None` ⇒ the exact existing
     // whole-vault search below, byte-for-byte.
     let has_pinned_sources = explicit_sources.map(|s| !s.is_empty()).unwrap_or(false);
-    // A BOARD scopes the ask on its own — presence of the board, not presence of text.
-    // A derived-only board yields no `SourceRef`s, and an all-sealed board yields no
-    // brief either; both must still skip the vault-wide search, because the user
-    // composed the universe the question may be answered from.
-    let has_board_scope = board_brief.is_some();
-    // ONE value keys BOTH the budget reservation below and the join further down.
-    // Keeping them on different values (raw for the subtraction, trimmed for the join)
-    // let a whitespace-only brief shrink the corpus budget while contributing no text.
-    // `dashboard_brief_inner` never returns whitespace-only today, so this is defensive,
-    // not a live defect — collapsing it here is what keeps it that way.
-    let board_brief = board_brief.unwrap_or("");
-    let board_brief = if board_brief.trim().is_empty() {
-        ""
-    } else {
-        board_brief
-    };
-    let (corpus, sources) = if has_pinned_sources || pinned_org_item_id.is_some() || has_board_scope
-    {
+    let (corpus, sources) = if has_pinned_sources || pinned_org_item_id.is_some() {
         // PINNED corpus (deterministic; vault-wide search SKIPPED). Pack the pinned ORG item FIRST
         // (the shared note being viewed — pinned so it's ALWAYS in context; the local Brain's search
         // never surfaces org-feed content), then the explicit sources (+ their gated link-expansion).
         // In current callers the two are mutually exclusive — the org viewer sends only the org id,
         // the note editor sends only explicit sources — so no double-budget concern arises.
-        // Reserve the brief's room BEFORE packing the sources, not after. Prepending it
-        // to an already-full corpus let the packed prompt exceed the resolved ASK-role
-        // budget by the brief's length — up to 25% on a small provider budget. One
-        // budget, shared, with the board's own views taking their documented slice.
-        let budget = crate::summarize::vault_context::budget_for(&ask_conn)
-            .saturating_sub(board_brief.chars().count());
+        let budget = crate::summarize::vault_context::budget_for(&ask_conn);
         let mut corpus = String::new();
         if let Some(org_id) = pinned_org_item_id {
             corpus.push_str(&crate::summarize::vault_context::pack_pinned_org_item(
@@ -569,8 +545,8 @@ pub(crate) fn build_ask_vault_floor_prompt(
         }
         let sources = if let Some(srcs) = explicit_sources.filter(|s| !s.is_empty()) {
             let (src_corpus, src_sources) =
-                crate::summarize::vault_context::build_vault_context_pinned_visible(
-                    db, srcs, &ask_conn, unlocked,
+                crate::summarize::vault_context::build_vault_context_pinned_visible_with_budget(
+                    db, srcs, budget, unlocked,
                 )?;
             if !corpus.is_empty() && !src_corpus.is_empty() {
                 corpus.push_str("\n\n");
@@ -604,39 +580,10 @@ pub(crate) fn build_ask_vault_floor_prompt(
             db, question, &ask_conn, unlocked,
         )?
     };
-    // The board's own views go FIRST — they are what the user is looking at while
-    // typing, and the header tells the model not to re-derive them.
-    //
-    // NO truncation here. The brief arrives already bounded by
-    // `dashboards::brief_allowance`, which cuts between WHOLE rendered tiles. A second
-    // cut at this layer was a real defect: each rendered tile is one possibly-multiline
-    // string, so re-truncating by `.lines()` split inside a tile and could keep a
-    // heading while dropping the rows under it.
-    // `is_empty`, not `trim().is_empty()` — whitespace-only was already collapsed to ""
-    // above, so this reads the SAME value the budget reservation was keyed on.
-    let corpus = if board_brief.is_empty() {
-        corpus
-    } else if corpus.is_empty() {
-        board_brief.to_string()
-    } else {
-        format!("{board_brief}\n\n{corpus}")
-    };
     if corpus.trim().is_empty() {
-        // A BOARD-scoped ask that packs nothing is not an empty vault — it is a board
-        // whose tiles the session cannot read. Telling that user to "record and
-        // summarize a meeting first" sends them to fix the wrong thing entirely, and
-        // this change is what makes the state reachable, so it is this change's to get
-        // right. The message names the situation WITHOUT naming what is in the board:
-        // an all-sealed and a genuinely-empty board produce the same words, so the
-        // text discloses nothing the gate withholds.
-        let answer = if has_board_scope {
-            "Nothing on this board is readable right now — unlock its folders, or add \
-             tiles with content you can see."
-        } else {
-            "No meeting notes to search yet — record and summarize a meeting first."
-        };
         return Ok(AskFloorPrompt::Empty(AskVaultResult {
-            answer: answer.to_string(),
+            answer: "No meeting notes to search yet — record and summarize a meeting first."
+                .to_string(),
             sources: Vec::new(),
             citations: Vec::new(),
         }));

--- a/src-tauri/src/commands/ask_history.rs
+++ b/src-tauri/src/commands/ask_history.rs
@@ -1,13 +1,10 @@
-//! Durable Ask Brain conversation commands for the three v1 scopes.
-//!
-//! Org/dashboard/record-time assistant callers keep using their existing stateless commands and
-//! `assistant_interactions`; this module is the only durable conversation seam.
+//! Durable Ask Brain conversation commands for vault, note, and meeting anchors. An optional
+//! dashboard ID composes current board material/derived views into any of those scopes while the
+//! backend remains the sole authority for history and immutable first-turn provenance.
 
 use super::*;
-use crate::storage::models::{
-    AskConversation, AskConversationScope, AskConversationSendResult, AskConversationSummary,
-    SourceRef,
-};
+use crate::storage::models::{AskConversationScope, AskConversationSendResult, SourceRef};
+use tauri::ipc::Response;
 
 #[derive(Debug, Clone)]
 pub(crate) enum DurableScopeSnapshot {
@@ -74,6 +71,53 @@ pub(crate) fn capture_durable_scope_under_lifecycle(
     }
 }
 
+#[cfg(test)]
+pub(crate) fn serialize_durable_send_response_with_dispatch(
+    state: &AppState,
+    snapshot: &DurableScopeSnapshot,
+    ask_dispatch: &AskDispatchSnapshot,
+    dashboard: Option<&crate::commands::dashboards::DashboardContextWitness>,
+    payload: &AskConversationSendResult,
+) -> Result<Response, AppError> {
+    let _lifecycle = lifecycle_guard(state);
+    require_durable_scope_under_lifecycle(state, snapshot)?;
+    require_current_ask_dispatch_under_lifecycle(state, ask_dispatch)?;
+    if let Some(witness) = dashboard {
+        let unlocked = unlocked_snapshot(state)?;
+        crate::commands::dashboards::require_current_dashboard_context_witness_under_lifecycle(
+            state, witness, &unlocked,
+        )?;
+    }
+    serde_json::to_string(payload)
+        .map(Response::new)
+        .map_err(|_| AppError::Unavailable("conversation response encoding failed".into()))
+}
+
+#[cfg(test)]
+pub(crate) fn serialize_durable_send_response(
+    state: &AppState,
+    snapshot: &DurableScopeSnapshot,
+    dashboard: Option<&crate::commands::dashboards::DashboardContextWitness>,
+    payload: &AskConversationSendResult,
+) -> Result<Response, AppError> {
+    let ask_dispatch = {
+        let _lifecycle = lifecycle_guard(state);
+        let config = state
+            .config
+            .lock()
+            .map_err(|_| AppError::Config("config mutex poisoned".into()))?
+            .clone();
+        capture_ask_dispatch_snapshot_under_lifecycle(state, &config)?
+    };
+    serialize_durable_send_response_with_dispatch(
+        state,
+        snapshot,
+        &ask_dispatch,
+        dashboard,
+        payload,
+    )
+}
+
 pub(crate) fn require_durable_scope_under_lifecycle(
     state: &AppState,
     snapshot: &DurableScopeSnapshot,
@@ -92,23 +136,97 @@ pub(crate) fn require_durable_scope_under_lifecycle(
     }
 }
 
+pub(crate) fn require_durable_scope_for_dispatch_with_ask(
+    state: &AppState,
+    snapshot: &DurableScopeSnapshot,
+    ask_dispatch: &AskDispatchSnapshot,
+    dashboard: Option<&crate::commands::dashboards::DashboardContextWitness>,
+) -> Result<(), AppError> {
+    let _lifecycle = lifecycle_guard(state);
+    require_durable_scope_under_lifecycle(state, snapshot)?;
+    require_current_ask_dispatch_under_lifecycle(state, ask_dispatch)?;
+    if let Some(witness) = dashboard {
+        let unlocked = unlocked_snapshot(state)?;
+        crate::commands::dashboards::require_current_dashboard_context_witness_under_lifecycle(
+            state, witness, &unlocked,
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
 pub(crate) fn require_durable_scope_for_dispatch(
     state: &AppState,
     snapshot: &DurableScopeSnapshot,
+    dashboard: Option<&crate::commands::dashboards::DashboardContextWitness>,
 ) -> Result<(), AppError> {
-    let _lifecycle = lifecycle_guard(state);
-    require_durable_scope_under_lifecycle(state, snapshot)
+    let ask_dispatch = {
+        let _lifecycle = lifecycle_guard(state);
+        let config = state
+            .config
+            .lock()
+            .map_err(|_| AppError::Config("config mutex poisoned".into()))?
+            .clone();
+        capture_ask_dispatch_snapshot_under_lifecycle(state, &config)?
+    };
+    require_durable_scope_for_dispatch_with_ask(state, snapshot, &ask_dispatch, dashboard)
 }
 
 pub(crate) fn durable_dispatch_admission(
     app: &AppHandle,
     snapshot: DurableScopeSnapshot,
+    ask_dispatch: AskDispatchSnapshot,
+    dashboard: Option<crate::commands::dashboards::DashboardContextWitness>,
 ) -> crate::state::ContentDispatchAdmission {
     crate::state::ContentDispatchAdmission::new(app, move |state| {
-        require_durable_scope_under_lifecycle(state, &snapshot)
+        require_durable_scope_under_lifecycle(state, &snapshot)?;
+        require_current_ask_dispatch_under_lifecycle(state, &ask_dispatch)?;
+        if let Some(witness) = dashboard.as_ref() {
+            let unlocked = unlocked_snapshot(state)?;
+            crate::commands::dashboards::require_current_dashboard_context_witness_under_lifecycle(
+                state, witness, &unlocked,
+            )?;
+        }
+        Ok(())
     })
 }
 
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn persist_ask_exchange_after_await_with_dispatch(
+    state: &AppState,
+    snapshot: &DurableScopeSnapshot,
+    ask_dispatch: &AskDispatchSnapshot,
+    scope: &AskConversationScope,
+    conversation_id: Option<&str>,
+    resume_cursor: Option<crate::storage::ask_conversation_store::AskConversationCursor>,
+    question: &str,
+    answer: &str,
+    selected_sources: &[SourceRef],
+    assistant_sources: &[crate::storage::models::VaultSource],
+    assistant_citations: &[String],
+    dependency_folders: &[String],
+    dashboard: Option<&crate::commands::dashboards::DashboardContextWitness>,
+) -> Result<crate::storage::ask_conversation_store::PersistedAskExchange, AppError> {
+    let _lifecycle = lifecycle_guard(state);
+    persist_ask_exchange_under_lifecycle(
+        state,
+        snapshot,
+        ask_dispatch,
+        scope,
+        conversation_id,
+        resume_cursor,
+        question,
+        answer,
+        selected_sources,
+        assistant_sources,
+        assistant_citations,
+        dependency_folders,
+        dashboard,
+    )
+}
+
+#[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn persist_ask_exchange_after_await(
     state: &AppState,
@@ -122,9 +240,58 @@ pub(crate) fn persist_ask_exchange_after_await(
     assistant_sources: &[crate::storage::models::VaultSource],
     assistant_citations: &[String],
     dependency_folders: &[String],
+    dashboard: Option<&crate::commands::dashboards::DashboardContextWitness>,
 ) -> Result<crate::storage::ask_conversation_store::PersistedAskExchange, AppError> {
-    let _lifecycle = lifecycle_guard(state);
+    let ask_dispatch = {
+        let _lifecycle = lifecycle_guard(state);
+        let config = state
+            .config
+            .lock()
+            .map_err(|_| AppError::Config("config mutex poisoned".into()))?
+            .clone();
+        capture_ask_dispatch_snapshot_under_lifecycle(state, &config)?
+    };
+    persist_ask_exchange_after_await_with_dispatch(
+        state,
+        snapshot,
+        &ask_dispatch,
+        scope,
+        conversation_id,
+        resume_cursor,
+        question,
+        answer,
+        selected_sources,
+        assistant_sources,
+        assistant_citations,
+        dependency_folders,
+        dashboard,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn persist_ask_exchange_under_lifecycle(
+    state: &AppState,
+    snapshot: &DurableScopeSnapshot,
+    ask_dispatch: &AskDispatchSnapshot,
+    scope: &AskConversationScope,
+    conversation_id: Option<&str>,
+    resume_cursor: Option<crate::storage::ask_conversation_store::AskConversationCursor>,
+    question: &str,
+    answer: &str,
+    selected_sources: &[SourceRef],
+    assistant_sources: &[crate::storage::models::VaultSource],
+    assistant_citations: &[String],
+    dependency_folders: &[String],
+    dashboard: Option<&crate::commands::dashboards::DashboardContextWitness>,
+) -> Result<crate::storage::ask_conversation_store::PersistedAskExchange, AppError> {
     require_durable_scope_under_lifecycle(state, snapshot)?;
+    require_current_ask_dispatch_under_lifecycle(state, ask_dispatch)?;
+    if let Some(witness) = dashboard {
+        let unlocked = unlocked_snapshot(state)?;
+        crate::commands::dashboards::require_current_dashboard_context_witness_under_lifecycle(
+            state, witness, &unlocked,
+        )?;
+    }
     // The provider seam may assemble its final retrieval context after the caller's initial
     // dependency snapshot. Visibility reductions bump `seal_epoch` and fail the revalidation
     // above; a visibility increase does not. Union the NOW-visible folders while the same
@@ -150,7 +317,7 @@ pub(crate) fn persist_ask_exchange_after_await(
         .collect::<std::collections::BTreeSet<_>>();
     dependency_folders.extend(current_visible);
     let dependency_folders = dependency_folders.into_iter().collect::<Vec<_>>();
-    state.db.persist_ask_exchange_cas(
+    state.db.persist_ask_exchange_cas_with_dispatch(
         scope,
         conversation_id,
         resume_cursor,
@@ -160,7 +327,124 @@ pub(crate) fn persist_ask_exchange_after_await(
         assistant_sources,
         assistant_citations,
         &dependency_folders,
+        dashboard.map(|witness| witness.dashboard_id.as_str()),
+        dashboard.map(|witness| witness.generation),
+        dashboard.map(|witness| witness.input_digest.as_str()),
+        ask_dispatch.generation,
         &chrono::Utc::now().to_rfc3339(),
+    )
+}
+
+/// Commit the canonical exchange and encode the exact committed identities without releasing the
+/// lifecycle mutex between those two operations. Config/consent writers therefore cannot create a
+/// hidden committed turn whose stale result is refused only at IPC serialization.
+#[allow(clippy::too_many_arguments)]
+fn finish_persisted_ask_send_after_await(
+    state: &AppState,
+    snapshot: &DurableScopeSnapshot,
+    ask_dispatch: &AskDispatchSnapshot,
+    scope: &AskConversationScope,
+    conversation_id: Option<&str>,
+    resume_cursor: Option<crate::storage::ask_conversation_store::AskConversationCursor>,
+    question: &str,
+    answer: String,
+    selected_sources: &[SourceRef],
+    assistant_sources: Vec<crate::storage::models::VaultSource>,
+    assistant_citations: Vec<String>,
+    dependency_folders: &[String],
+    dashboard: Option<&crate::commands::dashboards::DashboardContextWitness>,
+) -> Result<Response, AppError> {
+    finish_persisted_ask_send_after_await_core(
+        state,
+        snapshot,
+        ask_dispatch,
+        scope,
+        conversation_id,
+        resume_cursor,
+        question,
+        answer,
+        selected_sources,
+        assistant_sources,
+        assistant_citations,
+        dependency_folders,
+        dashboard,
+        || {},
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn finish_persisted_ask_send_after_await_core(
+    state: &AppState,
+    snapshot: &DurableScopeSnapshot,
+    ask_dispatch: &AskDispatchSnapshot,
+    scope: &AskConversationScope,
+    conversation_id: Option<&str>,
+    resume_cursor: Option<crate::storage::ask_conversation_store::AskConversationCursor>,
+    question: &str,
+    answer: String,
+    selected_sources: &[SourceRef],
+    assistant_sources: Vec<crate::storage::models::VaultSource>,
+    assistant_citations: Vec<String>,
+    dependency_folders: &[String],
+    dashboard: Option<&crate::commands::dashboards::DashboardContextWitness>,
+    after_commit: impl FnOnce(),
+) -> Result<Response, AppError> {
+    let _lifecycle = lifecycle_guard(state);
+    let committed = persist_ask_exchange_under_lifecycle(
+        state,
+        snapshot,
+        ask_dispatch,
+        scope,
+        conversation_id,
+        resume_cursor,
+        question,
+        &answer,
+        selected_sources,
+        &assistant_sources,
+        &assistant_citations,
+        dependency_folders,
+        dashboard,
+    )?;
+    after_commit();
+    let payload = AskConversationSendResult {
+        conversation_id: committed.conversation_id,
+        user_message_id: committed.user_message_id,
+        assistant_message_id: committed.assistant_message_id,
+        answer: answer.trim().to_string(),
+        sources: assistant_sources,
+        citations: assistant_citations,
+    };
+    serde_json::to_string(&payload)
+        .map(Response::new)
+        .map_err(|_| AppError::Unavailable("conversation response encoding failed".into()))
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn finish_persisted_ask_send_after_await_with_hook(
+    state: &AppState,
+    snapshot: &DurableScopeSnapshot,
+    ask_dispatch: &AskDispatchSnapshot,
+    scope: &AskConversationScope,
+    question: &str,
+    answer: String,
+    after_commit: impl FnOnce(),
+) -> Result<Response, AppError> {
+    finish_persisted_ask_send_after_await_core(
+        state,
+        snapshot,
+        ask_dispatch,
+        scope,
+        None,
+        None,
+        question,
+        answer,
+        &[],
+        Vec::new(),
+        Vec::new(),
+        &[],
+        None,
+        after_commit,
     )
 }
 
@@ -192,19 +476,122 @@ fn normalized_sources_for_scope(
     }
 }
 
+fn resolve_conversation_dashboard_id(
+    continuing: bool,
+    requested: Option<&str>,
+    persisted: Option<String>,
+) -> Result<Option<String>, AppError> {
+    let requested = requested
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string);
+    if !continuing {
+        return Ok(requested);
+    }
+    if requested.is_some() && requested != persisted {
+        return Err(AppError::InvalidArg(
+            "conversation dashboard scope cannot be changed".into(),
+        ));
+    }
+    Ok(persisted)
+}
+
+pub(crate) fn require_persisted_dashboard_provenance_under_lifecycle(
+    state: &AppState,
+    scope: &AskConversationScope,
+    provenance: &crate::storage::ask_conversation_store::AskDashboardProvenance,
+    config: &AppConfig,
+    unlocked: &std::collections::HashSet<String>,
+) -> Result<(), AppError> {
+    let ask_conn =
+        crate::summarize::roles::provider_target(crate::summarize::roles::Role::Ask, config)
+            .connection;
+    let excluded_meeting = match scope {
+        AskConversationScope::Meeting { ref_id } => Some(ref_id.as_str()),
+        AskConversationScope::Vault | AskConversationScope::Note { .. } => None,
+    };
+    let budget = excluded_meeting.map_or_else(
+        || crate::summarize::vault_context::budget_for(&ask_conn),
+        |_| {
+            crate::summarize::vault_context::budget_for(&ask_conn)
+                .min(crate::summarize::chat::MAX_PINNED_SOURCE_CHARS)
+        },
+    );
+    let current = crate::commands::dashboards::dashboard_composite_context(
+        &state.db,
+        &provenance.dashboard_id,
+        unlocked,
+        budget,
+        &provenance.selected_sources,
+        excluded_meeting,
+    )?;
+    let (_, exists_now) = state.db.dashboard_context_state(&provenance.dashboard_id)?;
+    if !exists_now
+        || current.witness.generation != provenance.generation
+        || current.witness.input_digest != provenance.input_digest
+    {
+        return Err(AppError::Locked("conversation is unavailable".into()));
+    }
+    Ok(())
+}
+
 /// Bounded, exact-scope, newest-first list. Unknown and invisible scopes both return an empty list.
 #[tauri::command]
 pub fn list_ask_conversations(
     state: State<'_, AppState>,
     scope: AskConversationScope,
-) -> Result<Vec<AskConversationSummary>, AppError> {
-    let _lifecycle = lifecycle_guard(state.inner());
-    let unlocked = unlocked_snapshot(state.inner())?;
-    match capture_durable_scope_under_lifecycle(state.inner(), &scope) {
-        Ok(_) => state.db.list_ask_conversations(&scope, &unlocked),
-        Err(AppError::Locked(_) | AppError::InvalidArg(_)) => Ok(Vec::new()),
-        Err(error) => Err(error),
-    }
+) -> Result<Response, AppError> {
+    list_ask_conversations_inner(state.inner(), &scope)
+}
+
+pub(crate) fn list_ask_conversations_inner(
+    state: &AppState,
+    scope: &AskConversationScope,
+) -> Result<Response, AppError> {
+    let _lifecycle = lifecycle_guard(state);
+    let config = state
+        .config
+        .lock()
+        .map_err(|_| AppError::Config("config mutex poisoned".into()))?
+        .clone();
+    let unlocked = unlocked_snapshot(state)?;
+    let visible = match capture_durable_scope_under_lifecycle(state, scope) {
+        Ok(_) => {
+            let ids = state.db.list_ask_conversation_ids(scope, &unlocked)?;
+            let mut visible = Vec::new();
+            for id in ids {
+                let Some(preflight) = state
+                    .db
+                    .ask_conversation_preflight(scope, &id, &unlocked)?
+                else {
+                    continue;
+                };
+                if preflight.dashboard.as_ref().map_or(true, |provenance| {
+                    require_persisted_dashboard_provenance_under_lifecycle(
+                        state,
+                        scope,
+                        provenance,
+                        &config,
+                        &unlocked,
+                    )
+                    .is_ok()
+                }) {
+                    if let Some(summary) = state
+                        .db
+                        .ask_conversation_summary_after_preflight(scope, &id)?
+                    {
+                        visible.push(summary);
+                    }
+                }
+            }
+            visible
+        }
+        Err(AppError::Locked(_) | AppError::InvalidArg(_)) => Vec::new(),
+        Err(error) => return Err(error),
+    };
+    serde_json::to_string(&visible)
+        .map(Response::new)
+        .map_err(|_| AppError::Unavailable("conversation response encoding failed".into()))
 }
 
 /// Bounded exact-scope load. Unknown, wrong-scope and invisible IDs deliberately share one error.
@@ -213,24 +600,53 @@ pub fn load_ask_conversation(
     state: State<'_, AppState>,
     scope: AskConversationScope,
     conversation_id: String,
-) -> Result<AskConversation, AppError> {
-    let _lifecycle = lifecycle_guard(state.inner());
-    let unlocked = unlocked_snapshot(state.inner())?;
-    match capture_durable_scope_under_lifecycle(state.inner(), &scope) {
+) -> Result<Response, AppError> {
+    load_ask_conversation_inner(state.inner(), &scope, &conversation_id)
+}
+
+pub(crate) fn load_ask_conversation_inner(
+    state: &AppState,
+    scope: &AskConversationScope,
+    conversation_id: &str,
+) -> Result<Response, AppError> {
+    let _lifecycle = lifecycle_guard(state);
+    let config = state
+        .config
+        .lock()
+        .map_err(|_| AppError::Config("config mutex poisoned".into()))?
+        .clone();
+    let unlocked = unlocked_snapshot(state)?;
+    match capture_durable_scope_under_lifecycle(state, scope) {
         Ok(_) => {}
         Err(AppError::Locked(_) | AppError::InvalidArg(_)) => {
             return Err(AppError::Locked("conversation is unavailable".into()));
         }
         Err(error) => return Err(error),
     }
-    state
+    let preflight = state
         .db
-        .load_ask_conversation(&scope, &conversation_id, &unlocked)?
-        .ok_or_else(|| AppError::Locked("conversation is unavailable".into()))
+        .ask_conversation_preflight(scope, conversation_id, &unlocked)?
+        .ok_or_else(|| AppError::Locked("conversation is unavailable".into()))?;
+    if let Some(provenance) = preflight.dashboard.as_ref() {
+        require_persisted_dashboard_provenance_under_lifecycle(
+            state,
+            scope,
+            provenance,
+            &config,
+            &unlocked,
+        )?;
+    }
+    let payload = state
+        .db
+        .load_ask_conversation(scope, conversation_id, &unlocked)?
+        .ok_or_else(|| AppError::Locked("conversation is unavailable".into()))?;
+    serde_json::to_string(&payload)
+        .map(Response::new)
+        .map_err(|_| AppError::Unavailable("conversation response encoding failed".into()))
 }
 
-/// Durable top-level/note Ask. The scope is restricted to vault or authored note; org and dashboard
-/// stay on the legacy stateless command. Canonical history comes from SQLite, never the WebView.
+/// Durable top-level/note Ask. Canonical history and optional dashboard provenance come from
+/// SQLite, never the WebView.
 #[tauri::command]
 #[allow(clippy::too_many_arguments)]
 pub async fn ask_vault_persisted(
@@ -241,7 +657,8 @@ pub async fn ask_vault_persisted(
     conversation_id: Option<String>,
     ask_trace_id: Option<String>,
     explicit_sources: Option<Vec<SourceRef>>,
-) -> Result<AskConversationSendResult, AppError> {
+    dashboard_id: Option<String>,
+) -> Result<Response, AppError> {
     if !matches!(
         scope,
         AskConversationScope::Vault | AskConversationScope::Note { .. }
@@ -253,27 +670,109 @@ pub async fn ask_vault_persisted(
     if question.trim().is_empty() {
         return Err(AppError::InvalidArg("question is empty".into()));
     }
-    let (snapshot, history, resume_cursor, dependency_folders) = {
-        let _lifecycle = lifecycle_guard(state.inner());
-        let unlocked = unlocked_snapshot(state.inner())?;
-        let snapshot = capture_durable_scope_under_lifecycle(state.inner(), &scope)?;
-        let (history, resume_cursor) = match conversation_id.as_deref() {
-            Some(id) => {
-                let context = state
-                    .db
-                    .ask_conversation_context(&scope, id, &unlocked)?
-                    .ok_or_else(|| AppError::Locked("conversation is unavailable".into()))?;
-                (context.turns, Some(context.cursor))
-            }
-            None => (Vec::new(), None),
-        };
-        let dependencies = state.db.visible_folder_ids(&unlocked)?;
-        (snapshot, history, resume_cursor, dependencies)
-    };
     // An authored-note conversation must be grounded in that exact note. Do not trust the WebView
     // to remember the anchor: inject it backend-side when absent, while preserving any additional
     // user-selected sources.
-    let explicit_sources = normalized_sources_for_scope(&scope, explicit_sources)?;
+    let mut explicit_sources = normalized_sources_for_scope(&scope, explicit_sources)?;
+    let (
+        snapshot,
+        history,
+        resume_cursor,
+        dependency_folders,
+        dashboard_id,
+        canonical_sources,
+        dashboard_witness,
+        ask_dispatch,
+    ) = {
+        let _lifecycle = lifecycle_guard(state.inner());
+        let config = state
+            .config
+            .lock()
+            .map_err(|_| AppError::Config("config mutex poisoned".into()))?
+            .clone();
+        let unlocked = unlocked_snapshot(state.inner())?;
+        let ask_dispatch =
+            capture_ask_dispatch_snapshot_under_lifecycle(state.inner(), &config)?;
+        let snapshot = capture_durable_scope_under_lifecycle(state.inner(), &scope)?;
+        let (history, resume_cursor, persisted_dashboard_id, canonical_sources) =
+            match conversation_id.as_deref() {
+                Some(id) => {
+                    let preflight = state
+                        .db
+                        .ask_conversation_preflight(&scope, id, &unlocked)?
+                        .ok_or_else(|| AppError::Locked("conversation is unavailable".into()))?;
+                    if preflight.ask_dispatch_generation != ask_dispatch.generation {
+                        return Err(AppError::Locked("conversation is unavailable".into()));
+                    }
+                    let canonical_sources = preflight
+                        .dashboard
+                        .as_ref()
+                        .map(|provenance| provenance.selected_sources.clone());
+                    if let Some(provenance) = preflight.dashboard.as_ref() {
+                        require_persisted_dashboard_provenance_under_lifecycle(
+                            state.inner(),
+                            &scope,
+                            provenance,
+                            &config,
+                            &unlocked,
+                        )?;
+                    }
+                    let context = state
+                        .db
+                        .ask_conversation_context_after_preflight(id, preflight)?;
+                    (
+                        context.turns,
+                        Some(context.cursor),
+                        context.dashboard.map(|dashboard| dashboard.dashboard_id),
+                        canonical_sources,
+                    )
+                }
+                None => (Vec::new(), None, None, None),
+            };
+        let dashboard_id = resolve_conversation_dashboard_id(
+            conversation_id.is_some(),
+            dashboard_id.as_deref(),
+            persisted_dashboard_id,
+        )?;
+        let sources_for_witness = canonical_sources
+            .as_deref()
+            .or(explicit_sources.as_deref())
+            .unwrap_or_default();
+        let dashboard_witness = if let Some(id) = dashboard_id.as_deref() {
+            let ask_conn = crate::summarize::roles::provider_target(
+                crate::summarize::roles::Role::Ask,
+                &config,
+            )
+            .connection;
+            Some(
+                crate::commands::dashboards::dashboard_composite_context(
+                    &state.db,
+                    id,
+                    &unlocked,
+                    crate::summarize::vault_context::budget_for(&ask_conn),
+                    sources_for_witness,
+                    None,
+                )?
+                .witness,
+            )
+        } else {
+            None
+        };
+        let dependencies = state.db.visible_folder_ids(&unlocked)?;
+        (
+            snapshot,
+            history,
+            resume_cursor,
+            dependencies,
+            dashboard_id,
+            canonical_sources,
+            dashboard_witness,
+            ask_dispatch,
+        )
+    };
+    if let Some(canonical_sources) = canonical_sources {
+        explicit_sources = (!canonical_sources.is_empty()).then_some(canonical_sources);
+    }
     let selected_sources = explicit_sources.clone().unwrap_or_default();
     let result = ask_vault_inner(
         &app,
@@ -283,31 +782,27 @@ pub async fn ask_vault_persisted(
         ask_trace_id,
         explicit_sources,
         None,
-        None,
+        dashboard_id.clone(),
         Some(snapshot.clone()),
+        dashboard_witness.clone(),
+        Some(ask_dispatch.clone()),
     )
     .await?;
-    let committed = persist_ask_exchange_after_await(
+    finish_persisted_ask_send_after_await(
         state.inner(),
         &snapshot,
+        &ask_dispatch,
         &scope,
         conversation_id.as_deref(),
         resume_cursor,
         &question,
-        &result.answer,
+        result.answer,
         &selected_sources,
-        &result.sources,
-        &result.citations,
+        result.sources,
+        result.citations,
         &dependency_folders,
-    )?;
-    Ok(AskConversationSendResult {
-        conversation_id: committed.conversation_id,
-        user_message_id: committed.user_message_id,
-        assistant_message_id: committed.assistant_message_id,
-        answer: result.answer,
-        sources: result.sources,
-        citations: result.citations,
-    })
+        dashboard_witness.as_ref(),
+    )
 }
 
 /// Durable exact-meeting Ask. Canonical history is loaded from SQLite and the successful answer is
@@ -320,30 +815,116 @@ pub async fn chat_meeting_persisted(
     question: String,
     conversation_id: Option<String>,
     explicit_sources: Option<Vec<SourceRef>>,
-) -> Result<AskConversationSendResult, AppError> {
+    dashboard_id: Option<String>,
+) -> Result<Response, AppError> {
     if question.trim().is_empty() {
         return Err(AppError::InvalidArg("question is empty".into()));
     }
     let scope = AskConversationScope::Meeting {
         ref_id: meeting_id.clone(),
     };
-    let (snapshot, history, resume_cursor, dependency_folders) = {
+    let mut explicit_sources = explicit_sources;
+    let (
+        snapshot,
+        history,
+        resume_cursor,
+        dependency_folders,
+        dashboard_id,
+        canonical_sources,
+        dashboard_witness,
+        ask_dispatch,
+    ) = {
         let _lifecycle = lifecycle_guard(state.inner());
+        let config = state
+            .config
+            .lock()
+            .map_err(|_| AppError::Config("config mutex poisoned".into()))?
+            .clone();
         let unlocked = unlocked_snapshot(state.inner())?;
+        let ask_dispatch =
+            capture_ask_dispatch_snapshot_under_lifecycle(state.inner(), &config)?;
         let snapshot = capture_durable_scope_under_lifecycle(state.inner(), &scope)?;
-        let (history, resume_cursor) = match conversation_id.as_deref() {
-            Some(id) => {
-                let context = state
-                    .db
-                    .ask_conversation_context(&scope, id, &unlocked)?
-                    .ok_or_else(|| AppError::Locked("conversation is unavailable".into()))?;
-                (context.turns, Some(context.cursor))
-            }
-            None => (Vec::new(), None),
+        let (history, resume_cursor, persisted_dashboard_id, canonical_sources) =
+            match conversation_id.as_deref() {
+                Some(id) => {
+                    let preflight = state
+                        .db
+                        .ask_conversation_preflight(&scope, id, &unlocked)?
+                        .ok_or_else(|| AppError::Locked("conversation is unavailable".into()))?;
+                    if preflight.ask_dispatch_generation != ask_dispatch.generation {
+                        return Err(AppError::Locked("conversation is unavailable".into()));
+                    }
+                    let canonical_sources = preflight
+                        .dashboard
+                        .as_ref()
+                        .map(|provenance| provenance.selected_sources.clone());
+                    if let Some(provenance) = preflight.dashboard.as_ref() {
+                        require_persisted_dashboard_provenance_under_lifecycle(
+                            state.inner(),
+                            &scope,
+                            provenance,
+                            &config,
+                            &unlocked,
+                        )?;
+                    }
+                    let context = state
+                        .db
+                        .ask_conversation_context_after_preflight(id, preflight)?;
+                    (
+                        context.turns,
+                        Some(context.cursor),
+                        context.dashboard.map(|dashboard| dashboard.dashboard_id),
+                        canonical_sources,
+                    )
+                }
+                None => (Vec::new(), None, None, None),
+            };
+        let dashboard_id = resolve_conversation_dashboard_id(
+            conversation_id.is_some(),
+            dashboard_id.as_deref(),
+            persisted_dashboard_id,
+        )?;
+        let sources_for_witness = canonical_sources
+            .as_deref()
+            .or(explicit_sources.as_deref())
+            .unwrap_or_default();
+        let dashboard_witness = if let Some(id) = dashboard_id.as_deref() {
+            let ask_conn = crate::summarize::roles::provider_target(
+                crate::summarize::roles::Role::Ask,
+                &config,
+            )
+            .connection;
+            let budget = crate::summarize::vault_context::budget_for(&ask_conn)
+                .min(crate::summarize::chat::MAX_PINNED_SOURCE_CHARS);
+            Some(
+                crate::commands::dashboards::dashboard_composite_context(
+                    &state.db,
+                    id,
+                    &unlocked,
+                    budget,
+                    sources_for_witness,
+                    Some(&meeting_id),
+                )?
+                .witness,
+            )
+        } else {
+            None
         };
         let dependencies = state.db.visible_folder_ids(&unlocked)?;
-        (snapshot, history, resume_cursor, dependencies)
+        (
+            snapshot,
+            history,
+            resume_cursor,
+            dependencies,
+            dashboard_id,
+            canonical_sources,
+            dashboard_witness,
+            ask_dispatch,
+        )
     };
+    if let Some(canonical_sources) = canonical_sources {
+        explicit_sources = (!canonical_sources.is_empty()).then_some(canonical_sources);
+    }
     let selected_sources = explicit_sources.clone().unwrap_or_default();
     let meeting_snapshot = match &snapshot {
         DurableScopeSnapshot::Meeting { snapshot, .. } => snapshot.clone(),
@@ -360,30 +941,27 @@ pub async fn chat_meeting_persisted(
         question.clone(),
         history,
         explicit_sources,
+        dashboard_id,
         Some(meeting_snapshot),
+        dashboard_witness.clone(),
+        Some(ask_dispatch.clone()),
     )
     .await?;
-    let committed = persist_ask_exchange_after_await(
+    finish_persisted_ask_send_after_await(
         state.inner(),
         &snapshot,
+        &ask_dispatch,
         &scope,
         conversation_id.as_deref(),
         resume_cursor,
         &question,
-        &answer,
-        &selected_sources,
-        &[],
-        &[],
-        &dependency_folders,
-    )?;
-    Ok(AskConversationSendResult {
-        conversation_id: committed.conversation_id,
-        user_message_id: committed.user_message_id,
-        assistant_message_id: committed.assistant_message_id,
         answer,
-        sources: Vec::new(),
-        citations: Vec::new(),
-    })
+        &selected_sources,
+        Vec::new(),
+        Vec::new(),
+        &dependency_folders,
+        dashboard_witness.as_ref(),
+    )
 }
 
 #[cfg(test)]
@@ -404,6 +982,23 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(sources.len(), 1, "anchor must not duplicate on resume");
+    }
+
+    #[test]
+    fn continuation_keeps_dashboard_identity_and_rejects_scope_switch() {
+        assert_eq!(
+            resolve_conversation_dashboard_id(true, None, Some("board-a".into())).unwrap(),
+            Some("board-a".into())
+        );
+        assert_eq!(
+            resolve_conversation_dashboard_id(true, Some("board-a"), Some("board-a".into()),)
+                .unwrap(),
+            Some("board-a".into())
+        );
+        assert!(matches!(
+            resolve_conversation_dashboard_id(true, Some("board-b"), Some("board-a".into()),),
+            Err(AppError::InvalidArg(_))
+        ));
     }
 
     #[test]

--- a/src-tauri/src/commands/dashboards.rs
+++ b/src-tauri/src/commands/dashboards.rs
@@ -2,8 +2,9 @@
 //! already exist in the vault.
 //!
 //! ## The one rule that governs this file
-//! A dashboard is a set of POINTERS. It stores no meeting content, and **every tile payload is
-//! resolved through an existing gated reader at read time** — `Db::*_visible` /
+//! A dashboard is primarily a set of POINTERS. Its one content-bearing tile, Living Answer, stores
+//! only a backend-generated cache with exact readable-folder and composite-context provenance.
+//! **Every tile payload is resolved through a gated reader at read time** — `Db::*_visible` /
 //! `get_*_if_visible` / `list_open_commitments` — never by a fresh ungated query. A tile whose
 //! source is sealed-and-not-session-unlocked resolves to [`TileData::Locked`], which carries no
 //! title, no snippet, no counts, and no dates. That is what keeps a board from becoming a back
@@ -16,24 +17,43 @@
 //! * `ref_id` is never validated for existence at write time. A tile pointing at a deleted row
 //!   resolves to [`TileData::Missing`] rather than erroring the whole board.
 //!
-//! Board-scoped Ask reuses the SHIPPED `ask_vault(explicit_sources: …)` path verbatim
-//! ([`get_dashboard_sources`] just hands it the board's visible sources), so this feature adds
-//! **no new AI path, no new egress surface, and no new redaction seam**.
+//! Board-scoped Ask is assembled by [`dashboard_composite_context`], then dispatched through the
+//! existing prepacked authorized provider path. Consent, redaction, egress ledger, lifecycle
+//! admission, and exact post-await witness validation remain at that shared backend seam.
 
 use serde::{Deserialize, Serialize};
-use tauri::State;
+use tauri::{ipc::Response, AppHandle, State};
 
 use crate::error::AppError;
 use crate::links::LinkKind;
 use crate::state::AppState;
 use crate::storage::dashboards_store::{
-    MAX_DASHBOARDS, MAX_SPAN, MAX_TILES_PER_BOARD, MIN_SPAN, TILE_KINDS,
+    LivingAnswerCacheState, MAX_DASHBOARDS, MAX_SPAN, MAX_TILES_PER_BOARD, MIN_SPAN, TILE_KINDS,
 };
 use crate::storage::models::{Dashboard, DashboardTile, SourceRef};
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DashboardContextWitness {
+    pub(crate) dashboard_id: String,
+    pub(crate) generation: i64,
+    pub(crate) ask_dispatch_generation: i64,
+    pub(crate) input_digest: String,
+    corpus_budget: usize,
+    additional_sources: Vec<SourceRef>,
+    excluded_meeting_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DashboardCompositeContext {
+    pub(crate) witness: DashboardContextWitness,
+    pub(crate) packed_corpus: String,
+    pub(crate) packed_sources: Vec<crate::storage::models::VaultSource>,
+}
+
 /// Longest accepted board title / tile heading. Bounds the DTO and the `.canvas` export.
 const MAX_TITLE_LEN: usize = 120;
-/// Longest accepted `config` JSON blob (the Living-answer question + cached answer).
+/// Longest accepted legacy/general `config` JSON blob. Living-answer content is persisted only in
+/// its provenance-separated columns after the backend has sanitized the add request.
 const MAX_CONFIG_LEN: usize = 8 * 1024;
 /// Rows shown inside a list-shaped tile (reminders / promises / drift steps / numbers).
 const TILE_ROWS: usize = 6;
@@ -176,7 +196,7 @@ pub enum TileData {
         owner: Option<String>,
         rows: Vec<TileRow>,
     },
-    /// A pinned question plus the answer last computed for it (by the FE, through `ask_vault`).
+    /// A pinned question plus the answer last computed by the backend-owned refresh command.
     ///
     /// `withheld` is the lock-model half: a cached answer is a PARAPHRASE of the sources it was
     /// built from, so once any of those sources is sealed-and-not-unlocked the answer stops being
@@ -189,7 +209,8 @@ pub enum TileData {
     },
 }
 
-/// The persisted `config` bag. Every field optional — an older row deserializes fine.
+/// Compatibility/request shape for historical tile configs and Living-answer creation. Resolved
+/// Living-answer content never hydrates this bag; it comes from dedicated provenance-gated columns.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TileConfig {
@@ -202,6 +223,10 @@ pub struct TileConfig {
     /// `living_answer` — the pinned question and its last answer.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub question: Option<String>,
+    /// Backend-owned readable-folder snapshot for the question itself. `None` is legacy and
+    /// unprovable; `Some([])` is a valid question created while no folders were readable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub question_readable_folders: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub answer: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -226,41 +251,12 @@ pub struct TileConfig {
     pub answer_readable_folders: Option<Vec<String>>,
 }
 
-/// Decide whether a cached Living answer may still be shown.
-///
-/// Split out as a PURE function on purpose: `resolve_tile` needs a `State<AppState>`, so nothing
-/// could test the gate in place — and an independent verifier proved that disabling the previous
-/// gate left the entire suite green. This one has a direct oracle
-/// (`living_answer_gate_withholds_when_a_folder_stopped_being_readable`).
-///
-/// Fail-closed: an answer with no recorded readable set, or an empty one, is withheld.
-pub(crate) fn living_answer_withheld(
-    has_answer: bool,
-    recorded_readable: &[String],
-    currently_readable: &std::collections::HashSet<String>,
-) -> bool {
-    if !has_answer {
-        return false;
-    }
-    if recorded_readable.is_empty() {
-        return true; // un-gateable (legacy row) ⇒ withhold
-    }
-    !recorded_readable
-        .iter()
-        .all(|id| currently_readable.contains(id))
-}
-
 /// Every folder the session can currently read: unlocked outright, or sealed but session-unlocked.
 fn readable_folder_ids(
     db: &crate::storage::Db,
     unlocked: &std::collections::HashSet<String>,
 ) -> Result<std::collections::HashSet<String>, AppError> {
-    Ok(db
-        .list_folders()?
-        .into_iter()
-        .filter(|f| !f.locked || unlocked.contains(&f.id))
-        .map(|f| f.id)
-        .collect())
+    Ok(db.visible_folder_ids(unlocked)?.into_iter().collect())
 }
 
 // ── helpers ────────────────────────────────────────────────────────────────────────────────────
@@ -302,6 +298,28 @@ fn clean_tint(raw: Option<String>) -> Option<String> {
 fn parse_config(raw: Option<&str>) -> TileConfig {
     raw.and_then(|s| serde_json::from_str::<TileConfig>(s).ok())
         .unwrap_or_default()
+}
+
+fn sanitize_living_answer_config_for_add(
+    raw: Option<&str>,
+    readable: &std::collections::HashSet<String>,
+) -> Result<String, AppError> {
+    let mut cfg = raw
+        .map(serde_json::from_str::<TileConfig>)
+        .transpose()
+        .map_err(|e| AppError::InvalidArg(format!("invalid tile config: {e}")))?
+        .unwrap_or_default();
+    cfg.question = Some(clean_title(
+        cfg.question.as_deref().unwrap_or_default(),
+        "question",
+    )?);
+    cfg.question_readable_folders = Some(readable.iter().cloned().collect());
+    cfg.answer = None;
+    cfg.answered_at = None;
+    cfg.answer_sources = None;
+    cfg.answer_readable_folders = None;
+    serde_json::to_string(&cfg)
+        .map_err(|e| AppError::Storage(format!("encoding tile config failed: {e}")))
 }
 
 fn snippet_of(text: &str, max: usize) -> String {
@@ -373,6 +391,7 @@ pub fn create_dashboard(
     emoji: Option<String>,
     tint: Option<String>,
 ) -> Result<Dashboard, AppError> {
+    let _lifecycle = super::lifecycle_guard(state.inner());
     if state.db.dashboard_count()? >= MAX_DASHBOARDS {
         return Err(AppError::InvalidArg(format!(
             "dashboard limit reached ({MAX_DASHBOARDS})"
@@ -403,6 +422,7 @@ pub fn update_dashboard(
     tint: Option<String>,
     pinned: Option<bool>,
 ) -> Result<Dashboard, AppError> {
+    let _lifecycle = super::lifecycle_guard(state.inner());
     let title = match title {
         Some(t) => Some(clean_title(&t, "title")?),
         None => None,
@@ -426,11 +446,13 @@ pub fn update_dashboard(
 
 #[tauri::command]
 pub fn delete_dashboard(state: State<'_, AppState>, id: String) -> Result<bool, AppError> {
+    let _lifecycle = super::lifecycle_guard(state.inner());
     state.db.delete_dashboard(&id)
 }
 
 #[tauri::command]
 pub fn reorder_dashboards(state: State<'_, AppState>, ids: Vec<String>) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state.inner());
     state.db.reorder_dashboards(&ids)
 }
 
@@ -446,6 +468,7 @@ pub fn add_dashboard_tile(
     span: Option<i64>,
     config: Option<String>,
 ) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state.inner());
     if !TILE_KINDS.contains(&kind.as_str()) {
         return Err(AppError::InvalidArg(format!("unknown tile kind: {kind}")));
     }
@@ -463,6 +486,7 @@ pub fn add_dashboard_tile(
         Some(t) if !t.trim().is_empty() => Some(clean_title(&t, "tile title")?),
         _ => None,
     };
+    let title = (kind != "living_answer").then_some(title).flatten();
     if let Some(c) = config.as_deref() {
         if c.len() > MAX_CONFIG_LEN {
             return Err(AppError::InvalidArg("tile config too large".into()));
@@ -470,8 +494,35 @@ pub fn add_dashboard_tile(
         serde_json::from_str::<TileConfig>(c)
             .map_err(|e| AppError::InvalidArg(format!("invalid tile config: {e}")))?;
     }
+    let mut question_provenance = None;
+    let config = if kind == "living_answer" {
+        let unlocked = super::unlocked_snapshot(state.inner())?;
+        let readable = readable_folder_ids(&state.db, &unlocked)?;
+        let encoded = sanitize_living_answer_config_for_add(config.as_deref(), &readable)?;
+        let question = parse_config(Some(&encoded)).question.unwrap_or_default();
+        question_provenance = Some((
+            question,
+            serde_json::to_string(&readable)
+                .map_err(|e| AppError::Storage(format!("encoding provenance failed: {e}")))?,
+        ));
+        None
+    } else {
+        config
+    };
     let id = uuid::Uuid::new_v4().to_string();
     let now = now_iso();
+    if let Some((question, provenance)) = question_provenance.as_ref() {
+        state.db.insert_dashboard_living_answer_tile(
+            &id,
+            &dashboard_id,
+            span.unwrap_or(4),
+            question,
+            provenance,
+            &now,
+        )?;
+        state.db.touch_dashboard(&dashboard_id, &now)?;
+        return Ok(());
+    }
     state.db.insert_dashboard_tile(
         &id,
         &dashboard_id,
@@ -497,9 +548,15 @@ pub fn update_dashboard_tile(
     span: Option<i64>,
     config: Option<String>,
 ) -> Result<(), AppError> {
-    let Some(existing) = state.db.get_dashboard_tile(&id)? else {
+    let _lifecycle = super::lifecycle_guard(state.inner());
+    let Some((dashboard_id, existing_kind)) = state.db.dashboard_tile_metadata(&id)? else {
         return Err(AppError::InvalidArg(format!("no tile with id {id}")));
     };
+    if existing_kind == "living_answer" && config.is_some() {
+        return Err(AppError::InvalidArg(
+            "living-answer config is backend-owned".into(),
+        ));
+    }
     let title = match title {
         Some(t) if !t.trim().is_empty() => Some(clean_title(&t, "tile title")?),
         _ => None,
@@ -514,70 +571,20 @@ pub fn update_dashboard_tile(
     state
         .db
         .update_dashboard_tile(&id, title.as_deref(), span, config.as_deref())?;
-    state
-        .db
-        .touch_dashboard(&existing.dashboard_id, &now_iso())?;
+    state.db.touch_dashboard(&dashboard_id, &now_iso())?;
     // Same reason as `add_dashboard_tile`: never return the raw row. Reachable proof this
     // mattered — the Arrange-mode resize control fires for a SEALED tile, so returning the row
     // would push that tile's stored title/config into the webview.
     Ok(())
 }
 
-/// Persist a Living-answer result, stamping the readable-folder snapshot that gates it.
-///
-/// The FE cannot compute that snapshot (it has no folder/lock view), and letting it write the
-/// answer through the generic `update_dashboard_tile` is what made the cache un-gateable. So the
-/// backend owns this write end-to-end.
-#[tauri::command]
-pub fn set_dashboard_answer(
-    state: State<'_, AppState>,
-    id: String,
-    question: String,
-    answer: String,
-) -> Result<(), AppError> {
-    let Some(existing) = state.db.get_dashboard_tile(&id)? else {
-        return Err(AppError::InvalidArg(format!("no tile with id {id}")));
-    };
-    if existing.kind != "living_answer" {
-        return Err(AppError::InvalidArg(
-            "only a living-answer tile stores an answer".into(),
-        ));
-    }
-    let question = clean_title(&question, "question")?;
-    if answer.len() > MAX_CONFIG_LEN {
-        return Err(AppError::InvalidArg("answer too large".into()));
-    }
-    // Snapshot under the lifecycle guard so a relock cannot land between computing the readable
-    // set and storing it — otherwise the answer would be stamped with a MORE permissive set than
-    // was actually in force, which is the one direction that would weaken the gate.
-    let _lifecycle = super::lifecycle_guard(state.inner());
-    let unlocked = super::unlocked_snapshot(state.inner())?;
-    let readable: Vec<String> = readable_folder_ids(&state.db, &unlocked)?
-        .into_iter()
-        .collect();
-
-    let mut cfg = parse_config(existing.config.as_deref());
-    cfg.question = Some(question);
-    cfg.answer = Some(answer);
-    cfg.answered_at = Some(now_iso());
-    cfg.answer_readable_folders = Some(readable);
-    let encoded = serde_json::to_string(&cfg)
-        .map_err(|e| AppError::Storage(format!("encoding tile config failed: {e}")))?;
-    if encoded.len() > MAX_CONFIG_LEN {
-        return Err(AppError::InvalidArg("answer too large".into()));
-    }
-    state
-        .db
-        .update_dashboard_tile(&id, None, None, Some(&encoded))?;
-    state
-        .db
-        .touch_dashboard(&existing.dashboard_id, &now_iso())?;
-    Ok(())
-}
-
 #[tauri::command]
 pub fn delete_dashboard_tile(state: State<'_, AppState>, id: String) -> Result<bool, AppError> {
-    let board = state.db.get_dashboard_tile(&id)?.map(|t| t.dashboard_id);
+    let _lifecycle = super::lifecycle_guard(state.inner());
+    let board = state
+        .db
+        .dashboard_tile_metadata(&id)?
+        .map(|(dashboard_id, _kind)| dashboard_id);
     let removed = state.db.delete_dashboard_tile(&id)?;
     if let Some(b) = board {
         state.db.touch_dashboard(&b, &now_iso())?;
@@ -591,6 +598,7 @@ pub fn reorder_dashboard_tiles(
     dashboard_id: String,
     tile_ids: Vec<String>,
 ) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state.inner());
     state.db.reorder_dashboard_tiles(&dashboard_id, &tile_ids)?;
     state.db.touch_dashboard(&dashboard_id, &now_iso())
 }
@@ -599,34 +607,38 @@ pub fn reorder_dashboard_tiles(
 
 /// One board with every tile resolved through the gated readers.
 #[tauri::command]
-pub fn get_dashboard(
-    state: State<'_, AppState>,
-    id: String,
-) -> Result<Option<DashboardDetailDto>, AppError> {
+pub fn get_dashboard(state: State<'_, AppState>, id: String) -> Result<Response, AppError> {
     // TOCTOU: hold the lock lifecycle guard across the gate AND every tile read, exactly like
     // `commands/meetings.rs::get_meeting_detail`. Without it a relock landing between the
     // `unlocked_snapshot` below and a later tile's read would resolve that tile against a stale
     // "unlocked" view and return content from a folder that is sealed by the time it ships.
     let _lifecycle = super::lifecycle_guard(state.inner());
     let Some(dashboard) = state.db.get_dashboard(&id)? else {
-        return Ok(None);
+        return serde_json::to_string(&Option::<DashboardDetailDto>::None)
+            .map(Response::new)
+            .map_err(|_| AppError::Unavailable("dashboard response encoding failed".into()));
     };
-    let tiles = state.db.list_dashboard_tiles(&id)?;
+    let tiles = state.db.list_dashboard_tile_structures(&id)?;
     let unlocked = super::unlocked_snapshot(state.inner())?;
     let resolved = tiles
         .into_iter()
         .map(|tile| {
             let data = resolve_tile(&state.db, &tile, &unlocked)?;
-            Ok(ResolvedTileDto {
-                tile: redact_tile_chrome(tile, &data),
-                data,
-            })
+            let mut tile = DashboardTile {
+                title: None,
+                ..tile
+            };
+            tile.config = None;
+            Ok(ResolvedTileDto { tile, data })
         })
         .collect::<Result<Vec<_>, AppError>>()?;
-    Ok(Some(DashboardDetailDto {
+    let payload = Some(DashboardDetailDto {
         dashboard,
         tiles: resolved,
-    }))
+    });
+    serde_json::to_string(&payload)
+        .map(Response::new)
+        .map_err(|_| AppError::Unavailable("dashboard response encoding failed".into()))
 }
 
 /// Could this tile's payload NOT be fully resolved for the current session?
@@ -673,24 +685,25 @@ pub(crate) fn redact_tile_chrome(mut tile: DashboardTile, data: &TileData) -> Da
     let withheld = tile_is_withheld(data);
     if withheld {
         tile.title = None;
-        tile.config = None;
     }
+    // Config is an internal persistence envelope (and can contain cached derived text). TileData
+    // is the only authorized wire projection; no caller needs the raw config.
+    tile.config = None;
     tile
 }
 
-/// The board's VISIBLE sources, ready to hand to `ask_vault(explicit_sources: …)`. A sealed source
-/// is absent — so a board-scoped Ask can never retrieve from a locked folder, and the answer is
-/// deterministic over exactly what the user composed.
+/// The board's currently visible material pointers. This IPC is retained for non-AI UI consumers;
+/// dashboard Ask resolves material and derived context together through `dashboard_composite_context`.
 #[tauri::command]
-pub fn get_dashboard_sources(
-    state: State<'_, AppState>,
-    id: String,
-) -> Result<Vec<SourceRef>, AppError> {
+pub fn get_dashboard_sources(state: State<'_, AppState>, id: String) -> Result<Response, AppError> {
     // Same TOCTOU discipline as `get_dashboard`: gate and read under one lifecycle guard.
     let _lifecycle = super::lifecycle_guard(state.inner());
-    let tiles = state.db.list_dashboard_tiles(&id)?;
+    let tiles = state.db.list_dashboard_tile_structures(&id)?;
     let unlocked = super::unlocked_snapshot(state.inner())?;
-    dashboard_sources_inner(&state.db, tiles, &unlocked)
+    let payload = dashboard_sources_inner(&state.db, tiles, &unlocked)?;
+    serde_json::to_string(&payload)
+        .map(Response::new)
+        .map_err(|_| AppError::Unavailable("dashboard response encoding failed".into()))
 }
 
 /// The header the board brief is packed under. Instructional on purpose: without
@@ -705,29 +718,31 @@ const MAX_BRIEF_CHARS: usize = 4000;
 
 /// What a board's DERIVED tiles SAY, as prompt text.
 ///
-/// THE ASYMMETRY THIS CLOSES. `get_dashboard_sources` maps only note/meeting/
-/// document to a `SourceRef` — correct, and unchanged here, because `SourceRef.kind`
-/// is a `LinkKind` and a drift lane is not a retrievable document. But nothing else
-/// carried the other seven kinds into the prompt either, while `tools.rs::tool_specs`
-/// exposes `get_dashboard` to the agentic loop and the local MCP server. Board Ask
-/// pins its sources, and `ask_vault` routes any non-empty pinned list to the
-/// deterministic floor — so the agentic path, and with it that tool, is SKIPPED.
-///
-/// The result was that the in-app "Ask this board" saw strictly LESS of the board
-/// than Claude Code did over MCP: a user could look at a Promise ledger, click the
-/// board's own suggested question — "Who owes me something on this board?" — and
-/// the model could not see that tile.
+/// Material pointers pack as full gated sources; this renderer supplies the other derived views
+/// to `dashboard_composite_context`, so the provider sees the same composed board the user sees.
 ///
 /// This adds no new gated reader and no new egress class. It walks the SHIPPED
 /// path (`resolve_tile` → [`tile_is_withheld`] → `render_tile_for_agent`), which is
 /// the same one the MCP surface already reads, so the two cannot disagree about
 /// what a tile says.
+#[cfg(test)]
 pub(crate) fn dashboard_brief_inner(
     db: &crate::storage::Db,
     tiles: Vec<DashboardTile>,
     unlocked: &std::collections::HashSet<String>,
     max_chars: usize,
 ) -> Result<String, AppError> {
+    let lines = dashboard_brief_lines(db, tiles, unlocked)?;
+    Ok(render_dashboard_brief(&lines, max_chars))
+}
+
+/// Resolve every derived tile exactly once. The complete canonical render and its budget-capped
+/// provider projection must be two views of these same values, not two independent DB read passes.
+fn dashboard_brief_lines(
+    db: &crate::storage::Db,
+    tiles: Vec<DashboardTile>,
+    unlocked: &std::collections::HashSet<String>,
+) -> Result<Vec<String>, AppError> {
     let mut lines: Vec<String> = Vec::new();
     for tile in tiles {
         // Material kinds are already packed as SOURCES, with their full text. Repeating
@@ -769,13 +784,17 @@ pub(crate) fn dashboard_brief_inner(
             lines.push(rendered);
         }
     }
+    Ok(lines)
+}
+
+fn render_dashboard_brief(lines: &[String], max_chars: usize) -> String {
     if lines.is_empty() {
-        return Ok(String::new());
+        return String::new();
     }
     // The cap must bound the OUTPUT, so a budget too small to hold the label yields
     // nothing rather than a header that already breaches it.
     if max_chars < BRIEF_HEADER.chars().count() {
-        return Ok(String::new());
+        return String::new();
     }
     let mut out = String::from(BRIEF_HEADER);
     let mut wrote = 0usize;
@@ -785,7 +804,7 @@ pub(crate) fn dashboard_brief_inner(
         // `+ 1` is the newline this push would add; clippy prefers the strict form.
         if tile_text.chars().count() < remaining {
             out.push('\n');
-            out.push_str(&tile_text);
+            out.push_str(tile_text);
             wrote += 1;
             continue;
         }
@@ -801,7 +820,7 @@ pub(crate) fn dashboard_brief_inner(
         // as written left a BARE HEADER — the exact "views that do not exist" lie the
         // empty-board path is careful to avoid, reintroduced by an unconditional
         // increment. Nothing written means nothing counted.
-        let partial = truncate_tile(&tile_text, remaining);
+        let partial = truncate_tile(tile_text, remaining);
         if !partial.is_empty() {
             out.push_str(&partial);
             wrote += 1;
@@ -811,9 +830,9 @@ pub(crate) fn dashboard_brief_inner(
     // A bare header is the same "views that do not exist" lie an empty board is
     // careful to avoid.
     if wrote == 0 {
-        return Ok(String::new());
+        return String::new();
     }
-    Ok(out)
+    out
 }
 
 /// Keep a rendered tile's heading plus whole rows within `budget`, and count the rest.
@@ -853,54 +872,513 @@ fn truncate_tile(tile_text: &str, budget: usize) -> String {
     out
 }
 
-/// The board's derived tiles as prompt text, for `ask_vault`. `""` when there are none.
-///
-/// DELIBERATELY NOT A `#[tauri::command]`. The frontend passes a board ID and the
-/// backend derives the text; letting the FE hand a finished string into the prompt
-/// would be a new injection surface AND would put content generation outside the
-/// gate. It also means this adds no IPC surface and no `generate_handler!` entry.
-///
-/// Takes the caller's `unlocked` snapshot rather than taking its own: `ask_vault`
-/// already holds one, and gating the brief against a SECOND, later snapshot is
-/// exactly the TOCTOU that `get_dashboard`'s `lifecycle_guard` exists to prevent.
-pub(crate) fn dashboard_brief_for_ask(
+/// Resolve one ID-only dashboard into its complete, current AI scope under the caller's lifecycle
+/// interval. Missing/deleted IDs fail closed; an existing but empty/all-sealed board remains a real
+/// empty scope and never means vault-wide.
+pub(crate) fn dashboard_composite_context(
     db: &crate::storage::Db,
     dashboard_id: &str,
     unlocked: &std::collections::HashSet<String>,
     corpus_budget: usize,
-) -> Result<String, AppError> {
-    let tiles = db.list_dashboard_tiles(dashboard_id)?;
-    dashboard_brief_inner(db, tiles, unlocked, brief_allowance(corpus_budget))
-}
-
-/// The board-scoped input `ask_vault` hands to the floor prompt builder.
-///
-/// `None` ⇒ not asked from a board; every other Ask surface is byte-identical.
-/// `Some(brief)` ⇒ asked from a board, and the brief MAY BE EMPTY — an all-sealed
-/// board has nothing to show but still scopes the question. Collapsing that to
-/// `None` is the routing defect review caught: the ask fell through to a
-/// vault-wide search and answered from content the user never composed.
-///
-/// This exists as one function so the composition can be TESTED rather than read.
-/// Its two halves — the blank-id normalization and the empty-brief preservation —
-/// previously lived inline in `ask_vault`, where no test could reach them without a
-/// Tauri `State`, so a recurrence of that exact routing bug would have gone
-/// unnoticed with every added test still green.
-pub(crate) fn board_scoped_brief(
-    db: &crate::storage::Db,
-    dashboard_id: Option<&str>,
-    unlocked: &std::collections::HashSet<String>,
-    corpus_budget: usize,
-) -> Result<Option<String>, AppError> {
-    let Some(id) = dashboard_id.map(str::trim).filter(|s| !s.is_empty()) else {
-        return Ok(None);
-    };
-    Ok(Some(dashboard_brief_for_ask(
+    additional_sources: &[SourceRef],
+    excluded_meeting_id: Option<&str>,
+) -> Result<DashboardCompositeContext, AppError> {
+    dashboard_composite_context_inner(
         db,
-        id,
+        dashboard_id,
         unlocked,
         corpus_budget,
-    )?))
+        additional_sources,
+        excluded_meeting_id,
+        false,
+    )
+}
+
+/// Living Answers are cached syntheses, not evidence for regenerating themselves. Excluding every
+/// Living Answer (not only the target) keeps two answer tiles from recursively conditioning each
+/// other and makes the stored corpus digest stable after the cache write.
+pub(crate) fn living_answer_composite_context(
+    db: &crate::storage::Db,
+    dashboard_id: &str,
+    unlocked: &std::collections::HashSet<String>,
+    corpus_budget: usize,
+) -> Result<DashboardCompositeContext, AppError> {
+    dashboard_composite_context_inner(db, dashboard_id, unlocked, corpus_budget, &[], None, true)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn dashboard_composite_context_inner(
+    db: &crate::storage::Db,
+    dashboard_id: &str,
+    unlocked: &std::collections::HashSet<String>,
+    corpus_budget: usize,
+    additional_sources: &[SourceRef],
+    excluded_meeting_id: Option<&str>,
+    exclude_living_answers: bool,
+) -> Result<DashboardCompositeContext, AppError> {
+    use sha2::{Digest, Sha256};
+
+    let (generation, exists_now) = if exclude_living_answers {
+        db.dashboard_structural_context_state(dashboard_id)?
+    } else {
+        db.dashboard_context_state(dashboard_id)?
+    };
+    if !exists_now {
+        return Err(AppError::Locked("dashboard is unavailable".into()));
+    }
+    let mut tiles = db.list_dashboard_tile_structures(dashboard_id)?;
+    if exclude_living_answers {
+        tiles.retain(|tile| tile.kind != "living_answer");
+    }
+    let mut source_refs = additional_sources.to_vec();
+    for source in dashboard_sources_inner(db, tiles.clone(), unlocked)? {
+        if !source_refs
+            .iter()
+            .any(|existing| existing.kind == source.kind && existing.id == source.id)
+        {
+            source_refs.push(source);
+        }
+    }
+    source_refs.retain(|source| {
+        excluded_meeting_id.map_or(true, |meeting_id| {
+            source.kind != crate::links::LinkKind::Meeting || source.id != meeting_id
+        })
+    });
+    let brief_lines = dashboard_brief_lines(db, tiles, unlocked)?;
+    let full_derived_render = render_dashboard_brief(&brief_lines, usize::MAX);
+    let brief = render_dashboard_brief(&brief_lines, brief_allowance(corpus_budget));
+    let resolved_inputs =
+        crate::summarize::vault_context::resolve_vault_context_pinned_visible_inputs(
+            db,
+            &source_refs,
+            unlocked,
+        )?;
+    const COMPOSITE_SEPARATOR: &str = "\n\n";
+    let has_resolved_sources =
+        !resolved_inputs.explicit_sources.is_empty() || !resolved_inputs.neighbours.is_empty();
+    let separator_budget = usize::from(!brief.is_empty() && has_resolved_sources)
+        * COMPOSITE_SEPARATOR.chars().count();
+    let source_budget = corpus_budget
+        .saturating_sub(brief.chars().count())
+        .saturating_sub(separator_budget);
+    let (source_corpus, packed_sources) =
+        crate::summarize::vault_context::build_vault_context_resolved_visible_with_budget(
+            db,
+            &resolved_inputs,
+            source_budget,
+            unlocked,
+        )?;
+    let packed_corpus = match (brief.is_empty(), source_corpus.is_empty()) {
+        (true, _) => source_corpus,
+        (_, true) => brief.clone(),
+        (false, false) => format!("{brief}{COMPOSITE_SEPARATOR}{source_corpus}"),
+    };
+    // The provider corpus is intentionally budget-capped; the lifecycle witness is not. Hash the
+    // complete canonical gated input graph so a source-tail edit or selected neighbour replacement
+    // that falls wholly beyond the packing cutoff still invalidates post-await admission.
+    let mut manifest = Sha256::new();
+    manifest_field(&mut manifest, "domain", b"murmur:dashboard-full-input:v1");
+    manifest_field(&mut manifest, "dashboard_id", dashboard_id.as_bytes());
+    manifest_field(
+        &mut manifest,
+        "corpus_budget",
+        corpus_budget.to_string().as_bytes(),
+    );
+    manifest_field(
+        &mut manifest,
+        "exclude_living_answers",
+        if exclude_living_answers { b"1" } else { b"0" },
+    );
+    manifest_field(
+        &mut manifest,
+        "excluded_meeting_id",
+        excluded_meeting_id.unwrap_or("").as_bytes(),
+    );
+    for source in additional_sources {
+        manifest_source_ref(&mut manifest, "additional_source", source);
+    }
+    manifest_field(
+        &mut manifest,
+        "full_derived_render",
+        full_derived_render.as_bytes(),
+    );
+    manifest_field(&mut manifest, "packed_corpus", packed_corpus.as_bytes());
+    for source in &resolved_inputs.explicit_sources {
+        manifest_source_ref(&mut manifest, "explicit_source", &source.source);
+        manifest_field(
+            &mut manifest,
+            "explicit_full_input",
+            &source.manifest_digest,
+        );
+    }
+    for neighbour in &resolved_inputs.neighbours {
+        manifest_source_ref(&mut manifest, "neighbour_source", &neighbour.source);
+        manifest_field(
+            &mut manifest,
+            "neighbour_full_input",
+            &neighbour.manifest_digest,
+        );
+    }
+    let input_digest = format!("{:x}", manifest.finalize());
+    let ask_dispatch_generation = db.ask_dispatch_generation()?;
+    Ok(DashboardCompositeContext {
+        witness: DashboardContextWitness {
+            dashboard_id: dashboard_id.to_string(),
+            generation,
+            ask_dispatch_generation,
+            input_digest,
+            corpus_budget,
+            additional_sources: additional_sources.to_vec(),
+            excluded_meeting_id: excluded_meeting_id.map(str::to_string),
+        },
+        packed_corpus,
+        packed_sources,
+    })
+}
+
+/// Canonical unambiguous manifest field: both the label and value are byte-length-prefixed. This
+/// avoids delimiter collisions even when authored content contains arbitrary punctuation/newlines.
+fn manifest_field(hasher: &mut sha2::Sha256, label: &str, value: &[u8]) {
+    use sha2::Digest;
+
+    let label_len = u64::try_from(label.len()).unwrap_or(u64::MAX);
+    let value_len = u64::try_from(value.len()).unwrap_or(u64::MAX);
+    hasher.update(label_len.to_be_bytes());
+    hasher.update(label.as_bytes());
+    hasher.update(value_len.to_be_bytes());
+    hasher.update(value);
+}
+
+fn manifest_source_ref(hasher: &mut sha2::Sha256, role: &str, source: &SourceRef) {
+    manifest_field(hasher, "source_role", role.as_bytes());
+    manifest_field(hasher, "source_kind", source.kind.as_str().as_bytes());
+    manifest_field(hasher, "source_id", source.id.as_bytes());
+}
+
+pub(crate) fn require_dashboard_context_witness(
+    db: &crate::storage::Db,
+    witness: &DashboardContextWitness,
+    unlocked: &std::collections::HashSet<String>,
+) -> Result<(), AppError> {
+    let current = dashboard_composite_context(
+        db,
+        &witness.dashboard_id,
+        unlocked,
+        witness.corpus_budget,
+        &witness.additional_sources,
+        witness.excluded_meeting_id.as_deref(),
+    )?;
+    let (_, exists_now) = db.dashboard_context_state(&witness.dashboard_id)?;
+    if !exists_now || current.witness != *witness {
+        return Err(AppError::Locked(
+            "dashboard changed while generating the answer".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn current_ask_corpus_budget_under_lifecycle(
+    state: &AppState,
+    witness: &DashboardContextWitness,
+) -> Result<usize, AppError> {
+    let config = state
+        .config
+        .lock()
+        .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
+    let budget = super::resolved_ask_corpus_budget(&config);
+    Ok(if witness.excluded_meeting_id.is_some() {
+        budget.min(crate::summarize::chat::MAX_PINNED_SOURCE_CHARS)
+    } else {
+        budget
+    })
+}
+
+/// Revalidate both the dashboard material and the live Ask-provider packing budget while the
+/// caller owns the lifecycle guard. A witness is authorization for one exact provider input, not
+/// permission to reconstruct that input later with its now-stale budget.
+pub(crate) fn require_current_dashboard_context_witness_under_lifecycle(
+    state: &AppState,
+    witness: &DashboardContextWitness,
+    unlocked: &std::collections::HashSet<String>,
+) -> Result<(), AppError> {
+    if witness.corpus_budget != current_ask_corpus_budget_under_lifecycle(state, witness)? {
+        return Err(AppError::Locked(
+            "Ask provider changed while generating the answer".into(),
+        ));
+    }
+    require_dashboard_context_witness(&state.db, witness, unlocked)
+}
+
+pub(crate) fn require_living_answer_context_witness(
+    db: &crate::storage::Db,
+    witness: &DashboardContextWitness,
+    unlocked: &std::collections::HashSet<String>,
+) -> Result<(), AppError> {
+    let current = living_answer_composite_context(
+        db,
+        &witness.dashboard_id,
+        unlocked,
+        witness.corpus_budget,
+    )?;
+    if current.witness != *witness {
+        return Err(AppError::Locked(
+            "dashboard changed while generating the answer".into(),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn require_current_living_answer_context_witness_under_lifecycle(
+    state: &AppState,
+    witness: &DashboardContextWitness,
+    unlocked: &std::collections::HashSet<String>,
+) -> Result<(), AppError> {
+    if witness.corpus_budget != current_ask_corpus_budget_under_lifecycle(state, witness)? {
+        return Err(AppError::Locked(
+            "Ask provider changed while generating the answer".into(),
+        ));
+    }
+    require_living_answer_context_witness(&state.db, witness, unlocked)
+}
+
+fn decode_folder_provenance(raw: Option<&str>) -> Option<Vec<String>> {
+    let folders = serde_json::from_str::<Vec<String>>(raw?).ok()?;
+    folders
+        .iter()
+        .all(|folder| !folder.trim().is_empty())
+        .then_some(folders)
+}
+
+fn living_answer_withheld() -> TileData {
+    TileData::LivingAnswer {
+        question: String::new(),
+        answer: None,
+        answered_at: None,
+        withheld: true,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn persist_dashboard_living_answer_after_await_with_dispatch(
+    state: &AppState,
+    visibility: &super::DurableScopeSnapshot,
+    ask_dispatch: &super::AskDispatchSnapshot,
+    witness: &DashboardContextWitness,
+    readable_folders: &[String],
+    dashboard_id: &str,
+    tile_id: &str,
+    question: &str,
+    answer: &str,
+    answered_at: &str,
+) -> Result<Response, AppError> {
+    let _lifecycle = super::lifecycle_guard(state);
+    super::require_durable_scope_under_lifecycle(state, visibility)?;
+    super::require_current_ask_dispatch_under_lifecycle(state, ask_dispatch)?;
+    let unlocked = super::unlocked_snapshot(state)?;
+    require_current_living_answer_context_witness_under_lifecycle(state, witness, &unlocked)?;
+    let currently_readable = readable_folder_ids(&state.db, &unlocked)?;
+    if readable_folders
+        .iter()
+        .any(|folder| !currently_readable.contains(folder))
+    {
+        return Err(AppError::Locked(
+            "content visibility changed while generating the answer".into(),
+        ));
+    }
+    let readable_json = serde_json::to_string(readable_folders)
+        .map_err(|e| AppError::Storage(format!("encoding provenance failed: {e}")))?;
+    if !state.db.store_dashboard_living_answer_cas_with_dispatch(
+        tile_id,
+        dashboard_id,
+        question,
+        answer,
+        answered_at,
+        &readable_json,
+        witness.generation,
+        &witness.input_digest,
+        witness.corpus_budget,
+        witness.ask_dispatch_generation,
+    )? {
+        return Err(AppError::Locked(
+            "dashboard changed while generating the answer".into(),
+        ));
+    }
+    let payload = serde_json::to_string(&TileData::LivingAnswer {
+        question: question.to_string(),
+        answer: Some(answer.to_string()),
+        answered_at: Some(answered_at.to_string()),
+        withheld: false,
+    })
+    .map_err(|_| AppError::Unavailable("dashboard response encoding failed".into()))?;
+    Ok(Response::new(payload))
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn persist_dashboard_living_answer_after_await(
+    state: &AppState,
+    visibility: &super::DurableScopeSnapshot,
+    witness: &DashboardContextWitness,
+    readable_folders: &[String],
+    dashboard_id: &str,
+    tile_id: &str,
+    question: &str,
+    answer: &str,
+    answered_at: &str,
+) -> Result<Response, AppError> {
+    let ask_dispatch = {
+        let _lifecycle = super::lifecycle_guard(state);
+        let config = state
+            .config
+            .lock()
+            .map_err(|_| AppError::Config("config mutex poisoned".into()))?
+            .clone();
+        super::capture_ask_dispatch_snapshot_under_lifecycle(state, &config)?
+    };
+    persist_dashboard_living_answer_after_await_with_dispatch(
+        state,
+        visibility,
+        &ask_dispatch,
+        witness,
+        readable_folders,
+        dashboard_id,
+        tile_id,
+        question,
+        answer,
+        answered_at,
+    )
+}
+
+pub(crate) type LivingAnswerRefreshPreflight = (
+    super::DurableScopeSnapshot,
+    DashboardCompositeContext,
+    Vec<String>,
+    crate::settings::config::AppConfig,
+    super::AskDispatchSnapshot,
+);
+
+/// Resolve the exact Living Answer dispatch inputs inside one lifecycle interval. Keeping the
+/// complete preflight in a headless helper makes the non-reentrant-lock contract executable: the
+/// command and its regression test run this same path, including the under-lifecycle visibility
+/// snapshot capture.
+pub(crate) fn refresh_dashboard_answer_preflight(
+    state: &AppState,
+    dashboard_id: &str,
+    tile_id: &str,
+    question: &str,
+) -> Result<LivingAnswerRefreshPreflight, AppError> {
+    let _lifecycle = super::lifecycle_guard(state);
+    let config = state
+        .config
+        .lock()
+        .map_err(|_| AppError::Config("config mutex poisoned".into()))?
+        .clone();
+    let ask_dispatch = super::capture_ask_dispatch_snapshot_under_lifecycle(state, &config)?;
+    let unlocked = super::unlocked_snapshot(state)?;
+    let Some((owner, kind)) = state.db.dashboard_tile_metadata(tile_id)? else {
+        return Err(AppError::InvalidArg("living answer is unavailable".into()));
+    };
+    if owner != dashboard_id || kind != "living_answer" {
+        return Err(AppError::InvalidArg("living answer is unavailable".into()));
+    }
+    let Some(preflight) = state.db.dashboard_living_answer_preflight(tile_id)? else {
+        return Err(AppError::InvalidArg("living answer is unavailable".into()));
+    };
+    let readable = readable_folder_ids(&state.db, &unlocked)?;
+    let question_folders =
+        decode_folder_provenance(preflight.question_readable_folders_json.as_deref())
+            .ok_or_else(|| AppError::Locked("living answer is unavailable".into()))?;
+    if !question_folders
+        .iter()
+        .all(|folder| readable.contains(folder))
+    {
+        return Err(AppError::Locked("living answer is unavailable".into()));
+    }
+    let stored_question = state
+        .db
+        .dashboard_living_question_after_preflight(tile_id)?
+        .ok_or_else(|| AppError::Locked("living answer is unavailable".into()))?;
+    if stored_question != question {
+        return Err(AppError::InvalidArg(
+            "living-answer question is backend-owned".into(),
+        ));
+    }
+    let ask_conn =
+        crate::summarize::roles::provider_target(crate::summarize::roles::Role::Ask, &config)
+            .connection;
+    let context = living_answer_composite_context(
+        &state.db,
+        dashboard_id,
+        &unlocked,
+        crate::summarize::vault_context::budget_for(&ask_conn),
+    )?;
+    let mut readable_folders = readable.into_iter().collect::<Vec<_>>();
+    readable_folders.sort();
+    Ok((
+        super::DurableScopeSnapshot::Vault(
+            super::capture_content_visibility_snapshot_under_lifecycle(state),
+        ),
+        context,
+        readable_folders,
+        config,
+        ask_dispatch,
+    ))
+}
+
+/// Generate and persist one Living Answer without accepting model output or provenance from the
+/// WebView. The existing dashboard Ask core owns provider selection, consent, redaction and the
+/// content-free egress ledger. This command owns only the cache admission around that call.
+#[tauri::command]
+pub async fn refresh_dashboard_answer(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    dashboard_id: String,
+    tile_id: String,
+    question: String,
+) -> Result<Response, AppError> {
+    let question = clean_title(&question, "question")?;
+    let (visibility, context, readable_folders, config, ask_dispatch) =
+        refresh_dashboard_answer_preflight(state.inner(), &dashboard_id, &tile_id, &question)?;
+    let witness = context.witness.clone();
+    let dispatch_visibility = visibility.clone();
+    let dispatch_witness = witness.clone();
+    let dispatch_ask = ask_dispatch.clone();
+    let dispatch_admission = crate::state::ContentDispatchAdmission::new(&app, move |current| {
+        super::require_durable_scope_under_lifecycle(current, &dispatch_visibility)?;
+        super::require_current_ask_dispatch_under_lifecycle(current, &dispatch_ask)?;
+        let unlocked = super::unlocked_snapshot(current)?;
+        require_current_living_answer_context_witness_under_lifecycle(
+            current,
+            &dispatch_witness,
+            &unlocked,
+        )
+    });
+    let result = super::ask_vault_prepacked_dashboard_authorized(
+        &context,
+        &config,
+        &question,
+        &[],
+        &state.heavy_inference,
+        dispatch_admission,
+    )
+    .await?;
+    if result.answer.trim().is_empty() || result.answer.len() > MAX_CONFIG_LEN {
+        return Err(AppError::InvalidArg("answer too large or empty".into()));
+    }
+
+    let answered_at = now_iso();
+    persist_dashboard_living_answer_after_await_with_dispatch(
+        state.inner(),
+        &visibility,
+        &ask_dispatch,
+        &witness,
+        &readable_folders,
+        &dashboard_id,
+        &tile_id,
+        &question,
+        &result.answer,
+        &answered_at,
+    )
 }
 
 /// How much of the prompt the brief may take.
@@ -967,9 +1445,12 @@ fn source_is_visible(
     unlocked: &std::collections::HashSet<String>,
 ) -> Result<bool, AppError> {
     Ok(match source.kind {
-        LinkKind::Note => db.note_markdown_if_visible(&source.id, unlocked)?.is_some(),
-        LinkKind::Meeting => db.meeting_is_visible(&source.id, unlocked)?,
-        LinkKind::Document => db.get_document_if_visible(&source.id, unlocked)?.is_some(),
+        LinkKind::Note => db.note_is_visible(&source.id, unlocked)?,
+        LinkKind::Meeting => {
+            db.meeting_is_visible(&source.id, unlocked)?
+                && db.dashboard_ref_exists("meeting", &source.id)?
+        }
+        LinkKind::Document => db.document_is_visible(&source.id, unlocked)?,
     })
 }
 
@@ -979,8 +1460,6 @@ pub(crate) fn resolve_tile(
     tile: &DashboardTile,
     unlocked: &std::collections::HashSet<String>,
 ) -> Result<TileData, AppError> {
-    let cfg = parse_config(tile.config.as_deref());
-
     // Kinds that need an anchor.
     let needs_ref = matches!(
         tile.kind.as_str(),
@@ -993,13 +1472,7 @@ pub(crate) fn resolve_tile(
 
     match tile.kind.as_str() {
         "note" => {
-            // `list_notes_visible(None, …)` is the SAME gated reader the Notes list uses; a sealed
-            // note is simply absent from it, which is exactly the Locked signal we want.
-            let Some(note) = db
-                .list_notes_visible(None, unlocked)?
-                .into_iter()
-                .find(|n| n.id == ref_id)
-            else {
+            let Some(note) = db.get_document_if_visible_kind(&ref_id, "note", unlocked)? else {
                 // Absent can mean sealed OR deleted. Distinguish with an EXISTENCE-only probe —
                 // it returns a bool, never a title or folder.
                 return Ok(if db.dashboard_ref_exists("note", &ref_id)? {
@@ -1008,26 +1481,20 @@ pub(crate) fn resolve_tile(
                     TileData::Missing
                 });
             };
-            if note.locked {
-                return Ok(TileData::Locked);
-            }
             Ok(TileData::Note {
                 id: note.id,
-                title: note.title,
-                snippet: snippet_of(&note.snippet, 220),
-                updated_at: note.updated_at,
+                title: note.title.unwrap_or(note.name),
+                snippet: snippet_of(&note.markdown, 220),
+                updated_at: note.updated_at.unwrap_or(note.created_at),
             })
         }
         "meeting" => {
-            if !db.meeting_is_visible(&ref_id, unlocked)? {
-                return Ok(if db.get_meeting(&ref_id)?.is_some() {
+            let Some(m) = db.get_meeting_if_visible(&ref_id, unlocked)? else {
+                return Ok(if db.dashboard_ref_exists("meeting", &ref_id)? {
                     TileData::Locked
                 } else {
                     TileData::Missing
                 });
-            }
-            let Some(m) = db.get_meeting(&ref_id)? else {
-                return Ok(TileData::Missing);
             };
             Ok(TileData::Meeting {
                 id: m.id,
@@ -1038,7 +1505,7 @@ pub(crate) fn resolve_tile(
             })
         }
         "document" => {
-            let Some(doc) = db.get_document_if_visible(&ref_id, unlocked)? else {
+            let Some(doc) = db.get_document_if_visible_kind(&ref_id, "document", unlocked)? else {
                 return Ok(if db.dashboard_ref_exists("document", &ref_id)? {
                     TileData::Locked
                 } else {
@@ -1056,11 +1523,7 @@ pub(crate) fn resolve_tile(
             })
         }
         "person" => {
-            let Some(node) = db
-                .list_entities_visible(unlocked)?
-                .into_iter()
-                .find(|e| e.id == ref_id)
-            else {
+            let Some(node) = db.get_entity_node_visible(&ref_id, unlocked)? else {
                 // An entity visible ONLY through sealed meetings is indistinguishable from an
                 // unknown one — the same non-leak contract `get_entity_detail` keeps, and the
                 // reason this arm must NOT fall back to any stored name. `redact_tile_chrome`
@@ -1086,19 +1549,17 @@ pub(crate) fn resolve_tile(
             // "smart" reminder's TITLE is authored from meeting content, so a reminder whose
             // every anchor points at a source the session cannot read is withheld here.
             let mut rows: Vec<(i64, TileRow)> = db
-                .list_stored_reminders()?
+                .list_dashboard_reminders_visible(unlocked)?
                 .into_iter()
-                .filter(|r| matches!(r.state, crate::storage::models::ReminderState::Active))
-                .filter(|r| reminder_provenance_is_readable(db, r, unlocked))
-                .map(|r| {
+                .map(|(title, due_at)| {
                     // Due in the past ⇒ "due" (needs attention), else "open".
                     let now_ms = chrono::Utc::now().timestamp_millis();
-                    let status = if r.due_at <= now_ms { "due" } else { "open" };
+                    let status = if due_at <= now_ms { "due" } else { "open" };
                     (
-                        r.due_at,
+                        due_at,
                         TileRow {
-                            text: r.title,
-                            meta: Some(format_epoch_day(r.due_at)),
+                            text: title,
+                            meta: Some(format_epoch_day(due_at)),
                             status: Some(status.to_string()),
                             source: None,
                         },
@@ -1115,24 +1576,27 @@ pub(crate) fn resolve_tile(
         "drift" => {
             // The bitemporal fact history for the entity, already gated by `list_facts_visible`.
             let facts = db.list_facts_visible(&ref_id, unlocked)?;
+            let entity = entity_name(db, &ref_id, unlocked)?;
+            if entity == ENTITY_HIDDEN {
+                return Ok(TileData::Drift {
+                    entity,
+                    predicate: String::new(),
+                    rows: vec![],
+                });
+            }
             if facts.is_empty() {
-                let entity = entity_name(db, &ref_id, unlocked)?;
                 return Ok(TileData::Drift {
                     // A hidden entity emits NO stored predicate either. Nothing writes
                     // `config.predicate` today, but the day a UI lets a user pin one chosen from
                     // an entity's facts, echoing it back for a sealed entity would be a leak.
-                    predicate: if entity == ENTITY_HIDDEN {
-                        String::new()
-                    } else {
-                        cfg.predicate.unwrap_or_default()
-                    },
+                    predicate: String::new(),
                     entity,
                     rows: vec![],
                 });
             }
             // Pick the predicate with the most recorded values (the one that actually moved),
             // unless the tile pins one.
-            let predicate = cfg.predicate.clone().unwrap_or_else(|| {
+            let predicate = {
                 let mut counts: std::collections::HashMap<&str, usize> =
                     std::collections::HashMap::new();
                 for f in &facts {
@@ -1143,7 +1607,7 @@ pub(crate) fn resolve_tile(
                     .max_by_key(|(_, n)| *n)
                     .map(|(p, _)| p.to_string())
                     .unwrap_or_default()
-            });
+            };
             let mut steps: Vec<_> = facts
                 .iter()
                 .filter(|f| f.predicate == predicate)
@@ -1169,7 +1633,7 @@ pub(crate) fn resolve_tile(
                 .rev()
                 .collect();
             Ok(TileData::Drift {
-                entity: entity_name(db, &ref_id, unlocked)?,
+                entity,
                 predicate,
                 rows,
             })
@@ -1230,7 +1694,7 @@ pub(crate) fn resolve_tile(
             })
         }
         "promises" => {
-            let owner = cfg.owner.clone();
+            let owner = None;
             let items = db.list_open_commitments(unlocked, owner.as_deref())?;
             let rows = items
                 .into_iter()
@@ -1259,15 +1723,130 @@ pub(crate) fn resolve_tile(
             //
             // Fail-closed on a legacy row: an answer with no recorded sources cannot be checked,
             // so it is withheld rather than trusted.
-            let has_answer = cfg.answer.as_ref().is_some_and(|a| !a.trim().is_empty());
-            let recorded = cfg.answer_readable_folders.unwrap_or_default();
-            let withheld =
-                living_answer_withheld(has_answer, &recorded, &readable_folder_ids(db, unlocked)?);
+            let readable = readable_folder_ids(db, unlocked)?;
+            let Some(preflight) = db.dashboard_living_answer_preflight(&tile.id)? else {
+                return Ok(living_answer_withheld());
+            };
+            let Some(question_provenance) =
+                decode_folder_provenance(preflight.question_readable_folders_json.as_deref())
+            else {
+                return Ok(living_answer_withheld());
+            };
+            if !question_provenance
+                .iter()
+                .all(|folder| readable.contains(folder))
+            {
+                return Ok(living_answer_withheld());
+            }
+            match &preflight.answer {
+                LivingAnswerCacheState::Empty => {
+                    let Some(question) = db.dashboard_living_question_after_preflight(&tile.id)?
+                    else {
+                        return Ok(living_answer_withheld());
+                    };
+                    return Ok(TileData::LivingAnswer {
+                        question,
+                        answer: None,
+                        answered_at: None,
+                        withheld: false,
+                    });
+                }
+                LivingAnswerCacheState::Malformed => return Ok(living_answer_withheld()),
+                LivingAnswerCacheState::Valid {
+                    readable_folders_json,
+                    context_generation,
+                    context_digest,
+                    context_budget,
+                    ask_dispatch_generation,
+                } => {
+                    let Some(answer_folders) =
+                        decode_folder_provenance(Some(readable_folders_json))
+                    else {
+                        return Ok(living_answer_withheld());
+                    };
+                    let Ok(context_budget) = usize::try_from(*context_budget) else {
+                        return Ok(living_answer_withheld());
+                    };
+                    if context_budget == 0 || context_budget > 200_000 {
+                        return Ok(living_answer_withheld());
+                    }
+                    let current = living_answer_composite_context(
+                        db,
+                        &tile.dashboard_id,
+                        unlocked,
+                        context_budget,
+                    )?;
+                    if *ask_dispatch_generation != current.witness.ask_dispatch_generation {
+                        let Some(question) =
+                            db.dashboard_living_question_after_preflight(&tile.id)?
+                        else {
+                            return Ok(living_answer_withheld());
+                        };
+                        return Ok(TileData::LivingAnswer {
+                            question,
+                            answer: None,
+                            answered_at: None,
+                            withheld: false,
+                        });
+                    }
+                    if *context_generation != current.witness.generation
+                        || *context_digest != current.witness.input_digest
+                        || !answer_folders
+                            .iter()
+                            .all(|folder| readable.contains(folder))
+                    {
+                        return Ok(living_answer_withheld());
+                    }
+                }
+            }
+            let ask_dispatch_generation = match preflight.answer {
+                LivingAnswerCacheState::Valid {
+                    ask_dispatch_generation,
+                    ..
+                } => ask_dispatch_generation,
+                LivingAnswerCacheState::Empty | LivingAnswerCacheState::Malformed => {
+                    return Ok(living_answer_withheld());
+                }
+            };
+            let Some(content) = db.dashboard_living_answer_content_after_preflight_with_dispatch(
+                &tile.id,
+                ask_dispatch_generation,
+                match &preflight.answer {
+                    LivingAnswerCacheState::Valid {
+                        context_generation,
+                        ..
+                    } => *context_generation,
+                    LivingAnswerCacheState::Empty | LivingAnswerCacheState::Malformed => -1,
+                },
+                match &preflight.answer {
+                    LivingAnswerCacheState::Valid { context_digest, .. } => context_digest,
+                    LivingAnswerCacheState::Empty | LivingAnswerCacheState::Malformed => "",
+                },
+                match &preflight.answer {
+                    LivingAnswerCacheState::Valid { context_budget, .. } => *context_budget,
+                    LivingAnswerCacheState::Empty | LivingAnswerCacheState::Malformed => -1,
+                },
+            )?
+            else {
+                return Ok(living_answer_withheld());
+            };
+            let question = content.question;
+            let answer = content.answer;
+            let answered_at = content.answered_at;
+            if question.trim().is_empty()
+                || answer.as_ref().is_some_and(|value| value.trim().is_empty())
+                || answered_at
+                    .as_ref()
+                    .is_some_and(|value| value.trim().is_empty())
+                || (answer.is_some() != answered_at.is_some())
+            {
+                return Ok(living_answer_withheld());
+            }
             Ok(TileData::LivingAnswer {
-                question: cfg.question.unwrap_or_default(),
-                answer: if withheld { None } else { cfg.answer },
-                answered_at: if withheld { None } else { cfg.answered_at },
-                withheld,
+                question,
+                answer,
+                answered_at,
+                withheld: false,
             })
         }
         other => Err(AppError::InvalidArg(format!("unknown tile kind: {other}"))),
@@ -1362,14 +1941,14 @@ pub(crate) fn render_tile_for_agent(tile: &DashboardTile, data: &TileData) -> St
             // NEVER fall back to the stored title when the answer is withheld: that title is
             // exactly the field a legacy row copied from the source. An unnamed withheld tile is
             // anonymous, which is the correct outcome.
-            let q = match (question.trim().is_empty(), *withheld) {
-                (true, true) => "(untitled)".to_string(),
-                (true, false) => heading("living answer"),
-                _ => question.clone(),
-            };
             if *withheld {
-                format!("- living answer: {q}\n    [saved answer withheld — a source is sealed]")
+                "- living answer\n    [saved answer withheld — a source is sealed]".to_string()
             } else {
+                let q = if question.trim().is_empty() {
+                    heading("living answer")
+                } else {
+                    question.clone()
+                };
                 format!(
                     "- living answer: {q}\n    {}",
                     answer.as_deref().unwrap_or("(not answered yet)")
@@ -1381,37 +1960,10 @@ pub(crate) fn render_tile_for_agent(tile: &DashboardTile, data: &TileData) -> St
 
 /// Is a reminder's PROVENANCE readable in this session?
 ///
-/// `true` when it has no anchors at all (a hand-written reminder is the user's own data), or when
-/// at least one anchor still resolves through its gated reader. Withholding a reminder whose every
-/// anchor is sealed is what stops an agent reading a title that was authored from sealed content.
-fn reminder_provenance_is_readable(
-    db: &crate::storage::Db,
-    reminder: &crate::storage::models::StoredReminder,
-    unlocked: &std::collections::HashSet<String>,
-) -> bool {
-    if reminder.sources.is_empty() {
-        return true;
-    }
-    reminder.sources.iter().any(|anchor| {
-        let kind = match anchor.kind.as_str() {
-            "meeting" => LinkKind::Meeting,
-            "note" => LinkKind::Note,
-            "document" => LinkKind::Document,
-            // An anchor kind we do not understand cannot be proven readable ⇒ it does not count.
-            _ => return false,
-        };
-        source_is_visible(
-            db,
-            &SourceRef {
-                kind,
-                id: anchor.id.clone(),
-            },
-            unlocked,
-        )
-        .unwrap_or(false)
-    })
-}
-
+/// `true` when a manual reminder has no anchors (the user's own data), or when every recorded
+/// anchor resolves through its gated reader. A smart reminder with no anchors is unprovable and
+/// fails closed. A title can be derived jointly from multiple anchors, so one readable anchor
+/// never declassifies text influenced by a sealed one.
 /// The placeholder an entity-anchored tile shows when its entity is not currently visible. Also
 /// the signal `redact_tile_chrome` reads to strip that tile's stored chrome.
 const ENTITY_HIDDEN: &str = "—";
@@ -1424,9 +1976,7 @@ fn entity_name(
     unlocked: &std::collections::HashSet<String>,
 ) -> Result<String, AppError> {
     Ok(db
-        .list_entities_visible(unlocked)?
-        .into_iter()
-        .find(|e| e.id == entity_id)
+        .get_entity_node_visible(entity_id, unlocked)?
         .map(|e| e.name)
         .unwrap_or_else(|| ENTITY_HIDDEN.to_string()))
 }

--- a/src-tauri/src/commands/documents.rs
+++ b/src-tauri/src/commands/documents.rs
@@ -789,7 +789,13 @@ pub(crate) fn persist_generated_note(
                 .db
                 .insert_note(&id, &prepared.folder_id, &name, &prepared.title, "", now)?;
         }
-        index_wikilinks_best_effort(state, crate::links::LinkKind::Note, &id, "");
+        index_wikilinks_best_effort_under_lifecycle(
+            state,
+            &_lifecycle,
+            crate::links::LinkKind::Note,
+            &id,
+            "",
+        );
     }
 
     // ATTACHMENTS (best-effort — a failure keeps the text note, never loses the untouched source).

--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -247,7 +247,7 @@ fn link_endpoint_is_unlocked(
             // `Some` ⇒ visible/unlocked, `None` ⇒ sealed-or-unknown ⇒ refuse. Documents stay
             // linkable (the chooser AND the Ask source-picker both offer them) and still fail-closed.
             let unlocked = unlocked_snapshot(state)?;
-            Ok(state.db.get_document_if_visible(id, &unlocked)?.is_some())
+            Ok(state.db.document_is_visible(id, &unlocked)?)
         }
     }
 }

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -86,7 +86,8 @@ pub fn add_mcp_server(
 /// Remove one MCP server (its tool disappears from the brain on the next spec build).
 #[tauri::command]
 pub fn remove_mcp_server(state: State<'_, AppState>, server_id: String) -> Result<(), AppError> {
-    state.db.delete_mcp_server(&server_id)
+    let _lifecycle = super::lifecycle_guard(state.inner());
+    state.db.delete_mcp_server_for_ask(&server_id)
 }
 
 /// Grant the ONE-TIME per-server egress consent for an MCP server. Mirrors
@@ -96,15 +97,23 @@ pub fn consent_to_mcp_server(
     state: State<'_, AppState>,
     server_id: String,
 ) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state.inner());
     if state.db.get_mcp_server(&server_id)?.is_none() {
         return Err(AppError::InvalidArg(format!("no MCP server {server_id}")));
     }
-    state.db.set_mcp_server_consented(&server_id, true)
+    state
+        .db
+        .set_mcp_server_consented_for_ask(&server_id, true)
+        .map(|_| ())
 }
 
 /// Revoke an MCP server's egress consent — it drops out of the connector registry and the brain's
 /// tool list on the next build (fail-closed).
 #[tauri::command]
 pub fn revoke_mcp_consent(state: State<'_, AppState>, server_id: String) -> Result<(), AppError> {
-    state.db.set_mcp_server_consented(&server_id, false)
+    let _lifecycle = super::lifecycle_guard(state.inner());
+    state
+        .db
+        .set_mcp_server_consented_for_ask(&server_id, false)
+        .map(|_| ())
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -64,7 +64,8 @@ mod reminders;
 pub use reminders::*;
 
 // Dashboards — user-composed boards of tiles over EXISTING sources. Every tile payload resolves
-// through the gated readers at read time; the module adds no ungated query and no new AI path.
+// through gated readers at read time; composite Ask uses the shared authorized provider/egress
+// seam and revalidates its backend-owned witness after every await.
 mod dashboards;
 pub use dashboards::*;
 
@@ -376,13 +377,21 @@ pub(crate) struct ContentVisibilitySnapshot {
     seal_epoch: u64,
 }
 
+/// Capture the current authorization epoch while the caller already owns `lifecycle_guard`.
+/// Keeping this twin explicit prevents nested locking of the non-reentrant lifecycle mutex.
+pub(crate) fn capture_content_visibility_snapshot_under_lifecycle(
+    state: &AppState,
+) -> ContentVisibilitySnapshot {
+    ContentVisibilitySnapshot {
+        seal_epoch: state.seal_epoch.load(std::sync::atomic::Ordering::SeqCst),
+    }
+}
+
 /// Capture the current content-authorization generation under the same lifecycle mutex as every
 /// lock transition. Call this BEFORE assembling a visible multi-source corpus.
 pub(crate) fn capture_content_visibility_snapshot(state: &AppState) -> ContentVisibilitySnapshot {
     let _lifecycle = lifecycle_guard(state);
-    ContentVisibilitySnapshot {
-        seal_epoch: state.seal_epoch.load(std::sync::atomic::Ordering::SeqCst),
-    }
+    capture_content_visibility_snapshot_under_lifecycle(state)
 }
 
 pub(crate) fn require_current_content_visibility_snapshot_under_lifecycle(
@@ -2299,12 +2308,7 @@ pub async fn update_note(
     .await?;
     // If the edit re-published ≥1 org copy, ping open org views (Notes list + Settings) so the fresh
     // title/body shows without a manual "Sync now". Best-effort — a republish failure never fails the save.
-    if republish_org_shares_for_source_notifying(
-        state.inner(),
-        Some(&meeting_id),
-        None,
-        &app,
-    )
+    if republish_org_shares_for_source_notifying(state.inner(), Some(&meeting_id), None, &app)
         .await
         .unwrap_or(0)
         > 0
@@ -4172,7 +4176,13 @@ pub(crate) fn rename_meeting_inner(
     if title.is_empty() {
         return Err(AppError::InvalidArg("title cannot be empty".into()));
     }
-    state.db.set_meeting_title(meeting_id, title)?;
+    // The title is part of dashboard material/composite digests. Serialize this short canonical
+    // write with history preflight+hydration so a durable dashboard conversation can never validate
+    // the old title and then hydrate its old turns after the new title has landed.
+    {
+        let _lifecycle = lifecycle_guard(state);
+        state.db.set_meeting_title(meeting_id, title)?;
+    }
     // Keep the companion note's managed title + front-matter `[[Meeting]]` link in sync with the new
     // title. Best-effort — a sync failure NEVER fails the rename (the title is already persisted).
     sync_companion_note_title_best_effort_with(state, meeting_id, embedder);
@@ -4215,6 +4225,100 @@ pub(crate) fn pack_chat_pinned_sources(
     Ok(corpus)
 }
 
+pub(crate) fn resolved_ask_corpus_budget(config: &AppConfig) -> usize {
+    let connection = crate::summarize::roles::provider_target(
+        crate::summarize::roles::Role::Ask,
+        config,
+    )
+    .connection;
+    crate::summarize::vault_context::budget_for(&connection)
+}
+
+/// Durable authorization captured for one Ask dispatch. The monotonic generation defeats
+/// A->B->A ABA changes; the exact projection additionally fails closed if a writer mutates the
+/// in-memory config without rotating the generation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AskDispatchSnapshot {
+    pub(crate) generation: i64,
+    projection: String,
+}
+
+pub(crate) fn ask_dispatch_projection(config: &AppConfig) -> String {
+    let provider = crate::summarize::roles::provider_target(
+        crate::summarize::roles::Role::Ask,
+        config,
+    );
+    let reasoner = crate::summarize::roles::reasoner_target(
+        crate::summarize::roles::Role::Ask,
+        config,
+    );
+    serde_json::json!({
+        "provider": [provider.connection, provider.model, provider.effort],
+        "reasoner": [reasoner.connection, reasoner.model, reasoner.effort],
+        "effectiveModel": crate::summarize::effective_model_requested(&provider, config),
+        "cloudConsent": config.cloud_egress_consented,
+        "anthropicModel": config.anthropic_model,
+        "ollama": [config.ollama_base_url, config.ollama_model],
+        "gateway": [config.gateway_base_url, config.gateway_model],
+        "claude": [config.claude_binary, config.claude_code_inherit_env.to_string()],
+        "local": [
+            config.brain_model_path.clone().unwrap_or_default(),
+            config.brain_model_id.clone().unwrap_or_default(),
+            config.brain_light_model_id.clone().unwrap_or_default(),
+            config.brain_heavy_model_id.clone().unwrap_or_default(),
+            config.brain_idle_timeout_secs.to_string(),
+            config.brain_ready_timeout_secs.to_string(),
+            config.brain_hard_cap_secs.to_string(),
+        ],
+        "retrieval": [
+            config.embed_model_id.clone().unwrap_or_default(),
+            config.semantic_search_enabled,
+            config.user_memory_enabled,
+            config.ask_jit_retrieval,
+            config.brain_heavy_grammar_enabled,
+            config.loop_transcript_compaction,
+        ],
+        "connectors": {
+            "web": [config.web_search_enabled, config.web_search_consented],
+            "jira": [config.jira_enabled, config.jira_consented],
+            "jiraEndpoint": [config.jira_base_url, config.jira_email],
+            "slack": [config.slack_enabled, config.slack_consented],
+            "notion": [config.notion_enabled, config.notion_consented],
+            "clickup": [config.clickup_enabled, config.clickup_consented],
+            "clickupTeam": config.clickup_team_id,
+        },
+    })
+    .to_string()
+}
+
+pub(crate) fn capture_ask_dispatch_snapshot_under_lifecycle(
+    state: &AppState,
+    config: &AppConfig,
+) -> Result<AskDispatchSnapshot, AppError> {
+    Ok(AskDispatchSnapshot {
+        generation: state.db.ask_dispatch_generation()?,
+        projection: ask_dispatch_projection(config),
+    })
+}
+
+pub(crate) fn require_current_ask_dispatch_under_lifecycle(
+    state: &AppState,
+    expected: &AskDispatchSnapshot,
+) -> Result<(), AppError> {
+    let config = state
+        .config
+        .lock()
+        .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
+    if state.db.ask_dispatch_generation()? != expected.generation
+        || ask_dispatch_projection(&config) != expected.projection
+    {
+        return Err(AppError::Locked(
+            "Ask provider changed while generating the answer".into(),
+        ));
+    }
+    Ok(())
+}
+
 /// Grounded Q&A over a meeting's transcript ("chat with the meeting"). The configured
 /// provider answers strictly from the transcript, explicitly pinned sources, and running history.
 #[tauri::command]
@@ -4225,7 +4329,16 @@ pub async fn chat_meeting(
     question: String,
     history: Vec<ChatTurn>,
     explicit_sources: Option<Vec<crate::storage::models::SourceRef>>,
+    dashboard_id: Option<String>,
 ) -> Result<String, AppError> {
+    if dashboard_id
+        .as_deref()
+        .is_some_and(|id| !id.trim().is_empty())
+    {
+        return Err(AppError::InvalidArg(
+            "dashboard chat requires a persisted conversation".into(),
+        ));
+    }
     chat_meeting_inner(
         &app,
         state.inner(),
@@ -4233,11 +4346,18 @@ pub async fn chat_meeting(
         question,
         history,
         explicit_sources,
+        dashboard_id,
+        None,
+        None,
         None,
     )
     .await
 }
 
+// This is the single gated meeting-chat boundary. Its arguments deliberately keep the caller's
+// content snapshot and dashboard witness adjacent to the user inputs so neither authorization
+// token can be accidentally reconstructed after provider dispatch.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn chat_meeting_inner(
     app: &AppHandle,
     state: &AppState,
@@ -4245,19 +4365,168 @@ pub(crate) async fn chat_meeting_inner(
     question: String,
     history: Vec<ChatTurn>,
     explicit_sources: Option<Vec<crate::storage::models::SourceRef>>,
+    dashboard_id: Option<String>,
     authoritative_snapshot: Option<MeetingContentSnapshot>,
+    authoritative_dashboard: Option<dashboards::DashboardContextWitness>,
+    authoritative_ask_dispatch: Option<AskDispatchSnapshot>,
 ) -> Result<String, AppError> {
     if question.trim().is_empty() {
         return Err(AppError::InvalidArg("question is empty".into()));
     }
-    let visibility = match authoritative_snapshot {
+    require_backend_owned_dashboard_history(
+        authoritative_snapshot.is_some(),
+        dashboard_id.as_deref(),
+        &history,
+    )?;
+    let (inputs, config) = meeting_provider_inputs(
+        state,
+        &meeting_id,
+        authoritative_snapshot,
+        dashboard_id.as_deref(),
+        explicit_sources.as_deref().unwrap_or_default(),
+        &history,
+        &question,
+    )?;
+    let dashboard_witness = inputs.dashboard.clone();
+    if authoritative_ask_dispatch
+        .as_ref()
+        .is_some_and(|expected| expected != &inputs.ask_dispatch)
+    {
+        return Err(AppError::Locked(
+            "Ask provider changed while preparing the answer".into(),
+        ));
+    }
+    if let Some(expected) = authoritative_dashboard.as_ref() {
+        if dashboard_witness.as_ref() != Some(expected) {
+            return Err(AppError::Locked(
+                "dashboard changed while preparing the answer".into(),
+            ));
+        }
+    }
+    // ASK role: meeting chat is a Q&A surface. With role keys absent this resolves to the same
+    // default provider as before (the legacy chat path always ignored `brain_backend`).
+    let config_for_dispatch = config.clone();
+    let heavy_for_dispatch = state.heavy_inference.clone();
+    let meeting_for_admission = meeting_id.clone();
+    let inputs_for_admission = inputs.clone();
+    let dashboard_id_for_admission = dashboard_id.clone();
+    let sources_for_admission = explicit_sources.clone().unwrap_or_default();
+    let history_for_admission = history.clone();
+    let question_for_admission = question.clone();
+    let dispatch_admission = crate::state::ContentDispatchAdmission::new(app, move |state| {
+        require_meeting_dashboard_scope_under_lifecycle(
+            state,
+            &meeting_for_admission,
+            &inputs_for_admission,
+            dashboard_id_for_admission.as_deref(),
+            &sources_for_admission,
+            &history_for_admission,
+            &question_for_admission,
+        )
+    });
+    let answer = dispatch_admission
+        .run(|| async {
+            let provider = crate::summarize::provider_for(
+                crate::summarize::roles::Role::Ask,
+                &config_for_dispatch,
+                &heavy_for_dispatch,
+            )?;
+            provider.complete(&inputs.system, &inputs.user).await
+        })
+        .await?;
+    require_meeting_dashboard_scope_for_return(
+        state,
+        &meeting_id,
+        &inputs,
+        dashboard_id.as_deref(),
+        explicit_sources.as_deref().unwrap_or_default(),
+        &history,
+        &question,
+    )?;
+    Ok(answer)
+}
+
+#[derive(Clone)]
+struct MeetingProviderInputs {
+    visibility: MeetingContentSnapshot,
+    dashboard: Option<dashboards::DashboardContextWitness>,
+    ask_dispatch: AskDispatchSnapshot,
+    system: String,
+    user: String,
+    input_digest: String,
+}
+
+fn composed_provider_input_digest(system: &str, user: &str) -> String {
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    hasher.update(system.as_bytes());
+    hasher.update([0]);
+    hasher.update(user.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn meeting_provider_inputs(
+    state: &AppState,
+    meeting_id: &str,
+    authoritative_snapshot: Option<MeetingContentSnapshot>,
+    dashboard_id: Option<&str>,
+    additional_sources: &[crate::storage::models::SourceRef],
+    history: &[ChatTurn],
+    question: &str,
+) -> Result<(MeetingProviderInputs, AppConfig), AppError> {
+    let _lifecycle = lifecycle_guard(state);
+    let config = state
+        .config
+        .lock()
+        .map_err(|_| AppError::Config("config mutex poisoned".into()))?
+        .clone();
+    let inputs = meeting_provider_inputs_under_lifecycle(
+        state,
+        meeting_id,
+        authoritative_snapshot,
+        &config,
+        dashboard_id,
+        additional_sources,
+        history,
+        question,
+    )?;
+    Ok((inputs, config))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn meeting_provider_inputs_under_lifecycle(
+    state: &AppState,
+    meeting_id: &str,
+    authoritative_snapshot: Option<MeetingContentSnapshot>,
+    config: &AppConfig,
+    dashboard_id: Option<&str>,
+    additional_sources: &[crate::storage::models::SourceRef],
+    history: &[ChatTurn],
+    question: &str,
+) -> Result<MeetingProviderInputs, AppError> {
+    let snapshot = match authoritative_snapshot {
         Some(snapshot) => {
-            require_current_meeting_content_snapshot(state, &meeting_id, &snapshot)?;
+            require_current_meeting_content_snapshot_under_lifecycle(state, meeting_id, &snapshot)?;
             snapshot
         }
-        None => capture_meeting_content_snapshot(state, &meeting_id)?,
+        None => {
+            if !meeting_is_unlocked(state, meeting_id)? {
+                return Err(AppError::Locked(
+                    "this meeting's folder is locked — unlock it and retry".into(),
+                ));
+            }
+            MeetingContentSnapshot {
+                folder_id: state.db.folder_for_meeting(meeting_id)?,
+                visibility: ContentVisibilitySnapshot {
+                    seal_epoch: state.seal_epoch.load(std::sync::atomic::Ordering::SeqCst),
+                },
+                active_related: active_related_witness(state, meeting_id)?,
+            }
+        }
     };
-    let segments = state.db.get_segments(&meeting_id)?;
+    let segments = state.db.get_segments(meeting_id)?;
     if segments.is_empty() {
         return Err(AppError::InvalidArg(
             "this meeting has no transcript to chat about yet".into(),
@@ -4265,56 +4534,126 @@ pub(crate) async fn chat_meeting_inner(
     }
     let transcript = segments
         .iter()
-        .map(|s| format!("[{:.0}s] {}", s.start_s, s.text.trim()))
+        .map(|segment| format!("[{:.0}s] {}", segment.start_s, segment.text.trim()))
         .collect::<Vec<_>>()
         .join("\n");
-    let config = {
-        state
-            .config
-            .lock()
-            .map_err(|_| AppError::Config("config mutex poisoned".into()))?
-            .clone()
-    };
-    // Inject the gated cross-meeting USER MEMORY brief (parity with the @brain agentic loop): derived
-    // from VISIBLE user facts only under the LIVE unlock snapshot, empty when memory is disabled ⇒
-    // byte-identical prompt. Rides this surface's existing redaction + consent egress (no new class).
     let unlocked = unlocked_snapshot(state)?;
-    // note↔meeting-links PR-2 — SOURCE-SCOPED augmentation: when the FE pins explicit sources (the
-    // linked notes/meetings the user chose above the chat input), APPEND their gated PINNED corpus
-    // (+ capped, gated link-expansion) to this meeting's transcript grounding — the meeting stays the
-    // primary context, the pinned items add cross-item context. Every leg is `unlocked`-gated (a
-    // sealed pinned source/neighbour contributes NOTHING — never a leak). `None`/empty ⇒ byte-
-    // identical to the pre-change transcript-only grounding.
-    let mut pinned_sources = String::new();
-    if let Some(sources) = explicit_sources.filter(|s| !s.is_empty()) {
+    let composite = match dashboard_id.map(str::trim).filter(|id| !id.is_empty()) {
+        Some(id) => {
+            let ask_conn = crate::summarize::roles::provider_target(
+                crate::summarize::roles::Role::Ask,
+                config,
+            )
+            .connection;
+            let budget = crate::summarize::vault_context::budget_for(&ask_conn)
+                .min(crate::summarize::chat::MAX_PINNED_SOURCE_CHARS);
+            Some(dashboards::dashboard_composite_context(
+                &state.db,
+                id,
+                &unlocked,
+                budget,
+                additional_sources,
+                Some(meeting_id),
+            )?)
+        }
+        None => None,
+    };
+    let pinned_sources = if let Some(context) = composite.as_ref() {
+        context.packed_corpus.clone()
+    } else if additional_sources.is_empty() {
+        String::new()
+    } else {
         let ask_conn =
-            crate::summarize::roles::provider_target(crate::summarize::roles::Role::Ask, &config)
+            crate::summarize::roles::provider_target(crate::summarize::roles::Role::Ask, config)
                 .connection;
-        pinned_sources =
-            pack_chat_pinned_sources(&state.db, &meeting_id, &sources, &ask_conn, &unlocked)?;
-    }
-    // ASK role: meeting chat is a Q&A surface. With role keys absent this resolves to the same
-    // default provider as before (the legacy chat path always ignored `brain_backend`).
-    let provider = crate::summarize::provider_for(
-        crate::summarize::roles::Role::Ask,
-        &config,
-        &state.heavy_inference,
-    )?;
-    let memory_brief = gated_memory_brief_for_injection(state, &unlocked, &question);
-    let (system, user) = crate::summarize::chat::build_with_sources(
+        pack_chat_pinned_sources(
+            &state.db,
+            meeting_id,
+            additional_sources,
+            &ask_conn,
+            &unlocked,
+        )?
+    };
+    let memory_brief = if composite.is_some() {
+        String::new()
+    } else {
+        gated_memory_brief_for_injection(state, &unlocked, question)
+    };
+    let (system, user) = crate::summarize::chat::build_with_composite_sources(
         &transcript,
         &pinned_sources,
-        &history,
-        &question,
+        history,
+        question,
         &memory_brief,
+        composite.is_some(),
     );
-    let dispatch_admission =
-        meeting_dispatch_admission(app, meeting_id.clone(), visibility.clone());
-    let answer = dispatch_admission
-        .run(|| provider.complete(&system, &user))
-        .await?;
-    require_current_meeting_content_snapshot(state, &meeting_id, &visibility)?;
-    Ok(answer)
+    let input_digest = composed_provider_input_digest(&system, &user);
+    Ok(MeetingProviderInputs {
+        visibility: snapshot,
+        dashboard: composite.map(|context| context.witness),
+        ask_dispatch: capture_ask_dispatch_snapshot_under_lifecycle(state, config)?,
+        system,
+        user,
+        input_digest,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn require_meeting_dashboard_scope_under_lifecycle(
+    state: &AppState,
+    meeting_id: &str,
+    expected: &MeetingProviderInputs,
+    dashboard_id: Option<&str>,
+    additional_sources: &[crate::storage::models::SourceRef],
+    history: &[ChatTurn],
+    question: &str,
+) -> Result<(), AppError> {
+    let config = state
+        .config
+        .lock()
+        .map_err(|_| AppError::Config("config mutex poisoned".into()))?
+        .clone();
+    let current = meeting_provider_inputs_under_lifecycle(
+        state,
+        meeting_id,
+        Some(expected.visibility.clone()),
+        &config,
+        dashboard_id,
+        additional_sources,
+        history,
+        question,
+    )?;
+    if current.dashboard != expected.dashboard
+        || current.ask_dispatch != expected.ask_dispatch
+        || current.input_digest != expected.input_digest
+    {
+        return Err(AppError::Locked(
+            "meeting or dashboard context changed while generating the answer".into(),
+        ));
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn require_meeting_dashboard_scope_for_return(
+    state: &AppState,
+    meeting_id: &str,
+    expected: &MeetingProviderInputs,
+    dashboard_id: Option<&str>,
+    additional_sources: &[crate::storage::models::SourceRef],
+    history: &[ChatTurn],
+    question: &str,
+) -> Result<(), AppError> {
+    let _lifecycle = lifecycle_guard(state);
+    require_meeting_dashboard_scope_under_lifecycle(
+        state,
+        meeting_id,
+        expected,
+        dashboard_id,
+        additional_sources,
+        history,
+        question,
+    )
 }
 
 /// Per-meeting open/done action-item counts across the VISIBLE library, for the saved-views meetings
@@ -4666,8 +5005,19 @@ pub(crate) async fn build_and_persist_entities(
     // wikilink edges (resolved target ids) and suggest content-similar neighbours from the meeting's
     // chunks/vectors (indexed earlier in the pipeline; model-gated inside). Both best-effort — a link
     // failure never fails the graph/note (both already succeeded).
-    index_wikilinks_best_effort(state, crate::links::LinkKind::Meeting, meeting_id, markdown);
-    auto_link_semantic_best_effort(state, crate::links::LinkKind::Meeting, meeting_id);
+    index_wikilinks_best_effort_under_lifecycle(
+        state,
+        &_lifecycle,
+        crate::links::LinkKind::Meeting,
+        meeting_id,
+        markdown,
+    );
+    auto_link_semantic_best_effort_under_lifecycle(
+        state,
+        &_lifecycle,
+        crate::links::LinkKind::Meeting,
+        meeting_id,
+    );
 
     Ok(payload)
 }
@@ -4896,6 +5246,20 @@ fn index_wikilinks_best_effort(
     src_id: &str,
     body: &str,
 ) {
+    let lifecycle = lifecycle_guard(state);
+    index_wikilinks_best_effort_under_lifecycle(state, &lifecycle, src_kind, src_id, body);
+}
+
+/// Same hook for callers that already own the lifecycle barrier. Keeping the guard proof in the
+/// signature prevents the non-reentrant mutex from being acquired twice while still ensuring link
+/// membership cannot change across an exact dashboard-history admission.
+fn index_wikilinks_best_effort_under_lifecycle(
+    state: &AppState,
+    _lifecycle: &std::sync::MutexGuard<'_, ()>,
+    src_kind: crate::links::LinkKind,
+    src_id: &str,
+    body: &str,
+) {
     let unlocked = match unlocked_snapshot(state) {
         Ok(u) => u,
         Err(e) => {
@@ -4903,10 +5267,12 @@ fn index_wikilinks_best_effort(
             return;
         }
     };
-    if let Err(e) = state
+    // Link membership contributes to the exact dashboard corpus. Resolution + replacement are
+    // short synchronous DB work and must share the lifecycle barrier with history admission.
+    let result = state
         .db
-        .index_wikilinks_for_source(src_kind, src_id, body, &unlocked)
-    {
+        .index_wikilinks_for_source(src_kind, src_id, body, &unlocked);
+    if let Err(e) = result {
         tracing::warn!(target: "links", error = %e, "wikilink index failed (text saved)");
     }
 }
@@ -4916,6 +5282,18 @@ fn index_wikilinks_best_effort(
 /// `SEMANTIC_LINK_CAP` content-similar neighbours (mutual-kNN / floor / cap; see `auto_link_semantic`).
 /// BEST-EFFORT: a failure logs (counts only) and never fails the caller. O(k·log n) — no corpus scan.
 fn auto_link_semantic_best_effort(state: &AppState, kind: crate::links::LinkKind, id: &str) {
+    let lifecycle = lifecycle_guard(state);
+    auto_link_semantic_best_effort_under_lifecycle(state, &lifecycle, kind, id);
+}
+
+/// Guard-owning twin of [`auto_link_semantic_best_effort`] for pipeline stages that already hold
+/// the lifecycle barrier.
+fn auto_link_semantic_best_effort_under_lifecycle(
+    state: &AppState,
+    _lifecycle: &std::sync::MutexGuard<'_, ()>,
+    kind: crate::links::LinkKind,
+    id: &str,
+) {
     // GUARD: only run with the real embedder present — a stub vector carries no meaning, so a
     // stub-space "neighbour" would be noise. (The chunk index itself already refuses stub vectors.)
     if !crate::embed::embed_model_present() {
@@ -4928,7 +5306,10 @@ fn auto_link_semantic_best_effort(state: &AppState, kind: crate::links::LinkKind
             return;
         }
     };
-    if let Err(e) = state.db.auto_link_semantic(kind, id, &unlocked) {
+    // The embedder/index build happened before this hook. Serialize the bounded kNN-derived link
+    // replacement so an exact dashboard witness cannot be validated across a membership change.
+    let result = state.db.auto_link_semantic(kind, id, &unlocked);
+    if let Err(e) = result {
         tracing::warn!(target: "links", error = %e, "semantic auto-link failed (index intact)");
     }
 }
@@ -5097,6 +5478,14 @@ pub async fn ask_vault(
     // FE camelCase `dashboardId`. `None`/empty ⇒ byte-identical to before.
     dashboard_id: Option<String>,
 ) -> Result<AskVaultResult, AppError> {
+    if dashboard_id
+        .as_deref()
+        .is_some_and(|id| !id.trim().is_empty())
+    {
+        return Err(AppError::InvalidArg(
+            "dashboard Ask requires a persisted conversation".into(),
+        ));
+    }
     ask_vault_inner(
         &app,
         state.inner(),
@@ -5106,6 +5495,8 @@ pub async fn ask_vault(
         explicit_sources,
         pinned_org_item_id,
         dashboard_id,
+        None,
+        None,
         None,
     )
     .await
@@ -5122,6 +5513,8 @@ pub(crate) async fn ask_vault_inner(
     pinned_org_item_id: Option<String>,
     dashboard_id: Option<String>,
     authoritative_snapshot: Option<DurableScopeSnapshot>,
+    authoritative_dashboard: Option<dashboards::DashboardContextWitness>,
+    authoritative_ask_dispatch: Option<AskDispatchSnapshot>,
 ) -> Result<AskVaultResult, AppError> {
     let durable_history = authoritative_snapshot.is_some();
     if question.trim().is_empty() {
@@ -5129,17 +5522,27 @@ pub(crate) async fn ask_vault_inner(
     }
     let visibility = authoritative_snapshot
         .unwrap_or_else(|| DurableScopeSnapshot::Vault(capture_content_visibility_snapshot(state)));
-    let dispatch_admission = durable_dispatch_admission(app, visibility.clone());
-    let config = {
-        state
+    let (config, ask_dispatch) = {
+        let _lifecycle = lifecycle_guard(state);
+        let config = state
             .config
             .lock()
             .map_err(|_| AppError::Config("config mutex poisoned".into()))?
-            .clone()
+            .clone();
+        let dispatch = capture_ask_dispatch_snapshot_under_lifecycle(state, &config)?;
+        (config, dispatch)
     };
+    if authoritative_ask_dispatch
+        .as_ref()
+        .is_some_and(|expected| expected != &ask_dispatch)
+    {
+        return Err(AppError::Locked(
+            "Ask provider changed while preparing the answer".into(),
+        ));
+    }
     // The same 12-message discipline as the chat panel (CHAT_CONTEXT_TURNS): bounds prompt growth +
     // cloud egress on BOTH paths. The LATEST question still drives retrieval either way.
-    let history: Vec<ChatTurn> = capped_ask_history(&history).to_vec();
+    let mut history: Vec<ChatTurn> = capped_ask_history(&history).to_vec();
 
     // note↔meeting-links PR-2 — SOURCE-SCOPED (pinned) Ask. When the FE source picker sends a
     // non-empty explicit source list, retrieval is PINNED to exactly those items (+ their capped,
@@ -5155,6 +5558,10 @@ pub(crate) async fn ask_vault_inner(
     // floor entirely, and fell through to a vault-wide search with its board id silently
     // dropped. Review caught it; the motivating scenario was the one still broken.
     let board_id = dashboard_id.filter(|s| !s.trim().is_empty());
+    require_backend_owned_dashboard_history(durable_history, board_id.as_deref(), &history)?;
+    if board_id.is_some() {
+        remove_duplicate_dashboard_question(&mut history, &question);
+    }
     if pinned_sources.is_some() || pinned_org.is_some() || board_id.is_some() {
         // Snapshot AND resolve under ONE guard, exactly as `get_dashboard` does. Sharing
         // the caller's snapshot is not enough on its own: it prevents a second, later
@@ -5163,32 +5570,82 @@ pub(crate) async fn ask_vault_inner(
         // cannot cover that window either — it runs AFTER the provider call, so it
         // suppresses the RESULT, not the disclosure. The guard is dropped before the
         // await below; it is held only for the reads it has to bracket.
-        let (unlocked, board_brief) =
-            board_scoped_floor_inputs(state, &config, board_id.as_deref())?;
-        let memory_brief = gated_memory_brief_for_injection(state, &unlocked, &question);
-        let reranker = crate::rerank::active_reranker(
-            state
-                .reasoner
-                .current_for(crate::summarize::roles::Role::Ask),
+        let (unlocked, composite, scoped_config) = dashboard_composite_floor_inputs_current(
+            state,
+            board_id.as_deref(),
+            pinned_sources.as_deref().unwrap_or_default(),
+        )?;
+        let dashboard_witness = composite.as_ref().map(|context| context.witness.clone());
+        if let Some(expected) = authoritative_dashboard.as_ref() {
+            if dashboard_witness.as_ref() != Some(expected) {
+                return Err(AppError::Locked(
+                    "dashboard changed while preparing the answer".into(),
+                ));
+            }
+        }
+        // A dashboard is a closed composite scope. Cross-vault user-memory would silently widen it.
+        let memory_brief = if composite.is_some() {
+            String::new()
+        } else {
+            gated_memory_brief_for_injection(state, &unlocked, &question)
+        };
+        let dispatch_admission = durable_dispatch_admission(
+            app,
+            visibility.clone(),
+            ask_dispatch.clone(),
+            dashboard_witness.clone(),
         );
-        let result = ask_vault_floor_authorized(
-            &state.db,
-            &config,
-            &unlocked,
-            &question,
-            &history,
-            &memory_brief,
-            Some(reranker),
-            &state.heavy_inference,
-            pinned_sources,
-            pinned_org,
-            board_brief.as_deref(),
-            dispatch_admission.clone(),
-        )
-        .await?;
-        require_durable_scope_for_dispatch(state, &visibility)?;
+        let result = if let Some(context) = composite.as_ref() {
+            if pinned_org.is_some() {
+                return Err(AppError::InvalidArg(
+                    "dashboard and organization scopes cannot be combined".into(),
+                ));
+            }
+            ask_vault_prepacked_dashboard_authorized(
+                context,
+                &scoped_config,
+                &question,
+                &history,
+                &state.heavy_inference,
+                dispatch_admission.clone(),
+            )
+            .await?
+        } else {
+            let reranker = crate::rerank::active_reranker(
+                state
+                    .reasoner
+                    .current_for(crate::summarize::roles::Role::Ask),
+            );
+            ask_vault_floor_authorized(
+                &state.db,
+                &scoped_config,
+                &unlocked,
+                &question,
+                &history,
+                &memory_brief,
+                Some(reranker),
+                &state.heavy_inference,
+                pinned_sources,
+                pinned_org,
+                dispatch_admission.clone(),
+            )
+            .await?
+        };
+        require_durable_scope_for_dispatch_with_ask(
+            state,
+            &visibility,
+            &ask_dispatch,
+            dashboard_witness.as_ref(),
+        )?;
         return Ok(result);
     }
+
+    let dispatch_admission = durable_dispatch_admission(
+        app,
+        visibility.clone(),
+        ask_dispatch.clone(),
+        authoritative_dashboard.clone(),
+    );
 
     // Agentic path — CLOUD-connection roles only (the same rule as the in-meeting brain:
     // local-GGUF multi-step tool-call reliability is unproven). The eligibility gate keys on the
@@ -5204,12 +5661,14 @@ pub(crate) async fn ask_vault_inner(
         let q = question.clone();
         let h = history.clone();
         let attempt_admission = dispatch_admission.clone();
+        let attempt_config = config.clone();
         let attempt = tokio::task::spawn_blocking(move || {
             ask_vault_agentic_attempt(
                 &handle,
                 &q,
                 &h,
                 &thread_id,
+                attempt_config,
                 attempt_admission,
                 durable_history,
             )
@@ -5217,7 +5676,12 @@ pub(crate) async fn ask_vault_inner(
         .await
         .map_err(|e| AppError::Other(anyhow::anyhow!("ask task join failed: {e}")))??;
         if let Some(result) = attempt {
-            require_durable_scope_for_dispatch(state, &visibility)?;
+            require_durable_scope_for_dispatch_with_ask(
+                state,
+                &visibility,
+                &ask_dispatch,
+                authoritative_dashboard.as_ref(),
+            )?;
             return Ok(result);
         }
     }
@@ -5249,11 +5713,15 @@ pub(crate) async fn ask_vault_inner(
         &state.heavy_inference,
         None, // whole-vault path: no explicit sources ⇒ the existing search corpus, unchanged.
         None, // …and no pinned org item — this is the vault-wide fallthrough.
-        None, // …and no board: a board-scoped ask never reaches this branch.
         dispatch_admission,
     )
     .await?;
-    require_durable_scope_for_dispatch(state, &visibility)?;
+    require_durable_scope_for_dispatch_with_ask(
+        state,
+        &visibility,
+        &ask_dispatch,
+        authoritative_dashboard.as_ref(),
+    )?;
     Ok(result)
 }
 
@@ -5270,39 +5738,104 @@ pub(crate) enum AskFloorPrompt {
     },
 }
 
-/// THE FLOOR — the pre-agentic Ask-My-Vault implementation: gated corpus pack + ONE provider
-/// completion, with the original error/consent semantics (`make_provider`'s fail-closed consent
-/// gate errors exactly as before). Runs on the local/off brain backend and whenever the agentic
-/// attempt did not converge or errored.
-/// The session snapshot and the board brief, both taken under ONE `lifecycle_guard`.
-///
-/// Extracted so the ORDERING is executed by a test rather than read from a diff.
-/// Sharing the caller's snapshot is not sufficient on its own: it prevents a second,
-/// later snapshot, but only the guard serializes against a relock landing between the
-/// snapshot and the last `resolve_tile`. The later
-/// `require_current_content_visibility_snapshot` cannot cover that window either —
-/// it runs AFTER the provider call, so it suppresses the RESULT, not the disclosure.
-///
-/// The guard is released with the returned tuple, before any `.await`.
-pub(crate) fn board_scoped_floor_inputs(
+/// Reject caller-supplied history for dashboard chat unless it came from the durable backend seam.
+fn require_backend_owned_dashboard_history(
+    durable_history: bool,
+    dashboard_id: Option<&str>,
+    history: &[ChatTurn],
+) -> Result<(), AppError> {
+    if !durable_history
+        && dashboard_id.is_some_and(|id| !id.trim().is_empty())
+        && !history.is_empty()
+    {
+        return Err(AppError::Locked(
+            "dashboard conversations require backend-owned history".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Resolve the complete board corpus and its unlock snapshot under one lifecycle interval. The
+/// guard is released with the returned values before any provider `.await`.
+#[cfg(test)]
+pub(crate) fn dashboard_composite_floor_inputs(
     state: &AppState,
     config: &AppConfig,
     dashboard_id: Option<&str>,
-) -> Result<(std::collections::HashSet<String>, Option<String>), AppError> {
+    additional_sources: &[crate::storage::models::SourceRef],
+) -> Result<
+    (
+        std::collections::HashSet<String>,
+        Option<dashboards::DashboardCompositeContext>,
+    ),
+    AppError,
+> {
     with_board_scoped_floor_inputs(state, |unlocked| {
-        // The SAME budget the corpus is packed against, resolved from the ASK role's
-        // connection exactly as `build_ask_vault_floor_prompt` does — so the brief's share
-        // is a documented fraction of ONE budget, not a second, unrelated cap.
+        let Some(id) = dashboard_id.map(str::trim).filter(|id| !id.is_empty()) else {
+            return Ok(None);
+        };
         let ask_conn =
             crate::summarize::roles::provider_target(crate::summarize::roles::Role::Ask, config)
                 .connection;
         let budget = crate::summarize::vault_context::budget_for(&ask_conn);
-        crate::commands::dashboards::board_scoped_brief(&state.db, dashboard_id, unlocked, budget)
+        dashboards::dashboard_composite_context(
+            &state.db,
+            id,
+            unlocked,
+            budget,
+            additional_sources,
+            None,
+        )
+        .map(Some)
     })
+}
+
+/// Production resolver for provider inputs: capture the config which determines the Ask budget
+/// inside the same lifecycle interval as the dashboard witness. The returned config is the exact
+/// provider selection used for dispatch after the guard is released.
+fn dashboard_composite_floor_inputs_current(
+    state: &AppState,
+    dashboard_id: Option<&str>,
+    additional_sources: &[crate::storage::models::SourceRef],
+) -> Result<
+    (
+        std::collections::HashSet<String>,
+        Option<dashboards::DashboardCompositeContext>,
+        AppConfig,
+    ),
+    AppError,
+> {
+    let _lifecycle = lifecycle_guard(state);
+    let config = state
+        .config
+        .lock()
+        .map_err(|_| AppError::Config("config mutex poisoned".into()))?
+        .clone();
+    let unlocked = unlocked_snapshot(state)?;
+    let composite = match dashboard_id.map(str::trim).filter(|id| !id.is_empty()) {
+        Some(id) => {
+            let ask_conn = crate::summarize::roles::provider_target(
+                crate::summarize::roles::Role::Ask,
+                &config,
+            )
+            .connection;
+            Some(dashboards::dashboard_composite_context(
+                &state.db,
+                id,
+                &unlocked,
+                crate::summarize::vault_context::budget_for(&ask_conn),
+                additional_sources,
+                None,
+            )?)
+        }
+        None => None,
+    };
+    Ok((unlocked, composite, config))
 }
 
 /// Execute a board-input resolver inside the same lifecycle interval as its unlock snapshot.
 /// Kept separate so the serialization property has a deterministic two-thread oracle.
+#[cfg(test)]
 pub(crate) fn with_board_scoped_floor_inputs<T>(
     state: &AppState,
     resolve: impl FnOnce(&std::collections::HashSet<String>) -> Result<T, AppError>,
@@ -5329,7 +5862,6 @@ async fn ask_vault_floor(
     heavy: &std::sync::Arc<tokio::sync::Semaphore>,
     explicit_sources: Option<Vec<crate::storage::models::SourceRef>>,
     pinned_org_item_id: Option<String>,
-    board_brief: Option<&str>,
 ) -> Result<AskVaultResult, AppError> {
     ask_vault_floor_core(
         db,
@@ -5342,7 +5874,6 @@ async fn ask_vault_floor(
         heavy,
         explicit_sources,
         pinned_org_item_id,
-        board_brief,
         None,
     )
     .await
@@ -5360,10 +5891,6 @@ async fn ask_vault_floor_authorized(
     heavy: &std::sync::Arc<tokio::sync::Semaphore>,
     explicit_sources: Option<Vec<crate::storage::models::SourceRef>>,
     pinned_org_item_id: Option<String>,
-    // The board's derived tiles, already gated and rendered. `None` for every
-    // non-board caller, which keeps the packed prompt byte-identical for them;
-    // `Some("")` is a board that scopes the ask but has nothing readable to show.
-    board_brief: Option<&str>,
     dispatch_admission: crate::state::ContentDispatchAdmission,
 ) -> Result<AskVaultResult, AppError> {
     ask_vault_floor_core(
@@ -5377,10 +5904,65 @@ async fn ask_vault_floor_authorized(
         heavy,
         explicit_sources,
         pinned_org_item_id,
-        board_brief,
         Some(dispatch_admission),
     )
     .await
+}
+
+pub(crate) async fn ask_vault_prepacked_dashboard_authorized(
+    context: &dashboards::DashboardCompositeContext,
+    config: &AppConfig,
+    question: &str,
+    history: &[ChatTurn],
+    heavy: &std::sync::Arc<tokio::sync::Semaphore>,
+    dispatch_admission: crate::state::ContentDispatchAdmission,
+) -> Result<AskVaultResult, AppError> {
+    if context.packed_corpus.trim().is_empty() {
+        return Ok(AskVaultResult {
+            answer: "Nothing on this board is readable right now — unlock its folders, or add \
+                     tiles with content you can see."
+                .to_string(),
+            sources: Vec::new(),
+            citations: Vec::new(),
+        });
+    }
+    let config = config.clone();
+    let heavy = heavy.clone();
+    ask_vault_prepacked_dashboard_dispatch(context, question, history, dispatch_admission, move || {
+        crate::summarize::provider_for(crate::summarize::roles::Role::Ask, &config, &heavy)
+    })
+    .await
+}
+
+async fn ask_vault_prepacked_dashboard_dispatch<F>(
+    context: &dashboards::DashboardCompositeContext,
+    question: &str,
+    history: &[ChatTurn],
+    dispatch_admission: crate::state::ContentDispatchAdmission,
+    provider_factory: F,
+) -> Result<AskVaultResult, AppError>
+where
+    F: FnOnce() -> Result<
+        std::sync::Arc<dyn crate::summarize::provider::SummarizerProvider>,
+        AppError,
+    >,
+{
+    let (system, user) = crate::summarize::vault_chat::build_for_dashboard(
+        &context.packed_corpus,
+        history,
+        question,
+    );
+    let answer = dispatch_admission
+        .run(|| async {
+            let provider = provider_factory()?;
+            provider.complete(&system, &user).await
+        })
+        .await?;
+    Ok(AskVaultResult {
+        answer,
+        sources: context.packed_sources.clone(),
+        citations: Vec::new(),
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -5395,7 +5977,6 @@ async fn ask_vault_floor_core(
     heavy: &std::sync::Arc<tokio::sync::Semaphore>,
     explicit_sources: Option<Vec<crate::storage::models::SourceRef>>,
     pinned_org_item_id: Option<String>,
-    board_brief: Option<&str>,
     dispatch_admission: Option<crate::state::ContentDispatchAdmission>,
 ) -> Result<AskVaultResult, AppError> {
     // `build_ask_vault_floor_prompt` does the LOCAL/on-device work — query embedding (Candle/
@@ -5413,7 +5994,6 @@ async fn ask_vault_floor_core(
     let question_owned = question.to_string();
     let history_owned = history.to_vec();
     let memory_brief_owned = memory_brief.to_string();
-    let board_brief_owned = board_brief.map(str::to_string);
     let prompt = tokio::task::spawn_blocking(move || {
         build_ask_vault_floor_prompt(
             &db_for_prompt,
@@ -5425,7 +6005,6 @@ async fn ask_vault_floor_core(
             reranker.as_deref(),
             explicit_sources.as_deref(),
             pinned_org_item_id.as_deref(),
-            board_brief_owned.as_deref(),
         )
     })
     .await
@@ -5439,11 +6018,29 @@ async fn ask_vault_floor_core(
         } => {
             // ASK role. With role keys absent this builds the legacy default provider for EVERY
             // brain_backend (the pre-role floor ignored it) — original error/consent semantics.
-            let provider =
-                crate::summarize::provider_for(crate::summarize::roles::Role::Ask, config, heavy)?;
             let answer = match dispatch_admission {
-                Some(admission) => admission.run(|| provider.complete(&system, &user)).await?,
-                None => provider.complete(&system, &user).await?,
+                Some(admission) => {
+                    let config = config.clone();
+                    let heavy = heavy.clone();
+                    admission
+                        .run(|| async {
+                            let provider = crate::summarize::provider_for(
+                                crate::summarize::roles::Role::Ask,
+                                &config,
+                                &heavy,
+                            )?;
+                            provider.complete(&system, &user).await
+                        })
+                        .await?
+                }
+                None => {
+                    let provider = crate::summarize::provider_for(
+                        crate::summarize::roles::Role::Ask,
+                        config,
+                        heavy,
+                    )?;
+                    provider.complete(&system, &user).await?
+                }
             };
             Ok(AskVaultResult {
                 answer,
@@ -5737,6 +6334,11 @@ pub(crate) fn save_config_inner(state: &AppState, config: AppConfigDto) -> Resul
         crate::settings::validate_model_size_source(source)?;
     }
 
+    // Provider-role selection determines the exact Ask packing budget. Serialize the durable
+    // config write and cache replacement with dashboard/history preflight, dispatch polling, and
+    // post-await CAS. Lock order is lifecycle -> config -> DB throughout this interval.
+    let _lifecycle = lifecycle_guard(state);
+
     // Generic Settings cannot change `embed_model_id`: `dto_to_config` preserves it from this
     // mutex-protected cache, while the dedicated selector takes the model-selection write barrier
     // before taking the same mutex. Do not make an unrelated Settings save wait behind a minutes-
@@ -5746,6 +6348,11 @@ pub(crate) fn save_config_inner(state: &AppState, config: AppConfigDto) -> Resul
         .lock()
         .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
     let new_config = dto_to_config(config, &cache);
+    if ask_dispatch_projection(&cache) != ask_dispatch_projection(&new_config) {
+        // Rotate FIRST. AppConfig::save is row-wise; a later failure may over-invalidate, but no
+        // partial provider/config mutation can retain the old dispatch authorization.
+        state.db.advance_ask_dispatch_generation()?;
+    }
     new_config.save(&state.db)?;
     *cache = new_config;
 
@@ -6326,12 +6933,7 @@ pub async fn resummarize(
     // COMMIT BOUNDARY: a re-summarize rewrites the meeting's note → BEST-EFFORT re-publish any org
     // shares of it so members see the fresh summary. Best-effort — never fails the re-summarize. If
     // ≥1 org copy was re-published, ping open org views so the fresh summary shows without a manual sync.
-    if republish_org_shares_for_source_notifying(
-        state.inner(),
-        Some(&meeting_id),
-        None,
-        &app,
-    )
+    if republish_org_shares_for_source_notifying(state.inner(), Some(&meeting_id), None, &app)
         .await
         .unwrap_or(0)
         > 0

--- a/src-tauri/src/commands/model_perf.rs
+++ b/src-tauri/src/commands/model_perf.rs
@@ -156,12 +156,21 @@ pub fn brain_posture(state: State<'_, AppState>) -> Result<crate::settings::Post
 pub fn set_brain_posture(state: State<'_, AppState>, posture: String) -> Result<(), AppError> {
     let p = crate::settings::Posture::from_settable(&posture)
         .ok_or_else(|| AppError::InvalidArg(format!("not a settable posture: {posture}")))?;
+    // A posture can change the Ask connection and therefore its dashboard packing budget. Keep
+    // the same lifecycle -> config -> DB order as save_config so an in-flight witness observes
+    // either the complete old posture or the complete new one.
+    let _lifecycle = super::lifecycle_guard(state.inner());
     let mut c = state
         .config
         .lock()
         .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
-    crate::settings::postures::apply_posture(&mut c, p);
-    c.save(&state.db)?;
+    let mut new_config = c.clone();
+    crate::settings::postures::apply_posture(&mut new_config, p);
+    if super::ask_dispatch_projection(&c) != super::ask_dispatch_projection(&new_config) {
+        state.db.advance_ask_dispatch_generation()?;
+    }
+    new_config.save(&state.db)?;
+    *c = new_config;
     Ok(())
 }
 
@@ -235,21 +244,27 @@ pub fn select_brain_model(state: State<'_, AppState>, model_id: String) -> Resul
 pub(crate) fn select_brain_model_inner(state: &AppState, model_id: String) -> Result<(), AppError> {
     let model = crate::reason::brain_model_by_id(&model_id)
         .ok_or_else(|| AppError::InvalidArg(format!("unknown brain model id: {model_id}")))?;
+    let _lifecycle = super::lifecycle_guard(state);
     let mut c = state
         .config
         .lock()
         .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
+    let mut next = c.clone();
     // Keep the legacy single-model id (BrainBackend::Local + custom-path fallback) …
-    c.brain_model_id = Some(model_id.clone());
+    next.brain_model_id = Some(model_id.clone());
     // … AND wire the CLASS handle so the Brain-Live `light()` / Fully-Local `heavy()` handles actually
     // use what the user just selected. Without this, selecting a light model leaves `light()` pointing
     // at the registry DEFAULT (a different, un-downloaded GGUF) → it silently resolves to the stub and
     // Realtime Reactions never fire despite Brain Live being "on".
     match model.class {
-        crate::reason::ModelClass::Light => c.brain_light_model_id = Some(model_id),
-        crate::reason::ModelClass::Heavy => c.brain_heavy_model_id = Some(model_id),
+        crate::reason::ModelClass::Light => next.brain_light_model_id = Some(model_id),
+        crate::reason::ModelClass::Heavy => next.brain_heavy_model_id = Some(model_id),
     }
-    c.save(&state.db)?;
+    if super::ask_dispatch_projection(&c) != super::ask_dispatch_projection(&next) {
+        state.db.advance_ask_dispatch_generation()?;
+    }
+    next.save(&state.db)?;
+    *c = next;
     Ok(())
 }
 
@@ -350,6 +365,7 @@ pub(crate) fn select_embed_model_inner(
     let model = crate::embed::embed_model_by_id(&model_id)
         .ok_or_else(|| AppError::InvalidArg(format!("unknown embed model id: {model_id}")))?;
 
+    let _lifecycle = super::lifecycle_guard(state);
     let reindex_needed = crate::embed::with_embed_selection_update(|| {
         let mut c = state
             .config
@@ -372,9 +388,13 @@ pub(crate) fn select_embed_model_inner(
         // all old-model vector partitions with the setting write; chunks/FTS remain available.
         let mut candidate = c.clone();
         candidate.embed_model_id = Some(model.id.to_string());
-        state
-            .db
-            .set_embed_model_selection(model.id, reindex_needed)?;
+        if reindex_needed {
+            state
+                .db
+                .set_embed_model_selection_for_ask(model.id, true)?;
+        } else {
+            state.db.set_embed_model_selection(model.id, false)?;
+        }
         let selected_id = candidate.embed_model_id.clone();
         *c = candidate;
         Ok((reindex_needed, selected_id))

--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -120,7 +120,13 @@ pub(crate) fn create_note_inner(
     // Brain v3 PR-3 — LINK ENGINE: index the (empty) body's wikilinks so a create with no body
     // establishes a clean empty edge set; the first `update_note_doc` re-indexes real `[[Title]]`s.
     // No semantic pass on birth (no vectors yet). Best-effort.
-    index_wikilinks_best_effort(state, crate::links::LinkKind::Note, &id, "");
+    index_wikilinks_best_effort_under_lifecycle(
+        state,
+        &_lifecycle,
+        crate::links::LinkKind::Note,
+        &id,
+        "",
+    );
     tracing::info!(target: "notes", note_id = %id, folder_id = %folder_id, "note created");
     Ok(id)
 }

--- a/src-tauri/src/commands/reminders.rs
+++ b/src-tauri/src/commands/reminders.rs
@@ -1114,11 +1114,24 @@ mod runtime_probe {
         let original = runtime.original_config.take().ok_or_else(|| {
             AppError::Unavailable("runtime original configuration is unavailable".into())
         })?;
+        let _lifecycle = crate::commands::lifecycle_guard(state);
+        let current_projection = state
+            .config
+            .lock()
+            .map_err(|_| AppError::Unavailable("runtime config is unavailable".into()))
+            .map(|config| crate::commands::ask_dispatch_projection(&config))?;
+        if current_projection != crate::commands::ask_dispatch_projection(&original) {
+            state.db.advance_ask_dispatch_generation()?;
+        }
         original.save(&state.db)?;
         *state
             .config
             .lock()
             .map_err(|_| AppError::Unavailable("runtime config is unavailable".into()))? = original;
+        // The debug runtime fixture also changes provider credentials after restoring config.
+        // Rotate before either fallible deletion; partial cleanup may over-invalidate but cannot
+        // leave an old authorization live against a changed Keychain.
+        state.db.advance_ask_dispatch_generation()?;
         crate::secrets::delete_secret(crate::summarize::ANTHROPIC_KEY_ACCOUNT)?;
         crate::secrets::delete_secret(crate::summarize::GATEWAY_KEY_ACCOUNT)?;
         drop(runtime);

--- a/src-tauri/src/commands/secrets.rs
+++ b/src-tauri/src/commands/secrets.rs
@@ -16,6 +16,8 @@
 
 use crate::error::AppError;
 use crate::secrets;
+use crate::state::AppState;
+use tauri::State;
 
 // The AI-Gateway keychain account const stays in `commands/mod.rs` (shared with the gateway
 // model-listing helpers that were NOT moved); reach it via `super`.
@@ -24,14 +26,31 @@ use super::GATEWAY_KEY_ACCOUNT;
 /// Keychain account for the Anthropic API key (matches `summarize::ANTHROPIC_KEY_ACCOUNT`).
 const ANTHROPIC_KEY_ACCOUNT: &str = "anthropic_api_key";
 
+fn set_ask_secret(
+    state: &AppState,
+    account: &str,
+    value: Option<&str>,
+) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state);
+    let current = secrets::get_secret(account)?;
+    let next = value.map(str::trim).filter(|value| !value.is_empty());
+    if current.as_deref().map(str::trim) == next {
+        return Ok(());
+    }
+    // Rotate before the fallible Keychain mutation: failure may over-invalidate, never authorize a
+    // provider/connector holding credentials that no longer match the captured dispatch.
+    state.db.advance_ask_dispatch_generation()?;
+    match next {
+        Some(value) => secrets::set_secret(account, value),
+        None => secrets::delete_secret(account),
+    }
+}
+
 /// Store/replace the BYO Jira API token in the Keychain (account "jira_api_token"). An empty input
 /// clears it. NEVER logged, NEVER returned to the FE — only `has_*` reports presence.
 #[tauri::command]
-pub fn set_jira_token(key: String) -> Result<(), AppError> {
-    if key.trim().is_empty() {
-        return secrets::delete_secret(crate::connectors::jira::JIRA_TOKEN_ACCOUNT);
-    }
-    secrets::set_secret(crate::connectors::jira::JIRA_TOKEN_ACCOUNT, key.trim())
+pub fn set_jira_token(state: State<'_, AppState>, key: String) -> Result<(), AppError> {
+    set_ask_secret(&state, crate::connectors::jira::JIRA_TOKEN_ACCOUNT, Some(&key))
 }
 
 /// Whether a Jira token is currently stored (UI shows "set"/"not set"; never the value).
@@ -47,11 +66,8 @@ pub fn has_jira_token() -> Result<bool, AppError> {
 /// Store/replace the BYO Slack user token in the Keychain (account "slack_user_token"). An empty
 /// input clears it. NEVER logged, NEVER returned to the FE — only `has_*` reports presence.
 #[tauri::command]
-pub fn set_slack_token(key: String) -> Result<(), AppError> {
-    if key.trim().is_empty() {
-        return secrets::delete_secret(crate::connectors::slack::SLACK_TOKEN_ACCOUNT);
-    }
-    secrets::set_secret(crate::connectors::slack::SLACK_TOKEN_ACCOUNT, key.trim())
+pub fn set_slack_token(state: State<'_, AppState>, key: String) -> Result<(), AppError> {
+    set_ask_secret(&state, crate::connectors::slack::SLACK_TOKEN_ACCOUNT, Some(&key))
 }
 
 /// Whether a Slack token is currently stored (UI shows "set"/"not set"; never the value).
@@ -67,11 +83,8 @@ pub fn has_slack_token() -> Result<bool, AppError> {
 /// Store/replace the BYO Notion integration token in the Keychain (account "notion_api_token"). An
 /// empty input clears it. NEVER logged, NEVER returned to the FE — only `has_*` reports presence.
 #[tauri::command]
-pub fn set_notion_token(key: String) -> Result<(), AppError> {
-    if key.trim().is_empty() {
-        return secrets::delete_secret(crate::connectors::notion::NOTION_TOKEN_ACCOUNT);
-    }
-    secrets::set_secret(crate::connectors::notion::NOTION_TOKEN_ACCOUNT, key.trim())
+pub fn set_notion_token(state: State<'_, AppState>, key: String) -> Result<(), AppError> {
+    set_ask_secret(&state, crate::connectors::notion::NOTION_TOKEN_ACCOUNT, Some(&key))
 }
 
 /// Whether a Notion token is currently stored (UI shows "set"/"not set"; never the value).
@@ -87,13 +100,11 @@ pub fn has_notion_token() -> Result<bool, AppError> {
 /// Store/replace the BYO ClickUp personal API token in the Keychain (account "clickup_api_token").
 /// An empty input clears it. NEVER logged, NEVER returned to the FE — only `has_*` reports presence.
 #[tauri::command]
-pub fn set_clickup_token(key: String) -> Result<(), AppError> {
-    if key.trim().is_empty() {
-        return secrets::delete_secret(crate::connectors::clickup::CLICKUP_TOKEN_ACCOUNT);
-    }
-    secrets::set_secret(
+pub fn set_clickup_token(state: State<'_, AppState>, key: String) -> Result<(), AppError> {
+    set_ask_secret(
+        &state,
         crate::connectors::clickup::CLICKUP_TOKEN_ACCOUNT,
-        key.trim(),
+        Some(&key),
     )
 }
 
@@ -109,12 +120,8 @@ pub fn has_clickup_token() -> Result<bool, AppError> {
 
 /// Store/replace the Anthropic API key in Keychain (account "anthropic_api_key").
 #[tauri::command]
-pub fn set_anthropic_key(key: String) -> Result<(), AppError> {
-    if key.trim().is_empty() {
-        // Empty input clears the stored key.
-        return secrets::delete_secret(ANTHROPIC_KEY_ACCOUNT);
-    }
-    secrets::set_secret(ANTHROPIC_KEY_ACCOUNT, &key)
+pub fn set_anthropic_key(state: State<'_, AppState>, key: String) -> Result<(), AppError> {
+    set_ask_secret(&state, ANTHROPIC_KEY_ACCOUNT, Some(&key))
 }
 
 /// Whether an Anthropic key is currently stored (UI shows "set"/"not set"; never the value).
@@ -128,14 +135,19 @@ pub fn has_anthropic_key() -> Result<bool, AppError> {
 /// The key is NEVER logged and NEVER returned to the FE — only `has_gateway_key` reports presence.
 /// Uses a SEPARATE keychain account from the Anthropic key (R3 — no cross-provider fallback).
 #[tauri::command]
-pub fn set_gateway_key(key: String) -> Result<(), AppError> {
+pub fn set_gateway_key(state: State<'_, AppState>, key: String) -> Result<(), AppError> {
+    validate_gateway_key(&key)?;
+    set_ask_secret(&state, GATEWAY_KEY_ACCOUNT, Some(&key))
+}
+
+pub(crate) fn validate_gateway_key(key: &str) -> Result<(), AppError> {
     if key.trim().is_empty() {
         return Err(AppError::InvalidArg(
             "gateway API key must not be empty; use clear_gateway_key to remove an existing key"
                 .into(),
         ));
     }
-    secrets::set_secret(GATEWAY_KEY_ACCOUNT, key.trim())
+    Ok(())
 }
 
 /// Whether an AI Gateway key is currently stored (UI shows "set"/"not set"; never the value).
@@ -149,19 +161,16 @@ pub fn has_gateway_key() -> Result<bool, AppError> {
 /// Remove the stored AI Gateway API key from the Keychain.
 /// Idempotent — no error if no key is stored. Mirrors `set_anthropic_key("")` semantics.
 #[tauri::command]
-pub fn clear_gateway_key() -> Result<(), AppError> {
-    secrets::delete_secret(GATEWAY_KEY_ACCOUNT)
+pub fn clear_gateway_key(state: State<'_, AppState>) -> Result<(), AppError> {
+    set_ask_secret(&state, GATEWAY_KEY_ACCOUNT, None)
 }
 
 /// Store/replace the BYO web-search (Brave) API key in the Keychain (account "web_search_api_key").
 /// An empty input clears it. The key is NEVER logged and NEVER returned to the FE — only `has_*`
 /// reports presence. Mirrors `set_anthropic_key`.
 #[tauri::command]
-pub fn set_web_search_api_key(key: String) -> Result<(), AppError> {
-    if key.trim().is_empty() {
-        return secrets::delete_secret(crate::connectors::web::WEB_SEARCH_KEY_ACCOUNT);
-    }
-    secrets::set_secret(crate::connectors::web::WEB_SEARCH_KEY_ACCOUNT, key.trim())
+pub fn set_web_search_api_key(state: State<'_, AppState>, key: String) -> Result<(), AppError> {
+    set_ask_secret(&state, crate::connectors::web::WEB_SEARCH_KEY_ACCOUNT, Some(&key))
 }
 
 /// Whether a web-search API key is currently stored (UI shows "set"/"not set"; never the value).

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -34,11 +34,17 @@ use crate::storage::models::{NoteTemplate, NoteTemplateSection};
 /// the FE matches the `[cloud-consent]` CODE (never the prose) and surfaces the consent prompt.
 #[tauri::command]
 pub fn consent_to_cloud_egress(state: State<'_, AppState>) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state.inner());
     let mut cache = state
         .config
         .lock()
         .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
-    cache.grant_cloud_egress_consent(&state.db)?;
+    if !cache.cloud_egress_consented {
+        state
+            .db
+            .set_cloud_egress_consent_and_advance_ask_dispatch(true)?;
+        cache.cloud_egress_consented = true;
+    }
     Ok(())
 }
 
@@ -50,11 +56,19 @@ pub fn consent_to_cloud_egress(state: State<'_, AppState>) -> Result<(), AppErro
 /// Idempotent; a settings save can still neither grant nor revoke (the DTO stays preserve-only).
 #[tauri::command]
 pub fn revoke_cloud_egress(state: State<'_, AppState>) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state.inner());
     let mut cache = state
         .config
         .lock()
         .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
-    cache.revoke_cloud_egress(&state.db)?;
+    if cache.cloud_egress_consented {
+        // Revoke in memory before the fallible durable write. If persistence fails, this process
+        // remains fail-closed; the DB transaction changes consent+generation together on success.
+        cache.cloud_egress_consented = false;
+        state
+            .db
+            .set_cloud_egress_consent_and_advance_ask_dispatch(false)?;
+    }
     Ok(())
 }
 
@@ -66,11 +80,15 @@ pub fn revoke_cloud_egress(state: State<'_, AppState>) -> Result<(), AppError> {
 /// brain's tool registry and the redacted query never leaves the device.
 #[tauri::command]
 pub fn consent_to_web_search(state: State<'_, AppState>) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state.inner());
     let mut cache = state
         .config
         .lock()
         .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
-    cache.grant_web_search_consent(&state.db)?;
+    if !cache.web_search_consented {
+        state.db.advance_ask_dispatch_generation()?;
+        cache.grant_web_search_consent(&state.db)?;
+    }
     Ok(())
 }
 
@@ -79,11 +97,15 @@ pub fn consent_to_web_search(state: State<'_, AppState>) -> Result<(), AppError>
 /// (provided Jira is also enabled + configured + a token is stored). Idempotent.
 #[tauri::command]
 pub fn consent_to_jira(state: State<'_, AppState>) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state.inner());
     let mut cache = state
         .config
         .lock()
         .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
-    cache.grant_jira_consent(&state.db)?;
+    if !cache.jira_consented {
+        state.db.advance_ask_dispatch_generation()?;
+        cache.grant_jira_consent(&state.db)?;
+    }
     Ok(())
 }
 
@@ -92,11 +114,15 @@ pub fn consent_to_jira(state: State<'_, AppState>) -> Result<(), AppError> {
 /// (provided Slack is also enabled + a token is stored). Idempotent.
 #[tauri::command]
 pub fn consent_to_slack(state: State<'_, AppState>) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state.inner());
     let mut cache = state
         .config
         .lock()
         .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
-    cache.grant_slack_consent(&state.db)?;
+    if !cache.slack_consented {
+        state.db.advance_ask_dispatch_generation()?;
+        cache.grant_slack_consent(&state.db)?;
+    }
     Ok(())
 }
 
@@ -105,11 +131,15 @@ pub fn consent_to_slack(state: State<'_, AppState>) -> Result<(), AppError> {
 /// tool (provided Notion is also enabled + a token is stored). Idempotent.
 #[tauri::command]
 pub fn consent_to_notion(state: State<'_, AppState>) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state.inner());
     let mut cache = state
         .config
         .lock()
         .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
-    cache.grant_notion_consent(&state.db)?;
+    if !cache.notion_consented {
+        state.db.advance_ask_dispatch_generation()?;
+        cache.grant_notion_consent(&state.db)?;
+    }
     Ok(())
 }
 
@@ -118,11 +148,15 @@ pub fn consent_to_notion(state: State<'_, AppState>) -> Result<(), AppError> {
 /// tool (provided ClickUp is also enabled + a workspace id and token are configured). Idempotent.
 #[tauri::command]
 pub fn consent_to_clickup(state: State<'_, AppState>) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state.inner());
     let mut cache = state
         .config
         .lock()
         .map_err(|_| AppError::Config("config mutex poisoned".into()))?;
-    cache.grant_clickup_consent(&state.db)?;
+    if !cache.clickup_consented {
+        state.db.advance_ask_dispatch_generation()?;
+        cache.grant_clickup_consent(&state.db)?;
+    }
     Ok(())
 }
 

--- a/src-tauri/src/commands/tests/ask_vault_tests.rs
+++ b/src-tauri/src/commands/tests/ask_vault_tests.rs
@@ -63,6 +63,133 @@ fn seed_sealed(db: &Db, meeting_id: &str, folder_id: &str, title: &str) {
     seed_note(db, meeting_id, title, "", Some(folder_id));
 }
 
+struct PromptSpyProvider {
+    calls: std::sync::atomic::AtomicUsize,
+    systems: Mutex<Vec<String>>,
+}
+
+#[async_trait::async_trait]
+impl crate::summarize::provider::SummarizerProvider for PromptSpyProvider {
+    fn id(&self) -> &str {
+        "prompt-spy"
+    }
+    async fn availability(&self) -> crate::summarize::provider::Availability {
+        crate::summarize::provider::Availability::Available
+    }
+    async fn summarize(
+        &self,
+        _request: &crate::summarize::provider::SummarizeRequest,
+    ) -> crate::error::Result<String> {
+        Ok(String::new())
+    }
+    async fn complete(&self, system: &str, _user: &str) -> crate::error::Result<String> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        self.systems.lock().unwrap().push(system.to_string());
+        Ok("answer".into())
+    }
+}
+
+#[test]
+fn shipped_dashboard_provider_sink_omits_global_memory_and_mutation_refuses_before_call() {
+    let db = tmp_db();
+    seed_note(&db, "m1", "Board note", "BOARD MATERIAL", None);
+    db.insert_dashboard("b1", "Board", None, None, "2026-08-01T09:00:00Z")
+        .unwrap();
+    db.insert_dashboard_tile(
+        "t1",
+        "b1",
+        "meeting",
+        Some("m1"),
+        None,
+        4,
+        None,
+        "2026-08-01T09:00:01Z",
+    )
+    .unwrap();
+    let context = crate::commands::dashboards::dashboard_composite_context(
+        &db,
+        "b1",
+        &HashSet::new(),
+        200_000,
+        &[],
+        None,
+    )
+    .unwrap();
+    // The global memory block must not exist at all on the shipped prepacked board provider seam.
+    let spy = std::sync::Arc::new(PromptSpyProvider {
+        calls: std::sync::atomic::AtomicUsize::new(0),
+        systems: Mutex::new(Vec::new()),
+    });
+    let admission = crate::state::ContentDispatchAdmission::for_test(
+        std::sync::Arc::new(Mutex::new(())),
+        || Ok(()),
+    );
+    let out = block_on(ask_vault_prepacked_dashboard_dispatch(
+        &context,
+        "question",
+        &[],
+        admission,
+        {
+            let spy = spy.clone();
+            move || {
+                Ok(spy
+                    as std::sync::Arc<dyn crate::summarize::provider::SummarizerProvider>)
+            }
+        },
+    ))
+    .unwrap();
+    assert_eq!(out.answer, "answer");
+    let system = spy.systems.lock().unwrap().join("\n");
+    assert!(!system.contains("WHAT YOU KNOW ABOUT THE USER"));
+
+    let stale = context.witness.clone();
+    db.delete_dashboard_tile("t1").unwrap();
+    let db = std::sync::Arc::new(db);
+    let admission =
+        crate::state::ContentDispatchAdmission::for_test(std::sync::Arc::new(Mutex::new(())), {
+            let db = db.clone();
+            move || {
+                crate::commands::dashboards::require_dashboard_context_witness(
+                    &db,
+                    &stale,
+                    &HashSet::new(),
+                )
+            }
+        });
+    let before = spy.calls.load(std::sync::atomic::Ordering::SeqCst);
+    let err = block_on(ask_vault_prepacked_dashboard_dispatch(
+        &context,
+        "question",
+        &[],
+        admission,
+        {
+            let spy = spy.clone();
+            move || {
+                Ok(spy
+                    as std::sync::Arc<dyn crate::summarize::provider::SummarizerProvider>)
+            }
+        },
+    ))
+    .unwrap_err();
+    assert!(matches!(err, AppError::Locked(_)));
+    assert_eq!(spy.calls.load(std::sync::atomic::Ordering::SeqCst), before);
+}
+
+#[test]
+fn stateless_dashboard_history_is_refused_before_any_provider_path() {
+    let history = vec![ChatTurn {
+        role: "assistant".into(),
+        content: "old secret".into(),
+    }];
+    assert!(require_backend_owned_dashboard_history(false, None, &history).is_ok());
+    assert!(matches!(
+        require_backend_owned_dashboard_history(false, Some("b1"), &history),
+        Err(AppError::Locked(_))
+    ));
+    assert!(require_backend_owned_dashboard_history(true, Some("b1"), &history).is_ok());
+    assert!(require_backend_owned_dashboard_history(false, Some("b1"), &[]).is_ok());
+}
+
 /// A reasoner whose `structured()` returns canned JSON in sequence (a test double — the
 /// production loop drives the real ReasonerCell dispatch). Exhaustion yields an empty answer,
 /// which the loop treats as non-convergence.
@@ -251,10 +378,8 @@ fn ask_floor_prompt_matches_pre_change_implementation() {
     // Empty memory brief ⇒ the floor prompt must stay BYTE-IDENTICAL to the pre-memory build.
     let (want_system, want_user) = crate::summarize::vault_chat::build(&corpus, &history, q, "");
 
-    match build_ask_vault_floor_prompt(
-        &db, &cfg, &unlocked, q, &history, "", None, None, None, None,
-    )
-    .unwrap()
+    match build_ask_vault_floor_prompt(&db, &cfg, &unlocked, q, &history, "", None, None, None)
+        .unwrap()
     {
         AskFloorPrompt::Ready {
             system,
@@ -286,7 +411,7 @@ fn ask_floor_prompt_matches_pre_change_implementation() {
 
     // The empty-vault early return keeps the EXACT pre-change canned answer.
     let empty = tmp_db();
-    match build_ask_vault_floor_prompt(&empty, &cfg, &unlocked, q, &[], "", None, None, None, None)
+    match build_ask_vault_floor_prompt(&empty, &cfg, &unlocked, q, &[], "", None, None, None)
         .unwrap()
     {
         AskFloorPrompt::Empty(r) => {
@@ -331,7 +456,6 @@ fn ask_floor_preserves_no_consent_error_semantics() {
         "",
         None,
         &std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
-        None,
         None,
         None,
     ));
@@ -428,7 +552,7 @@ fn loopback_ollama_ask_paths_revalidate_visibility_before_provider_dispatch() {
         content: "PRIOR-HISTORY-WOULD-REACH-THE-PROVIDER".into(),
     }];
     let prompt = build_ask_vault_floor_prompt(
-        &db, &cfg, &unlocked, "atlas", &history, "", None, None, None, None,
+        &db, &cfg, &unlocked, "atlas", &history, "", None, None, None,
     )
     .unwrap();
     let AskFloorPrompt::Ready { system, user, .. } = prompt else {
@@ -458,7 +582,6 @@ fn loopback_ollama_ask_paths_revalidate_visibility_before_provider_dispatch() {
         "",
         None,
         &std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
-        None,
         None,
         None,
         floor_admission,
@@ -1280,6 +1403,26 @@ fn ask_history_char_budget_preserves_the_exact_boundary() {
     assert!(over_prior.chars().count() <= ASK_HISTORY_TEST_BUDGET);
     assert!(over_prior.starts_with(ASK_HISTORY_TEST_OMISSION_MARKER));
     assert!(over_prior.contains("User: …"));
+}
+
+#[test]
+fn dashboard_history_drops_only_a_duplicate_current_question() {
+    let mut history = vec![
+        ChatTurn {
+            role: "assistant".into(),
+            content: "earlier answer".into(),
+        },
+        ChatTurn {
+            role: "user".into(),
+            content: "  current question  ".into(),
+        },
+    ];
+    remove_duplicate_dashboard_question(&mut history, "current question");
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].content, "earlier answer");
+
+    remove_duplicate_dashboard_question(&mut history, "different question");
+    assert_eq!(history.len(), 1, "unrelated history remains stable");
 }
 
 /// SURFACE SPLIT: the vault executor must NOT advertise `propose_note` (the Ask page has no

--- a/src-tauri/src/commands/tests/dashboard_brief_tests.rs
+++ b/src-tauri/src/commands/tests/dashboard_brief_tests.rs
@@ -1,23 +1,22 @@
 //! THE BOARD-BRIEF ORACLE — what a board's DERIVED tiles contribute to its own Ask.
 //!
-//! The asymmetry this closes: `tools.rs::tool_specs` exposes `get_dashboard` to the
-//! agentic loop and the local MCP server, so an external agent sees every tile. But
-//! board Ask pins its sources, and `ask_vault` routes any non-empty pinned list to
-//! the deterministic floor — skipping the agentic path and therefore that tool. The
-//! in-app "Ask this board" saw strictly LESS of the board than Claude Code did.
+//! Dashboard Ask now builds one exact composite corpus from its material pointers and gated
+//! derived views, then sends it through the dedicated dashboard prompt persona. This module pins
+//! that corpus and its lock behavior at both the resolver and prompt-builder seams.
 //!
 //! Every test here carries a CONTROL. A leak assertion that would also pass with the
 //! gate deleted proves nothing, and this feature has already shipped one such gate:
 //! the adversarial review of PR #562 found the answer-cache check was both incomplete
 //! AND unfalsifiable — disabling it left all 2732 tests green.
 //!
-//! ## EVIDENCE MAP — every derived kind, proven at the PACKED PROVIDER PROMPT
+//! ## EVIDENCE MAP — every derived kind, proven at the dashboard prompt-builder sink
 //!
 //! The negative that matters is not "the brief omits it" but "the prompt that LEAVES
 //! the process omits it". Each row below asserts absence (or indistinguishability) on
-//! `packed_scoped(..)` / `packed_user(..)` output — the sink itself, not
-//! `dashboard_brief_inner`'s return value one layer earlier — and each carries a
-//! control that flips it, so none can go vacuous.
+//! `packed_scoped(..)` / `packed_user(..)` are unit helpers over already-gated parts; they prove
+//! the active `vault_chat::build_for_dashboard` persona but are not called production resolvers.
+//! Separate production oracles below enter through `dashboard_composite_context` before driving
+//! that same prompt builder. Each negative carries a control that flips it.
 //!
 //! | kind | packed-sink negative | control that flips it |
 //! | --- | --- | --- |
@@ -36,9 +35,8 @@
 //!
 //! ## Honest RED limit
 //!
-//! The primary contract claim is not executable against the base commit: the board
-//! brief sink and its function argument did not exist there, so the new prompt test
-//! cannot compile on that tree. Its RED is structural. The lock-model claims remain
+//! The primary contract claim is not executable against the base commit: neither the composite
+//! resolver nor the dashboard prompt path existed there. Its RED is structural. The lock claims remain
 //! falsifiable through the paired sealed/unlocked controls above.
 //!
 use super::*;
@@ -56,6 +54,14 @@ fn file_db(label: &str) -> crate::storage::Db {
         TEST_DEK,
     )
     .unwrap()
+}
+
+fn block_on<F: std::future::Future>(future: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(future)
 }
 
 fn seed_folder(db: &crate::storage::Db, id: &str, locked: bool) {
@@ -293,14 +299,12 @@ fn the_brief_is_bounded_and_never_cut_mid_row() {
 //
 // Both reviews landed the same MAJOR on the first cut of this change: every test
 // above asserts on `dashboard_brief_inner`'s return value, which is an INTERMEDIATE
-// string. None of them drove `build_ask_vault_floor_prompt`, so the whole wiring —
-// the scope trigger, the allowance, the tile-boundary truncation, the join with the
-// corpus, and the interaction with the empty-corpus early return — was unexercised.
+// string. The helpers below drive the active dashboard prompt builder, not the legacy
+// vault floor, so prompt-sink assertions exercise the same persona used in production.
 // An invariant proven one layer below the one the model actually reads is not proven.
 
-// `commands/mod.rs` mounts ask.rs as `ask_commands` and re-exports it, so the floor
-// builder is reachable from this nested test module the same way `ask_vault_tests`
-// reaches it.
+// The vault floor import is used only as a non-dashboard control. Dashboard cases below use
+// `vault_chat::build_for_dashboard` or the active prepacked authorized seam.
 use crate::commands::{build_ask_vault_floor_prompt, AskFloorPrompt};
 use crate::settings::AppConfig;
 
@@ -313,7 +317,8 @@ fn packed_user(
     packed_scoped(db, unlocked, Some(brief), sources)
 }
 
-/// `None` = not asked from a board at all; `Some("")` = a board with nothing readable.
+/// Unit-only prompt-builder seam over already-gated parts. Production scope is resolved by
+/// `dashboard_composite_context`; callers must not treat this helper as an authorization gate.
 fn packed_scoped(
     db: &crate::storage::Db,
     unlocked: &HashSet<String>,
@@ -336,29 +341,49 @@ fn packed_with_provider(
         cloud_egress_consented: true,
         ..AppConfig::default()
     };
-    match build_ask_vault_floor_prompt(
-        db,
-        &cfg,
-        unlocked,
-        "who owes me something on this board?",
-        &[],
-        "",
-        None,
-        sources,
-        None,
-        brief,
-    )
-    .unwrap()
-    {
-        // BOTH halves. `vault_chat::build` packs the corpus into the SYSTEM message and
-        // leaves the user turn as the bare question, so asserting on `user` alone would
-        // pass vacuously no matter what the brief did.
-        AskFloorPrompt::Ready { system, user, .. } => Some(format!(
-            "{system}
-{user}"
-        )),
-        AskFloorPrompt::Empty(_) => None,
+    let Some(brief) = brief else {
+        return match build_ask_vault_floor_prompt(
+            db,
+            &cfg,
+            unlocked,
+            "who owes me something on this board?",
+            &[],
+            "",
+            None,
+            sources,
+            None,
+        )
+        .unwrap()
+        {
+            AskFloorPrompt::Ready { system, user, .. } => Some(format!("{system}\n{user}")),
+            AskFloorPrompt::Empty(_) => None,
+        };
+    };
+    let brief = if brief.trim().is_empty() { "" } else { brief };
+    let budget = crate::summarize::vault_context::budget_for(&cfg.provider_id)
+        .saturating_sub(brief.chars().count());
+    let (source_corpus, _) =
+        crate::summarize::vault_context::build_vault_context_pinned_visible_with_budget(
+            db,
+            sources.unwrap_or_default(),
+            budget,
+            unlocked,
+        )
+        .unwrap();
+    let corpus = match (brief.trim().is_empty(), source_corpus.is_empty()) {
+        (true, _) => source_corpus,
+        (_, true) => brief.to_string(),
+        (false, false) => format!("{brief}\n\n{source_corpus}"),
+    };
+    if corpus.trim().is_empty() {
+        return None;
     }
+    let (system, user) = crate::summarize::vault_chat::build_for_dashboard(
+        &corpus,
+        &[],
+        "who owes me something on this board?",
+    );
+    Some(format!("{system}\n{user}"))
 }
 
 /// The ledger row reaches the PACKED PROMPT, on a board whose tiles are ALL derived —
@@ -367,9 +392,8 @@ fn packed_with_provider(
 ///
 /// ITS RED STATE IS STRUCTURAL, NOT AN EXECUTED FAILING RUN, and that distinction is
 /// worth stating rather than letting "RED-before-GREEN" be read as more than it is:
-/// this test cannot be compiled against the base commit, because neither
-/// `dashboard_brief_inner` nor `build_ask_vault_floor_prompt`'s tenth argument exists
-/// there. Pre-patch the sink was absent, so a derived tile could not reach the prompt
+/// this test cannot be compiled against the base commit because the composite dashboard prompt
+/// path did not exist there. Pre-patch the sink was absent, so a derived tile could not reach it
 /// by construction. The EXECUTED red-before-green in this change is the routing bug
 /// the reviews caught mid-flight — a derived-only board silently skipping the floor —
 /// which `an_all_withheld_board_never_falls_back_to_the_whole_vault` now pins.
@@ -430,104 +454,6 @@ fn a_sealed_row_never_reaches_the_packed_prompt() {
     assert!(
         user.contains("the sealed obligation"),
         "unlocking must restore it, or the leak test is vacuous: {user}"
-    );
-}
-
-/// A caller with no board is byte-identical to before — the equivalence that keeps
-/// every other Ask surface (note editor, org viewer, vault-wide) untouched.
-#[test]
-fn an_empty_brief_leaves_the_packed_prompt_unchanged() {
-    let db = file_db("packed-equivalence");
-    seed_folder(&db, "f-open", false);
-    seed_meeting_with_commitment(&db, "m1", "f-open", "ship it");
-
-    let sources = vec![SourceRef {
-        kind: crate::links::LinkKind::Meeting,
-        id: "m1".to_string(),
-    }];
-    let no_board = packed_scoped(&db, &HashSet::new(), None, Some(&sources));
-    let with_empty = packed_user(&db, &HashSet::new(), "", Some(&sources));
-    let with_blank = packed_user(&db, &HashSet::new(), "   \n  ", Some(&sources));
-    assert_eq!(
-        with_empty, with_blank,
-        "a blank brief must not perturb the packed prompt"
-    );
-    // …and neither perturbs it relative to NO BOARD AT ALL. This is the contract's
-    // byte-identity clause for the PINNED caller (the note editor), which the shipped
-    // floor-equivalence test does not reach — it only compares the whole-vault search
-    // path, where every scope pin is `None`.
-    assert_eq!(
-        no_board, with_empty,
-        "with no board, a pinned-sources ask must pack byte-identically to before"
-    );
-    assert!(
-        with_empty
-            .as_deref()
-            .map(|u| !u.contains(BRIEF_HEADER))
-            .unwrap_or(false),
-        "no board ⇒ no board header"
-    );
-
-    // The ORG-VIEWER caller too, not just the pinned-sources one. Both share the
-    // `saturating_sub` and the `trim().is_empty()` join, so this is belt-and-braces —
-    // but "shares the code path" is an argument, and the contract asks for equality.
-    let org_none = build_ask_vault_floor_prompt(
-        db_ref(&db),
-        &cfg_for_test(),
-        &HashSet::new(),
-        "who owes me something on this board?",
-        &[],
-        "",
-        None,
-        None,
-        Some("org-item-that-does-not-exist"),
-        None,
-    );
-    let org_blank = build_ask_vault_floor_prompt(
-        db_ref(&db),
-        &cfg_for_test(),
-        &HashSet::new(),
-        "who owes me something on this board?",
-        &[],
-        "",
-        None,
-        None,
-        Some("org-item-that-does-not-exist"),
-        Some("   \n  "),
-    );
-    let org_empty = build_ask_vault_floor_prompt(
-        db_ref(&db),
-        &cfg_for_test(),
-        &HashSet::new(),
-        "who owes me something on this board?",
-        &[],
-        "",
-        None,
-        None,
-        Some("org-item-that-does-not-exist"),
-        Some(""),
-    );
-    // Among BOARD-SCOPED calls, a blank brief adds nothing — the claim this sub-case
-    // is actually able to make.
-    assert_eq!(
-        org_blank.map(prompt_text).ok(),
-        org_empty.map(prompt_text).ok(),
-        "a blank brief must not perturb the org-pinned caller"
-    );
-    // A no-board call carries no board header. This REPLACED an assertion that
-    // `None` and `Some("")` pack IDENTICALLY, which was true only by accident: with no
-    // sources and a missing org item nothing packs, so both landed on the same canned
-    // empty answer. Scope is carried by the PRESENCE of the board, so those two are
-    // different callers — one has a board open and one does not — and they are now
-    // distinguishable exactly where that matters: the board-scoped one says the board
-    // is unreadable instead of telling the user to go record a meeting. Asserting them
-    // equal would pin the misdirecting message in place.
-    let org_none_text = org_none
-        .map(prompt_text)
-        .expect("org-pinned ask must resolve");
-    assert!(
-        !org_none_text.contains(BRIEF_HEADER),
-        "no board ⇒ no board header, for the org-pinned caller too: {org_none_text}"
     );
 }
 
@@ -692,9 +618,11 @@ fn truncation_never_keeps_a_tile_heading_without_its_rows() {
 /// only rendered on screen; the brief makes it an Ask-provider egress, so the
 /// negative belongs here too and not only in the on-screen tests.
 #[test]
-fn a_reminder_anchored_only_to_a_sealed_meeting_contributes_nothing() {
+fn a_multi_anchor_reminder_requires_every_source_to_be_readable() {
     let db = file_db("reminders-sealed");
+    seed_folder(&db, "f-open", false);
     seed_folder(&db, "f-sealed", true);
+    seed_meeting_with_commitment(&db, "m-open", "f-open", "irrelevant");
     seed_meeting_with_commitment(&db, "m-sealed", "f-sealed", "irrelevant");
 
     db.create_reminder(
@@ -705,22 +633,31 @@ fn a_reminder_anchored_only_to_a_sealed_meeting_contributes_nothing() {
             due_at: 1_780_000_000_000,
             repeat_every: None,
             repeat_unit: None,
-            sources: vec![ReminderSourceAnchor {
-                kind: "meeting".to_string(),
-                id: "m-sealed".to_string(),
-            }],
+            sources: vec![
+                ReminderSourceAnchor {
+                    kind: "meeting".to_string(),
+                    id: "m-open".to_string(),
+                },
+                ReminderSourceAnchor {
+                    kind: "meeting".to_string(),
+                    id: "m-sealed".to_string(),
+                },
+            ],
         },
-        ReminderOrigin::Manual,
+        ReminderOrigin::Smart,
         1_780_000_000_000,
     )
     .unwrap();
+    db.lock()
+        .execute("UPDATE reminders SET title=x'00' WHERE id='r1'", [])
+        .unwrap();
 
     let tiles = vec![tile("t1", "reminders", None, 0)];
     let brief =
         dashboard_brief_inner(&db, tiles.clone(), &HashSet::new(), MAX_BRIEF_CHARS).unwrap();
     assert!(
         !brief.contains("CHASE THE SEALED THING"),
-        "a reminder whose only anchor is sealed must not reach a prompt: {brief}"
+        "one readable anchor must not declassify a title derived from a sealed anchor: {brief}"
     );
     let packed = packed_scoped(&db, &HashSet::new(), Some(&brief), None).unwrap_or_default();
     assert!(
@@ -730,6 +667,12 @@ fn a_reminder_anchored_only_to_a_sealed_meeting_contributes_nothing() {
 
     // CONTROL — unlock the folder and the SAME assertion finds it, so the negative is
     // the provenance gate rather than a reminder that was never stored.
+    db.lock()
+        .execute(
+            "UPDATE reminders SET title='CHASE THE SEALED THING' WHERE id='r1'",
+            [],
+        )
+        .unwrap();
     let unlocked: HashSet<String> = ["f-sealed".to_string()].into_iter().collect();
     let brief = dashboard_brief_inner(&db, tiles, &unlocked, MAX_BRIEF_CHARS).unwrap();
     assert!(
@@ -744,6 +687,204 @@ fn a_reminder_anchored_only_to_a_sealed_meeting_contributes_nothing() {
     );
 }
 
+/// A document anchor is read defensively even though the current reminder composer still writes
+/// only note/meeting anchors. This keeps a forward-compatible on-disk row honest: a readable
+/// document-derived reminder reaches both the resolved tile and provider corpus, while sealed or
+/// deleted documents contribute nothing.
+#[test]
+fn a_document_anchored_reminder_requires_a_readable_document() {
+    let db = file_db("reminders-document-anchor");
+    seed_folder(&db, "f-open", false);
+    seed_folder(&db, "f-sealed", true);
+    db.insert_document(
+        "d-open",
+        "f-open",
+        "open.txt",
+        "readable document body",
+        "document",
+        1_780_000_000_000,
+    )
+    .unwrap();
+    db.insert_document(
+        "d-sealed",
+        "f-sealed",
+        "sealed.txt",
+        "sealed document body",
+        "document",
+        1_780_000_000_001,
+    )
+    .unwrap();
+    db.insert_document(
+        "d-deleted",
+        "f-open",
+        "deleted.txt",
+        "deleted document body",
+        "document",
+        1_780_000_000_002,
+    )
+    .unwrap();
+
+    for (id, title) in [
+        ("r-open", "READABLE DOCUMENT REMINDER"),
+        ("r-sealed", "SEALED DOCUMENT REMINDER"),
+        ("r-deleted", "DELETED DOCUMENT REMINDER"),
+    ] {
+        db.create_reminder(
+            id,
+            &ReminderDraft {
+                title: title.to_string(),
+                details: None,
+                due_at: 1_780_000_000_000,
+                repeat_every: None,
+                repeat_unit: None,
+                sources: Vec::new(),
+            },
+            ReminderOrigin::Smart,
+            1_780_000_000_000,
+        )
+        .unwrap();
+    }
+
+    // The shipped writer deliberately retains its note/meeting-only storage contract. Seed the
+    // defensive forward-compatibility read seam without changing that public write surface as part
+    // of the dashboard feature.
+    db.lock()
+        .execute_batch(
+            "PRAGMA ignore_check_constraints=ON;
+             INSERT INTO reminder_sources(reminder_id,source_kind,source_id) VALUES
+               ('r-open','document','d-open'),
+               ('r-sealed','document','d-sealed'),
+               ('r-deleted','document','d-deleted');
+             PRAGMA ignore_check_constraints=OFF;",
+        )
+        .unwrap();
+    db.delete_document("d-deleted").unwrap();
+
+    let reminder_tile = tile("t-reminders", "reminders", None, 0);
+    let resolved = resolve_tile(&db, &reminder_tile, &HashSet::new()).unwrap();
+    let TileData::Reminders { rows, due_count } = resolved else {
+        panic!("the reminders tile must stay resolved");
+    };
+    assert_eq!(due_count, 1);
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].text, "READABLE DOCUMENT REMINDER");
+
+    db.insert_dashboard("b1", "Board", None, None, "2026-08-01T09:00:00Z")
+        .unwrap();
+    db.insert_dashboard_tile(
+        "t-reminders",
+        "b1",
+        "reminders",
+        None,
+        None,
+        4,
+        None,
+        "2026-08-01T09:00:00Z",
+    )
+    .unwrap();
+    let context =
+        dashboard_composite_context(&db, "b1", &HashSet::new(), 200_000, &[], None).unwrap();
+    let (system, user) = crate::summarize::vault_chat::build_for_dashboard(
+        &context.packed_corpus,
+        &[],
+        "Which reminders are on this board?",
+    );
+    let prompt = format!("{system}\n{user}");
+    assert!(prompt.contains("READABLE DOCUMENT REMINDER"));
+    assert!(!prompt.contains("SEALED DOCUMENT REMINDER"));
+    assert!(!prompt.contains("DELETED DOCUMENT REMINDER"));
+
+    // CONTROL — the same sealed row appears only after its folder is session-unlocked.
+    let unlocked: HashSet<String> = ["f-sealed".to_string()].into_iter().collect();
+    let context = dashboard_composite_context(&db, "b1", &unlocked, 200_000, &[], None).unwrap();
+    let (system, user) = crate::summarize::vault_chat::build_for_dashboard(
+        &context.packed_corpus,
+        &[],
+        "Which reminders are on this board?",
+    );
+    let prompt = format!("{system}\n{user}");
+    assert!(prompt.contains("SEALED DOCUMENT REMINDER"));
+    assert!(!prompt.contains("DELETED DOCUMENT REMINDER"));
+}
+
+#[test]
+fn smart_reminder_without_provenance_fails_closed_but_manual_reminder_is_visible() {
+    let db = file_db("reminders-empty-provenance");
+    db.create_reminder(
+        "r-smart",
+        &ReminderDraft {
+            title: "SMART SOURCE-LOST SECRET".to_string(),
+            details: None,
+            due_at: 1_780_000_000_000,
+            repeat_every: None,
+            repeat_unit: None,
+            sources: vec![],
+        },
+        ReminderOrigin::Smart,
+        1_780_000_000_000,
+    )
+    .unwrap();
+    db.create_reminder(
+        "r-manual",
+        &ReminderDraft {
+            title: "MANUAL OWNED REMINDER".to_string(),
+            details: None,
+            due_at: 1_780_000_000_001,
+            repeat_every: None,
+            repeat_unit: None,
+            sources: vec![],
+        },
+        ReminderOrigin::Manual,
+        1_780_000_000_001,
+    )
+    .unwrap();
+
+    let brief = dashboard_brief_inner(
+        &db,
+        vec![tile("t1", "reminders", None, 0)],
+        &HashSet::new(),
+        MAX_BRIEF_CHARS,
+    )
+    .unwrap();
+    let packed = packed_scoped(&db, &HashSet::new(), Some(&brief), None).unwrap();
+    assert!(!packed.contains("SMART SOURCE-LOST SECRET"));
+    assert!(
+        packed.contains("MANUAL OWNED REMINDER"),
+        "manual source-less reminders are user-authored and keep the negative non-vacuous: {packed}"
+    );
+}
+
+#[test]
+fn derived_board_brief_never_hydrates_residual_tile_chrome_or_config() {
+    let db = file_db("derived-poisoned-chrome");
+    db.insert_dashboard("b-derived", "Board", None, None, "2026-08-01T09:00:00Z")
+        .unwrap();
+    db.insert_dashboard_tile(
+        "t-promises",
+        "b-derived",
+        "promises",
+        None,
+        Some("RESIDUAL DERIVED TITLE"),
+        4,
+        Some(r#"{"owner":"RESIDUAL OWNER"}"#),
+        "2026-08-01T09:00:00Z",
+    )
+    .unwrap();
+    db.lock()
+        .execute(
+            "UPDATE dashboard_tiles SET title=x'00',config=x'01' WHERE id='t-promises'",
+            [],
+        )
+        .unwrap();
+
+    let tiles = db.list_dashboard_tile_structures("b-derived").unwrap();
+    let brief = dashboard_brief_inner(&db, tiles, &HashSet::new(), MAX_BRIEF_CHARS).unwrap();
+    assert!(
+        brief.contains("promises"),
+        "gated derived payload still renders: {brief}"
+    );
+}
+
 /// GAP 1 — the SEVENTH derived kind. A `livingAnswer` whose cached answer was
 /// stamped against a folder that is no longer fully readable resolves with
 /// `withheld: true`, and a withheld cached answer is a PARAPHRASE of content the
@@ -752,44 +893,417 @@ fn a_reminder_anchored_only_to_a_sealed_meeting_contributes_nothing() {
 fn a_withheld_living_answer_contributes_nothing() {
     let db = file_db("living-answer-withheld");
     seed_folder(&db, "f-sealed", true);
-    seed_meeting_with_commitment(&db, "m-sealed", "f-sealed", "irrelevant");
+    db.insert_dashboard("b1", "Board", None, None, "2026-08-01T09:00:00Z")
+        .unwrap();
+    db.insert_dashboard_tile(
+        "t1",
+        "b1",
+        "living_answer",
+        None,
+        None,
+        4,
+        None,
+        "2026-08-01T09:00:00Z",
+    )
+    .unwrap();
+    db.stamp_dashboard_question_provenance("t1", "will it land?", r#"["f-sealed"]"#)
+        .unwrap();
+    db.lock()
+        .execute("UPDATE dashboard_tiles SET config=x'00' WHERE id='t1'", [])
+        .unwrap();
+    let t = db.list_dashboard_tile_structures("b1").unwrap().remove(0);
 
-    // A cached answer stamped against a folder that is sealed and NOT session-unlocked.
-    let cfg = serde_json::json!({
-        "question": "will it land?",
-        "answer": "CACHED PARAPHRASE OF SEALED CONTENT",
-        "answeredAt": "2026-08-01T09:00:00Z",
-        "answerReadableFolders": ["f-sealed"],
-    })
-    .to_string();
-    let mut t = tile("t1", "living_answer", None, 0);
-    t.config = Some(cfg);
+    let locked_data = resolve_tile(&db, &t, &HashSet::new()).unwrap();
+    let TileData::LivingAnswer {
+        question,
+        answer,
+        withheld,
+        ..
+    } = &locked_data
+    else {
+        panic!("expected living-answer data")
+    };
+    assert!(*withheld);
+    assert!(
+        question.is_empty(),
+        "withheld question must be absent on the wire"
+    );
+    assert!(answer.is_none());
+    let redacted = redact_tile_chrome(t.clone(), &locked_data);
+    let rendered = render_tile_for_agent(&redacted, &locked_data);
+    assert!(!rendered.contains("will it land?"));
+    assert!(!rendered.contains("will it land?"));
 
     let brief =
         dashboard_brief_inner(&db, vec![t.clone()], &HashSet::new(), MAX_BRIEF_CHARS).unwrap();
-    assert!(
-        !brief.contains("CACHED PARAPHRASE OF SEALED CONTENT"),
-        "a withheld cached answer must not reach a prompt: {brief}"
-    );
+    assert!(!brief.contains("will it land?"));
+    assert!(!brief.contains("will it land?"));
     let packed = packed_user(&db, &HashSet::new(), &brief, None).unwrap_or_default();
-    assert!(!packed.contains("CACHED PARAPHRASE OF SEALED CONTENT"));
+    assert!(!packed.contains("will it land?"));
 
     // CONTROL — session-unlock the stamped folder and the SAME string reappears, so the
     // negative above is the withheld predicate rather than an unparsed config.
     let unlocked: HashSet<String> = ["f-sealed".to_string()].into_iter().collect();
+    let unlocked_data = resolve_tile(&db, &t, &unlocked).unwrap();
+    let TileData::LivingAnswer {
+        question,
+        answer,
+        withheld,
+        ..
+    } = &unlocked_data
+    else {
+        panic!("expected living-answer data")
+    };
+    assert!(!*withheld);
+    assert_eq!(question, "will it land?");
+    assert!(answer.is_none());
+    assert!(render_tile_for_agent(&t, &unlocked_data).contains("will it land?"));
     let brief = dashboard_brief_inner(&db, vec![t], &unlocked, MAX_BRIEF_CHARS).unwrap();
+    assert!(brief.contains("will it land?"));
+}
+
+#[test]
+fn a_readable_backend_stamped_living_answer_reaches_the_production_resolver() {
+    let db = file_db("living-answer-readable-cache");
+    seed_folder(&db, "f-open", false);
+    seed_meeting_with_commitment(&db, "m-source", "f-open", "ship on Friday");
+    db.insert_dashboard("b1", "Board", None, None, "2026-08-01T09:00:00Z")
+        .unwrap();
+    db.insert_dashboard_living_answer_tile(
+        "t-readable",
+        "b1",
+        4,
+        "Will it ship?",
+        r#"["f-open"]"#,
+        "2026-08-01T09:00:00Z",
+    )
+    .unwrap();
+    db.insert_dashboard_tile(
+        "t-promises",
+        "b1",
+        "promises",
+        None,
+        None,
+        4,
+        None,
+        "2026-08-01T09:00:01Z",
+    )
+    .unwrap();
+    let context = living_answer_composite_context(&db, "b1", &HashSet::new(), 200_000).unwrap();
+    db.lock()
+        .execute(
+            "UPDATE dashboard_tiles SET
+               living_answer='YES — READABLE CACHE',
+               living_answered_at='2026-08-01T09:01:00Z',
+               answer_readable_folders_json='[\"f-open\"]',
+               living_answer_context_generation=?1,
+               living_answer_context_digest=?2,
+               living_answer_context_budget=200000,
+               living_answer_ask_dispatch_generation=?3
+             WHERE id='t-readable'",
+            rusqlite::params![
+                context.witness.generation,
+                context.witness.input_digest,
+                context.witness.ask_dispatch_generation,
+            ],
+        )
+        .unwrap();
+    let tile = db.list_dashboard_tile_structures("b1").unwrap().remove(0);
+
+    let data = resolve_tile(&db, &tile, &HashSet::new()).unwrap();
+    let TileData::LivingAnswer {
+        question,
+        answer,
+        answered_at,
+        withheld,
+    } = &data
+    else {
+        panic!("expected living answer")
+    };
+    assert_eq!(question, "Will it ship?");
+    assert_eq!(answer.as_deref(), Some("YES — READABLE CACHE"));
+    assert_eq!(answered_at.as_deref(), Some("2026-08-01T09:01:00Z"));
+    assert!(!withheld);
+    let wire = serde_json::to_string(&ResolvedTileDto {
+        tile: tile.clone(),
+        data: data.clone(),
+    })
+    .unwrap();
+    assert!(wire.contains("YES — READABLE CACHE"));
+    assert!(render_tile_for_agent(&tile, &data).contains("YES — READABLE CACHE"));
     assert!(
-        brief.contains("CACHED PARAPHRASE OF SEALED CONTENT"),
-        "unlocking must restore it, or the leak test is vacuous: {brief}"
+        dashboard_brief_inner(&db, vec![tile], &HashSet::new(), MAX_BRIEF_CHARS)
+            .unwrap()
+            .contains("YES — READABLE CACHE")
     );
+
+    db.lock()
+        .execute(
+            "UPDATE notes SET markdown='## Action items\n- [ ] Marcus — SOURCE MUTATED\n'
+              WHERE meeting_id='m-source'",
+            [],
+        )
+        .unwrap();
+    let tile = db
+        .list_dashboard_tile_structures("b1")
+        .unwrap()
+        .into_iter()
+        .find(|tile| tile.id == "t-readable")
+        .unwrap();
+    let stale = resolve_tile(&db, &tile, &HashSet::new()).unwrap();
+    assert!(matches!(
+        stale,
+        TileData::LivingAnswer {
+            answer: None,
+            withheld: true,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn malformed_or_unreadable_living_answer_content_is_never_hydrated() {
+    let db = file_db("living-answer-malformed-cache");
+    seed_folder(&db, "f-sealed", true);
+    db.insert_dashboard("b1", "Board", None, None, "2026-08-01T09:00:00Z")
+        .unwrap();
+    db.insert_dashboard_living_answer_tile(
+        "t-malformed",
+        "b1",
+        4,
+        "QUESTION SENTINEL",
+        r#"["f-sealed"]"#,
+        "2026-08-01T09:00:00Z",
+    )
+    .unwrap();
+    let generation = db.dashboard_context_state("b1").unwrap().0;
+    db.lock()
+        .execute(
+            "UPDATE dashboard_tiles SET
+               living_answer=?2,
+               living_answered_at='2026-08-01T09:01:00Z',
+               answer_readable_folders_json='[\"f-sealed\"]',
+               living_answer_context_generation=?1,
+               living_answer_context_digest='exact-packed-digest',
+               config='{\"answer\":\"LEGACY CONFIG SENTINEL\",\"answerReadableFolders\":[]}'
+             WHERE id='t-malformed'",
+            rusqlite::params![generation, b"SECRET BLOB-ANSWER".as_slice()],
+        )
+        .unwrap();
+    let tile = db.list_dashboard_tile_structures("b1").unwrap().remove(0);
+
+    for unlocked in [HashSet::new(), HashSet::from(["f-sealed".to_string()])] {
+        let data = resolve_tile(&db, &tile, &unlocked).unwrap();
+        assert!(matches!(
+            data,
+            TileData::LivingAnswer {
+                ref question,
+                answer: None,
+                answered_at: None,
+                withheld: true,
+            } if question.is_empty()
+        ));
+        let wire = serde_json::to_string(&ResolvedTileDto {
+            tile: redact_tile_chrome(tile.clone(), &data),
+            data: data.clone(),
+        })
+        .unwrap();
+        for secret in [
+            "QUESTION SENTINEL",
+            "SECRET BLOB-ANSWER",
+            "LEGACY CONFIG SENTINEL",
+        ] {
+            assert!(!wire.contains(secret), "secret reached wire: {wire}");
+            assert!(!render_tile_for_agent(&tile, &data).contains(secret));
+        }
+    }
+}
+
+#[test]
+fn living_answer_provider_context_excludes_every_cached_living_answer() {
+    let db = file_db("living-answer-no-self-conditioning");
+    seed_folder(&db, "f-open", false);
+    seed_meeting_with_commitment(&db, "m-source", "f-open", "GROUNDING MARKER");
+    db.insert_dashboard("b1", "Board", None, None, "2026-08-01T09:00:00Z")
+        .unwrap();
+    for (id, question) in [("answer-a", "Question A?"), ("answer-b", "Question B?")] {
+        db.insert_dashboard_living_answer_tile(
+            id,
+            "b1",
+            4,
+            question,
+            r#"["f-open"]"#,
+            "2026-08-01T09:00:00Z",
+        )
+        .unwrap();
+    }
+    db.insert_dashboard_tile(
+        "promises",
+        "b1",
+        "promises",
+        None,
+        None,
+        4,
+        None,
+        "2026-08-01T09:00:01Z",
+    )
+    .unwrap();
+    let excluded = living_answer_composite_context(&db, "b1", &HashSet::new(), 200_000).unwrap();
+    for (id, answer) in [
+        ("answer-a", "OLD CACHE A MUST NOT CONDITION"),
+        ("answer-b", "OLD CACHE B MUST NOT CONDITION"),
+    ] {
+        db.lock()
+            .execute(
+                "UPDATE dashboard_tiles SET
+                   living_answer=?2,
+                   living_answered_at='2026-08-01T09:01:00Z',
+                   answer_readable_folders_json='[\"f-open\"]',
+                   living_answer_context_generation=?3,
+                   living_answer_context_digest=?4,
+                   living_answer_context_budget=200000,
+                   living_answer_ask_dispatch_generation=?5
+                 WHERE id=?1",
+                rusqlite::params![
+                    id,
+                    answer,
+                    excluded.witness.generation,
+                    excluded.witness.input_digest,
+                    excluded.witness.ask_dispatch_generation,
+                ],
+            )
+            .unwrap();
+    }
+
+    let general =
+        dashboard_composite_context(&db, "b1", &HashSet::new(), 200_000, &[], None).unwrap();
+    assert!(general.packed_corpus.contains("OLD CACHE A MUST NOT CONDITION"));
+    assert!(general.packed_corpus.contains("OLD CACHE B MUST NOT CONDITION"));
+    let provider = living_answer_composite_context(&db, "b1", &HashSet::new(), 200_000).unwrap();
+    assert!(provider.packed_corpus.contains("GROUNDING MARKER"));
+    assert!(!provider.packed_corpus.contains("OLD CACHE A MUST NOT CONDITION"));
+    assert!(!provider.packed_corpus.contains("OLD CACHE B MUST NOT CONDITION"));
+}
+
+#[test]
+fn refreshing_a_second_living_answer_does_not_hide_the_first() {
+    let db = file_db("living-answer-two-caches");
+    seed_folder(&db, "f-open", false);
+    seed_meeting_with_commitment(&db, "m-source", "f-open", "GROUNDING MARKER");
+    db.insert_dashboard("b1", "Board", None, None, "2026-08-01T09:00:00Z")
+        .unwrap();
+    for (id, question) in [("answer-a", "Question A?"), ("answer-b", "Question B?")] {
+        db.insert_dashboard_living_answer_tile(
+            id,
+            "b1",
+            4,
+            question,
+            r#"["f-open"]"#,
+            "2026-08-01T09:00:00Z",
+        )
+        .unwrap();
+    }
+    db.insert_dashboard_tile(
+        "promises",
+        "b1",
+        "promises",
+        None,
+        None,
+        4,
+        None,
+        "2026-08-01T09:00:01Z",
+    )
+    .unwrap();
+    let context = living_answer_composite_context(&db, "b1", &HashSet::new(), 200_000).unwrap();
+    for (id, question, answer) in [
+        ("answer-a", "Question A?", "ANSWER A REMAINS"),
+        ("answer-b", "Question B?", "ANSWER B REMAINS"),
+    ] {
+        assert!(db
+            .store_dashboard_living_answer_cas(
+                id,
+                "b1",
+                question,
+                answer,
+                "2026-08-01T09:01:00Z",
+                r#"["f-open"]"#,
+                context.witness.generation,
+                &context.witness.input_digest,
+                200_000,
+            )
+            .unwrap());
+    }
+    assert_eq!(
+        db.dashboard_structural_context_state("b1").unwrap().0,
+        context.witness.generation,
+        "cache writes must not mutate the structural incarnation"
+    );
+    for (id, expected) in [
+        ("answer-a", "ANSWER A REMAINS"),
+        ("answer-b", "ANSWER B REMAINS"),
+    ] {
+        let tile = db
+            .list_dashboard_tile_structures("b1")
+            .unwrap()
+            .into_iter()
+            .find(|tile| tile.id == id)
+            .unwrap();
+        let resolved = resolve_tile(&db, &tile, &HashSet::new()).unwrap();
+        assert!(matches!(
+            resolved,
+            TileData::LivingAnswer {
+                answer: Some(ref answer),
+                withheld: false,
+                ..
+            } if answer == expected
+        ));
+    }
+}
+
+#[test]
+fn a_question_without_an_answer_is_withheld_after_its_creation_scope_relocks() {
+    let db = file_db("living-question-withheld");
+    seed_folder(&db, "f-sealed", true);
+    db.insert_dashboard("b1", "Board", None, None, "2026-08-01T09:00:00Z")
+        .unwrap();
+    db.insert_dashboard_tile(
+        "t-question",
+        "b1",
+        "living_answer",
+        None,
+        None,
+        4,
+        None,
+        "now",
+    )
+    .unwrap();
+    db.stamp_dashboard_question_provenance(
+        "t-question",
+        "QUESTION DERIVED FROM SEALED SENTINEL",
+        r#"["f-sealed"]"#,
+    )
+    .unwrap();
+    let t = db.list_dashboard_tile_structures("b1").unwrap().remove(0);
+
+    let locked = resolve_tile(&db, &t, &HashSet::new()).unwrap();
+    let locked_json = serde_json::to_string(&ResolvedTileDto {
+        tile: redact_tile_chrome(t.clone(), &locked),
+        data: locked.clone(),
+    })
+    .unwrap();
+    assert!(!locked_json.contains("QUESTION DERIVED FROM SEALED SENTINEL"));
+    assert!(!render_tile_for_agent(&t, &locked).contains("QUESTION DERIVED"));
+
+    let unlocked: HashSet<String> = ["f-sealed".to_string()].into_iter().collect();
+    let visible = resolve_tile(&db, &t, &unlocked).unwrap();
+    assert!(render_tile_for_agent(&t, &visible).contains("QUESTION DERIVED FROM SEALED SENTINEL"));
 }
 
 /// GAP 2 — the PRODUCTION wiring, not one layer in.
 ///
 /// Every other test here enters at `dashboard_brief_inner` with a hand-built
-/// `HashSet`. That proves the rule but not the plumbing: `dashboard_brief_for_ask`
-/// reads the board's tiles from the DB and applies `brief_allowance`, and neither
-/// was executed. A gate established by READING a diff is not a gate that ran.
+/// `HashSet`. This drives the shipped composite resolver, including its DB tile read,
+/// derived brief allowance, material-source packing, and session visibility gate.
 #[test]
 fn the_production_brief_entry_point_gates_on_the_session_snapshot() {
     let db = file_db("production-wiring");
@@ -809,26 +1323,28 @@ fn the_production_brief_entry_point_gates_on_the_session_snapshot() {
     )
     .unwrap();
 
-    let brief = dashboard_brief_for_ask(&db, "b-live", &HashSet::new(), 200_000).unwrap();
+    let context =
+        dashboard_composite_context(&db, "b-live", &HashSet::new(), 200_000, &[], None).unwrap();
     assert!(
-        !brief.contains("the sealed obligation"),
-        "the production entry point must gate on the session snapshot: {brief}"
+        !context.packed_corpus.contains("the sealed obligation"),
+        "the production entry point must gate on the session snapshot: {}",
+        context.packed_corpus
     );
 
     // CONTROL — the same call with the folder session-unlocked finds it.
     let unlocked: HashSet<String> = ["f-sealed".to_string()].into_iter().collect();
-    let brief = dashboard_brief_for_ask(&db, "b-live", &unlocked, 200_000).unwrap();
+    let context =
+        dashboard_composite_context(&db, "b-live", &unlocked, 200_000, &[], None).unwrap();
     assert!(
-        brief.contains("the sealed obligation"),
-        "unlocking must restore it, or the wiring test is vacuous: {brief}"
+        context.packed_corpus.contains("the sealed obligation"),
+        "unlocking must restore it, or the wiring test is vacuous: {}",
+        context.packed_corpus
     );
 
-    // An unknown board id is empty, never an error — a stale id must not fail an Ask.
-    assert!(
-        dashboard_brief_for_ask(&db, "no-such-board", &unlocked, 200_000)
-            .unwrap()
-            .is_empty()
-    );
+    assert!(matches!(
+        dashboard_composite_context(&db, "no-such-board", &unlocked, 200_000, &[], None),
+        Err(AppError::Locked(_))
+    ));
 }
 
 /// The brief takes its slice OUT OF the corpus budget rather than on top of it.
@@ -837,7 +1353,7 @@ fn the_production_brief_entry_point_gates_on_the_session_snapshot() {
 /// 200k budget and a small vault there is slack: the corpus packs whole either way and
 /// the brief genuinely adds — correctly, since the prompt is still inside budget. An
 /// earlier version of this test ran exactly there, and therefore passed with or without
-/// `saturating_sub(board_brief.chars().count())` in `ask.rs`. A test that cannot fail is
+/// the composite resolver's shared source-budget subtraction. A test that cannot fail is
 /// not evidence — the same vacuity the adversarial review of PR #562 caught in this
 /// feature's answer-cache gate.
 ///
@@ -876,23 +1392,32 @@ fn the_brief_comes_out_of_the_corpus_budget_when_the_budget_binds() {
     let without = packed_with_provider(&db, &HashSet::new(), None, Some(&sources), "ollama")
         .unwrap_or_default();
 
+    let board_grounding = with_board
+        .split_once("DASHBOARD GROUNDING:\n")
+        .map(|(_, grounding)| grounding.split("\nUser:").next().unwrap_or(grounding))
+        .expect("board prompt must label its mixed grounding");
+    let legacy_grounding = without
+        .split_once("MEETING NOTES:\n")
+        .map(|(_, grounding)| grounding.split("\nUser:").next().unwrap_or(grounding))
+        .expect("non-board prompt must retain the legacy grounding label");
+
     assert!(
-        without.chars().count() > 3_000,
+        legacy_grounding.chars().count() > 3_000,
         "the no-board corpus must actually saturate the 4000-char budget, or this test proves nothing: {}",
-        without.chars().count()
+        legacy_grounding.chars().count()
     );
     // Equal to within the two-character `\n\n` that joins brief to corpus. Without
     // the subtraction the delta would be the brief's own length — hundreds of chars at
     // this allowance — so a 4-char tolerance still falsifies decisively.
-    let delta = with_board
+    let delta = board_grounding
         .chars()
         .count()
-        .saturating_sub(without.chars().count());
+        .saturating_sub(legacy_grounding.chars().count());
     assert!(
         delta <= 4,
         "the brief must displace corpus, not stack on it: board {} vs no-board {} (delta {delta}, brief {})",
-        with_board.chars().count(),
-        without.chars().count(),
+        board_grounding.chars().count(),
+        legacy_grounding.chars().count(),
         brief.chars().count()
     );
 }
@@ -959,12 +1484,8 @@ fn one_oversized_ledger_still_reaches_the_prompt_as_a_counted_prefix() {
 
 // ── THE PRODUCTION COMPOSITION ────────────────────────────────────────────────
 //
-// Everything above tests a PIECE: `dashboard_brief_inner` (the rule),
-// `dashboard_brief_for_ask` (the DB read), `build_ask_vault_floor_prompt` (the pack).
-// The glue in `ask_vault` — normalize the id, resolve the brief, PRESERVE `Some("")`,
-// forward it — was verified by reading, and that is where the routing defect actually
-// lived: a derived-only board skipping the floor entirely. `board_scoped_brief` is
-// that glue, extracted so these tests drive the shipped code rather than a copy of it.
+// Everything above tests a PIECE. These tests enter through the shipped composite resolver and
+// assert the exact packed corpus handed to the provider seam.
 
 /// End to end at the production seam: a board id in, a promises row out of the packed
 /// provider prompt — with no hand-assembled intermediate.
@@ -987,23 +1508,369 @@ fn the_production_composition_puts_a_ledger_row_in_the_packed_prompt() {
     )
     .unwrap();
 
-    let brief = board_scoped_brief(&db, Some("b-1"), &HashSet::new(), 200_000).unwrap();
-    let brief = brief.expect("a board id must yield board scope");
-    let packed = packed_scoped(&db, &HashSet::new(), Some(&brief), None)
-        .expect("a board-scoped ask must produce a prompt");
+    let context =
+        dashboard_composite_context(&db, "b-1", &HashSet::new(), 200_000, &[], None).unwrap();
+    let (system, user) = crate::summarize::vault_chat::build_for_dashboard(
+        &context.packed_corpus,
+        &[],
+        "who owes me something on this board?",
+    );
+    let packed = format!("{system}\n{user}");
     assert!(
         packed.contains("send the Acme paperwork"),
         "the production path must carry the ledger row to the provider prompt: {packed}"
     );
 }
 
+#[test]
+fn active_prepacked_dashboard_empty_and_withheld_return_the_same_safe_message() {
+    let db = file_db("prepacked-empty-withheld");
+    db.insert_dashboard("empty", "Empty", None, None, "2026-08-01T09:00:00Z")
+        .unwrap();
+    db.insert_dashboard(
+        "withheld",
+        "Withheld",
+        None,
+        None,
+        "2026-08-01T09:00:00Z",
+    )
+    .unwrap();
+    seed_folder(&db, "f-sealed", true);
+    seed_meeting_with_commitment(
+        &db,
+        "m-sealed",
+        "f-sealed",
+        "SEALED WITHHELD PROMISE",
+    );
+    db.insert_dashboard_tile(
+        "withheld-meeting",
+        "withheld",
+        "meeting",
+        Some("m-sealed"),
+        None,
+        4,
+        None,
+        "2026-08-01T09:00:00Z",
+    )
+    .unwrap();
+    let empty =
+        dashboard_composite_context(&db, "empty", &HashSet::new(), 200_000, &[], None).unwrap();
+    let withheld = dashboard_composite_context(
+        &db,
+        "withheld",
+        &HashSet::new(),
+        200_000,
+        &[],
+        None,
+    )
+    .unwrap();
+    assert!(empty.packed_corpus.is_empty());
+    assert!(withheld.packed_corpus.is_empty());
+    let unlocked: HashSet<String> = ["f-sealed".to_string()].into_iter().collect();
+    let visible =
+        dashboard_composite_context(&db, "withheld", &unlocked, 200_000, &[], None).unwrap();
+    assert!(
+        visible.packed_corpus.contains("SEALED WITHHELD PROMISE"),
+        "unlock control must prove the withheld board is not merely empty"
+    );
+
+    let admission = crate::state::ContentDispatchAdmission::for_test(
+        std::sync::Arc::new(std::sync::Mutex::new(())),
+        || Ok(()),
+    );
+    let heavy = std::sync::Arc::new(tokio::sync::Semaphore::new(1));
+    let config = AppConfig::default();
+    let empty_result = block_on(crate::commands::ask_vault_prepacked_dashboard_authorized(
+        &empty,
+        &config,
+        "question",
+        &[],
+        &heavy,
+        admission.clone(),
+    ))
+    .unwrap();
+    let withheld_result = block_on(crate::commands::ask_vault_prepacked_dashboard_authorized(
+        &withheld,
+        &config,
+        "question",
+        &[],
+        &heavy,
+        admission,
+    ))
+    .unwrap();
+
+    assert_eq!(empty_result.answer, withheld_result.answer);
+    assert_eq!(
+        empty_result.answer,
+        "Nothing on this board is readable right now — unlock its folders, or add tiles with content you can see."
+    );
+    assert!(empty_result.sources.is_empty() && empty_result.citations.is_empty());
+    assert!(withheld_result.sources.is_empty() && withheld_result.citations.is_empty());
+}
+
+#[test]
+fn id_only_composite_resolves_material_and_derived_with_dedupe() {
+    let db = file_db("composite-material-derived");
+    seed_folder(&db, "f-open", false);
+    seed_meeting_with_commitment(&db, "m1", "f-open", "send the board packet");
+    db.insert_dashboard("b-composite", "Board", None, None, "2026-08-01T09:00:00Z")
+        .unwrap();
+    for tile_id in ["material-a", "material-duplicate"] {
+        db.insert_dashboard_tile(
+            tile_id,
+            "b-composite",
+            "meeting",
+            Some("m1"),
+            None,
+            4,
+            None,
+            "2026-08-01T09:00:00Z",
+        )
+        .unwrap();
+    }
+    db.insert_dashboard_tile(
+        "derived",
+        "b-composite",
+        "promises",
+        None,
+        None,
+        4,
+        None,
+        "2026-08-01T09:00:00Z",
+    )
+    .unwrap();
+
+    let context =
+        dashboard_composite_context(&db, "b-composite", &HashSet::new(), 200_000, &[], None)
+            .unwrap();
+    assert_eq!(
+        context.packed_sources.len(),
+        1,
+        "duplicate material pointers dedupe"
+    );
+    assert_eq!(context.packed_sources[0].meeting_id, "m1");
+    assert!(context.packed_corpus.contains("send the board packet"));
+    require_dashboard_context_witness(&db, &context.witness, &HashSet::new()).unwrap();
+
+    db.upsert_note(&NoteRecord {
+        meeting_id: "m1".to_string(),
+        provider_id: "test".to_string(),
+        markdown: "## Action items\n- [ ] Marcus — changed after capture\n".to_string(),
+        created_at: "2026-08-01T09:01:00Z".to_string(),
+        exported_path: None,
+        model_requested: None,
+        model_served: None,
+        gateway_host: None,
+    })
+    .unwrap();
+    assert!(matches!(
+        require_dashboard_context_witness(&db, &context.witness, &HashSet::new()),
+        Err(AppError::Locked(_))
+    ));
+
+    db.delete_dashboard_tile("derived").unwrap();
+    assert!(matches!(
+        require_dashboard_context_witness(&db, &context.witness, &HashSet::new()),
+        Err(AppError::Locked(_))
+    ));
+}
+
+#[test]
+fn derived_tile_beyond_brief_cutoff_changes_exact_witness_not_provider_corpus() {
+    let db = file_db("derived-beyond-cutoff-witness");
+    seed_folder(&db, "f-open", false);
+    for i in 0..6 {
+        seed_meeting_with_commitment(
+            &db,
+            &format!("m-{i}"),
+            "f-open",
+            &format!("long obligation {i} with enough words to consume the brief allowance"),
+        );
+    }
+    db.create_reminder(
+        "late-reminder",
+        &ReminderDraft {
+            title: "REMINDER-A".to_string(),
+            details: None,
+            due_at: 1_780_000_000_000,
+            repeat_every: None,
+            repeat_unit: None,
+            sources: Vec::new(),
+        },
+        ReminderOrigin::Manual,
+        1_780_000_000_000,
+    )
+    .unwrap();
+    db.insert_dashboard("b-derived", "Board", None, None, "now")
+        .unwrap();
+    db.insert_dashboard_tile(
+        "promises",
+        "b-derived",
+        "promises",
+        None,
+        None,
+        4,
+        None,
+        "now",
+    )
+    .unwrap();
+    db.insert_dashboard_tile(
+        "reminders",
+        "b-derived",
+        "reminders",
+        None,
+        None,
+        4,
+        None,
+        "later",
+    )
+    .unwrap();
+
+    let before =
+        dashboard_composite_context(&db, "b-derived", &HashSet::new(), 1_000, &[], None).unwrap();
+    assert!(!before.packed_corpus.contains("REMINDER-A"));
+    db.lock()
+        .execute(
+            "UPDATE reminders SET title='REMINDER-B' WHERE id='late-reminder'",
+            [],
+        )
+        .unwrap();
+    let after =
+        dashboard_composite_context(&db, "b-derived", &HashSet::new(), 1_000, &[], None).unwrap();
+    assert_eq!(before.packed_corpus, after.packed_corpus);
+    assert_ne!(before.witness.input_digest, after.witness.input_digest);
+}
+
+#[test]
+fn ninth_linked_neighbour_outside_cap_does_not_change_exact_witness() {
+    let db = file_db("ninth-neighbour-control");
+    seed_folder(&db, "f-open", false);
+    db.insert_note(
+        "hub",
+        "f-open",
+        "Hub",
+        "Hub",
+        &"hub body ".repeat(300),
+        1_700_000_000,
+    )
+    .unwrap();
+    for i in 0..9 {
+        let id = format!("n-{i}");
+        db.insert_note(
+            &id,
+            "f-open",
+            &id,
+            &id,
+            &format!("NEIGHBOUR-{i}-A"),
+            1_700_000_000,
+        )
+        .unwrap();
+        db.insert_link_for_test(
+            "note", "hub", "note", &id, "manual", 1.0, "user", "active",
+        );
+    }
+    db.insert_dashboard("b-links", "Board", None, None, "now")
+        .unwrap();
+    db.insert_dashboard_tile(
+        "hub-tile",
+        "b-links",
+        "note",
+        Some("hub"),
+        None,
+        4,
+        None,
+        "now",
+    )
+    .unwrap();
+    let before =
+        dashboard_composite_context(&db, "b-links", &HashSet::new(), 300, &[], None).unwrap();
+    db.lock()
+        .execute(
+            "UPDATE documents SET text='NEIGHBOUR-8-B' WHERE id='n-8'",
+            [],
+        )
+        .unwrap();
+    let after =
+        dashboard_composite_context(&db, "b-links", &HashSet::new(), 300, &[], None).unwrap();
+    assert_eq!(before.packed_corpus, after.packed_corpus);
+    assert_eq!(before.witness.input_digest, after.witness.input_digest);
+}
+
+#[test]
+fn identical_logical_edge_reinsert_does_not_change_exact_witness() {
+    let db = file_db("edge-row-id-control");
+    seed_folder(&db, "f-open", false);
+    db.insert_note("hub", "f-open", "Hub", "Hub", "hub body", 1_700_000_000)
+        .unwrap();
+    db.insert_note(
+        "near",
+        "f-open",
+        "Near",
+        "Near",
+        "neighbour body",
+        1_700_000_000,
+    )
+    .unwrap();
+    db.insert_link_for_test(
+        "note", "hub", "note", "near", "manual", 1.0, "user", "active",
+    );
+    db.insert_dashboard("b-edge", "Board", None, None, "now")
+        .unwrap();
+    db.insert_dashboard_tile(
+        "hub-tile",
+        "b-edge",
+        "note",
+        Some("hub"),
+        None,
+        4,
+        None,
+        "now",
+    )
+    .unwrap();
+    let before =
+        dashboard_composite_context(&db, "b-edge", &HashSet::new(), 2_000, &[], None).unwrap();
+    let old_id: i64 = db
+        .lock()
+        .query_row("SELECT id FROM links WHERE edge_type='manual'", [], |row| row.get(0))
+        .unwrap();
+    db.lock()
+        .execute("UPDATE links SET id=100 WHERE edge_type='manual'", [])
+        .unwrap();
+    let new_id: i64 = db
+        .lock()
+        .query_row("SELECT id FROM links WHERE edge_type='manual'", [], |row| row.get(0))
+        .unwrap();
+    assert_ne!(old_id, new_id, "the control must really replace the SQL row");
+    let after =
+        dashboard_composite_context(&db, "b-edge", &HashSet::new(), 2_000, &[], None).unwrap();
+    assert_eq!(before.packed_corpus, after.packed_corpus);
+    assert_eq!(before.witness.input_digest, after.witness.input_digest);
+}
+
+#[test]
+fn composite_resolver_rejects_unknown_or_deleted_ids() {
+    let db = file_db("composite-missing");
+    assert!(matches!(
+        dashboard_composite_context(&db, "missing", &HashSet::new(), 200_000, &[], None),
+        Err(AppError::Locked(_))
+    ));
+    db.insert_dashboard("gone", "Gone", None, None, "2026-08-01T09:00:00Z")
+        .unwrap();
+    db.delete_dashboard("gone").unwrap();
+    assert!(matches!(
+        dashboard_composite_context(&db, "gone", &HashSet::new(), 200_000, &[], None),
+        Err(AppError::Locked(_))
+    ));
+}
+
 /// The `Some("")` case at the same seam — the one the first cut collapsed to `None`.
 #[test]
 fn the_production_composition_keeps_scope_for_an_all_withheld_board() {
-    let db = file_db("composition-withheld");
+    let state = brief_state("composition-withheld");
+    let db = &state.db;
     // Readable and entirely unrelated to the board.
-    seed_folder(&db, "f-open", false);
-    seed_meeting_with_commitment(&db, "m-unrelated", "f-open", "UNRELATED VAULT CONTENT");
+    seed_folder(db, "f-open", false);
+    seed_meeting_with_commitment(db, "m-unrelated", "f-open", "UNRELATED VAULT CONTENT");
     // The board: one tile anchored to an entity nobody can see.
     db.insert_dashboard("b-2", "Board", None, None, "2026-08-01T09:00:00Z")
         .unwrap();
@@ -1019,26 +1886,23 @@ fn the_production_composition_keeps_scope_for_an_all_withheld_board() {
     )
     .unwrap();
 
-    let brief = board_scoped_brief(&db, Some("b-2"), &HashSet::new(), 200_000).unwrap();
-    assert_eq!(
-        brief.as_deref(),
-        Some(""),
-        "a board with nothing readable must still be Some — scope is presence, not text"
-    );
-
-    let packed = packed_scoped(&db, &HashSet::new(), brief.as_deref(), None).unwrap_or_default();
+    let cfg = AppConfig::default();
+    let (_, context) =
+        crate::commands::dashboard_composite_floor_inputs(&state, &cfg, Some("b-2"), &[])
+            .unwrap();
+    let packed = context
+        .expect("an existing board must preserve board scope")
+        .packed_corpus;
     assert!(
         !packed.contains("UNRELATED VAULT CONTENT"),
         "an all-withheld board must not answer from the whole vault: {packed}"
     );
 
     // CONTROL — no board id at all, and the SAME fixture reaches the vault-wide corpus.
-    assert_eq!(
-        board_scoped_brief(&db, None, &HashSet::new(), 200_000).unwrap(),
-        None,
-        "no board ⇒ no scope"
-    );
-    let vault_wide = packed_scoped(&db, &HashSet::new(), None, None).unwrap_or_default();
+    let (_, context) =
+        crate::commands::dashboard_composite_floor_inputs(&state, &cfg, None, &[]).unwrap();
+    assert!(context.is_none(), "no board ⇒ no scope");
+    let vault_wide = packed_scoped(db, &HashSet::new(), None, None).unwrap_or_default();
     assert!(
         vault_wide.contains("UNRELATED VAULT CONTENT"),
         "the vault-wide path must still see the vault, or the guard test is vacuous"
@@ -1050,25 +1914,18 @@ fn the_production_composition_keeps_scope_for_an_all_withheld_board() {
 /// byte-identical path.
 #[test]
 fn a_blank_dashboard_id_is_not_a_board() {
-    let db = file_db("composition-blank");
+    let state = brief_state("composition-blank");
+    let cfg = AppConfig::default();
     for id in ["", "   ", "\t\n"] {
-        assert_eq!(
-            board_scoped_brief(&db, Some(id), &HashSet::new(), 200_000).unwrap(),
-            None,
-            "a blank id must not scope the ask: {id:?}"
-        );
+        let (_, context) =
+            crate::commands::dashboard_composite_floor_inputs(&state, &cfg, Some(id), &[])
+                .unwrap();
+        assert!(context.is_none(), "a blank id must not scope the ask: {id:?}");
     }
 }
 
-/// The LEGACY living-answer config — no `answerReadableFolders` stamp at all.
-///
-/// A row written before the stamp existed cannot be checked against anything, so
-/// `resolve_tile` fails CLOSED (`living_answer_withheld` treats an empty recorded set
-/// as unverifiable). That is the correct direction, and it is the one that had no test
-/// at this sink: the existing case only covers a config where the stamp IS present.
-/// An unstamped cached answer is still a paraphrase of whatever the vault held when it
-/// was written, so trusting it would quote possibly-sealed content back into a prompt
-/// forever.
+/// Legacy config is never hydrated by the dedicated-question format. Without the separate
+/// provenance columns and `living_question`, the whole tile fails closed.
 #[test]
 fn an_unstamped_legacy_living_answer_fails_closed() {
     let db = file_db("living-answer-legacy");
@@ -1078,6 +1935,7 @@ fn an_unstamped_legacy_living_answer_fails_closed() {
     // question/answer/answeredAt, and NO `answerReadableFolders` key.
     let legacy = serde_json::json!({
         "question": "will it land?",
+        "questionReadableFolders": ["f-open"],
         "answer": "LEGACY CACHED PARAPHRASE",
         "answeredAt": "2026-08-01T09:00:00Z",
     })
@@ -1094,23 +1952,8 @@ fn an_unstamped_legacy_living_answer_fails_closed() {
     let packed = packed_scoped(&db, &HashSet::new(), Some(&brief), None).unwrap_or_default();
     assert!(!packed.contains("LEGACY CACHED PARAPHRASE"));
 
-    // CONTROL — the SAME answer with a stamp naming a readable folder DOES render, so
-    // the withholding above is the fail-closed rule and not a config that failed to
-    // parse (which would make this test pass for the wrong reason).
-    let stamped = serde_json::json!({
-        "question": "will it land?",
-        "answer": "LEGACY CACHED PARAPHRASE",
-        "answeredAt": "2026-08-01T09:00:00Z",
-        "answerReadableFolders": ["f-open"],
-    })
-    .to_string();
-    let mut t2 = tile("t1", "living_answer", None, 0);
-    t2.config = Some(stamped);
-    let brief = dashboard_brief_inner(&db, vec![t2], &HashSet::new(), MAX_BRIEF_CHARS).unwrap();
-    assert!(
-        brief.contains("LEGACY CACHED PARAPHRASE"),
-        "a stamped, readable answer does render — the control that keeps the negative honest: {brief}"
-    );
+    // Even a legacy config with an answer stamp is never hydrated by the new dedicated-question
+    // format; future answers need their own backend-owned write path.
 }
 
 /// A single row LONGER than the whole allowance.
@@ -1166,12 +2009,9 @@ fn a_cap_smaller_than_the_label_yields_nothing() {
 
 // ── THE GUARDED BLOCK, EXECUTED ───────────────────────────────────────────────
 //
-// Everything above enters at `board_scoped_brief` or below with a caller-supplied
-// `HashSet`, so the ordering `ask_vault` actually performs — acquire the lifecycle
-// guard, THEN take the session snapshot, THEN resolve every tile under it — was
-// established by reading the diff. `board_scoped_floor_inputs` is that block; these
-// drive it with a real `AppState`, which also exercises the fail-closed default (a
-// fresh state unlocks nothing) and the Role::Ask budget derivation inside the guard.
+// Everything above enters below the lifecycle boundary with a caller-supplied `HashSet`.
+// These drive `dashboard_composite_floor_inputs` with a real `AppState`, exercising the
+// lifecycle ordering, fail-closed default, and Role::Ask budget derivation together.
 
 /// An `AppState` over a real temp SQLCipher DB — no Keychain, no Tauri. Same shape
 /// `commands::lifecycle_tests::build_state` uses; duplicated rather than shared
@@ -1217,6 +2057,70 @@ fn brief_state(tag: &str) -> crate::state::AppState {
     }
 }
 
+/// Integration oracle for the current trunk's provider matrix: dashboard composition must derive
+/// its one shared corpus budget from the resolved Ask connection, not from the legacy provider id.
+#[test]
+fn local_dashboard_composite_uses_the_on_device_corpus_budget() {
+    let state = brief_state("local-dashboard-budget");
+    let db = &state.db;
+    seed_folder(db, "f-open", false);
+    seed_meeting_with_commitment(db, "m-derived", "f-open", "ship the local build");
+    db.insert_note(
+        "n-long",
+        "f-open",
+        "long-source",
+        "long source",
+        &format!("LOCAL-DASHBOARD-BUDGET {}", "ż".repeat(12_000)),
+        1_775_553_600,
+    )
+    .unwrap();
+    db.insert_dashboard("b-local", "Local board", None, None, "2026-08-01T09:00:00Z")
+        .unwrap();
+    db.insert_dashboard_tile(
+        "t-material",
+        "b-local",
+        "note",
+        Some("n-long"),
+        None,
+        4,
+        None,
+        "2026-08-01T09:00:00Z",
+    )
+    .unwrap();
+    db.insert_dashboard_tile(
+        "t-derived",
+        "b-local",
+        "promises",
+        None,
+        None,
+        4,
+        None,
+        "2026-08-01T09:00:00Z",
+    )
+    .unwrap();
+
+    let cfg = AppConfig {
+        role_ask_connection: crate::summarize::roles::CONN_LOCAL.to_string(),
+        ..AppConfig::default()
+    };
+    let (_, context) =
+        crate::commands::dashboard_composite_floor_inputs(&state, &cfg, Some("b-local"), &[])
+            .unwrap();
+    let context = context.expect("the existing board must remain a first-class scope");
+
+    assert_eq!(context.witness.corpus_budget, 4_000);
+    assert!(
+        context.packed_corpus.contains(BRIEF_HEADER),
+        "the fixture must exercise the derived-plus-material join"
+    );
+    assert!(context.packed_corpus.contains("LOCAL-DASHBOARD-BUDGET"));
+    let packed_chars = context.packed_corpus.chars().count();
+    assert!(
+        (3_900..=4_000).contains(&packed_chars),
+        "the fixture must saturate, but never exceed, the resolved on-device budget: {packed_chars}"
+    );
+}
+
 /// The block `ask_vault` runs, driven end to end: a sealed row contributes nothing,
 /// and the control proves the same call finds it once the session unlocks the folder.
 #[test]
@@ -1240,8 +2144,9 @@ fn the_guarded_floor_inputs_gate_on_the_session_unlock_set() {
     .unwrap();
     let cfg = AppConfig::default();
 
-    let (unlocked, brief) =
-        crate::commands::board_scoped_floor_inputs(&state, &cfg, Some("b-1")).unwrap();
+    let (unlocked, context) =
+        crate::commands::dashboard_composite_floor_inputs(&state, &cfg, Some("b-1"), &[])
+            .unwrap();
     assert!(
         unlocked.is_empty(),
         "a fresh session unlocks nothing — fail closed"
@@ -1250,7 +2155,9 @@ fn the_guarded_floor_inputs_gate_on_the_session_unlock_set() {
     // with NO ROWS, because every one of them failed the gate. That distinction is the
     // whole point: the model learns a ledger exists and is empty from here, never what
     // is in it.
-    let text = brief.clone().expect("a board id must yield board scope");
+    let text = context
+        .expect("a board id must yield board scope")
+        .packed_corpus;
     assert!(
         !text.contains("the sealed obligation"),
         "a sealed row must not reach the prompt: {text}"
@@ -1268,17 +2175,22 @@ fn the_guarded_floor_inputs_gate_on_the_session_unlock_set() {
         .lock()
         .unwrap()
         .insert("f-sealed".to_string());
-    let (unlocked, brief) =
-        crate::commands::board_scoped_floor_inputs(&state, &cfg, Some("b-1")).unwrap();
+    let (unlocked, context) =
+        crate::commands::dashboard_composite_floor_inputs(&state, &cfg, Some("b-1"), &[])
+            .unwrap();
     assert_eq!(unlocked.len(), 1, "the returned snapshot is the session's");
     assert!(
-        brief.unwrap_or_default().contains("the sealed obligation"),
+        context
+            .map(|value| value.packed_corpus)
+            .unwrap_or_default()
+            .contains("the sealed obligation"),
         "unlocking must restore the row, or the negative above is vacuous"
     );
 
     // No board id ⇒ no scope, from the same production entry point.
-    let (_, brief) = crate::commands::board_scoped_floor_inputs(&state, &cfg, None).unwrap();
-    assert_eq!(brief, None);
+    let (_, context) =
+        crate::commands::dashboard_composite_floor_inputs(&state, &cfg, None, &[]).unwrap();
+    assert!(context.is_none());
 }
 
 /// The production helper must keep the lifecycle mutex for the entire interval from
@@ -1497,27 +2409,6 @@ fn a_visible_entity_carries_no_row_from_a_sealed_meeting() {
         packed_visible.contains("SEALED-FIGURE-42"),
         "the control must reach the provider sink, or the packed negative is vacuous: {packed_visible}"
     );
-}
-
-/// Helpers for the org-equivalence assertion above.
-fn db_ref(db: &crate::storage::Db) -> &crate::storage::Db {
-    db
-}
-
-fn cfg_for_test() -> AppConfig {
-    AppConfig {
-        semantic_search_enabled: false,
-        provider_id: "claude_code".to_string(),
-        cloud_egress_consented: true,
-        ..AppConfig::default()
-    }
-}
-
-fn prompt_text(p: AskFloorPrompt) -> String {
-    match p {
-        AskFloorPrompt::Ready { system, user, .. } => format!("{system}\n{user}"),
-        AskFloorPrompt::Empty(r) => r.answer,
-    }
 }
 
 /// PULSE AT THE MIXED CASE — the aggregate twin of
@@ -1793,7 +2684,7 @@ fn a_visible_person_counts_nothing_from_a_sealed_meeting() {
 
 /// A relock racing the brief build cannot produce a HALF-GATED brief.
 ///
-/// `board_scoped_floor_inputs` takes `lifecycle_guard` BEFORE `unlocked_snapshot` and
+/// `dashboard_composite_floor_inputs` takes `lifecycle_guard` BEFORE `unlocked_snapshot` and
 /// holds it across every `resolve_tile`. Sharing the caller's snapshot alone would not
 /// give this: it prevents a second, later snapshot, but only the guard serializes
 /// against a relock landing between the snapshot and the last tile. The later
@@ -1875,11 +2766,14 @@ fn a_relock_racing_the_brief_build_cannot_half_gate_it() {
         };
 
         let cfg = AppConfig::default();
-        let (_, brief) =
-            crate::commands::board_scoped_floor_inputs(&state, &cfg, Some("b-1")).unwrap();
+        let (_, context) =
+            crate::commands::dashboard_composite_floor_inputs(&state, &cfg, Some("b-1"), &[])
+                .unwrap();
         racer.join().unwrap();
 
-        let brief = brief.unwrap_or_default();
+        let brief = context
+            .map(|value| value.packed_corpus)
+            .unwrap_or_default();
         let has_promise = brief.contains("the raced obligation");
         let has_reminder = brief.contains("THE RACED REMINDER");
         assert_eq!(
@@ -1900,8 +2794,8 @@ fn a_relock_racing_the_brief_build_cannot_half_gate_it() {
 /// The lock-security review filed this as INFO and it was right to: `dashboard_brief_inner`
 /// returns either `String::new()` or a string starting with `BRIEF_HEADER`, so the state is
 /// unreachable in production. It is pinned here anyway because "unreachable" was an accident
-/// of the producer, not a property of this function — and `ask.rs` is in the owned set of the
-/// next phase. The fix collapses whitespace-only to `""` ONCE, so both sites read one value.
+/// of the producer, not a property of the active dashboard packer. The helper collapses
+/// whitespace-only to `""` once, so reservation and prompt assembly read one value.
 ///
 /// The 600-space control makes any reservation for invisible text observable.
 #[test]
@@ -1928,92 +2822,17 @@ fn a_whitespace_only_brief_costs_no_corpus_budget() {
     let with_blank =
         packed_with_provider(&db, &HashSet::new(), Some(&blank), Some(&sources), "ollama")
             .unwrap_or_default();
-    let without = packed_with_provider(&db, &HashSet::new(), None, Some(&sources), "ollama")
+    let with_empty = packed_with_provider(&db, &HashSet::new(), Some(""), Some(&sources), "ollama")
         .unwrap_or_default();
 
     // Without a binding budget the two would match trivially and this would prove nothing.
     assert!(
-        without.chars().count() > 3_000,
+        with_empty.chars().count() > 3_000,
         "the corpus must saturate the 4000-char budget or this test is vacuous: {}",
-        without.chars().count()
+        with_empty.chars().count()
     );
     assert_eq!(
-        with_blank, without,
+        with_blank, with_empty,
         "a whitespace-only brief must neither add text nor take budget"
-    );
-}
-
-/// The canned answer for an EMPTY board-scoped ask must not send the user to fix the
-/// wrong thing — and must still disclose nothing.
-///
-/// A board whose every tile is withheld packs no corpus, so the floor returns
-/// `AskFloorPrompt::Empty`. That branch used to say "No meeting notes to search yet —
-/// record and summarize a meeting first", which is true of an empty VAULT and false of
-/// a board full of locked tiles: it tells someone whose content exists and is sealed to
-/// go record a meeting. This change is what makes that state reachable, so the wrong
-/// message is this change's to fix.
-///
-/// THE SECOND ASSERTION IS THE LOCK-RELEVANT ONE. An all-sealed board and a board with
-/// no tiles at all must produce the SAME words. If the sealed board got a distinguishable
-/// message, the message itself would answer "does this board have content?" for a session
-/// that is not allowed to know — disclosure by phrasing rather than by payload.
-#[test]
-fn a_board_scoped_empty_ask_does_not_tell_the_user_to_record() {
-    fn empty_answer(db: &crate::storage::Db, brief: Option<&str>) -> String {
-        let cfg = AppConfig {
-            semantic_search_enabled: false,
-            provider_id: "ollama".to_string(),
-            cloud_egress_consented: true,
-            ..AppConfig::default()
-        };
-        match build_ask_vault_floor_prompt(
-            db,
-            &cfg,
-            &HashSet::new(),
-            "who owes me something on this board?",
-            &[],
-            "",
-            None,
-            None,
-            None,
-            brief,
-        )
-        .unwrap()
-        {
-            AskFloorPrompt::Empty(result) => result.answer,
-            AskFloorPrompt::Ready { .. } => panic!("fixture must pack nothing"),
-        }
-    }
-
-    // A board whose every tile is withheld: scoped (`Some`), but with nothing to say.
-    let sealed_db = file_db("empty-ask-sealed");
-    seed_folder(&sealed_db, "f-sealed", true);
-    seed_meeting_with_commitment(&sealed_db, "m-sealed", "f-sealed", "a sealed obligation");
-    let sealed = empty_answer(&sealed_db, Some(""));
-
-    assert!(
-        !sealed.contains("record and summarize"),
-        "a board-scoped ask must not tell the user to record a meeting: {sealed}"
-    );
-    assert!(
-        sealed.contains("board"),
-        "the board-scoped answer must name the board, not the vault: {sealed}"
-    );
-
-    // NON-DISCLOSURE: a board with no tiles at all must read identically.
-    let bare_db = file_db("empty-ask-bare");
-    let bare = empty_answer(&bare_db, Some(""));
-    assert_eq!(
-        sealed, bare,
-        "an all-sealed board and an empty board must be indistinguishable from their \
-         answer — otherwise the phrasing itself discloses that content exists"
-    );
-
-    // CONTROL — without a board, the vault-wide wording is still the right one, so the
-    // assertion above is about board scope and not about the string having been deleted.
-    let no_board = empty_answer(&bare_db, None);
-    assert!(
-        no_board.contains("record and summarize"),
-        "an unscoped empty ask must keep the vault-wide guidance: {no_board}"
     );
 }

--- a/src-tauri/src/commands/tests/dashboard_cmd_tests.rs
+++ b/src-tauri/src/commands/tests/dashboard_cmd_tests.rs
@@ -11,12 +11,21 @@ use super::*;
 #[test]
 fn titles_are_trimmed_bounded_and_non_empty() {
     assert_eq!(clean_title("  Atlas GA  ", "title").unwrap(), "Atlas GA");
-    assert!(clean_title("   ", "title").is_err(), "whitespace-only is empty");
+    assert!(
+        clean_title("   ", "title").is_err(),
+        "whitespace-only is empty"
+    );
     assert!(clean_title("", "title").is_err());
     let long = "x".repeat(MAX_TITLE_LEN + 1);
-    assert!(clean_title(&long, "title").is_err(), "over-long titles are refused");
+    assert!(
+        clean_title(&long, "title").is_err(),
+        "over-long titles are refused"
+    );
     let ok = "x".repeat(MAX_TITLE_LEN);
-    assert!(clean_title(&ok, "title").is_ok(), "exactly at the cap is allowed");
+    assert!(
+        clean_title(&ok, "title").is_ok(),
+        "exactly at the cap is allowed"
+    );
     // Multi-byte titles are counted in CHARACTERS, not bytes.
     let pl = "ż".repeat(MAX_TITLE_LEN);
     assert!(clean_title(&pl, "title").is_ok());
@@ -62,7 +71,10 @@ fn tile_config_round_trips_and_tolerates_absent_fields() {
     };
     let json = serde_json::to_string(&cfg).unwrap();
     let back = parse_config(Some(&json));
-    assert_eq!(back.question.as_deref(), Some("Are we going to make Jun 14?"));
+    assert_eq!(
+        back.question.as_deref(),
+        Some("Are we going to make Jun 14?")
+    );
     assert_eq!(back.owner, None);
 
     // An empty object, a legacy row, and outright garbage all degrade to defaults rather than
@@ -136,7 +148,10 @@ fn locked_tile_sheds_its_user_authored_chrome() {
     };
 
     let redacted = redact_tile_chrome(tile.clone(), &TileData::Locked);
-    assert_eq!(redacted.title, None, "a sealed tile must not ship its title");
+    assert_eq!(
+        redacted.title, None,
+        "a sealed tile must not ship its title"
+    );
     assert_eq!(redacted.config, None, "nor the cached answer in its config");
     assert_eq!(redacted.span, 5, "layout is the user's own, and stays");
     assert_eq!(redacted.position, 2);
@@ -199,7 +214,10 @@ fn entity_tiles_shed_chrome_when_the_entity_is_not_visible() {
     );
 
     // Person degrades to Missing — same treatment.
-    assert_eq!(redact_tile_chrome(tile.clone(), &TileData::Missing).title, None);
+    assert_eq!(
+        redact_tile_chrome(tile.clone(), &TileData::Missing).title,
+        None
+    );
 
     // CONTROL: a VISIBLE entity keeps the tile's chrome.
     let visible = redact_tile_chrome(
@@ -231,24 +249,34 @@ fn withheld_living_answer_sheds_its_config() {
     let out = redact_tile_chrome(
         tile,
         &TileData::LivingAnswer {
-            question: "Will they renew?".into(),
+            question: String::new(),
             answer: None,
             answered_at: None,
             withheld: true,
         },
     );
-    assert_eq!(out.config, None, "the cached answer must not ride along in config");
+    assert_eq!(
+        out.config, None,
+        "the cached answer must not ride along in config"
+    );
     let json = serde_json::to_string(&ResolvedTileDto {
         tile: out,
         data: TileData::LivingAnswer {
-            question: "Will they renew?".into(),
+            question: String::new(),
             answer: None,
             answered_at: None,
             withheld: true,
         },
     })
     .unwrap();
-    assert!(!json.contains("churning"), "answer text on the wire: {json}");
+    assert!(
+        !json.contains("churning"),
+        "answer text on the wire: {json}"
+    );
+    assert!(
+        !json.contains("renew"),
+        "question/title text on the wire: {json}"
+    );
 }
 
 /// THE ORACLE the previous gate never had. An independent verifier proved that switching the old
@@ -259,47 +287,20 @@ fn withheld_living_answer_sheds_its_config() {
 /// path expands into linked NEIGHBOURS (`vault_context.rs`, `LINK_CONTEXT_CAP`) that no caller
 /// records — so only a bound on what was readable at the time can cover what the answer saw.
 #[test]
-fn living_answer_gate_withholds_when_a_folder_stopped_being_readable() {
-    let readable = |ids: &[&str]| -> std::collections::HashSet<String> {
-        ids.iter().map(|s| (*s).to_string()).collect()
-    };
-    let recorded = vec!["f-open".to_string(), "f-secret".to_string()];
-
-    // Everything still readable ⇒ the answer shows.
-    assert!(!living_answer_withheld(
-        true,
-        &recorded,
-        &readable(&["f-open", "f-secret", "f-new"]),
-    ));
-
-    // `f-secret` got sealed ⇒ WITHHELD, even though it was never a tile source: the answer could
-    // have paraphrased it via link expansion.
-    assert!(living_answer_withheld(
-        true,
-        &recorded,
-        &readable(&["f-open"]),
-    ));
-
-    // A folder that vanished entirely is also "not readable" ⇒ withheld.
-    assert!(living_answer_withheld(true, &recorded, &readable(&[])));
-
-    // FAIL-CLOSED: a legacy row with no recorded snapshot cannot be checked ⇒ withheld.
-    assert!(living_answer_withheld(true, &[], &readable(&["f-open"])));
-
-    // No answer at all is not "withheld" — the tile just has nothing yet.
-    assert!(!living_answer_withheld(false, &[], &readable(&[])));
-}
-
-#[test]
 fn living_answer_config_round_trips_its_readable_snapshot() {
     let cfg = TileConfig {
         question: Some("Will we make Jun 14?".into()),
+        question_readable_folders: Some(vec!["f-open".into()]),
         answer: Some("Probably not.".into()),
         answer_readable_folders: Some(vec!["f-open".into()]),
         ..Default::default()
     };
     let back = parse_config(Some(&serde_json::to_string(&cfg).unwrap()));
     assert_eq!(back.answer_readable_folders.as_ref().map(Vec::len), Some(1));
+    assert_eq!(
+        back.question_readable_folders.as_ref().map(Vec::len),
+        Some(1)
+    );
     // A legacy row (an answer, no recorded sources) parses — and the resolver treats that as
     // un-gateable, i.e. withheld. See `resolve_tile`'s living_answer arm.
     let legacy = parse_config(Some(r#"{"question":"q","answer":"a"}"#));
@@ -307,13 +308,27 @@ fn living_answer_config_round_trips_its_readable_snapshot() {
     assert!(legacy.answer.is_some());
 }
 
+#[test]
+fn living_answer_question_provenance_is_backend_owned_and_legacy_fails_closed() {
+    let readable: std::collections::HashSet<String> = ["f-real".to_string()].into_iter().collect();
+    let forged = r#"{"question":"source-derived question","questionReadableFolders":[],"answer":"forged answer","answerReadableFolders":[]}"#;
+    let encoded = sanitize_living_answer_config_for_add(Some(forged), &readable).unwrap();
+    let sanitized = parse_config(Some(&encoded));
+    assert_eq!(
+        sanitized.question_readable_folders,
+        Some(vec!["f-real".to_string()])
+    );
+    assert!(sanitized.answer.is_none());
+    assert!(sanitized.answer_readable_folders.is_none());
+}
+
 /// THE AGENT-SURFACE LEAK ORACLE. `render_tile_for_agent` feeds BOTH the local MCP server and the
 /// in-app agentic Ask loop, so a withheld tile that printed its stored title there would leak to a
 /// surface the screen-side redaction never sees. Every withheld state must print its state ONLY.
 #[test]
 fn agent_rendering_of_a_withheld_tile_prints_no_stored_chrome() {
-    let tile = |kind: &str, title: &str, config: Option<&str>| {
-        crate::storage::models::DashboardTile {
+    let tile =
+        |kind: &str, title: &str, config: Option<&str>| crate::storage::models::DashboardTile {
             id: "t1".into(),
             dashboard_id: "b1".into(),
             kind: kind.into(),
@@ -323,8 +338,7 @@ fn agent_rendering_of_a_withheld_tile_prints_no_stored_chrome() {
             position: 0,
             config: config.map(str::to_string),
             created_at: "2026-08-03T10:00:00Z".into(),
-        }
-    };
+        };
 
     for data in [TileData::Locked, TileData::Missing, TileData::Unconfigured] {
         let out = render_tile_for_agent(&tile("note", "Acme — termination terms", None), &data);
@@ -334,7 +348,7 @@ fn agent_rendering_of_a_withheld_tile_prints_no_stored_chrome() {
         );
     }
 
-    // A withheld living answer prints the question but never the cached text.
+    // A withheld living answer prints neither the source-derived question nor cached text.
     let out = render_tile_for_agent(
         &tile(
             "living_answer",
@@ -342,14 +356,26 @@ fn agent_rendering_of_a_withheld_tile_prints_no_stored_chrome() {
             Some(r#"{"answer":"No — they are churning"}"#),
         ),
         &TileData::LivingAnswer {
-            question: "Will they renew?".into(),
+            question: String::new(),
             answer: None,
             answered_at: None,
             withheld: true,
         },
     );
     assert!(out.contains("withheld"), "the agent is told WHY: {out}");
+    assert!(!out.contains("renew"), "cached question leaked: {out}");
     assert!(!out.contains("churning"), "cached answer leaked: {out}");
+
+    let visible = render_tile_for_agent(
+        &tile("living_answer", "Will they renew?", None),
+        &TileData::LivingAnswer {
+            question: "Will they renew?".into(),
+            answer: Some("They renewed".into()),
+            answered_at: None,
+            withheld: false,
+        },
+    );
+    assert!(visible.contains("Will they renew?") && visible.contains("They renewed"));
 
     // CONTROL: a visible tile does render its content, so the assertions above are not vacuous.
     let out = render_tile_for_agent(
@@ -547,9 +573,18 @@ fn a_meeting_tile_ships_started_at_as_camel_case() {
         has_audio: true,
     })
     .unwrap();
-    assert!(json.get("startedAt").is_some(), "the FE reads `startedAt`: {json}");
-    assert!(json.get("durationS").is_some(), "the FE reads `durationS`: {json}");
-    assert!(json.get("hasAudio").is_some(), "the FE reads `hasAudio`: {json}");
+    assert!(
+        json.get("startedAt").is_some(),
+        "the FE reads `startedAt`: {json}"
+    );
+    assert!(
+        json.get("durationS").is_some(),
+        "the FE reads `durationS`: {json}"
+    );
+    assert!(
+        json.get("hasAudio").is_some(),
+        "the FE reads `hasAudio`: {json}"
+    );
 }
 
 /// A note tile's timestamp, same class, different variant.
@@ -566,5 +601,8 @@ fn a_note_tile_ships_updated_at_as_camel_case() {
         updated_at: 1_760_000_000_000,
     })
     .unwrap();
-    assert!(json.get("updatedAt").is_some(), "the FE reads `updatedAt`: {json}");
+    assert!(
+        json.get("updatedAt").is_some(),
+        "the FE reads `updatedAt`: {json}"
+    );
 }

--- a/src-tauri/src/commands/tests/dashboard_source_scope_tests.rs
+++ b/src-tauri/src/commands/tests/dashboard_source_scope_tests.rs
@@ -119,7 +119,51 @@ fn a_sealed_source_never_enters_the_ask_scope() {
     // assertion above is testing the gate and not merely a seeding mistake.
     let unlocked: HashSet<String> = ["f-sealed".to_string()].into_iter().collect();
     let out = dashboard_sources_inner(&db, tiles, &unlocked).unwrap();
-    assert_eq!(out.len(), 2, "session-unlocking the folder restores the source");
+    assert_eq!(
+        out.len(),
+        2,
+        "session-unlocking the folder restores the source"
+    );
+}
+
+#[test]
+fn sealed_source_scope_and_resolution_never_hydrate_tile_payload() {
+    let db = file_db("sealed-poisoned-tile");
+    seed_folder(&db, "f-sealed", true);
+    seed_meeting(&db, "m-sealed", "f-sealed");
+    db.insert_dashboard("b1", "Board", None, None, "2026-08-01T09:00:00Z")
+        .unwrap();
+    db.insert_dashboard_tile(
+        "t-poison",
+        "b1",
+        "meeting",
+        Some("m-sealed"),
+        Some("residual"),
+        4,
+        Some("{}"),
+        "2026-08-01T09:00:00Z",
+    )
+    .unwrap();
+    db.lock()
+        .execute(
+            "UPDATE dashboard_tiles SET title=x'00',config=x'01' WHERE id='t-poison'",
+            [],
+        )
+        .unwrap();
+
+    let tiles = db.list_dashboard_tile_structures("b1").unwrap();
+    assert!(dashboard_sources_inner(&db, tiles.clone(), &HashSet::new())
+        .unwrap()
+        .is_empty());
+    assert!(matches!(
+        resolve_tile(&db, &tiles[0], &HashSet::new()).unwrap(),
+        TileData::Locked
+    ));
+    let unlocked: HashSet<String> = ["f-sealed".to_string()].into_iter().collect();
+    assert!(matches!(
+        resolve_tile(&db, &tiles[0], &unlocked).unwrap(),
+        TileData::Meeting { .. }
+    ));
 }
 
 /// A DERIVED tile is a view over the vault, not a retrievable document, so it
@@ -192,34 +236,12 @@ fn a_deleted_source_is_dropped_rather_than_erroring() {
     );
 }
 
-/// FINDING, recorded rather than silently encoded as intent (2026-08-04).
-///
-/// A `meeting` ref that resolves to NOTHING still enters the scope, because
-/// `meetings_store::Db::meeting_is_visible` ends in `Ok(!has_notes || has_visible)`
-/// — a meeting with no note row is visible BY CONSTRUCTION, and a meeting that
-/// does not exist trivially has no note row.
-///
-/// For a deleted meeting this is only wasteful: `fair_pack_explicit_sections`
-/// divides the prompt budget by the number of sources, so a stale tile silently
-/// shrinks every other source's share while contributing nothing.
-///
-/// The case worth a specialist's eye is the OTHER one this predicate admits: a
-/// meeting that exists, sits in a SEALED folder, and has no note row yet — the
-/// shape `lock-model.md` already calls out for audio ("recorded into an
-/// already-sealed folder, or a crash window"). This test does not assert that is
-/// safe; it pins the CURRENT behaviour so the change is visible if someone
-/// tightens the predicate, and flags it for `lock-security-reviewer`. Do not
-/// "fix" it inside a frontend density pass — `storage/**` is a lock-risk path.
 #[test]
-fn a_dangling_meeting_ref_currently_survives_the_gate() {
+fn a_dangling_meeting_ref_is_dropped() {
     let db = file_db("dangling-meeting");
     let tiles = vec![tile("t1", "meeting", Some("m-never-existed"), 0)];
     let out = dashboard_sources_inner(&db, tiles, &nothing_unlocked()).unwrap();
-    assert_eq!(
-        out.len(),
-        1,
-        "documents the fail-OPEN branch of meeting_is_visible; see the doc comment"
-    );
+    assert!(out.is_empty(), "a missing meeting is not readable material");
 }
 
 /// Two tiles pointing at the same source contribute ONE entry.
@@ -261,4 +283,200 @@ fn duplicate_tiles_dedupe_by_kind_and_id() {
         2,
         "a note and a meeting sharing an id are distinct sources"
     );
+}
+
+/// Cross-seam oracle for the canonical no-note ownership rule. This enters through the same
+/// resolver used by the dashboard DTO, the exact inner resolver serialized by
+/// `get_dashboard_sources`, the production composite provider packer, and the actual
+/// `tools::execute_tool(GetDashboard)` content-rendering leg invoked by MCP after JSON argument
+/// parsing. Only the IPC wrapper needs a runtime `State`; it adds lifecycle admission and
+/// serialization around `dashboard_sources_inner`, which owns the source reads exercised here.
+#[test]
+fn no_note_root_dashboard_stays_visible_without_fabricating_provider_content() {
+    const TITLE_SENTINEL: &str = "ROOT-LIVE-TITLE-SENTINEL";
+    const BODY_SENTINEL: &str = "FINALIZED-BODY-SENTINEL";
+    const CHROME_SENTINEL: &str = "LEGACY-CHROME-SENTINEL";
+    const AUDIO_PATH_SENTINEL: &str = "/tmp/ROOT-LIVE-AUDIO-PATH-SENTINEL.wav";
+
+    let db = file_db("no-note-cross-seam");
+    db.insert_meeting(&Meeting {
+        id: "m-live-root".to_string(),
+        started_at: "2026-08-13T10:00:00Z".to_string(),
+        ended_at: None,
+        title: Some(TITLE_SENTINEL.to_string()),
+        duration_s: 17,
+        audio_path: Some(AUDIO_PATH_SENTINEL.to_string()),
+        status: MeetingStatus::Recording,
+        folder_id: None,
+    })
+    .unwrap();
+    db.insert_dashboard("b1", "Board", None, None, "2026-08-13T10:00:00Z")
+        .unwrap();
+    db.insert_dashboard_tile(
+        "t-live-root",
+        "b1",
+        "meeting",
+        Some("m-live-root"),
+        Some(CHROME_SENTINEL),
+        4,
+        None,
+        "2026-08-13T10:00:00Z",
+    )
+    .unwrap();
+
+    let tiles = db.list_dashboard_tile_structures("b1").unwrap();
+    let nothing = HashSet::new();
+    let root_data = resolve_tile(&db, &tiles[0], &nothing).unwrap();
+    match &root_data {
+        TileData::Meeting {
+            title, has_audio, ..
+        } => {
+            assert_eq!(title.as_str(), TITLE_SENTINEL);
+            assert!(*has_audio);
+        }
+        other => panic!("a live no-note root meeting must produce its dashboard DTO: {other:?}"),
+    }
+
+    // The source-picker response may retain the typed pointer, but it has no title/body field and
+    // therefore cannot claim that a note exists. The actual provider sources remain empty.
+    let root_refs = dashboard_sources_inner(&db, tiles.clone(), &nothing).unwrap();
+    assert_eq!(root_refs.len(), 1);
+    let root_refs_json = serde_json::to_string(&root_refs).unwrap();
+    assert_eq!(root_refs_json, r#"[{"kind":"meeting","id":"m-live-root"}]"#);
+    assert!(!root_refs_json.contains(TITLE_SENTINEL));
+    assert!(!root_refs_json.contains(BODY_SENTINEL));
+    assert!(!root_refs_json.contains(CHROME_SENTINEL));
+    assert!(!root_refs_json.contains(AUDIO_PATH_SENTINEL));
+
+    let root_context =
+        dashboard_composite_context(&db, "b1", &nothing, 200_000, &[], None).unwrap();
+    assert!(root_context.packed_corpus.is_empty());
+    assert!(root_context.packed_sources.is_empty());
+    assert!(!root_context.packed_corpus.contains(TITLE_SENTINEL));
+    assert!(!root_context.packed_corpus.contains(AUDIO_PATH_SENTINEL));
+    let config = crate::settings::AppConfig::default();
+    let root_agent_render = crate::tools::execute_tool(
+        &crate::tools::ToolCall::GetDashboard {
+            dashboard_id: "b1".to_string(),
+        },
+        &db,
+        &nothing,
+        &config,
+    )
+    .unwrap();
+    assert!(root_agent_render.contains(TITLE_SENTINEL));
+    assert!(!root_agent_render.contains(AUDIO_PATH_SENTINEL));
+
+    // Finalization creates the sole canonical ownership edge (`notes.folder_id`). Seal the note
+    // with the production crypto primitive, verify it before blanking, and retain the wrapped key
+    // just as the command lifecycle does.
+    seed_folder(&db, "f-sealed-live", false);
+    db.upsert_note(&NoteRecord {
+        meeting_id: "m-live-root".to_string(),
+        provider_id: "test".to_string(),
+        markdown: BODY_SENTINEL.to_string(),
+        created_at: "2026-08-13T10:01:00Z".to_string(),
+        exported_path: None,
+        model_requested: None,
+        model_served: None,
+        gateway_host: None,
+    })
+    .unwrap();
+    db.set_meeting_folder("m-live-root", Some("f-sealed-live"))
+        .unwrap();
+    db.update_meeting_status("m-live-root", MeetingStatus::Summarized)
+        .unwrap();
+
+    let kek = crate::crypto::random_key().unwrap();
+    let content_key = crate::crypto::random_key().unwrap();
+    let wrapped_key = crate::crypto::encrypt(&kek, &content_key, b"").unwrap();
+    let content_blob = crate::crypto::encrypt(&content_key, BODY_SENTINEL.as_bytes(), b"").unwrap();
+    assert_eq!(
+        crate::crypto::decrypt(&content_key, &content_blob, b"").unwrap(),
+        BODY_SENTINEL.as_bytes(),
+        "the oracle must verify the blob before destroying plaintext"
+    );
+    db.set_folder_locked("f-sealed-live", true, Some(&wrapped_key))
+        .unwrap();
+    db.seal_note("m-live-root", "test", &content_blob).unwrap();
+    let sealed_notes = db.notes_in_folder("f-sealed-live").unwrap();
+    assert_eq!(sealed_notes[0].markdown, "");
+    assert!(sealed_notes[0].content_blob.is_some());
+
+    let locked_data = resolve_tile(&db, &tiles[0], &nothing).unwrap();
+    assert!(matches!(&locked_data, TileData::Locked));
+    let agent_render = crate::tools::execute_tool(
+        &crate::tools::ToolCall::GetDashboard {
+            dashboard_id: "b1".to_string(),
+        },
+        &db,
+        &nothing,
+        &config,
+    )
+    .unwrap();
+    assert!(agent_render.contains("sealed tile — redacted"));
+    for sentinel in [
+        TITLE_SENTINEL,
+        BODY_SENTINEL,
+        CHROME_SENTINEL,
+        AUDIO_PATH_SENTINEL,
+    ] {
+        assert!(
+            !agent_render.contains(sentinel),
+            "the shared MCP/agent render leaked {sentinel}: {agent_render}"
+        );
+    }
+    assert!(dashboard_sources_inner(&db, tiles.clone(), &nothing)
+        .unwrap()
+        .is_empty());
+    let locked_context =
+        dashboard_composite_context(&db, "b1", &nothing, 200_000, &[], None).unwrap();
+    assert!(locked_context.packed_corpus.is_empty());
+    assert!(locked_context.packed_sources.is_empty());
+    assert!(!locked_context.packed_corpus.contains(AUDIO_PATH_SENTINEL));
+
+    // Session unlock restores the plaintext after authenticating the retained blob, while the
+    // folder remains sealed. The same production seams must all become readable again.
+    let persisted_wrapped_key = db
+        .folder_wrapped_key("f-sealed-live")
+        .unwrap()
+        .expect("a real seal retains the wrapped content key");
+    let unwrapped = crate::crypto::decrypt(&kek, &persisted_wrapped_key, b"").unwrap();
+    let unwrapped_content_key: [u8; 32] = unwrapped.as_slice().try_into().unwrap();
+    let restored = crate::crypto::decrypt(&unwrapped_content_key, &content_blob, b"").unwrap();
+    db.restore_note_markdown(
+        "m-live-root",
+        "test",
+        std::str::from_utf8(&restored).unwrap(),
+    )
+    .unwrap();
+    let unlocked = HashSet::from(["f-sealed-live".to_string()]);
+    let unlocked_data = resolve_tile(&db, &tiles[0], &unlocked).unwrap();
+    match &unlocked_data {
+        TileData::Meeting { has_audio, .. } => assert!(*has_audio),
+        other => panic!("session unlock must restore the meeting DTO: {other:?}"),
+    }
+    assert_eq!(
+        dashboard_sources_inner(&db, tiles.clone(), &unlocked)
+            .unwrap()
+            .len(),
+        1
+    );
+    let unlocked_context =
+        dashboard_composite_context(&db, "b1", &unlocked, 200_000, &[], None).unwrap();
+    assert!(unlocked_context.packed_corpus.contains(TITLE_SENTINEL));
+    assert!(unlocked_context.packed_corpus.contains(BODY_SENTINEL));
+    assert!(!unlocked_context.packed_corpus.contains(AUDIO_PATH_SENTINEL));
+    assert_eq!(unlocked_context.packed_sources.len(), 1);
+    let unlocked_render = crate::tools::execute_tool(
+        &crate::tools::ToolCall::GetDashboard {
+            dashboard_id: "b1".to_string(),
+        },
+        &db,
+        &unlocked,
+        &config,
+    )
+    .unwrap();
+    assert!(unlocked_render.contains(TITLE_SENTINEL));
+    assert!(!unlocked_render.contains(AUDIO_PATH_SENTINEL));
 }

--- a/src-tauri/src/commands/tests/gateway_key_tests.rs
+++ b/src-tauri/src/commands/tests/gateway_key_tests.rs
@@ -3,7 +3,7 @@ use super::*;
 /// `set_gateway_key("")` must return `InvalidArg`, not silently succeed.
 #[test]
 fn set_gateway_key_empty_is_invalid_arg() {
-    let err = set_gateway_key(String::new()).unwrap_err();
+    let err = validate_gateway_key("").unwrap_err();
     assert!(
         matches!(err, AppError::InvalidArg(_)),
         "empty gateway key must be InvalidArg, got: {err:?}"
@@ -13,7 +13,7 @@ fn set_gateway_key_empty_is_invalid_arg() {
 /// `set_gateway_key("   ")` (whitespace-only) is also invalid.
 #[test]
 fn set_gateway_key_whitespace_is_invalid_arg() {
-    let err = set_gateway_key("   ".to_string()).unwrap_err();
+    let err = validate_gateway_key("   ").unwrap_err();
     assert!(
         matches!(err, AppError::InvalidArg(_)),
         "whitespace-only gateway key must be InvalidArg"

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -66,6 +66,43 @@
         }
     }
 
+    fn switch_ask_to_local_under_lifecycle(state: &AppState) {
+        let mut dto = {
+            let config = state.config.lock().unwrap();
+            config_to_dto(&config)
+        };
+        dto.role_ask_connection = crate::summarize::roles::CONN_LOCAL.to_string();
+        save_config_inner(state, dto).unwrap();
+    }
+
+    struct BudgetMutationProvider {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::summarize::provider::SummarizerProvider for BudgetMutationProvider {
+        fn id(&self) -> &str {
+            "budget-mutation-spy"
+        }
+
+        async fn availability(&self) -> crate::summarize::provider::Availability {
+            crate::summarize::provider::Availability::Available
+        }
+
+        async fn summarize(
+            &self,
+            _request: &crate::summarize::provider::SummarizeRequest,
+        ) -> crate::error::Result<String> {
+            Ok(String::new())
+        }
+
+        async fn complete(&self, _system: &str, _user: &str) -> crate::error::Result<String> {
+            self.calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok("stale answer".into())
+        }
+    }
+
     fn block_on<F: std::future::Future>(f: F) -> F::Output {
         tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -151,8 +188,8 @@
             detail: "PROJ-1 not found in Jira".into(),
             url: String::new(),
         };
-        let e2 =
-            apply_note_verify_markers_inner(&state, "m-vlock".to_string(), vec![finding]).unwrap_err();
+        let e2 = apply_note_verify_markers_inner(&state, "m-vlock".to_string(), vec![finding])
+            .unwrap_err();
         assert!(
             matches!(e2, AppError::Locked(_)),
             "apply must fail Locked, got: {e2:?}"
@@ -346,7 +383,8 @@
             url: "https://x/browse/PROJ-1".into(),
         };
         let once =
-            apply_note_verify_markers_inner(&state, "m-cb".to_string(), vec![finding.clone()]).unwrap();
+            apply_note_verify_markers_inner(&state, "m-cb".to_string(), vec![finding.clone()])
+                .unwrap();
         assert!(
             once.markdown.contains("> ⧗ note says"),
             "inline marker present"
@@ -366,7 +404,8 @@
         assert_eq!(db_md, once.markdown);
 
         // Re-apply: neither region stacks (one inline marker, one fenced callout).
-        let twice = apply_note_verify_markers_inner(&state, "m-cb".to_string(), vec![finding]).unwrap();
+        let twice =
+            apply_note_verify_markers_inner(&state, "m-cb".to_string(), vec![finding]).unwrap();
         assert_eq!(
             twice.markdown.matches("(via Jira)").count(),
             2,
@@ -376,7 +415,8 @@
         assert_eq!(twice.markdown.matches("<!-- murmur:verify -->").count(), 1);
 
         // Empty findings: markers + callout stripped, the ORIGINAL note restored byte-exact.
-        let undone = apply_note_verify_markers_inner(&state, "m-cb".to_string(), Vec::new()).unwrap();
+        let undone =
+            apply_note_verify_markers_inner(&state, "m-cb".to_string(), Vec::new()).unwrap();
         assert_eq!(
             undone.markdown, original,
             "byte-exact undo through the command"
@@ -781,6 +821,60 @@
         let to_dst: Vec<_> = edges.iter().filter(|e| e.other_id == "dst").collect();
         assert_eq!(to_dst.len(), 1, "exactly one chip for the pair");
         assert!(to_dst[0].manual, "the chip is flagged removable-manual");
+    }
+
+    /// Exact dashboard history expands visible linked neighbours. The derived-wikilink replacement
+    /// must therefore share the lifecycle interval used by dashboard-history authorization and
+    /// hydration: it cannot replace the live edge set while that exact witness is being consumed.
+    #[test]
+    fn derived_wikilink_replacement_waits_for_history_lifecycle_interval() {
+        let state = Arc::new(build_state("wikilink-history-lifecycle"));
+        make_open_folder(&state.db, "f-open", "Project");
+        seed_note_doc_cmd(
+            &state.db,
+            "src",
+            "f-open",
+            "Source Note",
+            "See [[Target Note]].",
+        );
+        seed_note_doc_cmd(&state.db, "dst", "f-open", "Target Note", "target body");
+
+        let lifecycle = lifecycle_guard(state.as_ref());
+        let worker_state = Arc::clone(&state);
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (done_tx, done_rx) = std::sync::mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            index_wikilinks_best_effort(
+                worker_state.as_ref(),
+                crate::links::LinkKind::Note,
+                "src",
+                "See [[Target Note]].",
+            );
+            done_tx.send(()).unwrap();
+        });
+
+        started_rx.recv().unwrap();
+        assert!(
+            done_rx
+                .recv_timeout(std::time::Duration::from_millis(100))
+                .is_err(),
+            "derived link replacement must wait for an active history lifecycle interval"
+        );
+        assert_eq!(
+            link_count_in(&state, "note", "src", "wikilink"),
+            0,
+            "no linked-neighbour membership may change before history hydration releases the interval"
+        );
+
+        drop(lifecycle);
+        done_rx.recv().unwrap();
+        worker.join().unwrap();
+        assert_eq!(
+            link_count_in(&state, "note", "src", "wikilink"),
+            1,
+            "the replacement lands after the history lifecycle interval"
+        );
     }
 
     /// Helper mirroring db.rs `link_count` for the command-test module.
@@ -1314,14 +1408,18 @@
 
         // No matching candidate → None (the caller surfaces the primary error).
         assert!(
-            try_unwrap_ck_with_candidates(&[[7u8; 32]], &wrapped, "f-rec", Some(&kek_new)).is_none()
+            try_unwrap_ck_with_candidates(&[[7u8; 32]], &wrapped, "f-rec", Some(&kek_new))
+                .is_none()
         );
         // AAD binding holds: the right KEK under the WRONG folder id must not unwrap.
         assert!(
-            try_unwrap_ck_with_candidates(&candidates, &wrapped, "f-other", Some(&kek_new)).is_none()
+            try_unwrap_ck_with_candidates(&candidates, &wrapped, "f-other", Some(&kek_new))
+                .is_none()
         );
         // The already-tried primary is skipped even if listed as a candidate.
-        assert!(try_unwrap_ck_with_candidates(&[kek_new], &wrapped, "f-rec", Some(&kek_new)).is_none());
+        assert!(
+            try_unwrap_ck_with_candidates(&[kek_new], &wrapped, "f-rec", Some(&kek_new)).is_none()
+        );
         // With NO already-tried key (the primary release itself failed), all candidates are tried.
         let (_, winner2, _) = try_unwrap_ck_with_candidates(&candidates, &wrapped, "f-rec", None)
             .expect("recovery with no primary must still find the sealing KEK");
@@ -1540,7 +1638,8 @@
     fn refresh_failure_fallback_policy() {
         let auth = refresh_failure_fallback(AppError::Auth("refused".into()), "cached".into());
         assert!(matches!(auth, Err(AppError::Auth(_))));
-        let net = refresh_failure_fallback(AppError::Unavailable("offline".into()), "cached".into());
+        let net =
+            refresh_failure_fallback(AppError::Unavailable("offline".into()), "cached".into());
         assert_eq!(net.unwrap(), "cached");
         let storage = refresh_failure_fallback(AppError::Storage("disk".into()), "cached".into());
         assert_eq!(storage.unwrap(), "cached");
@@ -1756,8 +1855,12 @@
             .set_folder_locked(&target.id, true, Some(&b"wrapped"[..]))
             .unwrap();
 
-        let again =
-            block_on(accept_share_inner(&state, "share-locked-idem".to_string(), None)).unwrap();
+        let again = block_on(accept_share_inner(
+            &state,
+            "share-locked-idem".to_string(),
+            None,
+        ))
+        .unwrap();
         assert_eq!(again.meeting_id, first.meeting_id);
         assert_eq!(again.title, "🔒 Locked");
     }
@@ -1802,7 +1905,8 @@
         );
 
         // (c) Replay to the WRONG recipient (grant addressed to `recipient`, opened by `attacker`).
-        let attacker = derive_identity(&generate_master_key().unwrap(), "attacker@acct", 1).unwrap();
+        let attacker =
+            derive_identity(&generate_master_key().unwrap(), "attacker@acct", 1).unwrap();
         let (up, content, sender_fp) = craft_valid_grant(&sender, &recipient, &env, "s-c", 1);
         let e = accept_ingest_verified(
             &state, &target, &attacker, &sender_fp, "s", &up, &content, "s-c", 1, 1,
@@ -3893,8 +3997,8 @@
         ));
 
         // STUB (default install): 0 imported, NO synthetic meeting left behind.
-        let n =
-            import_memories_inner(&state.db, &crate::reason::StubReasoner, true, "I like tea").unwrap();
+        let n = import_memories_inner(&state.db, &crate::reason::StubReasoner, true, "I like tea")
+            .unwrap();
         assert_eq!(n, 0);
         assert_eq!(
             count_import_meetings(&state.db),
@@ -3904,8 +4008,8 @@
         assert!(state.db.user_facts_all().unwrap().is_empty());
 
         // REAL extraction: 2 added, anchored to ONE synthetic meeting, visible via the gated read.
-        let n =
-            import_memories_inner(&state.db, &MockImportBrain, true, "chatgpt export text").unwrap();
+        let n = import_memories_inner(&state.db, &MockImportBrain, true, "chatgpt export text")
+            .unwrap();
         assert_eq!(n, 2);
         assert_eq!(count_import_meetings(&state.db), 1);
         let visible = state.db.list_user_facts_visible(&none).unwrap();
@@ -3919,8 +4023,8 @@
             .all(|f| f.meeting_id.as_deref().unwrap().starts_with("import-")));
 
         // RE-IMPORT of the same text: pure dedup — 0 new, and NO second synthetic meeting.
-        let n =
-            import_memories_inner(&state.db, &MockImportBrain, true, "chatgpt export text").unwrap();
+        let n = import_memories_inner(&state.db, &MockImportBrain, true, "chatgpt export text")
+            .unwrap();
         assert_eq!(n, 0, "re-import must reconcile to NoOps");
         assert_eq!(
             count_import_meetings(&state.db),
@@ -4605,7 +4709,8 @@
         let state = build_state("lock-clears-live");
         make_open_folder(&state.db, "f-lock", "Secret");
         seed_meeting(&state.db, "m1", "# note", Some("f-lock"));
-        *state.live_transcript.lock().unwrap() = "stale tail of the just-recorded meeting".to_string();
+        *state.live_transcript.lock().unwrap() =
+            "stale tail of the just-recorded meeting".to_string();
         assert!(
             state.recorder.lock().unwrap().is_none(),
             "precondition: not recording"
@@ -5089,10 +5194,16 @@
     fn discard_with_dev_kek_refuses_unproven_keychain_absence() {
         let state = build_state("discard-dev-kek-fail-closed");
         make_open_folder(&state.db, "f-lock", "Secret");
-        seed_meeting(&state.db, "m1", "# still recoverable elsewhere", Some("f-lock"));
+        seed_meeting(
+            &state.db,
+            "m1",
+            "# still recoverable elsewhere",
+            Some("f-lock"),
+        );
         lock_folder_inner(&state, "f-lock".to_string()).unwrap();
         let foreign_wrapped =
-            crate::crypto::encrypt(&[0x42u8; 32], &[0x24u8; 32], &aad_wrapped_ck("f-lock")).unwrap();
+            crate::crypto::encrypt(&[0x42u8; 32], &[0x24u8; 32], &aad_wrapped_ck("f-lock"))
+                .unwrap();
         state
             .db
             .set_folder_locked("f-lock", true, Some(&foreign_wrapped))
@@ -5180,7 +5291,8 @@
 
         // Make the folder unrecoverable (foreign wrapped key no candidate holds).
         let foreign_wrapped =
-            crate::crypto::encrypt(&[0x42u8; 32], &[0x24u8; 32], &aad_wrapped_ck("f-lock")).unwrap();
+            crate::crypto::encrypt(&[0x42u8; 32], &[0x24u8; 32], &aad_wrapped_ck("f-lock"))
+                .unwrap();
         state
             .db
             .set_folder_locked("f-lock", true, Some(&foreign_wrapped))
@@ -5660,8 +5772,8 @@
         let state = build_state("text-import");
         make_open_folder(&state.db, "f-open", "Project");
 
-        let id =
-            import_text_inner(&state, "Decisions", "We ship the beta on Friday.", "f-open").unwrap();
+        let id = import_text_inner(&state, "Decisions", "We ship the beta on Friday.", "f-open")
+            .unwrap();
         assert_eq!(
             get_document_inner(&state, &id).unwrap(),
             "We ship the beta on Friday.",
@@ -6535,7 +6647,8 @@
             detail: "secret link".to_string(),
             url: Some("[[Secret]]".to_string()),
         };
-        let stored = crate::enrich::apply_link_markers("# secret prose\n", std::slice::from_ref(&hit));
+        let stored =
+            crate::enrich::apply_link_markers("# secret prose\n", std::slice::from_ref(&hit));
         let id = create_note_inner(&state, Some(&fid), "Sealed note").unwrap();
         update_note_doc_inner(&state, &id, "Sealed note", &stored).unwrap();
         lock_folder_inner(&state, fid.clone()).unwrap();
@@ -6631,7 +6744,8 @@
     fn note_markdown_survives_lock_unlock_byte_identical() {
         let state = build_state("note-seal-cycle");
         let fid = create_note_folder_inner(&state, "Vault", None).unwrap().id;
-        let original = "---\ntags: [zażółć, launch]\n---\n# Decyzja 🔒\nAnna owns QA; ship on Friday.";
+        let original =
+            "---\ntags: [zażółć, launch]\n---\n# Decyzja 🔒\nAnna owns QA; ship on Friday.";
         let id = create_note_inner(&state, Some(&fid), "Decyzja").unwrap();
         update_note_doc_inner(&state, &id, "Decyzja", original).unwrap();
 
@@ -6740,7 +6854,8 @@
         let id = create_note_inner(&state, Some(&fid), "Draft").unwrap();
 
         // Cheap save: body persisted + retrievable via get_note, updated_at set…
-        let now = save_note_text_inner(&state, &id, "Draft", "Alpha bravo cheap-save body.").unwrap();
+        let now =
+            save_note_text_inner(&state, &id, "Draft", "Alpha bravo cheap-save body.").unwrap();
         let doc = get_note_inner(&state, &id).unwrap();
         assert_eq!(doc.markdown, "Alpha bravo cheap-save body.");
         assert_eq!(doc.updated_at, now);
@@ -8523,7 +8638,8 @@
         for n in state.db.notes_in_folder(folder_id).unwrap() {
             if let Some(blob) = &n.content_blob {
                 let aad = aad_content(folder_id, &n.meeting_id, &n.provider_id, "note");
-                let md = String::from_utf8(crate::crypto::decrypt(&ck, blob, &aad).unwrap()).unwrap();
+                let md =
+                    String::from_utf8(crate::crypto::decrypt(&ck, blob, &aad).unwrap()).unwrap();
                 state
                     .db
                     .restore_note_markdown(&n.meeting_id, &n.provider_id, &md)
@@ -8934,7 +9050,8 @@
             calls: std::sync::atomic::AtomicUsize::new(0),
             saw_guard_held: std::sync::atomic::AtomicBool::new(false),
         };
-        update_note_doc_inner_with(&state, "n1", "Plan", "quarterly plan body", Some(&probe)).unwrap();
+        update_note_doc_inner_with(&state, "n1", "Plan", "quarterly plan body", Some(&probe))
+            .unwrap();
         assert!(
             probe.calls.load(std::sync::atomic::Ordering::SeqCst) > 0,
             "the note re-index must actually run (the probe is exercised)"
@@ -9193,7 +9310,8 @@
 
         // PASS 2 — MODEL PRESENT (the model-arrived-later recovery the audit gap describes).
         let (meetings, docs) =
-            backfill_missing_brain_indexes(&state.db, true, true, &crate::embed::StubEmbedder).unwrap();
+            backfill_missing_brain_indexes(&state.db, true, true, &crate::embed::StubEmbedder)
+                .unwrap();
         assert_eq!(meetings, 1, "the note-carrying meeting is indexed");
         assert_eq!(
             docs, 2,
@@ -9209,7 +9327,8 @@
 
         // PASS 3 — IDEMPOTENT: full coverage ⇒ a re-run touches nothing.
         let (meetings, docs) =
-            backfill_missing_brain_indexes(&state.db, true, true, &crate::embed::StubEmbedder).unwrap();
+            backfill_missing_brain_indexes(&state.db, true, true, &crate::embed::StubEmbedder)
+                .unwrap();
         assert_eq!((meetings, docs), (0, 0), "re-run is a no-op");
     }
 
@@ -9270,7 +9389,8 @@
         }
 
         let (meetings, docs) =
-            backfill_missing_brain_indexes(&state.db, true, true, &crate::embed::StubEmbedder).unwrap();
+            backfill_missing_brain_indexes(&state.db, true, true, &crate::embed::StubEmbedder)
+                .unwrap();
         assert_eq!(
             (meetings, docs),
             (0, 0),
@@ -9897,12 +10017,7 @@
         }
         std::fs::write(&legacy, raw).unwrap();
         let recording = crate::audio::source::adopt_legacy_raw_recording(
-            &state.db,
-            meeting_id,
-            &legacy,
-            48_000,
-            None,
-            &inflight,
+            &state.db, meeting_id, &legacy, 48_000, None, &inflight,
         )
         .unwrap();
         std::fs::remove_file(legacy).unwrap();
@@ -10033,8 +10148,7 @@
             let folder_id = format!("f-{}", uuid::Uuid::new_v4());
             make_open_folder(&state.db, &folder_id, "CleanupLock");
             let meeting_id = uuid::Uuid::new_v4().hyphenated().to_string();
-            let fixture =
-                stage_released_archived_generation(&state, &meeting_id, Some(&folder_id));
+            let fixture = stage_released_archived_generation(&state, &meeting_id, Some(&folder_id));
 
             corrupt_archived_generation(&fixture);
             assert!(lock_folder_inner(&state, folder_id.clone()).is_err());
@@ -10193,7 +10307,10 @@
             let raw_path = active.mic_path.clone();
             assert!(move_into_locked_folder(&state, &active_id, &folder_id).is_err());
             assert_eq!(state.db.folder_for_meeting(&active_id).unwrap(), None);
-            assert!(raw_path.exists(), "refused Move preserves the exact raw source");
+            assert!(
+                raw_path.exists(),
+                "refused Move preserves the exact raw source"
+            );
             active.release_for_recovery(&state.db).unwrap();
         });
         std::fs::remove_dir_all(app_dir).unwrap();
@@ -10290,7 +10407,8 @@
         ));
 
         // Happy path: Error + a real on-disk WAV → claimed (Error → Recording), path resolved.
-        let wav = std::env::temp_dir().join(format!("murmur-retry-prep-{}.wav", std::process::id()));
+        let wav =
+            std::env::temp_dir().join(format!("murmur-retry-prep-{}.wav", std::process::id()));
         std::fs::write(&wav, b"RIFF-fake").unwrap();
         seed_meeting(&state.db, "m-retry", "# err", None);
         state
@@ -10336,7 +10454,8 @@
 
         // Establish a real locked folder and verified encrypted audio, then session-unlock just
         // long enough to capture the one-shot salvage CK.
-        let dir = std::env::temp_dir().join(format!("murmur-salvage-finalize-{}", std::process::id()));
+        let dir =
+            std::env::temp_dir().join(format!("murmur-salvage-finalize-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         let wav = dir.join("m-raced.wav");
@@ -10487,12 +10606,8 @@
             .content_blob;
 
         let replacement_ck = crate::crypto::random_key().unwrap();
-        let replacement_wrapped = crate::crypto::encrypt(
-            &kek,
-            &replacement_ck,
-            &aad_wrapped_ck("f-generation"),
-        )
-        .unwrap();
+        let replacement_wrapped =
+            crate::crypto::encrypt(&kek, &replacement_ck, &aad_wrapped_ck("f-generation")).unwrap();
         state
             .db
             .set_folder_locked("f-generation", true, Some(&replacement_wrapped))
@@ -10539,7 +10654,12 @@
     fn post_await_result_gate_refuses_cached_plaintext_after_relock() {
         let state = build_state("post-await-result-gate");
         make_open_folder(&state.db, "f-result", "Result");
-        seed_meeting(&state.db, "m-result", "# cached plaintext", Some("f-result"));
+        seed_meeting(
+            &state.db,
+            "m-result",
+            "# cached plaintext",
+            Some("f-result"),
+        );
         lock_folder_inner(&state, "f-result".into()).unwrap();
 
         let cached_markdown = "# cached plaintext".to_string();
@@ -10563,6 +10683,622 @@
         ));
     }
 
+    /// Regression for a shipped deadlock: Living Answer preflight already owns the non-reentrant
+    /// lifecycle mutex, so its visibility witness must use the under-lifecycle snapshot seam. This
+    /// drives the exact headless preflight called by the Tauri command and fails deterministically
+    /// if that path ever tries to acquire the same mutex twice.
+    #[test]
+    fn living_answer_refresh_preflight_does_not_relock_the_lifecycle_mutex() {
+        let state = Arc::new(build_state("living-answer-preflight-no-relock"));
+        state
+            .db
+            .insert_dashboard(
+                "board-preflight",
+                "Board",
+                None,
+                None,
+                "2026-08-13T10:00:00Z",
+            )
+            .unwrap();
+        state
+            .db
+            .insert_dashboard_living_answer_tile(
+                "tile-preflight",
+                "board-preflight",
+                4,
+                "What changed?",
+                "[]",
+                "2026-08-13T10:00:01Z",
+            )
+            .unwrap();
+
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            let result = crate::commands::dashboards::refresh_dashboard_answer_preflight(
+                &state,
+                "board-preflight",
+                "tile-preflight",
+                "What changed?",
+            );
+            tx.send(result.map(|(_, context, _, _, _)| context.packed_corpus))
+                .unwrap();
+        });
+
+        let corpus = rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("Living Answer preflight deadlocked on the lifecycle mutex")
+            .unwrap();
+        assert!(corpus.is_empty(), "the board contains only the excluded cache");
+    }
+
+    #[test]
+    fn save_config_waits_for_the_content_lifecycle_before_changing_ask_dispatch() {
+        let state = Arc::new(build_state("save-config-lifecycle"));
+        let mut dto = {
+            let config = state.config.lock().unwrap();
+            config_to_dto(&config)
+        };
+        dto.role_ask_connection = crate::summarize::roles::CONN_LOCAL.to_string();
+
+        let lifecycle = lifecycle_guard(&state);
+        let writer_state = state.clone();
+        let (started_tx, started_rx) = std::sync::mpsc::sync_channel(1);
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            tx.send(save_config_inner(&writer_state, dto)).unwrap();
+        });
+        started_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("config writer did not reach save_config_inner");
+        assert!(matches!(
+            rx.recv_timeout(std::time::Duration::from_millis(100)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        ));
+        assert_ne!(
+            state.config.lock().unwrap().role_ask_connection,
+            crate::summarize::roles::CONN_LOCAL,
+            "config must remain the old complete snapshot while lifecycle is held"
+        );
+        drop(lifecycle);
+        rx.recv_timeout(std::time::Duration::from_secs(2))
+            .expect("config writer stayed blocked after lifecycle release")
+            .unwrap();
+        assert_eq!(
+            state.config.lock().unwrap().role_ask_connection,
+            crate::summarize::roles::CONN_LOCAL
+        );
+    }
+
+    #[test]
+    fn ask_dispatch_generation_defeats_provider_aba_and_noop_saves() {
+        let state = build_state("ask-dispatch-aba");
+        let start = state.db.ask_dispatch_generation().unwrap();
+        let original = {
+            let config = state.config.lock().unwrap();
+            config_to_dto(&config)
+        };
+        save_config_inner(&state, original.clone()).unwrap();
+        assert_eq!(state.db.ask_dispatch_generation().unwrap(), start);
+
+        let mut changed = original.clone();
+        changed.role_ask_connection = crate::summarize::PROVIDER_GATEWAY.to_string();
+        changed.role_ask_model = "same-budget-model".to_string();
+        save_config_inner(&state, changed).unwrap();
+        assert_eq!(state.db.ask_dispatch_generation().unwrap(), start + 1);
+
+        save_config_inner(&state, original.clone()).unwrap();
+        assert_eq!(
+            state.db.ask_dispatch_generation().unwrap(),
+            start + 2,
+            "returning to byte-identical config must not revive generation N"
+        );
+
+        let mut memory_disabled = original;
+        memory_disabled.user_memory_enabled = false;
+        save_config_inner(&state, memory_disabled).unwrap();
+        assert_eq!(
+            state.db.ask_dispatch_generation().unwrap(),
+            start + 3,
+            "turning user memory off must revoke prompts captured while it was enabled"
+        );
+    }
+
+    #[test]
+    fn malformed_ask_dispatch_generation_fails_closed_and_cannot_be_coerced() {
+        let state = build_state("ask-dispatch-malformed");
+        {
+            let conn = state.db.lock();
+            conn.execute_batch(
+                "PRAGMA ignore_check_constraints=ON;
+                 UPDATE ask_dispatch_state SET generation='malformed' WHERE singleton=1;
+                 PRAGMA ignore_check_constraints=OFF;",
+            )
+            .unwrap();
+        }
+        assert!(state.db.ask_dispatch_generation().is_err());
+        assert!(state.db.advance_ask_dispatch_generation().is_err());
+        let raw: (String, String) = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT typeof(generation),CAST(generation AS TEXT)
+                   FROM ask_dispatch_state WHERE singleton=1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(raw, ("text".into(), "malformed".into()));
+    }
+
+    #[test]
+    fn history_commit_and_ipc_response_share_one_lifecycle_interval() {
+        let state = Arc::new(build_state("ask-history-atomic-response"));
+        let snapshot = DurableScopeSnapshot::Vault(capture_content_visibility_snapshot(&state));
+        let ask_dispatch = {
+            let _lifecycle = lifecycle_guard(&state);
+            let config = state.config.lock().unwrap().clone();
+            capture_ask_dispatch_snapshot_under_lifecycle(&state, &config).unwrap()
+        };
+        let (committed_tx, committed_rx) = std::sync::mpsc::sync_channel(1);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+        let worker_state = state.clone();
+        let worker_snapshot = snapshot.clone();
+        let worker_dispatch = ask_dispatch.clone();
+        let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            let result = finish_persisted_ask_send_after_await_with_hook(
+                &worker_state,
+                &worker_snapshot,
+                &worker_dispatch,
+                &crate::storage::models::AskConversationScope::Vault,
+                "question",
+                "answer".into(),
+                || {
+                    committed_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                },
+            );
+            done_tx.send(result.map(|_| ())).unwrap();
+        });
+        committed_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("finalizer did not commit");
+
+        let writer_state = state.clone();
+        let (writer_started_tx, writer_started_rx) = std::sync::mpsc::sync_channel(1);
+        let (writer_tx, writer_rx) = std::sync::mpsc::sync_channel(1);
+        std::thread::spawn(move || {
+            writer_started_tx.send(()).unwrap();
+            let mut dto = {
+                let config = writer_state.config.lock().unwrap();
+                config_to_dto(&config)
+            };
+            dto.role_ask_connection = crate::summarize::roles::CONN_LOCAL.to_string();
+            writer_tx
+                .send(save_config_inner(&writer_state, dto))
+                .unwrap();
+        });
+        writer_started_rx.recv().unwrap();
+        assert!(matches!(
+            writer_rx.recv_timeout(std::time::Duration::from_millis(100)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        ));
+        release_tx.send(()).unwrap();
+        done_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .unwrap()
+            .unwrap();
+        writer_rx.recv_timeout(std::time::Duration::from_secs(2)).unwrap().unwrap();
+        assert_eq!(
+            state
+                .db
+                .lock()
+                .query_row("SELECT COUNT(*) FROM ask_conversation_messages", [], |row| {
+                    row.get::<_, i64>(0)
+                })
+                .unwrap(),
+            2
+        );
+    }
+
+    /// A dashboard witness authorizes one exact provider/config projection. Changing the Ask role
+    /// after preflight must stop every continuation before plaintext is hydrated/dispatched,
+    /// persisted, cached, or serialized back across IPC.
+    #[test]
+    fn ask_dispatch_mutation_invalidates_history_dispatch_cache_and_response() {
+        let state = Arc::new(build_state("ask-budget-mutation"));
+        state
+            .db
+            .insert_dashboard(
+                "board-budget",
+                "Budget",
+                None,
+                None,
+                "2026-08-13T10:00:00Z",
+            )
+            .unwrap();
+        state
+            .db
+            .insert_dashboard_living_answer_tile(
+                "tile-budget",
+                "board-budget",
+                4,
+                "What changed?",
+                "[]",
+                "2026-08-13T10:00:01Z",
+            )
+            .unwrap();
+        let old_budget = {
+            let config = state.config.lock().unwrap();
+            let connection = crate::summarize::roles::provider_target(
+                crate::summarize::roles::Role::Ask,
+                &config,
+            )
+            .connection;
+            crate::summarize::vault_context::budget_for(&connection)
+        };
+        let context = crate::commands::dashboards::dashboard_composite_context(
+            &state.db,
+            "board-budget",
+            &HashSet::new(),
+            old_budget,
+            &[],
+            None,
+        )
+        .unwrap();
+        let meeting_context = crate::commands::dashboards::dashboard_composite_context(
+            &state.db,
+            "board-budget",
+            &HashSet::new(),
+            old_budget.min(crate::summarize::chat::MAX_PINNED_SOURCE_CHARS),
+            &[],
+            Some("meeting-anchor"),
+        )
+        .unwrap();
+        let living_context = crate::commands::dashboards::living_answer_composite_context(
+            &state.db,
+            "board-budget",
+            &HashSet::new(),
+            old_budget,
+        )
+        .unwrap();
+        let snapshot = DurableScopeSnapshot::Vault(capture_content_visibility_snapshot(&state));
+        let committed = persist_ask_exchange_after_await(
+            &state,
+            &snapshot,
+            &crate::storage::models::AskConversationScope::Vault,
+            None,
+            None,
+            "first question",
+            "first answer",
+            &[],
+            &[],
+            &[],
+            &[],
+            Some(&context.witness),
+        )
+        .unwrap();
+
+        switch_ask_to_local_under_lifecycle(&state);
+        let new_budget = {
+            let config = state.config.lock().unwrap();
+            let connection = crate::summarize::roles::provider_target(
+                crate::summarize::roles::Role::Ask,
+                &config,
+            )
+            .connection;
+            crate::summarize::vault_context::budget_for(&connection)
+        };
+        assert_ne!(old_budget, new_budget, "the fixture must change Ask budget");
+
+        let preflight = state
+            .db
+            .ask_conversation_preflight(
+                &crate::storage::models::AskConversationScope::Vault,
+                &committed.conversation_id,
+                &HashSet::new(),
+            )
+            .unwrap();
+        assert!(
+            preflight.is_none(),
+            "old dispatch generation must be rejected before history hydration"
+        );
+        state
+            .db
+            .lock()
+            .execute_batch(&format!(
+                "UPDATE ask_conversations SET title=x'80' WHERE id='{id}';
+                 UPDATE ask_conversation_messages SET content=x'80' WHERE conversation_id='{id}';",
+                id = committed.conversation_id
+            ))
+            .unwrap();
+        list_ask_conversations_inner(
+            &state,
+            &crate::storage::models::AskConversationScope::Vault,
+        )
+        .expect("stale-budget list must reject metadata before hydrating the poisoned title");
+        assert!(matches!(
+            load_ask_conversation_inner(
+                &state,
+                &crate::storage::models::AskConversationScope::Vault,
+                &committed.conversation_id,
+            ),
+            Err(AppError::Locked(_))
+        ));
+
+        let provider = Arc::new(BudgetMutationProvider {
+            calls: std::sync::atomic::AtomicUsize::new(0),
+        });
+        let gate_state = state.clone();
+        let stale_witness = context.witness.clone();
+        let admission = crate::state::ContentDispatchAdmission::for_test(
+            Arc::new(Mutex::new(())),
+            move || {
+                let _lifecycle = lifecycle_guard(&gate_state);
+                crate::commands::dashboards::require_current_dashboard_context_witness_under_lifecycle(
+                    &gate_state,
+                    &stale_witness,
+                    &HashSet::new(),
+                )
+            },
+        );
+        let dispatch_error = block_on(ask_vault_prepacked_dashboard_dispatch(
+            &context,
+            "second question",
+            &[],
+            admission,
+            {
+                let provider = provider.clone();
+                move || {
+                    Ok(provider
+                        as Arc<dyn crate::summarize::provider::SummarizerProvider>)
+                }
+            },
+        ))
+        .unwrap_err();
+        assert!(matches!(dispatch_error, AppError::Locked(_)));
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+
+        assert!(matches!(
+            persist_ask_exchange_after_await(
+                &state,
+                &snapshot,
+                &crate::storage::models::AskConversationScope::Vault,
+                Some(&committed.conversation_id),
+                None,
+                "second question",
+                "stale answer",
+                &[],
+                &[],
+                &[],
+                &[],
+                Some(&context.witness),
+            ),
+            Err(AppError::Locked(_))
+        ));
+        let message_count: i64 = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT COUNT(*) FROM ask_conversation_messages WHERE conversation_id=?1",
+                [&committed.conversation_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(message_count, 2, "stale exchange must add no history turns");
+
+        let payload = crate::storage::models::AskConversationSendResult {
+            conversation_id: committed.conversation_id.clone(),
+            user_message_id: committed.user_message_id.clone(),
+            assistant_message_id: committed.assistant_message_id.clone(),
+            answer: "stale answer".into(),
+            sources: Vec::new(),
+            citations: Vec::new(),
+        };
+        assert!(matches!(
+            serialize_durable_send_response(
+                &state,
+                &snapshot,
+                Some(&context.witness),
+                &payload,
+            ),
+            Err(AppError::Locked(_))
+        ));
+        {
+            let _lifecycle = lifecycle_guard(&state);
+            assert!(matches!(
+                crate::commands::dashboards::require_current_dashboard_context_witness_under_lifecycle(
+                    &state,
+                    &meeting_context.witness,
+                    &HashSet::new(),
+                ),
+                Err(AppError::Locked(_))
+            ));
+        }
+
+        assert!(matches!(
+            crate::commands::dashboards::persist_dashboard_living_answer_after_await(
+                &state,
+                &snapshot,
+                &living_context.witness,
+                &[],
+                "board-budget",
+                "tile-budget",
+                "What changed?",
+                "stale answer",
+                "2026-08-13T10:01:00Z",
+            ),
+            Err(AppError::Locked(_))
+        ));
+        let answer_type: String = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT typeof(living_answer) FROM dashboard_tiles WHERE id='tile-budget'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(answer_type, "null", "stale answer must add no cache content");
+    }
+
+    #[test]
+    fn ask_writer_withholds_old_living_answer_without_hydrating_or_clearing_it() {
+        let state = build_state("ask-budget-existing-cache");
+        state
+            .db
+            .insert_dashboard(
+                "board-cache",
+                "Cache",
+                None,
+                None,
+                "2026-08-13T10:00:00Z",
+            )
+            .unwrap();
+        state
+            .db
+            .insert_dashboard_living_answer_tile(
+                "tile-cache",
+                "board-cache",
+                4,
+                "What changed?",
+                "[]",
+                "2026-08-13T10:00:01Z",
+            )
+            .unwrap();
+        let old_budget = {
+            let config = state.config.lock().unwrap();
+            resolved_ask_corpus_budget(&config)
+        };
+        let old_context = crate::commands::dashboards::living_answer_composite_context(
+            &state.db,
+            "board-cache",
+            &HashSet::new(),
+            old_budget,
+        )
+        .unwrap();
+        assert!(state
+            .db
+            .store_dashboard_living_answer_cas(
+                "tile-cache",
+                "board-cache",
+                "What changed?",
+                "Old-budget answer",
+                "2026-08-13T10:01:00Z",
+                "[]",
+                old_context.witness.generation,
+                &old_context.witness.input_digest,
+                old_budget,
+            )
+            .unwrap());
+        let tile = state.db.get_dashboard_tile("tile-cache").unwrap().unwrap();
+        assert!(matches!(
+            crate::commands::dashboards::resolve_tile(&state.db, &tile, &HashSet::new()).unwrap(),
+            crate::commands::dashboards::TileData::LivingAnswer {
+                answer: Some(ref answer),
+                withheld: false,
+                ..
+            } if answer == "Old-budget answer"
+        ));
+        let general_before = state.db.dashboard_context_state("board-cache").unwrap().0;
+        let structural_before = state
+            .db
+            .dashboard_structural_context_state("board-cache")
+            .unwrap()
+            .0;
+
+        switch_ask_to_local_under_lifecycle(&state);
+
+        assert_eq!(state.db.dashboard_context_state("board-cache").unwrap().0, general_before);
+        assert_eq!(
+            state
+                .db
+                .dashboard_structural_context_state("board-cache")
+                .unwrap()
+                .0,
+            structural_before,
+            "a provider-budget change does not change board structure"
+        );
+        assert!(matches!(
+            state
+                .db
+                .dashboard_living_answer_preflight("tile-cache")
+                .unwrap()
+                .unwrap()
+                .answer,
+            crate::storage::dashboards_store::LivingAnswerCacheState::Valid { .. }
+        ));
+        assert!(matches!(
+            crate::commands::dashboards::resolve_tile(&state.db, &tile, &HashSet::new()).unwrap(),
+            crate::commands::dashboards::TileData::LivingAnswer {
+                ref question,
+                answer: None,
+                answered_at: None,
+                withheld: false,
+            } if question == "What changed?"
+        ));
+
+        let new_budget = {
+            let config = state.config.lock().unwrap();
+            resolved_ask_corpus_budget(&config)
+        };
+        let new_context = crate::commands::dashboards::living_answer_composite_context(
+            &state.db,
+            "board-cache",
+            &HashSet::new(),
+            new_budget,
+        )
+        .unwrap();
+        assert!(state
+            .db
+            .store_dashboard_living_answer_cas(
+                "tile-cache",
+                "board-cache",
+                "What changed?",
+                "Fresh local answer",
+                "2026-08-13T10:02:00Z",
+                "[]",
+                new_context.witness.generation,
+                &new_context.witness.input_digest,
+                new_budget,
+            )
+            .unwrap());
+        let general_after_refresh = state.db.dashboard_context_state("board-cache").unwrap().0;
+        let structural_after_refresh = state
+            .db
+            .dashboard_structural_context_state("board-cache")
+            .unwrap()
+            .0;
+        let mut same_budget_dto = {
+            let config = state.config.lock().unwrap();
+            config_to_dto(&config)
+        };
+        same_budget_dto.note_language = "pl".to_string();
+        save_config_inner(&state, same_budget_dto).unwrap();
+        assert_eq!(
+            state.db.dashboard_context_state("board-cache").unwrap().0,
+            general_after_refresh,
+            "an unrelated same-budget save must not invalidate the answer"
+        );
+        assert_eq!(
+            state
+                .db
+                .dashboard_structural_context_state("board-cache")
+                .unwrap()
+                .0,
+            structural_after_refresh
+        );
+        assert!(matches!(
+            crate::commands::dashboards::resolve_tile(&state.db, &tile, &HashSet::new()).unwrap(),
+            crate::commands::dashboards::TileData::LivingAnswer {
+                answer: Some(ref answer),
+                withheld: false,
+                ..
+            } if answer == "Fresh local answer"
+        ));
+    }
+
     /// RED-before-GREEN Ask-history oracle: a relock/delete generation change after inference must
     /// prevent BOTH the IPC result and the atomic user+assistant write. No orphan thread survives.
     #[test]
@@ -10583,15 +11319,480 @@
             &[],
             &[],
             &[],
+            None,
         )
         .unwrap_err();
         assert!(matches!(error, AppError::Locked(_)));
         let count: i64 = state
             .db
             .lock()
-            .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| row.get(0))
+            .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| {
+                row.get(0)
+            })
             .unwrap();
         assert_eq!(count, 0, "stale post-await result must persist no rows");
+    }
+
+    #[test]
+    fn dashboard_mutation_after_inference_writes_zero_history_rows() {
+        let state = build_state("ask-history-dashboard-race");
+        state
+            .db
+            .insert_dashboard("board-race", "X", None, None, "2026-08-06T10:00:00Z")
+            .unwrap();
+        let witness = crate::commands::dashboards::dashboard_composite_context(
+            &state.db,
+            "board-race",
+            &HashSet::new(),
+            200_000,
+            &[],
+            None,
+        )
+        .unwrap()
+        .witness;
+        let snapshot = DurableScopeSnapshot::Vault(capture_content_visibility_snapshot(&state));
+
+        state
+            .db
+            .insert_dashboard_tile(
+                "transient-tile",
+                "board-race",
+                "note",
+                Some("missing-note"),
+                None,
+                4,
+                None,
+                "2026-08-06T10:01:00Z",
+            )
+            .unwrap();
+        state.db.delete_dashboard_tile("transient-tile").unwrap();
+
+        let error = persist_ask_exchange_after_await(
+            &state,
+            &snapshot,
+            &crate::storage::models::AskConversationScope::Vault,
+            None,
+            None,
+            "question",
+            "stale answer",
+            &[],
+            &[],
+            &[],
+            &[],
+            Some(&witness),
+        )
+        .unwrap_err();
+        assert!(matches!(error, AppError::Locked(_)));
+        let count: i64 = state
+            .db
+            .lock()
+            .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn dashboard_source_tail_mutation_beyond_packing_cutoff_writes_zero_history_rows() {
+        let state = build_state("ask-history-dashboard-source-tail");
+        make_open_folder(&state.db, "f-open", "Open");
+        let original = format!("{}TAIL-A", "prefix ".repeat(200));
+        seed_note_doc_cmd(&state.db, "source-note", "f-open", "Source", &original);
+        state
+            .db
+            .insert_dashboard("board-tail", "X", None, None, "2026-08-06T10:00:00Z")
+            .unwrap();
+        state
+            .db
+            .insert_dashboard_tile(
+                "source-tile",
+                "board-tail",
+                "note",
+                Some("source-note"),
+                None,
+                4,
+                None,
+                "2026-08-06T10:00:00Z",
+            )
+            .unwrap();
+        let before = crate::commands::dashboards::dashboard_composite_context(
+            &state.db,
+            "board-tail",
+            &HashSet::new(),
+            300,
+            &[],
+            None,
+        )
+        .unwrap();
+        let snapshot = DurableScopeSnapshot::Vault(capture_content_visibility_snapshot(&state));
+
+        let replacement = format!("{}TAIL-B", "prefix ".repeat(200));
+        state
+            .db
+            .lock()
+            .execute(
+                "UPDATE documents SET text=?2 WHERE id=?1",
+                rusqlite::params!["source-note", replacement],
+            )
+            .unwrap();
+        let after = crate::commands::dashboards::dashboard_composite_context(
+            &state.db,
+            "board-tail",
+            &HashSet::new(),
+            300,
+            &[],
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            before.packed_corpus, after.packed_corpus,
+            "the changed tail must be wholly beyond the provider cutoff"
+        );
+        assert_ne!(before.witness.input_digest, after.witness.input_digest);
+
+        let error = persist_ask_exchange_after_await(
+            &state,
+            &snapshot,
+            &crate::storage::models::AskConversationScope::Vault,
+            None,
+            None,
+            "question",
+            "stale answer",
+            &[],
+            &[],
+            &[],
+            &[],
+            Some(&before.witness),
+        )
+        .unwrap_err();
+        assert!(matches!(error, AppError::Locked(_)));
+        let count: i64 = state
+            .db
+            .lock()
+            .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(count, 0, "a stale tail mutation must persist no history");
+    }
+
+    #[test]
+    fn empty_selected_source_title_mutation_writes_zero_history_rows() {
+        let state = build_state("ask-history-empty-source-title");
+        make_open_folder(&state.db, "f-open", "Open");
+        seed_note_doc_cmd(&state.db, "empty-note", "f-open", "TITLE-A", "");
+        state
+            .db
+            .insert_dashboard("board-empty", "X", None, None, "now")
+            .unwrap();
+        state
+            .db
+            .insert_dashboard_tile(
+                "empty-tile",
+                "board-empty",
+                "note",
+                Some("empty-note"),
+                None,
+                4,
+                None,
+                "now",
+            )
+            .unwrap();
+        let before = crate::commands::dashboards::dashboard_composite_context(
+            &state.db,
+            "board-empty",
+            &HashSet::new(),
+            300,
+            &[],
+            None,
+        )
+        .unwrap();
+        let snapshot = DurableScopeSnapshot::Vault(capture_content_visibility_snapshot(&state));
+        assert!(before.packed_corpus.is_empty());
+
+        state
+            .db
+            .lock()
+            .execute(
+                "UPDATE documents SET title='TITLE-B', name='TITLE-B' WHERE id='empty-note'",
+                [],
+            )
+            .unwrap();
+        let after = crate::commands::dashboards::dashboard_composite_context(
+            &state.db,
+            "board-empty",
+            &HashSet::new(),
+            300,
+            &[],
+            None,
+        )
+        .unwrap();
+        assert_eq!(before.packed_corpus, after.packed_corpus);
+        assert_ne!(before.witness.input_digest, after.witness.input_digest);
+
+        let error = persist_ask_exchange_after_await(
+            &state,
+            &snapshot,
+            &crate::storage::models::AskConversationScope::Vault,
+            None,
+            None,
+            "question",
+            "stale answer",
+            &[],
+            &[],
+            &[],
+            &[],
+            Some(&before.witness),
+        )
+        .unwrap_err();
+        assert!(matches!(error, AppError::Locked(_)));
+        let count: i64 = state
+            .db
+            .lock()
+            .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn living_answer_relock_after_provider_writes_zero_cache_content() {
+        let state = build_state("living-answer-post-await-relock");
+        make_open_folder(&state.db, "f-living", "Living");
+        state
+            .db
+            .insert_dashboard("board-living", "X", None, None, "2026-08-06T10:00:00Z")
+            .unwrap();
+        state
+            .db
+            .insert_dashboard_living_answer_tile(
+                "tile-living",
+                "board-living",
+                4,
+                "Will it ship?",
+                r#"["f-living"]"#,
+                "2026-08-06T10:00:00Z",
+            )
+            .unwrap();
+        let witness = crate::commands::dashboards::living_answer_composite_context(
+            &state.db,
+            "board-living",
+            &HashSet::new(),
+            200_000,
+        )
+        .unwrap()
+        .witness;
+        let snapshot = DurableScopeSnapshot::Vault(capture_content_visibility_snapshot(&state));
+
+        state
+            .db
+            .set_folder_locked("f-living", true, Some(&b"wrapped"[..]))
+            .unwrap();
+        bump_seal_epoch(&state);
+        let error = match crate::commands::dashboards::persist_dashboard_living_answer_after_await(
+            &state,
+            &snapshot,
+            &witness,
+            &["f-living".to_string()],
+            "board-living",
+            "tile-living",
+            "Will it ship?",
+            "STALE PROVIDER ANSWER",
+            "2026-08-06T10:01:00Z",
+        ) {
+            Ok(_) => panic!("stale answer was admitted"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, AppError::Locked(_)));
+        let answer_type: String = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT typeof(living_answer) FROM dashboard_tiles WHERE id='tile-living'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(answer_type, "null", "a relock must admit no cached answer");
+    }
+
+    #[test]
+    fn living_answer_dashboard_mutation_after_provider_writes_zero_cache_content() {
+        let state = build_state("living-answer-post-await-mutation");
+        state
+            .db
+            .insert_dashboard("board-living", "X", None, None, "2026-08-06T10:00:00Z")
+            .unwrap();
+        state
+            .db
+            .insert_dashboard_living_answer_tile(
+                "tile-living",
+                "board-living",
+                4,
+                "Will it ship?",
+                "[]",
+                "2026-08-06T10:00:00Z",
+            )
+            .unwrap();
+        let witness = crate::commands::dashboards::living_answer_composite_context(
+            &state.db,
+            "board-living",
+            &HashSet::new(),
+            200_000,
+        )
+        .unwrap()
+        .witness;
+        let snapshot = DurableScopeSnapshot::Vault(capture_content_visibility_snapshot(&state));
+        state
+            .db
+            .insert_dashboard_tile(
+                "mutation",
+                "board-living",
+                "promises",
+                None,
+                None,
+                4,
+                None,
+                "2026-08-06T10:00:30Z",
+            )
+            .unwrap();
+
+        let error = match crate::commands::dashboards::persist_dashboard_living_answer_after_await(
+            &state,
+            &snapshot,
+            &witness,
+            &[],
+            "board-living",
+            "tile-living",
+            "Will it ship?",
+            "STALE PROVIDER ANSWER",
+            "2026-08-06T10:01:00Z",
+        ) {
+            Ok(_) => panic!("stale answer was admitted"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, AppError::Locked(_)));
+        let answer_type: String = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT typeof(living_answer) FROM dashboard_tiles WHERE id='tile-living'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(answer_type, "null");
+    }
+
+    #[test]
+    fn out_of_budget_linked_neighbour_replacement_writes_zero_cache_content() {
+        let state = build_state("living-answer-neighbour-replacement");
+        make_open_folder(&state.db, "f-open", "Open");
+        seed_note_doc_cmd(
+            &state.db,
+            "source-note",
+            "f-open",
+            "Source",
+            &"source body ".repeat(300),
+        );
+        seed_note_doc_cmd(&state.db, "neighbour-a", "f-open", "A", "NEIGHBOUR-A");
+        seed_note_doc_cmd(&state.db, "neighbour-b", "f-open", "B", "NEIGHBOUR-B");
+        state.db.insert_link_for_test(
+            "note",
+            "source-note",
+            "note",
+            "neighbour-a",
+            "manual",
+            1.0,
+            "user",
+            "active",
+        );
+        state
+            .db
+            .insert_dashboard("board-link", "X", None, None, "2026-08-06T10:00:00Z")
+            .unwrap();
+        state
+            .db
+            .insert_dashboard_tile(
+                "source-tile",
+                "board-link",
+                "note",
+                Some("source-note"),
+                None,
+                4,
+                None,
+                "2026-08-06T10:00:00Z",
+            )
+            .unwrap();
+        state
+            .db
+            .insert_dashboard_living_answer_tile(
+                "answer-tile",
+                "board-link",
+                4,
+                "What changed?",
+                "[]",
+                "2026-08-06T10:00:01Z",
+            )
+            .unwrap();
+        let before = crate::commands::dashboards::living_answer_composite_context(
+            &state.db,
+            "board-link",
+            &HashSet::new(),
+            300,
+        )
+        .unwrap();
+        assert!(!before.packed_corpus.contains("NEIGHBOUR-A"));
+        let snapshot = DurableScopeSnapshot::Vault(capture_content_visibility_snapshot(&state));
+
+        state
+            .db
+            .lock()
+            .execute(
+                "UPDATE links SET dst_id='neighbour-b' WHERE src_kind='note' AND src_id='source-note' AND edge_type='manual'",
+                [],
+            )
+            .unwrap();
+        let after = crate::commands::dashboards::living_answer_composite_context(
+            &state.db,
+            "board-link",
+            &HashSet::new(),
+            300,
+        )
+        .unwrap();
+        assert_eq!(
+            before.packed_corpus, after.packed_corpus,
+            "the selected neighbour must remain wholly outside the provider budget"
+        );
+        assert_ne!(before.witness.input_digest, after.witness.input_digest);
+
+        let error = match crate::commands::dashboards::persist_dashboard_living_answer_after_await(
+            &state,
+            &snapshot,
+            &before.witness,
+            &[],
+            "board-link",
+            "answer-tile",
+            "What changed?",
+            "STALE PROVIDER ANSWER",
+            "2026-08-06T10:01:00Z",
+        ) {
+            Ok(_) => panic!("stale neighbour answer was admitted"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, AppError::Locked(_)));
+        let answer_type: String = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT typeof(living_answer) FROM dashboard_tiles WHERE id='answer-tile'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(answer_type, "null", "a stale neighbour must persist no cache");
     }
 
     #[test]
@@ -10638,7 +11839,8 @@
             state
                 .db
                 .lock()
-                .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| row.get::<_, i64>(0))
+                .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| row
+                    .get::<_, i64>(0))
                 .unwrap(),
             0
         );
@@ -10661,14 +11863,15 @@
         bump_seal_epoch(&state);
 
         for snapshot in [&vault, &note] {
-            let result = require_durable_scope_for_dispatch(&state, snapshot);
+            let result = require_durable_scope_for_dispatch(&state, snapshot, None);
             assert!(matches!(result, Err(AppError::Locked(_))));
         }
         assert_eq!(
             state
                 .db
                 .lock()
-                .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| row.get::<_, i64>(0))
+                .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| row
+                    .get::<_, i64>(0))
                 .unwrap(),
             0
         );
@@ -10682,14 +11885,14 @@
         let snapshot = capture_meeting_content_snapshot(&state, "m-admission").unwrap();
         bump_seal_epoch(&state);
 
-        let result =
-            require_current_meeting_content_snapshot(&state, "m-admission", &snapshot);
+        let result = require_current_meeting_content_snapshot(&state, "m-admission", &snapshot);
         assert!(matches!(result, Err(AppError::Locked(_))));
         assert_eq!(
             state
                 .db
                 .lock()
-                .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| row.get::<_, i64>(0))
+                .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| row
+                    .get::<_, i64>(0))
                 .unwrap(),
             0
         );
@@ -10721,13 +11924,16 @@
             &[],
             &[],
             &dependencies,
+            None,
         )
         .unwrap_err();
         assert!(matches!(error, AppError::Locked(_)));
         let count: i64 = state
             .db
             .lock()
-            .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| row.get(0))
+            .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| {
+                row.get(0)
+            })
             .unwrap();
         assert_eq!(count, 0);
     }
@@ -10746,7 +11952,11 @@
         let initial_dependencies = state.db.visible_folder_ids(&HashSet::new()).unwrap();
         assert_eq!(initial_dependencies, vec!["f-visible".to_string()]);
 
-        state.unlocked_folders.lock().unwrap().insert("f-late".into());
+        state
+            .unlocked_folders
+            .lock()
+            .unwrap()
+            .insert("f-late".into());
         let committed = persist_ask_exchange_after_await(
             &state,
             &snapshot,
@@ -10759,6 +11969,7 @@
             &[],
             &[],
             &initial_dependencies,
+            None,
         )
         .unwrap();
 
@@ -10775,7 +11986,10 @@
                 .collect::<std::result::Result<Vec<_>, _>>()
                 .unwrap()
         };
-        assert_eq!(dependencies, vec!["f-late".to_string(), "f-visible".to_string()]);
+        assert_eq!(
+            dependencies,
+            vec!["f-late".to_string(), "f-visible".to_string()]
+        );
     }
 
     /// An idempotent retry of an already-locked empty folder has no meeting/document ids for the
@@ -10805,7 +12019,9 @@
         let count: i64 = state
             .db
             .lock()
-            .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| row.get(0))
+            .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| {
+                row.get(0)
+            })
             .unwrap();
         assert_eq!(count, 0);
     }
@@ -10930,12 +12146,7 @@
         std::fs::write(&wav, b"RIFF-archived-audio").unwrap();
 
         make_open_folder(&state.db, "f-crash", "Crash");
-        seed_meeting(
-            &state.db,
-            "m-crashed",
-            "# crashed salvage",
-            Some("f-crash"),
-        );
+        seed_meeting(&state.db, "m-crashed", "# crashed salvage", Some("f-crash"));
         state
             .db
             .finalize_meeting(
@@ -11041,7 +12252,8 @@
     #[test]
     fn relock_reblank_leaves_completed_meeting_even_with_audio_on_disk() {
         let state = build_state("relock-noloss-status-leg");
-        let dir = std::env::temp_dir().join(format!("murmur-relock-statusleg-{}", std::process::id()));
+        let dir =
+            std::env::temp_dir().join(format!("murmur-relock-statusleg-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         let wav = dir.join("m-sum.wav");
@@ -11080,7 +12292,10 @@
             !segs.is_empty() && segs.iter().any(|s| !s.text.is_empty()),
             "a Summarized meeting's blob-less rows survive even with audio on disk (retry refuses non-Error)"
         );
-        assert!(wav.exists(), "the only plaintext audio copy must also survive");
+        assert!(
+            wav.exists(),
+            "the only plaintext audio copy must also survive"
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -11308,11 +12523,9 @@
             "get_config must carry the stored glossary to Settings"
         );
 
-        let mut old_client_json = serde_json::to_value(config_to_dto(&AppConfig::default())).unwrap();
-        old_client_json
-            .as_object_mut()
-            .unwrap()
-            .remove("glossary");
+        let mut old_client_json =
+            serde_json::to_value(config_to_dto(&AppConfig::default())).unwrap();
+        old_client_json.as_object_mut().unwrap().remove("glossary");
         let omitted: AppConfigDto = serde_json::from_value(old_client_json).unwrap();
         assert_eq!(
             dto_to_config(omitted, &current).glossary,
@@ -12959,7 +14172,10 @@
             .unwrap();
         state
             .db
-            .set_note_doc_exported_hash("n1", Some(&crate::export::note_content_hash("# My Note\n")))
+            .set_note_doc_exported_hash(
+                "n1",
+                Some(&crate::export::note_content_hash("# My Note\n")),
+            )
             .unwrap();
         // The user edits the exported file behind Murmur's back.
         std::fs::write(&md, "# My Note\nMY EXTERNAL NOTE\n").unwrap();
@@ -13665,10 +14881,7 @@
 
         let mut old_client_json =
             serde_json::to_value(config_to_dto(&AppConfig::default())).unwrap();
-        old_client_json
-            .as_object_mut()
-            .unwrap()
-            .remove("glossary");
+        old_client_json.as_object_mut().unwrap().remove("glossary");
         let omitted: AppConfigDto = serde_json::from_value(old_client_json).unwrap();
         save_config_inner(&state, omitted).unwrap();
         assert_eq!(state.config.lock().unwrap().glossary, "Konnect = Connect");
@@ -13864,11 +15077,14 @@
         // The load sweep judges `provider_model` by `provider_id`, like the save boundary. It was
         // briefly pinned to `"claude_code"` here, which meant a legitimate long Anthropic id was
         // cleared on EVERY LAUNCH — silently, since load performs no user-visible edit.
-        let db = Db::open_with_key(&tmp_db_path("long-anthropic-model-load"), DB_KEY).expect("open");
+        let db =
+            Db::open_with_key(&tmp_db_path("long-anthropic-model-load"), DB_KEY).expect("open");
         db.migrate().expect("migrate");
         let long = format!("hf.co/{}/model:Q4_K_M", "a".repeat(60));
-        db.set_setting("provider_id", "anthropic").expect("seed provider_id");
-        db.set_setting("provider_model", &long).expect("seed provider_model");
+        db.set_setting("provider_id", "anthropic")
+            .expect("seed provider_id");
+        db.set_setting("provider_model", &long)
+            .expect("seed provider_model");
         assert_eq!(
             crate::settings::config::AppConfig::load(&db)
                 .expect("load")
@@ -13880,8 +15096,10 @@
         // ...and the same id under an ARGV engine is still cleared, so the rule stayed a rule.
         let db = Db::open_with_key(&tmp_db_path("long-argv-model-load"), DB_KEY).expect("open");
         db.migrate().expect("migrate");
-        db.set_setting("provider_id", "claude_code").expect("seed provider_id");
-        db.set_setting("provider_model", &long).expect("seed provider_model");
+        db.set_setting("provider_id", "claude_code")
+            .expect("seed provider_id");
+        db.set_setting("provider_model", &long)
+            .expect("seed provider_model");
         assert_eq!(
             crate::settings::config::AppConfig::load(&db)
                 .expect("load")
@@ -13904,7 +15122,10 @@
     #[test]
     fn a_role_model_is_validated_against_its_own_connection() {
         let long_but_valid = format!("hf.co/{}/model:Q4_K_M", "a".repeat(60));
-        assert!(long_but_valid.len() > 64, "fixture must exceed the argv ceiling");
+        assert!(
+            long_but_valid.len() > 64,
+            "fixture must exceed the argv ceiling"
+        );
 
         // ARGV arm: too long for `--model`, so it must not be stored.
         let current = crate::settings::config::AppConfig {
@@ -14055,11 +15276,20 @@
         // ONLY input is the connection.
         for body_arm in ["anthropic", "ollama", "gateway"] {
             assert!(!connection_builds_argv(body_arm));
-            assert!(model_predicate_for(body_arm)(&long), "{body_arm} sends JSON");
+            assert!(
+                model_predicate_for(body_arm)(&long),
+                "{body_arm} sends JSON"
+            );
         }
         for argv_arm in ["claude_code", "codex_cli", "", "some_future_cli"] {
-            assert!(connection_builds_argv(argv_arm), "{argv_arm} must fail closed to argv");
-            assert!(!model_predicate_for(argv_arm)(&long), "{argv_arm} builds argv");
+            assert!(
+                connection_builds_argv(argv_arm),
+                "{argv_arm} must fail closed to argv"
+            );
+            assert!(
+                !model_predicate_for(argv_arm)(&long),
+                "{argv_arm} builds argv"
+            );
         }
 
         // `provider_model` is the ONE exception, and deliberately so: it is ALWAYS strict, whatever
@@ -14272,7 +15502,8 @@
                 crate::commands::model_predicate_for(&target.connection)(&target.model),
                 "provider_id={provider_id:?} role={role_connection:?} resolved to connection {:?} \
                  with model {:?}, which that arm cannot send",
-                target.connection, target.model
+                target.connection,
+                target.model
             );
             argv_legs_asserted += 1;
         }
@@ -14371,9 +15602,9 @@
             let target = resolve(Role::Notes, &saved);
             let ledger = crate::summarize::effective_model_requested(&target, &saved);
             let wire = match target.connection.as_str() {
-                "claude_code" => after_model_flag(crate::summarize::claude_code::model_args(
-                    &target.model,
-                )),
+                "claude_code" => {
+                    after_model_flag(crate::summarize::claude_code::model_args(&target.model))
+                }
                 "codex_cli" => {
                     after_model_flag(crate::summarize::codex_cli::model_args(&target.model))
                 }
@@ -14405,7 +15636,10 @@
                     target.model.is_empty(),
                     "this leg needs an EMPTY resolved model to exercise the fallback path"
                 );
-                assert_eq!(ledger, "", "an argv arm has no config fallback, and must not gain one");
+                assert_eq!(
+                    ledger, "",
+                    "an argv arm has no config fallback, and must not gain one"
+                );
             }
             checked += 1;
         }
@@ -14458,7 +15692,10 @@
         }
         // A 512-byte id — the ceiling the loose predicate now permits — behaves the same.
         let max_len = "a".repeat(512);
-        assert_eq!(resolve_brain_model(None, Some(&max_len)).expect("resolve"), None);
+        assert_eq!(
+            resolve_brain_model(None, Some(&max_len)).expect("resolve"),
+            None
+        );
     }
 
     /// The load sweep and the save boundary must agree for EVERY stored `provider_id`, including
@@ -14469,7 +15706,8 @@
         let db = Db::open_with_key(&tmp_db_path("empty-provider-id"), DB_KEY).expect("open");
         db.migrate().expect("migrate");
         db.set_setting("provider_id", "").expect("seed provider_id");
-        db.set_setting("provider_model", &long).expect("seed provider_model");
+        db.set_setting("provider_model", &long)
+            .expect("seed provider_model");
         let loaded = crate::settings::config::AppConfig::load(&db).expect("load");
         // Whether an empty engine is even REACHABLE decides how much this leg matters. Record the
         // answer instead of assuming it: if load normalises the blank away, the divergence this
@@ -14601,10 +15839,16 @@
         };
         let target = crate::summarize::roles::resolve(crate::summarize::roles::Role::Notes, &cfg);
         let ledger = crate::summarize::effective_model_requested(&target, &cfg);
-        assert_eq!(ledger, "", "with nothing configured the ledger records 'provider chose'");
+        assert_eq!(
+            ledger, "",
+            "with nothing configured the ledger records 'provider chose'"
+        );
 
-        let provider =
-            crate::summarize::anthropic::AnthropicProvider::with_effort(None, ledger.clone(), String::new());
+        let provider = crate::summarize::anthropic::AnthropicProvider::with_effort(
+            None,
+            ledger.clone(),
+            String::new(),
+        );
         assert_ne!(
             provider.model_for_test(),
             ledger,
@@ -14778,8 +16022,7 @@
         );
         // INJECTIVE, tested as a SET. Asserting each spelling on its own line is what let
         // `plain-model` and `plain_model` both become "Plain Model" unnoticed.
-        let labels: std::collections::HashSet<&String> =
-            options.iter().map(|o| &o.label).collect();
+        let labels: std::collections::HashSet<&String> = options.iter().map(|o| &o.label).collect();
         assert_eq!(labels.len(), ids.len(), "labels must stay distinguishable");
     }
 
@@ -14802,8 +16045,16 @@
         }
         // The looser predicate is looser on LENGTH ONLY. Every argv-injection shape stays refused
         // on both, because none of them is a real model id on any arm.
-        for hostile in ["--sandbox danger-full-access", "../../etc/passwd", "a b", "./m"] {
-            assert!(!valid_model_id(hostile), "{hostile:?} must be refused (argv)");
+        for hostile in [
+            "--sandbox danger-full-access",
+            "../../etc/passwd",
+            "a b",
+            "./m",
+        ] {
+            assert!(
+                !valid_model_id(hostile),
+                "{hostile:?} must be refused (argv)"
+            );
             assert!(
                 !valid_catalog_model_id(hostile),
                 "{hostile:?} must be refused (json body) — looser length must not mean looser shape"
@@ -14811,7 +16062,10 @@
         }
         // ...and the argv ceiling still bites where it belongs.
         let long = "a".repeat(65);
-        assert!(!valid_model_id(&long), "an argv id stays short-slug bounded");
+        assert!(
+            !valid_model_id(&long),
+            "an argv id stays short-slug bounded"
+        );
         assert!(valid_catalog_model_id(&long), "a body id may be longer");
     }
 
@@ -14877,7 +16131,10 @@
         );
         // Every legal connection resolves without ever being shown a model id.
         for conn in ["claude_code", "anthropic", "codex_cli", "local", "off"] {
-            assert!(static_connection_models(conn).is_ok(), "{conn} must resolve");
+            assert!(
+                static_connection_models(conn).is_ok(),
+                "{conn} must resolve"
+            );
         }
     }
 
@@ -14972,14 +16229,18 @@
         // Serialized shape the FE reads: `source` is a sibling of `options`, never inside them.
         let json = serde_json::to_value(&empty).expect("catalog serializes");
         assert_eq!(json["source"], "live");
-        assert!(json["options"].as_array().expect("options array").is_empty());
+        assert!(json["options"]
+            .as_array()
+            .expect("options array")
+            .is_empty());
     }
 
     /// An unknown connection id refuses with `InvalidArg` — never a panic, never an empty Ok.
     #[test]
     fn list_models_unknown_connection_refuses() {
         for conn in ["", "openai", "GATEWAY", "claude"] {
-            let err = static_connection_models(conn).expect_err("unknown connection must be refused");
+            let err =
+                static_connection_models(conn).expect_err("unknown connection must be refused");
             assert!(
                 matches!(err, AppError::InvalidArg(_)),
                 "expected InvalidArg for '{conn}', got: {err:?}"
@@ -16184,7 +17445,8 @@
         seed_locked_meeting_with_note(&state, "f-prev", "m-prev");
 
         // Sealed → refuse (the preview is a read, so it is gated too).
-        let err = preview_org_share_inner(&state, Some("m-prev".to_string()), None, true).unwrap_err();
+        let err =
+            preview_org_share_inner(&state, Some("m-prev".to_string()), None, true).unwrap_err();
         assert!(
             matches!(err, AppError::Locked(_)),
             "sealed preview must refuse"
@@ -16466,7 +17728,8 @@
         // PUBLISHER seals under hex(content_sha) — NOT the local row id. (The server would assign a
         // different item_id; we simulate that by using a DISTINCT server id below.)
         let publisher_nonce = org_item_nonce(&content_sha);
-        let (ciphertext, feed_sha) = seal_org_envelope(&ock, &env, "org-1", &publisher_nonce).unwrap();
+        let (ciphertext, feed_sha) =
+            seal_org_envelope(&ock, &env, "org-1", &publisher_nonce).unwrap();
         assert_eq!(feed_sha, content_sha, "the feed carries the PLAINTEXT hash");
 
         // CONSUMER derives the nonce from ONLY the feed's content_sha256 (it never learns row_id, and
@@ -16635,7 +17898,6 @@
                 None,
                 None,
                 Some("it-p"),
-                None,
             )
             .unwrap()
         };
@@ -16671,8 +17933,7 @@
                 assert!(!corpus.contains("POISON_FALLBACK"));
                 assert_eq!(corpus.matches("### [[").count(), 1);
                 assert!(
-                    corpus.chars().count()
-                        <= crate::summarize::vault_context::budget_for("ollama"),
+                    corpus.chars().count() <= crate::summarize::vault_context::budget_for("ollama"),
                     "the pinned Org corpus must honor the resolved local-provider budget"
                 );
                 assert!(sources.is_empty(), "an Org item is not a local VaultSource");
@@ -17611,7 +18872,9 @@
         );
         drop(lifecycle);
         let exported = worker.join().unwrap().unwrap().expect("exported path");
-        assert!(std::fs::read_to_string(exported).unwrap().contains("private body"));
+        assert!(std::fs::read_to_string(exported)
+            .unwrap()
+            .contains("private body"));
 
         let _ = std::fs::remove_dir_all(vault);
     }
@@ -18192,7 +19455,8 @@
             state
                 .db
                 .lock()
-                .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| row.get::<_, i64>(0))
+                .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| row
+                    .get::<_, i64>(0))
                 .unwrap(),
             0
         );
@@ -19010,10 +20274,13 @@
         let snapshot = build_org_share_snapshot(&state, None, Some("n-move"), true).unwrap();
         state.db.set_note_doc_folder("n-move", "f-b").unwrap();
 
-        assert!(
-            !org_share_snapshot_is_current(&state, None, Some("n-move"), &snapshot.source_version,)
-                .unwrap()
-        );
+        assert!(!org_share_snapshot_is_current(
+            &state,
+            None,
+            Some("n-move"),
+            &snapshot.source_version,
+        )
+        .unwrap());
     }
 
     /// EGRESS TOCTOU: every seal/relock/remove-lock bumps the monotonic epoch. Even when the source
@@ -19030,10 +20297,13 @@
         let snapshot = build_org_share_snapshot(&state, None, Some("n-seal"), true).unwrap();
         bump_seal_epoch(&state);
 
-        assert!(
-            !org_share_snapshot_is_current(&state, None, Some("n-seal"), &snapshot.source_version,)
-                .unwrap()
-        );
+        assert!(!org_share_snapshot_is_current(
+            &state,
+            None,
+            Some("n-seal"),
+            &snapshot.source_version,
+        )
+        .unwrap());
     }
 
     /// INLINE REPUBLISH: there is one atomic `/items` request and no anonymous `/blobs` staging
@@ -19049,14 +20319,7 @@
         make_open_folder(&state.db, "f-after", "After");
         state
             .db
-            .insert_note(
-                "n-race",
-                "f-before",
-                "race",
-                "Race",
-                "# fresh body",
-                1,
-            )
+            .insert_note("n-race", "f-before", "race", "Race", "# fresh body", 1)
             .unwrap();
         state
             .db
@@ -19260,7 +20523,8 @@
             2,
             "every locally-joined org yields a status (RED on a single-org .next())"
         );
-        let ids: std::collections::HashSet<&str> = statuses.iter().map(|s| s.org_id.as_str()).collect();
+        let ids: std::collections::HashSet<&str> =
+            statuses.iter().map(|s| s.org_id.as_str()).collect();
         assert!(ids.contains("org-own"), "the owned org appears");
         assert!(ids.contains("org-inv"), "the invited org appears");
 
@@ -19816,7 +21080,10 @@
         fn to_json(&self) -> String {
             let sha = match &self.content_sha256 {
                 Some(bytes) => {
-                    format!(",\"contentSha256\":\"{}\"", murmur_protocol::b64::encode(bytes))
+                    format!(
+                        ",\"contentSha256\":\"{}\"",
+                        murmur_protocol::b64::encode(bytes)
+                    )
                 }
                 None => String::new(),
             };
@@ -20926,7 +22193,8 @@
     /// it didn't catch `active_link_user_shares_for_folder`'s `WHERE state = 'active'` excluding every
     /// real 1:1-person share (100%-reproducible, not an edge case).
     #[test]
-    fn active_link_user_shares_for_folder_lists_active_1to1_and_excludes_revoked_and_other_folders() {
+    fn active_link_user_shares_for_folder_lists_active_1to1_and_excludes_revoked_and_other_folders()
+    {
         let state = build_state("folder-1to1-shares");
         make_open_folder(&state.db, "f1", "Team");
         make_open_folder(&state.db, "f2", "Other");
@@ -21298,7 +22566,8 @@
             "2026-07-04T10:00:00Z",
         );
         let accepted =
-            ingest_shared_note(&state, &target, &env, "SENDERFP", "sender-uuid", "share-lk").unwrap();
+            ingest_shared_note(&state, &target, &env, "SENDERFP", "sender-uuid", "share-lk")
+                .unwrap();
         let mid = accepted.meeting_id;
 
         // The note row must be SEALED (blob present) — never a raw plaintext note behind the lock.
@@ -21521,7 +22790,10 @@
 
         // ── GREEN: the anti-entropy sweep restarts at 0 and applies the tombstone. ────────────────
         let changed = block_on(org_reconcile_now_inner(&state)).unwrap();
-        assert_eq!(changed, 1, "the sweep evicted exactly one stale replica row");
+        assert_eq!(
+            changed, 1,
+            "the sweep evicted exactly one stale replica row"
+        );
         assert!(
             state.db.get_org_item("it-orphan").unwrap().is_none(),
             "the withdrawn item is gone from the read path"
@@ -21947,7 +23219,13 @@
     #[test]
     fn list_org_shares_is_scoped_to_the_requested_org() {
         let state = build_state("org-shares-scoped");
-        seed_org_at(&state.db, "org-a", "Alpha", "member", "2026-07-01T00:00:00Z");
+        seed_org_at(
+            &state.db,
+            "org-a",
+            "Alpha",
+            "member",
+            "2026-07-01T00:00:00Z",
+        );
         seed_org_at(&state.db, "org-b", "Beta", "member", "2026-07-02T00:00:00Z");
         state
             .db

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -400,7 +400,7 @@ pub fn run() {
             commands::update_dashboard_tile,
             commands::delete_dashboard_tile,
             commands::reorder_dashboard_tiles,
-            commands::set_dashboard_answer,
+            commands::refresh_dashboard_answer,
             commands::add_reminder,
             commands::pin_moment,
             commands::link_meeting_entities,

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -64,6 +64,7 @@ const VISIBILITY_RETRY_MESSAGE: &str = "content visibility changed; retry the re
 struct VisibilitySnapshot {
     seal_epoch: u64,
     unlocked_folders: HashSet<String>,
+    ask_dispatch_generation: Option<i64>,
 }
 
 /// The exact shared visibility authority used for one MCP request. Production constructs this only
@@ -98,6 +99,10 @@ impl<'a> RpcContext<'a> {
         Ok(VisibilitySnapshot {
             seal_epoch: self.seal_epoch.load(Ordering::SeqCst),
             unlocked_folders,
+            ask_dispatch_generation: match self.db {
+                Some(db) => Some(db.ask_dispatch_generation().map_err(|_| ())?),
+                None => None,
+            },
         })
     }
 }
@@ -816,6 +821,8 @@ fn send_rpc_reply(
                 state.unlocked_folders.as_ref(),
                 deadline,
             ) != Ok(true)
+                || pending.snapshot.ask_dispatch_generation
+                    != state.db.ask_dispatch_generation().ok()
             {
                 drop(lifecycle);
                 let refusal = rpc_err(pending.id, VISIBILITY_RETRY_CODE, VISIBILITY_RETRY_MESSAGE)
@@ -2543,6 +2550,7 @@ mod tests {
             snapshot: VisibilitySnapshot {
                 seal_epoch: state.seal_epoch.load(Ordering::SeqCst),
                 unlocked_folders: HashSet::new(),
+                ask_dispatch_generation: Some(state.db.ask_dispatch_generation().unwrap()),
             },
             outcome: Ok("SECRET_MUST_NOT_RENDER_OR_WRITE".into()),
         };
@@ -2767,6 +2775,7 @@ mod tests {
             snapshot: VisibilitySnapshot {
                 seal_epoch: 0,
                 unlocked_folders: HashSet::new(),
+                ask_dispatch_generation: None,
             },
             outcome: Ok("\u{0001}".repeat(MAX_TOOL_TEXT_BYTES)),
         };
@@ -3316,6 +3325,121 @@ mod tests {
         let _ = std::fs::remove_file(&p);
     }
 
+    #[test]
+    fn content_response_revalidation_discards_materialized_living_answer_after_ask_generation_bump()
+    {
+        const MARKER: &str = "OLD_LIVING_ANSWER_MUST_NOT_REACH_MCP";
+
+        let db_path =
+            crate::storage::db::unique_temp_path("murmur-mcp-living-answer-generation", "sqlite");
+        let state = AppState::init_at(&db_path, TEST_DEK).unwrap();
+        state
+            .db
+            .insert_dashboard(
+                "board-ask-generation",
+                "Ask generation board",
+                None,
+                None,
+                "2026-08-13T10:00:00Z",
+            )
+            .unwrap();
+        state
+            .db
+            .insert_dashboard_living_answer_tile(
+                "tile-ask-generation",
+                "board-ask-generation",
+                4,
+                "What changed?",
+                "[]",
+                "2026-08-13T10:00:01Z",
+            )
+            .unwrap();
+        let budget = {
+            let config = state.config.lock().unwrap();
+            crate::commands::resolved_ask_corpus_budget(&config)
+        };
+        let composite = crate::commands::living_answer_composite_context(
+            &state.db,
+            "board-ask-generation",
+            &HashSet::new(),
+            budget,
+        )
+        .unwrap();
+        assert!(state
+            .db
+            .store_dashboard_living_answer_cas(
+                "tile-ask-generation",
+                "board-ask-generation",
+                "What changed?",
+                MARKER,
+                "2026-08-13T10:01:00Z",
+                "[]",
+                composite.witness.generation,
+                &composite.witness.input_digest,
+                budget,
+            )
+            .unwrap());
+
+        let context = RpcContext::from_state(&state);
+        let params = json!({
+            "name": "get_dashboard",
+            "arguments": { "dashboardId": "board-ask-generation" }
+        });
+        let pending = match handle_tool_call(
+            &context,
+            json!(81),
+            Some(&params),
+            Instant::now() + REQUEST_DEADLINE,
+        ) {
+            RpcReply::Content(pending) => pending,
+            RpcReply::Immediate(response) => {
+                panic!("get_dashboard unexpectedly finalized early: {response}")
+            }
+        };
+        assert!(
+            pending
+                .outcome
+                .as_ref()
+                .is_ok_and(|text| text.contains(MARKER)),
+            "the regression must materialize the valid old-generation cache before the race"
+        );
+
+        {
+            let _lifecycle = state
+                .lifecycle
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            state.db.advance_ask_dispatch_generation().unwrap();
+        }
+        let gate = Arc::new(McpResponseGate::new());
+        let (mut client, mut server) = tcp_pair();
+        send_rpc_reply(
+            &mut server,
+            RpcReply::Content(pending),
+            &state,
+            &gate,
+            Instant::now() + REQUEST_DEADLINE,
+        );
+        drop(server);
+        let mut wire = String::new();
+        client.read_to_string(&mut wire).unwrap();
+        let (_, body) = wire.split_once("\r\n\r\n").expect("complete HTTP reply");
+        let response: Value = serde_json::from_str(body).expect("JSON-RPC response");
+        assert_eq!(response["error"]["code"], VISIBILITY_RETRY_CODE);
+        assert_eq!(
+            response["error"]["message"],
+            Value::String(VISIBILITY_RETRY_MESSAGE.into())
+        );
+        assert!(
+            !response.to_string().contains(MARKER),
+            "the response gate leaked a Living Answer materialized under an old Ask generation"
+        );
+        assert_eq!(gate.active_count(), 0);
+
+        drop(state);
+        let _ = std::fs::remove_file(db_path);
+    }
+
     /// KnowledgeDiff note context is reachable only through the fixed loopback MCP catalog, and a
     /// relock after materialization but before response production discards content AND bounded
     /// source-count metadata. The model-facing/GatedToolExecutor boundary is asserted separately in
@@ -3689,6 +3813,7 @@ mod tests {
         let snapshot = VisibilitySnapshot {
             seal_epoch: 41,
             unlocked_folders: original.clone(),
+            ask_dispatch_generation: None,
         };
         let epoch = AtomicU64::new(41);
         let unlocked = Mutex::new(original);

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -2607,7 +2607,7 @@ async fn summarize_and_export(
     let Some(vault_path) = config.vault_path.as_deref().filter(|p| !p.is_empty()) else {
         // Title the meeting so the library/detail view shows it (same title we'd derive on export).
         let title =
-            finalize_note_without_vault(&state.db, meeting_id, classification.as_str(), date_iso)?;
+            finalize_note_without_vault(state, meeting_id, classification.as_str(), date_iso)?;
         emit_status(
             app,
             "saved",
@@ -2646,7 +2646,7 @@ async fn summarize_and_export(
     // `meeting_locked` decision was read under the SAME lifecycle guard as the persist (W4).
     if meeting_locked {
         let title =
-            finalize_note_without_vault(&state.db, meeting_id, classification.as_str(), date_iso)?;
+            finalize_note_without_vault(state, meeting_id, classification.as_str(), date_iso)?;
         emit_status(
             app,
             "saved",
@@ -2773,7 +2773,7 @@ async fn summarize_and_export(
         // is written (the note is already durably sealed in the DB by that lock). Finish exactly
         // like the meeting-locked path above.
         let title =
-            finalize_note_without_vault(&state.db, meeting_id, classification.as_str(), date_iso)?;
+            finalize_note_without_vault(state, meeting_id, classification.as_str(), date_iso)?;
         emit_status(
             app,
             "saved",
@@ -2892,15 +2892,21 @@ fn persist_note_exported_path(
 /// from the note so the library/detail view shows it. The Obsidian vault is EXPORT-ONLY, so the
 /// no-vault path is a SUCCESS — it NEVER builds an `Export` error. Returns the derived title (for
 /// the graph-entity step). DB-only (no `AppHandle`/provider) so the no-vault contract is
-/// unit-testable in isolation.
+/// unit-testable in isolation. The title is part of the exact dashboard corpus witness, so the
+/// short canonical write shares the lifecycle barrier with dashboard-history authorization and
+/// hydration. Title derivation stays outside the critical section; the guard covers only the DB
+/// mutation and is never held over provider, graph, embedding, or filesystem work.
 fn finalize_note_without_vault(
-    db: &crate::storage::Db,
+    state: &AppState,
     meeting_id: &str,
     markdown: &str,
     date_iso: &str,
 ) -> Result<String> {
     let title = derive_title(markdown, date_iso);
-    db.set_meeting_title(meeting_id, &title)?;
+    {
+        let _lifecycle = crate::commands::lifecycle_guard(state);
+        state.db.set_meeting_title(meeting_id, &title)?;
+    }
     Ok(title)
 }
 
@@ -4568,7 +4574,7 @@ mod tests {
 
     /// The no-vault branch of `summarize_and_export`: with no vault configured the note is saved
     /// to the canonical DB (markdown + `exported_path = None`) and the meeting finishes in the
-    /// terminal `Summarized` state — NOT `Error`. We exercise the real DB-only tail
+    /// terminal `Summarized` state — NOT `Error`. We exercise the real state-backed tail
     /// (`finalize_note_without_vault`) plus the pre-branch writes `summarize_and_export` performs
     /// before it (the provider call + `AppHandle` emit are not unit-testable, so they're excluded;
     /// everything that determines success-vs-error and what lands in the DB is covered here).
@@ -4576,7 +4582,8 @@ mod tests {
     fn finalize_note_without_vault_saves_note_summarized_not_error() {
         use crate::storage::models::Meeting;
 
-        let db = crate::storage::Db::open_with_key(&temp_db_path("no-vault"), TEST_DEK).unwrap();
+        let state = AppState::init_at(&temp_db_path("no-vault"), TEST_DEK).unwrap();
+        let db = &state.db;
         let mid = "m-no-vault";
 
         // A freshly recorded meeting, mid-pipeline (still Recording, untitled).
@@ -4610,7 +4617,7 @@ mod tests {
         .unwrap();
 
         // The no-vault tail: titles the meeting and returns Ok (never the Export error).
-        let title = finalize_note_without_vault(&db, mid, markdown, "2026-06-27").unwrap();
+        let title = finalize_note_without_vault(&state, mid, markdown, "2026-06-27").unwrap();
         assert_eq!(title, "Q3 Planning");
 
         // Note is saved to the canonical DB with NO export path.
@@ -4633,6 +4640,69 @@ mod tests {
             "no-vault recording must finish Summarized, never Error"
         );
         assert_ne!(meeting.status, MeetingStatus::Error);
+    }
+
+    /// Exact dashboard-history provenance includes the meeting title. A no-vault pipeline finish
+    /// must therefore wait for the same lifecycle interval that authorizes and hydrates a durable
+    /// dashboard conversation: while the interval is held, neither the title write nor its return
+    /// can complete; after release, the canonical title lands exactly once.
+    #[test]
+    fn finalize_note_without_vault_title_waits_for_lifecycle_authorization() {
+        use crate::storage::models::Meeting;
+        use std::sync::{mpsc, Arc};
+        use std::time::Duration;
+
+        let state = Arc::new(
+            AppState::init_at(&temp_db_path("no-vault-title-lifecycle"), TEST_DEK).unwrap(),
+        );
+        let mid = "m-no-vault-title-lifecycle";
+        state
+            .db
+            .insert_meeting(&Meeting {
+                id: mid.to_string(),
+                started_at: "2026-06-27T09:00:00Z".to_string(),
+                ended_at: Some("2026-06-27T09:10:00Z".to_string()),
+                title: None,
+                duration_s: 600,
+                audio_path: None,
+                status: MeetingStatus::Summarized,
+                folder_id: None,
+            })
+            .unwrap();
+
+        let lifecycle = crate::commands::lifecycle_guard(state.as_ref());
+        let worker_state = Arc::clone(&state);
+        let (started_tx, started_rx) = mpsc::channel();
+        let (done_tx, done_rx) = mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            let result = finalize_note_without_vault(
+                worker_state.as_ref(),
+                mid,
+                "---\ntitle: Authorized title\n---\nBody.",
+                "2026-06-27",
+            );
+            done_tx.send(result).unwrap();
+        });
+
+        started_rx.recv().unwrap();
+        assert!(
+            done_rx.recv_timeout(Duration::from_millis(100)).is_err(),
+            "the title mutation must remain blocked inside an active history lifecycle interval"
+        );
+        assert_eq!(
+            state.db.get_meeting(mid).unwrap().unwrap().title,
+            None,
+            "no title may land before the lifecycle interval is released"
+        );
+
+        drop(lifecycle);
+        assert_eq!(done_rx.recv().unwrap().unwrap(), "Authorized title");
+        worker.join().unwrap();
+        assert_eq!(
+            state.db.get_meeting(mid).unwrap().unwrap().title.as_deref(),
+            Some("Authorized title")
+        );
     }
 
     /// brain2 realtime notes: `fold_manual_notes` appends a `## My notes` section with the typed

--- a/src-tauri/src/reason.rs
+++ b/src-tauri/src/reason.rs
@@ -768,6 +768,31 @@ impl ReasonerCell {
         self.current_for_with_token(role, None)
     }
 
+    /// Resolve from an exact caller-captured config. Durable Ask uses this together with its
+    /// dispatch-generation admission so provider construction cannot silently switch to a newer
+    /// target between preflight and the first authorized poll.
+    pub(crate) fn current_for_config(
+        &self,
+        role: Role,
+        cfg: &AppConfig,
+    ) -> Arc<dyn LocalReasoner> {
+        #[cfg(test)]
+        if let Some(f) = &self.fixed {
+            return Arc::clone(f);
+        }
+        let target = roles::reasoner_target(role, cfg);
+        match target.connection.as_str() {
+            roles::CONN_OFF => Arc::new(StubReasoner),
+            roles::CONN_LOCAL => admit_reasoner(self.local_cached(cfg, &target), None),
+            roles::CONN_AFM => admit_reasoner(afm::afm_reasoner_arc(cfg), None),
+            _ => Arc::new(CloudReasoner::for_role(
+                Arc::new(Mutex::new(cfg.clone())),
+                role,
+                Arc::clone(&self.heavy),
+            )),
+        }
+    }
+
     /// Exact-session dispatch for an explicitly recording-owned inference segment. The token is
     /// retained by both the admitted local-model decorator and the redacted cloud provider; the
     /// stub remains model-free.
@@ -1629,7 +1654,7 @@ fn block_on_complete(
 }
 
 fn block_on_complete_admitted(
-    provider: &Arc<dyn SummarizerProvider>,
+    provider_factory: impl FnOnce() -> Result<Arc<dyn SummarizerProvider>> + Send,
     system: &str,
     user: &str,
     admission: &crate::state::ContentDispatchAdmission,
@@ -1643,7 +1668,10 @@ fn block_on_complete_admitted(
                     .map_err(|e| {
                         AppError::Summarize(format!("cloud reasoner: runtime build failed: {e}"))
                     })?;
-                rt.block_on(admission.run(|| provider.complete(system, user)))
+                rt.block_on(admission.run(|| async {
+                    let provider = provider_factory()?;
+                    provider.complete(system, user).await
+                }))
             })
             .join()
             .map_err(|_| AppError::Summarize("cloud reasoner: worker thread panicked".into()))?
@@ -1667,8 +1695,7 @@ impl LocalReasoner for CloudReasoner {
         user: &str,
         admission: &crate::state::ContentDispatchAdmission,
     ) -> Result<String> {
-        let provider = self.build_provider()?;
-        block_on_complete_admitted(&provider, system, user, admission)
+        block_on_complete_admitted(|| self.build_provider(), system, user, admission)
     }
 
     fn reason_with_admitted(

--- a/src-tauri/src/storage/ask_conversation_store.rs
+++ b/src-tauri/src/storage/ask_conversation_store.rs
@@ -14,7 +14,7 @@ use crate::error::{AppError, Result};
 use crate::storage::db::{map_err, visibility_clause, Db};
 use crate::storage::models::{
     AskConversation, AskConversationMessage, AskConversationScope, AskConversationSourceRef,
-    AskConversationSummary, SourceRef, VaultSource,
+    AskConversationSummary, DashboardScopeRef, SourceRef, VaultSource,
 };
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -47,6 +47,37 @@ pub(crate) struct PersistedAskExchange {
 pub(crate) struct AskConversationContext {
     pub(crate) turns: Vec<crate::storage::models::ChatTurn>,
     pub(crate) cursor: AskConversationCursor,
+    pub(crate) dashboard: Option<AskDashboardProvenance>,
+}
+
+/// Content-free durable-thread preflight. Dashboard provenance must be revalidated before any
+/// message `content` column is hydrated.
+#[derive(Debug, Clone)]
+pub(crate) struct AskConversationPreflight {
+    pub(crate) cursor: AskConversationCursor,
+    pub(crate) dashboard: Option<AskDashboardProvenance>,
+    pub(crate) ask_dispatch_generation: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AskDashboardProvenance {
+    pub(crate) dashboard_id: String,
+    pub(crate) generation: i64,
+    pub(crate) input_digest: String,
+    pub(crate) selected_sources: Vec<SourceRef>,
+}
+
+struct ExistingConversationRow {
+    scope_kind: String,
+    scope_ref: Option<String>,
+    provenance_mode: String,
+    visibility_generation: i64,
+    revision: i64,
+    dependencies_ok: bool,
+    dashboard_id: Option<String>,
+    dashboard_context_generation: Option<i64>,
+    dashboard_context_digest: Option<String>,
+    ask_dispatch_generation: Option<i64>,
 }
 
 fn decode_json<T: serde::de::DeserializeOwned>(value: &str, label: &str) -> Result<T> {
@@ -72,52 +103,76 @@ impl Db {
         Ok(rows)
     }
 
-    pub(crate) fn list_ask_conversations(
+    /// Content-free list preflight. Callers validate dashboard provenance before asking for the
+    /// title-bearing summary.
+    pub(crate) fn list_ask_conversation_ids(
         &self,
         scope: &AskConversationScope,
         unlocked: &HashSet<String>,
-    ) -> Result<Vec<AskConversationSummary>> {
+    ) -> Result<Vec<String>> {
         let (kind, scope_ref) = scope.storage_parts();
         let conn = self.lock();
         let visible = visibility_clause("f", unlocked);
         let mut stmt = conn
             .prepare(&format!(
-                "SELECT id, title, created_at, updated_at,
-                        (SELECT COUNT(*) FROM ask_conversation_messages m
-                          WHERE m.conversation_id = c.id)
-                   FROM ask_conversations c
-                  WHERE scope_kind = ?1 AND scope_ref IS ?2
-                    AND provenance_mode = 'globalDerived'
-                    AND c.visibility_generation =
-                        (SELECT visibility_generation FROM ask_history_state WHERE singleton = 1)
-                    AND EXISTS (SELECT 1 FROM ask_conversation_messages m0
-                                 WHERE m0.conversation_id = c.id)
+                "SELECT c.id FROM ask_conversations c
+                  WHERE scope_kind=?1 AND scope_ref IS ?2
+                    AND provenance_mode='globalDerived'
+                    AND c.visibility_generation=(SELECT visibility_generation FROM ask_history_state WHERE singleton=1)
+                    AND typeof(c.ask_dispatch_generation)='integer'
+                    AND c.ask_dispatch_generation>=0
+                    AND c.ask_dispatch_generation=(SELECT generation FROM ask_dispatch_state WHERE singleton=1
+                      AND typeof(generation)='integer' AND generation>=0)
+                    AND EXISTS (SELECT 1 FROM ask_conversation_messages m WHERE m.conversation_id=c.id)
+                    AND (c.dashboard_id IS NULL OR EXISTS (
+                      SELECT 1 FROM dashboards board JOIN dashboard_context_state state ON state.dashboard_id=board.id
+                       WHERE board.id=c.dashboard_id AND state.exists_now=1
+                         AND state.generation=c.dashboard_context_generation))
                     AND NOT EXISTS (
-                      SELECT 1 FROM ask_conversation_dependencies d
-                      LEFT JOIN folders f ON f.id = d.dependency_ref
-                       WHERE d.conversation_id = c.id
-                         AND d.dependency_kind = 'folder'
-                         AND (f.id IS NULL OR NOT {visible})
-                    )
+                      SELECT 1 FROM ask_conversation_dependencies d LEFT JOIN folders f ON f.id=d.dependency_ref
+                       WHERE d.conversation_id=c.id AND d.dependency_kind='folder'
+                         AND (f.id IS NULL OR NOT {visible}))
                   ORDER BY updated_at DESC, id DESC LIMIT ?3"
             ))
             .map_err(map_err)?;
         let rows = stmt
             .query_map(
                 params![kind, scope_ref, ASK_CONVERSATION_LIST_LIMIT as i64],
-                |r| {
+                |row| row.get(0),
+            )
+            .map_err(map_err)?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(map_err)?;
+        Ok(rows)
+    }
+
+    pub(crate) fn ask_conversation_summary_after_preflight(
+        &self,
+        scope: &AskConversationScope,
+        id: &str,
+    ) -> Result<Option<AskConversationSummary>> {
+        let (kind, scope_ref) = scope.storage_parts();
+        self.lock()
+            .query_row(
+                "SELECT title,created_at,updated_at,
+                        (SELECT COUNT(*) FROM ask_conversation_messages m WHERE m.conversation_id=c.id)
+                   FROM ask_conversations c WHERE c.id=?1 AND scope_kind=?2 AND scope_ref IS ?3
+                    AND typeof(c.ask_dispatch_generation)='integer'
+                    AND c.ask_dispatch_generation=(SELECT generation FROM ask_dispatch_state WHERE singleton=1
+                      AND typeof(generation)='integer' AND generation>=0)",
+                params![id, kind, scope_ref],
+                |row| {
                     Ok(AskConversationSummary {
-                        id: r.get(0)?,
+                        id: id.to_string(),
                         scope: scope.clone(),
-                        title: r.get(1)?,
-                        created_at: r.get(2)?,
-                        updated_at: r.get(3)?,
-                        message_count: r.get::<_, i64>(4)?.max(0) as u32,
+                        title: row.get(0)?,
+                        created_at: row.get(1)?,
+                        updated_at: row.get(2)?,
+                        message_count: row.get::<_, i64>(3)?.max(0) as u32,
                     })
                 },
             )
-            .map_err(map_err)?;
-        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .optional()
             .map_err(map_err)
     }
 
@@ -133,14 +188,24 @@ impl Db {
         let thread = conn
             .query_row(
                 &format!(
-                    "SELECT title, selected_sources_json, created_at, updated_at
+                    "SELECT title, selected_sources_json, dashboard_id, created_at, updated_at
                    FROM ask_conversations c
                   WHERE c.id = ?1 AND c.scope_kind = ?2 AND c.scope_ref IS ?3
                     AND c.provenance_mode = 'globalDerived'
                     AND c.visibility_generation =
                         (SELECT visibility_generation FROM ask_history_state WHERE singleton = 1)
+                    AND c.ask_dispatch_generation =
+                        (SELECT generation FROM ask_dispatch_state WHERE singleton = 1
+                          AND typeof(generation)='integer' AND generation>=0)
+                    AND typeof(c.ask_dispatch_generation)='integer'
                     AND EXISTS (SELECT 1 FROM ask_conversation_messages m0
                                  WHERE m0.conversation_id = c.id)
+                    AND (c.dashboard_id IS NULL OR EXISTS (
+                      SELECT 1 FROM dashboards board
+                      JOIN dashboard_context_state state ON state.dashboard_id = board.id
+                       WHERE board.id = c.dashboard_id AND state.exists_now = 1
+                         AND state.generation = c.dashboard_context_generation
+                    ))
                     AND NOT EXISTS (
                       SELECT 1 FROM ask_conversation_dependencies d
                       LEFT JOIN folders f ON f.id = d.dependency_ref
@@ -154,14 +219,16 @@ impl Db {
                     Ok((
                         r.get::<_, String>(0)?,
                         r.get::<_, String>(1)?,
-                        r.get::<_, String>(2)?,
+                        r.get::<_, Option<String>>(2)?,
                         r.get::<_, String>(3)?,
+                        r.get::<_, String>(4)?,
                     ))
                 },
             )
             .optional()
             .map_err(map_err)?;
-        let Some((title, selected_sources_json, created_at, updated_at)) = thread else {
+        let Some((title, selected_sources_json, dashboard_id, created_at, updated_at)) = thread
+        else {
             return Ok(None);
         };
         let mut stmt = conn
@@ -171,6 +238,11 @@ impl Db {
                      SELECT id, ordinal, role, content, sources_json, citations_json, created_at
                        FROM ask_conversation_messages
                       WHERE conversation_id = ?1
+                        AND EXISTS (SELECT 1 FROM ask_conversations c
+                          WHERE c.id=conversation_id AND c.ask_dispatch_generation=
+                            (SELECT generation FROM ask_dispatch_state WHERE singleton=1
+                              AND typeof(generation)='integer' AND generation>=0)
+                            AND typeof(c.ask_dispatch_generation)='integer')
                       ORDER BY ordinal DESC LIMIT ?2
                    ) newest
                   ORDER BY ordinal ASC",
@@ -212,6 +284,14 @@ impl Db {
                 });
             }
         }
+        let dashboard = match dashboard_id.as_deref() {
+            Some(id) => self.get_dashboard(id)?.map(|dashboard| DashboardScopeRef {
+                id: dashboard.id,
+                title: dashboard.title,
+                emoji: dashboard.emoji,
+            }),
+            None => None,
+        };
         let mut messages = Vec::new();
         for (id, ordinal, role, content, sources_json, citations_json, created_at) in raw_messages {
             messages.push(AskConversationMessage {
@@ -229,32 +309,45 @@ impl Db {
             scope: scope.clone(),
             title,
             selected_sources,
+            dashboard,
             messages,
             created_at,
             updated_at,
         }))
     }
 
-    /// Canonical bounded prompt history. Unknown/wrong-scope/invisible IDs all return `None`.
-    pub(crate) fn ask_conversation_context(
+    pub(crate) fn ask_conversation_preflight(
         &self,
         scope: &AskConversationScope,
         conversation_id: &str,
         unlocked: &HashSet<String>,
-    ) -> Result<Option<AskConversationContext>> {
+    ) -> Result<Option<AskConversationPreflight>> {
         let (kind, scope_ref) = scope.storage_parts();
         let conn = self.lock();
         let visible = visibility_clause("f", unlocked);
         let exists = conn
             .query_row(
                 &format!(
-                    "SELECT c.revision FROM ask_conversations c
+                    "SELECT c.revision, c.dashboard_id, c.dashboard_context_generation,
+                            c.dashboard_context_digest, c.selected_sources_json,
+                            c.ask_dispatch_generation
+                       FROM ask_conversations c
                   WHERE c.id = ?1 AND c.scope_kind = ?2 AND c.scope_ref IS ?3
                     AND c.provenance_mode = 'globalDerived'
                     AND c.visibility_generation =
                         (SELECT visibility_generation FROM ask_history_state WHERE singleton = 1)
+                    AND c.ask_dispatch_generation =
+                        (SELECT generation FROM ask_dispatch_state WHERE singleton = 1
+                          AND typeof(generation)='integer' AND generation>=0)
+                    AND typeof(c.ask_dispatch_generation)='integer'
                     AND EXISTS (SELECT 1 FROM ask_conversation_messages m0
                                  WHERE m0.conversation_id = c.id)
+                    AND (c.dashboard_id IS NULL OR EXISTS (
+                      SELECT 1 FROM dashboards board
+                      JOIN dashboard_context_state state ON state.dashboard_id = board.id
+                       WHERE board.id = c.dashboard_id AND state.exists_now = 1
+                         AND state.generation = c.dashboard_context_generation
+                    ))
                     AND NOT EXISTS (
                       SELECT 1 FROM ask_conversation_dependencies d
                       LEFT JOIN folders f ON f.id = d.dependency_ref
@@ -264,12 +357,49 @@ impl Db {
                     )"
                 ),
                 params![conversation_id, kind, scope_ref],
-                |row| row.get::<_, i64>(0),
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                        row.get::<_, Option<i64>>(2)?,
+                        row.get::<_, Option<String>>(3)?,
+                        row.get::<_, String>(4)?,
+                        row.get::<_, i64>(5)?,
+                    ))
+                },
             )
             .optional()
             .map_err(map_err)?;
-        let Some(expected_revision) = exists else {
+        let Some((
+            expected_revision,
+            dashboard_id,
+            dashboard_generation,
+            dashboard_digest,
+            selected_json,
+            ask_dispatch_generation,
+        )) = exists
+        else {
             return Ok(None);
+        };
+        let dashboard = match (dashboard_id, dashboard_generation, dashboard_digest) {
+            (Some(dashboard_id), Some(generation), Some(input_digest)) => {
+                let persisted: Vec<PersistedAskSourceRef> =
+                    decode_json(&selected_json, "Ask selected sources")?;
+                Some(AskDashboardProvenance {
+                    dashboard_id,
+                    generation,
+                    input_digest,
+                    selected_sources: persisted
+                        .into_iter()
+                        .map(|source| SourceRef {
+                            kind: source.kind,
+                            id: source.id,
+                        })
+                        .collect(),
+                })
+            }
+            (None, None, None) => None,
+            _ => return Ok(None),
         };
         let expected_next_ordinal = conn
             .query_row(
@@ -279,15 +409,44 @@ impl Db {
                 |row| row.get::<_, i64>(0),
             )
             .map_err(map_err)?;
+        Ok(Some(AskConversationPreflight {
+            cursor: AskConversationCursor {
+                expected_next_ordinal,
+                expected_revision,
+            },
+            dashboard,
+            ask_dispatch_generation,
+        }))
+    }
+
+    /// Hydrate canonical bounded prompt history only after the caller validated preflight
+    /// provenance under the current lifecycle guard.
+    pub(crate) fn ask_conversation_context_after_preflight(
+        &self,
+        conversation_id: &str,
+        preflight: AskConversationPreflight,
+    ) -> Result<AskConversationContext> {
+        let conn = self.lock();
         let mut stmt = conn
             .prepare(
-                "SELECT role, content FROM ask_conversation_messages
-                  WHERE conversation_id = ?1 ORDER BY ordinal DESC LIMIT ?2",
+                "SELECT m.role, m.content FROM ask_conversation_messages m
+                  JOIN ask_conversations c ON c.id=m.conversation_id
+                  WHERE m.conversation_id = ?1
+                    AND c.ask_dispatch_generation=?3
+                    AND c.ask_dispatch_generation=
+                        (SELECT generation FROM ask_dispatch_state WHERE singleton=1
+                          AND typeof(generation)='integer' AND generation>=0)
+                    AND typeof(c.ask_dispatch_generation)='integer'
+                  ORDER BY m.ordinal DESC LIMIT ?2",
             )
             .map_err(map_err)?;
         let rows = stmt
             .query_map(
-                params![conversation_id, ASK_CONVERSATION_CONTEXT_TURNS as i64],
+                params![
+                    conversation_id,
+                    ASK_CONVERSATION_CONTEXT_TURNS as i64,
+                    preflight.ask_dispatch_generation
+                ],
                 |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)),
             )
             .map_err(map_err)?;
@@ -309,20 +468,34 @@ impl Db {
             });
         }
         bounded_newest_first.reverse();
-        Ok(Some(AskConversationContext {
+        Ok(AskConversationContext {
             turns: bounded_newest_first,
-            cursor: AskConversationCursor {
-                expected_next_ordinal,
-                expected_revision,
-            },
-        }))
+            cursor: preflight.cursor,
+            dashboard: preflight.dashboard,
+        })
+    }
+
+    /// Test-fixture convenience for non-dashboard conversations.
+    #[cfg(test)]
+    pub(crate) fn ask_conversation_context(
+        &self,
+        scope: &AskConversationScope,
+        conversation_id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Option<AskConversationContext>> {
+        let Some(preflight) = self.ask_conversation_preflight(scope, conversation_id, unlocked)?
+        else {
+            return Ok(None);
+        };
+        self.ask_conversation_context_after_preflight(conversation_id, preflight)
+            .map(Some)
     }
 
     /// Atomically create-or-continue a conversation and append exactly one user/assistant pair.
     /// The backend generates the UUID; provider failures never call this method, so no orphan user
     /// row or empty conversation can exist.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn persist_ask_exchange_cas(
+    pub(crate) fn persist_ask_exchange_cas_with_dispatch(
         &self,
         scope: &AskConversationScope,
         conversation_id: Option<&str>,
@@ -333,8 +506,20 @@ impl Db {
         assistant_sources: &[VaultSource],
         assistant_citations: &[String],
         visible_folder_ids: &[String],
+        dashboard_id: Option<&str>,
+        dashboard_context_generation: Option<i64>,
+        dashboard_context_digest: Option<&str>,
+        expected_ask_dispatch_generation: i64,
         now: &str,
     ) -> Result<PersistedAskExchange> {
+        let provenance_fields = usize::from(dashboard_id.is_some())
+            + usize::from(dashboard_context_generation.is_some())
+            + usize::from(dashboard_context_digest.is_some());
+        if provenance_fields != 0 && provenance_fields != 3 {
+            return Err(AppError::InvalidArg(
+                "dashboard provenance must be complete".into(),
+            ));
+        }
         let question = question.trim();
         let answer = answer.trim();
         if question.is_empty() || answer.is_empty() {
@@ -370,8 +555,21 @@ impl Db {
                 |row| row.get::<_, i64>(0),
             )
             .map_err(map_err)?;
+        let current_ask_dispatch_generation = tx
+            .query_row(
+                "SELECT generation FROM ask_dispatch_state WHERE singleton=1
+                   AND typeof(generation)='integer' AND generation>=0",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(map_err)?;
+        if current_ask_dispatch_generation != expected_ask_dispatch_generation {
+            return Err(AppError::Locked(
+                "Ask provider changed while generating the answer".into(),
+            ));
+        }
         let next_ordinal = if conversation_id.is_some() {
-            let existing: Option<(String, Option<String>, String, i64, i64, bool)> = tx
+            let existing: Option<ExistingConversationRow> = tx
                 .query_row(
                     "SELECT c.scope_kind, c.scope_ref, c.provenance_mode,
                             c.visibility_generation, c.revision,
@@ -379,38 +577,41 @@ impl Db {
                                        LEFT JOIN folders f ON f.id=d.dependency_ref
                                       WHERE d.conversation_id = c.id
                                         AND d.dependency_kind='folder'
-                                        AND f.id IS NULL)
+                                        AND f.id IS NULL),
+                            c.dashboard_id, c.dashboard_context_generation,
+                            c.dashboard_context_digest, c.ask_dispatch_generation
                        FROM ask_conversations c WHERE c.id = ?1",
                     params![id],
                     |r| {
-                        Ok((
-                            r.get(0)?,
-                            r.get(1)?,
-                            r.get(2)?,
-                            r.get(3)?,
-                            r.get(4)?,
-                            r.get(5)?,
-                        ))
+                        Ok(ExistingConversationRow {
+                            scope_kind: r.get(0)?,
+                            scope_ref: r.get(1)?,
+                            provenance_mode: r.get(2)?,
+                            visibility_generation: r.get(3)?,
+                            revision: r.get(4)?,
+                            dependencies_ok: r.get(5)?,
+                            dashboard_id: r.get(6)?,
+                            dashboard_context_generation: r.get(7)?,
+                            dashboard_context_digest: r.get(8)?,
+                            ask_dispatch_generation: r.get(9)?,
+                        })
                     },
                 )
                 .optional()
                 .map_err(map_err)?;
-            let Some((
-                existing_kind,
-                existing_ref,
-                provenance,
-                generation,
-                revision,
-                dependencies_ok,
-            )) = existing
+            let Some(existing) = existing
             else {
                 return Err(AppError::InvalidArg("conversation is unavailable".into()));
             };
-            if existing_kind != kind
-                || existing_ref.as_deref() != scope_ref
-                || provenance != "globalDerived"
-                || generation != current_generation
-                || !dependencies_ok
+            if existing.scope_kind != kind
+                || existing.scope_ref.as_deref() != scope_ref
+                || existing.provenance_mode != "globalDerived"
+                || existing.visibility_generation != current_generation
+                || !existing.dependencies_ok
+                || existing.dashboard_id.as_deref() != dashboard_id
+                || existing.dashboard_context_generation != dashboard_context_generation
+                || existing.dashboard_context_digest.as_deref() != dashboard_context_digest
+                || existing.ask_dispatch_generation != Some(expected_ask_dispatch_generation)
             {
                 return Err(AppError::InvalidArg("conversation is unavailable".into()));
             }
@@ -425,7 +626,7 @@ impl Db {
             if resume_cursor
                 != Some(AskConversationCursor {
                     expected_next_ordinal: next,
-                    expected_revision: revision,
+                    expected_revision: existing.revision,
                 })
             {
                 return Err(AppError::InvalidArg(
@@ -442,17 +643,23 @@ impl Db {
             let title = ask_conversation_title(question);
             tx.execute(
                 "INSERT INTO ask_conversations
-                    (id, scope_kind, scope_ref, title, selected_sources_json,
-                     provenance_mode, visibility_generation, revision, created_at, updated_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, 'globalDerived', ?6, 1, ?7, ?7)",
+                    (id, scope_kind, scope_ref, title, selected_sources_json, dashboard_id,
+                     dashboard_context_generation, dashboard_context_digest,
+                     ask_dispatch_generation, provenance_mode, visibility_generation, revision,
+                     created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, 'globalDerived', ?10, 1, ?11, ?11)",
                 params![
                     id,
                     kind,
                     scope_ref,
                     title,
                     selected_sources_json,
+                    dashboard_id,
+                    dashboard_context_generation,
+                    dashboard_context_digest,
+                    expected_ask_dispatch_generation,
                     current_generation,
-                    now
+                    now,
                 ],
             )
             .map_err(map_err)?;
@@ -521,6 +728,42 @@ impl Db {
         })
     }
 
+    #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn persist_ask_exchange_cas(
+        &self,
+        scope: &AskConversationScope,
+        conversation_id: Option<&str>,
+        resume_cursor: Option<AskConversationCursor>,
+        question: &str,
+        answer: &str,
+        selected_sources: &[SourceRef],
+        assistant_sources: &[VaultSource],
+        assistant_citations: &[String],
+        visible_folder_ids: &[String],
+        dashboard_id: Option<&str>,
+        dashboard_context_generation: Option<i64>,
+        dashboard_context_digest: Option<&str>,
+        now: &str,
+    ) -> Result<PersistedAskExchange> {
+        self.persist_ask_exchange_cas_with_dispatch(
+            scope,
+            conversation_id,
+            resume_cursor,
+            question,
+            answer,
+            selected_sources,
+            assistant_sources,
+            assistant_citations,
+            visible_folder_ids,
+            dashboard_id,
+            dashboard_context_generation,
+            dashboard_context_digest,
+            self.ask_dispatch_generation()?,
+            now,
+        )
+    }
+
     /// Test-fixture convenience only. Production durable sends must carry the cursor returned by
     /// `ask_conversation_context` into `persist_ask_exchange_cas`; this helper snapshots it
     /// immediately and therefore cannot model a provider-await race.
@@ -544,7 +787,7 @@ impl Db {
                 .map(|context| context.cursor),
             None => None,
         };
-        self.persist_ask_exchange_cas(
+        self.persist_ask_exchange_cas_with_dispatch(
             scope,
             conversation_id,
             cursor,
@@ -554,6 +797,10 @@ impl Db {
             assistant_sources,
             assistant_citations,
             visible_folder_ids,
+            None,
+            None,
+            None,
+            self.ask_dispatch_generation()?,
             now,
         )
         .map(|exchange| exchange.conversation_id)
@@ -773,6 +1020,9 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
+            None,
+            None,
             "2026-08-06T10:01:00Z",
         )
         .unwrap();
@@ -786,6 +1036,9 @@ mod tests {
             &[],
             &[],
             &[],
+            None,
+            None,
+            None,
             "2026-08-06T10:01:01Z",
         );
         assert!(matches!(stale, Err(AppError::InvalidArg(_))), "{stale:?}");
@@ -841,9 +1094,9 @@ mod tests {
         let unlocked = HashSet::new();
 
         for (scope_index, scope) in scopes.iter().enumerate() {
-            let listed = db.list_ask_conversations(scope, &unlocked).unwrap();
+            let listed = db.list_ask_conversation_ids(scope, &unlocked).unwrap();
             assert_eq!(listed.len(), 1);
-            assert_eq!(listed[0].id, ids[scope_index]);
+            assert_eq!(listed[0], ids[scope_index]);
             for (id_index, id) in ids.iter().enumerate() {
                 let expected = scope_index == id_index;
                 assert_eq!(
@@ -878,13 +1131,22 @@ mod tests {
     fn list_order_cap_and_load_keep_the_newest_window() {
         let db = db("bounds");
         let scope = AskConversationScope::Vault;
-        for index in 0..55 {
-            save(&db, &scope, None, &format!("2026-08-06T10:{index:02}:00Z"));
-        }
+        let saved = (0..55)
+            .map(|index| {
+                save(
+                    &db,
+                    &scope,
+                    None,
+                    &format!("2026-08-06T10:{index:02}:00Z"),
+                )
+            })
+            .collect::<Vec<_>>();
         let unlocked = HashSet::new();
-        let list = db.list_ask_conversations(&scope, &unlocked).unwrap();
+        let list = db.list_ask_conversation_ids(&scope, &unlocked).unwrap();
         assert_eq!(list.len(), ASK_CONVERSATION_LIST_LIMIT);
-        assert!(list[0].updated_at > list[1].updated_at);
+        assert_eq!(list[0], saved[54]);
+        assert_eq!(list[1], saved[53]);
+        assert_eq!(list.last(), Some(&saved[5]));
 
         let thread = save(&db, &scope, None, "2026-08-06T11:00:00Z");
         for index in 0..55 {
@@ -949,9 +1211,10 @@ mod tests {
         db.publish_fresh_folder_lock_and_purge_reminder_derived("f-empty", &[7; 48])
             .unwrap();
         assert!(db
-            .list_ask_conversations(&scope, &HashSet::new())
+            .list_ask_conversation_ids(&scope, &HashSet::new())
             .unwrap()
             .is_empty());
+
         let count: i64 = db
             .lock()
             .query_row("SELECT COUNT(*) FROM ask_conversations", [], |r| r.get(0))
@@ -971,9 +1234,11 @@ mod tests {
             .unwrap();
         let scope = AskConversationScope::Vault;
         let id = save(&db, &scope, None, "2026-08-06T10:00:00Z");
-        let list = db.list_ask_conversations(&scope, &HashSet::new()).unwrap();
+        let list = db
+            .list_ask_conversation_ids(&scope, &HashSet::new())
+            .unwrap();
         assert_eq!(list.len(), 1);
-        assert_eq!(list[0].id, id);
+        assert_eq!(list[0], id);
     }
 
     #[test]
@@ -1046,7 +1311,7 @@ mod tests {
             "oracle requires the simulated missed-delete row to survive physically"
         );
         assert!(reopened
-            .list_ask_conversations(&scope, &HashSet::new())
+            .list_ask_conversation_ids(&scope, &HashSet::new())
             .unwrap()
             .is_empty());
         assert!(reopened
@@ -1156,7 +1421,7 @@ mod tests {
             .unwrap();
         let scope = AskConversationScope::Vault;
         assert!(db
-            .list_ask_conversations(&scope, &HashSet::new())
+            .list_ask_conversation_ids(&scope, &HashSet::new())
             .unwrap()
             .is_empty());
         assert!(db
@@ -1233,5 +1498,191 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(loaded.selected_sources.is_empty());
+    }
+
+    #[test]
+    fn dashboard_history_persists_id_only_and_live_resolves_chrome() {
+        let db = db("dashboard-id-only");
+        db.insert_dashboard(
+            "board-a",
+            "Original title",
+            Some("🧭"),
+            None,
+            "2026-08-06T09:00:00Z",
+        )
+        .unwrap();
+        let scope = AskConversationScope::Vault;
+        let exchange = db
+            .persist_ask_exchange_cas(
+                &scope,
+                None,
+                None,
+                "Question",
+                "Answer",
+                &[],
+                &[],
+                &[],
+                &[],
+                Some("board-a"),
+                Some(1),
+                Some("exact-composite-digest"),
+                "2026-08-06T10:00:00Z",
+            )
+            .unwrap();
+
+        let stored: (Option<String>, String) = db
+            .lock()
+            .query_row(
+                "SELECT dashboard_id, selected_sources_json FROM ask_conversations WHERE id=?1",
+                [&exchange.conversation_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(stored.0.as_deref(), Some("board-a"));
+        assert_eq!(
+            stored.1, "[]",
+            "board children are never persisted as sources"
+        );
+
+        db.update_dashboard(
+            "board-a",
+            Some("Live title"),
+            Some("✨"),
+            None,
+            None,
+            "2026-08-06T11:00:00Z",
+        )
+        .unwrap();
+        let loaded = db
+            .load_ask_conversation(&scope, &exchange.conversation_id, &HashSet::new())
+            .unwrap()
+            .unwrap();
+        let dashboard = loaded.dashboard.expect("live dashboard metadata");
+        assert_eq!(dashboard.id, "board-a");
+        assert_eq!(dashboard.title, "Live title");
+        assert_eq!(dashboard.emoji.as_deref(), Some("✨"));
+
+        db.delete_dashboard("board-a").unwrap();
+        assert!(db
+            .load_ask_conversation(&scope, &exchange.conversation_id, &HashSet::new())
+            .unwrap()
+            .is_none());
+        assert!(db
+            .list_ask_conversation_ids(&scope, &HashSet::new())
+            .unwrap()
+            .is_empty());
+
+        // ABA: the public id is reusable, but the tombstone generation must keep history from
+        // the previous incarnation unavailable through every raw storage reader.
+        db.insert_dashboard(
+            "board-a",
+            "Recreated title",
+            Some("🧟"),
+            None,
+            "2026-08-06T12:00:00Z",
+        )
+        .unwrap();
+        assert!(db
+            .load_ask_conversation(&scope, &exchange.conversation_id, &HashSet::new())
+            .unwrap()
+            .is_none());
+        assert!(db
+            .ask_conversation_context(&scope, &exchange.conversation_id, &HashSet::new())
+            .unwrap()
+            .is_none());
+        assert!(db
+            .list_ask_conversation_ids(&scope, &HashSet::new())
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn partial_dashboard_provenance_is_rejected_before_storage() {
+        let db = db("dashboard-partial-provenance");
+        let error = db
+            .persist_ask_exchange_cas(
+                &AskConversationScope::Vault,
+                None,
+                None,
+                "Question",
+                "Answer",
+                &[],
+                &[],
+                &[],
+                &[],
+                Some("board-a"),
+                None,
+                None,
+                "2026-08-06T10:00:00Z",
+            )
+            .unwrap_err();
+        assert!(matches!(error, AppError::InvalidArg(_)));
+        let count: i64 = db
+            .lock()
+            .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn dashboard_preflight_reads_no_message_content_before_exact_validation() {
+        let db = db("dashboard-content-preflight");
+        db.insert_dashboard("board", "Board", None, None, "2026-08-06T09:00:00Z")
+            .unwrap();
+        let scope = AskConversationScope::Vault;
+        let exchange = db
+            .persist_ask_exchange_cas(
+                &scope,
+                None,
+                None,
+                "question",
+                "answer",
+                &[],
+                &[],
+                &[],
+                &[],
+                Some("board"),
+                Some(1),
+                Some("digest"),
+                "2026-08-06T10:00:00Z",
+            )
+            .unwrap();
+        db.lock()
+            .execute(
+                "UPDATE ask_conversation_messages SET content=x'FF' WHERE conversation_id=?1",
+                [&exchange.conversation_id],
+            )
+            .unwrap();
+        db.lock()
+            .execute(
+                "UPDATE ask_conversations SET title=x'01' WHERE id=?1",
+                [&exchange.conversation_id],
+            )
+            .unwrap();
+
+        assert_eq!(
+            db.list_ask_conversation_ids(&scope, &HashSet::new())
+                .unwrap(),
+            vec![exchange.conversation_id.clone()]
+        );
+        let preflight = db
+            .ask_conversation_preflight(&scope, &exchange.conversation_id, &HashSet::new())
+            .unwrap()
+            .expect("metadata-only preflight must not hydrate poisoned content");
+        assert_eq!(preflight.dashboard.unwrap().input_digest, "digest");
+        let preflight = db
+            .ask_conversation_preflight(&scope, &exchange.conversation_id, &HashSet::new())
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            db.ask_conversation_context_after_preflight(&exchange.conversation_id, preflight),
+            Err(AppError::Storage(_))
+        ));
+        assert!(matches!(
+            db.ask_conversation_summary_after_preflight(&scope, &exchange.conversation_id),
+            Err(AppError::Storage(_))
+        ));
     }
 }

--- a/src-tauri/src/storage/dashboards_store.rs
+++ b/src-tauri/src/storage/dashboards_store.rs
@@ -2,12 +2,14 @@
 //!
 //! A dashboard is a user-composed board of TILES over sources that already exist elsewhere in the
 //! vault (a meeting, a note, a document, an entity, or a derived view like the fact-drift lane).
-//! The tables here therefore store **pointers and layout, never content**: `dashboard_tiles` keeps a
-//! `kind` + an optional `ref_id` + cosmetic layout, and every tile READ resolves through the
-//! existing gated readers (`visibility_clause` / `meeting_is_unlocked`) at read time.
+//! Most rows therefore store pointers + layout. The one deliberate content cache is a
+//! `living_answer`: dedicated columns hold the backend-generated answer plus exact structural,
+//! corpus and readable-folder provenance; the command layer validates that provenance before it
+//! hydrates a single content column.
 //!
 //! ## Lock model (see `.claude/rules/lock-model.md`)
-//! * Nothing sealed is ever copied into these tables, so there is nothing here to seal or purge.
+//! * Living-answer text is a derived paraphrase, so it is withheld unless its backend-owned
+//!   folder stamp and exact excluded-Living corpus witness are still current.
 //! * A tile pointing at a sealed-and-not-session-unlocked source resolves to a MASKED tile at the
 //!   command layer — the board renders a redacted placeholder instead of leaking a title.
 //! * `ref_id` is intentionally NOT a foreign key: a deleted source must degrade the tile to
@@ -16,7 +18,7 @@
 //! The methods below are an inherent-impl split of [`crate::storage::db::Db`] across files, the
 //! same pattern the other `*_store.rs` modules use.
 
-use rusqlite::{OptionalExtension, Row};
+use rusqlite::{OptionalExtension, Row, Transaction};
 
 use crate::error::{AppError, Result};
 use crate::storage::db::{map_err, Db};
@@ -46,6 +48,13 @@ pub const MAX_TILES_PER_BOARD: i64 = 60;
 /// Hard ceiling on boards, for the same reason.
 pub const MAX_DASHBOARDS: i64 = 200;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LivingAnswerContent {
+    pub(crate) question: String,
+    pub(crate) answer: Option<String>,
+    pub(crate) answered_at: Option<String>,
+}
+
 fn row_to_dashboard(row: &Row<'_>) -> rusqlite::Result<Dashboard> {
     Ok(Dashboard {
         id: row.get(0)?,
@@ -73,10 +82,46 @@ fn row_to_tile(row: &Row<'_>) -> rusqlite::Result<DashboardTile> {
     })
 }
 
-const DASHBOARD_COLS: &str =
-    "id, title, emoji, tint, pinned, position, created_at, updated_at";
-const TILE_COLS: &str =
-    "id, dashboard_id, kind, ref_id, title, span, position, config, created_at";
+const DASHBOARD_COLS: &str = "id, title, emoji, tint, pinned, position, created_at, updated_at";
+const TILE_COLS: &str = "id, dashboard_id, kind, ref_id, title, span, position, config, created_at";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum LivingAnswerCacheState {
+    Empty,
+    Valid {
+        readable_folders_json: String,
+        context_generation: i64,
+        context_digest: String,
+        context_budget: i64,
+        ask_dispatch_generation: i64,
+    },
+    Malformed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LivingAnswerPreflight {
+    pub(crate) question_readable_folders_json: Option<String>,
+    pub(crate) answer: LivingAnswerCacheState,
+}
+
+fn advance_context_generation(
+    tx: &Transaction<'_>,
+    dashboard_id: &str,
+    exists_now: bool,
+) -> Result<()> {
+    tx.execute(
+        "INSERT INTO dashboard_context_state
+         (dashboard_id, generation, structural_generation, exists_now)
+         VALUES (?1, 1, 1, ?2)
+         ON CONFLICT(dashboard_id) DO UPDATE SET
+           generation = dashboard_context_state.generation + 1,
+           structural_generation = dashboard_context_state.structural_generation + 1,
+           exists_now = excluded.exists_now",
+        rusqlite::params![dashboard_id, i64::from(exists_now)],
+    )
+    .map_err(map_err)?;
+    Ok(())
+}
 
 impl Db {
     /// Every board, pinned first, then by explicit position, then newest-updated.
@@ -105,10 +150,39 @@ impl Db {
         Ok(out)
     }
 
+    /// Monotonic identity/lifecycle witness for one board. The state row survives deletion, so
+    /// delete→recreate and X→Y→X mutations cannot admit an answer built from stale board text.
+    pub(crate) fn dashboard_context_state(&self, id: &str) -> Result<(i64, bool)> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT generation, exists_now FROM dashboard_context_state WHERE dashboard_id=?1",
+            [id],
+            |row| Ok((row.get(0)?, row.get::<_, i64>(1)? != 0)),
+        )
+        .optional()
+        .map(|state| state.unwrap_or((0, false)))
+        .map_err(map_err)
+    }
+
+    pub(crate) fn dashboard_structural_context_state(&self, id: &str) -> Result<(i64, bool)> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT structural_generation, exists_now
+               FROM dashboard_context_state WHERE dashboard_id=?1",
+            [id],
+            |row| Ok((row.get(0)?, row.get::<_, i64>(1)? != 0)),
+        )
+        .optional()
+        .map(|state| state.unwrap_or((0, false)))
+        .map_err(map_err)
+    }
+
     pub fn dashboard_count(&self) -> Result<i64> {
         let conn = self.lock();
         let n = conn
-            .query_row("SELECT COUNT(*) FROM dashboards", [], |r| r.get::<_, i64>(0))
+            .query_row("SELECT COUNT(*) FROM dashboards", [], |r| {
+                r.get::<_, i64>(0)
+            })
             .map_err(map_err)?;
         Ok(n)
     }
@@ -122,24 +196,29 @@ impl Db {
         tint: Option<&str>,
         now: &str,
     ) -> Result<()> {
-        let conn = self.lock();
-        let next: i64 = conn
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let next: i64 = tx
             .query_row(
                 "SELECT COALESCE(MAX(position), -1) + 1 FROM dashboards",
                 [],
                 |r| r.get(0),
             )
             .map_err(map_err)?;
-        conn.execute(
+        tx.execute(
             "INSERT INTO dashboards (id, title, emoji, tint, pinned, position, created_at, updated_at)
              VALUES (?1, ?2, ?3, ?4, 0, ?5, ?6, ?6)",
             rusqlite::params![id, title, emoji, tint, next, now],
         )
         .map_err(map_err)?;
+        advance_context_generation(&tx, id, true)?;
+        tx.commit().map_err(map_err)?;
         Ok(())
     }
 
-    /// Patch a board's user-editable fields.
+    /// Patch board chrome only. Title/emoji/tint/pinned never enter the provider input, and durable
+    /// history intentionally resolves title/emoji live, so this does not advance context generation.
+    /// Tile/source/derived mutations below do advance it atomically with their content change.
     ///
     /// Three-state per nullable column, because plain `COALESCE(?, col)` can only ever SET a
     /// value — it makes "remove the emoji" unexpressible:
@@ -186,17 +265,19 @@ impl Db {
 
     /// Delete a board and (by cascade) its tiles. Returns false when the id was unknown.
     pub fn delete_dashboard(&self, id: &str) -> Result<bool> {
-        let conn = self.lock();
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
         // The FK cascade only fires with foreign_keys=ON; delete tiles explicitly so the row can
         // never be orphaned regardless of the connection pragma.
-        conn.execute(
-            "DELETE FROM dashboard_tiles WHERE dashboard_id = ?1",
-            [id],
-        )
-        .map_err(map_err)?;
-        let n = conn
+        tx.execute("DELETE FROM dashboard_tiles WHERE dashboard_id = ?1", [id])
+            .map_err(map_err)?;
+        let n = tx
             .execute("DELETE FROM dashboards WHERE id = ?1", [id])
             .map_err(map_err)?;
+        if n > 0 {
+            advance_context_generation(&tx, id, false)?;
+        }
+        tx.commit().map_err(map_err)?;
         Ok(n > 0)
     }
 
@@ -216,6 +297,358 @@ impl Db {
         Ok(rows)
     }
 
+    /// Structural board layout only. Source-derived `title`/`config` are deliberately NULL until
+    /// the command resolver authorizes the tile under the current lifecycle snapshot.
+    pub(crate) fn list_dashboard_tile_structures(
+        &self,
+        dashboard_id: &str,
+    ) -> Result<Vec<DashboardTile>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT id,dashboard_id,kind,ref_id,NULL,span,position,NULL,created_at
+                   FROM dashboard_tiles WHERE dashboard_id=?1
+                  ORDER BY position ASC,created_at ASC",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map([dashboard_id], row_to_tile)
+            .map_err(map_err)?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(map_err)?;
+        Ok(rows)
+    }
+
+    /// Content-free Living-answer preflight. This reads only provenance and SQLite type tags;
+    /// question/answer text is hydrated by `dashboard_living_answer_content_after_preflight`
+    /// only after the command layer proves every stamped folder is readable.
+    pub(crate) fn dashboard_living_answer_preflight(
+        &self,
+        id: &str,
+    ) -> Result<Option<LivingAnswerPreflight>> {
+        self.lock()
+            .query_row(
+                "SELECT CASE WHEN typeof(question_readable_folders_json)='text'
+                             THEN question_readable_folders_json ELSE NULL END,
+                        typeof(living_answer),
+                        typeof(living_answered_at),
+                        CASE WHEN typeof(answer_readable_folders_json)='text'
+                             THEN answer_readable_folders_json ELSE NULL END,
+                        CASE WHEN typeof(living_answer_context_generation)='integer'
+                             THEN living_answer_context_generation ELSE NULL END,
+                        CASE WHEN typeof(living_answer_context_digest)='text'
+                             THEN living_answer_context_digest ELSE NULL END,
+                        CASE WHEN typeof(living_answer_context_budget)='integer'
+                             THEN living_answer_context_budget ELSE NULL END,
+                        CASE WHEN typeof(living_answer_ask_dispatch_generation)='integer'
+                             THEN living_answer_ask_dispatch_generation ELSE NULL END
+                   FROM dashboard_tiles WHERE id=?1 AND kind='living_answer'",
+                [id],
+                |row| {
+                    let question_readable_folders_json = row.get(0)?;
+                    let answer_type: String = row.get(1)?;
+                    let answered_at_type: String = row.get(2)?;
+                    let readable_folders_json: Option<String> = row.get(3)?;
+                    let context_generation: Option<i64> = row.get(4)?;
+                    let context_digest: Option<String> = row.get(5)?;
+                    let context_budget: Option<i64> = row.get(6)?;
+                    let ask_dispatch_generation: Option<i64> = row.get(7)?;
+                    let answer = if answer_type == "null"
+                        && answered_at_type == "null"
+                        && readable_folders_json.is_none()
+                        && context_generation.is_none()
+                        && context_digest.is_none()
+                        && context_budget.is_none()
+                        && ask_dispatch_generation.is_none()
+                    {
+                        LivingAnswerCacheState::Empty
+                    } else if answer_type == "text" && answered_at_type == "text" {
+                        match (
+                            readable_folders_json,
+                            context_generation,
+                            context_digest,
+                            context_budget,
+                            ask_dispatch_generation,
+                        ) {
+                            (
+                                Some(readable_folders_json),
+                                Some(context_generation),
+                                Some(context_digest),
+                                Some(context_budget),
+                                Some(ask_dispatch_generation),
+                            ) => {
+                                LivingAnswerCacheState::Valid {
+                                    readable_folders_json,
+                                    context_generation,
+                                    context_digest,
+                                    context_budget,
+                                    ask_dispatch_generation,
+                                }
+                            }
+                            _ => LivingAnswerCacheState::Malformed,
+                        }
+                    } else {
+                        LivingAnswerCacheState::Malformed
+                    };
+                    Ok(LivingAnswerPreflight {
+                        question_readable_folders_json,
+                        answer,
+                    })
+                },
+            )
+            .optional()
+            .map_err(map_err)
+    }
+
+    pub(crate) fn dashboard_living_answer_content_after_preflight_with_dispatch(
+        &self,
+        id: &str,
+        expected_ask_dispatch_generation: i64,
+        expected_context_generation: i64,
+        expected_context_digest: &str,
+        expected_context_budget: i64,
+    ) -> Result<Option<LivingAnswerContent>> {
+        self.lock()
+            .query_row(
+                "SELECT tile.living_question,tile.living_answer,tile.living_answered_at
+                   FROM dashboard_tiles tile
+                   JOIN dashboard_context_state state ON state.dashboard_id=tile.dashboard_id
+                  WHERE tile.id=?1 AND tile.kind='living_answer'
+                    AND state.exists_now=1 AND state.structural_generation=?3
+                    AND tile.living_answer_context_generation=?3
+                    AND tile.living_answer_context_digest=?4
+                    AND tile.living_answer_context_budget=?5
+                    AND typeof(living_question)='text'
+                    AND living_answer_ask_dispatch_generation=?2
+                    AND typeof(living_answer_ask_dispatch_generation)='integer'
+                    AND living_answer_ask_dispatch_generation=
+                        (SELECT generation FROM ask_dispatch_state WHERE singleton=1
+                          AND typeof(generation)='integer' AND generation>=0)
+                    AND (living_answer IS NULL OR
+                         (typeof(living_answer)='text' AND
+                          typeof(living_answered_at)='text'))",
+                rusqlite::params![
+                    id,
+                    expected_ask_dispatch_generation,
+                    expected_context_generation,
+                    expected_context_digest,
+                    expected_context_budget,
+                ],
+                |row| {
+                    Ok(LivingAnswerContent {
+                        question: row.get(0)?,
+                        answer: row.get(1)?,
+                        answered_at: row.get(2)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(map_err)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn dashboard_living_answer_content_after_preflight(
+        &self,
+        id: &str,
+    ) -> Result<Option<LivingAnswerContent>> {
+        let Some(preflight) = self.dashboard_living_answer_preflight(id)? else {
+            return Ok(None);
+        };
+        let LivingAnswerCacheState::Valid {
+            context_generation,
+            context_digest,
+            context_budget,
+            ask_dispatch_generation,
+            ..
+        } = preflight.answer
+        else {
+            return Ok(None);
+        };
+        self.dashboard_living_answer_content_after_preflight_with_dispatch(
+            id,
+            ask_dispatch_generation,
+            context_generation,
+            &context_digest,
+            context_budget,
+        )
+    }
+
+    pub(crate) fn dashboard_living_question_after_preflight(
+        &self,
+        id: &str,
+    ) -> Result<Option<String>> {
+        self.lock()
+            .query_row(
+                "SELECT living_question FROM dashboard_tiles
+                  WHERE id=?1 AND kind='living_answer' AND typeof(living_question)='text'",
+                [id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(map_err)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn stamp_dashboard_question_provenance(
+        &self,
+        id: &str,
+        question: &str,
+        readable_folders_json: &str,
+    ) -> Result<()> {
+        self.lock()
+            .execute(
+                "UPDATE dashboard_tiles SET living_question=?2,question_readable_folders_json=?3
+                  WHERE id=?1",
+                rusqlite::params![id, question, readable_folders_json],
+            )
+            .map(|_| ())
+            .map_err(map_err)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn insert_dashboard_living_answer_tile(
+        &self,
+        id: &str,
+        dashboard_id: &str,
+        span: i64,
+        question: &str,
+        readable_folders_json: &str,
+        now: &str,
+    ) -> Result<()> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let next: i64 = tx
+            .query_row(
+                "SELECT COALESCE(MAX(position),-1)+1 FROM dashboard_tiles WHERE dashboard_id=?1",
+                [dashboard_id],
+                |row| row.get(0),
+            )
+            .map_err(map_err)?;
+        tx.execute(
+            "INSERT INTO dashboard_tiles
+             (id,dashboard_id,kind,span,position,created_at,living_question,question_readable_folders_json)
+             VALUES (?1,?2,'living_answer',?3,?4,?5,?6,?7)",
+            rusqlite::params![id, dashboard_id, span.clamp(MIN_SPAN, MAX_SPAN), next, now, question, readable_folders_json],
+        )
+        .map_err(map_err)?;
+        advance_context_generation(&tx, dashboard_id, true)?;
+        tx.commit().map_err(map_err)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn store_dashboard_living_answer_cas_with_dispatch(
+        &self,
+        id: &str,
+        dashboard_id: &str,
+        expected_question: &str,
+        answer: &str,
+        answered_at: &str,
+        readable_folders_json: &str,
+        expected_generation: i64,
+        context_digest: &str,
+        context_budget: usize,
+        expected_ask_dispatch_generation: i64,
+    ) -> Result<bool> {
+        let context_budget = i64::try_from(context_budget)
+            .map_err(|_| AppError::InvalidArg("living-answer context budget is too large".into()))?;
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let current_ask_dispatch_generation = tx
+            .query_row(
+                "SELECT generation FROM ask_dispatch_state WHERE singleton=1
+                   AND typeof(generation)='integer' AND generation>=0",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(map_err)?;
+        if current_ask_dispatch_generation != expected_ask_dispatch_generation {
+            return Ok(false);
+        }
+        let state = tx
+            .query_row(
+                "SELECT structural_generation,exists_now
+                   FROM dashboard_context_state WHERE dashboard_id=?1",
+                [dashboard_id],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)? != 0)),
+            )
+            .optional()
+            .map_err(map_err)?;
+        if state != Some((expected_generation, true)) {
+            return Ok(false);
+        }
+        let committed_generation = expected_generation;
+        let changed = tx
+            .execute(
+                "UPDATE dashboard_tiles SET
+                   living_answer=?4,
+                   living_answered_at=?5,
+                   answer_readable_folders_json=?6,
+                   living_answer_context_generation=?7,
+                   living_answer_context_digest=?8,
+                   living_answer_context_budget=?9,
+                   living_answer_ask_dispatch_generation=?10
+                 WHERE id=?1 AND dashboard_id=?2 AND kind='living_answer'
+                   AND typeof(living_question)='text' AND living_question=?3",
+                rusqlite::params![
+                    id,
+                    dashboard_id,
+                    expected_question,
+                    answer,
+                    answered_at,
+                    readable_folders_json,
+                    committed_generation,
+                    context_digest,
+                    context_budget,
+                    expected_ask_dispatch_generation,
+                ],
+            )
+            .map_err(map_err)?;
+        if changed != 1 {
+            return Ok(false);
+        }
+        tx.execute(
+            "UPDATE dashboard_context_state SET generation=generation+1
+              WHERE dashboard_id=?1 AND exists_now=1",
+            [dashboard_id],
+        )
+        .map_err(map_err)?;
+        tx.execute(
+            "UPDATE dashboards SET updated_at=?2 WHERE id=?1",
+            rusqlite::params![dashboard_id, answered_at],
+        )
+        .map_err(map_err)?;
+        tx.commit().map_err(map_err)?;
+        Ok(true)
+    }
+
+    #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn store_dashboard_living_answer_cas(
+        &self,
+        id: &str,
+        dashboard_id: &str,
+        expected_question: &str,
+        answer: &str,
+        answered_at: &str,
+        readable_folders_json: &str,
+        expected_generation: i64,
+        context_digest: &str,
+        context_budget: usize,
+    ) -> Result<bool> {
+        self.store_dashboard_living_answer_cas_with_dispatch(
+            id,
+            dashboard_id,
+            expected_question,
+            answer,
+            answered_at,
+            readable_folders_json,
+            expected_generation,
+            context_digest,
+            context_budget,
+            self.ask_dispatch_generation()?,
+        )
+    }
+
     /// The tile KINDS on every board, keyed by board id — the list view's miniature preview reads
     /// this instead of loading every tile's (gated) payload.
     pub fn dashboard_tile_kinds(&self) -> Result<Vec<(String, String, i64)>> {
@@ -228,7 +661,11 @@ impl Db {
             .map_err(map_err)?;
         let rows = stmt
             .query_map([], |r| {
-                Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?, r.get::<_, i64>(2)?))
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, i64>(2)?,
+                ))
             })
             .map_err(map_err)?
             .collect::<rusqlite::Result<Vec<_>>>()
@@ -244,6 +681,19 @@ impl Db {
             .optional()
             .map_err(map_err)?;
         Ok(out)
+    }
+
+    /// Content-free mutation anchor. Callers that only need ownership/kind must never hydrate
+    /// `title` or `config`, which can retain source-derived text while the source is sealed.
+    pub fn dashboard_tile_metadata(&self, id: &str) -> Result<Option<(String, String)>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT dashboard_id, kind FROM dashboard_tiles WHERE id = ?1",
+            [id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()
+        .map_err(map_err)
     }
 
     pub fn dashboard_tile_count(&self, dashboard_id: &str) -> Result<i64> {
@@ -274,15 +724,16 @@ impl Db {
         if !TILE_KINDS.contains(&kind) {
             return Err(AppError::InvalidArg(format!("unknown tile kind: {kind}")));
         }
-        let conn = self.lock();
-        let next: i64 = conn
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let next: i64 = tx
             .query_row(
                 "SELECT COALESCE(MAX(position), -1) + 1 FROM dashboard_tiles WHERE dashboard_id = ?1",
                 [dashboard_id],
                 |r| r.get(0),
             )
             .map_err(map_err)?;
-        conn.execute(
+        tx.execute(
             "INSERT INTO dashboard_tiles
                (id, dashboard_id, kind, ref_id, title, span, position, config, created_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
@@ -299,6 +750,8 @@ impl Db {
             ],
         )
         .map_err(map_err)?;
+        advance_context_generation(&tx, dashboard_id, true)?;
+        tx.commit().map_err(map_err)?;
         Ok(())
     }
 
@@ -311,8 +764,17 @@ impl Db {
         span: Option<i64>,
         config: Option<&str>,
     ) -> Result<bool> {
-        let conn = self.lock();
-        let n = conn
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let dashboard_id = tx
+            .query_row(
+                "SELECT dashboard_id FROM dashboard_tiles WHERE id=?1",
+                [id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(map_err)?;
+        let n = tx
             .execute(
                 "UPDATE dashboard_tiles
                     SET title  = CASE WHEN ?2 IS NULL THEN title
@@ -324,14 +786,35 @@ impl Db {
                 rusqlite::params![id, title, span.map(|s| s.clamp(MIN_SPAN, MAX_SPAN)), config],
             )
             .map_err(map_err)?;
+        if n > 0 {
+            if let Some(dashboard_id) = dashboard_id.as_deref() {
+                advance_context_generation(&tx, dashboard_id, true)?;
+            }
+        }
+        tx.commit().map_err(map_err)?;
         Ok(n > 0)
     }
 
     pub fn delete_dashboard_tile(&self, id: &str) -> Result<bool> {
-        let conn = self.lock();
-        let n = conn
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let dashboard_id = tx
+            .query_row(
+                "SELECT dashboard_id FROM dashboard_tiles WHERE id=?1",
+                [id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(map_err)?;
+        let n = tx
             .execute("DELETE FROM dashboard_tiles WHERE id = ?1", [id])
             .map_err(map_err)?;
+        if n > 0 {
+            if let Some(dashboard_id) = dashboard_id.as_deref() {
+                advance_context_generation(&tx, dashboard_id, true)?;
+            }
+        }
+        tx.commit().map_err(map_err)?;
         Ok(n > 0)
     }
 
@@ -344,14 +827,23 @@ impl Db {
     /// rows sharing a position — and the rendered order then depended on the secondary sort key
     /// rather than on what the user dragged.
     pub fn reorder_dashboard_tiles(&self, dashboard_id: &str, tile_ids: &[String]) -> Result<()> {
-        let existing: Vec<String> = self
-            .list_dashboard_tiles(dashboard_id)?
-            .into_iter()
-            .map(|t| t.id)
-            .collect();
-        let order = dense_order(tile_ids, &existing);
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
+        let existing = {
+            let mut stmt = tx
+                .prepare(
+                    "SELECT id FROM dashboard_tiles WHERE dashboard_id=?1
+                     ORDER BY position ASC, created_at ASC",
+                )
+                .map_err(map_err)?;
+            let rows = stmt
+                .query_map([dashboard_id], |row| row.get::<_, String>(0))
+                .map_err(map_err)?
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .map_err(map_err)?;
+            rows
+        };
+        let order = dense_order(tile_ids, &existing);
         for (i, tile_id) in order.iter().enumerate() {
             tx.execute(
                 "UPDATE dashboard_tiles SET position = ?3
@@ -359,6 +851,9 @@ impl Db {
                 rusqlite::params![tile_id, dashboard_id, i as i64],
             )
             .map_err(map_err)?;
+        }
+        if !order.is_empty() {
+            advance_context_generation(&tx, dashboard_id, true)?;
         }
         tx.commit().map_err(map_err)?;
         Ok(())
@@ -418,8 +913,7 @@ impl Db {
             _ => return Ok(false),
         };
         let conn = self.lock();
-        let sql =
-            format!("SELECT EXISTS (SELECT 1 FROM {table} WHERE id = ?1{kind_filter})");
+        let sql = format!("SELECT EXISTS (SELECT 1 FROM {table} WHERE id = ?1{kind_filter})");
         let exists: i64 = conn.query_row(&sql, [id], |r| r.get(0)).map_err(map_err)?;
         Ok(exists != 0)
     }
@@ -427,11 +921,7 @@ impl Db {
     /// Reorder BOARDS themselves (drag in the list view). Same permutation discipline as
     /// [`Self::reorder_dashboard_tiles`].
     pub fn reorder_dashboards(&self, ids: &[String]) -> Result<()> {
-        let existing: Vec<String> = self
-            .list_dashboards()?
-            .into_iter()
-            .map(|d| d.id)
-            .collect();
+        let existing: Vec<String> = self.list_dashboards()?.into_iter().map(|d| d.id).collect();
         let order = dense_order(ids, &existing);
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -359,7 +359,65 @@ impl Db {
 
     /// Idempotent CREATE TABLE IF NOT EXISTS migrations.
     pub fn migrate(&self) -> Result<()> {
-        let conn = self.lock();
+        let mut conn = self.lock();
+        let ask_dispatch_state_existed = conn
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='ask_dispatch_state'",
+                [],
+                |_| Ok(()),
+            )
+            .optional()
+            .map_err(map_err)?
+            .is_some();
+        let dispatch_stamp_column_exists = |table: &str, column: &str| -> Result<bool> {
+            conn.query_row(
+                "SELECT COUNT(*) FROM pragma_table_info(?1) WHERE name=?2",
+                rusqlite::params![table, column],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|count| count != 0)
+            .map_err(map_err)
+        };
+        if ask_dispatch_state_existed {
+            let (row_count, valid_count) = conn
+                .query_row(
+                    "SELECT COUNT(*),
+                            COALESCE(SUM(CASE WHEN singleton=1
+                                               AND typeof(generation)='integer'
+                                               AND generation>=0
+                                              THEN 1 ELSE 0 END),0)
+                       FROM ask_dispatch_state",
+                    [],
+                    |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+                )
+                .map_err(map_err)?;
+            if (row_count, valid_count) != (1, 1) {
+                return Err(AppError::Storage(
+                    "Ask dispatch generation is unavailable".into(),
+                ));
+            }
+        } else {
+            if dispatch_stamp_column_exists("ask_conversations", "ask_dispatch_generation")?
+                || dispatch_stamp_column_exists(
+                    "dashboard_tiles",
+                    "living_answer_ask_dispatch_generation",
+                )?
+            {
+                return Err(AppError::Storage(
+                    "Ask dispatch generation is unavailable".into(),
+                ));
+            }
+            let tx = conn.transaction().map_err(map_err)?;
+            tx.execute_batch(
+                "CREATE TABLE ask_dispatch_state (
+                   singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+                   generation INTEGER NOT NULL CHECK(typeof(generation)='integer' AND generation >= 0)
+                 );
+                 INSERT INTO ask_dispatch_state(singleton,generation) VALUES (1,0);",
+            )
+            .map_err(map_err)?;
+            tx.commit().map_err(map_err)?;
+        }
         conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS meetings (
                id TEXT PRIMARY KEY,
@@ -512,6 +570,13 @@ impl Db {
              );
              INSERT OR IGNORE INTO ask_history_state(singleton, visibility_generation)
                VALUES (1, 0);
+             -- Global authorization epoch for every Ask/provider dispatch. This is deliberately
+             -- separate from content visibility and dashboard generations: provider identity,
+             -- endpoint, model or consent may change while the source corpus stays byte-identical.
+             CREATE TABLE IF NOT EXISTS ask_dispatch_state (
+               singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
+               generation INTEGER NOT NULL CHECK(typeof(generation)='integer' AND generation >= 0)
+             );
              CREATE TABLE IF NOT EXISTS ask_conversations (
                id TEXT PRIMARY KEY,
                scope_kind TEXT NOT NULL CHECK(scope_kind IN ('vault', 'note', 'meeting')),
@@ -1105,10 +1170,11 @@ impl Db {
     ///   OPTIONAL anchor into an existing row (meeting / document / entity id) and is deliberately
     ///   NOT an FK: a tile whose target was deleted must degrade to a "missing source" tile rather
     ///   than cascade-delete a user's board layout. `config` is a small JSON bag for per-kind
-    ///   options (e.g. the Living-answer question). `position` is a dense integer order.
+    ///   options. Living answers use dedicated backend-owned content/provenance columns instead of
+    ///   caller-writable `config`. `position` is a dense integer order.
     ///
-    /// The tables carry no note text, no transcript, and no title copied from a gated row — the
-    /// board is a set of POINTERS, resolved through the gated readers on every read.
+    /// The tables carry no source note/transcript/title copy. The Living-answer cache is hydrated
+    /// only after its folder stamp + exact corpus witness pass the command-layer gate.
     fn migrate_dashboards(conn: &Connection) -> Result<()> {
         conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS dashboards (
@@ -1135,9 +1201,81 @@ impl Db {
                FOREIGN KEY (dashboard_id) REFERENCES dashboards(id) ON DELETE CASCADE
              );
              CREATE INDEX IF NOT EXISTS idx_dashboard_tiles_board
-               ON dashboard_tiles(dashboard_id, position);",
+               ON dashboard_tiles(dashboard_id, position);
+             CREATE TABLE IF NOT EXISTS dashboard_context_state (
+               dashboard_id TEXT PRIMARY KEY,
+               generation INTEGER NOT NULL DEFAULT 0,
+               structural_generation INTEGER NOT NULL DEFAULT 0,
+               exists_now INTEGER NOT NULL DEFAULT 0
+             );
+             INSERT OR IGNORE INTO dashboard_context_state (dashboard_id, generation, exists_now)
+               SELECT id, 0, 1 FROM dashboards;",
         )
         .map_err(map_err)?;
+        Self::add_column_if_missing(conn, "ask_conversations", "dashboard_id", "TEXT")?;
+        Self::add_column_if_missing(
+            conn,
+            "ask_conversations",
+            "dashboard_context_generation",
+            "INTEGER",
+        )?;
+        Self::add_column_if_missing(
+            conn,
+            "ask_conversations",
+            "dashboard_context_digest",
+            "TEXT",
+        )?;
+        Self::add_column_if_missing(
+            conn,
+            "ask_conversations",
+            "ask_dispatch_generation",
+            "INTEGER",
+        )?;
+        Self::add_column_if_missing(
+            conn,
+            "dashboard_tiles",
+            "question_readable_folders_json",
+            "TEXT",
+        )?;
+        Self::add_column_if_missing(
+            conn,
+            "dashboard_tiles",
+            "answer_readable_folders_json",
+            "TEXT",
+        )?;
+        Self::add_column_if_missing(conn, "dashboard_tiles", "living_question", "TEXT")?;
+        Self::add_column_if_missing(conn, "dashboard_tiles", "living_answer", "TEXT")?;
+        Self::add_column_if_missing(conn, "dashboard_tiles", "living_answered_at", "TEXT")?;
+        Self::add_column_if_missing(
+            conn,
+            "dashboard_tiles",
+            "living_answer_context_generation",
+            "INTEGER",
+        )?;
+        Self::add_column_if_missing(
+            conn,
+            "dashboard_tiles",
+            "living_answer_context_digest",
+            "TEXT",
+        )?;
+        Self::add_column_if_missing(
+            conn,
+            "dashboard_tiles",
+            "living_answer_context_budget",
+            "INTEGER",
+        )?;
+        Self::add_column_if_missing(
+            conn,
+            "dashboard_tiles",
+            "living_answer_ask_dispatch_generation",
+            "INTEGER",
+        )?;
+        Self::add_column_if_missing(
+            conn,
+            "dashboard_context_state",
+            "structural_generation",
+            "INTEGER NOT NULL DEFAULT 0",
+        )?;
         Ok(())
     }
 
@@ -4178,7 +4316,7 @@ impl Db {
         let conn = self.lock();
         let visible = visibility_clause("f", unlocked);
         let sql = format!(
-            "SELECT d.id, d.folder_id, d.kind, d.name, d.title, COALESCE(d.text, ''), d.updated_at
+            "SELECT d.id, d.folder_id, d.kind, d.name, d.title, COALESCE(d.text, ''), d.created_at, d.updated_at
                FROM documents d
                JOIN folders f ON f.id = d.folder_id
               WHERE d.id = ?1 AND {visible}"
@@ -4194,11 +4332,56 @@ impl Db {
                 // Brain v3 PR-2: render clean display text (strip the block-structure markers a PR-2
                 // upload stores). A note / legacy row has no markers → unchanged.
                 markdown: crate::extract::render_display_text(&raw),
-                updated_at: r.get(6)?,
+                created_at: r.get(6)?,
+                updated_at: r.get(7)?,
             })
         })
         .optional()
         .map_err(map_err)
+    }
+
+    pub(crate) fn get_document_if_visible_kind(
+        &self,
+        id: &str,
+        kind: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Option<DocumentSummary>> {
+        if !matches!(kind, "note" | "document") {
+            return Err(AppError::InvalidArg(
+                "invalid dashboard document kind".into(),
+            ));
+        }
+        let conn = self.lock();
+        let visible = visibility_clause("f", unlocked);
+        let sql = format!(
+            "SELECT d.id,d.folder_id,d.kind,d.name,d.title,COALESCE(d.text,''),d.created_at,d.updated_at
+               FROM documents d JOIN folders f ON f.id=d.folder_id
+              WHERE d.id=?1 AND d.kind=?2 AND {visible}"
+        );
+        conn.query_row(&sql, rusqlite::params![id, kind], |row| {
+            let raw: String = row.get(5)?;
+            Ok(DocumentSummary {
+                id: row.get(0)?,
+                folder_id: row.get(1)?,
+                kind: row.get(2)?,
+                name: row.get(3)?,
+                title: row.get(4)?,
+                markdown: crate::extract::render_display_text(&raw),
+                created_at: row.get(6)?,
+                updated_at: row.get(7)?,
+            })
+        })
+        .optional()
+        .map_err(map_err)
+    }
+
+    pub(crate) fn document_is_visible(&self, id: &str, unlocked: &HashSet<String>) -> Result<bool> {
+        let conn = self.lock();
+        let visible = visibility_clause("f", unlocked);
+        conn.query_row(
+            &format!("SELECT EXISTS(SELECT 1 FROM documents d JOIN folders f ON f.id=d.folder_id WHERE d.id=?1 AND d.kind='document' AND {visible})"),
+            [id], |row| row.get(0),
+        ).map_err(map_err)
     }
 
     // `folder_for_document` moved to `storage::folders_store` (God-file split) — still callable as inherent `db.method()` cross-file.
@@ -7146,7 +7329,8 @@ pub(crate) fn unique_temp_path(prefix: &str, ext: &str) -> std::path::PathBuf {
     // Reclaim fixtures abandoned by EARLIER test processes before minting a new one. Callers own a
     // bare `PathBuf` at 73 sites across 36 files, so nothing here can drop-clean the CURRENT run —
     // sweeping on entry bounds the steady state at one run's worth instead of unbounded growth.
-    SWEEP.call_once(|| sweep_stale_temp_fixtures(std::env::temp_dir().as_path(), STALE_FIXTURE_AGE));
+    SWEEP
+        .call_once(|| sweep_stale_temp_fixtures(std::env::temp_dir().as_path(), STALE_FIXTURE_AGE));
     let n = COUNTER.fetch_add(1, Ordering::Relaxed);
     let pid = std::process::id();
     let nanos = std::time::SystemTime::now()

--- a/src-tauri/src/storage/db_tests/dashboard_tests.rs
+++ b/src-tauri/src/storage/db_tests/dashboard_tests.rs
@@ -8,7 +8,9 @@
 //! These use `open_with_key` + a fixed literal DEK, so they never touch the Keychain.
 
 use super::*;
-use crate::storage::models::{EntityKind, Folder, Meeting, MeetingStatus, NoteRecord};
+use crate::storage::models::{
+    AskConversationScope, EntityKind, Folder, Meeting, MeetingStatus, NoteRecord,
+};
 
 /// The same fixed placeholder the sibling file-backed suites use — the documented
 /// MURMUR_DEV_DEK-shaped literal, never a real Keychain DEK.
@@ -22,10 +24,218 @@ fn file_db(label: &str) -> Db {
     .unwrap()
 }
 
+#[test]
+fn missing_ask_dispatch_singleton_is_never_reseeded_on_reopen() {
+    let path = super::unique_temp_path("meetnotes-dash-test-missing-ask-generation", "sqlite");
+    let db = Db::open_with_key(&path, TEST_DEK).unwrap();
+    assert_eq!(db.ask_dispatch_generation().unwrap(), 0);
+    let dashboard_id = board(&db, "missing-generation");
+    db.insert_dashboard_living_answer_tile(
+        "t-missing-generation",
+        &dashboard_id,
+        4,
+        "Must remain private",
+        "[]",
+        "2026-08-03T10:00:00Z",
+    )
+    .unwrap();
+    let context_generation = db
+        .dashboard_structural_context_state(&dashboard_id)
+        .unwrap()
+        .0;
+    db.store_dashboard_living_answer_cas(
+        "t-missing-generation",
+        &dashboard_id,
+        "Must remain private",
+        "OLD LIVING ANSWER MUST NOT REVIVE",
+        "2026-08-03T10:01:00Z",
+        "[]",
+        context_generation,
+        "missing-generation-digest",
+        200_000,
+    )
+    .unwrap();
+    let conversation_id = db
+        .persist_ask_exchange(
+            &AskConversationScope::Vault,
+            None,
+            "OLD HISTORY QUESTION MUST NOT REVIVE",
+            "OLD HISTORY ANSWER MUST NOT REVIVE",
+            &[],
+            &[],
+            &[],
+            &[],
+            "2026-08-03T10:02:00Z",
+        )
+        .unwrap();
+    db.lock()
+        .execute("DELETE FROM ask_dispatch_state WHERE singleton=1", [])
+        .unwrap();
+    drop(db);
+    assert!(matches!(
+        Db::open_with_key(&path, TEST_DEK),
+        Err(AppError::Storage(message)) if message == "Ask dispatch generation is unavailable"
+    ));
+
+    // Inspect the encrypted fixture without running `Db::migrate` again. The failed reopen must
+    // neither repair generation 0 (which would revive the stamped payloads) nor clear their bytes.
+    let conn = Connection::open(&path).unwrap();
+    conn.pragma_update(None, "key", format!("x'{TEST_DEK}'"))
+        .unwrap();
+    assert_eq!(
+        conn.query_row("SELECT COUNT(*) FROM ask_dispatch_state", [], |row| row
+            .get::<_, i64>(0))
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        conn.query_row(
+            "SELECT living_answer FROM dashboard_tiles WHERE id='t-missing-generation'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .unwrap(),
+        "OLD LIVING ANSWER MUST NOT REVIVE"
+    );
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM ask_conversation_messages WHERE conversation_id=?1",
+            [&conversation_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        2
+    );
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn missing_ask_dispatch_table_with_generation_stamps_is_never_reseeded() {
+    let path = super::unique_temp_path("meetnotes-dash-test-missing-ask-table", "sqlite");
+    let db = Db::open_with_key(&path, TEST_DEK).unwrap();
+    let dashboard_id = board(&db, "missing-generation-table");
+    db.insert_dashboard_living_answer_tile(
+        "t-missing-generation-table",
+        &dashboard_id,
+        4,
+        "Must remain private",
+        "[]",
+        "2026-08-03T10:00:00Z",
+    )
+    .unwrap();
+    let context_generation = db
+        .dashboard_structural_context_state(&dashboard_id)
+        .unwrap()
+        .0;
+    db.store_dashboard_living_answer_cas(
+        "t-missing-generation-table",
+        &dashboard_id,
+        "Must remain private",
+        "DROPPED TABLE ANSWER MUST NOT REVIVE",
+        "2026-08-03T10:01:00Z",
+        "[]",
+        context_generation,
+        "missing-generation-table-digest",
+        200_000,
+    )
+    .unwrap();
+    let conversation_id = db
+        .persist_ask_exchange(
+            &AskConversationScope::Vault,
+            None,
+            "DROPPED TABLE QUESTION MUST NOT REVIVE",
+            "DROPPED TABLE HISTORY MUST NOT REVIVE",
+            &[],
+            &[],
+            &[],
+            &[],
+            "2026-08-03T10:02:00Z",
+        )
+        .unwrap();
+    db.lock().execute_batch("DROP TABLE ask_dispatch_state;").unwrap();
+    drop(db);
+
+    assert!(matches!(
+        Db::open_with_key(&path, TEST_DEK),
+        Err(AppError::Storage(message)) if message == "Ask dispatch generation is unavailable"
+    ));
+    let conn = Connection::open(&path).unwrap();
+    conn.pragma_update(None, "key", format!("x'{TEST_DEK}'"))
+        .unwrap();
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='ask_dispatch_state'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        0,
+        "failed startup must not recreate a lost feature-era generation table"
+    );
+    assert_eq!(
+        conn.query_row(
+            "SELECT living_answer FROM dashboard_tiles WHERE id='t-missing-generation-table'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .unwrap(),
+        "DROPPED TABLE ANSWER MUST NOT REVIVE"
+    );
+    assert_eq!(
+        conn.query_row(
+            "SELECT COUNT(*) FROM ask_conversation_messages WHERE conversation_id=?1",
+            [&conversation_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        2
+    );
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
+fn malformed_ask_dispatch_singleton_is_not_coerced_on_reopen() {
+    let path = super::unique_temp_path("meetnotes-dash-test-malformed-ask-generation", "sqlite");
+    let db = Db::open_with_key(&path, TEST_DEK).unwrap();
+    db.lock()
+        .execute_batch(
+            "PRAGMA ignore_check_constraints=ON;
+             UPDATE ask_dispatch_state SET generation='corrupt' WHERE singleton=1;
+             PRAGMA ignore_check_constraints=OFF;",
+        )
+        .unwrap();
+    drop(db);
+
+    assert!(matches!(
+        Db::open_with_key(&path, TEST_DEK),
+        Err(AppError::Storage(message)) if message == "Ask dispatch generation is unavailable"
+    ));
+    let conn = Connection::open(&path).unwrap();
+    conn.pragma_update(None, "key", format!("x'{TEST_DEK}'"))
+        .unwrap();
+    assert_eq!(
+        conn.query_row(
+            "SELECT typeof(generation), CAST(generation AS TEXT) FROM ask_dispatch_state WHERE singleton=1",
+            [],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )
+        .unwrap(),
+        ("text".to_string(), "corrupt".to_string()),
+        "failed startup must not coerce malformed state into a reusable generation"
+    );
+    let _ = std::fs::remove_file(path);
+}
+
 fn board(db: &Db, title: &str) -> String {
     let id = format!("board-{title}");
-    db.insert_dashboard(&id, title, Some("🚀"), Some("indigo"), "2026-08-03T10:00:00Z")
-        .unwrap();
+    db.insert_dashboard(
+        &id,
+        title,
+        Some("🚀"),
+        Some("indigo"),
+        "2026-08-03T10:00:00Z",
+    )
+    .unwrap();
     id
 }
 
@@ -43,17 +253,119 @@ fn dashboard_crud_round_trips() {
 
     // Patch: only the supplied fields move; `None` leaves a column untouched.
     assert!(db
-        .update_dashboard(&id, Some("Atlas GA"), None, None, Some(true), "2026-08-03T11:00:00Z")
+        .update_dashboard(
+            &id,
+            Some("Atlas GA"),
+            None,
+            None,
+            Some(true),
+            "2026-08-03T11:00:00Z"
+        )
         .unwrap());
     let d = db.get_dashboard(&id).unwrap().unwrap();
     assert_eq!(d.title, "Atlas GA");
-    assert_eq!(d.emoji.as_deref(), Some("🚀"), "untouched field survives a patch");
+    assert_eq!(
+        d.emoji.as_deref(),
+        Some("🚀"),
+        "untouched field survives a patch"
+    );
     assert!(d.pinned);
     assert_eq!(d.updated_at, "2026-08-03T11:00:00Z");
 
     assert!(db.delete_dashboard(&id).unwrap());
     assert!(db.get_dashboard(&id).unwrap().is_none());
-    assert!(!db.delete_dashboard(&id).unwrap(), "second delete is a no-op");
+    assert!(
+        !db.delete_dashboard(&id).unwrap(),
+        "second delete is a no-op"
+    );
+}
+
+#[test]
+fn context_generation_is_monotonic_and_survives_delete_recreate() {
+    let db = file_db("context-generation");
+    assert_eq!(db.dashboard_context_state("stable-id").unwrap(), (0, false));
+
+    db.insert_dashboard("stable-id", "X", None, None, "2026-08-03T10:00:00Z")
+        .unwrap();
+    db.insert_dashboard_tile(
+        "t1",
+        "stable-id",
+        "note",
+        Some("n1"),
+        None,
+        4,
+        None,
+        "2026-08-03T10:00:01Z",
+    )
+    .unwrap();
+    db.insert_dashboard_tile(
+        "t2",
+        "stable-id",
+        "note",
+        Some("n2"),
+        None,
+        4,
+        None,
+        "2026-08-03T10:00:02Z",
+    )
+    .unwrap();
+    let created = db.dashboard_context_state("stable-id").unwrap();
+    let structural_created = db.dashboard_structural_context_state("stable-id").unwrap();
+    assert!(created.1);
+
+    db.reorder_dashboard_tiles("stable-id", &["t2".into(), "t1".into()])
+        .unwrap();
+    db.reorder_dashboard_tiles("stable-id", &["t1".into(), "t2".into()])
+        .unwrap();
+    let round_trip = db.dashboard_context_state("stable-id").unwrap();
+    let structural_round_trip = db.dashboard_structural_context_state("stable-id").unwrap();
+    assert!(
+        round_trip.0 > created.0,
+        "tile order X→Y→X must change the witness"
+    );
+    assert!(structural_round_trip.0 > structural_created.0);
+
+    db.delete_dashboard("stable-id").unwrap();
+    let deleted = db.dashboard_context_state("stable-id").unwrap();
+    let structural_deleted = db.dashboard_structural_context_state("stable-id").unwrap();
+    assert!(!deleted.1);
+    assert!(deleted.0 > round_trip.0);
+    assert!(!structural_deleted.1);
+    assert!(structural_deleted.0 > structural_round_trip.0);
+
+    db.insert_dashboard("stable-id", "X", None, None, "2026-08-03T10:03:00Z")
+        .unwrap();
+    let recreated = db.dashboard_context_state("stable-id").unwrap();
+    let structural_recreated = db.dashboard_structural_context_state("stable-id").unwrap();
+    assert!(recreated.1);
+    assert!(
+        recreated.0 > deleted.0,
+        "delete→recreate with the same id/payload must not restore a stale witness"
+    );
+    assert!(structural_recreated.1);
+    assert!(structural_recreated.0 > structural_deleted.0);
+}
+
+#[test]
+fn dashboard_chrome_update_does_not_invalidate_composite_identity() {
+    let db = file_db("context-chrome");
+    db.insert_dashboard("board", "Before", None, None, "2026-08-03T10:00:00Z")
+        .unwrap();
+    let before = db.dashboard_context_state("board").unwrap();
+    db.update_dashboard(
+        "board",
+        Some("After"),
+        Some("✨"),
+        Some("blue"),
+        Some(true),
+        "2026-08-03T10:01:00Z",
+    )
+    .unwrap();
+    assert_eq!(
+        db.dashboard_context_state("board").unwrap(),
+        before,
+        "live-resolved chrome is not provider grounding"
+    );
 }
 
 #[test]
@@ -63,7 +375,12 @@ fn pinned_boards_sort_first() {
     let b = board(&db, "b");
     db.update_dashboard(&b, None, None, None, Some(true), "2026-08-03T12:00:00Z")
         .unwrap();
-    let ids: Vec<String> = db.list_dashboards().unwrap().into_iter().map(|d| d.id).collect();
+    let ids: Vec<String> = db
+        .list_dashboards()
+        .unwrap()
+        .into_iter()
+        .map(|d| d.id)
+        .collect();
     assert_eq!(ids, vec![b, a], "pinned first, then position");
 }
 
@@ -88,7 +405,10 @@ fn tiles_append_clamp_and_reorder() {
     }
     let tiles = db.list_dashboard_tiles(&b).unwrap();
     assert_eq!(tiles.len(), 3);
-    assert_eq!(tiles[0].span, 12, "over-wide span clamps to the 12-col grid");
+    assert_eq!(
+        tiles[0].span, 12,
+        "over-wide span clamps to the 12-col grid"
+    );
     assert_eq!(tiles[1].span, 3, "under-wide span clamps to the minimum");
     assert_eq!(
         tiles.iter().map(|t| t.position).collect::<Vec<_>>(),
@@ -153,7 +473,11 @@ fn reorder_tolerates_partial_duplicate_and_unknown_ids() {
         "requested ids first (deduped), then the untouched rest in their prior order"
     );
     let positions: Vec<i64> = tiles.iter().map(|t| t.position).collect();
-    assert_eq!(positions, vec![0, 1, 2, 3], "positions stay dense and unique");
+    assert_eq!(
+        positions,
+        vec![0, 1, 2, 3],
+        "positions stay dense and unique"
+    );
 }
 
 /// `None` = leave alone, `Some("")` = clear, `Some(v)` = set. Plain `COALESCE` could only ever
@@ -162,12 +486,18 @@ fn reorder_tolerates_partial_duplicate_and_unknown_ids() {
 fn partial_updates_can_clear_a_nullable_column() {
     let db = file_db("clear-nullable");
     let id = board(&db, "clear");
-    assert_eq!(db.get_dashboard(&id).unwrap().unwrap().emoji.as_deref(), Some("🚀"));
+    assert_eq!(
+        db.get_dashboard(&id).unwrap().unwrap().emoji.as_deref(),
+        Some("🚀")
+    );
 
     // None leaves it.
     db.update_dashboard(&id, None, None, None, None, "2026-08-03T11:00:00Z")
         .unwrap();
-    assert_eq!(db.get_dashboard(&id).unwrap().unwrap().emoji.as_deref(), Some("🚀"));
+    assert_eq!(
+        db.get_dashboard(&id).unwrap().unwrap().emoji.as_deref(),
+        Some("🚀")
+    );
 
     // Empty string CLEARS it.
     db.update_dashboard(&id, None, Some(""), Some(""), None, "2026-08-03T12:00:00Z")
@@ -188,7 +518,8 @@ fn partial_updates_can_clear_a_nullable_column() {
         "2026-08-03T10:00:00Z",
     )
     .unwrap();
-    db.update_dashboard_tile("t1", Some(""), None, Some("")).unwrap();
+    db.update_dashboard_tile("t1", Some(""), None, Some(""))
+        .unwrap();
     let t = db.get_dashboard_tile("t1").unwrap().unwrap();
     assert_eq!(t.title, None);
     assert_eq!(t.config, None);
@@ -213,7 +544,16 @@ fn unknown_tile_kind_is_refused() {
     let db = file_db("kind-allowlist");
     let b = board(&db, "k");
     let err = db
-        .insert_dashboard_tile("x", &b, "rm -rf", None, None, 4, None, "2026-08-03T10:00:00Z")
+        .insert_dashboard_tile(
+            "x",
+            &b,
+            "rm -rf",
+            None,
+            None,
+            4,
+            None,
+            "2026-08-03T10:00:00Z",
+        )
         .unwrap_err();
     assert!(
         matches!(err, crate::error::AppError::InvalidArg(_)),
@@ -226,8 +566,17 @@ fn unknown_tile_kind_is_refused() {
 fn deleting_a_board_removes_its_tiles() {
     let db = file_db("cascade");
     let b = board(&db, "cascade");
-    db.insert_dashboard_tile("t1", &b, "note", Some("n1"), None, 4, None, "2026-08-03T10:00:00Z")
-        .unwrap();
+    db.insert_dashboard_tile(
+        "t1",
+        &b,
+        "note",
+        Some("n1"),
+        None,
+        4,
+        None,
+        "2026-08-03T10:00:00Z",
+    )
+    .unwrap();
     db.delete_dashboard(&b).unwrap();
     assert!(
         db.list_dashboard_tiles(&b).unwrap().is_empty(),
@@ -285,7 +634,9 @@ fn pulse_excludes_sealed_meetings_until_unlocked() {
     let db = file_db("pulse-gate");
     seed_folder(&db, "f-open", "Open", false);
     seed_folder(&db, "f-sealed", "Sealed", true);
-    let atlas = db.upsert_entity("Project Atlas", EntityKind::Project).unwrap();
+    let atlas = db
+        .upsert_entity("Project Atlas", EntityKind::Project)
+        .unwrap();
 
     seed_mentioned_meeting(&db, "m-open", "f-open", &atlas, "2026-08-01T09:00:00Z");
     seed_mentioned_meeting(&db, "m-sealed", "f-sealed", &atlas, "2026-08-02T09:00:00Z");
@@ -301,7 +652,8 @@ fn pulse_excludes_sealed_meetings_until_unlocked() {
     assert!(pulse[0].starts_with("2026-08-01"));
 
     // Session-unlock the folder: the same reader now includes it (reversible, not a hole).
-    let unlocked: std::collections::HashSet<String> = ["f-sealed".to_string()].into_iter().collect();
+    let unlocked: std::collections::HashSet<String> =
+        ["f-sealed".to_string()].into_iter().collect();
     let pulse = db
         .entity_mention_pulse_visible(&atlas, 100, &unlocked)
         .unwrap();
@@ -323,14 +675,212 @@ fn ref_exists_probe_is_existence_only() {
     );
 }
 
+#[test]
+fn tile_mutation_metadata_never_hydrates_residual_title_or_config() {
+    let db = file_db("tile-mutation-metadata");
+    let dashboard_id = board(&db, "metadata");
+    db.insert_dashboard_tile(
+        "t-secret",
+        &dashboard_id,
+        "living_answer",
+        None,
+        Some("RESIDUAL TITLE SENTINEL"),
+        4,
+        Some(r#"{"question":"RESIDUAL CONFIG SENTINEL"}"#),
+        "2026-08-03T10:00:00Z",
+    )
+    .unwrap();
+    db.lock()
+        .execute(
+            "UPDATE dashboard_tiles SET title=x'00', config=x'01' WHERE id='t-secret'",
+            [],
+        )
+        .unwrap();
+
+    assert_eq!(
+        db.dashboard_tile_metadata("t-secret").unwrap(),
+        Some((dashboard_id.clone(), "living_answer".to_string()))
+    );
+    let before = db.dashboard_context_state(&dashboard_id).unwrap();
+    db.reorder_dashboard_tiles(&dashboard_id, &["t-secret".to_string()])
+        .unwrap();
+    assert!(db.dashboard_context_state(&dashboard_id).unwrap().0 > before.0);
+}
+
+#[test]
+fn living_answer_birth_commits_question_provenance_and_generation_atomically() {
+    let db = file_db("living-answer-birth-atomic");
+    let dashboard_id = board(&db, "living");
+    let before = db.dashboard_context_state(&dashboard_id).unwrap();
+
+    db.insert_dashboard_living_answer_tile(
+        "t-living",
+        &dashboard_id,
+        4,
+        "What changed?",
+        r#"["f-open"]"#,
+        "2026-08-03T10:00:00Z",
+    )
+    .unwrap();
+
+    assert_eq!(
+        db.dashboard_living_question_after_preflight("t-living")
+            .unwrap()
+            .as_deref(),
+        Some("What changed?")
+    );
+    assert_eq!(
+        db.dashboard_living_answer_preflight("t-living")
+            .unwrap()
+            .unwrap()
+            .question_readable_folders_json
+            .as_deref(),
+        Some(r#"["f-open"]"#)
+    );
+    assert!(db.dashboard_context_state(&dashboard_id).unwrap().0 > before.0);
+
+    db.lock()
+        .execute_batch(
+            "CREATE TRIGGER fail_living_birth BEFORE INSERT ON dashboard_tiles
+             WHEN NEW.id='t-fail' BEGIN SELECT RAISE(ABORT, 'injected failure'); END;",
+        )
+        .unwrap();
+    let generation_before_failure = db.dashboard_context_state(&dashboard_id).unwrap();
+    assert!(db
+        .insert_dashboard_living_answer_tile(
+            "t-fail",
+            &dashboard_id,
+            4,
+            "Must not persist",
+            r#"["f-open"]"#,
+            "2026-08-03T10:01:00Z",
+        )
+        .is_err());
+    assert!(db.dashboard_tile_metadata("t-fail").unwrap().is_none());
+    assert_eq!(
+        db.dashboard_context_state(&dashboard_id).unwrap(),
+        generation_before_failure,
+        "a failed birth must leave neither an orphan tile nor a witness bump"
+    );
+}
+
+#[test]
+fn living_answer_cache_write_is_atomic_and_generation_bound() {
+    let db = file_db("living-answer-cache-cas");
+    let dashboard_id = board(&db, "living-cache");
+    db.insert_dashboard_living_answer_tile(
+        "t-living",
+        &dashboard_id,
+        4,
+        "What changed?",
+        r#"["f-open"]"#,
+        "2026-08-03T10:00:00Z",
+    )
+    .unwrap();
+    let expected_generation = db
+        .dashboard_structural_context_state(&dashboard_id)
+        .unwrap()
+        .0;
+    let general_before = db.dashboard_context_state(&dashboard_id).unwrap().0;
+
+    assert!(db
+        .store_dashboard_living_answer_cas(
+            "t-living",
+            &dashboard_id,
+            "What changed?",
+            "The launch moved to Friday.",
+            "2026-08-03T10:01:00Z",
+            r#"["f-open"]"#,
+            expected_generation,
+            "packed-context-digest",
+            200_000,
+        )
+        .unwrap());
+    let committed_generation = db
+        .dashboard_structural_context_state(&dashboard_id)
+        .unwrap()
+        .0;
+    assert_eq!(committed_generation, expected_generation);
+    assert_eq!(
+        db.dashboard_context_state(&dashboard_id).unwrap().0,
+        general_before + 1,
+        "cache writes invalidate general board/history witnesses only"
+    );
+    assert_eq!(
+        db.dashboard_living_answer_content_after_preflight("t-living")
+            .unwrap(),
+        Some(crate::storage::dashboards_store::LivingAnswerContent {
+            question: "What changed?".to_string(),
+            answer: Some("The launch moved to Friday.".to_string()),
+            answered_at: Some("2026-08-03T10:01:00Z".to_string()),
+        })
+    );
+    assert_eq!(
+        db.dashboard_living_answer_preflight("t-living")
+            .unwrap()
+            .unwrap()
+            .answer,
+        crate::storage::dashboards_store::LivingAnswerCacheState::Valid {
+            readable_folders_json: r#"["f-open"]"#.to_string(),
+            context_generation: committed_generation,
+            context_digest: "packed-context-digest".to_string(),
+            context_budget: 200_000,
+            ask_dispatch_generation: db.ask_dispatch_generation().unwrap(),
+        }
+    );
+
+    db.insert_dashboard_tile(
+        "t-mutation",
+        &dashboard_id,
+        "promises",
+        None,
+        None,
+        4,
+        None,
+        "2026-08-03T10:02:00Z",
+    )
+    .unwrap();
+    assert!(!db
+        .store_dashboard_living_answer_cas(
+            "t-living",
+            &dashboard_id,
+            "What changed?",
+            "STALE OVERWRITE",
+            "2026-08-03T10:03:00Z",
+            r#"["f-open"]"#,
+            committed_generation,
+            "stale-digest",
+            200_000,
+        )
+        .unwrap());
+    assert!(
+        db.dashboard_living_answer_content_after_preflight("t-living")
+            .unwrap()
+            .is_none(),
+        "a dashboard mutation must withhold the old cache before content hydration"
+    );
+}
+
 /// `migrate()` runs on EVERY open; the new tables must not break that (and must survive it).
 #[test]
 fn migrate_is_idempotent_with_dashboards() {
     let path = super::unique_temp_path("meetnotes-dash-idempotent", "sqlite");
     let db = Db::open_with_key(&path, TEST_DEK).unwrap();
     let b = board(&db, "keep");
-    db.insert_dashboard_tile("t1", &b, "note", Some("n1"), None, 4, None, "2026-08-03T10:00:00Z")
-        .unwrap();
+    db.insert_dashboard_tile(
+        "t1",
+        &b,
+        "note",
+        Some("n1"),
+        None,
+        4,
+        None,
+        "2026-08-03T10:00:00Z",
+    )
+    .unwrap();
+    let state_before_reopen = db.dashboard_context_state(&b).unwrap();
+    let structural_before_reopen = db.dashboard_structural_context_state(&b).unwrap();
+    assert!(state_before_reopen.1);
     drop(db);
 
     // Re-open (migrate runs again) — the board and its tile survive untouched.
@@ -338,4 +888,126 @@ fn migrate_is_idempotent_with_dashboards() {
     db.migrate().unwrap();
     assert_eq!(db.list_dashboards().unwrap().len(), 1);
     assert_eq!(db.list_dashboard_tiles(&b).unwrap().len(), 1);
+    let conn = db.lock();
+    let columns = conn
+        .prepare("PRAGMA table_info(ask_conversations)")
+        .unwrap()
+        .query_map([], |row| row.get::<_, String>(1))
+        .unwrap()
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .unwrap();
+    for column in [
+        "dashboard_id",
+        "dashboard_context_generation",
+        "dashboard_context_digest",
+        "ask_dispatch_generation",
+    ] {
+        assert!(
+            columns.iter().any(|found| found == column),
+            "missing {column}"
+        );
+    }
+    let state: (i64, i64) = conn
+        .query_row(
+            "SELECT generation, exists_now FROM dashboard_context_state WHERE dashboard_id=?1",
+            [&b],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        state,
+        (state_before_reopen.0, i64::from(state_before_reopen.1)),
+        "reopening and rerunning migration must preserve the durable witness"
+    );
+    let structural: i64 = conn
+        .query_row(
+            "SELECT structural_generation FROM dashboard_context_state WHERE dashboard_id=?1",
+            [&b],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(structural, structural_before_reopen.0);
+}
+
+#[test]
+fn pre_composite_schema_upgrades_additively_and_preserves_legacy_history() {
+    let db = file_db("pre-composite-upgrade");
+    let board_id = board(&db, "legacy-board");
+    let scope = AskConversationScope::Vault;
+    let conversation_id = db
+        .persist_ask_exchange(
+            &scope,
+            None,
+            "legacy question",
+            "legacy answer",
+            &[],
+            &[],
+            &[],
+            &[],
+            "2026-08-03T10:00:00Z",
+        )
+        .unwrap();
+
+    // Construct the exact pre-feature shape while retaining the rest of the real encrypted
+    // schema. Destructive DDL is test-fixture setup only; production migration remains additive.
+    db.lock()
+        .execute_batch(
+            "DROP TABLE ask_dispatch_state;
+             DROP TABLE dashboard_context_state;
+             ALTER TABLE ask_conversations DROP COLUMN dashboard_context_digest;
+             ALTER TABLE ask_conversations DROP COLUMN dashboard_context_generation;
+             ALTER TABLE ask_conversations DROP COLUMN dashboard_id;
+             ALTER TABLE ask_conversations DROP COLUMN ask_dispatch_generation;
+             ALTER TABLE dashboard_tiles DROP COLUMN question_readable_folders_json;
+             ALTER TABLE dashboard_tiles DROP COLUMN answer_readable_folders_json;
+             ALTER TABLE dashboard_tiles DROP COLUMN living_question;
+             ALTER TABLE dashboard_tiles DROP COLUMN living_answer;
+             ALTER TABLE dashboard_tiles DROP COLUMN living_answered_at;
+             ALTER TABLE dashboard_tiles DROP COLUMN living_answer_context_generation;
+             ALTER TABLE dashboard_tiles DROP COLUMN living_answer_context_digest;
+             ALTER TABLE dashboard_tiles DROP COLUMN living_answer_context_budget;
+             ALTER TABLE dashboard_tiles DROP COLUMN living_answer_ask_dispatch_generation;",
+        )
+        .unwrap();
+
+    db.migrate().unwrap();
+    db.migrate().unwrap();
+    let state: (i64, i64) = db
+        .lock()
+        .query_row(
+            "SELECT generation, exists_now FROM dashboard_context_state WHERE dashboard_id=?1",
+            [&board_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(state, (0, 1));
+    assert_eq!(
+        db.dashboard_structural_context_state(&board_id).unwrap(),
+        (0, true)
+    );
+    let tile_columns = db
+        .lock()
+        .prepare("PRAGMA table_info(dashboard_tiles)")
+        .unwrap()
+        .query_map([], |row| row.get::<_, String>(1))
+        .unwrap()
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .unwrap();
+    for column in [
+        "question_readable_folders_json",
+        "answer_readable_folders_json",
+        "living_question",
+        "living_answer",
+        "living_answered_at",
+        "living_answer_context_generation",
+        "living_answer_context_digest",
+        "living_answer_context_budget",
+        "living_answer_ask_dispatch_generation",
+    ] {
+        assert!(tile_columns.iter().any(|found| found == column));
+    }
+    let legacy = db
+        .load_ask_conversation(&scope, &conversation_id, &std::collections::HashSet::new())
+        .unwrap();
+    assert!(legacy.is_none(), "legacy unstamped history must fail closed");
 }

--- a/src-tauri/src/storage/db_tests/lock_tests.rs
+++ b/src-tauri/src/storage/db_tests/lock_tests.rs
@@ -525,6 +525,92 @@ fn mcp_visibility_filter() {
     assert!(visible_after.contains("sealed1"));
 }
 
+/// A meeting has no independent folder column: its canonical ownership edge is created only when
+/// a note row receives `notes.folder_id`. Live/crash-recovery meetings therefore remain visible at
+/// the vault root before their first note, while the same meeting must disappear atomically from
+/// every meeting-row resolver once its note is owned by a sealed folder.
+#[test]
+fn no_note_live_meeting_is_root_visible_until_note_establishes_locked_ownership() {
+    let db = file_db("no-note-root-ownership");
+    let empty: HashSet<String> = HashSet::new();
+    let title = "live root visibility sentinel";
+
+    db.insert_meeting(&Meeting {
+        id: "live-root".to_string(),
+        started_at: "2026-08-13T10:00:00Z".to_string(),
+        ended_at: None,
+        title: Some(title.to_string()),
+        duration_s: 17,
+        audio_path: Some("/tmp/live-root.wav".to_string()),
+        status: MeetingStatus::Recording,
+        folder_id: None,
+    })
+    .unwrap();
+
+    let live = db
+        .get_meeting_if_visible("live-root", &empty)
+        .unwrap()
+        .expect("a no-note live recording is canonically unfiled and visible");
+    assert_eq!(live.title.as_deref(), Some(title));
+    assert_eq!(live.audio_path.as_deref(), Some("/tmp/live-root.wav"));
+    assert_eq!(live.folder_id, None);
+    assert_eq!(live.status, MeetingStatus::Recording);
+    assert!(db.meeting_is_visible("live-root", &empty).unwrap());
+    assert!(db
+        .meeting_by_title_visible(title, &empty)
+        .unwrap()
+        .is_some());
+    assert!(db
+        .list_meetings_visible(50, &empty)
+        .unwrap()
+        .iter()
+        .any(|meeting| meeting.id == "live-root"));
+
+    seed_folder(&db, "secret-live", "Secret live");
+    db.upsert_note(&NoteRecord {
+        meeting_id: "live-root".to_string(),
+        provider_id: "claude_code".to_string(),
+        markdown: "# finalized\n".to_string(),
+        created_at: "2026-08-13T10:01:00Z".to_string(),
+        exported_path: None,
+        model_requested: None,
+        model_served: None,
+        gateway_host: None,
+    })
+    .unwrap();
+    db.set_meeting_folder("live-root", Some("secret-live"))
+        .unwrap();
+    db.update_meeting_status("live-root", MeetingStatus::Summarized)
+        .unwrap();
+    let kek = crate::crypto::random_key().unwrap();
+    seal_folder(&db, "secret-live", &kek);
+
+    assert!(db
+        .get_meeting_if_visible("live-root", &empty)
+        .unwrap()
+        .is_none());
+    assert!(!db.meeting_is_visible("live-root", &empty).unwrap());
+    assert!(db
+        .meeting_by_title_visible(title, &empty)
+        .unwrap()
+        .is_none());
+    assert!(!db
+        .list_meetings_visible(50, &empty)
+        .unwrap()
+        .iter()
+        .any(|meeting| meeting.id == "live-root"));
+
+    session_unlock(&db, "secret-live", &kek);
+    let unlocked = HashSet::from(["secret-live".to_string()]);
+    let restored = db
+        .get_meeting_if_visible("live-root", &unlocked)
+        .unwrap()
+        .expect("session unlock restores the canonically owned meeting row");
+    assert_eq!(restored.title.as_deref(), Some(title));
+    assert_eq!(restored.audio_path.as_deref(), Some("/tmp/live-root.wav"));
+    assert_eq!(restored.folder_id.as_deref(), Some("secret-live"));
+}
+
 #[test]
 fn remove_lock_re_plaintexts() {
     let db = file_db("remove");
@@ -1723,7 +1809,7 @@ fn forget_entity_fact_closes_the_row_and_is_idempotent() {
         "re-forget is a no-op (idempotent)"
     );
     assert!(db
-        .list_ask_conversations(&AskConversationScope::Vault, &HashSet::new())
+        .list_ask_conversation_ids(&AskConversationScope::Vault, &HashSet::new())
         .unwrap()
         .is_empty());
 
@@ -1789,7 +1875,7 @@ fn forget_and_clear_user_facts() {
         "re-forget is a no-op"
     );
     assert!(db
-        .list_ask_conversations(&AskConversationScope::Vault, &HashSet::new())
+        .list_ask_conversation_ids(&AskConversationScope::Vault, &HashSet::new())
         .unwrap()
         .is_empty());
     let after = db.list_user_facts_visible(&HashSet::new()).unwrap();
@@ -1828,7 +1914,7 @@ fn forget_and_clear_user_facts() {
         "no user memory after clear"
     );
     assert!(db
-        .list_ask_conversations(&AskConversationScope::Vault, &HashSet::new())
+        .list_ask_conversation_ids(&AskConversationScope::Vault, &HashSet::new())
         .unwrap()
         .is_empty());
 }

--- a/src-tauri/src/storage/graph_store.rs
+++ b/src-tauri/src/storage/graph_store.rs
@@ -1000,6 +1000,49 @@ impl Db {
             neighbors,
         }))
     }
+
+    /// Exact-ID entity projection for dashboard tiles. It applies the same mention visibility gate
+    /// as the capped list without hydrating unrelated entity names or dropping a selected entity
+    /// merely because 500 others rank ahead of it.
+    pub(crate) fn get_entity_node_visible(
+        &self,
+        entity_id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Option<GraphNode>> {
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let sql = format!(
+            "SELECT e.id,e.name,e.kind,COUNT(em.meeting_id) AS cnt
+               FROM entities e
+               JOIN entity_mentions em ON em.entity_id=e.id
+               JOIN meetings m ON m.id=em.meeting_id
+              WHERE e.id=?1 AND (
+                NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id=m.id)
+                OR EXISTS (SELECT 1 FROM notes n LEFT JOIN folders f ON f.id=n.folder_id
+                            WHERE n.meeting_id=m.id AND {visible}))
+              GROUP BY e.id,e.name,e.kind HAVING cnt>0"
+        );
+        let row = conn
+            .query_row(&sql, [entity_id], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, i64>(3)?,
+                ))
+            })
+            .optional()
+            .map_err(map_err)?;
+        row.map(|(id, name, kind, mention_count)| {
+            Ok(GraphNode {
+                id,
+                name,
+                kind: EntityKind::from_str(&kind)?,
+                mention_count,
+            })
+        })
+        .transpose()
+    }
 }
 
 /// One VISIBLE note/document node row for the full-brain graph, pre-typed: `(kind, id, label, date)`

--- a/src-tauri/src/storage/links.rs
+++ b/src-tauri/src/storage/links.rs
@@ -2707,31 +2707,35 @@ impl Db {
     ) -> Result<Option<String>> {
         match kind {
             crate::links::LinkKind::Meeting => {
-                if !self.meeting_is_visible(id, unlocked)? {
-                    return Ok(None);
-                }
-                let conn = self.lock();
-                conn.query_row(
-                    "SELECT COALESCE(NULLIF(TRIM(title), ''), 'Meeting') FROM meetings WHERE id = ?1",
-                    rusqlite::params![id],
-                    |r| r.get::<_, String>(0),
-                )
-                .optional()
-                .map_err(map_err)
+                // One gated SQL read: never authorize and then hydrate the title in a second
+                // connection interval where a relock could land between the two operations.
+                Ok(self.get_meeting_if_visible(id, unlocked)?.map(|meeting| {
+                    meeting
+                        .title
+                        .filter(|title| !title.trim().is_empty())
+                        .unwrap_or_else(|| "Meeting".to_string())
+                }))
             }
             crate::links::LinkKind::Note | crate::links::LinkKind::Document => {
                 let conn = self.lock();
                 let visible = visibility_clause("f", unlocked);
+                let expected_kind = match kind {
+                    crate::links::LinkKind::Note => "note",
+                    crate::links::LinkKind::Document => "document",
+                    crate::links::LinkKind::Meeting => unreachable!(),
+                };
                 let sql = format!(
                     "SELECT COALESCE(NULLIF(TRIM(d.title), ''), d.name)
                        FROM documents d
                        JOIN folders f ON f.id = d.folder_id
-                      WHERE d.id = ?1 AND {visible}
+                      WHERE d.id = ?1 AND d.kind = ?2 AND {visible}
                       LIMIT 1"
                 );
-                conn.query_row(&sql, rusqlite::params![id], |r| r.get::<_, String>(0))
-                    .optional()
-                    .map_err(map_err)
+                conn.query_row(&sql, rusqlite::params![id, expected_kind], |r| {
+                    r.get::<_, String>(0)
+                })
+                .optional()
+                .map_err(map_err)
             }
         }
     }

--- a/src-tauri/src/storage/mcp_store.rs
+++ b/src-tauri/src/storage/mcp_store.rs
@@ -97,6 +97,36 @@ impl Db {
         Ok(())
     }
 
+    /// Remove a server and rotate Ask authorization in the same transaction only when the server
+    /// was consented (and therefore part of the effective durable-Ask tool surface).
+    pub(crate) fn delete_mcp_server_for_ask(&self, id: &str) -> Result<()> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let consented = tx
+            .query_row("SELECT consented FROM mcp_servers WHERE id=?1", [id], |row| {
+                row.get::<_, i64>(0)
+            })
+            .optional()
+            .map_err(map_err)?
+            == Some(1);
+        tx.execute("DELETE FROM mcp_servers WHERE id=?1", [id])
+            .map_err(map_err)?;
+        if consented {
+            let rotated = tx.execute(
+                "UPDATE ask_dispatch_state SET generation=generation+1 WHERE singleton=1
+                   AND typeof(generation)='integer' AND generation>=0 AND generation<9223372036854775807",
+                [],
+            )
+            .map_err(map_err)?;
+            if rotated != 1 {
+                return Err(AppError::Storage(
+                    "Ask dispatch generation is unavailable".into(),
+                ));
+            }
+        }
+        tx.commit().map_err(map_err)
+    }
+
     /// Flip one MCP server's per-server egress consent (the ONLY writer of `consented`).
     pub fn set_mcp_server_consented(&self, id: &str, consented: bool) -> Result<()> {
         let conn = self.lock();
@@ -106,6 +136,37 @@ impl Db {
         )
         .map_err(map_err)?;
         Ok(())
+    }
+
+    /// Flip MCP consent and rotate Ask authorization atomically. Idempotent writes do neither.
+    pub(crate) fn set_mcp_server_consented_for_ask(
+        &self,
+        id: &str,
+        consented: bool,
+    ) -> Result<bool> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let changed = tx
+            .execute(
+                "UPDATE mcp_servers SET consented=?2 WHERE id=?1 AND consented<>?2",
+                rusqlite::params![id, consented as i64],
+            )
+            .map_err(map_err)?;
+        if changed == 1 {
+            let rotated = tx.execute(
+                "UPDATE ask_dispatch_state SET generation=generation+1 WHERE singleton=1
+                   AND typeof(generation)='integer' AND generation>=0 AND generation<9223372036854775807",
+                [],
+            )
+            .map_err(map_err)?;
+            if rotated != 1 {
+                return Err(AppError::Storage(
+                    "Ask dispatch generation is unavailable".into(),
+                ));
+            }
+        }
+        tx.commit().map_err(map_err)?;
+        Ok(changed == 1)
     }
 }
 

--- a/src-tauri/src/storage/meetings_store.rs
+++ b/src-tauri/src/storage/meetings_store.rs
@@ -655,6 +655,41 @@ impl Db {
             .transpose()
     }
 
+    /// Full meeting row through one SQL visibility predicate. Unlike a check-then-`get_meeting`
+    /// pair, a concurrent relock cannot land between authorization and reading title/audio_path.
+    ///
+    /// Canonical ownership invariant: a meeting's only folder edge is `notes.folder_id`, so a
+    /// meeting with no note rows is necessarily unfiled/root-visible. That state is intentional
+    /// for live recordings and crash-recovery ghosts. Do not infer a former seal from optional
+    /// artifacts: segment/timeline/manual-note blobs and encrypted audio can all legitimately be
+    /// absent. Once a note establishes folder ownership, the predicate below gates and hydrates
+    /// the row in the same SQL statement.
+    pub fn get_meeting_if_visible(
+        &self,
+        id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Option<Meeting>> {
+        let conn = self.lock();
+        let visible = visibility_clause("n", unlocked);
+        let sql = format!(
+            "SELECT m.id, m.started_at, m.ended_at, m.title, m.duration_s, m.audio_path, m.status,
+                    (SELECT nf.folder_id FROM notes nf
+                      WHERE nf.meeting_id = m.id AND nf.folder_id IS NOT NULL LIMIT 1)
+               FROM meetings m
+              WHERE m.id = ?1 AND (
+                    NOT EXISTS (SELECT 1 FROM notes nn WHERE nn.meeting_id = m.id)
+                    OR EXISTS (
+                      SELECT 1 FROM notes n
+                       LEFT JOIN folders f ON f.id = n.folder_id
+                       WHERE n.meeting_id = m.id AND {visible}
+                    ))"
+        );
+        conn.query_row(&sql, rusqlite::params![id], row_to_meeting)
+            .optional()
+            .map_err(map_err)?
+            .transpose()
+    }
+
     /// CASE-FOLDED twin of [`Self::meeting_by_title_visible`] (brain-v3 audit Fix 6): the same
     /// gated resolver but comparing `LOWER(m.title) = LOWER(?1)` so `[[project x]]` resolves a
     /// meeting titled "Project X". Used ONLY as [`Self::resolve_wikilink`]'s meeting-leg fallback

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -722,6 +722,7 @@ pub struct DocumentSummary {
     pub name: String,
     pub title: Option<String>,
     pub markdown: String,
+    pub created_at: i64,
     pub updated_at: Option<i64>,
 }
 
@@ -1160,6 +1161,16 @@ pub struct AskConversationSourceRef {
     pub title: String,
 }
 
+/// Live dashboard chrome for a durable composite scope. Only `dashboard_id` is persisted on the
+/// conversation; title/emoji are resolved from the current board row on every load.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DashboardScopeRef {
+    pub id: String,
+    pub title: String,
+    pub emoji: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AskConversation {
@@ -1167,6 +1178,7 @@ pub struct AskConversation {
     pub scope: AskConversationScope,
     pub title: String,
     pub selected_sources: Vec<AskConversationSourceRef>,
+    pub dashboard: Option<DashboardScopeRef>,
     pub messages: Vec<AskConversationMessage>,
     pub created_at: String,
     pub updated_at: String,

--- a/src-tauri/src/storage/reminder_store.rs
+++ b/src-tauri/src/storage/reminder_store.rs
@@ -13,7 +13,7 @@ use std::borrow::Cow;
 
 use crate::error::{AppError, Result};
 use crate::reminder_audit::ReminderAuditCandidate;
-use crate::storage::db::{map_err, Db};
+use crate::storage::db::{map_err, visibility_clause, Db};
 use crate::storage::models::{
     ReminderDraft, ReminderOrigin, ReminderRepeatUnit, ReminderSourceAnchor, ReminderState,
     ReminderSuggestionGateAnchor, StoredReminder, StoredReminderOccurrence,
@@ -1168,6 +1168,58 @@ impl Db {
             reminder.sources = list_sources(&conn, &reminder.id)?;
         }
         Ok(reminders)
+    }
+
+    /// Dashboard/agent projection that authorizes every Smart-reminder anchor in SQL BEFORE
+    /// hydrating its title. Manual reminders with no anchors are user-authored and remain valid;
+    /// Smart reminders with no anchors, unknown kinds, deleted sources, or any sealed source fail
+    /// closed. The normal reminder writer still accepts only note/meeting anchors; the document
+    /// arm keeps imported/future rows on the same typed visibility gate instead of silently
+    /// dropping a readable source. Returns only the two fields the dashboard renders.
+    pub(crate) fn list_dashboard_reminders_visible(
+        &self,
+        unlocked: &std::collections::HashSet<String>,
+    ) -> Result<Vec<(String, i64)>> {
+        let conn = self.lock();
+        // `visibility_clause` deliberately uses the canonical `f` folder alias. Keep each
+        // correlated source subquery scoped to that alias instead of assuming its parameter
+        // rewrites the SQL identifier (it does not).
+        let folder_visible = visibility_clause("f", unlocked);
+        let sql = format!(
+            "SELECT r.title, r.due_at
+               FROM reminders r
+              WHERE r.state='active'
+                AND (r.origin='manual' OR EXISTS (
+                      SELECT 1 FROM reminder_sources present WHERE present.reminder_id=r.id))
+                AND NOT EXISTS (
+                  SELECT 1 FROM reminder_sources rs
+                   WHERE rs.reminder_id=r.id AND (
+                     (rs.source_kind='meeting' AND NOT EXISTS (
+                       SELECT 1 FROM meetings m WHERE m.id=rs.source_id AND (
+                         NOT EXISTS (SELECT 1 FROM notes any_n WHERE any_n.meeting_id=m.id)
+                         OR EXISTS (SELECT 1 FROM notes mn
+                           LEFT JOIN folders f ON f.id=mn.folder_id
+                          WHERE mn.meeting_id=m.id AND {folder_visible})
+                       )))
+                     OR (rs.source_kind='note' AND NOT EXISTS (
+                       SELECT 1 FROM documents d
+                       JOIN folders f ON f.id=d.folder_id
+                       WHERE d.id=rs.source_id AND d.kind='note' AND {folder_visible}))
+                     OR (rs.source_kind='document' AND NOT EXISTS (
+                       SELECT 1 FROM documents d
+                       JOIN folders f ON f.id=d.folder_id
+                       WHERE d.id=rs.source_id AND d.kind='document' AND {folder_visible}))
+                     OR rs.source_kind NOT IN ('meeting','note','document')
+                   ))
+              ORDER BY r.due_at ASC, r.id ASC"
+        );
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .map_err(map_err)?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(map_err)?;
+        Ok(rows)
     }
 
     pub fn get_stored_reminder(&self, id: &str) -> Result<Option<StoredReminder>> {

--- a/src-tauri/src/storage/settings_store.rs
+++ b/src-tauri/src/storage/settings_store.rs
@@ -50,6 +50,93 @@ impl Db {
         Ok(())
     }
 
+    /// Current global Ask-dispatch authorization generation. Captured with the effective Ask
+    /// config under the process lifecycle mutex and compared again at every dispatch/read CAS.
+    pub(crate) fn ask_dispatch_generation(&self) -> Result<i64> {
+        self.lock()
+            .query_row(
+                "SELECT generation FROM ask_dispatch_state WHERE singleton=1
+                   AND typeof(generation)='integer' AND generation>=0",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(map_err)
+    }
+
+    /// Advance the durable Ask-dispatch generation before a multi-row AppConfig save. A later
+    /// config-save failure may conservatively over-invalidate, but can never leave an old provider
+    /// authorization usable after a partially persisted change.
+    pub(crate) fn advance_ask_dispatch_generation(&self) -> Result<i64> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        tx.execute(
+            "UPDATE ask_dispatch_state SET generation=generation+1 WHERE singleton=1
+               AND typeof(generation)='integer' AND generation>=0 AND generation<9223372036854775807",
+            [],
+        )
+        .map_err(map_err)
+        .and_then(|changed| {
+            if changed == 1 {
+                Ok(changed)
+            } else {
+                Err(crate::error::AppError::Storage(
+                    "Ask dispatch generation is unavailable".into(),
+                ))
+            }
+        })?;
+        let generation = tx
+            .query_row(
+                "SELECT generation FROM ask_dispatch_state WHERE singleton=1
+                   AND typeof(generation)='integer' AND generation>=0",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(map_err)?;
+        tx.commit().map_err(map_err)?;
+        Ok(generation)
+    }
+
+    /// Persist cloud consent and rotate Ask authorization atomically. Callers compare the cached
+    /// value first, so idempotent grant/revoke operations do not rotate the generation.
+    pub(crate) fn set_cloud_egress_consent_and_advance_ask_dispatch(
+        &self,
+        consented: bool,
+    ) -> Result<i64> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        tx.execute(
+            "INSERT INTO settings(key,value) VALUES ('cloud_egress_consented',?1)
+             ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+            [if consented { "true" } else { "false" }],
+        )
+        .map_err(map_err)?;
+        tx.execute(
+            "UPDATE ask_dispatch_state SET generation=generation+1 WHERE singleton=1
+               AND typeof(generation)='integer' AND generation>=0 AND generation<9223372036854775807",
+            [],
+        )
+        .map_err(map_err)
+        .and_then(|changed| {
+            if changed == 1 {
+                Ok(changed)
+            } else {
+                Err(crate::error::AppError::Storage(
+                    "Ask dispatch generation is unavailable".into(),
+                ))
+            }
+        })?;
+        let generation = tx
+            .query_row(
+                "SELECT generation FROM ask_dispatch_state WHERE singleton=1
+                   AND typeof(generation)='integer' AND generation>=0",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(map_err)?;
+        tx.commit().map_err(map_err)?;
+        Ok(generation)
+    }
+
     /// Persist the selected embedding-model id and, when its resolved model changed, invalidate
     /// every vector partition in the SAME transaction. Chunks + FTS stay intact, so retrieval
     /// degrades to keyword-only until the explicit/background reindex repopulates vectors.
@@ -76,6 +163,38 @@ impl Db {
         }
         tx.commit().map_err(map_err)?;
         Ok(())
+    }
+
+    /// Ask-aware embedding-model switch: setting, vector invalidation and dispatch-generation
+    /// rotation commit atomically so retrieval can never resume with an old authorization.
+    pub(crate) fn set_embed_model_selection_for_ask(
+        &self,
+        model_id: &str,
+        invalidate_vectors: bool,
+    ) -> Result<()> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        tx.execute(
+            "INSERT INTO settings (key, value) VALUES ('embed_model_id', ?1)
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            rusqlite::params![model_id],
+        )
+        .map_err(map_err)?;
+        if invalidate_vectors {
+            delete_all_vector_partitions(&tx)?;
+        }
+        let rotated = tx.execute(
+            "UPDATE ask_dispatch_state SET generation=generation+1 WHERE singleton=1
+               AND typeof(generation)='integer' AND generation>=0 AND generation<9223372036854775807",
+            [],
+        )
+        .map_err(map_err)?;
+        if rotated != 1 {
+            return Err(crate::error::AppError::Storage(
+                "Ask dispatch generation is unavailable".into(),
+            ));
+        }
+        tx.commit().map_err(map_err)
     }
 
     /// Clear every model-dependent vector partition in one transaction while preserving all

--- a/src-tauri/src/summarize/chat.rs
+++ b/src-tauri/src/summarize/chat.rs
@@ -39,6 +39,24 @@ pub fn build_with_sources(
     question: &str,
     memory_brief: &str,
 ) -> (String, String) {
+    build_with_composite_sources(
+        transcript,
+        pinned_sources,
+        history,
+        question,
+        memory_brief,
+        false,
+    )
+}
+
+pub fn build_with_composite_sources(
+    transcript: &str,
+    pinned_sources: &str,
+    history: &[ChatTurn],
+    question: &str,
+    memory_brief: &str,
+    dashboard_scope: bool,
+) -> (String, String) {
     let t = if transcript.chars().count() > MAX_TRANSCRIPT_CHARS {
         let head: String = transcript.chars().take(MAX_TRANSCRIPT_CHARS).collect();
         format!("{head}\n[transcript truncated]")
@@ -65,7 +83,18 @@ pub fn build_with_sources(
         )
     };
 
-    let system = if pinned.trim().is_empty() {
+    let system = if dashboard_scope {
+        format!(
+            "You are a helpful assistant answering questions about ONE primary meeting within a \
+USER-COMPOSED DASHBOARD. Base answers strictly on the meeting transcript and readable dashboard \
+grounding below. The dashboard grounding can include notes, recordings, documents, capped active \
+linked context, and derived views. Preserve the meeting as the primary anchor while treating the \
+dashboard as a mixed-source corpus. If the answer is not in either section, say you \
+don't know. Never invent facts, decisions, or attributions. Do not claim there is no dashboard \
+context merely because privacy gating omitted some items. Be concise and concrete.\n\n\
+MEETING TRANSCRIPT:\n{t}\n\nDASHBOARD GROUNDING:\n{pinned}"
+        )
+    } else if pinned.trim().is_empty() {
         // Keep the original transcript-only prompt byte-for-byte when the picker is empty or every
         // selected source was gated away.
         format!(
@@ -158,6 +187,23 @@ mod tests {
         let legacy = build("transcript", &[], "question", "memory");
         let blank = build_with_sources("transcript", "   ", &[], "question", "memory");
         assert_eq!(blank, legacy);
+    }
+
+    #[test]
+    fn meeting_dashboard_prompt_keeps_anchor_and_names_composite_scope() {
+        let (system, _) = build_with_composite_sources(
+            "primary transcript",
+            "### [[Plan]]\ndocument body\n\n- promises\n    · ship it",
+            &[],
+            "q",
+            "must not appear",
+            true,
+        );
+        assert!(system.contains("ONE primary meeting"));
+        assert!(system.contains("USER-COMPOSED DASHBOARD"));
+        assert!(system.contains("DASHBOARD GROUNDING"));
+        assert!(!system.contains("meeting notes only"));
+        assert!(!system.contains("must not appear"));
     }
 
     /// EMPTY memory brief ⇒ byte-identical to the pre-memory prompt (no block); a present brief ⇒

--- a/src-tauri/src/summarize/vault_chat.rs
+++ b/src-tauri/src/summarize/vault_chat.rs
@@ -57,6 +57,32 @@ Never output YAML or front-matter.\n\n\
     (system, render_conversation(history, question))
 }
 
+/// Board-scoped variant for a mixed user-composed corpus. The grounding may contain notes,
+/// recordings, imported documents, capped linked context, and rendered derived views, so the
+/// meeting-notes-only persona would describe its provenance falsely.
+pub fn build_for_dashboard(corpus: &str, history: &[ChatTurn], question: &str) -> (String, String) {
+    let system = format!(
+        "You answer questions about ONE USER-COMPOSED DASHBOARD, using ONLY the readable grounding \
+material provided below. The dashboard can contain meeting recordings, authored notes, imported \
+documents, capped active linked context, and derived views already computed by Murmur.\n\
+Rules:\n\
+- Treat this as dashboard context and preserve its curated scope; never search or infer from the \
+rest of the vault.\n\
+- Answer strictly from the readable material and derived views below. If the answer is not there, \
+say you don't know. Never invent facts, decisions, or attributions.\n\
+- Cite named source material inline using its [[Title]] exactly as given when available.\n\
+- Do not claim that dashboard context is unavailable merely because some dashboard items are \
+sealed, missing, or omitted by the privacy gate.\n\
+- Be concise and concrete.\n\
+{coordinates}\n\
+- Format as clean, scannable Markdown: a one-line **bold takeaway** first, then tight bullets or \
+short `##` sections. Never output YAML or front-matter.\n\n\
+DASHBOARD GROUNDING:\n{corpus}",
+        coordinates = FACT_COORDINATE_RULES,
+    );
+    (system, render_conversation(history, question))
+}
+
 /// Render the optional USER MEMORY block. EMPTY brief ⇒ EMPTY string (byte-identical prompt); a
 /// present brief ⇒ a small labelled block terminated by a blank line so the following section header
 /// stays on its own line. Shared by the corpus floor ([`build`]) and the agentic persona
@@ -307,6 +333,29 @@ mod tests {
         assert!(s.contains("[[Sync]]"));
         assert!(u.contains("User: What shipped?"));
         assert!(u.trim_end().ends_with("Assistant:"));
+    }
+
+    #[test]
+    fn dashboard_prompt_describes_mixed_composite_provenance() {
+        let (system, user) = build_for_dashboard(
+            "### [[Plan]] · document\nbody\n\n- promises\n    · ship it",
+            &[],
+            "What is next?",
+        );
+        assert!(system.contains("USER-COMPOSED DASHBOARD"));
+        assert!(system.contains("derived views"));
+        assert!(system.contains("DASHBOARD GROUNDING"));
+        assert!(!system.contains("using ONLY the meeting notes"));
+        assert!(!system.contains("MEETING NOTES:"));
+        assert!(user.contains("User: What is next?"));
+    }
+
+    #[test]
+    fn dashboard_builder_does_not_change_non_dashboard_prompt() {
+        let normal = build("corpus", &[], "question", "");
+        assert!(normal.0.contains("PAST MEETINGS"));
+        assert!(normal.0.contains("MEETING NOTES:"));
+        assert!(!normal.0.contains("USER-COMPOSED DASHBOARD"));
     }
 
     /// RED-before-GREEN from the local Qwen bake-off: one negative budget status must not negate an

--- a/src-tauri/src/summarize/vault_context.rs
+++ b/src-tauri/src/summarize/vault_context.rs
@@ -24,6 +24,79 @@ use crate::storage::Db;
 /// graph into one prompt.
 const LINK_CONTEXT_CAP: usize = 8;
 
+/// The exact, gated source graph selected for a pinned provider corpus. Keeping selection separate
+/// from packing lets lifecycle witnesses hash every selected input even when the provider budget
+/// later truncates all of its bytes.
+#[derive(Debug, Clone)]
+pub(crate) struct PinnedVisibleInputs {
+    pub(crate) explicit_sources: Vec<ResolvedPinnedSource>,
+    pub(crate) neighbours: Vec<ResolvedPinnedSource>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedPinnedSource {
+    pub(crate) source: SourceRef,
+    header: String,
+    body: String,
+    body_required: bool,
+    pub(crate) manifest_digest: [u8; 32],
+    pub(crate) vault_sources: Vec<VaultSource>,
+}
+
+fn hash_manifest_field(hasher: &mut sha2::Sha256, label: &str, value: &[u8]) {
+    use sha2::Digest;
+
+    let label_len = u64::try_from(label.len()).unwrap_or(u64::MAX);
+    let value_len = u64::try_from(value.len()).unwrap_or(u64::MAX);
+    hasher.update(label_len.to_be_bytes());
+    hasher.update(label.as_bytes());
+    hasher.update(value_len.to_be_bytes());
+    hasher.update(value);
+}
+
+fn source_manifest_digest(
+    effective_title: &str,
+    started_at: Option<&str>,
+    body_present: bool,
+    body: &str,
+) -> [u8; 32] {
+    use sha2::Digest;
+
+    let mut hasher = sha2::Sha256::new();
+    hash_manifest_field(&mut hasher, "domain", b"murmur:pinned-source-input:v1");
+    hash_manifest_field(&mut hasher, "effective_title", effective_title.as_bytes());
+    hash_manifest_field(
+        &mut hasher,
+        "started_at",
+        started_at.unwrap_or("").as_bytes(),
+    );
+    hash_manifest_field(
+        &mut hasher,
+        "body_present",
+        if body_present { b"1" } else { b"0" },
+    );
+    if body_present {
+        hash_manifest_field(&mut hasher, "full_body", body.as_bytes());
+    }
+    hasher.finalize().into()
+}
+
+impl ResolvedPinnedSource {
+    /// Preserve the established packer contract: a source needs room for its header plus at least
+    /// 200 body characters; otherwise it contributes no truncated header and no source chip.
+    fn section_for_budget(&self, budget: usize) -> Option<String> {
+        let remaining = budget.saturating_sub(self.header.len());
+        if remaining < 200 {
+            return None;
+        }
+        let body: String = self.body.chars().take(remaining).collect();
+        if self.body_required && body.trim().is_empty() {
+            return None;
+        }
+        Some(format!("{}{body}", self.header))
+    }
+}
+
 /// Char budget for the corpus, by provider. Weak on-device models (the explicit local Brain,
 /// Apple Foundation Models, and Ollama) have small context windows, so cap them much tighter;
 /// API/CLI models get headroom. Reuse `related_context`'s canonical classification so a new
@@ -325,45 +398,6 @@ fn pack_meetings(
     Ok((corpus, sources))
 }
 
-/// note↔meeting-links PR-2 — pack ONE standalone note/document (`documents` table row) into the
-/// budget-capped `corpus`, headed by a `### [[Title]] · id:` citation mirroring [`pack_meetings`].
-/// The read is GATED: `get_document_if_visible` returns `None` for a sealed-and-not-session-unlocked
-/// note/document, so its (possibly-stale-plaintext) body never enters the corpus (E9). Reads BOTH
-/// `kind='note'` and `kind='document'` rows (the gated reader is not kind-restricted). Returns
-/// `true` iff something was packed (so the caller can count what actually contributed).
-fn pack_notes(
-    db: &Db,
-    doc_id: &str,
-    budget: usize,
-    corpus: &mut String,
-    unlocked: &HashSet<String>,
-) -> Result<bool> {
-    if corpus.len() >= budget {
-        return Ok(false);
-    }
-    // GATE: sealed-and-not-unlocked note/document ⇒ `None` ⇒ contributes nothing.
-    let Some(doc) = db.get_document_if_visible(doc_id, unlocked)? else {
-        return Ok(false);
-    };
-    // Prefer the authored title; a `kind='document'` upload leaves title NULL → fall back to `name`.
-    let title = doc
-        .title
-        .filter(|t| !t.trim().is_empty())
-        .unwrap_or(doc.name);
-    let header = format!("\n\n### [[{title}]] · id:{}\n", doc.id);
-    let remaining = budget.saturating_sub(corpus.len() + header.len());
-    if remaining < 200 {
-        return Ok(false);
-    }
-    let chunk: String = doc.markdown.chars().take(remaining).collect();
-    if chunk.trim().is_empty() {
-        return Ok(false);
-    }
-    corpus.push_str(&header);
-    corpus.push_str(&chunk);
-    Ok(true)
-}
-
 /// Pack ONE PINNED org item (a read-only SHARED org-feed note being VIEWED in the org-item viewer)
 /// into a budget-capped corpus chunk, headed by a `### [[Title]] · shared · id:` citation mirroring
 /// [`pack_notes`]. Used by the Ask floor so "Ask about this shared note" is ALWAYS grounded in the
@@ -456,46 +490,46 @@ pub(crate) fn build_vault_context_pinned_visible_with_budget(
         return Ok((String::new(), Vec::new()));
     }
 
+    let inputs = resolve_vault_context_pinned_visible_inputs(db, sources, unlocked)?;
+    build_vault_context_resolved_visible_with_budget(db, &inputs, budget, unlocked)
+}
+
+/// Resolve the typed-visible explicit set and its ordered, deduped active-neighbour expansion once.
+/// Both the provider packer and the dashboard's exact lifecycle manifest consume this value, so
+/// neither can silently select a different ninth neighbour or a different typed endpoint.
+pub(crate) fn resolve_vault_context_pinned_visible_inputs(
+    db: &Db,
+    sources: &[SourceRef],
+    unlocked: &HashSet<String>,
+) -> Result<PinnedVisibleInputs> {
+    if sources.is_empty() {
+        return Ok(PinnedVisibleInputs {
+            explicit_sources: Vec::new(),
+            neighbours: Vec::new(),
+        });
+    }
+
     // Dedupe explicit identities while preserving picker order.
     let mut explicit_keys: HashSet<(String, String)> = HashSet::new();
-    let mut explicit_sources: Vec<&SourceRef> = Vec::new();
+    let mut explicit_refs: Vec<SourceRef> = Vec::new();
     for source in sources {
         let key = (source.kind.as_str().to_string(), source.id.clone());
-        if explicit_keys.insert(key) {
-            explicit_sources.push(source);
-        }
-    }
-
-    // Build each EXPLICIT source as a content-only section. Each read remains behind the same
-    // visible packer; link expansion deliberately does not happen here.
-    let mut sections: Vec<(String, Vec<VaultSource>)> = Vec::new();
-    for source in &explicit_sources {
-        match source.kind {
+        let typed_visible = match source.kind {
             LinkKind::Meeting => {
-                if let Some(meeting) = db.get_meeting(&source.id)? {
-                    let (section, section_sources) =
-                        pack_meetings(db, vec![meeting], budget, unlocked)?;
-                    if !section.trim().is_empty() {
-                        sections.push((section, section_sources));
-                    }
-                }
+                db.meeting_is_visible(&source.id, unlocked)?
+                    && db.dashboard_ref_exists("meeting", &source.id)?
             }
-            LinkKind::Note | LinkKind::Document => {
-                let mut section = String::new();
-                if pack_notes(db, &source.id, budget, &mut section, unlocked)?
-                    && !section.trim().is_empty()
-                {
-                    sections.push((section, Vec::new()));
-                }
-            }
+            LinkKind::Note => db.note_is_visible(&source.id, unlocked)?,
+            LinkKind::Document => db.document_is_visible(&source.id, unlocked)?,
+        };
+        if typed_visible && explicit_keys.insert(key) {
+            explicit_refs.push(source.clone());
         }
     }
-    let (mut corpus, mut vault_sources) = fair_pack_explicit_sections(sections, budget);
 
-    // ONE global link expansion: one explicit set, one neighbour dedupe, one cap across ALL sources.
     let mut seen_neighbours: HashSet<(String, String)> = HashSet::new();
-    let mut neighbours: Vec<(LinkKind, String)> = Vec::new();
-    'outer: for source in &explicit_sources {
+    let mut neighbours = Vec::new();
+    'outer: for source in &explicit_refs {
         let edges = db.links_for_visible(source.kind, &source.id, unlocked)?;
         for edge in edges {
             if edge.status != "active" {
@@ -508,33 +542,156 @@ pub(crate) fn build_vault_context_pinned_visible_with_budget(
             if explicit_keys.contains(&key) || !seen_neighbours.insert(key.clone()) {
                 continue;
             }
-            neighbours.push((other_kind, key.1));
+            neighbours.push(SourceRef {
+                kind: other_kind,
+                id: key.1,
+            });
             if neighbours.len() >= LINK_CONTEXT_CAP {
                 break 'outer;
             }
         }
     }
+    let explicit_sources = explicit_refs
+        .iter()
+        .map(|source| resolve_pinned_source(db, source, unlocked))
+        .collect::<Result<Vec<_>>>()?;
+    let neighbours = neighbours
+        .iter()
+        .map(|source| resolve_pinned_source(db, source, unlocked))
+        .collect::<Result<Vec<_>>>()?;
+    Ok(PinnedVisibleInputs {
+        explicit_sources,
+        neighbours,
+    })
+}
+
+fn resolve_pinned_source(
+    db: &Db,
+    source: &SourceRef,
+    unlocked: &HashSet<String>,
+) -> Result<ResolvedPinnedSource> {
+    let (header, body, effective_title, started_at, body_present, vault_sources) = match source.kind
+    {
+        LinkKind::Meeting => match db.get_meeting_if_visible(&source.id, unlocked)? {
+            Some(meeting) => {
+                let title = meeting
+                    .title
+                    .clone()
+                    .unwrap_or_else(|| "(untitled)".to_string());
+                let Some(note) = db.get_note_if_visible(&source.id, unlocked)? else {
+                    return Ok(ResolvedPinnedSource {
+                        source: source.clone(),
+                        header: String::new(),
+                        body: String::new(),
+                        body_required: false,
+                        manifest_digest: source_manifest_digest(
+                            &title,
+                            Some(&meeting.started_at),
+                            false,
+                            "",
+                        ),
+                        vault_sources: Vec::new(),
+                    });
+                };
+                let date = meeting
+                    .started_at
+                    .split(['T', ' '])
+                    .next()
+                    .unwrap_or("")
+                    .to_string();
+                let header = format!("\n\n### [[{title}]] · {date} · id:{}\n", meeting.id);
+                let source = VaultSource {
+                    meeting_id: meeting.id,
+                    title: title.clone(),
+                    started_at: meeting.started_at,
+                    origin: None,
+                };
+                (
+                    header,
+                    note.markdown,
+                    title,
+                    Some(source.started_at.clone()),
+                    true,
+                    vec![source],
+                )
+            }
+            None => (
+                String::new(),
+                String::new(),
+                String::new(),
+                None,
+                false,
+                Vec::new(),
+            ),
+        },
+        LinkKind::Note | LinkKind::Document => {
+            let Some(document) =
+                db.get_document_if_visible_kind(&source.id, source.kind.as_str(), unlocked)?
+            else {
+                return Ok(ResolvedPinnedSource {
+                    source: source.clone(),
+                    header: String::new(),
+                    body: String::new(),
+                    body_required: true,
+                    manifest_digest: source_manifest_digest("", None, false, ""),
+                    vault_sources: Vec::new(),
+                });
+            };
+            let title = document
+                .title
+                .filter(|title| !title.trim().is_empty())
+                .unwrap_or(document.name);
+            (
+                format!("\n\n### [[{title}]] · id:{}\n", document.id),
+                document.markdown,
+                title,
+                None,
+                true,
+                Vec::new(),
+            )
+        }
+    };
+    let manifest_digest =
+        source_manifest_digest(&effective_title, started_at.as_deref(), body_present, &body);
+    Ok(ResolvedPinnedSource {
+        source: source.clone(),
+        header,
+        body,
+        body_required: source.kind != LinkKind::Meeting,
+        manifest_digest,
+        vault_sources,
+    })
+}
+
+pub(crate) fn build_vault_context_resolved_visible_with_budget(
+    _db: &Db,
+    inputs: &PinnedVisibleInputs,
+    budget: usize,
+    _unlocked: &HashSet<String>,
+) -> Result<(String, Vec<VaultSource>)> {
+    if budget == 0 || inputs.explicit_sources.is_empty() {
+        return Ok((String::new(), Vec::new()));
+    }
+
+    // Pack each EXPLICIT source from the already gated snapshot. No database read or link
+    // expansion happens here; the lifecycle manifest consumes the same resolved source bytes.
+    let mut sections: Vec<(String, Vec<VaultSource>)> = Vec::new();
+    for source in &inputs.explicit_sources {
+        if let Some(section) = source.section_for_budget(budget) {
+            sections.push((section, source.vault_sources.clone()));
+        }
+    }
+    let (mut corpus, mut vault_sources) = fair_pack_explicit_sections(sections, budget);
 
     // Neighbours fill only budget left after every explicit source got its fair share.
-    for (kind, id) in neighbours {
+    for neighbour in &inputs.neighbours {
         let remaining = budget.saturating_sub(corpus.chars().count());
         if remaining == 0 {
             break;
         }
-        match kind {
-            LinkKind::Meeting => {
-                if let Some(meeting) = db.get_meeting(&id)? {
-                    let (chunk, chunk_sources) =
-                        pack_meetings(db, vec![meeting], remaining, unlocked)?;
-                    corpus.push_str(&chunk);
-                    vault_sources.extend(chunk_sources);
-                }
-            }
-            LinkKind::Note | LinkKind::Document => {
-                let mut chunk = String::new();
-                pack_notes(db, &id, remaining, &mut chunk, unlocked)?;
-                corpus.push_str(&chunk);
-            }
+        if let Some(chunk) = neighbour.section_for_budget(remaining) {
+            corpus.push_str(&chunk);
+            vault_sources.extend(neighbour.vault_sources.clone());
         }
     }
     Ok((corpus, vault_sources))
@@ -543,8 +700,8 @@ pub(crate) fn build_vault_context_pinned_visible_with_budget(
 /// Pack exactly the caller-selected sources under one fair budget, without the neighbour expansion
 /// used by Ask. Convert-to-note uses this for a meeting's ACTIVE Related edges: the linked items are
 /// useful secondary context, but a link-of-a-link was never selected for this conversion and must
-/// not silently enter the provider prompt. Every content read stays behind the same visible packers
-/// as [`build_vault_context_pinned_visible_with_budget`].
+/// not silently enter the provider prompt. Every content read is resolved once through the same
+/// typed, visibility-gated snapshot as [`build_vault_context_pinned_visible_with_budget`].
 pub(crate) fn build_vault_context_exact_visible_with_budget(
     db: &Db,
     sources: &[SourceRef],
@@ -555,37 +712,17 @@ pub(crate) fn build_vault_context_exact_visible_with_budget(
         return Ok(String::new());
     }
 
-    // Resolve meeting rows ONLY through the visibility query before touching title/audio metadata.
-    // `get_meeting` is intentionally ungated and therefore forbidden on this cross-meeting path.
-    let visible_meetings = db
-        .list_meetings_visible(i64::MAX, unlocked)?
-        .into_iter()
-        .map(|meeting| (meeting.id.clone(), meeting))
-        .collect::<std::collections::HashMap<_, _>>();
     let mut seen: HashSet<(String, String)> = HashSet::new();
-    let mut sections: Vec<(String, Vec<VaultSource>)> = Vec::new();
+    let mut sections = Vec::new();
     for source in sources {
         let key = (source.kind.as_str().to_string(), source.id.clone());
         if !seen.insert(key) {
             continue;
         }
-        match source.kind {
-            LinkKind::Meeting => {
-                if let Some(meeting) = visible_meetings.get(&source.id).cloned() {
-                    let (section, section_sources) =
-                        pack_meetings(db, vec![meeting], budget, unlocked)?;
-                    if !section.trim().is_empty() {
-                        sections.push((section, section_sources));
-                    }
-                }
-            }
-            LinkKind::Note | LinkKind::Document => {
-                let mut section = String::new();
-                if pack_notes(db, &source.id, budget, &mut section, unlocked)?
-                    && !section.trim().is_empty()
-                {
-                    sections.push((section, Vec::new()));
-                }
+        let resolved = resolve_pinned_source(db, source, unlocked)?;
+        if let Some(section) = resolved.section_for_budget(budget) {
+            if !section.trim().is_empty() {
+                sections.push((section, resolved.vault_sources));
             }
         }
     }
@@ -598,12 +735,12 @@ pub(crate) fn build_vault_context_exact_visible_with_budget(
 /// their ACTIVE linked neighbours (packed AFTER, filling remaining budget only) — NEVER a
 /// vault-wide search.
 ///
-/// GATE (E9, load-bearing): every leg reads only through the `*_visible` readers against the live
-/// `unlocked` set. A meeting source packs through [`pack_meetings`] (its `get_note_if_visible`
-/// second gate drops a sealed meeting's note); a note/document source packs through [`pack_notes`]
-/// (`get_document_if_visible` gate). Link-expansion uses [`Db::links_for_visible`], which is ALREADY
-/// both-endpoint gated — so a sealed explicit source or a sealed neighbour contributes NOTHING and
-/// is never even enumerated. No content read bypasses these gates.
+/// GATE (E9, load-bearing): explicit sources and capped neighbours are first resolved into one
+/// typed, visibility-gated [`PinnedVisibleInputs`] snapshot against the live `unlocked` set. The
+/// provider packer and dashboard lifecycle manifest then consume those same bytes, so there is no
+/// second content read between authorization and dispatch. Link expansion uses
+/// [`Db::links_for_visible`], whose endpoints are already gated; a sealed explicit source or sealed
+/// neighbour contributes nothing and is never enumerated.
 ///
 /// Returns `(corpus, sources)` — `sources` carries the VaultSource chips for the MEETING sources
 /// that actually packed (notes/documents are not meetings, so they add no chip, matching
@@ -950,6 +1087,199 @@ mod tests {
         }
     }
 
+    fn d_src(id: &str) -> SourceRef {
+        SourceRef {
+            kind: LinkKind::Document,
+            id: id.to_string(),
+        }
+    }
+
+    #[test]
+    fn resolved_snapshot_preserves_the_legacy_200_character_pack_floor() {
+        let db = temp_db();
+        seed_folder(&db, "floor");
+        seed_note(&db, "empty-meeting", "Empty meeting", "", Some("floor"));
+        db.insert_note(
+            "hub",
+            "floor",
+            "Hub",
+            "Hub",
+            &"H".repeat(260),
+            1_700_000_000,
+        )
+        .unwrap();
+        db.insert_note(
+            "near",
+            "floor",
+            "Near",
+            "Near",
+            "NEIGHBOUR MUST NOT FIT",
+            1_700_000_000,
+        )
+        .unwrap();
+        db.insert_link_for_test(
+            "note", "hub", "note", "near", "manual", 1.0, "user", "active",
+        );
+
+        let too_small = build_vault_context_pinned_visible_with_budget(
+            &db,
+            &[n_src("hub")],
+            100,
+            &HashSet::new(),
+        )
+        .unwrap()
+        .0;
+        assert!(
+            too_small.is_empty(),
+            "no partial header below the 200-char floor"
+        );
+
+        let tight = build_vault_context_pinned_visible_with_budget(
+            &db,
+            &[n_src("hub")],
+            300,
+            &HashSet::new(),
+        )
+        .unwrap()
+        .0;
+        assert!(tight.contains("Hub"));
+        assert!(!tight.contains("NEIGHBOUR MUST NOT FIT"));
+
+        let (empty_meeting, sources) = build_vault_context_pinned_visible_with_budget(
+            &db,
+            &[m_src("empty-meeting")],
+            300,
+            &HashSet::new(),
+        )
+        .unwrap();
+        assert!(empty_meeting.contains("Empty meeting"));
+        assert_eq!(
+            sources.len(),
+            1,
+            "an empty meeting note retains its source chip"
+        );
+    }
+
+    #[test]
+    fn pinned_provider_corpus_enforces_note_document_kind_before_body_read() {
+        let db = temp_db();
+        seed_folder(&db, "typed-open");
+        db.insert_document(
+            "real-note",
+            "typed-open",
+            "Note",
+            "note",
+            "note",
+            1_700_000_000,
+        )
+        .unwrap();
+        db.insert_document(
+            "real-doc",
+            "typed-open",
+            "Document",
+            "doc",
+            "document",
+            1_700_000_000,
+        )
+        .unwrap();
+        db.insert_document(
+            "neighbour",
+            "typed-open",
+            "Neighbour",
+            "FORGED-NEIGHBOUR-SENTINEL",
+            "document",
+            1_700_000_000,
+        )
+        .unwrap();
+        db.insert_link_for_test(
+            "document",
+            "real-note",
+            "document",
+            "neighbour",
+            "manual",
+            1.0,
+            "user",
+            "active",
+        );
+        db.insert_link_for_test(
+            "note",
+            "real-doc",
+            "document",
+            "neighbour",
+            "manual",
+            1.0,
+            "user",
+            "active",
+        );
+        db.lock()
+            .execute(
+                "UPDATE documents SET text=x'00' WHERE id IN ('real-note','real-doc')",
+                [],
+            )
+            .unwrap();
+
+        let (forged, _) = build_vault_context_pinned_visible(
+            &db,
+            &[d_src("real-note"), n_src("real-doc")],
+            "anthropic",
+            &HashSet::new(),
+        )
+        .unwrap();
+        assert!(forged.is_empty());
+        assert!(!forged.contains("FORGED-NEIGHBOUR-SENTINEL"));
+
+        db.lock()
+            .execute(
+                "UPDATE documents SET text=CASE id WHEN 'real-note' THEN 'NOTE-KIND-SENTINEL' ELSE 'DOCUMENT-KIND-SENTINEL' END WHERE id IN ('real-note','real-doc')",
+                [],
+            )
+            .unwrap();
+
+        let (valid, _) = build_vault_context_pinned_visible(
+            &db,
+            &[n_src("real-note"), d_src("real-doc")],
+            "anthropic",
+            &HashSet::new(),
+        )
+        .unwrap();
+        assert!(valid.contains("NOTE-KIND-SENTINEL"));
+        assert!(valid.contains("DOCUMENT-KIND-SENTINEL"));
+    }
+
+    #[test]
+    fn pinned_provider_corpus_typed_control_fixture() {
+        let db = temp_db();
+        seed_folder(&db, "typed-control");
+        db.insert_document(
+            "real-note",
+            "typed-control",
+            "Note",
+            "NOTE-KIND-SENTINEL",
+            "note",
+            1_700_000_000,
+        )
+        .unwrap();
+        db.insert_document(
+            "real-doc",
+            "typed-control",
+            "Document",
+            "DOCUMENT-KIND-SENTINEL",
+            "document",
+            1_700_000_000,
+        )
+        .unwrap();
+
+        let (valid, _) = build_vault_context_pinned_visible(
+            &db,
+            &[n_src("real-note"), d_src("real-doc")],
+            "anthropic",
+            &HashSet::new(),
+        )
+        .unwrap();
+        assert!(valid.contains("NOTE-KIND-SENTINEL"));
+        assert!(valid.contains("DOCUMENT-KIND-SENTINEL"));
+    }
+
     /// Meeting-chat regression: a note the user EXPLICITLY picked must still reach the provider
     /// prompt when the anchor meeting transcript is longer than the transcript budget. The old
     /// command appended the pinned corpus after the transcript and then truncated the combined
@@ -1175,6 +1505,64 @@ mod tests {
         assert!(chat_corpus2.contains("SEALED-NOTE-BODY"));
     }
 
+    #[test]
+    fn gated_meeting_row_hides_residual_title_audio_and_plaintext_until_unlocked() {
+        let db = temp_db();
+        seed_folder(&db, "f-locked-row");
+        db.insert_meeting(&Meeting {
+            id: "m-residual".into(),
+            started_at: "2026-06-26T09:00:00Z".into(),
+            ended_at: None,
+            title: Some("RESIDUAL-TITLE-SENTINEL".into()),
+            duration_s: 60,
+            audio_path: Some("/tmp/RESIDUAL-AUDIO-SENTINEL.wav".into()),
+            status: MeetingStatus::Summarized,
+            folder_id: None,
+        })
+        .unwrap();
+        db.upsert_note(&NoteRecord {
+            meeting_id: "m-residual".into(),
+            provider_id: "test".into(),
+            markdown: "RESIDUAL-BODY-SENTINEL".into(),
+            created_at: "2026-06-26T09:05:00Z".into(),
+            exported_path: None,
+            model_requested: None,
+            model_served: None,
+            gateway_host: None,
+        })
+        .unwrap();
+        db.set_note_folder("m-residual", Some("f-locked-row"))
+            .unwrap();
+        db.set_folder_locked("f-locked-row", true, None).unwrap();
+
+        let nothing = HashSet::new();
+        assert!(db
+            .get_meeting_if_visible("m-residual", &nothing)
+            .unwrap()
+            .is_none());
+        let (packed, sources) =
+            build_vault_context_pinned_visible(&db, &[m_src("m-residual")], "anthropic", &nothing)
+                .unwrap();
+        assert!(packed.is_empty());
+        assert!(sources.is_empty());
+        assert!(!packed.contains("RESIDUAL-TITLE-SENTINEL"));
+        assert!(!packed.contains("RESIDUAL-AUDIO-SENTINEL"));
+        assert!(!packed.contains("RESIDUAL-BODY-SENTINEL"));
+
+        let unlocked: HashSet<String> = ["f-locked-row".to_string()].into_iter().collect();
+        let visible = db
+            .get_meeting_if_visible("m-residual", &unlocked)
+            .unwrap()
+            .expect("session unlock restores the full meeting row");
+        assert_eq!(visible.title.as_deref(), Some("RESIDUAL-TITLE-SENTINEL"));
+        let (packed, sources) =
+            build_vault_context_pinned_visible(&db, &[m_src("m-residual")], "anthropic", &unlocked)
+                .unwrap();
+        assert!(packed.contains("RESIDUAL-TITLE-SENTINEL"));
+        assert!(packed.contains("RESIDUAL-BODY-SENTINEL"));
+        assert_eq!(sources.len(), 1);
+    }
+
     /// Link-aware expansion pulls in an explicit source's ACTIVE linked neighbour's content — and a
     /// SEALED neighbour is DROPPED (the both-endpoint gate holds through the expansion).
     #[test]
@@ -1229,6 +1617,23 @@ mod tests {
     fn exact_conversion_context_is_visible_and_never_expands_links_of_links() {
         let db = temp_db();
         seed_note(&db, "open-linked", "Open linked", "OPEN-LINKED-BODY", None);
+        seed_folder(&db, "f-conversion-open");
+        seed_doc_note(
+            &db,
+            "exact-note",
+            "f-conversion-open",
+            "Exact note",
+            "EXACT-NOTE-BODY",
+        );
+        db.insert_document(
+            "exact-document",
+            "f-conversion-open",
+            "Exact document",
+            "EXACT-DOCUMENT-BODY",
+            "document",
+            1_700_000_000,
+        )
+        .unwrap();
         seed_folder(&db, "f-conversion-locked");
         seed_note(
             &db,
@@ -1237,13 +1642,7 @@ mod tests {
             "SEALED-LINKED-BODY",
             Some("f-conversion-locked"),
         );
-        seed_note(
-            &db,
-            "second-hop",
-            "Second hop",
-            "SECOND-HOP-BODY",
-            None,
-        );
+        seed_note(&db, "second-hop", "Second hop", "SECOND-HOP-BODY", None);
         db.upsert_manual_link("meeting", "open-linked", "meeting", "second-hop")
             .unwrap();
         db.set_folder_locked("f-conversion-locked", true, None)
@@ -1251,12 +1650,25 @@ mod tests {
 
         let corpus = build_vault_context_exact_visible_with_budget(
             &db,
-            &[m_src("open-linked"), m_src("sealed-linked")],
+            &[
+                m_src("open-linked"),
+                n_src("exact-note"),
+                n_src("exact-note"),
+                d_src("exact-document"),
+                n_src("exact-document"),
+                m_src("sealed-linked"),
+            ],
             20_000,
             &HashSet::new(),
         )
         .unwrap();
         assert!(corpus.contains("OPEN-LINKED-BODY"));
+        assert_eq!(corpus.matches("EXACT-NOTE-BODY").count(), 1);
+        assert_eq!(corpus.matches("EXACT-DOCUMENT-BODY").count(), 1);
+        let meeting_pos = corpus.find("OPEN-LINKED-BODY").unwrap();
+        let note_pos = corpus.find("EXACT-NOTE-BODY").unwrap();
+        let document_pos = corpus.find("EXACT-DOCUMENT-BODY").unwrap();
+        assert!(meeting_pos < note_pos && note_pos < document_pos);
         assert!(!corpus.contains("SEALED-LINKED-BODY"));
         assert!(!corpus.contains("SEALED-TITLE-MUST-NOT-ENTER"));
         assert!(

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -1173,21 +1173,20 @@ pub fn execute_tool(
                 return Ok(format!("No dashboard with id {dashboard_id}."));
             };
             let tiles = db
-                .list_dashboard_tiles(dashboard_id)
+                .list_dashboard_tile_structures(dashboard_id)
                 .map_err(|e| AppError::Storage(format!("dashboard tiles failed: {e}")))?;
             let mut out = format!("# {} (dashboard)\n", board.title);
             if tiles.is_empty() {
                 out.push_str("(no tiles yet)");
                 return Ok(out);
             }
-            for tile in &tiles {
+            for mut tile in tiles {
                 // The SAME gated resolver the UI uses. A sealed source renders redacted here too.
-                let data = crate::commands::resolve_tile(db, tile, unlocked)?;
-                // Redact BEFORE rendering, exactly as `get_dashboard` does for the UI. The agent
-                // path calls `resolve_tile` directly, so without this the renderer would still see
-                // a withheld tile's stored `title`/`config` — and a legacy row (written by a build
-                // that copied the source's title) would hand a sealed source's name to an agent.
-                let tile = crate::commands::redact_tile_chrome(tile.clone(), &data);
+                let data = crate::commands::resolve_tile(db, &tile, unlocked)?;
+                // Headings come entirely from gated TileData. Legacy stored chrome/config may
+                // paraphrase content that has since sealed, so this surface never hydrates it.
+                tile.title = None;
+                tile.config = None;
                 out.push_str(&crate::commands::render_tile_for_agent(&tile, &data));
                 out.push('\n');
             }

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -16,6 +16,7 @@ import type {
   TileKind,
   LinkEdge,
   LinkKind,
+  LivingAnswerTileData,
   SourceRef,
   WikiTarget,
   CompanionAppendResult,
@@ -185,8 +186,7 @@ export const EVENT_NER_DOWNLOAD = "murmur://ner-download";
 export const EVENT_STORAGE_PRUNED = "murmur://storage-pruned";
 // Recording hit the 4h hard TIME cap and self-stopped (distinct from the byte-based prune).
 export const EVENT_RECORDING_CAPPED = "murmur://recording-capped";
-export const EVENT_RECORDING_CAPTURE_FAULT =
-  "murmur://recording-capture-fault";
+export const EVENT_RECORDING_CAPTURE_FAULT = "murmur://recording-capture-fault";
 export const EVENT_MIC_AUTO_UNMUTED = "murmur://mic-auto-unmuted";
 // Brain v2 L5 — a scheduled brief was STAGED (propose-accept; run id + label + size only).
 export const EVENT_BRIEF_PROPOSED = "murmur://brief-proposed";
@@ -202,14 +202,12 @@ export const EVENT_CONTENT_DELETED = "murmur://content-deleted";
 /** Count-only invalidation for the first-class Murmur reminder inbox. */
 export const EVENT_REMINDERS_UPDATED = "murmur://reminders-updated";
 /** Kind + opaque source id only; Smart cards re-audit through the gated command. */
-export const EVENT_REMINDER_SOURCE_UPDATED =
-  "murmur://reminder-source-updated";
+export const EVENT_REMINDER_SOURCE_UPDATED = "murmur://reminder-source-updated";
 /** No-payload privacy barrier: every cached reminder source title must be discarded immediately. */
 export const EVENT_REMINDER_VISIBILITY_INVALIDATED =
   "murmur://reminder-visibility-invalidated";
 /** No-payload privacy barrier: every durable Ask history cache must be purged immediately. */
-export const EVENT_ASK_HISTORY_INVALIDATED =
-  "murmur://ask-history-invalidated";
+export const EVENT_ASK_HISTORY_INVALIDATED = "murmur://ask-history-invalidated";
 
 /**
  * Thin wrapper over @tauri-apps/api invoke/listen. One method per Tauri command
@@ -307,7 +305,10 @@ export class IpcService {
     meetingId: string,
     findings: VerifyFindingDto[],
   ): Promise<NoteDto> {
-    return invoke<NoteDto>("apply_note_verify_markers", { meetingId, findings });
+    return invoke<NoteDto>("apply_note_verify_markers", {
+      meetingId,
+      findings,
+    });
   }
 
   /**
@@ -465,7 +466,12 @@ export class IpcService {
     password: string,
     saveRecovery: boolean,
   ): Promise<string | null> {
-    return invoke<string | null>("account_signup", { email, code, password, saveRecovery });
+    return invoke<string | null>("account_signup", {
+      email,
+      code,
+      password,
+      saveRecovery,
+    });
   }
 
   /** Log in (OPAQUE); unwraps MK for the session and stores the tokens in the Keychain. */
@@ -699,9 +705,11 @@ export class IpcService {
    * whenever the scrub toggle flips (the markdown + counts change). Refuses
    * (`Locked`) a sealed source. Mirrors the spec `preview_org_share`.
    */
-  previewOrgShare(
-    args: { meetingId?: string; documentId?: string; scrub: boolean },
-  ): Promise<OrgSharePreview> {
+  previewOrgShare(args: {
+    meetingId?: string;
+    documentId?: string;
+    scrub: boolean;
+  }): Promise<OrgSharePreview> {
     return invoke<OrgSharePreview>("preview_org_share", {
       meetingId: args.meetingId ?? null,
       documentId: args.documentId ?? null,
@@ -1261,9 +1269,8 @@ export class IpcService {
   // Boards of tiles over EXISTING sources. `getDashboard` returns every tile
   // already resolved through the backend's gated readers — a sealed source
   // arrives as `{ kind: "locked" }` with no payload, so the FE cannot leak what
-  // it was never given. Board-scoped Ask reuses the shipped `askVault(…,
-  // explicitSources)` path with `getDashboardSources()`; there is no separate
-  // dashboard AI command and therefore no new egress surface.
+  // it was never given. Board-scoped Ask sends only `dashboardId`; the backend
+  // resolves the live composite under the same privacy/egress seams.
 
   /** Every board with its layout metadata (no gated payload read). */
   listDashboards(): Promise<DashboardSummary[]> {
@@ -1340,22 +1347,24 @@ export class IpcService {
     return invoke<void>("update_dashboard_tile", { id, ...patch });
   }
 
-  /**
-   * Persist a Living-answer result. The BACKEND writes it, because the gate that
-   * governs the cached answer is a snapshot of which folders were readable at
-   * answer time — something the FE cannot compute, and something no list of
-   * sources can substitute for (Ask expands into linked neighbours).
-   */
-  setDashboardAnswer(
-    id: string,
-    question: string,
-    answer: string,
-  ): Promise<void> {
-    return invoke<void>("set_dashboard_answer", { id, question, answer });
-  }
-
   deleteDashboardTile(id: string): Promise<boolean> {
     return invoke<boolean>("delete_dashboard_tile", { id });
+  }
+
+  /**
+   * Rebuild one Living Answer from the dashboard's current backend-gated scope.
+   * The caller supplies identity + question only; answer/provenance stay backend-owned.
+   */
+  refreshDashboardAnswer(
+    dashboardId: string,
+    tileId: string,
+    question: string,
+  ): Promise<LivingAnswerTileData> {
+    return invoke<LivingAnswerTileData>("refresh_dashboard_answer", {
+      dashboardId,
+      tileId,
+      question,
+    });
   }
 
   reorderDashboardTiles(dashboardId: string, tileIds: string[]): Promise<void> {
@@ -1975,6 +1984,7 @@ export class IpcService {
     conversationId?: string,
     explicitSources?: SourceRef[],
     askTraceId?: string,
+    dashboardId?: string,
   ): Promise<AskConversationSendResult> {
     return invoke<AskConversationSendResult>("ask_vault_persisted", {
       scope,
@@ -1982,6 +1992,7 @@ export class IpcService {
       conversationId,
       askTraceId,
       ...(explicitSources?.length ? { explicitSources } : {}),
+      ...(dashboardId ? { dashboardId } : {}),
     });
   }
 
@@ -1991,12 +2002,14 @@ export class IpcService {
     question: string,
     conversationId?: string,
     explicitSources?: SourceRef[],
+    dashboardId?: string,
   ): Promise<AskConversationSendResult> {
     return invoke<AskConversationSendResult>("chat_meeting_persisted", {
       meetingId,
       question,
       conversationId,
       ...(explicitSources?.length ? { explicitSources } : {}),
+      ...(dashboardId ? { dashboardId } : {}),
     });
   }
 
@@ -2878,7 +2891,9 @@ export class IpcService {
    * locked folder never exposes a typed view.
    */
   getNoteFolderSchema(folderId: string): Promise<PropertySchemaField[]> {
-    return invoke<PropertySchemaField[]>("get_note_folder_schema", { folderId });
+    return invoke<PropertySchemaField[]>("get_note_folder_schema", {
+      folderId,
+    });
   }
 
   /**
@@ -2935,7 +2950,9 @@ export class IpcService {
    * the FE must confirm first. Returns the reopened FolderNode.
    */
   discardUnrecoverableFolderLock(folderId: string): Promise<FolderNode> {
-    return invoke<FolderNode>("discard_unrecoverable_folder_lock", { folderId });
+    return invoke<FolderNode>("discard_unrecoverable_folder_lock", {
+      folderId,
+    });
   }
 
   /**
@@ -2943,7 +2960,9 @@ export class IpcService {
    * and discards its lock IF the key is unrecoverable. `null` when the meeting is at the vault root
    * or its folder is already open. Refuses (rejects) if the folder is actually recoverable.
    */
-  discardUnrecoverableMeetingLock(meetingId: string): Promise<FolderNode | null> {
+  discardUnrecoverableMeetingLock(
+    meetingId: string,
+  ): Promise<FolderNode | null> {
     return invoke<FolderNode | null>("discard_unrecoverable_meeting_lock", {
       meetingId,
     });
@@ -3094,9 +3113,7 @@ export class IpcService {
    * so the card can render the live tool-trace chips ("Searching notes… ✓").
    * NO PII — tool name + a coarse count only.
    */
-  onAssistantTool(
-    cb: (p: AssistantToolPayload) => void,
-  ): Promise<UnlistenFn> {
+  onAssistantTool(cb: (p: AssistantToolPayload) => void): Promise<UnlistenFn> {
     return listen<AssistantToolPayload>(EVENT_ASSISTANT_TOOL, (e) =>
       cb(e.payload),
     );
@@ -3117,9 +3134,7 @@ export class IpcService {
   }
 
   /** Fires with progress for the in-flight Whisper transcribe-model download. */
-  onModelDownload(
-    cb: (p: ModelDownloadProgress) => void,
-  ): Promise<UnlistenFn> {
+  onModelDownload(cb: (p: ModelDownloadProgress) => void): Promise<UnlistenFn> {
     return listen<ModelDownloadProgress>(EVENT_MODEL_DOWNLOAD, (e) =>
       cb(e.payload),
     );
@@ -3137,9 +3152,7 @@ export class IpcService {
   }
 
   /** Fires with progress for an in-flight local brain-model download. */
-  onBrainDownload(
-    cb: (p: BrainDownloadProgress) => void,
-  ): Promise<UnlistenFn> {
+  onBrainDownload(cb: (p: BrainDownloadProgress) => void): Promise<UnlistenFn> {
     return listen<BrainDownloadProgress>(EVENT_BRAIN_DOWNLOAD, (e) =>
       cb(e.payload),
     );
@@ -3157,9 +3170,7 @@ export class IpcService {
   }
 
   /** Fires with per-file progress for the in-flight embedding-model download. */
-  onEmbedDownload(
-    cb: (p: EmbedDownloadProgress) => void,
-  ): Promise<UnlistenFn> {
+  onEmbedDownload(cb: (p: EmbedDownloadProgress) => void): Promise<UnlistenFn> {
     return listen<EmbedDownloadProgress>(EVENT_EMBED_DOWNLOAD, (e) =>
       cb(e.payload),
     );
@@ -3176,9 +3187,7 @@ export class IpcService {
    * NO PII (the `documentId` is a random UUID; no filename/text). Subscribe once
    * per open Brain view and release the returned {@link UnlistenFn} on teardown.
    */
-  onDocImportProgress(
-    cb: (p: DocImportProgress) => void,
-  ): Promise<UnlistenFn> {
+  onDocImportProgress(cb: (p: DocImportProgress) => void): Promise<UnlistenFn> {
     return listen<DocImportProgress>(EVENT_DOC_IMPORT, (e) => cb(e.payload));
   }
 

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -82,8 +82,7 @@ export interface AppInfo {
 }
 
 export type Availability =
-  | { Available: true }
-  | { Unavailable: { reason: string } };
+  { Available: true } | { Unavailable: { reason: string } };
 
 export interface ProviderStatus {
   id: string;
@@ -651,11 +650,7 @@ export interface WhisperRecommendationDto {
  * Mirrors the Rust `LiveCaptions::dto_state`.
  */
 export type LiveCaptionsState =
-  | ""
-  | "ready"
-  | "noModel"
-  | "modelMissing"
-  | "pinnedHeavy";
+  "" | "ready" | "noModel" | "modelMissing" | "pinnedHeavy";
 
 /**
  * What a `download_model` call ended up doing. A user-initiated CANCEL is a
@@ -1023,12 +1018,7 @@ export interface StopResult {
 }
 
 export type MeetingStatus =
-  | "DRAFT"
-  | "RECORDING"
-  | "TRANSCRIBED"
-  | "SUMMARIZED"
-  | "EXPORTED"
-  | "ERROR";
+  "DRAFT" | "RECORDING" | "TRANSCRIBED" | "SUMMARIZED" | "EXPORTED" | "ERROR";
 
 export interface Meeting {
   id: string;
@@ -1421,11 +1411,7 @@ export interface BriefProposedPayload {
 
 /** Vault Audit — the deterministic hygiene-pass kinds. */
 export type AuditFindingKind =
-  | "broken_link"
-  | "orphan"
-  | "stale"
-  | "contradiction"
-  | "unlinked_mention";
+  "broken_link" | "orphan" | "stale" | "contradiction" | "unlinked_mention";
 
 /**
  * Vault Audit — one run's summary (`run_vault_audit` / the audit-updated
@@ -1507,8 +1493,7 @@ export interface ChatTurn {
 
 /** Exact durable Ask-history namespace. Org and dashboard Ask stay stateless. */
 export type AskConversationScope =
-  | { kind: "vault" }
-  | { kind: "note" | "meeting"; refId: string };
+  { kind: "vault" } | { kind: "note" | "meeting"; refId: string };
 
 /** One bounded, newest-first row in the durable Ask-history browser. */
 export interface AskConversationSummary {
@@ -1537,6 +1522,8 @@ export interface AskConversation {
   scope: AskConversationScope;
   title: string;
   selectedSources: SourceRef[];
+  /** Live-resolved composite scope; null when absent, deleted or not readable. */
+  dashboard?: DashboardScopeRef | null;
   messages: AskConversationMessage[];
   createdAt: string;
   updatedAt: string;
@@ -1795,6 +1782,20 @@ export interface SourceRef {
   kind: LinkKind;
   id: string;
   title?: string;
+}
+
+/**
+ * Metadata-only identity of the ONE user-composed dashboard that scopes an Ask.
+ *
+ * This deliberately is not a {@link SourceRef}: a dashboard is a composite over
+ * live, backend-gated material and derived views, never a fourth `LinkKind`.
+ * `title` and `emoji` are display metadata resolved live by the backend on
+ * history load; only `id` is authoritative and persisted.
+ */
+export interface DashboardScopeRef {
+  id: string;
+  title: string;
+  emoji: string | null;
 }
 
 /**
@@ -3249,12 +3250,7 @@ export function parseViewConfig(config: string): ViewConfig {
 
 /** Cosmetic accent key; the FE maps it to a design token, never a raw colour. */
 export type DashboardTint =
-  | "indigo"
-  | "amber"
-  | "mint"
-  | "orchid"
-  | "azure"
-  | "coral";
+  "indigo" | "amber" | "mint" | "orchid" | "azure" | "coral";
 
 /** Every tile kind the backend can store AND resolve. */
 export type TileKind =
@@ -3382,6 +3378,9 @@ export type TileData =
       /** True when a cached answer is being withheld because a source is sealed. */
       withheld: boolean;
     };
+
+/** The only tile payload the backend-owned Living Answer refresh may return. */
+export type LivingAnswerTileData = Extract<TileData, { kind: "livingAnswer" }>;
 
 /** A tile plus its resolved (already gated) payload. */
 export interface ResolvedTile extends DashboardTile {

--- a/src/app/design-system/source-picker/source-picker.component.html
+++ b/src/app/design-system/source-picker/source-picker.component.html
@@ -2,8 +2,41 @@
      render as removable chips above the trigger; the trigger opens the OPAQUE
      candidate popover (T3). -->
 <div class="sp" [class.is-open]="open()">
-  @if (selected().length > 0) {
+  @if (dashboard() || selected().length > 0) {
     <ul class="sp-chips" aria-label="Selected sources">
+      @if (dashboard(); as board) {
+        <li
+          class="sp-chip sp-dashboard-chip pill"
+          data-testid="selected-dashboard-chip"
+        >
+          <span class="sp-chip-badge" aria-hidden="true">{{
+            board.emoji || "▦"
+          }}</span>
+          <span class="sp-chip-title">{{ board.title }}</span>
+          <button
+            type="button"
+            class="sp-chip-remove"
+            [attr.aria-label]="'Remove dashboard ' + board.title"
+            [disabled]="disabled()"
+            (click)="removeDashboard()"
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 16 16"
+              fill="none"
+              aria-hidden="true"
+            >
+              <path
+                d="M4 4l8 8M12 4l-8 8"
+                stroke="currentColor"
+                stroke-width="1.6"
+                stroke-linecap="round"
+              />
+            </svg>
+          </button>
+        </li>
+      }
       @for (c of visibleChips(); track c.kind + c.id) {
         <li class="sp-chip pill">
           <span class="sp-chip-badge" aria-hidden="true">
@@ -157,9 +190,8 @@
         (scroll)="onScroll()"
       >
         <!--
-          Boards first: a dashboard is the user's OWN declaration of what belongs
-          together, so it is the strongest scope on offer. Picking one expands it
-          into its visible sources (sealed ones are dropped backend-side).
+          Boards first: in composite mode a click selects ONE board identity;
+          expand mode preserves the Reminders flat-source contract.
         -->
         @if (dashboardRows().length > 0) {
           <p class="sp-group">Dashboards</p>
@@ -168,8 +200,13 @@
               type="button"
               class="sp-row menu-item sp-board"
               role="option"
-              [attr.aria-selected]="false"
-              [disabled]="disabled() || selectionLimitReached() || expandingBoard() === board.id"
+              [attr.aria-selected]="dashboard()?.id === board.id"
+              [attr.aria-label]="'Use dashboard ' + board.title"
+              [disabled]="
+                disabled() ||
+                selectionLimitReached() ||
+                expandingBoard() === board.id
+              "
               (click)="pickDashboard(board)"
             >
               <span class="sp-title">
@@ -179,7 +216,13 @@
                 {{ board.title }}
               </span>
               <span class="sp-kind">
-                {{ expandingBoard() === board.id ? "adding…" : board.tileCount + " tiles" }}
+                {{
+                  dashboard()?.id === board.id
+                    ? "selected"
+                    : expandingBoard() === board.id
+                      ? "adding…"
+                      : board.tileCount + " tiles"
+                }}
               </span>
             </button>
           }

--- a/src/app/design-system/source-picker/source-picker.component.scss
+++ b/src/app/design-system/source-picker/source-picker.component.scss
@@ -63,6 +63,10 @@
   padding: var(--space-1) var(--space-1) var(--space-1) var(--space-2);
   max-width: 220px;
 }
+.sp-dashboard-chip {
+  border-color: var(--accent-ring);
+  background: var(--accent-soft);
+}
 .sp-chip-badge {
   display: inline-flex;
   align-items: center;
@@ -89,7 +93,9 @@
   color: var(--text-muted);
   cursor: pointer;
   flex: none;
-  transition: background var(--transition-fast), color var(--transition-fast);
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast);
 }
 .sp-chip-remove:hover {
   background: var(--surface-hover);

--- a/src/app/design-system/source-picker/source-picker.component.ts
+++ b/src/app/design-system/source-picker/source-picker.component.ts
@@ -15,6 +15,7 @@ import {
 } from "@angular/core";
 import { IpcService } from "../../core/ipc.service";
 import type {
+  DashboardScopeRef,
   DashboardSummary,
   LinkKind,
   NoteCitation,
@@ -83,6 +84,13 @@ export class SourcePickerComponent {
 
   /** Two-way: the picked sources rendered as removable chips. */
   readonly selected = model<SourceRef[]>([]);
+  /** Two-way composite dashboard identity, separate from material sources. */
+  readonly dashboard = model<DashboardScopeRef | null>(null);
+  /**
+   * `expand` preserves the historical Reminders contract. `composite` selects
+   * one ID-only board scope without fetching or retaining its child sources.
+   */
+  readonly dashboardMode = input<"expand" | "composite">("expand");
   /** Placeholder for the popover search input. */
   readonly placeholder = input("Add a note or meeting…");
   /** Label on the trigger button. */
@@ -92,12 +100,9 @@ export class SourcePickerComponent {
   /** Optional hard cap. Removal remains available at the cap unless disabled. */
   readonly selectionLimit = input<number | null>(null);
   /**
-   * Offer the user's DASHBOARDS as pickable scopes. Picking one expands it into
-   * the board's own VISIBLE sources (`get_dashboard_sources`, which drops sealed
-   * ones) and adds them, so a board becomes usable as context anywhere this
-   * picker is — Ask, note chat, reminders — without any command learning a new
-   * parameter. Default ON: a board is the user's own declaration of what belongs
-   * together, which is exactly what a source picker is for.
+   * Offer the user's dashboards as scopes. The default `expand` mode preserves
+   * Reminders' flat-source storage contract; Ask/chat hosts opt into `composite`
+   * and receive one metadata-only dashboard identity instead.
    */
   readonly allowDashboards = input(true);
   /**
@@ -122,7 +127,7 @@ export class SourcePickerComponent {
     if (!this.allowDashboards()) return [];
     const q = this.query().trim().toLowerCase();
     return this._dashboards()
-      .filter((d) => d.tileCount > 0)
+      .filter((d) => this.dashboardMode() === "composite" || d.tileCount > 0)
       .filter((d) => !q || d.title.toLowerCase().includes(q))
       .slice(0, 6);
   });
@@ -312,6 +317,7 @@ export class SourcePickerComponent {
     this.candidates.set([]);
     this._dashboards.set([]);
     this.selected.set([]);
+    this.dashboard.set(null);
     this.expandingBoard.set(null);
     this.activeIndex.set(0);
     this._loading.set(false);
@@ -494,17 +500,25 @@ export class SourcePickerComponent {
   }
 
   /**
-   * Expand a board into its own VISIBLE sources and add them all.
+   * Select a dashboard according to this picker's explicit mode.
    *
-   * The board is a SCOPE, not a source: `SourceRef.kind` is a `LinkKind`
-   * (meeting/note/document), so a dashboard cannot be one. Expanding here rather
-   * than teaching every consumer a `dashboardIds` parameter is what makes boards
-   * work as context EVERYWHERE this picker is used, with no protocol change and
-   * no new backend seam. The backend drops sealed sources from that list, so
-   * picking a board can never widen scope past what the session may read.
+   * Composite mode emits one metadata-only identity and performs no source read.
+   * Expand mode is the legacy Reminders path: it fetches the board's currently
+   * visible material refs and merges them into `selected`.
    */
   async pickDashboard(board: DashboardSummary): Promise<void> {
     if (this.disabled() || this.selectionLimitReached()) return;
+    if (this.dashboardMode() === "composite") {
+      // Metadata is display-only. The host sends exactly this ID and the backend
+      // resolves the authoritative live board under its privacy gate.
+      this.dashboard.set({
+        id: board.id,
+        title: board.title,
+        emoji: board.emoji,
+      });
+      this.close();
+      return;
+    }
     const epoch = this.privacyEpoch;
     this.expandingBoard.set(board.id);
     try {
@@ -518,7 +532,11 @@ export class SourcePickerComponent {
         for (const src of sources) {
           if (!allowed.has(src.kind)) continue;
           if (seen.has(src.kind + src.id)) continue;
-          if (limit !== null && Number.isInteger(limit) && out.length >= limit) {
+          if (
+            limit !== null &&
+            Number.isInteger(limit) &&
+            out.length >= limit
+          ) {
             break;
           }
           seen.add(src.kind + src.id);
@@ -556,6 +574,10 @@ export class SourcePickerComponent {
     this.selected.update((list) =>
       list.filter((s) => !(s.kind === ref.kind && s.id === ref.id)),
     );
+  }
+
+  removeDashboard(): void {
+    if (!this.disabled()) this.dashboard.set(null);
   }
 
   // --- Positioning (reused from the link picker) ---------------------------

--- a/src/app/features/ask/ask/ask.component.html
+++ b/src/app/features/ask/ask/ask.component.html
@@ -3,8 +3,8 @@
     <div class="ask-head-text">
       <h2 class="ask-title">Ask your meetings</h2>
       <p class="ask-intro">
-        Ask a question and get an answer grounded across every meeting in
-        your vault — with links to the meetings it came from.
+        Ask a question and get an answer grounded across every meeting in your
+        vault — with links to the meetings it came from.
       </p>
     </div>
     <div class="ask-head-actions">
@@ -55,8 +55,8 @@
       <span class="empty-mark" aria-hidden="true"></span>
       <p class="empty-title">Nothing to ask about yet</p>
       <p class="empty">
-        Record your first meeting or write a note, and you can chat across
-        your whole vault here.
+        Record your first meeting or write a note, and you can chat across your
+        whole vault here.
       </p>
     </div>
   } @else {
@@ -74,172 +74,172 @@
           (retryRequested)="retryHistory()"
         />
       } @else {
-      <!-- Message list (also the scroll region) -->
-      <div
-        #scroller
-        class="ask-log"
-        role="log"
-        aria-live="polite"
-        aria-label="Conversation"
-      >
-        @if (conversation().length === 0 && !pending()) {
-          <!-- Empty state: a friendly prompt + tappable starter chips. -->
-          <div class="ask-empty">
-            <span class="ask-empty-mark" aria-hidden="true"></span>
-            <p class="ask-empty-title">Chat across all your meetings</p>
-            <p class="ask-empty-copy">
-              Ask about decisions, owners, and follow-ups spanning your
-              entire history — answers cite the meetings they came from.
-            </p>
-            <div
-              class="ask-starters"
-              role="group"
-              aria-label="Suggested questions"
-            >
-              @for (s of starters; track s) {
-                <button
-                  type="button"
-                  class="ask-chip"
-                  [style.--i]="$index"
-                  [disabled]="!historyPrivacyReady()"
-                  (click)="ask(s)"
-                >
-                  {{ s }}
-                </button>
-              }
-            </div>
-          </div>
-        } @else {
-          @for (turn of conversation(); track turn.id) {
-            <div
-              class="ask-row"
-              [class.is-user]="turn.role === 'user'"
-              [class.is-assistant]="turn.role === 'assistant'"
-            >
+        <!-- Message list (also the scroll region) -->
+        <div
+          #scroller
+          class="ask-log"
+          role="log"
+          aria-live="polite"
+          aria-label="Conversation"
+        >
+          @if (conversation().length === 0 && !pending()) {
+            <!-- Empty state: a friendly prompt + tappable starter chips. -->
+            <div class="ask-empty">
+              <span class="ask-empty-mark" aria-hidden="true"></span>
+              <p class="ask-empty-title">Chat across all your meetings</p>
+              <p class="ask-empty-copy">
+                Ask about decisions, owners, and follow-ups spanning your entire
+                history — answers cite the meetings they came from.
+              </p>
               <div
-                class="ask-bubble"
-                [attr.aria-label]="
-                  (turn.role === 'user' ? 'You' : 'Assistant') + ' said'
-                "
+                class="ask-starters"
+                role="group"
+                aria-label="Suggested questions"
               >
-                @if (turn.role === "assistant") {
-                  <app-markdown [markdown]="turn.content" />
-                } @else {
-                  {{ turn.content }}
+                @for (s of starters; track s) {
+                  <button
+                    type="button"
+                    class="ask-chip"
+                    [style.--i]="$index"
+                    [disabled]="!historyPrivacyReady()"
+                    (click)="ask(s)"
+                  >
+                    {{ s }}
+                  </button>
                 }
               </div>
-
-              <!-- Source meetings the answer was grounded in (collapsible). -->
-              @if (turn.role === "assistant" && turn.sources?.length) {
-                <app-sources
-                  class="ask-sources"
-                  [sources]="turn.sources"
-                />
-              }
             </div>
-          }
-
-          <!-- In-flight reply: live tool-trace chips once the agentic loop
-               starts calling tools, the "Thinking…" dots until then. -->
-          @if (pending()) {
-            <div class="ask-row is-assistant">
-              @if (trace().length > 0) {
+          } @else {
+            @for (turn of conversation(); track turn.id) {
+              <div
+                class="ask-row"
+                [class.is-user]="turn.role === 'user'"
+                [class.is-assistant]="turn.role === 'assistant'"
+              >
                 <div
-                  class="ask-bubble ask-trace"
-                  role="status"
-                  aria-label="Tool use"
+                  class="ask-bubble"
+                  [attr.aria-label]="
+                    (turn.role === 'user' ? 'You' : 'Assistant') + ' said'
+                  "
                 >
-                  @for (t of trace(); track t.id) {
-                    <span
-                      class="ask-trace-chip"
-                      [class.is-running]="t.state === 'running'"
-                      [class.is-web]="t.tool === 'web_search'"
-                      [class.is-failed]="!t.ok"
-                    >
-                      <span class="ask-trace-ico" aria-hidden="true">
-                        @if (t.state === "running") {
-                          <span class="ask-trace-spin"></span>
-                        } @else if (!t.ok) {
-                          ⚠
-                        } @else {
-                          ✓
-                        }
-                      </span>
-                      {{ toolLabel(t.tool) }}
-                      @if (t.state === "done" && t.count) {
-                        <span class="ask-trace-count">{{ t.count }}</span>
-                      }
-                    </span>
+                  @if (turn.role === "assistant") {
+                    <app-markdown [markdown]="turn.content" />
+                  } @else {
+                    {{ turn.content }}
                   }
                 </div>
-              } @else {
-                <div class="ask-bubble ask-typing" aria-label="Thinking">
-                  <span class="ask-dot"></span>
-                  <span class="ask-dot"></span>
-                  <span class="ask-dot"></span>
-                </div>
-              }
+
+                <!-- Source meetings the answer was grounded in (collapsible). -->
+                @if (turn.role === "assistant" && turn.sources?.length) {
+                  <app-sources class="ask-sources" [sources]="turn.sources" />
+                }
+              </div>
+            }
+
+            <!-- In-flight reply: live tool-trace chips once the agentic loop
+               starts calling tools, the "Thinking…" dots until then. -->
+            @if (pending()) {
+              <div class="ask-row is-assistant">
+                @if (trace().length > 0) {
+                  <div
+                    class="ask-bubble ask-trace"
+                    role="status"
+                    aria-label="Tool use"
+                  >
+                    @for (t of trace(); track t.id) {
+                      <span
+                        class="ask-trace-chip"
+                        [class.is-running]="t.state === 'running'"
+                        [class.is-web]="t.tool === 'web_search'"
+                        [class.is-failed]="!t.ok"
+                      >
+                        <span class="ask-trace-ico" aria-hidden="true">
+                          @if (t.state === "running") {
+                            <span class="ask-trace-spin"></span>
+                          } @else if (!t.ok) {
+                            ⚠
+                          } @else {
+                            ✓
+                          }
+                        </span>
+                        {{ toolLabel(t.tool) }}
+                        @if (t.state === "done" && t.count) {
+                          <span class="ask-trace-count">{{ t.count }}</span>
+                        }
+                      </span>
+                    }
+                  </div>
+                } @else {
+                  <div class="ask-bubble ask-typing" aria-label="Thinking">
+                    <span class="ask-dot"></span>
+                    <span class="ask-dot"></span>
+                    <span class="ask-dot"></span>
+                  </div>
+                }
+              </div>
+            }
+          }
+
+          <!-- Inline error with a retry affordance (keeps the question). -->
+          @if (error(); as err) {
+            <div class="ask-error" role="alert">
+              <span class="ask-error-text">{{ err }}</span>
+              <button
+                type="button"
+                class="btn btn-ghost ask-retry"
+                (click)="retry()"
+                [disabled]="pending() || !historyPrivacyReady()"
+              >
+                Retry
+              </button>
             </div>
           }
-        }
+        </div>
 
-        <!-- Inline error with a retry affordance (keeps the question). -->
-        @if (error(); as err) {
-          <div class="ask-error" role="alert">
-            <span class="ask-error-text">{{ err }}</span>
-            <button
-              type="button"
-              class="btn btn-ghost ask-retry"
-              (click)="retry()"
-              [disabled]="pending() || !historyPrivacyReady()"
-            >
-              Retry
-            </button>
-          </div>
-        }
-      </div>
-
-      <!-- Source-scoped Brain: OPTIONALLY narrow the answer to specific notes /
+        <!-- Source-scoped Brain: OPTIONALLY narrow the answer to specific notes /
            meetings (+ their links). Empty (the default) ⇒ the whole vault. -->
-      <mur-source-picker
-        class="ask-sources"
-        [(selected)]="sources"
-        [disabled]="pending() || !historyPrivacyReady()"
-        triggerLabel="Sources"
-        placeholder="Scope to a note or meeting…"
-      />
-
-      <!-- Composer: textarea (Enter sends · Shift+Enter newline) + Send. -->
-      <form class="ask-composer" (submit)="onSubmit($event)">
-        <textarea
-          #input
-          class="ask-input"
-          rows="1"
-          autocapitalize="sentences"
-          autocomplete="off"
-          spellcheck="true"
-          aria-label="Your question"
-          placeholder="Ask anything about your meetings…"
-          [value]="draft()"
+        <mur-source-picker
+          class="ask-sources"
+          [selected]="sources()"
+          (selectedChange)="onSourcesChange($event)"
+          [dashboard]="dashboard()"
+          (dashboardChange)="onDashboardChange($event)"
+          dashboardMode="composite"
           [disabled]="pending() || !historyPrivacyReady()"
-          (input)="onDraftInput($event)"
-          (keydown)="onKeydown($event)"
-        ></textarea>
-        <button
-          type="submit"
-          class="btn btn-primary ask-send"
-          [disabled]="!canSend()"
-          [attr.aria-label]="pending() ? 'Sending' : 'Send'"
-        >
-          @if (pending()) {
-            <span class="ask-send-spin" aria-hidden="true"></span>
-          } @else {
-            <span class="ask-send-arrow" aria-hidden="true"></span>
-          }
-        </button>
-      </form>
+          triggerLabel="Sources"
+          placeholder="Scope to a note or meeting…"
+        />
+
+        <!-- Composer: textarea (Enter sends · Shift+Enter newline) + Send. -->
+        <form class="ask-composer" (submit)="onSubmit($event)">
+          <textarea
+            #input
+            class="ask-input"
+            rows="1"
+            autocapitalize="sentences"
+            autocomplete="off"
+            spellcheck="true"
+            aria-label="Your question"
+            placeholder="Ask anything about your meetings…"
+            [value]="draft()"
+            [disabled]="pending() || !historyPrivacyReady()"
+            (input)="onDraftInput($event)"
+            (keydown)="onKeydown($event)"
+          ></textarea>
+          <button
+            type="submit"
+            class="btn btn-primary ask-send"
+            [disabled]="!canSend()"
+            [attr.aria-label]="pending() ? 'Sending' : 'Send'"
+          >
+            @if (pending()) {
+              <span class="ask-send-spin" aria-hidden="true"></span>
+            } @else {
+              <span class="ask-send-arrow" aria-hidden="true"></span>
+            }
+          </button>
+        </form>
       }
     </div>
   }
 </section>
-  

--- a/src/app/features/ask/ask/ask.component.ts
+++ b/src/app/features/ask/ask/ask.component.ts
@@ -19,6 +19,7 @@ import type {
   AskConversation,
   AskConversationScope,
   AskConversationSummary,
+  DashboardScopeRef,
   SourceRef,
   VaultSource,
 } from "../../../core/models";
@@ -130,6 +131,8 @@ export class AskComponent implements OnInit {
    * their links; empty ⇒ pass `undefined` (whole-vault) to {@link askVault}.
    */
   readonly sources = signal<SourceRef[]>([]);
+  /** One composite board identity; never expanded into child SourceRefs in the WebView. */
+  readonly dashboard = signal<DashboardScopeRef | null>(null);
 
   /** Durable SQLite conversation id; distinct from the per-request trace id. */
   readonly conversationId = signal<string | null>(null);
@@ -400,6 +403,30 @@ export class AskComponent implements OnInit {
     void this.historyPrivacy.ensureReady();
   }
 
+  /**
+   * A durable thread cannot change composite identity in place. User selection
+   * therefore starts a fresh conversation while preserving manual sources.
+   * History restore writes `dashboard` directly and never enters this handler.
+   */
+  onDashboardChange(next: DashboardScopeRef | null): void {
+    if (this.dashboard()?.id === next?.id) return;
+    const sources = this.sources();
+    if (this.conversationId() !== null || this.conversation().length > 0) {
+      this.resetConversation(false);
+      this.sources.set(sources);
+    }
+    this.dashboard.set(next);
+  }
+
+  onSourcesChange(next: SourceRef[]): void {
+    const dashboard = this.dashboard();
+    if (this.conversationId() !== null || this.conversation().length > 0) {
+      this.resetConversation(false);
+      this.dashboard.set(dashboard);
+    }
+    this.sources.set(next);
+  }
+
   /** Load and resume one canonical conversation, including its saved sources. */
   async resumeConversation(id: string): Promise<void> {
     if (this.pending() || !this.historyPrivacyReady()) {
@@ -419,6 +446,7 @@ export class AskComponent implements OnInit {
       this.requestSeq++;
       this.conversationId.set(detail.id);
       this.sources.set(detail.selectedSources);
+      this.dashboard.set(detail.dashboard ?? null);
       this.conversation.set(this.renderTurns(detail));
       this.draft.set("");
       this.error.set(null);
@@ -487,6 +515,7 @@ export class AskComponent implements OnInit {
         conversationId,
         scope.length ? scope : undefined,
         askThreadId,
+        this.dashboard()?.id,
       );
       if (requestSeq !== this.requestSeq) {
         return;
@@ -558,6 +587,7 @@ export class AskComponent implements OnInit {
     this.draft.set("");
     this.error.set(null);
     this.sources.set([]);
+    this.dashboard.set(null);
     this.historyOpen.set(false);
     this.historyLoading.set(false);
     this.historyError.set(null);
@@ -614,7 +644,8 @@ export class AskComponent implements OnInit {
 
   /** The scrollable message log. */
   private readonly scroller = viewChild<ElementRef<HTMLDivElement>>("scroller");
-  private readonly composer = viewChild<ElementRef<HTMLTextAreaElement>>("input");
+  private readonly composer =
+    viewChild<ElementRef<HTMLTextAreaElement>>("input");
   private readonly sourcePicker = viewChild(SourcePickerComponent);
 
   private focusComposer(): void {

--- a/src/app/features/dashboards/dashboard-compose/dashboard-compose.component.html
+++ b/src/app/features/dashboards/dashboard-compose/dashboard-compose.component.html
@@ -1,0 +1,92 @@
+<section
+  class="compose-workspace"
+  aria-labelledby="compose-title"
+  data-testid="dashboard-compose"
+>
+  <header class="compose-intro">
+    <div>
+      <span class="eyebrow">Board structure</span>
+      <h2 id="compose-title">Arrange what belongs here</h2>
+      <p>
+        Drag a handle or use Move earlier and Move later. Changes save as you
+        go.
+      </p>
+    </div>
+    <span class="count"
+      >{{ rows().length }} {{ rows().length === 1 ? "item" : "items" }}</span
+    >
+  </header>
+
+  <ol class="compose-list panel-card" aria-label="Board items in order">
+    @for (row of rows(); track row.tile.id) {
+      <li
+        class="compose-row"
+        [class.is-dragging]="draggingId() === row.tile.id"
+        [class.is-drop-target]="dropTargetId() === row.tile.id"
+        [attr.data-tile-id]="row.tile.id"
+        [attr.data-kind]="row.tile.data.kind"
+        (dragover)="onDragOver(row.tile, $event)"
+        (drop)="onDrop(row.tile, $event)"
+      >
+        <button
+          type="button"
+          class="drag-handle"
+          draggable="true"
+          [attr.aria-disabled]="busy()"
+          [attr.aria-label]="
+            'Drag to reorder ' +
+            row.title +
+            '. Alt+Arrow Up or Alt+Arrow Down also moves it.'
+          "
+          (dragstart)="onDragStart(row.tile, $event)"
+          (dragend)="onDragEnd()"
+          (keydown)="onHandleKeydown(row.tile, $event)"
+        >
+          <span aria-hidden="true">⠿</span>
+        </button>
+        <span
+          class="kind-mark"
+          [class.is-sealed]="row.tile.data.kind === 'locked'"
+          aria-hidden="true"
+        >
+          <mur-icon [icon]="row.icon" />
+        </span>
+        <div class="row-copy">
+          <span class="row-kind">{{ row.label }}</span>
+          <strong>{{ row.title }}</strong>
+          <span class="row-state">{{ row.state }}</span>
+        </div>
+        <div class="row-actions" [attr.aria-label]="'Actions for ' + row.title">
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm"
+            [attr.aria-disabled]="row.first || busy()"
+            [attr.aria-label]="'Move earlier ' + row.title"
+            (click)="moveBy(row.tile, -1)"
+          >
+            Move earlier
+          </button>
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm"
+            [attr.aria-disabled]="row.last || busy()"
+            [attr.aria-label]="'Move later ' + row.title"
+            (click)="moveBy(row.tile, 1)"
+          >
+            Move later
+          </button>
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm remove"
+            [attr.aria-disabled]="busy()"
+            [attr.aria-label]="'Remove ' + row.title + ' from board'"
+            (click)="!busy() && remove.emit(row.tile)"
+          >
+            Remove
+          </button>
+        </div>
+      </li>
+    }
+  </ol>
+  <p class="sr-only" aria-live="polite">{{ announcement() }}</p>
+</section>

--- a/src/app/features/dashboards/dashboard-compose/dashboard-compose.component.scss
+++ b/src/app/features/dashboards/dashboard-compose/dashboard-compose.component.scss
@@ -1,0 +1,162 @@
+:host {
+  display: block;
+  min-width: 0;
+}
+.compose-workspace {
+  width: min(100%, 920px);
+  min-width: 0;
+  margin: 0 auto;
+}
+.compose-intro {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+.compose-intro h2 {
+  margin: var(--space-1) 0;
+  font-size: 1.2rem;
+  letter-spacing: -0.025em;
+}
+.compose-intro p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+.eyebrow {
+  color: var(--text-tertiary);
+  font-size: 0.66rem;
+  font-weight: 680;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.compose-list {
+  margin: 0;
+  padding: var(--space-2);
+  list-style: none;
+  overflow: hidden;
+}
+.compose-row {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr);
+  align-items: center;
+  gap: var(--space-2) var(--space-3);
+  min-width: 0;
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--border-subtle);
+  transition:
+    background var(--transition-fast),
+    opacity var(--transition-fast);
+}
+.compose-row:last-child {
+  border-bottom: 0;
+}
+.compose-row.is-dragging {
+  opacity: 0.45;
+}
+.compose-row.is-drop-target {
+  background: var(--accent-soft);
+}
+.drag-handle {
+  display: grid;
+  place-items: center;
+  width: var(--space-6);
+  height: var(--space-7);
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 1rem;
+  cursor: grab;
+}
+.drag-handle:active {
+  cursor: grabbing;
+}
+.drag-handle:hover,
+.drag-handle:focus-visible {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+.drag-handle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-ring);
+}
+.kind-mark {
+  display: grid;
+  place-items: center;
+  width: var(--space-7);
+  height: var(--space-7);
+  border-radius: var(--radius-sm);
+  background: var(--surface-input);
+  color: var(--text-secondary);
+}
+.kind-mark.is-sealed {
+  color: var(--text-muted);
+}
+.kind-mark mur-icon {
+  width: var(--space-4);
+  height: var(--space-4);
+}
+.row-copy {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: var(--space-1);
+}
+.row-copy strong,
+.row-kind,
+.row-state {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.row-kind {
+  color: var(--text-tertiary);
+  font-size: 0.65rem;
+  font-weight: 650;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.row-copy strong {
+  color: var(--text-primary);
+  font-size: 0.84rem;
+}
+.row-state {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+.row-actions {
+  display: flex;
+  flex-wrap: wrap;
+  grid-column: 2 / -1;
+  justify-content: flex-start;
+  gap: var(--space-1);
+  min-width: 0;
+}
+.row-actions .remove {
+  color: var(--danger);
+}
+.row-actions [aria-disabled="true"],
+.drag-handle[aria-disabled="true"] {
+  opacity: 0.45;
+  cursor: default;
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+@media (max-width: 1100px) {
+  .compose-intro {
+    align-items: flex-start;
+  }
+}

--- a/src/app/features/dashboards/dashboard-compose/dashboard-compose.component.ts
+++ b/src/app/features/dashboards/dashboard-compose/dashboard-compose.component.ts
@@ -1,0 +1,188 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output,
+  signal,
+} from "@angular/core";
+import type { ResolvedTile, TileData } from "../../../core/models";
+import {
+  MurIconComponent,
+  type ShellIcon,
+} from "../../../design-system/icon/icon.component";
+
+const LABEL: Record<TileData["kind"], string> = {
+  locked: "Sealed item",
+  missing: "Missing source",
+  unconfigured: "Needs setup",
+  note: "Note",
+  meeting: "Recording",
+  document: "Document",
+  person: "Person",
+  reminders: "Reminders",
+  drift: "Drift view",
+  numbers: "Numbers view",
+  pulse: "Pulse view",
+  promises: "Promises view",
+  livingAnswer: "Living answer",
+};
+
+const ICON: Record<TileData["kind"], ShellIcon> = {
+  locked: "lock",
+  missing: "document",
+  unconfigured: "plus",
+  note: "notes",
+  meeting: "meetings",
+  document: "document",
+  person: "people",
+  reminders: "reminders",
+  drift: "drift",
+  numbers: "numbers",
+  pulse: "pulse",
+  promises: "promises",
+  livingAnswer: "ask",
+};
+
+@Component({
+  selector: "app-dashboard-compose",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MurIconComponent],
+  templateUrl: "./dashboard-compose.component.html",
+  styleUrl: "./dashboard-compose.component.scss",
+})
+export class DashboardComposeComponent {
+  readonly tiles = input.required<readonly ResolvedTile[]>();
+  readonly busy = input(false);
+  readonly move = output<{ tile: ResolvedTile; delta: -1 | 1 }>();
+  readonly remove = output<ResolvedTile>();
+  readonly reorder = output<{ tileId: string; targetId: string }>();
+  readonly draggingId = signal<string | null>(null);
+  readonly dropTargetId = signal<string | null>(null);
+  readonly announcement = signal("");
+  readonly rows = computed(() =>
+    this.tiles().map((tile, index, all) => ({
+      tile,
+      index,
+      first: index === 0,
+      last: index === all.length - 1,
+      label: LABEL[tile.data.kind],
+      icon: ICON[tile.data.kind],
+      title: this.title(tile),
+      state: this.state(tile),
+    })),
+  );
+
+  onDragStart(tile: ResolvedTile, event: DragEvent): void {
+    if (this.busy()) {
+      event.preventDefault();
+      return;
+    }
+    this.draggingId.set(tile.id);
+    event.dataTransfer?.setData("text/plain", tile.id);
+    if (event.dataTransfer) event.dataTransfer.effectAllowed = "move";
+  }
+
+  onDragOver(tile: ResolvedTile, event: DragEvent): void {
+    if (!this.draggingId()) return;
+    event.preventDefault();
+    this.dropTargetId.set(tile.id);
+  }
+
+  onDrop(target: ResolvedTile, event: DragEvent): void {
+    event.preventDefault();
+    const tileId = this.draggingId();
+    this.onDragEnd();
+    if (tileId && tileId !== target.id && !this.busy()) {
+      const moved = this.tiles().find((tile) => tile.id === tileId);
+      const position =
+        this.tiles().findIndex((tile) => tile.id === target.id) + 1;
+      if (moved) {
+        this.announcement.set(
+          `${this.title(moved)} moved to position ${position} of ${this.tiles().length}`,
+        );
+      }
+      this.reorder.emit({ tileId, targetId: target.id });
+    }
+  }
+
+  onDragEnd(): void {
+    this.draggingId.set(null);
+    this.dropTargetId.set(null);
+  }
+
+  moveBy(tile: ResolvedTile, delta: -1 | 1): void {
+    if (this.busy()) return;
+    const index = this.tiles().findIndex(
+      (candidate) => candidate.id === tile.id,
+    );
+    if (index < 0 || index + delta < 0 || index + delta >= this.tiles().length)
+      return;
+    this.announcement.set(
+      `${this.title(tile)} moved to position ${index + delta + 1} of ${this.tiles().length}`,
+    );
+    this.move.emit({ tile, delta });
+  }
+
+  onHandleKeydown(tile: ResolvedTile, event: KeyboardEvent): void {
+    if (this.busy()) return;
+    if (!event.altKey) return;
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      this.moveBy(tile, -1);
+    } else if (event.key === "ArrowDown") {
+      event.preventDefault();
+      this.moveBy(tile, 1);
+    }
+  }
+
+  private title(tile: ResolvedTile): string {
+    const data = tile.data;
+    if (data.kind === "locked") return "Sealed item";
+    if (data.kind === "missing") return "Source removed";
+    if (data.kind === "unconfigured") return "Not configured";
+    if (tile.title?.trim()) return tile.title.trim();
+    switch (data.kind) {
+      case "note":
+      case "meeting":
+      case "document":
+        return data.title;
+      case "person":
+        return data.name;
+      case "drift":
+        return `${data.entity} · ${data.predicate || "history"}`;
+      case "numbers":
+      case "pulse":
+        return data.entity;
+      case "livingAnswer":
+        return data.question || "Living answer";
+      default:
+        return LABEL[data.kind];
+    }
+  }
+
+  private state(tile: ResolvedTile): string {
+    const data = tile.data;
+    switch (data.kind) {
+      case "locked":
+        return "Content hidden until its folder is unlocked";
+      case "missing":
+        return "The source is no longer available";
+      case "unconfigured":
+        return "Choose a source to finish setup";
+      case "reminders":
+        return `${data.rows.length} reminder ${data.rows.length === 1 ? "item" : "items"}`;
+      case "promises":
+        return `${data.rows.length} open ${data.rows.length === 1 ? "promise" : "promises"}`;
+      case "livingAnswer":
+        return data.answer ? "Answer ready" : "Waiting for an answer";
+      case "note":
+      case "document":
+        return data.snippet.trim() ? "Readable material" : "No preview text";
+      case "meeting":
+        return data.hasAudio ? "Audio available" : "Transcript material";
+      default:
+        return "Live derived board view";
+    }
+  }
+}

--- a/src/app/features/dashboards/dashboard-projection.ts
+++ b/src/app/features/dashboards/dashboard-projection.ts
@@ -49,6 +49,7 @@ export interface BoardProjection {
     detail: string;
     answeredAt: string | null;
     source: SourceRef | null;
+    answerRefresh: { tileId: string; question: string } | null;
   };
   attention: CommitmentView[];
   evidence: MaterialSourceView[];
@@ -146,7 +147,12 @@ export function projectDashboard(tiles: readonly ResolvedTile[]): BoardProjectio
   let missingCount = 0;
   let derivedViewCount = 0;
   let hasGoodZero = false;
-  let livingAnswer: { title: string; detail: string; answeredAt: string | null } | null = null;
+  let livingAnswer: {
+    tileId: string;
+    title: string;
+    detail: string;
+    answeredAt: string | null;
+  } | null = null;
 
   for (const tile of tiles) {
     const data = tile.data;
@@ -187,10 +193,13 @@ export function projectDashboard(tiles: readonly ResolvedTile[]): BoardProjectio
         });
         break;
       case "livingAnswer":
-        if (!livingAnswer && !data.withheld && data.answer) {
+        if (!livingAnswer && !data.withheld && data.question.trim()) {
           livingAnswer = {
+            tileId: tile.id,
             title: data.question,
-            detail: data.answer,
+            detail:
+              data.answer ??
+              "No saved answer yet. Refresh it from this board's current readable scope.",
             answeredAt: data.answeredAt,
           };
         }
@@ -236,6 +245,10 @@ export function projectDashboard(tiles: readonly ResolvedTile[]): BoardProjectio
         detail: livingAnswer.detail,
         answeredAt: livingAnswer.answeredAt,
         source: null,
+        answerRefresh: {
+          tileId: livingAnswer.tileId,
+          question: livingAnswer.title,
+        },
       }
     : firstSource
       ? {
@@ -244,21 +257,26 @@ export function projectDashboard(tiles: readonly ResolvedTile[]): BoardProjectio
           detail: firstSource.detail,
           answeredAt: null,
           source: firstSource.source,
+          answerRefresh: null,
         }
       : commitments.length === 0 && hasGoodZero
         ? {
             label: "Current state",
             title: "Nothing open",
-            detail: "The board's configured commitment views have no open items.",
+            detail:
+              "The board's configured commitment views have no open items.",
             answeredAt: null,
             source: null,
+            answerRefresh: null,
           }
         : {
             label: "Current state",
             title: "No readable material yet",
-            detail: "Add a note, recording or document, or unlock a sealed source.",
+            detail:
+              "Add a note, recording or document, or unlock a sealed source.",
             answeredAt: null,
             source: null,
+            answerRefresh: null,
           };
 
   return {

--- a/src/app/features/dashboards/dashboard-read/dashboard-read.component.html
+++ b/src/app/features/dashboards/dashboard-read/dashboard-read.component.html
@@ -8,6 +8,22 @@
         @if (projection().dominant.answeredAt; as answeredAt) {
           <p class="answer-age">Answered {{ formatDate(answeredAt) }}</p>
         }
+        @if (projection().dominant.answerRefresh; as answerRefresh) {
+          <button
+            type="button"
+            class="source-action"
+            [disabled]="refreshingAnswerId() !== null"
+            (click)="refresh(answerRefresh)"
+          >
+            {{
+              refreshingAnswerId() === answerRefresh.tileId
+                ? "Refreshing…"
+                : projection().dominant.answeredAt
+                  ? "Re-answer"
+                  : "Answer now"
+            }}
+          </button>
+        }
         @if (projection().dominant.source; as source) {
           <button type="button" class="source-action" (click)="open(source)">
             Open source <span aria-hidden="true">→</span>

--- a/src/app/features/dashboards/dashboard-read/dashboard-read.component.ts
+++ b/src/app/features/dashboards/dashboard-read/dashboard-read.component.ts
@@ -16,10 +16,16 @@ import type {
 export class DashboardReadComponent {
   readonly lens = input.required<DashboardLens>();
   readonly projection = input.required<BoardProjection>();
+  readonly refreshingAnswerId = input<string | null>(null);
   readonly openSource = output<SourceRef>();
+  readonly refreshAnswer = output<{ tileId: string; question: string }>();
 
   open(source: SourceRef | null): void {
     if (source) this.openSource.emit(source);
+  }
+
+  refresh(answer: { tileId: string; question: string }): void {
+    this.refreshAnswer.emit(answer);
   }
 
   formatDate(iso: string): string {

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
@@ -1,16 +1,43 @@
-<header class="head">
+<header class="head" [class.is-compose]="mode() === 'compose'">
   <div class="head-text">
     <button type="button" class="crumb" (click)="back()">← Dashboards</button>
     @if (renaming()) {
       <form class="rename" (submit)="commitRename(); $event.preventDefault()">
-        <input #renameField class="rename-field" type="text" [value]="renameDraft()" (input)="onRenameInput($event)" (keydown.escape)="cancelRename()" aria-label="Board name" />
-        <button type="submit" class="btn btn-primary btn-sm" [disabled]="!renameDraft().trim()">Save</button>
-        <button type="button" class="btn btn-ghost btn-sm" (click)="cancelRename()">Cancel</button>
+        <input
+          #renameField
+          class="rename-field"
+          type="text"
+          [value]="renameDraft()"
+          (input)="onRenameInput($event)"
+          (keydown.escape)="cancelRename()"
+          aria-label="Board name"
+        />
+        <button
+          type="submit"
+          class="btn btn-primary btn-sm"
+          [disabled]="!renameDraft().trim()"
+        >
+          Save
+        </button>
+        <button
+          type="button"
+          class="btn btn-ghost btn-sm"
+          (click)="cancelRename()"
+        >
+          Cancel
+        </button>
       </form>
     } @else {
       <h1>
-        <button type="button" class="title-edit" (click)="startRename()" [attr.aria-label]="'Rename this board — ' + (board()?.title ?? '')">
-          @if (board()?.emoji; as emoji) { <span class="emoji">{{ emoji }}</span> }
+        <button
+          type="button"
+          class="title-edit"
+          (click)="startRename()"
+          [attr.aria-label]="'Rename this board — ' + (board()?.title ?? '')"
+        >
+          @if (board()?.emoji; as emoji) {
+            <span class="emoji">{{ emoji }}</span>
+          }
           {{ board()?.title ?? "Board" }}
         </button>
       </h1>
@@ -18,102 +45,183 @@
   </div>
 
   @if (mode() === "read") {
-    <button type="button" class="btn btn-ghost secondary-action" [disabled]="!privacyReady()" (click)="openAsk()"><mur-icon icon="ask" /> Ask</button>
-    @if (!isEmpty()) { <button type="button" class="btn btn-ghost" (click)="enterCompose()">Compose</button> }
+    <button
+      type="button"
+      class="btn btn-ghost secondary-action"
+      [disabled]="!privacyReady()"
+      (click)="openAsk()"
+    >
+      <mur-icon icon="ask" /> Ask
+    </button>
+    @if (!isEmpty()) {
+      <button type="button" class="btn btn-ghost" (click)="enterCompose()">
+        Compose
+      </button>
+    }
   } @else {
     <span class="compose-hint">Drag or use Move earlier / Move later</span>
-    <button type="button" class="btn btn-primary" [class.is-open]="paletteOpen()" (click)="togglePalette($event)">
+    <button
+      type="button"
+      class="btn btn-primary"
+      [class.is-open]="paletteOpen()"
+      (click)="togglePalette($event)"
+    >
       <mur-icon icon="plus" /> {{ paletteOpen() ? "Close" : "Add to board" }}
     </button>
-    <button type="button" class="btn btn-ghost" (click)="leaveCompose()">Done</button>
+    <button type="button" class="btn btn-ghost" (click)="leaveCompose()">
+      Done
+    </button>
   }
 </header>
 
-@if (error(); as err) { <div class="banner banner-error" role="alert">{{ err }}</div> }
+@if (error(); as err) {
+  <div class="banner banner-error" role="alert">{{ err }}</div>
+}
 
 @if (!privacyReady() && !privacyError()) {
-  <mur-empty-state><mur-spinner /> Establishing a secure board session…</mur-empty-state>
+  <mur-empty-state
+    ><mur-spinner /> Establishing a secure board session…</mur-empty-state
+  >
 } @else if (privacyRefreshing() || loading()) {
   <mur-empty-state><mur-spinner /> Re-checking this board…</mur-empty-state>
 } @else if (boardUnavailable()) {
   <mur-empty-state>
     <strong>Board unavailable.</strong>
-    <p class="empty-copy">{{ privacyError() ?? "Murmur could not safely resolve this board's current readable scope." }}</p>
-    <button type="button" class="btn btn-primary" (click)="retryLoad()">Try again</button>
+    <p class="empty-copy">
+      {{
+        privacyError() ??
+          "Murmur could not safely resolve this board's current readable scope."
+      }}
+    </p>
+    <button type="button" class="btn btn-primary" (click)="retryLoad()">
+      Try again
+    </button>
   </mur-empty-state>
 } @else if (isEmpty() && !askOpen()) {
   <mur-empty-state>
     <strong>Start with material for this board.</strong>
-    <p class="empty-copy">Add a Note, Recording or Document. Derived views can follow once the board has something readable to work from.</p>
-    <button type="button" class="btn btn-primary" (click)="openPalette($event)">Add a Note, Recording or Document</button>
+    <p class="empty-copy">
+      Add a Note, Recording or Document. Derived views can follow once the board
+      has something readable to work from.
+    </p>
+    <button type="button" class="btn btn-primary" (click)="openPalette($event)">
+      Add a Note, Recording or Document
+    </button>
   </mur-empty-state>
 } @else if (mode() === "compose") {
-  <section class="compose" aria-label="Compose board tiles">
-    @for (tile of tiles(); track tile.id; let first = $first; let last = $last) {
-      <app-dashboard-tile
-        [tile]="tile"
-        [editing]="true"
-        [allowRefreshAnswer]="false"
-        [duplicateOf]="duplicateOf(tile)"
-        [canMoveEarlier]="!first"
-        [canMoveLater]="!last"
-        [dragging]="draggingId() === tile.id"
-        [dropTarget]="dropTargetId() === tile.id"
-        draggable="true"
-        (dragstart)="onDragStart(tile, $event)"
-        (dragover)="onDragOver(tile, $event)"
-        (dragleave)="onDragLeave(tile)"
-        (drop)="onDrop(tile, $event)"
-        (dragend)="onDragEnd()"
-        (moveEarlier)="moveTile(tile, -1)"
-        (moveLater)="moveTile(tile, 1)"
-        (remove)="removeTile(tile)"
-        (widen)="widen(tile)"
-        (narrow)="narrow(tile)"
-        (openSource)="openSource($event)"
-      />
-    }
-  </section>
+  <app-dashboard-compose
+    [tiles]="tiles()"
+    [busy]="composeBusy()"
+    (move)="moveTile($event.tile, $event.delta)"
+    (reorder)="reorderTile($event)"
+    (remove)="removeTile($event)"
+  />
 } @else {
   <div class="workspace" [class.has-ask]="askOpen()">
     <main class="reading">
       <nav class="lenses" aria-label="Dashboard lenses">
         @for (item of lenses; track item.id) {
-          <button type="button" [class.active]="lens() === item.id" [attr.aria-current]="lens() === item.id ? 'page' : null" (click)="selectLens(item.id)">{{ item.label }}</button>
+          <button
+            type="button"
+            [class.active]="lens() === item.id"
+            [attr.aria-current]="lens() === item.id ? 'page' : null"
+            (click)="selectLens(item.id)"
+          >
+            {{ item.label }}
+          </button>
         }
       </nav>
-      <app-dashboard-read [lens]="lens()" [projection]="projection()" (openSource)="openSource($event)" />
+      <app-dashboard-read
+        [lens]="lens()"
+        [projection]="projection()"
+        [refreshingAnswerId]="answerRefreshingTileId()"
+        (openSource)="openSource($event)"
+        (refreshAnswer)="refreshLivingAnswer($event)"
+      />
     </main>
 
     @if (askOpen()) {
       <aside class="ask" aria-label="Ask this board">
         <header class="ask-head">
-          <div><span class="eyebrow">On demand</span><h2>Ask this board</h2></div>
-          <button type="button" class="btn btn-ghost btn-sm" (click)="closeAsk()" aria-label="Close Ask">Close</button>
+          <div>
+            <span class="eyebrow">On demand</span>
+            <h2>Ask this board</h2>
+          </div>
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm"
+            (click)="closeAsk()"
+            aria-label="Close Ask"
+          >
+            Close
+          </button>
         </header>
         <p class="scope">
-          Uses {{ sourceCount() }} currently readable material {{ sourceCount() === 1 ? "source" : "sources" }}, this board's derived views, and permitted gated linked context. This is the allowed scope, not a claim that every sentence is exact cited evidence.
-          @if (projection().sealedCount > 0) { <span>{{ projection().sealedCount }} sealed {{ projection().sealedCount === 1 ? "item is" : "items are" }} excluded.</span> }
+          Uses {{ sourceCount() }} currently readable material
+          {{ sourceCount() === 1 ? "source" : "sources" }}, this board's derived
+          views, and permitted gated linked context. This is the allowed scope,
+          not a claim that every sentence is exact cited evidence.
+          @if (projection().sealedCount > 0) {
+            <span
+              >{{ projection().sealedCount }} sealed
+              {{ projection().sealedCount === 1 ? "item is" : "items are" }}
+              excluded.</span
+            >
+          }
         </p>
         <div class="thread">
           @for (turn of turns(); track turn.id) {
             @if (turn.role === "error") {
-              <div class="banner is-danger" role="alert"><span>{{ turn.text }}</span><button type="button" class="btn btn-ghost btn-sm" (click)="retry(turn)">Try again</button></div>
+              <div class="banner is-danger" role="alert">
+                <span>{{ turn.text }}</span
+                ><button
+                  type="button"
+                  class="btn btn-ghost btn-sm"
+                  (click)="retry(turn)"
+                >
+                  Try again
+                </button>
+              </div>
             } @else if (turn.role === "user") {
               <div class="bubble me">{{ turn.text }}</div>
             } @else {
-              <div class="bubble"><app-markdown [markdown]="turn.text" compact /></div>
+              <div class="bubble">
+                <app-markdown [markdown]="turn.text" compact />
+              </div>
             }
           } @empty {
             <div class="suggestions">
-              @for (suggestion of suggestions; track suggestion) { <button type="button" class="suggestion" (click)="askSuggestion(suggestion)">{{ suggestion }}</button> }
+              @for (suggestion of suggestions; track suggestion) {
+                <button
+                  type="button"
+                  class="suggestion"
+                  (click)="askSuggestion(suggestion)"
+                >
+                  {{ suggestion }}
+                </button>
+              }
             </div>
           }
-          @if (asking()) { <div class="bubble thinking"><mur-spinner /> Thinking…</div> }
+          @if (asking()) {
+            <div class="bubble thinking"><mur-spinner /> Thinking…</div>
+          }
         </div>
         <form class="composer" (submit)="ask(); $event.preventDefault()">
-          <input class="ask-field" type="text" placeholder="Ask about this board…" [value]="draft()" (input)="onDraft($event)" aria-label="Ask a question about this board" />
-          <button type="submit" class="btn btn-primary btn-sm" [disabled]="!draft().trim() || asking()">Ask</button>
+          <input
+            class="ask-field"
+            type="text"
+            placeholder="Ask about this board…"
+            [value]="draft()"
+            (input)="onDraft($event)"
+            aria-label="Ask a question about this board"
+          />
+          <button
+            type="submit"
+            class="btn btn-primary btn-sm"
+            [disabled]="!draft().trim() || asking()"
+          >
+            Ask
+          </button>
         </form>
       </aside>
     }

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.scss
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.scss
@@ -1,54 +1,298 @@
-:host { display: flex; flex-direction: column; min-width: 0; min-height: 0; padding: 0 var(--space-2) var(--space-5); }
-.head { display: flex; align-items: flex-end; gap: var(--space-2); padding: var(--space-2) 0 var(--space-4); }
-.head-text { flex: 1; min-width: 0; }
-.head h1 { margin: var(--space-1) 0 0; font-size: 1.5rem; font-weight: 680; letter-spacing: -0.035em; }
-.crumb { padding: 0; border: 0; background: none; color: var(--text-muted); font: inherit; font-size: 0.76rem; cursor: pointer; }
-.crumb:hover { color: var(--text-primary); }
-.emoji { font-size: 1.35rem; line-height: 1; }
-.title-edit { display: inline-flex; align-items: center; gap: var(--space-2); margin-left: calc(var(--space-2) * -1); padding: var(--space-1) var(--space-2); border: 1px solid transparent; border-radius: var(--radius-sm); background: none; color: inherit; font: inherit; cursor: text; }
-.title-edit:hover, .title-edit:focus-visible { border-color: var(--border-subtle); background: var(--surface-input); }
-.rename { display: flex; align-items: center; gap: var(--space-2); }
-.rename-field { min-width: 260px; padding: var(--space-1) var(--space-2); border: 1px solid var(--border-strong); border-radius: var(--radius-sm); background: var(--surface-input); color: var(--text-primary); font-size: 1.05rem; font-weight: 640; }
-.head mur-icon { width: var(--space-4); height: var(--space-4); }
-.compose-hint { color: var(--text-tertiary); font-size: 0.72rem; white-space: nowrap; }
-.banner-error { margin-bottom: var(--space-3); }
-.empty-copy { max-width: 48ch; margin: var(--space-2) auto var(--space-4); color: var(--text-muted); }
+:host {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  padding: 0 var(--space-2) var(--space-5);
+}
+.head {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-2);
+  padding: var(--space-2) 0 var(--space-4);
+}
+.head.is-compose {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  background: var(--surface-base);
+}
+.head-text {
+  flex: 1;
+  min-width: 0;
+}
+.head h1 {
+  margin: var(--space-1) 0 0;
+  font-size: 1.5rem;
+  font-weight: 680;
+  letter-spacing: -0.035em;
+}
+.crumb {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 0.76rem;
+  cursor: pointer;
+}
+.crumb:hover {
+  color: var(--text-primary);
+}
+.emoji {
+  font-size: 1.35rem;
+  line-height: 1;
+}
+.title-edit {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-left: calc(var(--space-2) * -1);
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: text;
+}
+.title-edit:hover,
+.title-edit:focus-visible {
+  border-color: var(--border-subtle);
+  background: var(--surface-input);
+}
+.rename {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.rename-field {
+  min-width: 260px;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--surface-input);
+  color: var(--text-primary);
+  font-size: 1.05rem;
+  font-weight: 640;
+}
+.head mur-icon {
+  width: var(--space-4);
+  height: var(--space-4);
+}
+.compose-hint {
+  color: var(--text-tertiary);
+  font-size: 0.72rem;
+  white-space: nowrap;
+}
+.banner-error {
+  margin-bottom: var(--space-3);
+}
+.empty-copy {
+  max-width: 48ch;
+  margin: var(--space-2) auto var(--space-4);
+  color: var(--text-muted);
+}
 
-.workspace { display: grid; grid-template-columns: minmax(0, 1fr); gap: var(--space-4); min-width: 0; min-height: 0; flex: 1; }
-.workspace.has-ask { grid-template-columns: minmax(0, 1fr) minmax(300px, 360px); }
-.reading { min-width: 0; overflow: auto; padding-bottom: var(--space-5); }
-.lenses { display: flex; gap: var(--space-1); margin-bottom: var(--space-4); padding: var(--space-1); overflow-x: auto; border: 1px solid var(--border-subtle); border-radius: var(--radius-pill); background: var(--surface-input); width: max-content; max-width: 100%; }
-.lenses button { flex: none; padding: var(--space-2) var(--space-3); border: 0; border-radius: var(--radius-pill); background: none; color: var(--text-secondary); font: inherit; font-size: 0.76rem; cursor: pointer; }
-.lenses button.active { background: var(--shell-active-bg); color: var(--shell-active-text); box-shadow: var(--shell-active-shadow); }
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--space-4);
+  min-width: 0;
+  min-height: 0;
+  flex: 1;
+}
+.workspace.has-ask {
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 360px);
+}
+.reading {
+  min-width: 0;
+  overflow: auto;
+  padding-bottom: var(--space-5);
+}
+.lenses {
+  display: flex;
+  gap: var(--space-1);
+  margin-bottom: var(--space-4);
+  padding: var(--space-1);
+  overflow-x: auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: var(--surface-input);
+  width: max-content;
+  max-width: 100%;
+}
+.lenses button {
+  flex: none;
+  padding: var(--space-2) var(--space-3);
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: none;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 0.76rem;
+  cursor: pointer;
+}
+.lenses button.active {
+  background: var(--shell-active-bg);
+  color: var(--shell-active-text);
+  box-shadow: var(--shell-active-shadow);
+}
 
-.compose { display: grid; grid-template-columns: repeat(12, minmax(0, 1fr)); grid-auto-rows: max-content; align-content: start; gap: var(--space-3); min-width: 0; overflow: auto; padding-bottom: var(--space-5); }
-
-.ask { display: flex; flex-direction: column; min-width: 0; min-height: 0; overflow: hidden; border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--surface-raised); backdrop-filter: blur(var(--shell-glass-blur)) saturate(var(--shell-glass-saturate)); }
-.ask-head { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3); padding: var(--space-3) var(--space-4); border-bottom: 1px solid var(--border-subtle); }
-.ask-head h2 { margin: var(--space-1) 0 0; font-size: 0.88rem; }
-.eyebrow { color: var(--text-tertiary); font-size: 0.64rem; font-weight: 650; letter-spacing: 0.08em; text-transform: uppercase; }
-.scope { margin: var(--space-3) var(--space-4) 0; padding: var(--space-3); border: 1px solid var(--accent-ring); border-radius: var(--radius-sm); background: var(--accent-soft); color: var(--text-secondary); font-size: 0.7rem; line-height: 1.5; }
-.scope span { display: block; margin-top: var(--space-1); color: var(--text-tertiary); }
-.thread { display: flex; flex: 1; flex-direction: column; gap: var(--space-3); min-height: 0; overflow: auto; padding: var(--space-4); }
-.thread .banner { display: flex; align-items: center; justify-content: space-between; gap: var(--space-2); font-size: 0.8rem; }
-.bubble { padding: var(--space-3); border: 1px solid var(--border-subtle); border-radius: var(--radius-md); background: var(--surface-input); color: var(--text-secondary); font-size: 0.8rem; line-height: 1.6; }
-.bubble.me { align-self: flex-end; max-width: 88%; border-color: transparent; background: var(--accent); color: var(--text-on-accent); white-space: pre-wrap; }
-.bubble.thinking { display: flex; align-items: center; gap: var(--space-2); color: var(--text-muted); }
-.suggestions { display: flex; flex-direction: column; gap: var(--space-2); }
-.suggestion { padding: var(--space-2) var(--space-3); border: 1px solid var(--border-subtle); border-radius: var(--radius-sm); background: var(--surface-input); color: var(--text-secondary); font: inherit; font-size: 0.76rem; text-align: left; cursor: pointer; }
-.suggestion:hover { background: var(--surface-hover); color: var(--text-primary); }
-.composer { display: flex; align-items: center; gap: var(--space-2); padding: var(--space-3); border-top: 1px solid var(--border-subtle); }
-.ask-field { flex: 1; min-width: 0; padding: var(--space-2) var(--space-3); border: 1px solid var(--border-subtle); border-radius: var(--radius-pill); background: var(--surface-input); color: var(--text-primary); font: inherit; font-size: 0.78rem; }
-.ask-field:focus-visible { outline: none; border-color: var(--accent-ring); box-shadow: 0 0 0 var(--space-1) var(--accent-soft); }
+.ask {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface-raised);
+  backdrop-filter: blur(var(--shell-glass-blur))
+    saturate(var(--shell-glass-saturate));
+}
+.ask-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-subtle);
+}
+.ask-head h2 {
+  margin: var(--space-1) 0 0;
+  font-size: 0.88rem;
+}
+.eyebrow {
+  color: var(--text-tertiary);
+  font-size: 0.64rem;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.scope {
+  margin: var(--space-3) var(--space-4) 0;
+  padding: var(--space-3);
+  border: 1px solid var(--accent-ring);
+  border-radius: var(--radius-sm);
+  background: var(--accent-soft);
+  color: var(--text-secondary);
+  font-size: 0.7rem;
+  line-height: 1.5;
+}
+.scope span {
+  display: block;
+  margin-top: var(--space-1);
+  color: var(--text-tertiary);
+}
+.thread {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-height: 0;
+  overflow: auto;
+  padding: var(--space-4);
+}
+.thread .banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  font-size: 0.8rem;
+}
+.bubble {
+  padding: var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-input);
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.6;
+}
+.bubble.me {
+  align-self: flex-end;
+  max-width: 88%;
+  border-color: transparent;
+  background: var(--accent);
+  color: var(--text-on-accent);
+  white-space: pre-wrap;
+}
+.bubble.thinking {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--text-muted);
+}
+.suggestions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.suggestion {
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--surface-input);
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 0.76rem;
+  text-align: left;
+  cursor: pointer;
+}
+.suggestion:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+.composer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-top: 1px solid var(--border-subtle);
+}
+.ask-field {
+  flex: 1;
+  min-width: 0;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: var(--surface-input);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 0.78rem;
+}
+.ask-field:focus-visible {
+  outline: none;
+  border-color: var(--accent-ring);
+  box-shadow: 0 0 0 var(--space-1) var(--accent-soft);
+}
 
 @media (max-width: 1080px) {
-  .workspace.has-ask { grid-template-columns: minmax(0, 1fr); }
-  .ask { max-height: 360px; }
-  .secondary-action { margin-left: auto; }
+  .workspace.has-ask {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .ask {
+    max-height: 360px;
+  }
+  .secondary-action {
+    margin-left: auto;
+  }
 }
 @media (max-width: 720px) {
-  .head { align-items: center; flex-wrap: wrap; }
-  .head-text { flex-basis: 100%; }
-  .compose-hint { display: none; }
+  .head {
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .head-text {
+    flex-basis: 100%;
+  }
+  .compose-hint {
+    display: none;
+  }
 }
-@media (prefers-reduced-motion: reduce) { .lenses button { transition: none; } }
+@media (prefers-reduced-motion: reduce) {
+  .lenses button {
+    transition: none;
+  }
+}

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
@@ -15,7 +15,6 @@ import { ActivatedRoute, Router } from "@angular/router";
 import { IpcService } from "../../../core/ipc.service";
 import { AskHistoryPrivacyBarrierService } from "../../../core/ask-history-privacy-barrier.service";
 import type {
-  ChatTurn,
   DashboardDetail,
   ResolvedTile,
   SourceRef,
@@ -34,12 +33,9 @@ import {
   TilePaletteService,
   type TileChoice,
 } from "../../../services/tile-palette.service";
-import { DashboardTileComponent } from "../dashboard-tile/dashboard-tile.component";
+import { DashboardComposeComponent } from "../dashboard-compose/dashboard-compose.component";
 import { DashboardReadComponent } from "../dashboard-read/dashboard-read.component";
-import {
-  projectDashboard,
-  type DashboardLens,
-} from "../dashboard-projection";
+import { projectDashboard, type DashboardLens } from "../dashboard-projection";
 
 interface BoardTurn {
   id: number;
@@ -48,7 +44,6 @@ interface BoardTurn {
   retry?: string;
 }
 
-const HISTORY_TURNS = 12;
 const SUGGESTIONS = [
   "What needs attention?",
   "Which commitments are still open?",
@@ -70,7 +65,7 @@ const LENSES: readonly { id: DashboardLens; label: string }[] = [
     MurEmptyStateComponent,
     MurIconComponent,
     MurSpinnerComponent,
-    DashboardTileComponent,
+    DashboardComposeComponent,
     DashboardReadComponent,
     MarkdownComponent,
   ],
@@ -89,8 +84,8 @@ export class DashboardViewComponent {
   private removePrivacyInvalidator: (() => void) | null = null;
 
   constructor() {
-    this.removePrivacyInvalidator = this.privacyBarrier.registerInvalidator(() =>
-      this.invalidateAndRefresh(),
+    this.removePrivacyInvalidator = this.privacyBarrier.registerInvalidator(
+      () => this.invalidateAndRefresh(),
     );
     void this.privacyBarrier.ensureReady();
     inject(DestroyRef).onDestroy(() => {
@@ -107,7 +102,8 @@ export class DashboardViewComponent {
   readonly boardUnavailable = signal(false);
   readonly privacyReady = this.privacyBarrier.ready;
   readonly privacyError = this.privacyBarrier.error;
-  readonly error = this.service.error;
+  private readonly mutationError = signal<string | null>(null);
+  readonly error = computed(() => this.mutationError() ?? this.service.error());
   readonly paletteOpen = this.palette.open;
   readonly mode = signal<"read" | "compose">("read");
   readonly lens = signal<DashboardLens>("brief");
@@ -154,35 +150,44 @@ export class DashboardViewComponent {
 
   readonly renaming = signal(false);
   readonly renameDraft = signal("");
-  private readonly renameField = viewChild<ElementRef<HTMLInputElement>>("renameField");
+  private readonly renameField =
+    viewChild<ElementRef<HTMLInputElement>>("renameField");
   private readonly _focusRename = effect(() => {
     this.renameField()?.nativeElement.select();
   });
 
-  readonly draggingId = signal<string | null>(null);
-  readonly dropTargetId = signal<string | null>(null);
+  readonly composeBusy = signal(false);
 
   readonly turns = signal<BoardTurn[]>([]);
   readonly asking = signal(false);
   readonly draft = signal("");
-  readonly sourceCount = signal(0);
+  readonly sourceCount = computed(
+    () => this.projection().readableMaterialCount,
+  );
   readonly askOpen = signal(false);
   readonly suggestions = SUGGESTIONS;
   private askToken = 0;
+  private readonly conversationId = signal<string | null>(null);
   private nextTurnId = 1;
   private refreshToken = 0;
+  private answerRefreshToken = 0;
+  readonly answerRefreshingTileId = signal<string | null>(null);
   private folderVisibilityStamp: string | null = null;
 
   private readonly _resetOnBoardChange = effect(() => {
     this.id();
     untracked(() => {
       this.askToken += 1;
+      this.answerRefreshToken += 1;
+      this.answerRefreshingTileId.set(null);
+      this.conversationId.set(null);
       this.turns.set([]);
       this.draft.set("");
       this.asking.set(false);
       this.askOpen.set(false);
       this.mode.set("read");
       this.lens.set("brief");
+      this.composeBusy.set(false);
     });
   });
 
@@ -200,7 +205,6 @@ export class DashboardViewComponent {
         // become admissible after the barrier has moved to error.
         this.refreshToken += 1;
         this.board.set(null);
-        this.sourceCount.set(0);
         this.loading.set(privacyError === null);
         this.privacyRefreshing.set(privacyError === null);
         this.boardUnavailable.set(privacyError !== null);
@@ -225,6 +229,9 @@ export class DashboardViewComponent {
 
   private invalidateAndRefresh(): void {
     this.askToken += 1;
+    this.answerRefreshToken += 1;
+    this.answerRefreshingTileId.set(null);
+    this.conversationId.set(null);
     this.refreshToken += 1;
     this.turns.set([]);
     this.draft.set("");
@@ -234,10 +241,9 @@ export class DashboardViewComponent {
     this.renameDraft.set("");
     this.mode.set("read");
     this.lens.set("brief");
-    this.sourceCount.set(0);
+    this.composeBusy.set(false);
     this.board.set(null);
     this.orderOverride.set(null);
-    this.onDragEnd();
     if (this.palette.open()) this.palette.dismiss();
     const id = this.id();
     if (id && this.privacyReady()) {
@@ -260,7 +266,9 @@ export class DashboardViewComponent {
     const values: string[] = [];
     const visit = (items: typeof nodes): void => {
       for (const node of items) {
-        values.push(`${node.id}:${node.locked ? 1 : 0}:${node.unlocked ? 1 : 0}`);
+        values.push(
+          `${node.id}:${node.locked ? 1 : 0}:${node.unlocked ? 1 : 0}`,
+        );
         visit((node.children ?? []) as typeof nodes);
       }
     };
@@ -275,10 +283,7 @@ export class DashboardViewComponent {
     this.privacyRefreshing.set(true);
     this.loading.set(true);
     try {
-      const [detail, sources] = await Promise.all([
-        this.ipc.getDashboard(id),
-        this.ipc.getDashboardSources(id),
-      ]);
+      const detail = await this.ipc.getDashboard(id);
       if (
         token !== this.refreshToken ||
         this.id() !== id ||
@@ -287,12 +292,10 @@ export class DashboardViewComponent {
         return;
       }
       if (detail === null) {
-        this.sourceCount.set(0);
         this.boardUnavailable.set(true);
         return;
       }
       this.board.set(detail);
-      this.sourceCount.set(sources.length);
       this.boardUnavailable.set(false);
     } catch {
       if (
@@ -303,7 +306,6 @@ export class DashboardViewComponent {
         return;
       }
       this.board.set(null);
-      this.sourceCount.set(0);
       this.boardUnavailable.set(true);
     } finally {
       if (
@@ -368,15 +370,15 @@ export class DashboardViewComponent {
   }
 
   leaveCompose(): void {
-    this.draggingId.set(null);
-    this.dropTargetId.set(null);
     this.mode.set("read");
   }
 
   startRename(): void {
     const board = this.board();
     if (!board) return;
-    this.renameDraft.set(board.emoji ? `${board.emoji} ${board.title}` : board.title);
+    this.renameDraft.set(
+      board.emoji ? `${board.emoji} ${board.title}` : board.title,
+    );
     this.renaming.set(true);
   }
 
@@ -394,58 +396,73 @@ export class DashboardViewComponent {
     if (!typed || !board) return;
     this.renaming.set(false);
     const { emoji, title } = splitLeadingEmoji(typed);
-    if (title === board.title && (emoji ?? null) === (board.emoji ?? null)) return;
+    if (title === board.title && (emoji ?? null) === (board.emoji ?? null))
+      return;
+    this.resetAskContext();
     await this.service.update(board.id, { title, emoji: emoji ?? "" });
     await this.refresh(board.id);
   }
 
-  onDragStart(tile: ResolvedTile, event: DragEvent): void {
-    if (this.mode() !== "compose") return;
-    this.draggingId.set(tile.id);
-    event.dataTransfer?.setData("text/plain", tile.id);
-    if (event.dataTransfer) event.dataTransfer.effectAllowed = "move";
-  }
-
-  onDragOver(tile: ResolvedTile, event: DragEvent): void {
-    if (this.mode() !== "compose" || !this.draggingId()) return;
-    event.preventDefault();
-    if (event.dataTransfer) event.dataTransfer.dropEffect = "move";
-    this.dropTargetId.set(tile.id);
-  }
-
-  onDragLeave(tile: ResolvedTile): void {
-    if (this.dropTargetId() === tile.id) this.dropTargetId.set(null);
-  }
-
-  onDragEnd(): void {
-    this.draggingId.set(null);
-    this.dropTargetId.set(null);
-  }
-
-  async onDrop(target: ResolvedTile, event: DragEvent): Promise<void> {
-    event.preventDefault();
-    const sourceId = this.draggingId();
-    this.onDragEnd();
-    if (!sourceId || sourceId === target.id) return;
-    await this.moveTo(sourceId, this.tiles().findIndex((tile) => tile.id === target.id));
-  }
-
   async moveTile(tile: ResolvedTile, delta: -1 | 1): Promise<void> {
-    const index = this.tiles().findIndex((candidate) => candidate.id === tile.id);
+    const index = this.tiles().findIndex(
+      (candidate) => candidate.id === tile.id,
+    );
     await this.moveTo(tile.id, index + delta);
+  }
+
+  async reorderTile(event: {
+    tileId: string;
+    targetId: string;
+  }): Promise<void> {
+    const destination = this.tiles().findIndex(
+      (tile) => tile.id === event.targetId,
+    );
+    await this.moveTo(event.tileId, destination);
   }
 
   private async moveTo(tileId: string, destination: number): Promise<void> {
     const ids = this.tiles().map((tile) => tile.id);
     const from = ids.indexOf(tileId);
-    if (from < 0 || destination < 0 || destination >= ids.length || from === destination) return;
+    if (
+      from < 0 ||
+      destination < 0 ||
+      destination >= ids.length ||
+      from === destination
+    )
+      return;
+    this.resetAskContext();
     ids.splice(destination, 0, ...ids.splice(from, 1));
+    const previous = this.tiles().map((tile) => tile.id);
+    const token = ++this.refreshToken;
     this.orderOverride.set(ids);
+    this.composeBusy.set(true);
+    this.mutationError.set(null);
     try {
-      await this.service.reorderTiles(this.id(), ids);
-      await this.refresh(this.id());
+      await this.ipc.reorderDashboardTiles(this.id(), ids);
+      if (token !== this.refreshToken || !this.privacyReady()) return;
+      // Keep the optimistic canonical order mounted so keyboard focus and the
+      // compact list never disappear during a slow persistence round trip.
+      this.board.update((board) =>
+        board
+          ? {
+              ...board,
+              tiles: ids
+                .map((id) => board.tiles.find((tile) => tile.id === id))
+                .filter((tile): tile is ResolvedTile => tile !== undefined),
+            }
+          : board,
+      );
+    } catch {
+      if (token !== this.refreshToken || !this.privacyReady()) return;
+      this.orderOverride.set(previous);
+      this.mutationError.set(
+        "Couldn’t save the new board order. The previous order was restored.",
+      );
     } finally {
-      this.orderOverride.set(null);
+      if (token === this.refreshToken) {
+        this.orderOverride.set(null);
+        this.composeBusy.set(false);
+      }
     }
   }
 
@@ -456,12 +473,13 @@ export class DashboardViewComponent {
   async openPalette(event?: Event): Promise<void> {
     if (!this.privacyReady()) return;
     const explicit = event?.currentTarget;
-    const invoker = explicit instanceof HTMLElement
-      ? explicit
-      : document.activeElement instanceof HTMLElement &&
-          document.activeElement !== document.body
-        ? document.activeElement
-        : null;
+    const invoker =
+      explicit instanceof HTMLElement
+        ? explicit
+        : document.activeElement instanceof HTMLElement &&
+            document.activeElement !== document.body
+          ? document.activeElement
+          : null;
     const choice = await this.palette.request();
     if (choice) await this.addTile(choice);
     if (invoker?.isConnected) invoker.focus();
@@ -474,6 +492,7 @@ export class DashboardViewComponent {
 
   async addTile(choice: TileChoice): Promise<void> {
     if (!this.privacyReady()) return;
+    this.resetAskContext();
     await this.service.addTile(this.id(), choice.kind, {
       refId: choice.refId,
       title: choice.title,
@@ -483,21 +502,34 @@ export class DashboardViewComponent {
   }
 
   async removeTile(tile: ResolvedTile): Promise<void> {
-    if (!this.privacyReady()) return;
-    await this.service.removeTile(tile.id);
-    await this.refresh(this.id());
-  }
-
-  async widen(tile: ResolvedTile): Promise<void> {
-    if (!this.privacyReady()) return;
-    await this.service.updateTile(tile.id, { span: Math.min(12, tile.span + 1) });
-    await this.refresh(this.id());
-  }
-
-  async narrow(tile: ResolvedTile): Promise<void> {
-    if (!this.privacyReady()) return;
-    await this.service.updateTile(tile.id, { span: Math.max(3, tile.span - 1) });
-    await this.refresh(this.id());
+    if (!this.privacyReady() || this.composeBusy()) return;
+    const before = this.board();
+    if (!before) return;
+    this.resetAskContext();
+    const token = ++this.refreshToken;
+    this.composeBusy.set(true);
+    this.mutationError.set(null);
+    this.board.set({
+      ...before,
+      tiles: before.tiles.filter((candidate) => candidate.id !== tile.id),
+    });
+    try {
+      const removed = await this.ipc.deleteDashboardTile(tile.id);
+      if (!removed) throw new Error("Tile was not removed");
+    } catch {
+      if (
+        token === this.refreshToken &&
+        this.id() === before.id &&
+        this.privacyReady()
+      ) {
+        this.board.set(before);
+        this.mutationError.set(
+          "Couldn’t remove this board item. It was restored.",
+        );
+      }
+    } finally {
+      if (token === this.refreshToken) this.composeBusy.set(false);
+    }
   }
 
   openSource(source: SourceRef): void {
@@ -510,6 +542,94 @@ export class DashboardViewComponent {
         break;
       default:
         void this.router.navigate(["/brain"]);
+    }
+  }
+
+  async refreshLivingAnswer(answer: {
+    tileId: string;
+    question: string;
+  }): Promise<void> {
+    const board = this.board();
+    const question = answer.question.trim();
+    const tile = board?.tiles.find(
+      (candidate) => candidate.id === answer.tileId,
+    );
+    if (
+      !board ||
+      !this.privacyReady() ||
+      this.answerRefreshingTileId() !== null ||
+      !question ||
+      tile?.data.kind !== "livingAnswer" ||
+      tile.data.withheld ||
+      tile.data.question.trim() !== question
+    ) {
+      return;
+    }
+
+    this.resetAskContext();
+    const boardId = board.id;
+    const refreshWitness = this.refreshToken;
+    const token = ++this.answerRefreshToken;
+    const owns = (): boolean =>
+      token === this.answerRefreshToken &&
+      refreshWitness === this.refreshToken &&
+      this.id() === boardId &&
+      this.privacyReady();
+    this.answerRefreshingTileId.set(tile.id);
+    this.mutationError.set(null);
+
+    try {
+      const refreshed = await this.ipc.refreshDashboardAnswer(
+        boardId,
+        tile.id,
+        question,
+      );
+      if (!owns()) return;
+      if (
+        refreshed.kind !== "livingAnswer" ||
+        refreshed.withheld ||
+        refreshed.question.trim() !== question ||
+        !refreshed.answer?.trim()
+      ) {
+        throw new Error("The refreshed answer was not readable.");
+      }
+
+      const current = this.board()?.tiles.find(
+        (candidate) => candidate.id === tile.id,
+      );
+      if (
+        current?.data.kind !== "livingAnswer" ||
+        current.data.withheld ||
+        current.data.question.trim() !== question
+      ) {
+        return;
+      }
+      this.board.update((detail) =>
+        detail?.id === boardId
+          ? {
+              ...detail,
+              tiles: detail.tiles.map((candidate) =>
+                candidate.id === tile.id
+                  ? { ...candidate, data: refreshed }
+                  : candidate,
+              ),
+            }
+          : detail,
+      );
+
+      const latest = await this.ipc.getDashboard(boardId);
+      if (!owns()) return;
+      if (latest === null) {
+        throw new Error("The refreshed board is no longer available.");
+      }
+      this.board.set(latest);
+    } catch (error) {
+      if (!owns()) return;
+      this.mutationError.set(this.errors.humanize(error, "generic"));
+    } finally {
+      if (token === this.answerRefreshToken) {
+        this.answerRefreshingTileId.set(null);
+      }
     }
   }
 
@@ -535,6 +655,7 @@ export class DashboardViewComponent {
     if (!this.privacyReady()) return;
     const question = this.draft().trim();
     if (!question || this.asking()) return;
+    const conversationId = this.conversationId() ?? undefined;
     this.draft.set("");
     this.turns.update((turns) => [
       ...turns,
@@ -546,37 +667,24 @@ export class DashboardViewComponent {
     const current = () => this.askToken === token;
     const owns = () => current() && this.id() === boardId;
     try {
-      const sources = await this.ipc.getDashboardSources(boardId);
-      if (!owns()) return;
-      this.sourceCount.set(sources.length);
-      if (sources.length === 0 && this.tiles().length === 0) {
-        this.turns.update((turns) => [
-          ...turns,
-          {
-            id: this.nextTurnId++,
-            role: "assistant",
-            text: "This board has no readable sources yet — add a note, recording or document, or unlock a sealed source, and ask again.",
-          },
-        ]);
-        return;
-      }
-      const result = await this.ipc.askVault(
+      const result = await this.ipc.askVaultPersisted(
+        { kind: "vault" },
         question,
-        this.askHistory(),
+        conversationId,
         undefined,
-        sources,
         undefined,
         boardId,
       );
       if (!owns()) return;
+      this.conversationId.set(result.conversationId ?? null);
       this.turns.update((turns) => [
         ...turns,
         { id: this.nextTurnId++, role: "assistant", text: result.answer },
       ]);
     } catch (error) {
       if (!owns()) return;
-      this.turns.update((turns) => [
-        ...turns,
+      this.conversationId.set(null);
+      this.turns.set([
         {
           id: this.nextTurnId++,
           role: "error",
@@ -589,21 +697,22 @@ export class DashboardViewComponent {
     }
   }
 
-  private askHistory(): ChatTurn[] {
-    return this.turns()
-      .filter((turn) => turn.role !== "error")
-      .slice(-HISTORY_TURNS)
-      .map((turn) => ({
-        role: turn.role as "user" | "assistant",
-        content: turn.text,
-      }));
+  private resetAskContext(): void {
+    this.askToken += 1;
+    this.answerRefreshToken += 1;
+    this.answerRefreshingTileId.set(null);
+    this.conversationId.set(null);
+    this.turns.set([]);
+    this.draft.set("");
+    this.asking.set(false);
   }
 
   retry(turn: BoardTurn): void {
     if (!turn.retry) return;
-    this.turns.update((turns) => turns.filter((candidate) => candidate.id !== turn.id));
+    this.turns.update((turns) =>
+      turns.filter((candidate) => candidate.id !== turn.id),
+    );
     this.draft.set(turn.retry);
     void this.ask();
   }
-
 }

--- a/src/app/features/detail/meeting-chat/meeting-chat.component.html
+++ b/src/app/features/detail/meeting-chat/meeting-chat.component.html
@@ -72,128 +72,132 @@
       (retryRequested)="retryHistory()"
     />
   } @else {
-  <!-- Message list (also the scroll region) -->
-  <div
-    #scroller
-    class="chat-log"
-    role="log"
-    aria-live="polite"
-    aria-label="Conversation"
-  >
-    @if (conversation().length === 0 && !pending()) {
-      <!-- Empty state: a friendly prompt + tappable starter chips. -->
-      <div class="chat-empty">
-        <span class="chat-empty-mark" aria-hidden="true"></span>
-        <p class="chat-empty-title">Chat with this meeting</p>
-        <p class="chat-empty-copy">
-          Ask anything about what was said — decisions, owners, follow-ups.
-        </p>
-        <div
-          class="chat-starters"
-          role="group"
-          aria-label="Suggested questions"
-        >
-          @for (s of starters; track s) {
-            <button
-              type="button"
-              class="chat-chip"
-              [style.--i]="$index"
-              [disabled]="!historyPrivacyReady()"
-              (click)="ask(s)"
-            >
-              {{ s }}
-            </button>
-          }
-        </div>
-      </div>
-    } @else {
-      @for (turn of conversation(); track turn.id) {
-        <div
-          class="chat-row"
-          [class.is-user]="turn.role === 'user'"
-          [class.is-assistant]="turn.role === 'assistant'"
-        >
+    <!-- Message list (also the scroll region) -->
+    <div
+      #scroller
+      class="chat-log"
+      role="log"
+      aria-live="polite"
+      aria-label="Conversation"
+    >
+      @if (conversation().length === 0 && !pending()) {
+        <!-- Empty state: a friendly prompt + tappable starter chips. -->
+        <div class="chat-empty">
+          <span class="chat-empty-mark" aria-hidden="true"></span>
+          <p class="chat-empty-title">Chat with this meeting</p>
+          <p class="chat-empty-copy">
+            Ask anything about what was said — decisions, owners, follow-ups.
+          </p>
           <div
-            class="chat-bubble"
-            [attr.aria-label]="
-              (turn.role === 'user' ? 'You' : 'Assistant') + ' said'
-            "
+            class="chat-starters"
+            role="group"
+            aria-label="Suggested questions"
           >
-            @if (turn.role === "assistant") {
-              <app-markdown [markdown]="turn.content" compact />
-            } @else {
-              {{ turn.content }}
+            @for (s of starters; track s) {
+              <button
+                type="button"
+                class="chat-chip"
+                [style.--i]="$index"
+                [disabled]="!historyPrivacyReady()"
+                (click)="ask(s)"
+              >
+                {{ s }}
+              </button>
             }
           </div>
         </div>
+      } @else {
+        @for (turn of conversation(); track turn.id) {
+          <div
+            class="chat-row"
+            [class.is-user]="turn.role === 'user'"
+            [class.is-assistant]="turn.role === 'assistant'"
+          >
+            <div
+              class="chat-bubble"
+              [attr.aria-label]="
+                (turn.role === 'user' ? 'You' : 'Assistant') + ' said'
+              "
+            >
+              @if (turn.role === "assistant") {
+                <app-markdown [markdown]="turn.content" compact />
+              } @else {
+                {{ turn.content }}
+              }
+            </div>
+          </div>
+        }
+
+        <!-- "Thinking…" typing indicator while a reply is in flight. -->
+        @if (pending()) {
+          <div class="chat-row is-assistant">
+            <div class="chat-bubble chat-typing" aria-label="Thinking">
+              <span class="chat-dot"></span>
+              <span class="chat-dot"></span>
+              <span class="chat-dot"></span>
+            </div>
+          </div>
+        }
       }
 
-      <!-- "Thinking…" typing indicator while a reply is in flight. -->
-      @if (pending()) {
-        <div class="chat-row is-assistant">
-          <div class="chat-bubble chat-typing" aria-label="Thinking">
-            <span class="chat-dot"></span>
-            <span class="chat-dot"></span>
-            <span class="chat-dot"></span>
-          </div>
+      <!-- Inline error with a retry affordance (keeps the question intact). -->
+      @if (error(); as err) {
+        <div class="chat-error" role="alert">
+          <span class="chat-error-text">{{ err }}</span>
+          <button
+            type="button"
+            class="btn btn-ghost chat-retry"
+            (click)="retry()"
+            [disabled]="pending() || !historyPrivacyReady()"
+          >
+            Retry
+          </button>
         </div>
       }
-    }
+    </div>
 
-    <!-- Inline error with a retry affordance (keeps the question intact). -->
-    @if (error(); as err) {
-      <div class="chat-error" role="alert">
-        <span class="chat-error-text">{{ err }}</span>
-        <button
-          type="button"
-          class="btn btn-ghost chat-retry"
-          (click)="retry()"
-          [disabled]="pending() || !historyPrivacyReady()"
-        >
-          Retry
-        </button>
-      </div>
-    }
-  </div>
-
-  <!-- Source-scoped Brain: pick which notes/meetings ground the answer (pre-filled
+    <!-- Source-scoped Brain: pick which notes/meetings ground the answer (pre-filled
        with this meeting + its active links). Empty ⇒ the whole-meeting default. -->
-  <mur-source-picker
-    class="chat-sources"
-    [(selected)]="sources"
-    [disabled]="pending() || !historyPrivacyReady()"
-    triggerLabel="Sources"
-    placeholder="Scope to a note or meeting…"
-  />
-
-  <!-- Composer: textarea (Enter sends · Shift+Enter newline) + Send. -->
-  <form class="chat-composer" (submit)="onSubmit($event)">
-    <textarea
-      #input
-      class="chat-input"
-      rows="1"
-      autocapitalize="sentences"
-      autocomplete="off"
-      spellcheck="true"
-      aria-label="Your question"
-      placeholder="Ask about this meeting…"
-      [value]="draft()"
+    <mur-source-picker
+      class="chat-sources"
+      [selected]="sources()"
+      (selectedChange)="onSourcesChange($event)"
+      [dashboard]="dashboard()"
+      (dashboardChange)="onDashboardChange($event)"
+      dashboardMode="composite"
       [disabled]="pending() || !historyPrivacyReady()"
-      (input)="onDraftInput($event)"
-      (keydown)="onKeydown($event)"
-    ></textarea>
-    <button
-      type="submit"
-      class="btn btn-primary chat-send"
-      [disabled]="!canSend()"
-      [attr.aria-label]="pending() ? 'Sending' : 'Send'"
-    >
-      @if (pending()) {
-        <span class="chat-send-spin" aria-hidden="true"></span>
-      } @else {
-        <span class="chat-send-arrow" aria-hidden="true"></span>
-      }
-    </button>
-  </form>
+      triggerLabel="Sources"
+      placeholder="Scope to a note or meeting…"
+    />
+
+    <!-- Composer: textarea (Enter sends · Shift+Enter newline) + Send. -->
+    <form class="chat-composer" (submit)="onSubmit($event)">
+      <textarea
+        #input
+        class="chat-input"
+        rows="1"
+        autocapitalize="sentences"
+        autocomplete="off"
+        spellcheck="true"
+        aria-label="Your question"
+        placeholder="Ask about this meeting…"
+        [value]="draft()"
+        [disabled]="pending() || !historyPrivacyReady()"
+        (input)="onDraftInput($event)"
+        (keydown)="onKeydown($event)"
+      ></textarea>
+      <button
+        type="submit"
+        class="btn btn-primary chat-send"
+        [disabled]="!canSend()"
+        [attr.aria-label]="pending() ? 'Sending' : 'Send'"
+      >
+        @if (pending()) {
+          <span class="chat-send-spin" aria-hidden="true"></span>
+        } @else {
+          <span class="chat-send-arrow" aria-hidden="true"></span>
+        }
+      </button>
+    </form>
   }
 </div>

--- a/src/app/features/detail/meeting-chat/meeting-chat.component.ts
+++ b/src/app/features/detail/meeting-chat/meeting-chat.component.ts
@@ -19,6 +19,7 @@ import type {
   AskConversationScope,
   AskConversationSummary,
   ChatTurn,
+  DashboardScopeRef,
   SourceRef,
 } from "../../../core/models";
 import { SourceScopeService } from "../../../services/source-scope.service";
@@ -114,6 +115,8 @@ export class MeetingChatComponent {
    * grounding. `send()` passes `undefined` when empty (see below).
    */
   readonly sources = signal<SourceRef[]>([]);
+  /** Optional ID-only composite board beside the meeting's canonical anchor. */
+  readonly dashboard = signal<DashboardScopeRef | null>(null);
   private readonly defaultSources = signal<SourceRef[]>([]);
 
   /**
@@ -290,6 +293,26 @@ export class MeetingChatComponent {
     void this.historyPrivacy.ensureReady();
   }
 
+  /** A board switch cannot mutate an existing durable thread's identity. */
+  onDashboardChange(next: DashboardScopeRef | null): void {
+    if (this.dashboard()?.id === next?.id) return;
+    const sources = this.sources();
+    if (this.conversationId() !== null || this.conversation().length > 0) {
+      this.resetConversation(false);
+      this.sources.set(sources);
+    }
+    this.dashboard.set(next);
+  }
+
+  onSourcesChange(next: SourceRef[]): void {
+    const dashboard = this.dashboard();
+    if (this.conversationId() !== null || this.conversation().length > 0) {
+      this.resetConversation(false);
+      this.dashboard.set(dashboard);
+    }
+    this.sources.set(next);
+  }
+
   async resumeConversation(id: string): Promise<void> {
     if (this.pending() || !this.historyPrivacyReady()) {
       return;
@@ -307,6 +330,7 @@ export class MeetingChatComponent {
       this.prefillSeq++;
       this.conversationId.set(detail.id);
       this.sources.set(detail.selectedSources);
+      this.dashboard.set(detail.dashboard ?? null);
       this.conversation.set(this.renderTurns(detail));
       this.draft.set("");
       this.error.set(null);
@@ -361,6 +385,7 @@ export class MeetingChatComponent {
         question,
         conversationId,
         selectedSources.length ? selectedSources : undefined,
+        this.dashboard()?.id,
       );
       if (
         requestSeq !== this.requestSeq ||
@@ -437,8 +462,10 @@ export class MeetingChatComponent {
       this.prefillSeq++;
       this.defaultSources.set([]);
       this.sources.set([]);
+      this.dashboard.set(null);
     } else {
       this.sources.set(this.defaultSources());
+      this.dashboard.set(null);
     }
     this.historyOpen.set(false);
     this.historyLoading.set(false);
@@ -500,7 +527,8 @@ export class MeetingChatComponent {
 
   /** The scrollable message log. */
   private readonly scroller = viewChild<ElementRef<HTMLDivElement>>("scroller");
-  private readonly composer = viewChild<ElementRef<HTMLTextAreaElement>>("input");
+  private readonly composer =
+    viewChild<ElementRef<HTMLTextAreaElement>>("input");
   private readonly sourcePicker = viewChild(SourcePickerComponent);
 
   private focusComposer(): void {

--- a/src/app/features/notes/note-chat/note-chat.component.html
+++ b/src/app/features/notes/note-chat/note-chat.component.html
@@ -83,129 +83,134 @@
       (retryRequested)="retryHistory()"
     />
   } @else {
-  <!-- Message list (also the scroll region) -->
-  <div
-    #scroller
-    class="chat-log"
-    role="log"
-    aria-live="polite"
-    aria-label="Conversation"
-  >
-    @if (conversation().length === 0 && !pending()) {
-      <!-- Empty state: a friendly prompt + tappable starter chips. -->
-      <div class="chat-empty">
-        <span class="chat-empty-mark" aria-hidden="true"></span>
-        <p class="chat-empty-title">Chat with this note</p>
-        <p class="chat-empty-copy">
-          Ask anything about this note — summarize it, spot gaps, or find
-          related meetings.
-        </p>
-        <div
-          class="chat-starters"
-          role="group"
-          aria-label="Suggested questions"
-        >
-          @for (s of starters; track s) {
-            <button
-              type="button"
-              class="chat-chip"
-              [style.--i]="$index"
-              [disabled]="!historyPrivacyReady()"
-              (click)="ask(s)"
-            >
-              {{ s }}
-            </button>
-          }
-        </div>
-      </div>
-    } @else {
-      @for (turn of conversation(); track turn.id) {
-        <div
-          class="chat-row"
-          [class.is-user]="turn.role === 'user'"
-          [class.is-assistant]="turn.role === 'assistant'"
-        >
+    <!-- Message list (also the scroll region) -->
+    <div
+      #scroller
+      class="chat-log"
+      role="log"
+      aria-live="polite"
+      aria-label="Conversation"
+    >
+      @if (conversation().length === 0 && !pending()) {
+        <!-- Empty state: a friendly prompt + tappable starter chips. -->
+        <div class="chat-empty">
+          <span class="chat-empty-mark" aria-hidden="true"></span>
+          <p class="chat-empty-title">Chat with this note</p>
+          <p class="chat-empty-copy">
+            Ask anything about this note — summarize it, spot gaps, or find
+            related meetings.
+          </p>
           <div
-            class="chat-bubble"
-            [attr.aria-label]="
-              (turn.role === 'user' ? 'You' : 'Assistant') + ' said'
-            "
+            class="chat-starters"
+            role="group"
+            aria-label="Suggested questions"
           >
-            @if (turn.role === "assistant") {
-              <app-markdown [markdown]="turn.content" compact />
-            } @else {
-              {{ turn.content }}
+            @for (s of starters; track s) {
+              <button
+                type="button"
+                class="chat-chip"
+                [style.--i]="$index"
+                [disabled]="!historyPrivacyReady()"
+                (click)="ask(s)"
+              >
+                {{ s }}
+              </button>
             }
           </div>
         </div>
+      } @else {
+        @for (turn of conversation(); track turn.id) {
+          <div
+            class="chat-row"
+            [class.is-user]="turn.role === 'user'"
+            [class.is-assistant]="turn.role === 'assistant'"
+          >
+            <div
+              class="chat-bubble"
+              [attr.aria-label]="
+                (turn.role === 'user' ? 'You' : 'Assistant') + ' said'
+              "
+            >
+              @if (turn.role === "assistant") {
+                <app-markdown [markdown]="turn.content" compact />
+              } @else {
+                {{ turn.content }}
+              }
+            </div>
+          </div>
+        }
+
+        <!-- "Thinking…" typing indicator while a reply is in flight. -->
+        @if (pending()) {
+          <div class="chat-row is-assistant">
+            <div class="chat-bubble chat-typing" aria-label="Thinking">
+              <span class="chat-dot"></span>
+              <span class="chat-dot"></span>
+              <span class="chat-dot"></span>
+            </div>
+          </div>
+        }
       }
 
-      <!-- "Thinking…" typing indicator while a reply is in flight. -->
-      @if (pending()) {
-        <div class="chat-row is-assistant">
-          <div class="chat-bubble chat-typing" aria-label="Thinking">
-            <span class="chat-dot"></span>
-            <span class="chat-dot"></span>
-            <span class="chat-dot"></span>
-          </div>
+      <!-- Inline error with a retry affordance (keeps the question intact). -->
+      @if (error(); as err) {
+        <div class="chat-error" role="alert">
+          <span class="chat-error-text">{{ err }}</span>
+          <button
+            type="button"
+            class="btn btn-ghost chat-retry"
+            (click)="retry()"
+            [disabled]="pending() || !historyPrivacyReady()"
+          >
+            Retry
+          </button>
         </div>
       }
-    }
+    </div>
 
-    <!-- Inline error with a retry affordance (keeps the question intact). -->
-    @if (error(); as err) {
-      <div class="chat-error" role="alert">
-        <span class="chat-error-text">{{ err }}</span>
-        <button
-          type="button"
-          class="btn btn-ghost chat-retry"
-          (click)="retry()"
-          [disabled]="pending() || !historyPrivacyReady()"
-        >
-          Retry
-        </button>
-      </div>
-    }
-  </div>
-
-  <!-- Source-scoped Brain: which notes/meetings ground the answer (pre-filled
+    <!-- Source-scoped Brain: which notes/meetings ground the answer (pre-filled
        with this note + its active links). Editable — add or remove sources. -->
-  <mur-source-picker
-    class="chat-sources"
-    [(selected)]="sources"
-    [disabled]="pending() || !historyPrivacyReady()"
-    triggerLabel="Sources"
-    placeholder="Scope to a note or meeting…"
-  />
-
-  <!-- Composer: textarea (Enter sends · Shift+Enter newline) + Send. -->
-  <form class="chat-composer" (submit)="onSubmit($event)">
-    <textarea
-      #input
-      class="chat-input"
-      rows="1"
-      autocapitalize="sentences"
-      autocomplete="off"
-      spellcheck="true"
-      aria-label="Your question"
-      placeholder="Ask about this note…"
-      [value]="draft()"
+    <mur-source-picker
+      class="chat-sources"
+      [selected]="sources()"
+      (selectedChange)="onSourcesChange($event)"
+      [dashboard]="dashboard()"
+      (dashboardChange)="onDashboardChange($event)"
+      dashboardMode="composite"
+      [allowDashboards]="anchorKind() === 'note'"
       [disabled]="pending() || !historyPrivacyReady()"
-      (input)="onDraftInput($event)"
-      (keydown)="onKeydown($event)"
-    ></textarea>
-    <button
-      type="submit"
-      class="btn btn-primary chat-send"
-      [disabled]="!canSend()"
-      [attr.aria-label]="pending() ? 'Sending' : 'Send'"
-    >
-      @if (pending()) {
-        <span class="chat-send-spin" aria-hidden="true"></span>
-      } @else {
-        <span class="chat-send-arrow" aria-hidden="true"></span>
-      }
-    </button>
-  </form>
+      triggerLabel="Sources"
+      placeholder="Scope to a note or meeting…"
+    />
+
+    <!-- Composer: textarea (Enter sends · Shift+Enter newline) + Send. -->
+    <form class="chat-composer" (submit)="onSubmit($event)">
+      <textarea
+        #input
+        class="chat-input"
+        rows="1"
+        autocapitalize="sentences"
+        autocomplete="off"
+        spellcheck="true"
+        aria-label="Your question"
+        placeholder="Ask about this note…"
+        [value]="draft()"
+        [disabled]="pending() || !historyPrivacyReady()"
+        (input)="onDraftInput($event)"
+        (keydown)="onKeydown($event)"
+      ></textarea>
+      <button
+        type="submit"
+        class="btn btn-primary chat-send"
+        [disabled]="!canSend()"
+        [attr.aria-label]="pending() ? 'Sending' : 'Send'"
+      >
+        @if (pending()) {
+          <span class="chat-send-spin" aria-hidden="true"></span>
+        } @else {
+          <span class="chat-send-arrow" aria-hidden="true"></span>
+        }
+      </button>
+    </form>
   }
 </div>

--- a/src/app/features/notes/note-chat/note-chat.component.ts
+++ b/src/app/features/notes/note-chat/note-chat.component.ts
@@ -19,6 +19,7 @@ import type {
   AskConversationScope,
   AskConversationSummary,
   ChatTurn,
+  DashboardScopeRef,
   SourceRef,
 } from "../../../core/models";
 import { SourceScopeService } from "../../../services/source-scope.service";
@@ -131,6 +132,8 @@ export class NoteChatComponent {
    * itself is one of the sources, so the scope is never whole-vault by default).
    */
   readonly sources = signal<SourceRef[]>([]);
+  /** Optional ID-only composite board beside this note's canonical anchor. */
+  readonly dashboard = signal<DashboardScopeRef | null>(null);
   private readonly defaultSources = signal<SourceRef[]>([]);
 
   /** Durable history is local-authored-note only; Org stays intentionally stateless. */
@@ -187,9 +190,11 @@ export class NoteChatComponent {
     const seq = ++this.prefillSeq;
     if (kind !== "note") {
       // Org anchor: pinned server-side via `pinnedOrgItemId`; an org item is not a local SourceRef,
-      // so prefilling a note scope for its id would be wrong. Start the picker empty.
+      // so prefilling a note scope for its id would be wrong. Start the picker empty and make the
+      // unsupported pinned-org + dashboard combination impossible even across component reuse.
       this.defaultSources.set([]);
       this.sources.set([]);
+      this.dashboard.set(null);
       return;
     }
     if (!privacyReady) {
@@ -337,6 +342,30 @@ export class NoteChatComponent {
     void this.historyPrivacy.ensureReady();
   }
 
+  /** A board switch cannot mutate an existing durable thread's identity. */
+  onDashboardChange(next: DashboardScopeRef | null): void {
+    if (this.anchorKind() === "org") {
+      this.dashboard.set(null);
+      return;
+    }
+    if (this.dashboard()?.id === next?.id) return;
+    const sources = this.sources();
+    if (this.conversationId() !== null || this.conversation().length > 0) {
+      this.resetConversation(false);
+      this.sources.set(sources);
+    }
+    this.dashboard.set(next);
+  }
+
+  onSourcesChange(next: SourceRef[]): void {
+    const dashboard = this.dashboard();
+    if (this.conversationId() !== null || this.conversation().length > 0) {
+      this.resetConversation(false);
+      this.dashboard.set(dashboard);
+    }
+    this.sources.set(next);
+  }
+
   async resumeConversation(id: string): Promise<void> {
     if (
       !this.historyEnabled() ||
@@ -358,6 +387,7 @@ export class NoteChatComponent {
       this.prefillSeq++;
       this.conversationId.set(detail.id);
       this.sources.set(detail.selectedSources);
+      this.dashboard.set(detail.dashboard ?? null);
       this.conversation.set(this.renderTurns(detail));
       this.draft.set("");
       this.error.set(null);
@@ -427,6 +457,7 @@ export class NoteChatComponent {
           undefined,
           selectedSources.length ? selectedSources : undefined,
           this.noteId(),
+          undefined,
         );
         answer = result.answer;
       } else {
@@ -435,6 +466,8 @@ export class NoteChatComponent {
           question,
           conversationId,
           selectedSources.length ? selectedSources : undefined,
+          undefined,
+          this.dashboard()?.id,
         );
         answer = result.answer;
         persistedConversationId = result.conversationId;
@@ -517,8 +550,10 @@ export class NoteChatComponent {
       this.prefillSeq++;
       this.defaultSources.set([]);
       this.sources.set([]);
+      this.dashboard.set(null);
     } else {
       this.sources.set(this.defaultSources());
+      this.dashboard.set(null);
     }
     this.historyOpen.set(false);
     this.historyLoading.set(false);
@@ -580,7 +615,8 @@ export class NoteChatComponent {
 
   /** The scrollable message log. */
   private readonly scroller = viewChild<ElementRef<HTMLDivElement>>("scroller");
-  private readonly composer = viewChild<ElementRef<HTMLTextAreaElement>>("input");
+  private readonly composer =
+    viewChild<ElementRef<HTMLTextAreaElement>>("input");
   private readonly sourcePicker = viewChild(SourcePickerComponent);
 
   private focusComposer(): void {


### PR DESCRIPTION
## Summary

Makes dashboards a first-class, closed AI scope across top-level Ask, note chat, meeting chat, and dashboard Ask, while replacing the oversized edit cards with a dedicated compact Compose workspace.

## What changed

- Adds one removable dashboard chip beside existing anchors and manually selected sources. The WebView sends only `dashboardId`; the backend owns child expansion and authorization.
- Splits dashboard Read and Compose modes. Compose now has a compact ordered list, Add to board / Done, drag reorder, keyboard Move earlier / Move later, remove, optimistic updates, rollback, and constrained responsive layout.
- Keeps Read's useful derived views and explicit empty, missing, sealed, zero, superseded, and cached-answer states.
- Makes dashboard history backend-owned and provenance-bound, including safe resume/refusal after relock, mutation, deletion/recreation, or provider/config changes.
- Moves Living Answer generation entirely behind the backend provider/admission seam. The client sends only dashboard ID, tile ID, and question.
- Preserves Reminders' existing flat material-source expansion and the upstream meeting-workspace/Brain behavior.

## Privacy and integrity

- Resolves dashboard material and derived views through typed, visibility-gated snapshots; empty, deleted, malformed, or fully sealed boards never fall back to vault-wide retrieval or global user memory.
- Binds provider input to the exact packed corpus plus a full-input manifest, covering mutations beyond prompt cutoffs and ABA transitions.
- Uses a monotonic Ask-dispatch generation across provider/config/consent/credential changes, provider admission polls, history/cache CAS, IPC serialization, and MCP response registration.
- Keeps cloud dispatch on the canonical consent, redaction, and content-free egress-ledger path.
- Keeps SQLite canonical with additive/idempotent migrations; raw tile chrome/config and audio paths never cross IPC/MCP/provider boundaries.

## Verification

Hash-bound Harness task `dashboard-composite-context-release-final` passed on base `4ee937b4e713aa840686a49cd7bd83366159fcb2`:

- Commit: `4a494f387eab4cb5243abb66bfa6adfd2002d70d`
- Harness diff: `97bbefa240951677e687c43037d779b60cad8fd44b20f3dbee49e687e427e8db`
- Harness evidence: `c8c29caa5c17b35435ae81a6bdc2ea1f297ba688463c1548f33a21000a09c66e`
- Rust library: 2,985 passed, 0 failed, 18 ignored
- Clippy (`--lib --tests`, warnings denied): passed
- Angular lint and production build: passed
- Chromium + WebKit Playwright: 660 passed, 2 skipped
- Fresh combined, lock-security, and egress-security Codex reviews: passed
- Agent config audit: 152/152 passed

GitHub Actions remains the merge authority.
