### PR TITLE
fix(deps): update h2 past RustSec advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3123,9 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary
- update h2 from 0.4.15 to 0.4.16
- remove RUSTSEC-2026-0258 without unrelated dependency graph drift

## Verification
- cargo audit: green; 20 existing allowed warnings only
- cargo test --lib --locked -- --test-threads=1: 2985 passed, 18 ignored
- cargo clippy --lib --tests --locked -- -D warnings
- npx ng lint
- npx ng build
- git diff --check
- independent adversarial review: PASS on exact 545-byte lockfile diff

## Runtime
Browser/runtime reproduction is not applicable to this lockfile-only dependency security update.

Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0258