### PR TITLE
fix(harness): bound oversized review prompts

### DIFF
--- a/.agents/harness/v2_selftest.py
+++ b/.agents/harness/v2_selftest.py
@@ -2634,6 +2634,172 @@ def specialist_source_context_cases(test: Tests) -> None:
         )
 
 
+def large_review_prompt_cases(test: Tests) -> None:
+    """Keep every changed line while bounding oversized reviewer prompts."""
+
+    with tempfile.TemporaryDirectory(prefix="murmur-v2-large-review-") as raw:
+        repo = Path(raw) / "repo"
+        base_sha = _init_repo(repo)
+        contract = {
+            "task_id": "large-review-selftest",
+            "description": "review a large exact diff without dropping changes",
+        }
+        plan: Dict[str, Any] = {
+            "base_sha": base_sha,
+            "changed_paths": ["owned.txt"],
+            "claims": [],
+            "actual_risk_flags": [],
+            "checks": [],
+            "diff_sha256": "0" * 64,
+            "plan_sha256": "1" * 64,
+            "protocol_sha256": "2" * 64,
+            "server_required": False,
+        }
+
+        small_diff = (
+            b"diff --git a/owned.txt b/owned.txt\n"
+            b"--- a/owned.txt\n"
+            b"+++ b/owned.txt\n"
+            b"@@ -1,2 +1,2 @@\n"
+            b" unchanged-small-context\n"
+            b"-old\n"
+            b"+new\n"
+        )
+        small_prompt = verifier.combined_review_prompt(
+            contract,
+            {
+                **plan,
+                "diff_sha256": hashlib.sha256(small_diff).hexdigest(),
+            },
+            small_diff,
+            [],
+            "combined",
+            repo,
+            repo,
+            policy_text="policy",
+            proof_gap_policy_text="policy",
+        )
+        test.true(
+            "LARGE REVIEW keeps historical full rendering below the bound",
+            " unchanged-small-context" in small_prompt
+            and verifier.REVIEW_DIFF_CONTEXT_ELISION_NOTE not in small_prompt,
+        )
+
+        context_line = " unique-unchanged-context-to-elide\n"
+        context_count = (
+            verifier.REVIEW_PROMPT_MAX_CHARS // len(context_line)
+        ) + 128
+        large_diff = (
+            "diff --git a/owned.txt b/owned.txt\n"
+            "--- a/owned.txt\n"
+            "+++ b/owned.txt\n"
+            f"@@ -1,{context_count + 1} +1,{context_count + 1} @@\n"
+            + (context_line * context_count)
+            + "-changed-old-sentinel\n"
+            + "+changed-new-sentinel\n"
+            + "diff --git a/blob.bin b/blob.bin\n"
+            + "GIT binary patch\n"
+            + "literal 3\n"
+            + "binary-patch-sentinel\n"
+        ).encode("utf-8")
+        large_plan = {
+            **plan,
+            "diff_sha256": hashlib.sha256(large_diff).hexdigest(),
+        }
+        first = verifier.combined_review_prompt(
+            contract,
+            large_plan,
+            large_diff,
+            [],
+            "combined",
+            repo,
+            repo,
+            policy_text="policy",
+            proof_gap_policy_text="policy",
+        )
+        second = verifier.combined_review_prompt(
+            contract,
+            large_plan,
+            large_diff,
+            [],
+            "combined",
+            repo,
+            repo,
+            policy_text="policy",
+            proof_gap_policy_text="policy",
+        )
+        test.true(
+            "LARGE REVIEW elides only hunk context and stays deterministic",
+            first == second
+            and len(first) <= verifier.REVIEW_PROMPT_MAX_CHARS
+            and verifier.REVIEW_DIFF_CONTEXT_ELISION_NOTE in first
+            and "unique-unchanged-context-to-elide" not in first
+            and "-changed-old-sentinel" in first
+            and "+changed-new-sentinel" in first
+            and "binary-patch-sentinel" in first
+            and large_plan["diff_sha256"] in first,
+        )
+
+        unicode_path = repo / "unicode.txt"
+        unicode_path.write_text(
+            "old\u0085 continuation-nel-old\u2028 continuation-ls-old"
+            "\u2029 continuation-ps-old\n",
+            encoding="utf-8",
+        )
+        _git(repo, "add", unicode_path.relative_to(repo).as_posix())
+        _git(repo, "commit", "-q", "-m", "unicode diff base")
+        unicode_path.write_text(
+            "new\u0085 continuation-nel-new\u2028 continuation-ls-new"
+            "\u2029 continuation-ps-new\n",
+            encoding="utf-8",
+        )
+        unicode_diff = _git(repo, "diff", "--binary")
+        unicode_rendered = verifier._review_diff_without_hunk_context(
+            unicode_diff
+        )
+        test.true(
+            "LARGE REVIEW preserves Git changed lines containing Unicode separators",
+            all(
+                marker in unicode_rendered
+                for marker in (
+                    "continuation-nel-old",
+                    "continuation-ls-old",
+                    "continuation-ps-old",
+                    "continuation-nel-new",
+                    "continuation-ls-new",
+                    "continuation-ps-new",
+                )
+            ),
+        )
+
+        changed_only_diff = (
+            "diff --git a/owned.txt b/owned.txt\n"
+            "--- a/owned.txt\n"
+            "+++ b/owned.txt\n"
+            "@@ -0,0 +1 @@\n"
+            "+"
+            + ("x" * (verifier.REVIEW_PROMPT_MAX_CHARS + 1))
+        ).encode("utf-8")
+        test.raises(
+            "LARGE REVIEW fails closed when changed lines alone exceed the bound",
+            lambda: verifier.combined_review_prompt(
+                contract,
+                {
+                    **plan,
+                    "diff_sha256": hashlib.sha256(changed_only_diff).hexdigest(),
+                },
+                changed_only_diff,
+                [],
+                "combined",
+                repo,
+                repo,
+                policy_text="policy",
+                proof_gap_policy_text="policy",
+            ),
+            "remains over the reviewer input bound",
+        )
+
+
 def _learnings_segment(prompt: str) -> str:
     """Return the injected learnings block, or "" when none was bound."""
 
@@ -9999,6 +10165,7 @@ def main() -> int:
     verdict_cases(test)
     focused_review_evidence_cases(test)
     specialist_source_context_cases(test)
+    large_review_prompt_cases(test)
     review_learnings_prompt_cases(test)
     instruction_paths_learnings_cases(test)
     retry_cases(test)

--- a/.agents/harness/verifier.py
+++ b/.agents/harness/verifier.py
@@ -95,6 +95,14 @@ SPECIALIST_SOURCE_CONTEXT_LABEL = (
     "(snapshot-derived source evidence only; not runtime proof): "
 )
 MAX_LEARNINGS_BYTES = 16_000
+REVIEW_PROMPT_MAX_CHARS = 1_040_000
+REVIEW_DIFF_CONTEXT_ELISION_NOTE = (
+    "Review rendering: unchanged unified-diff hunk context was elided because "
+    "the complete review prompt exceeded the bounded reviewer input. Every "
+    "added or removed line, file header, hunk header, and binary-patch "
+    "representation remains. The canonical full diff SHA-256 above is "
+    "authoritative.\n"
+)
 LEARNINGS_DIR = ".claude/learnings"
 LEARNINGS_HEADING = "## Recurring patterns"
 # The header carries the guard, not just the body: a reviewer who skims or whose
@@ -2031,6 +2039,31 @@ def _review_server_checkout_attestation(
     }
 
 
+def _review_diff_without_hunk_context(diff: str) -> str:
+    """Drop only unchanged unified-diff hunk lines from reviewer rendering."""
+
+    rendered: List[str] = []
+    in_hunk = False
+    # A Git patch is LF-delimited.  str.splitlines() also treats Unicode NEL,
+    # LINE SEPARATOR, and PARAGRAPH SEPARATOR as boundaries, which can split a
+    # single changed Git line and make its continuation look like removable
+    # context.  Splitting and joining on literal LF preserves every such code
+    # point inside the changed line as Git emitted it.
+    for line in diff.split("\n"):
+        if line.startswith("diff --git "):
+            in_hunk = False
+            rendered.append(line)
+            continue
+        if line.startswith("@@"):
+            in_hunk = True
+            rendered.append(line)
+            continue
+        if in_hunk and line.startswith(" "):
+            continue
+        rendered.append(line)
+    return "\n".join(rendered)
+
+
 def combined_review_prompt(
     contract: Mapping[str, Any],
     plan: Mapping[str, Any],
@@ -2094,31 +2127,49 @@ def combined_review_prompt(
     eligible_probes = allowed_probe_ids(plan)
     source_context = specialist_source_context(worktree, plan, kind)
     learnings = review_learnings_section(worktree, plan, kind)
-    return (
-        f"{policy}\n\n"
-        "## Exact v2 task\n"
-        f"Task: {contract['task_id']}\n"
-        f"Acceptance contract:\n{contract['description']}\n\n"
-        f"Changed paths: {json.dumps(plan['changed_paths'])}\n"
-        f"Claims: {json.dumps(plan['claims'])}\n"
-        f"Actual sensitive risks: {json.dumps(plan['actual_risk_flags'])}\n"
-        f"Diff SHA-256: {plan['diff_sha256']}\n"
-        f"Plan SHA-256: {plan['plan_sha256']}\n"
-        f"Protocol SHA-256: {plan['protocol_sha256']}\n"
-        "Check and probe evidence (commands, hashes, bounded output, and any "
-        "source proof gaps): "
-        f"{json.dumps(check_summary, sort_keys=True)}\n"
-        f"{specialist_source_context_section(source_context)}"
-        f"Context-eligible probe IDs: {json.dumps(eligible_probes)}\n"
-        f"{server_section}"
-        "## Exact diff\n"
-        f"{diff.decode('utf-8', 'replace')}\n\n"
-        # Repo-authored text never occupies the final position: the harness's
-        # own non-negotiable closing instruction stays last, so no learnings
-        # line is the last thing the reviewer reads before deciding.
-        f"{learnings}"
-        f"{review_closing}"
-    )
+
+    def render(exact_diff: str, rendering_note: str = "") -> str:
+        return (
+            f"{policy}\n\n"
+            "## Exact v2 task\n"
+            f"Task: {contract['task_id']}\n"
+            f"Acceptance contract:\n{contract['description']}\n\n"
+            f"Changed paths: {json.dumps(plan['changed_paths'])}\n"
+            f"Claims: {json.dumps(plan['claims'])}\n"
+            f"Actual sensitive risks: {json.dumps(plan['actual_risk_flags'])}\n"
+            f"Diff SHA-256: {plan['diff_sha256']}\n"
+            f"Plan SHA-256: {plan['plan_sha256']}\n"
+            f"Protocol SHA-256: {plan['protocol_sha256']}\n"
+            "Check and probe evidence (commands, hashes, bounded output, and any "
+            "source proof gaps): "
+            f"{json.dumps(check_summary, sort_keys=True)}\n"
+            f"{specialist_source_context_section(source_context)}"
+            f"Context-eligible probe IDs: {json.dumps(eligible_probes)}\n"
+            f"{server_section}"
+            "## Exact diff\n"
+            f"{rendering_note}"
+            f"{exact_diff}\n\n"
+            # Repo-authored text never occupies the final position: the harness's
+            # own non-negotiable closing instruction stays last, so no learnings
+            # line is the last thing the reviewer reads before deciding.
+            f"{learnings}"
+            f"{review_closing}"
+        )
+
+    full_diff = diff.decode("utf-8", "replace")
+    full_prompt = render(full_diff)
+    if len(full_prompt) <= REVIEW_PROMPT_MAX_CHARS:
+        return full_prompt
+
+    rendered_diff = _review_diff_without_hunk_context(full_diff)
+    bounded_prompt = render(rendered_diff, REVIEW_DIFF_CONTEXT_ELISION_NOTE)
+    if len(bounded_prompt) > REVIEW_PROMPT_MAX_CHARS:
+        raise runtime.HarnessError(
+            "v2 review prompt remains over the reviewer input bound after "
+            "eliding unchanged hunk context; split the task without dropping "
+            "changed lines"
+        )
+    return bounded_prompt
 
 
 def invoke_readonly_review(


### PR DESCRIPTION
## Summary

- bound generated reviewer prompts below the Codex request-size ceiling
- preserve every changed line plus file/hunk/binary evidence and the canonical full-diff SHA
- fail closed when changed evidence alone cannot fit
- add actual-Git, binary, Unicode line-separator, changed-line overflow, and byte-identity selftest oracles

## Exact review

Fresh independent reviewer: **PASS**

- base: `34409b3f058cadf437fb55a29352fabbb9c33da8`
- head: `570e3e0f6b72f99a549083dfe2bb5045e16d963d`
- exact diff SHA-256: `92cfe5037c06b82c17623dbc66111449345d19446dec6606725b27f35c319ef9`
- stable patch-id: `427e7bb17e44c0335f18fd35f2f3c158853b983a`
- only `.agents/harness/verifier.py` and `.agents/harness/v2_selftest.py` changed

## Verification

- `scripts/agent-config-audit --ci` — PASS (152 checks)
- `scripts/agent-harness selftest` — PASS (v2 646, fault 39, metrics 70 assertions)
- `RUST_TEST_THREADS=1 bash scripts/ci.sh` — PASS
  - Rust lib: 2985 passed, 18 ignored
  - murmur-brain: 7 passed
  - cargo audit/deny/build: PASS
  - Angular lint/build: PASS
  - browser E2E: 660 passed, 2 skipped
  - headless Whisper→provider-stub→Obsidian E2E: PASS
  - mic+system mixing E2E: PASS
- `git diff --check origin/murmur...HEAD` — PASS

## Track C comparison

The required comparison was executed, but Claude Code hit its weekly limit on every call. Therefore this run is **NOT COMPARABLE** and is not claimed as evidence that the scaffold improves behavior. The JSON receipt is retained outside the repository.

| Task | none | full |
|---|---:|---:|
| additive-migration | 0/0, 3 errors | 0/0, 3 errors |
| analysis-only | 0/0, 3 errors | 0/0, 3 errors |
| angular22-noop | 0/0, 3 errors | 0/0, 3 errors |
| csp-style-src-nonce | 0/0, 3 errors | 0/0, 3 errors |
| lock-masked-dto | 0/0, 3 errors | 0/0, 3 errors |
| overlay-opaque-surface | 0/0, 3 errors | 0/0, 3 errors |
| seal-verify-before-destroy | 0/0, 3 errors | 0/0, 3 errors |
| secret-sk-proj | 0/0, 3 errors | 0/0, 3 errors |
| **Total** | **0/0, 24 errors** | **0/0, 24 errors** |

Limit message: weekly limit, reset Aug 25 at 11:00 Europe/Warsaw.
