### PR TITLE
feat(sharing): add crash-safe storage foundation

### DIFF
--- a/src-tauri/src/commands/dashboards.rs
+++ b/src-tauri/src/commands/dashboards.rs
@@ -1451,6 +1451,9 @@ fn source_is_visible(
                 && db.dashboard_ref_exists("meeting", &source.id)?
         }
         LinkKind::Document => db.document_is_visible(&source.id, unlocked)?,
+        // Org graph endpoints are storage-only in this compatibility stack. The command-layer
+        // activation lands in the following stacked change, so base dashboard reads fail closed.
+        LinkKind::Org => false,
     })
 }
 

--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -249,6 +249,10 @@ fn link_endpoint_is_unlocked(
             let unlocked = unlocked_snapshot(state)?;
             Ok(state.db.document_is_visible(id, &unlocked)?)
         }
+        // Org endpoints are introduced at the storage layer first. Until the stacked command/IPC
+        // activation lands, every base command treats them as unavailable rather than widening a
+        // content surface early.
+        crate::links::LinkKind::Org => Ok(false),
     }
 }
 
@@ -352,9 +356,13 @@ pub(crate) fn unlink_items_inner(
 ) -> Result<(), AppError> {
     let src = parse_link_kind(src_kind)?;
     let dst = parse_link_kind(dst_kind)?;
-    // SCOPE the guard around gate + row-delete only; release before the note-body strip below (which
-    // re-enters the guard via `update_note_doc_inner`). Same non-reentrancy discipline as `link_items`.
-    {
+    let edge = crate::storage::models::ManualLinkEdge {
+        src_kind: src_kind.to_string(),
+        src_id: src_id.to_string(),
+        dst_kind: dst_kind.to_string(),
+        dst_id: dst_id.to_string(),
+    };
+    let cleanup_queued = {
         let _lifecycle = lifecycle_guard(state);
         // ── GATE both endpoints (never mutate a note body / reveal a neighbour behind a lock). ──
         if !link_endpoint_is_unlocked(state, src, src_id)?
@@ -364,26 +372,16 @@ pub(crate) fn unlink_items_inner(
                 "one of these items is locked — unlock it to unlink".into(),
             ));
         }
-        // ── Delete ONLY the manual edge (wikilink/companion/semantic rows for the pair untouched). ──
+        let prepared_seals = prepare_manual_marker_seals(state, std::slice::from_ref(&edge))?;
+        // Strip any legacy source marker, enqueue its exact vault cleanup, and delete ONLY the
+        // selected manual edge in one transaction. A stale/missing seal rolls every mutation back.
         state
             .db
-            .delete_manual_link(src.as_str(), src_id, dst.as_str(), dst_id)?;
-    }
-    // ── A NOTE source: strip the matching [[Title]] from its managed block (best-effort). ──
-    if matches!(src, crate::links::LinkKind::Note) {
-        let unlocked = unlocked_snapshot(state)?;
-        if let Some(title) = state
-            .db
-            .link_endpoint_title_visible(dst, dst_id, &unlocked)?
-        {
-            if let Err(e) = strip_manual_link_marker(state, src_id, &title) {
-                tracing::warn!(
-                    target: "links",
-                    error = %e,
-                    "manual link marker strip skipped (row removed)"
-                );
-            }
-        }
+            .delete_manual_links_with_marker_seals(std::slice::from_ref(&edge), &prepared_seals)?
+    };
+    if cleanup_queued {
+        let _lifecycle = lifecycle_guard(state);
+        drain_lock_marker_export_cleanup(&state.db)?;
     }
     tracing::info!(
         target: "links",
@@ -394,46 +392,68 @@ pub(crate) fn unlink_items_inner(
     Ok(())
 }
 
-/// note↔meeting-links PR-1 — LEGACY CLEANUP: remove ONE `[[title]]` [`ContextHit`] from an owned
-/// note's PRE-EXISTING managed `murmur:links` block (imported before the block was retired), re-
-/// applying the block with that hit filtered out. Reuses [`crate::enrich::extract_link_hits`] +
-/// [`crate::enrich::apply_link_markers`] so any other hits that lived alongside it survive and the
-/// block strips to nothing once its last hit is removed. WRITE-GATED via `update_note_doc_inner`
-/// (refuses a sealed folder). A no-op (the note is unchanged) when the block never carried the hit —
-/// which is the common case now, since `link_items` no longer WRITES the marker.
-fn strip_manual_link_marker(state: &AppState, note_id: &str, title: &str) -> Result<(), AppError> {
-    let row = {
-        let _lifecycle = lifecycle_guard(state);
-        let Some((folder_id, _created_at, _updated_at)) = state.db.note_gate_anchor(note_id)? else {
-            return Ok(());
-        };
-        if !folder_is_unlocked(state, &folder_id)? {
-            return Err(AppError::Locked(
-                "this note is locked — unlock it before removing its link marker".into(),
+/// Prepare verify-before-destroy ciphertext for a legacy marker in a session-unlocked locked note.
+/// The storage transaction independently recomputes the stripped plaintext and accepts this blob
+/// only when it decrypts byte-identical under the same folder/note AAD.
+fn prepare_manual_marker_seals(
+    state: &AppState,
+    manual_edges: &[crate::storage::models::ManualLinkEdge],
+) -> Result<Vec<crate::storage::links::PreparedManualMarkerSeal>, AppError> {
+    let unlocked = unlocked_snapshot(state)?;
+    let mut titles_by_note: std::collections::HashMap<String, std::collections::HashSet<String>> =
+        std::collections::HashMap::new();
+    for edge in manual_edges {
+        let src = parse_link_kind(&edge.src_kind)?;
+        if src != crate::links::LinkKind::Note {
+            continue;
+        }
+        let dst = parse_link_kind(&edge.dst_kind)?;
+        let title = state
+            .db
+            .link_endpoint_title_visible(dst, &edge.dst_id, &unlocked)?
+            .ok_or_else(|| {
+                AppError::Locked("one of these items is no longer available to unlink".into())
+            })?;
+        let title = crate::enrich::sanitize(&title);
+        if title.trim().is_empty() {
+            return Err(AppError::InvalidArg(
+                "a linked item has no usable marker title".into(),
             ));
         }
-        let Some(row) = state.db.get_note_row(note_id)? else {
-            return Ok(());
+        titles_by_note
+            .entry(edge.src_id.clone())
+            .or_default()
+            .insert(title);
+    }
+
+    let mut prepared = Vec::new();
+    for (note_id, titles) in titles_by_note {
+        let row = state.db.get_note_row(&note_id)?.ok_or_else(|| {
+            AppError::Locked("a linked note is no longer available to unlink".into())
+        })?;
+        let Some(stripped_text) =
+            crate::storage::Db::strip_titles_from_managed_block(&row.text, &titles)
+        else {
+            continue;
         };
-        row
-    };
-    let marker = format!("[[{title}]]");
-    let mut hits = crate::enrich::extract_link_hits(&row.text);
-    let before = hits.len();
-    hits.retain(|h| h.detail != marker);
-    if hits.len() == before {
-        return Ok(()); // the marker was not in the managed block → note unchanged.
+        let folder_locked = state
+            .db
+            .folder_by_id(&row.folder_id)?
+            .map(|folder| folder.locked)
+            .ok_or_else(|| AppError::Locked("a linked note folder is unavailable".into()))?;
+        if folder_locked {
+            let text_blob = sealed_document_blob(state, &row.folder_id, &note_id, &stripped_text)?;
+            let content_key = session_folder_ck(state, &row.folder_id)?;
+            prepared.push(crate::storage::links::PreparedManualMarkerSeal {
+                note_id,
+                folder_id: row.folder_id,
+                stripped_text,
+                text_blob,
+                content_key,
+            });
+        }
     }
-    let merged = crate::enrich::apply_link_markers(&row.text, &hits);
-    if merged != row.text {
-        let title_disp = row
-            .title
-            .clone()
-            .filter(|t| !t.is_empty())
-            .unwrap_or_else(|| row.name.clone());
-        update_note_doc_inner(state, note_id, &title_disp, &merged)?;
-    }
-    Ok(())
+    Ok(prepared)
 }
 
 /// Resolve a clicked `[[Title]]` wikilink to a VISIBLE note/meeting/org-item to navigate to.

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -934,6 +934,143 @@
         );
     }
 
+    #[test]
+    fn unlink_refuses_sealed_not_session_unlocked_note_without_any_cleanup_side_effect() {
+        let vault = tmp_vault("unlink-sealed-refusal");
+        let state = build_state_with_vault("unlink-sealed-refusal", &vault);
+        let folder_id = create_note_folder_inner(&state, "Secret", None).unwrap().id;
+        let source_id = create_note_inner(&state, Some(&folder_id), "Source Note").unwrap();
+        let target_id = create_note_inner(&state, Some(&folder_id), "Target Note").unwrap();
+        let legacy_hit = crate::enrich::ContextHit {
+            source: "note".into(),
+            detail: "[[Target Note]]".into(),
+            url: None,
+        };
+        let legacy_body =
+            crate::enrich::apply_link_markers("original body\n", std::slice::from_ref(&legacy_hit));
+        update_note_doc_inner(&state, &source_id, "Source Note", &legacy_body).unwrap();
+        state
+            .db
+            .upsert_manual_link("note", &source_id, "note", &target_id)
+            .unwrap();
+        let exported_path = state
+            .db
+            .get_note_row(&source_id)
+            .unwrap()
+            .unwrap()
+            .exported_path
+            .unwrap();
+
+        lock_folder_inner(&state, folder_id).unwrap();
+        let before: (String, Option<Vec<u8>>) = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT text,text_blob FROM documents WHERE id=?1",
+                rusqlite::params![source_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert!(before.0.is_empty());
+        assert!(before.1.is_some());
+        assert!(!std::path::Path::new(&exported_path).exists());
+        let links_before = manual_link_count(&state, "note", &source_id);
+
+        let err = unlink_items_inner(&state, "note", &source_id, "note", &target_id).unwrap_err();
+        assert!(matches!(err, AppError::Locked(_)));
+
+        let after: (String, Option<Vec<u8>>) = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT text,text_blob FROM documents WHERE id=?1",
+                rusqlite::params![source_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(after, before, "sealed plaintext/blob must remain byte-identical");
+        assert_eq!(manual_link_count(&state, "note", &source_id), links_before);
+        assert!(state.db.pending_lock_marker_export_cleanup().unwrap().is_empty());
+        assert!(
+            !std::path::Path::new(&exported_path).exists(),
+            "the failed command must not recreate or mutate the sealed vault export"
+        );
+    }
+
+    #[test]
+    fn session_unlocked_unlink_seals_marker_cleanup_and_scrubs_vault_before_success() {
+        let vault = tmp_vault("unlink-session-unlocked").canonicalize().unwrap();
+        let state = build_state_with_vault("unlink-session-unlocked", &vault);
+        state
+            .db
+            .set_setting("vault_path", &vault.to_string_lossy())
+            .unwrap();
+        let folder_id = create_note_folder_inner(&state, "Secret", None).unwrap().id;
+        let source_id = create_note_inner(&state, Some(&folder_id), "Source Note").unwrap();
+        let target_id = create_note_inner(&state, Some(&folder_id), "Target Note").unwrap();
+        let legacy_hit = crate::enrich::ContextHit {
+            source: "note".into(),
+            detail: "[[Target Note]]".into(),
+            url: None,
+        };
+        let legacy_body =
+            crate::enrich::apply_link_markers("original body\n", std::slice::from_ref(&legacy_hit));
+        update_note_doc_inner(&state, &source_id, "Source Note", &legacy_body).unwrap();
+        state
+            .db
+            .upsert_manual_link("note", &source_id, "note", &target_id)
+            .unwrap();
+
+        lock_folder_inner(&state, folder_id.clone()).unwrap();
+        let kek = secrets::get_or_create_master_kek().unwrap();
+        let wrapped = state.db.folder_wrapped_key(&folder_id).unwrap().unwrap();
+        let ck_vec = crate::crypto::decrypt(&kek, &wrapped, &aad_wrapped_ck(&folder_id)).unwrap();
+        let ck: [u8; 32] = ck_vec.try_into().expect("CK is 32 bytes");
+        *state.master_kek.lock().unwrap() = Some(Zeroizing::new(kek));
+        unseal_folder_extras(&state, &folder_id, &ck, None).unwrap();
+        state
+            .unlocked_folders
+            .lock()
+            .unwrap()
+            .insert(folder_id.clone());
+        state
+            .db
+            .upsert_manual_link("note", &source_id, "note", &target_id)
+            .unwrap();
+        let exported_path = state
+            .db
+            .get_note_row(&source_id)
+            .unwrap()
+            .unwrap()
+            .exported_path
+            .unwrap();
+        assert!(std::fs::read_to_string(&exported_path)
+            .unwrap()
+            .contains("[[Target Note]]"));
+
+        unlink_items_inner(&state, "note", &source_id, "note", &target_id).unwrap();
+
+        assert_eq!(manual_link_count(&state, "note", &source_id), 0);
+        assert!(state.db.pending_lock_marker_export_cleanup().unwrap().is_empty());
+        let (text, blob): (String, Vec<u8>) = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT text,text_blob FROM documents WHERE id=?1",
+                rusqlite::params![source_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert!(text.is_empty(), "locked cleanup must not retain plaintext beside its seal");
+        assert_eq!(
+            crate::crypto::decrypt(&ck, &blob, &aad_document(&folder_id, &source_id)).unwrap(),
+            b"original body\n"
+        );
+        let exported = std::fs::read_to_string(&exported_path).unwrap();
+        assert!(!exported.contains("[[Target Note]]"));
+        assert!(!exported.contains("murmur:links"));
+    }
+
     /// A sealed-and-not-session-unlocked endpoint refuses the link with `AppError::Locked` BEFORE any
     /// write — never link behind a lock, never reveal a locked neighbour.
     #[test]
@@ -18135,6 +18272,39 @@
         );
     }
 
+    /// The org browser header reader is intentionally finite. A corrupt/oversized local replica
+    /// must not turn one IPC call into an unbounded allocation; retain the newest 500 rows only.
+    #[test]
+    fn list_org_items_is_bounded_to_the_newest_500_headers() {
+        let state = build_state("org-list-items-bound");
+        for seq in 1_u64..=501 {
+            state
+                .db
+                .upsert_org_item(
+                    &format!("bounded-{seq}"),
+                    "org-bounded",
+                    seq,
+                    "member",
+                    &format!("Item {seq}"),
+                    "body",
+                    "2026-07-11T09:00:00Z",
+                    1,
+                    1,
+                    &[seq as u8; 32],
+                    None,
+                    None,
+                    None,
+                )
+                .unwrap();
+        }
+
+        let items = state.db.list_org_items("org-bounded").unwrap();
+        assert_eq!(items.len(), 500);
+        assert_eq!(items.first().unwrap().seq, 501);
+        assert_eq!(items.last().unwrap().seq, 2);
+        assert!(items.iter().all(|item| item.item_id != "bounded-1"));
+    }
+
     /// F-org-editable: `list_org_items_inner` ENRICHES an item the caller published with an
     /// `owned_source` ref plus the source's CURRENT title (so the author's own card links to the
     /// editable original and never shows a stale publish-time snapshot), while an item shared by
@@ -20457,7 +20627,7 @@
             .db
             .set_org_share_uploaded("dup", "item-dup", "2026-07-11T09:05:00Z")
             .unwrap();
-        // A NOT-yet-uploaded sibling (a stuck pending retry) for the same source — redundant, cancelled.
+        // A NOT-yet-uploaded sibling is ambiguous: NULL item id is not proof the remote POST never landed.
         state
             .db
             .insert_org_share(
@@ -20500,8 +20670,8 @@
         );
         assert_eq!(
             state.db.get_org_share("pending").unwrap().unwrap().state,
-            "revoked",
-            "a redundant not-yet-uploaded sibling is cancelled locally (no server item)"
+            "queued",
+            "an ambiguous queued NULL-item sibling stays fail-closed"
         );
     }
 
@@ -20645,6 +20815,135 @@
             state.db.get_org_state("org-b").unwrap().unwrap().last_seq,
             20
         );
+    }
+
+    /// The authenticated feed/import path is membership-gated before its first socket, then commits
+    /// an opened envelope only while that same local org membership still exists. This is the
+    /// command-level companion to the storage race oracle: a guessed org id gets zero network and
+    /// zero plaintext; a joined org traverses the real feed + blob + open + storage chain.
+    #[test]
+    fn org_sync_import_requires_membership_before_feed_and_plaintext_commit() {
+        use std::io::{Read, Write};
+        use crate::share::org_envelope::{
+            seal_org_envelope, OrgEnvelope, OrgItemKind, OrgSourceKind,
+        };
+
+        let ock = [9_u8; 32];
+        let env = OrgEnvelope::new(
+            OrgItemKind::Note,
+            "Member plan",
+            "authenticated member-only body",
+            "anna",
+            "2026-07-11T09:00:00Z",
+            1,
+            OrgSourceKind::Document,
+        );
+        let sha = env.content_sha256();
+        let nonce = org_item_nonce(&sha);
+        let (ciphertext, _) = seal_org_envelope(&ock, &env, "org-member", &nonce).unwrap();
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let requests = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let requests_for_server = std::sync::Arc::clone(&requests);
+        let server = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            let mut served = 0usize;
+            while served < 2 && std::time::Instant::now() < deadline {
+                let (mut socket, _) = match listener.accept() {
+                    Ok(pair) => pair,
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(10));
+                        continue;
+                    }
+                    Err(error) => panic!("member import mock accept failed: {error}"),
+                };
+                socket
+                    .set_read_timeout(Some(std::time::Duration::from_secs(1)))
+                    .unwrap();
+                let mut request = [0_u8; 8192];
+                let read = socket.read(&mut request).unwrap();
+                let request = String::from_utf8_lossy(&request[..read]).into_owned();
+                let first_line = request.lines().next().unwrap_or_default().to_string();
+                requests_for_server.lock().unwrap().push(first_line.clone());
+                assert!(
+                    request.to_ascii_lowercase().contains("authorization: bearer a"),
+                    "both feed and blob reads must use the authenticated session"
+                );
+
+                if first_line.contains("/v1/orgs/org-member/items?") {
+                    let body = format!(
+                        "{{\"items\":[{{\"itemId\":\"member-item\",\"seq\":1,\"authorUserId\":\"author-1\",\"rev\":1,\"generation\":1,\"createdAt\":\"2026-07-11T09:00:00Z\",\"tombstoned\":false,\"blobId\":\"member-blob\",\"contentSha256\":\"{}\"}}],\"nextSeq\":1}}",
+                        murmur_protocol::b64::encode(&sha)
+                    );
+                    write!(
+                        socket,
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    )
+                    .unwrap();
+                } else if first_line.contains("/v1/blobs/member-blob") {
+                    write!(
+                        socket,
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/octet-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                        ciphertext.len()
+                    )
+                    .unwrap();
+                    socket.write_all(&ciphertext).unwrap();
+                } else {
+                    panic!("unexpected member import request: {first_line}");
+                }
+                socket.flush().unwrap();
+                served += 1;
+            }
+            served
+        });
+
+        let state = build_state("org-sync-member-admission");
+        state.config.lock().unwrap().share_base_url = format!("http://{addr}");
+        seed_live_session(&state);
+
+        assert!(matches!(
+            block_on(org_sync_one_now_inner(&state, "org-outsider")),
+            Err(AppError::InvalidArg(_))
+        ));
+        assert!(
+            requests.lock().unwrap().is_empty(),
+            "a non-member org id must be rejected before the first socket"
+        );
+        assert!(state.db.list_org_items("org-outsider").unwrap().is_empty());
+
+        seed_org(&state.db, "org-member", "Member org", "member", 1);
+        state
+            .org_ock_cache
+            .lock()
+            .unwrap()
+            .insert(("org-member".to_string(), 1), Zeroizing::new(ock));
+        let report = block_on(org_sync_one_now_inner(&state, "org-member")).unwrap();
+        assert_eq!(server.join().unwrap(), 2, "one feed plus one blob read");
+        assert_eq!(report.pulled, 1);
+        assert_eq!(report.ingested, 1);
+        let stored = state
+            .db
+            .get_org_item("member-item")
+            .unwrap()
+            .expect("the authenticated member envelope must commit");
+        assert_eq!(stored.markdown, "authenticated member-only body");
+        assert_eq!(
+            state
+                .db
+                .lock()
+                .query_row(
+                    "SELECT org_id FROM org_items WHERE item_id='member-item'",
+                    [],
+                    |row| row.get::<_, String>(0),
+                )
+                .unwrap(),
+            "org-member"
+        );
+        assert_eq!(state.db.org_last_seq_for("org-member").unwrap(), 1);
     }
 
     /// FIX D (per-item sync robustness, RED→GREEN): a TERMINAL-bad item at seq N must NOT stall the
@@ -22135,7 +22434,9 @@
             .db
             .set_org_share_failed("s-stuck", "republish_upload_failed", "t")
             .unwrap();
-        // A never-published failed row (no item_id) must stay excluded — no live server item.
+        // A legacy generic-failed row with no item_id is ambiguous and must stay visible to every
+        // destructive folder/revoke gate; old clients could lose a POST response before persisting
+        // the returned server identity.
         state
             .db
             .insert_note("n2", "f1", "doc", "Doc2", "# body2", 1)
@@ -22162,21 +22463,27 @@
 
         let active = state.db.active_org_shares_for_folder("f1").unwrap();
         assert_eq!(
-                active.len(),
-                1,
-                "the stuck failed-with-item_id share IS surfaced; the never-published failed row stays excluded: {active:?}"
-            );
+            active.len(),
+            2,
+            "destructive folder enumeration must include the legacy generic-failed NULL identity: {active:?}"
+        );
         assert_eq!(active[0].0.as_deref(), Some("item-stuck"));
+        assert!(
+            active.iter().any(|(item_id, _)| item_id.is_none()),
+            "the second active row must be the ambiguous NULL-item legacy share: {active:?}"
+        );
 
         // Same fix must apply to the bulk-revoke enumeration (`revoke_shares_for_folder`'s source).
         let ids = state.db.active_org_share_ids_for_folder("f1").unwrap();
         assert_eq!(
             ids.len(),
-            1,
-            "bulk-revoke must also see the stuck failed-with-item_id share: {ids:?}"
+            2,
+            "bulk revoke must see both the known-live and ambiguous legacy rows: {ids:?}"
         );
         assert_eq!(ids[0].0, "s-stuck");
         assert_eq!(ids[0].1.as_deref(), Some("item-stuck"));
+        assert_eq!(ids[1].0, "s-dead");
+        assert_eq!(ids[1].1, None);
     }
 
     /// Closes the pre-existing lock×shares HOLE: before `active_link_user_shares_for_folder`, a folder

--- a/src-tauri/src/links.rs
+++ b/src-tauri/src/links.rs
@@ -4,7 +4,7 @@
 //! co-located with the schema, as every other table). THIS module owns the parts that are pure
 //! functions of their inputs — no DB, no clock, no network — so they are unit-testable in isolation:
 //!
-//! - the [`LinkKind`] endpoint enum (`meeting|note|document`) + its string round-trip;
+//! - the [`LinkKind`] endpoint enum (`meeting|note|document|org`) + its string round-trip;
 //! - the [`EdgeType`] enum (`wikilink|companion|semantic`) + directedness;
 //! - endpoint CANONICALIZATION for undirected (semantic) edges (`src<dst` so a pair is stored once);
 //! - the SEMANTIC AUTO-LINKER math: the mutual-kNN / floor / cap candidate selection over already-
@@ -43,6 +43,9 @@ pub enum LinkKind {
     Meeting,
     Note,
     Document,
+    /// A private local edge to a Shared Brain document. Its local id is the revision-stable,
+    /// org-scoped `org_id:doc_id` composite, never a feed `item_id` and never uploaded.
+    Org,
 }
 
 impl LinkKind {
@@ -52,6 +55,7 @@ impl LinkKind {
             LinkKind::Meeting => "meeting",
             LinkKind::Note => "note",
             LinkKind::Document => "document",
+            LinkKind::Org => "org",
         }
     }
 
@@ -62,6 +66,7 @@ impl LinkKind {
             "meeting" => Some(LinkKind::Meeting),
             "note" => Some(LinkKind::Note),
             "document" => Some(LinkKind::Document),
+            "org" => Some(LinkKind::Org),
             _ => None,
         }
     }
@@ -196,7 +201,12 @@ mod tests {
 
     #[test]
     fn link_kind_and_edge_type_round_trip_strings() {
-        for k in [LinkKind::Meeting, LinkKind::Note, LinkKind::Document] {
+        for k in [
+            LinkKind::Meeting,
+            LinkKind::Note,
+            LinkKind::Document,
+            LinkKind::Org,
+        ] {
             assert_eq!(LinkKind::parse(k.as_str()), Some(k));
         }
         assert_eq!(LinkKind::parse("bogus"), None);

--- a/src-tauri/src/storage/attachment_store.rs
+++ b/src-tauri/src/storage/attachment_store.rs
@@ -133,6 +133,104 @@ impl Db {
                ON note_attachments(org_item_id);",
         )
         .map_err(map_err)?;
+        conn.execute_batch(
+            "CREATE TRIGGER IF NOT EXISTS org_share_attachment_source_version_ai
+               AFTER INSERT ON note_attachments
+               BEGIN
+                 UPDATE org_items SET projection_sha256=NULL WHERE item_id=NEW.org_item_id;
+                 UPDATE org_shares SET source_version = source_version + 1
+                  WHERE (NEW.document_id IS NOT NULL AND document_id = NEW.document_id)
+                     OR (NEW.meeting_id IS NOT NULL AND meeting_id = NEW.meeting_id);
+                 UPDATE org_shares SET republish_dirty = republish_dirty + 1
+                  WHERE state IN ('queued','uploaded','failed') AND
+                    ((NEW.document_id IS NOT NULL AND document_id = NEW.document_id)
+                     OR (NEW.meeting_id IS NOT NULL AND meeting_id = NEW.meeting_id));
+                 INSERT INTO org_source_versions(source_kind,source_id,version)
+                   SELECT 'document',NEW.document_id,1 WHERE NEW.document_id IS NOT NULL
+                   ON CONFLICT(source_kind,source_id) DO UPDATE SET version=version+1;
+                 INSERT INTO org_source_versions(source_kind,source_id,version)
+                   SELECT 'meeting',NEW.meeting_id,1 WHERE NEW.meeting_id IS NOT NULL
+                   ON CONFLICT(source_kind,source_id) DO UPDATE SET version=version+1;
+               END;
+             CREATE TRIGGER IF NOT EXISTS org_share_attachment_source_version_ad
+               AFTER DELETE ON note_attachments
+               BEGIN
+                 UPDATE org_items SET projection_sha256=NULL WHERE item_id=OLD.org_item_id;
+                 UPDATE org_shares SET source_version = source_version + 1
+                  WHERE (OLD.document_id IS NOT NULL AND document_id = OLD.document_id)
+                     OR (OLD.meeting_id IS NOT NULL AND meeting_id = OLD.meeting_id);
+                 UPDATE org_shares SET republish_dirty = republish_dirty + 1
+                  WHERE state IN ('queued','uploaded','failed') AND
+                    ((OLD.document_id IS NOT NULL AND document_id = OLD.document_id)
+                     OR (OLD.meeting_id IS NOT NULL AND meeting_id = OLD.meeting_id));
+                 INSERT INTO org_source_versions(source_kind,source_id,version)
+                   SELECT 'document',OLD.document_id,1 WHERE OLD.document_id IS NOT NULL
+                   ON CONFLICT(source_kind,source_id) DO UPDATE SET version=version+1;
+                 INSERT INTO org_source_versions(source_kind,source_id,version)
+                   SELECT 'meeting',OLD.meeting_id,1 WHERE OLD.meeting_id IS NOT NULL
+                   ON CONFLICT(source_kind,source_id) DO UPDATE SET version=version+1;
+               END;
+             CREATE TRIGGER IF NOT EXISTS org_item_attachment_projection_au
+               AFTER UPDATE ON note_attachments
+               BEGIN
+                 UPDATE org_items SET projection_sha256=NULL
+                  WHERE item_id IS OLD.org_item_id OR item_id IS NEW.org_item_id;
+               END;
+             CREATE TRIGGER IF NOT EXISTS org_share_attachment_source_version_au_v2
+               AFTER UPDATE ON note_attachments
+               BEGIN
+                 UPDATE org_items SET projection_sha256=NULL
+                  WHERE item_id IS OLD.org_item_id OR item_id IS NEW.org_item_id;
+                 UPDATE org_shares SET source_version = source_version + 1
+                  WHERE (OLD.document_id IS NOT NULL AND document_id = OLD.document_id)
+                     OR (OLD.meeting_id IS NOT NULL AND meeting_id = OLD.meeting_id)
+                     OR (NEW.document_id IS NOT NULL AND document_id = NEW.document_id)
+                     OR (NEW.meeting_id IS NOT NULL AND meeting_id = NEW.meeting_id);
+                 UPDATE org_shares SET republish_dirty = republish_dirty + 1
+                  WHERE state IN ('queued','uploaded','failed') AND
+                    ((OLD.document_id IS NOT NULL AND document_id = OLD.document_id)
+                     OR (OLD.meeting_id IS NOT NULL AND meeting_id = OLD.meeting_id)
+                     OR (NEW.document_id IS NOT NULL AND document_id = NEW.document_id)
+                     OR (NEW.meeting_id IS NOT NULL AND meeting_id = NEW.meeting_id));
+                 INSERT INTO org_source_versions(source_kind,source_id,version)
+                   SELECT 'document',OLD.document_id,1 WHERE OLD.document_id IS NOT NULL
+                   ON CONFLICT(source_kind,source_id) DO UPDATE SET version=version+1;
+                 INSERT INTO org_source_versions(source_kind,source_id,version)
+                   SELECT 'document',NEW.document_id,1
+                    WHERE NEW.document_id IS NOT NULL AND NEW.document_id IS NOT OLD.document_id
+                   ON CONFLICT(source_kind,source_id) DO UPDATE SET version=version+1;
+                 INSERT INTO org_source_versions(source_kind,source_id,version)
+                   SELECT 'meeting',OLD.meeting_id,1 WHERE OLD.meeting_id IS NOT NULL
+                   ON CONFLICT(source_kind,source_id) DO UPDATE SET version=version+1;
+                 INSERT INTO org_source_versions(source_kind,source_id,version)
+                   SELECT 'meeting',NEW.meeting_id,1
+                    WHERE NEW.meeting_id IS NOT NULL AND NEW.meeting_id IS NOT OLD.meeting_id
+                   ON CONFLICT(source_kind,source_id) DO UPDATE SET version=version+1;
+               END;
+             CREATE TRIGGER IF NOT EXISTS closing_attachment_insert_guard
+               BEFORE INSERT ON note_attachments
+               WHEN EXISTS(SELECT 1 FROM org_share_closures c WHERE
+                 (c.scope_kind='document' AND c.scope_id=NEW.document_id) OR
+                 (c.scope_kind='meeting' AND c.scope_id=NEW.meeting_id))
+               BEGIN SELECT RAISE(ABORT,'share source is closing'); END;
+             CREATE TRIGGER IF NOT EXISTS closing_attachment_delete_guard
+               BEFORE DELETE ON note_attachments
+               WHEN EXISTS(SELECT 1 FROM org_share_closures c WHERE
+                 ((c.scope_kind='document' AND c.scope_id=OLD.document_id) OR
+                  (c.scope_kind='meeting' AND c.scope_id=OLD.meeting_id))
+                 AND ((c.scope_kind='document' AND EXISTS(
+                        SELECT 1 FROM documents d WHERE d.id=OLD.document_id)) OR
+                      (c.scope_kind='meeting' AND EXISTS(
+                        SELECT 1 FROM meetings m WHERE m.id=OLD.meeting_id))))
+               BEGIN SELECT RAISE(ABORT,'share source is closing'); END;
+             CREATE TRIGGER IF NOT EXISTS closing_attachment_update_guard
+               BEFORE UPDATE ON note_attachments
+               WHEN EXISTS(SELECT 1 FROM org_share_closures c WHERE
+                 (c.scope_kind='document' AND (c.scope_id=OLD.document_id OR c.scope_id=NEW.document_id)) OR
+                 (c.scope_kind='meeting' AND (c.scope_id=OLD.meeting_id OR c.scope_id=NEW.meeting_id)))
+               BEGIN SELECT RAISE(ABORT,'share source is closing'); END;",
+        )
+        .map_err(map_err)?;
         Ok(())
     }
 
@@ -156,7 +254,7 @@ impl Db {
                 let provider_id = conn
                     .query_row(
                         "SELECT provider_id FROM notes WHERE meeting_id = ?1
-                           ORDER BY created_at DESC LIMIT 1",
+                           ORDER BY created_at DESC, provider_id DESC LIMIT 1",
                         rusqlite::params![owner_id],
                         |r| r.get::<_, String>(0),
                     )

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -113,6 +113,79 @@ pub(crate) fn map_err(e: rusqlite::Error) -> AppError {
     AppError::Storage(e.to_string())
 }
 
+/// Insert one content-free outbound-share egress row inside the caller's transaction.
+///
+/// The dispatch id is the durable idempotency key shared with the state-machine write. Keeping
+/// both writes in the same transaction means a failed/rolled-back dispatch never leaves a phantom
+/// ledger row, while the partial unique index rejects a second non-NULL record for the same
+/// dispatch. The row carries metadata only: never a URL, key, title, or note body.
+#[allow(dead_code)]
+pub(crate) fn insert_share_egress_dispatch_tx(
+    tx: &rusqlite::Transaction<'_>,
+    ts: i64,
+    host: &str,
+    kind: &str,
+    bytes: usize,
+    dispatch_id: &str,
+) -> Result<i64> {
+    if dispatch_id.trim().is_empty() {
+        return Err(AppError::InvalidArg(
+            "share egress dispatch id must not be blank".into(),
+        ));
+    }
+    if host.trim().is_empty() {
+        return Err(AppError::InvalidArg(
+            "share egress host must not be blank".into(),
+        ));
+    }
+    if kind.trim().is_empty() {
+        return Err(AppError::InvalidArg(
+            "share egress kind must not be blank".into(),
+        ));
+    }
+    let byte_count = i64::try_from(bytes).map_err(|_| {
+        AppError::InvalidArg("share egress byte count exceeds SQLite INTEGER range".into())
+    })?;
+    tx.execute(
+        "INSERT INTO share_egress_log (ts, host, kind, byte_count, dispatch_id)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        rusqlite::params![ts, host, kind, byte_count, dispatch_id],
+    )
+    .map_err(map_err)?;
+    Ok(tx.last_insert_rowid())
+}
+
+#[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
+pub(crate) fn insert_org_read_egress_dispatch_tx(
+    tx: &rusqlite::Transaction<'_>,
+    ts: i64,
+    host: &str,
+    kind: &str,
+    dispatch_id: &str,
+    org_id: &str,
+    doc_id: &str,
+    since_seq: u64,
+    limit: u32,
+) -> Result<i64> {
+    if org_id.trim().is_empty() || doc_id.trim().is_empty() || limit == 0 {
+        return Err(AppError::InvalidArg(
+            "org recovery read witness must be complete".into(),
+        ));
+    }
+    let row_id = insert_share_egress_dispatch_tx(tx, ts, host, kind, 0, dispatch_id)?;
+    let since_seq = i64::try_from(since_seq)
+        .map_err(|_| AppError::InvalidArg("org recovery cursor exceeds SQLite range".into()))?;
+    tx.execute(
+        "UPDATE share_egress_log
+            SET org_id = ?2, doc_id = ?3, since_seq = ?4, page_limit = ?5
+          WHERE id = ?1 AND dispatch_id = ?6",
+        rusqlite::params![row_id, org_id, doc_id, since_seq, limit as i64, dispatch_id],
+    )
+    .map_err(map_err)?;
+    Ok(row_id)
+}
+
 /// Process-global, one-time registration of the sqlite-vec `vec0` virtual-table module through
 /// SQLite's auto-extension hook, so EVERY connection opened afterwards (the main keyed handle, the
 /// MCP reader thread, file-backed test DBs) can CREATE and query `vec_chunks`. MUST run BEFORE
@@ -293,11 +366,25 @@ pub struct EgressLedger {
     pub recent: Vec<EgressRecentRow>,
 }
 
+/// Content-free local witness for an outbound share whose remote revocation is not yet proven.
+/// The owner binding prevents another signed-in account from seeing or retrying this journal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) struct OutboundRevokePendingRow {
+    pub share_id: String,
+    pub meeting_id: Option<String>,
+    pub document_id: Option<String>,
+    pub mode: String,
+    pub rev: u32,
+    pub created_at: String,
+}
+
 /// Thread-safe SQLite wrapper (internal Mutex<rusqlite::Connection>).
 pub struct Db {
     conn: Mutex<Connection>,
 }
 
+#[allow(dead_code)]
 impl Db {
     /// Opens the encrypted DB (fetching the SQLCipher key from the Keychain) + runs migrations.
     /// This is the path used by the MCP server thread too — it transparently keys the handle.
@@ -357,7 +444,9 @@ impl Db {
         Ok(db)
     }
 
-    /// Idempotent CREATE TABLE IF NOT EXISTS migrations.
+    /// Idempotent CREATE TABLE IF NOT EXISTS migrations. Every schema/data step after the
+    /// read-only legacy preflight runs in one outer transaction: a late migration failure must
+    /// never leave an earlier table, trigger, column, or backfill looking successfully installed.
     pub fn migrate(&self) -> Result<()> {
         let mut conn = self.lock();
         let ask_dispatch_state_existed = conn
@@ -407,8 +496,10 @@ impl Db {
                     "Ask dispatch generation is unavailable".into(),
                 ));
             }
-            let tx = conn.transaction().map_err(map_err)?;
-            tx.execute_batch(
+        }
+        let conn = conn.transaction().map_err(map_err)?;
+        if !ask_dispatch_state_existed {
+            conn.execute_batch(
                 "CREATE TABLE ask_dispatch_state (
                    singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
                    generation INTEGER NOT NULL CHECK(typeof(generation)='integer' AND generation >= 0)
@@ -416,7 +507,6 @@ impl Db {
                  INSERT INTO ask_dispatch_state(singleton,generation) VALUES (1,0);",
             )
             .map_err(map_err)?;
-            tx.commit().map_err(map_err)?;
         }
         conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS meetings (
@@ -910,6 +1000,121 @@ impl Db {
         // deliberately separate from note_chunks so the load-bearing meeting-gating joins stay
         // untouched. Additive + guarded so migrate() stays idempotent.
         Self::migrate_documents(&conn)?;
+        conn.execute_batch(
+            "CREATE TRIGGER IF NOT EXISTS org_shares_closure_insert_guard
+             BEFORE INSERT ON org_shares
+             WHEN NEW.state NOT IN ('revoke_pending','revoked') AND (
+               EXISTS(SELECT 1 FROM org_share_closures c WHERE
+                 (c.scope_kind='meeting' AND c.scope_id=NEW.meeting_id) OR
+                 (c.scope_kind='document' AND c.scope_id=NEW.document_id)) OR
+               EXISTS(SELECT 1 FROM org_share_closures c WHERE c.scope_kind='folder' AND (
+                 (NEW.document_id IS NOT NULL AND EXISTS(
+                   SELECT 1 FROM documents d WHERE d.id=NEW.document_id AND d.folder_id=c.scope_id)) OR
+                 (NEW.meeting_id IS NOT NULL AND EXISTS(
+                   SELECT 1 FROM notes n WHERE n.meeting_id=NEW.meeting_id
+                    AND n.folder_id=c.scope_id))))
+             ) BEGIN SELECT RAISE(ABORT,'org share source is closing'); END;
+             CREATE TRIGGER IF NOT EXISTS org_shares_closure_update_guard
+             BEFORE UPDATE ON org_shares
+             WHEN NEW.state NOT IN ('revoke_pending','revoked') AND (
+               EXISTS(SELECT 1 FROM org_share_closures c WHERE
+                 (c.scope_kind='meeting' AND c.scope_id=NEW.meeting_id) OR
+                 (c.scope_kind='document' AND c.scope_id=NEW.document_id)) OR
+               EXISTS(SELECT 1 FROM org_share_closures c WHERE c.scope_kind='folder' AND (
+                 (NEW.document_id IS NOT NULL AND EXISTS(
+                   SELECT 1 FROM documents d WHERE d.id=NEW.document_id AND d.folder_id=c.scope_id)) OR
+                 (NEW.meeting_id IS NOT NULL AND EXISTS(
+                   SELECT 1 FROM notes n WHERE n.meeting_id=NEW.meeting_id
+                    AND n.folder_id=c.scope_id))))
+             ) BEGIN SELECT RAISE(ABORT,'org share source is closing'); END;
+             ",
+        )
+        .map_err(map_err)?;
+        // Freeze the exact plaintext source while a destructive revoke is in flight: a cleanup may
+        // either revoke+delete the snapshot or observe a prior edit and abandon, but it can never
+        // revoke an old snapshot and then keep a newly-edited source locally.
+        conn.execute_batch(
+            "CREATE TRIGGER IF NOT EXISTS closing_document_content_update_guard
+             BEFORE UPDATE OF folder_id,name,kind,title,text,created_at ON documents
+             WHEN EXISTS(SELECT 1 FROM org_share_closures c WHERE
+               c.scope_kind='document' AND c.scope_id=OLD.id)
+             BEGIN SELECT RAISE(ABORT,'document source is closing'); END;
+             CREATE TRIGGER IF NOT EXISTS closing_meeting_note_insert_guard
+             BEFORE INSERT ON notes
+             WHEN EXISTS(SELECT 1 FROM org_share_closures c WHERE
+               c.scope_kind='meeting' AND c.scope_id=NEW.meeting_id)
+             BEGIN SELECT RAISE(ABORT,'meeting source is closing'); END;
+             CREATE TRIGGER IF NOT EXISTS closing_meeting_note_update_guard
+             BEFORE UPDATE OF folder_id,markdown,created_at,provider_id ON notes
+             WHEN EXISTS(SELECT 1 FROM org_share_closures c WHERE
+               c.scope_kind='meeting' AND c.scope_id=OLD.meeting_id)
+             BEGIN SELECT RAISE(ABORT,'meeting source is closing'); END;
+             CREATE TRIGGER IF NOT EXISTS closing_meeting_note_delete_guard
+             BEFORE DELETE ON notes
+             WHEN EXISTS(SELECT 1 FROM org_share_closures c WHERE
+               c.scope_kind='meeting' AND c.scope_id=OLD.meeting_id)
+               AND EXISTS(SELECT 1 FROM meetings m WHERE m.id=OLD.meeting_id)
+             BEGIN SELECT RAISE(ABORT,'meeting source is closing'); END;
+             CREATE TRIGGER IF NOT EXISTS closing_meeting_title_update_guard
+             BEFORE UPDATE OF title ON meetings
+             WHEN EXISTS(SELECT 1 FROM org_share_closures c WHERE
+               c.scope_kind='meeting' AND c.scope_id=OLD.id)
+             BEGIN SELECT RAISE(ABORT,'meeting source is closing'); END;
+             CREATE TRIGGER IF NOT EXISTS closing_document_identity_update_guard_v2
+             BEFORE UPDATE OF name,kind ON documents
+             WHEN EXISTS(SELECT 1 FROM org_share_closures c WHERE
+               c.scope_kind='document' AND c.scope_id=OLD.id)
+             BEGIN SELECT RAISE(ABORT,'document source is closing'); END;",
+        )
+        .map_err(map_err)?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS org_source_versions (
+               source_kind TEXT NOT NULL CHECK(source_kind IN ('meeting','document')),
+               source_id TEXT NOT NULL,
+               version INTEGER NOT NULL DEFAULT 0 CHECK(version >= 0),
+               PRIMARY KEY(source_kind, source_id)
+             );",
+        )
+        .map_err(map_err)?;
+        conn.execute_batch(
+            "CREATE TRIGGER IF NOT EXISTS org_share_note_source_version_au
+               AFTER UPDATE OF markdown, created_at, provider_id ON notes
+               WHEN OLD.markdown IS NOT NEW.markdown OR OLD.created_at IS NOT NEW.created_at
+                 OR OLD.provider_id IS NOT NEW.provider_id
+               BEGIN
+                 UPDATE org_shares SET source_version = source_version + 1
+                  WHERE meeting_id = NEW.meeting_id;
+                 INSERT INTO org_source_versions(source_kind,source_id,version)
+                   VALUES('meeting',NEW.meeting_id,1)
+                   ON CONFLICT(source_kind,source_id) DO UPDATE SET version=version+1;
+               END;
+             CREATE TRIGGER IF NOT EXISTS org_share_note_source_version_ai AFTER INSERT ON notes
+               BEGIN
+                 UPDATE org_shares SET source_version = source_version + 1
+                  WHERE meeting_id = NEW.meeting_id;
+                 INSERT INTO org_source_versions(source_kind,source_id,version)
+                   VALUES('meeting',NEW.meeting_id,1)
+                   ON CONFLICT(source_kind,source_id) DO UPDATE SET version=version+1;
+               END;
+             CREATE TRIGGER IF NOT EXISTS org_share_note_source_version_ad AFTER DELETE ON notes
+               BEGIN
+                 UPDATE org_shares SET source_version = source_version + 1
+                  WHERE meeting_id = OLD.meeting_id;
+                 INSERT INTO org_source_versions(source_kind,source_id,version)
+                   VALUES('meeting',OLD.meeting_id,1)
+                   ON CONFLICT(source_kind,source_id) DO UPDATE SET version=version+1;
+               END;
+             CREATE TRIGGER IF NOT EXISTS org_share_meeting_source_version_au
+               AFTER UPDATE OF title ON meetings WHEN OLD.title IS NOT NEW.title
+               BEGIN
+                 UPDATE org_shares SET source_version = source_version + 1
+                  WHERE meeting_id = NEW.id;
+                 INSERT INTO org_source_versions(source_kind,source_id,version)
+                   VALUES('meeting',NEW.id,1)
+                   ON CONFLICT(source_kind,source_id) DO UPDATE SET version=version+1;
+               END;",
+        )
+        .map_err(map_err)?;
         // NOTES feature — AUTHORED `documents(kind='note')` rows gain an authoring layer over the
         // existing document substrate (seal/gate/brain-index reused verbatim). Three additive,
         // guarded columns (idempotent; NULL-safe for every legacy row):
@@ -927,6 +1132,38 @@ impl Db {
         Self::add_column_if_missing(&conn, "documents", "title", "TEXT")?;
         Self::add_column_if_missing(&conn, "documents", "updated_at", "INTEGER")?;
         Self::add_column_if_missing(&conn, "documents", "exported_path", "TEXT")?;
+        conn.execute_batch(
+            "CREATE TRIGGER IF NOT EXISTS org_share_document_source_version_au
+               AFTER UPDATE OF title, text ON documents
+               WHEN OLD.title IS NOT NEW.title OR OLD.text IS NOT NEW.text
+               BEGIN
+                 UPDATE org_shares SET source_version = source_version + 1 WHERE document_id = NEW.id;
+                 INSERT INTO org_source_versions(source_kind,source_id,version) VALUES('document',NEW.id,1)
+                   ON CONFLICT(source_kind,source_id) DO UPDATE SET version=version+1;
+               END;
+             CREATE TRIGGER IF NOT EXISTS org_share_document_source_version_ai AFTER INSERT ON documents
+               BEGIN
+                 INSERT INTO org_source_versions(source_kind,source_id,version) VALUES('document',NEW.id,1)
+                   ON CONFLICT(source_kind,source_id) DO UPDATE SET version=version+1;
+               END;
+             CREATE TRIGGER IF NOT EXISTS org_share_document_source_version_ad AFTER DELETE ON documents
+               BEGIN
+                 UPDATE org_shares SET source_version = source_version + 1 WHERE document_id = OLD.id;
+                 INSERT INTO org_source_versions(source_kind,source_id,version) VALUES('document',OLD.id,1)
+                   ON CONFLICT(source_kind,source_id) DO UPDATE SET version=version+1;
+               END;
+             CREATE TRIGGER IF NOT EXISTS org_share_document_identity_source_version_au_v2
+               AFTER UPDATE OF folder_id,name,kind,created_at ON documents
+               WHEN OLD.folder_id IS NOT NEW.folder_id OR OLD.name IS NOT NEW.name
+                 OR OLD.kind IS NOT NEW.kind OR OLD.created_at IS NOT NEW.created_at
+               BEGIN
+                 UPDATE org_shares SET source_version=source_version+1 WHERE document_id=NEW.id;
+                 INSERT INTO org_source_versions(source_kind,source_id,version)
+                   VALUES('document',NEW.id,1)
+                   ON CONFLICT(source_kind,source_id) DO UPDATE SET version=version+1;
+               END;",
+        )
+        .map_err(map_err)?;
         // Export-collision guard (2026-07-16): the authored-note twin of `notes.exported_hash` —
         // the SHA-256 (lowercase hex) of the text Murmur last wrote to this note's exported vault
         // `.md`. Refreshed on every vault (re)export; NULL for legacy rows (grandfathered). See the
@@ -1017,6 +1254,7 @@ impl Db {
                mode       TEXT NOT NULL,
                rev        INTEGER NOT NULL DEFAULT 1,
                state      TEXT NOT NULL DEFAULT 'active',
+               owner_user_id TEXT,
                created_at TEXT NOT NULL
              );
              CREATE INDEX IF NOT EXISTS idx_outbound_shares_meeting ON outbound_shares(meeting_id);
@@ -1027,8 +1265,25 @@ impl Db {
                ts         INTEGER NOT NULL,
                host       TEXT NOT NULL,
                kind       TEXT NOT NULL,
-               byte_count INTEGER NOT NULL DEFAULT 0
+               byte_count INTEGER NOT NULL DEFAULT 0,
+               dispatch_id TEXT,
+               org_id      TEXT,
+               doc_id      TEXT,
+               since_seq   INTEGER,
+               page_limit  INTEGER
              );",
+        )
+        .map_err(map_err)?;
+        Self::add_column_if_missing(&conn, "share_egress_log", "dispatch_id", "TEXT")?;
+        Self::add_column_if_missing(&conn, "share_egress_log", "org_id", "TEXT")?;
+        Self::add_column_if_missing(&conn, "share_egress_log", "doc_id", "TEXT")?;
+        Self::add_column_if_missing(&conn, "share_egress_log", "since_seq", "INTEGER")?;
+        Self::add_column_if_missing(&conn, "share_egress_log", "page_limit", "INTEGER")?;
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_share_egress_log_dispatch_id
+               ON share_egress_log(dispatch_id)
+             WHERE dispatch_id IS NOT NULL",
+            [],
         )
         .map_err(map_err)?;
 
@@ -1095,6 +1350,40 @@ impl Db {
         // resolves the NOTE title (gated on the note's folder) instead. Legacy meeting shares keep
         // `document_id` NULL → byte-identical behavior.
         Self::add_column_if_missing(&conn, "outbound_shares", "document_id", "TEXT")?;
+        Self::add_column_if_missing(&conn, "outbound_shares", "owner_user_id", "TEXT")?;
+        // The durable close barrier governs every remote sharing mode. Create these guards only
+        // after the additive `outbound_shares.document_id` migration exists on both fresh and
+        // upgraded databases.
+        conn.execute_batch(
+            "CREATE TRIGGER IF NOT EXISTS outbound_shares_closure_insert_guard
+             BEFORE INSERT ON outbound_shares
+             WHEN NEW.state NOT IN ('revoke_pending','revoked') AND (
+               EXISTS(SELECT 1 FROM org_share_closures c WHERE
+                 (c.scope_kind='meeting' AND c.scope_id=NEW.meeting_id) OR
+                 (c.scope_kind='document' AND c.scope_id=NEW.document_id)) OR
+               EXISTS(SELECT 1 FROM org_share_closures c WHERE c.scope_kind='folder' AND (
+                 (NEW.document_id IS NOT NULL AND EXISTS(
+                   SELECT 1 FROM documents d WHERE d.id=NEW.document_id AND d.folder_id=c.scope_id)) OR
+                 (NEW.meeting_id <> '' AND EXISTS(
+                   SELECT 1 FROM notes n WHERE n.meeting_id=NEW.meeting_id
+                    AND n.folder_id=c.scope_id))))
+             ) BEGIN SELECT RAISE(ABORT,'share source is closing'); END;
+             CREATE TRIGGER IF NOT EXISTS outbound_shares_closure_update_guard
+             BEFORE UPDATE ON outbound_shares
+             WHEN NEW.state NOT IN ('revoke_pending','revoked') AND (
+               EXISTS(SELECT 1 FROM org_share_closures c WHERE
+                 (c.scope_kind='meeting' AND c.scope_id=NEW.meeting_id) OR
+                 (c.scope_kind='document' AND c.scope_id=NEW.document_id)) OR
+               EXISTS(SELECT 1 FROM org_share_closures c WHERE c.scope_kind='folder' AND (
+                 (NEW.document_id IS NOT NULL AND EXISTS(
+                   SELECT 1 FROM documents d WHERE d.id=NEW.document_id AND d.folder_id=c.scope_id)) OR
+                 (NEW.meeting_id <> '' AND EXISTS(
+                   SELECT 1 FROM notes n WHERE n.meeting_id=NEW.meeting_id
+                    AND n.folder_id=c.scope_id))))
+             ) BEGIN SELECT RAISE(ABORT,'share source is closing'); END;
+             ",
+        )
+        .map_err(map_err)?;
 
         // Re-Truth: guarded ALTERs for the supersession undo pre-images. The columns are also in the
         // `CREATE TABLE IF NOT EXISTS supersessions` above (so a fresh DB gets them there and these are
@@ -1160,6 +1449,7 @@ impl Db {
         // re-gated at read time (`visibility_clause` / `meeting_is_unlocked`), so a board can
         // never become an ungated back door into a sealed folder.
         Self::migrate_dashboards(&conn)?;
+        conn.commit().map_err(map_err)?;
         Ok(())
     }
 
@@ -1397,8 +1687,7 @@ impl Db {
             "INSERT INTO fts_doc_chunks(rowid, text) SELECT id, text FROM doc_chunks;"
         };
         let batch = format!(
-            "BEGIN IMMEDIATE;
-             CREATE VIRTUAL TABLE IF NOT EXISTS fts_doc_chunks USING fts5(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS fts_doc_chunks USING fts5(
                  text,
                  content='doc_chunks',
                  content_rowid='id',
@@ -1420,16 +1709,10 @@ impl Db {
                    VALUES ('delete', old.id, old.text);
                  INSERT INTO fts_doc_chunks(rowid, text) VALUES (new.id, new.text);
              END;
-             {backfill}
-             COMMIT;"
+             {backfill}"
         );
-        let res = conn.execute_batch(&batch);
-        if res.is_err() {
-            // A failed batch leaves the explicit transaction open on this connection — roll it
-            // back so the error path hands later code a clean connection state.
-            let _ = conn.execute_batch("ROLLBACK;");
-        }
-        res.map_err(map_err)?;
+        // The caller-wide migration transaction owns CREATE + backfill atomicity.
+        conn.execute_batch(&batch).map_err(map_err)?;
         Ok(())
     }
 
@@ -1686,15 +1969,13 @@ impl Db {
             conn.execute_batch(CREATE).map_err(map_err)?;
             return Ok(());
         }
-        // First build: create + one-time backfill ATOMICALLY (rollback-on-drop guards a crash).
-        let tx = conn.unchecked_transaction().map_err(map_err)?;
-        tx.execute_batch(CREATE).map_err(map_err)?;
-        tx.execute_batch(
+        // The caller-wide migration transaction owns CREATE + one-time backfill atomicity.
+        conn.execute_batch(CREATE).map_err(map_err)?;
+        conn.execute_batch(
             "INSERT INTO fts_user_facts(rowid, subject, predicate, object)
                SELECT rowid, subject, predicate, object FROM user_facts;",
         )
         .map_err(map_err)?;
-        tx.commit().map_err(map_err)?;
         Ok(())
     }
 
@@ -1798,17 +2079,71 @@ impl Db {
                generation     INTEGER NOT NULL DEFAULT 1,
                content_sha256 BLOB,
                item_id        TEXT,
+               scrub          INTEGER NOT NULL DEFAULT 1 CHECK(scrub IN (0,1)),
                state          TEXT NOT NULL DEFAULT 'queued'
                               CHECK (state IN ('queued','uploaded','failed','revoke_pending','revoked')),
                last_error     TEXT,
                created_at     TEXT NOT NULL,
-               updated_at     TEXT NOT NULL
+               updated_at     TEXT NOT NULL,
+               dispatch_id    TEXT
              );
              CREATE INDEX IF NOT EXISTS idx_org_shares_org ON org_shares(org_id);
              CREATE INDEX IF NOT EXISTS idx_org_shares_state ON org_shares(state);
              CREATE INDEX IF NOT EXISTS idx_org_shares_item ON org_shares(item_id);",
         )
         .map_err(map_err)?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS org_share_closures (
+               scope_kind TEXT NOT NULL CHECK(scope_kind IN ('meeting','document','folder')),
+               scope_id TEXT NOT NULL,
+               phase TEXT NOT NULL CHECK(phase IN ('closing','closed')),
+               created_at TEXT NOT NULL,
+               PRIMARY KEY(scope_kind,scope_id)
+             );",
+        )
+        .map_err(map_err)?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS org_access_attempts (
+               seq INTEGER PRIMARY KEY AUTOINCREMENT,
+               dispatch_id TEXT NOT NULL UNIQUE,
+               org_id TEXT NOT NULL,
+               doc_id TEXT NOT NULL,
+               old_access TEXT NOT NULL CHECK(old_access IN ('view','edit')),
+               new_access TEXT NOT NULL CHECK(new_access IN ('view','edit')),
+               actor_user_id TEXT NOT NULL,
+               owner_user_id TEXT NOT NULL,
+               state TEXT NOT NULL DEFAULT 'pending'
+                 CHECK(state IN ('pending','applied','failed')),
+               created_at TEXT NOT NULL
+             );
+             CREATE INDEX IF NOT EXISTS idx_org_access_attempts_document
+               ON org_access_attempts(org_id,doc_id,seq);",
+        )
+        .map_err(map_err)?;
+        Self::add_column_if_missing(conn, "org_shares", "dispatch_id", "TEXT")?;
+        Self::add_column_if_missing(
+            conn,
+            "org_shares",
+            "republish_dirty",
+            "INTEGER NOT NULL DEFAULT 0 CHECK(republish_dirty >= 0)",
+        )?;
+        Self::add_column_if_missing(
+            conn,
+            "org_shares",
+            "source_version",
+            "INTEGER NOT NULL DEFAULT 0 CHECK(source_version >= 0)",
+        )?;
+        Self::add_column_if_missing(
+            conn,
+            "org_shares",
+            "republish_deferred",
+            "INTEGER NOT NULL DEFAULT 0 CHECK(republish_deferred IN (0,1))",
+        )?;
+        conn.execute(
+            "UPDATE org_shares SET republish_dirty=republish_dirty+1, republish_deferred=0
+              WHERE republish_deferred=1 AND state IN ('queued','uploaded','failed')",
+            [],
+        ).map_err(map_err)?;
         // Per-instance org toggle: which JOINED orgs actually contribute content on THIS install
         // (Settings → Organization). Default enabled (1) so every existing membership stays active
         // pre-upgrade. Guarded/additive per the migration rule.
@@ -1868,6 +2203,7 @@ impl Db {
                rev            INTEGER NOT NULL DEFAULT 1,
                generation     INTEGER NOT NULL DEFAULT 1,
                content_sha256 BLOB,
+               is_current     INTEGER NOT NULL DEFAULT 0,
                tombstoned     INTEGER NOT NULL DEFAULT 0
              );
              CREATE INDEX IF NOT EXISTS idx_org_items_org ON org_items(org_id);
@@ -1896,6 +2232,73 @@ impl Db {
         // for the local-replica upserts done at share/republish time (the next feed sync fills it in;
         // those machines already edit via their local source). Guarded so a re-migrated DB is a no-op.
         Self::add_column_if_missing(conn, "org_items", "author_user_id", "TEXT")?;
+        // Stable opaque document identity + server-enforced collaboration metadata. Legacy rows
+        // remain readable with NULL doc/owner and default view; they are not durable link targets.
+        Self::add_column_if_missing(conn, "org_items", "doc_id", "TEXT")?;
+        Self::add_column_if_missing(
+            conn,
+            "org_items",
+            "access",
+            "TEXT NOT NULL DEFAULT 'view' CHECK(access IN ('view','edit'))",
+        )?;
+        Self::add_column_if_missing(conn, "org_items", "document_owner_user_id", "TEXT")?;
+        Self::add_column_if_missing(
+            conn,
+            "org_items",
+            "is_current",
+            "INTEGER NOT NULL DEFAULT 0 CHECK(is_current IN (0,1))",
+        )?;
+        Self::add_column_if_missing(conn, "org_items", "projection_sha256", "BLOB")?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_org_items_doc ON org_items(org_id, doc_id, rev DESC)",
+            [],
+        )
+        .map_err(map_err)?;
+        Self::add_column_if_missing(conn, "org_shares", "doc_id", "TEXT")?;
+        Self::add_column_if_missing(
+            conn,
+            "org_shares",
+            "access",
+            "TEXT NOT NULL DEFAULT 'view' CHECK(access IN ('view','edit'))",
+        )?;
+        // Persist the caller's scrub choice so a crash/ambiguous POST retry seals the same canonical
+        // plaintext. Existing rows default fail-safe to scrubbed.
+        Self::add_column_if_missing(
+            conn,
+            "org_shares",
+            "scrub",
+            "INTEGER NOT NULL DEFAULT 1 CHECK(scrub IN (0,1))",
+        )?;
+        Self::add_column_if_missing(conn, "org_shares", "expected_actor_user_id", "TEXT")?;
+        Self::add_column_if_missing(conn, "org_shares", "expected_owner_user_id", "TEXT")?;
+        conn.execute(
+            "UPDATE org_shares SET last_error='recovery_witness_missing'
+              WHERE state='failed'
+                AND last_error IN ('initial_post_pending','initial_post_replayable','direct_put_pending',
+                                   'republish_put_pending','republish_post_pending',
+                                   'projection_pending')
+                AND (dispatch_id IS NULL OR trim(dispatch_id)='' OR length(dispatch_id)!=36
+                  OR substr(dispatch_id,9,1)!='-' OR substr(dispatch_id,14,1)!='-'
+                  OR substr(dispatch_id,19,1)!='-' OR substr(dispatch_id,24,1)!='-'
+                  OR doc_id IS NULL OR trim(doc_id)='' OR length(doc_id)!=36
+                  OR substr(doc_id,9,1)!='-' OR substr(doc_id,14,1)!='-'
+                  OR substr(doc_id,19,1)!='-' OR substr(doc_id,24,1)!='-'
+                  OR trim(org_id)='' OR length(org_id)!=36
+                  OR substr(org_id,9,1)!='-' OR substr(org_id,14,1)!='-'
+                  OR substr(org_id,19,1)!='-' OR substr(org_id,24,1)!='-'
+                  OR content_sha256 IS NULL OR length(content_sha256)!=32
+                  OR expected_actor_user_id IS NULL OR trim(expected_actor_user_id)=''
+                  OR expected_owner_user_id IS NULL OR trim(expected_owner_user_id)=''
+                  OR access NOT IN ('view','edit') OR rev < 1 OR generation < 1
+                  OR (meeting_id IS NOT NULL AND document_id IS NOT NULL)
+                  OR (last_error IN ('initial_post_pending','initial_post_replayable','republish_put_pending',
+                                     'republish_post_pending')
+                      AND meeting_id IS NULL AND document_id IS NULL)
+                  OR (last_error IN ('direct_put_pending','republish_put_pending')
+                      AND (item_id IS NULL OR trim(item_id)='')))",
+            [],
+        )
+        .map_err(map_err)?;
         // vec0 int8 KNN table (width = EMBED_DIM; compile-time const, no user input). int8 per the
         // scale spike — see the doc comment. Values are inserted via `vec_int8(?)` (a raw i8 blob).
         conn.execute_batch(&format!(
@@ -1998,6 +2401,38 @@ impl Db {
         Ok(())
     }
 
+    /// Durable pre-dispatch journal for a mode-A link create. A lost response therefore still
+    /// leaves enough source identity for folder/source revoke to DELETE the remote share id before
+    /// sealing or destroying local plaintext.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn insert_outbound_share_attempt(
+        &self,
+        share_id: &str,
+        meeting_id: Option<&str>,
+        document_id: Option<&str>,
+        mode: &str,
+        rev: u32,
+        owner_user_id: &str,
+        created_at: &str,
+    ) -> Result<()> {
+        if meeting_id.is_some() == document_id.is_some() {
+            return Err(crate::error::AppError::InvalidArg(
+                "exactly one outbound share source is required".into(),
+            ));
+        }
+        let conn = self.lock();
+        conn.execute(
+            "INSERT INTO outbound_shares
+               (share_id,meeting_id,document_id,mode,rev,state,owner_user_id,created_at)
+             VALUES(?1,COALESCE(?2,''),?3,?4,?5,'create_pending',?6,?7)",
+            rusqlite::params![
+                share_id, meeting_id, document_id, mode, rev as i64, owner_user_id, created_at
+            ],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
     /// Record an outbound NOTE share (WP6). The share anchors on a `documents(kind='note')` id in the
     /// additive `document_id` column; the NOT NULL `meeting_id` is stored as '' so the meeting-title
     /// join skips it and `list_my_shares` resolves the NOTE title instead. Mirrors
@@ -2094,6 +2529,44 @@ impl Db {
         Ok(())
     }
 
+    /// Owner-bound local revoke journals, including rows no longer returned by the relay. These
+    /// rows remain user-visible until a verified DELETE completes; absence from a list response is
+    /// not deletion proof.
+    pub(crate) fn outbound_revoke_pending_for_owner(
+        &self,
+        owner_user_id: &str,
+    ) -> Result<Vec<OutboundRevokePendingRow>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT share_id,NULLIF(meeting_id,''),document_id,mode,rev,created_at
+                   FROM outbound_shares
+                  WHERE state='revoke_pending' AND owner_user_id=?1
+                  ORDER BY created_at DESC,share_id ASC",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map([owner_user_id], |row| {
+                let rev = row.get::<_, i64>(4)?;
+                Ok(OutboundRevokePendingRow {
+                    share_id: row.get(0)?,
+                    meeting_id: row.get(1)?,
+                    document_id: row.get(2)?,
+                    mode: row.get(3)?,
+                    rev: u32::try_from(rev).map_err(|_| {
+                        rusqlite::Error::IntegralValueOutOfRange(4, rev)
+                    })?,
+                    created_at: row.get(5)?,
+                })
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
     // `insert_share_egress` / `count_share_egress_by_kind` moved to `storage::egress_store`
     // (God-file split) alongside the other egress-ledger writers — still callable as inherent
     // `db.method()` cross-file. Content-free `share_egress_log` rows.
@@ -2168,11 +2641,11 @@ impl Db {
         let conn = self.lock();
         let mut stmt = conn
             .prepare(
-                "SELECT s.share_id, s.mode
+                "SELECT DISTINCT s.share_id, s.mode
                    FROM outbound_shares s
                    LEFT JOIN notes n     ON n.meeting_id = s.meeting_id
                    LEFT JOIN documents d ON d.id = s.document_id
-                  WHERE s.state IN ('active', 'sent', 'awaiting_key')
+                  WHERE s.state <> 'revoked'
                     AND (n.folder_id = ?1 OR d.folder_id = ?1)",
             )
             .map_err(map_err)?;
@@ -2186,6 +2659,102 @@ impl Db {
             out.push(r.map_err(map_err)?);
         }
         Ok(out)
+    }
+
+    /// True when any local remote-share journal (link, directed user, or organization) still
+    /// represents potentially-readable server ciphertext for this exact source. All non-terminal
+    /// rows count, including ambiguous create attempts: absence of a success response is not proof
+    /// that the relay did not commit the mutation.
+    pub(crate) fn source_has_active_remote_share(
+        &self,
+        meeting_id: Option<&str>,
+        document_id: Option<&str>,
+    ) -> Result<bool> {
+        if meeting_id.is_some() == document_id.is_some() {
+            return Err(crate::error::AppError::InvalidArg(
+                "exactly one share source is required".into(),
+            ));
+        }
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT EXISTS(
+               SELECT 1 FROM outbound_shares
+                WHERE state <> 'revoked'
+                  AND ((?1 IS NOT NULL AND meeting_id=?1)
+                    OR (?2 IS NOT NULL AND document_id=?2))
+               UNION ALL
+               SELECT 1 FROM org_shares
+                WHERE state <> 'revoked'
+                  AND ((?1 IS NOT NULL AND meeting_id=?1)
+                    OR (?2 IS NOT NULL AND document_id=?2))
+             )",
+            rusqlite::params![meeting_id, document_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(map_err)
+        .map(|exists| exists != 0)
+    }
+
+    pub(crate) fn active_outbound_shares_for_source(
+        &self,
+        meeting_id: Option<&str>,
+        document_id: Option<&str>,
+    ) -> Result<Vec<String>> {
+        if meeting_id.is_some() == document_id.is_some() {
+            return Err(crate::error::AppError::InvalidArg(
+                "exactly one share source is required".into(),
+            ));
+        }
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT share_id FROM outbound_shares
+                  WHERE state <> 'revoked'
+                    AND ((?1 IS NOT NULL AND meeting_id=?1)
+                      OR (?2 IS NOT NULL AND document_id=?2))
+                  ORDER BY share_id",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![meeting_id, document_id], |row| row.get(0))
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    pub(crate) fn outbound_shares_in_state(&self, state: &str) -> Result<Vec<String>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare("SELECT share_id FROM outbound_shares WHERE state=?1 ORDER BY share_id")
+            .map_err(map_err)?;
+        let rows = stmt.query_map([state], |row| row.get(0)).map_err(map_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    pub(crate) fn outbound_share_owner(&self, share_id: &str) -> Result<Option<String>> {
+        self.lock()
+            .query_row(
+                "SELECT owner_user_id FROM outbound_shares WHERE share_id=?1",
+                [share_id],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .optional()
+            .map_err(map_err)
+            .map(Option::flatten)
+    }
+
+    pub(crate) fn folder_has_active_remote_share(&self, folder_id: &str) -> Result<bool> {
+        if !self.active_link_user_shares_for_folder(folder_id)?.is_empty() {
+            return Ok(true);
+        }
+        Ok(!self.active_org_share_ids_for_folder(folder_id)?.is_empty())
     }
 
     // `active_org_share_ids_for_folder` moved to `storage::org_store` (God-file split) — still callable as inherent `db.method()` cross-file.
@@ -2234,6 +2803,45 @@ impl Db {
     /// for the gated title derivation (NO title column, spec §7). `state` = `'sent'` (registered) or
     /// `'awaiting_key'` (invited/unregistered). New rows leave the legacy raw `nk` column NULL; the
     /// wrapped key means a re-locked session (no MK) can no longer decrypt an already-shared envelope.
+    #[allow(clippy::too_many_arguments)]
+    pub fn insert_outbound_user_share_with_owner(
+        &self,
+        share_id: &str,
+        meeting_id: &str,
+        rev: u32,
+        created_at: &str,
+        state: &str,
+        nk_wrapped: &[u8],
+        recipient_acct_id: &str,
+        recipient_email: &str,
+        content_hash: &[u8],
+        owner_user_id: &str,
+    ) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "INSERT OR REPLACE INTO outbound_shares
+               (share_id, meeting_id, mode, rev, state, created_at,
+                nk_wrapped, recipient_acct_id, recipient_email, content_hash, owner_user_id)
+             VALUES (?1, ?2, 'user', ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            rusqlite::params![
+                share_id,
+                meeting_id,
+                rev as i64,
+                state,
+                created_at,
+                nk_wrapped,
+                recipient_acct_id,
+                recipient_email,
+                content_hash,
+                owner_user_id
+            ],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Backward-compatible journal writer for the command layer at this stack's base revision.
+    /// The next stack layer switches production calls to the owner-bound variant above.
     #[allow(clippy::too_many_arguments)]
     pub fn insert_outbound_user_share(
         &self,
@@ -2547,6 +3155,7 @@ impl Db {
     pub fn delete_meeting(&self, id: &str) -> Result<Vec<String>> {
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
+        let has_share_closure = Self::source_closure_ready_for_delete_tx(&tx, "meeting", id)?;
         Self::refuse_nonterminal_recording_generation_tx(&tx, id)?;
         // Drop derived chunks/vectors FIRST, in the same tx. `vec_chunks` is a vec0 virtual table
         // with no foreign key, so the `meetings` ON DELETE CASCADE reaches `note_chunks` but NOT
@@ -2597,6 +3206,14 @@ impl Db {
         Self::purge_retired_recording_generations_tx(&tx, id)?;
         tx.execute("DELETE FROM meetings WHERE id = ?1", rusqlite::params![id])
             .map_err(map_err)?;
+        if has_share_closure {
+            tx.execute(
+                "UPDATE org_share_closures SET phase='closed'
+                  WHERE scope_kind='meeting' AND scope_id=?1 AND phase='closing'",
+                rusqlite::params![id],
+            )
+            .map_err(map_err)?;
+        }
         tx.commit().map_err(map_err)?;
         Ok(rollup_exports)
     }
@@ -4403,6 +5020,7 @@ impl Db {
     pub fn delete_document(&self, id: &str) -> Result<()> {
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
+        let has_share_closure = Self::source_closure_ready_for_delete_tx(&tx, "document", id)?;
         Self::purge_doc_chunks_tx(&tx, &[id.to_string()])?;
         // Brain v3 PR-3: purge every `links` row whose SRC OR DST is this deleted document/note in the
         // same tx — a note id IS a document id, so both kinds are covered by `purge_links_tx`. A
@@ -4414,8 +5032,75 @@ impl Db {
         Self::purge_all_ask_conversations_tx(&tx)?;
         tx.execute("DELETE FROM documents WHERE id = ?1", rusqlite::params![id])
             .map_err(map_err)?;
+        if has_share_closure {
+            tx.execute(
+                "UPDATE org_share_closures SET phase='closed'
+                  WHERE scope_kind='document' AND scope_id=?1 AND phase='closing'",
+                rusqlite::params![id],
+            )
+            .map_err(map_err)?;
+        }
         tx.commit().map_err(map_err)?;
         Ok(())
+    }
+
+    /// If a destructive share barrier exists, deletion may cross it only after every local
+    /// journal for the exact source is terminal. The caller's parent DELETE, attachment cascade,
+    /// and closure phase transition then commit in the same SQLite transaction.
+    fn source_closure_ready_for_delete_tx(
+        tx: &rusqlite::Transaction<'_>,
+        source_kind: &str,
+        source_id: &str,
+    ) -> Result<bool> {
+        let has_closure = tx
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM org_share_closures
+                  WHERE scope_kind=?1 AND scope_id=?2 AND phase='closing')",
+                rusqlite::params![source_kind, source_id],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(map_err)?
+            != 0;
+        let nonterminal: i64 = match source_kind {
+            "meeting" => tx
+                .query_row(
+                    "SELECT
+                       (SELECT COUNT(*) FROM outbound_shares
+                         WHERE meeting_id=?1 AND state<>'revoked') +
+                       (SELECT COUNT(*) FROM org_shares
+                         WHERE meeting_id=?1 AND state<>'revoked')",
+                    [source_id],
+                    |row| row.get(0),
+                )
+                .map_err(map_err)?,
+            "document" => tx
+                .query_row(
+                    "SELECT
+                       (SELECT COUNT(*) FROM outbound_shares
+                         WHERE document_id=?1 AND state<>'revoked') +
+                       (SELECT COUNT(*) FROM org_shares
+                         WHERE document_id=?1 AND state<>'revoked')",
+                    [source_id],
+                    |row| row.get(0),
+                )
+                .map_err(map_err)?,
+            _ => {
+                return Err(crate::error::AppError::InvalidArg(
+                    "invalid share closure source".into(),
+                ));
+            }
+        };
+        if nonterminal != 0 {
+            return Err(crate::error::AppError::Unavailable(
+                if has_closure {
+                    "remote share revocation is not yet durably complete"
+                } else {
+                    "source deletion requires a durable share closure before remote revocation"
+                }
+                .into(),
+            ));
+        }
+        Ok(has_closure)
     }
 
     /// (Re)index a VISIBLE document's plaintext into `doc_chunks` (always — the `fts_doc_chunks`

--- a/src-tauri/src/storage/db_tests/tests.rs
+++ b/src-tauri/src/storage/db_tests/tests.rs
@@ -99,6 +99,327 @@ fn migrate_is_idempotent() {
     );
 }
 
+/// A late migration failure must roll back the entire schema/data upgrade, not leave an earlier
+/// additive table or backfill installed. A deliberately malformed attachment table survives the
+/// failed attempt byte-for-byte; after removing that external obstruction, the same connection
+/// migrates successfully and remains idempotent.
+#[test]
+fn migrate_rolls_back_every_earlier_step_when_a_late_attachment_step_fails() {
+    register_vec_extension();
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "PRAGMA foreign_keys = ON;
+         CREATE TABLE note_attachments (sentinel TEXT NOT NULL);
+         INSERT INTO note_attachments(sentinel) VALUES ('keep-me');",
+    )
+    .unwrap();
+    let db = Db {
+        conn: Mutex::new(conn),
+    };
+    let schema_snapshot = |db: &Db| -> Vec<(String, String, String)> {
+        let conn = db.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT type, name, COALESCE(sql, '')
+                   FROM sqlite_master
+                  WHERE name NOT LIKE 'sqlite_%'
+                  ORDER BY type, name",
+            )
+            .unwrap();
+        stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+            .unwrap()
+            .map(|row| row.unwrap())
+            .collect()
+    };
+    let before = schema_snapshot(&db);
+
+    assert!(
+        db.migrate().is_err(),
+        "the malformed late attachment substrate must reject migration"
+    );
+    assert_eq!(
+        schema_snapshot(&db),
+        before,
+        "a late failure must roll back every earlier schema step"
+    );
+    assert_eq!(
+        db.lock()
+            .query_row(
+                "SELECT sentinel FROM note_attachments",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap(),
+        "keep-me",
+        "the pre-existing obstruction must remain untouched"
+    );
+
+    db.lock()
+        .execute_batch("DROP TABLE note_attachments;")
+        .unwrap();
+    db.migrate().unwrap();
+    db.migrate().unwrap();
+    assert!(
+        db.lock()
+            .query_row(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='note_attachments'",
+                [],
+                |_| Ok(()),
+            )
+            .optional()
+            .unwrap()
+            .is_some(),
+        "the unobstructed retry must install the late schema"
+    );
+}
+
+/// Dispatch correlation is an additive upgrade: legacy share rows remain valid with NULL stamps,
+/// while both tables gain the nullable column and the ledger gains a partial unique index.
+#[test]
+fn migrate_adds_dispatch_correlation_to_legacy_share_tables() {
+    register_vec_extension();
+    let conn = Connection::open_in_memory().unwrap();
+    conn.execute_batch(
+        "PRAGMA foreign_keys = ON;
+         CREATE TABLE share_egress_log (
+           id         INTEGER PRIMARY KEY AUTOINCREMENT,
+           ts         INTEGER NOT NULL,
+           host       TEXT NOT NULL,
+           kind       TEXT NOT NULL,
+           byte_count INTEGER NOT NULL DEFAULT 0
+         );
+         INSERT INTO share_egress_log(ts, host, kind, byte_count)
+           VALUES (1, 'relay.example', 'legacy_one', 10),
+                  (2, 'relay.example', 'legacy_two', 20);
+         CREATE TABLE org_shares (
+           id             TEXT PRIMARY KEY,
+           org_id         TEXT NOT NULL,
+           meeting_id     TEXT,
+           document_id    TEXT,
+           kind           TEXT NOT NULL,
+           title          TEXT,
+           rev            INTEGER NOT NULL DEFAULT 1,
+           generation     INTEGER NOT NULL DEFAULT 1,
+           content_sha256 BLOB,
+           item_id        TEXT,
+           scrub          INTEGER NOT NULL DEFAULT 1 CHECK(scrub IN (0,1)),
+           state          TEXT NOT NULL DEFAULT 'queued'
+                          CHECK (state IN ('queued','uploaded','failed','revoke_pending','revoked')),
+           last_error     TEXT,
+           created_at     TEXT NOT NULL,
+           updated_at     TEXT NOT NULL
+         );
+         INSERT INTO org_shares(
+           id, org_id, kind, state, created_at, updated_at
+         ) VALUES (
+           'legacy-share', 'legacy-org', 'note', 'queued', '2026-08-13T00:00:00Z',
+           '2026-08-13T00:00:00Z'
+         );",
+    )
+    .unwrap();
+    let db = Db {
+        conn: Mutex::new(conn),
+    };
+
+    db.migrate().unwrap();
+    db.migrate().unwrap();
+
+    let conn = db.lock();
+    for table in ["org_shares", "share_egress_log"] {
+        let dispatch_columns: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info(?1) WHERE name = 'dispatch_id'",
+                rusqlite::params![table],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(dispatch_columns, 1, "{table}.dispatch_id must be additive");
+    }
+    let legacy_null_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM share_egress_log WHERE dispatch_id IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(legacy_null_rows, 2, "legacy NULL ledger rows must coexist");
+    let legacy_org_dispatch: Option<String> = conn
+        .query_row(
+            "SELECT dispatch_id FROM org_shares WHERE id = 'legacy-share'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(legacy_org_dispatch, None);
+    let (unique, partial): (i64, i64) = conn
+        .query_row(
+            "SELECT \"unique\", partial
+               FROM pragma_index_list('share_egress_log')
+              WHERE name = 'idx_share_egress_log_dispatch_id'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!((unique, partial), (1, 1));
+    let indexed_column: String = conn
+        .query_row(
+            "SELECT name FROM pragma_index_info('idx_share_egress_log_dispatch_id')",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(indexed_column, "dispatch_id");
+}
+
+#[test]
+fn share_egress_dispatch_rejects_duplicate_non_null_id_but_allows_legacy_nulls() {
+    let db = mem_db();
+    let mut conn = db.lock();
+    conn.execute(
+        "INSERT INTO share_egress_log(ts, host, kind, byte_count) VALUES (1, 'relay', 'legacy', 0)",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO share_egress_log(ts, host, kind, byte_count) VALUES (2, 'relay', 'legacy', 0)",
+        [],
+    )
+    .unwrap();
+    {
+        let tx = conn.transaction().unwrap();
+        insert_share_egress_dispatch_tx(&tx, 3, "relay", "org_share_publish", 42, "dispatch-1")
+            .unwrap();
+        tx.commit().unwrap();
+    }
+    {
+        let tx = conn.transaction().unwrap();
+        let duplicate =
+            insert_share_egress_dispatch_tx(&tx, 4, "relay", "org_share_publish", 43, "dispatch-1");
+        assert!(matches!(duplicate, Err(crate::error::AppError::Storage(_))));
+        tx.rollback().unwrap();
+    }
+
+    let (null_rows, stamped_rows): (i64, i64) = conn
+        .query_row(
+            "SELECT SUM(dispatch_id IS NULL), SUM(dispatch_id = 'dispatch-1')
+               FROM share_egress_log",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!((null_rows, stamped_rows), (2, 1));
+}
+
+#[test]
+fn share_egress_dispatch_transaction_rollback_leaves_no_ledger_row() {
+    let db = mem_db();
+    let mut conn = db.lock();
+    let row_id = {
+        let tx = conn.transaction().unwrap();
+        let row_id = insert_share_egress_dispatch_tx(
+            &tx,
+            10,
+            "relay",
+            "org_share_publish",
+            99,
+            "dispatch-rollback",
+        )
+        .unwrap();
+        let visible_inside_tx: i64 = tx
+            .query_row(
+                "SELECT COUNT(*) FROM share_egress_log WHERE id = ?1",
+                rusqlite::params![row_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(visible_inside_tx, 1);
+        tx.rollback().unwrap();
+        row_id
+    };
+    let persisted: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM share_egress_log WHERE id = ?1",
+            rusqlite::params![row_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(persisted, 0);
+}
+
+#[test]
+fn org_recovery_read_dispatch_binds_exact_content_free_page_witness() {
+    let db = mem_db();
+    let mut conn = db.lock();
+    let tx = conn.transaction().unwrap();
+    let row_id = insert_org_read_egress_dispatch_tx(
+        &tx,
+        11,
+        "relay.example",
+        "org_document_history_read",
+        "read-dispatch-1",
+        "org-1",
+        "doc-1",
+        200,
+        200,
+    )
+    .unwrap();
+    tx.commit().unwrap();
+    let witness: (String, String, String, String, i64, i64, i64) = conn
+        .query_row(
+            "SELECT host, kind, dispatch_id, org_id, since_seq, page_limit, byte_count
+               FROM share_egress_log WHERE id = ?1 AND doc_id = 'doc-1'",
+            rusqlite::params![row_id],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                ))
+            },
+        )
+        .unwrap();
+    assert_eq!(
+        witness,
+        (
+            "relay.example".into(),
+            "org_document_history_read".into(),
+            "read-dispatch-1".into(),
+            "org-1".into(),
+            200,
+            200,
+            0,
+        )
+    );
+}
+
+#[test]
+fn share_egress_dispatch_rejects_blank_identifiers_and_labels() {
+    let db = mem_db();
+    let mut conn = db.lock();
+    let tx = conn.transaction().unwrap();
+    for (host, kind, dispatch_id) in [
+        ("relay", "org_share_publish", "  "),
+        ("\t", "org_share_publish", "dispatch-host"),
+        ("relay", "\n", "dispatch-kind"),
+    ] {
+        assert!(matches!(
+            insert_share_egress_dispatch_tx(&tx, 1, host, kind, 0, dispatch_id),
+            Err(crate::error::AppError::InvalidArg(_))
+        ));
+    }
+    tx.rollback().unwrap();
+    let rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM share_egress_log", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert_eq!(rows, 0);
+}
+
 /// MODEL-SELECTION ATOMICITY: publishing a genuinely different embedder must never leave
 /// vectors produced by the previous model in any retrieval partition. Source chunks/FTS are
 /// intentionally retained by the production method; this focused test exercises the four
@@ -251,6 +572,10 @@ fn sha32(tag: u8) -> Vec<u8> {
     vec![tag; 32]
 }
 
+const STABLE_ORG_ID: &str = "11111111-1111-4111-8111-111111111111";
+const STABLE_DOC_ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const STABLE_DOC_RACE_ID: &str = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
 /// Join `org_id` locally (enabled by default) — the retrieval legs INNER JOIN `org_state`
 /// (per-instance org toggle), so any test that ingests `org_items` directly must seed this first,
 /// mirroring how production content can never exist without a prior join.
@@ -266,6 +591,1946 @@ fn seed_org_state(db: &Db, org_id: &str) {
         context_enabled: true,
     })
     .unwrap();
+}
+
+#[test]
+fn republish_projection_is_full_witness_monotonic_and_purges_all_older_plaintext() {
+    let db = mem_db();
+    seed_org_state(&db, STABLE_ORG_ID);
+    db.insert_org_share(
+        "share-projection",
+        STABLE_ORG_ID,
+        None,
+        Some("source-projection"),
+        "note",
+        Some("Title"),
+        3,
+        1,
+        &sha32(3),
+        "2026-08-13T00:00:00Z",
+    )
+    .unwrap();
+    db.lock()
+        .execute(
+            "UPDATE org_shares SET state='uploaded', item_id='head-r3', doc_id=?2,
+                    access='edit', dispatch_id='dispatch-r3',
+                    expected_actor_user_id='owner', expected_owner_user_id='owner'
+              WHERE id=?1",
+            rusqlite::params!["share-projection", STABLE_DOC_ID],
+        )
+        .unwrap();
+    for (item, seq, rev) in [("head-r1", 1_u64, 1_u32), ("head-r2", 2, 2)] {
+        db.upsert_org_item(
+            item,
+            STABLE_ORG_ID,
+            seq,
+            "owner",
+            item,
+            &format!("plaintext-{item}"),
+            "2026-08-13T00:00:00Z",
+            rev,
+            1,
+            &sha32(rev as u8),
+            None,
+            Some("owner"),
+            None,
+        )
+        .unwrap();
+        db.set_org_item_document_metadata(item, Some(STABLE_DOC_ID), "edit", Some("owner"))
+            .unwrap();
+    }
+    db.repair_org_reconcile_metadata(
+        "head-r2",
+        STABLE_ORG_ID,
+        1,
+        Some(STABLE_DOC_ID),
+        "edit",
+        Some("owner"),
+        true,
+    )
+    .unwrap();
+    let prepared = Db::prepare_org_item_index("head-r3", "t", "plaintext-r3", None).unwrap();
+    let projection = crate::storage::org_store::OrgRepublishProjection {
+        item_id: "head-r3",
+        seq: 3,
+        author_hint: "owner",
+        title: "head-r3",
+        markdown: "plaintext-r3",
+        created_at: "t",
+        source_kind: None,
+        author_user_id: Some("owner"),
+        prepared: &prepared,
+        attachments: &[],
+    };
+    assert!(db
+        .commit_org_republish_projection_if_current(
+            "share-projection",
+            "dispatch-r3",
+            STABLE_ORG_ID,
+            STABLE_DOC_ID,
+            "edit",
+            3,
+            1,
+            &sha32(3),
+            "owner",
+            "owner",
+            None,
+            None,
+            false,
+            &projection,
+        )
+        .unwrap()
+        .changed);
+    for old in ["head-r1", "head-r2"] {
+        let (tombstoned, title, markdown): (i64, String, String) = db
+            .lock()
+            .query_row(
+                "SELECT tombstoned,title,markdown FROM org_items WHERE item_id=?1",
+                [old],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!((tombstoned, title, markdown), (1, String::new(), String::new()));
+    }
+
+    let newer = Db::prepare_org_item_index("head-r4", "t", "newer", None).unwrap();
+    db.commit_local_org_replica_with_metadata(
+        "head-r4", STABLE_ORG_ID, 4, "owner", "head-r4", "newer", "t", 4, 1,
+        &sha32(4), None, Some("owner"), &newer, None, Some(STABLE_DOC_ID), "edit",
+        Some("owner"), true,
+    )
+    .unwrap();
+    assert!(!db
+        .commit_org_republish_projection_if_current(
+            "share-projection", "dispatch-r3", STABLE_ORG_ID, STABLE_DOC_ID, "edit", 3, 1,
+            &sha32(3), "owner", "owner", None, None, false, &projection,
+        )
+        .unwrap()
+        .changed);
+    assert_eq!(
+        db.current_org_document_status(STABLE_ORG_ID, STABLE_DOC_ID)
+            .unwrap()
+            .unwrap()
+            .0,
+        "head-r4"
+    );
+}
+
+#[test]
+fn republish_projection_repairs_same_seq_attachment_bundle_before_clearing_journal() {
+    let db = mem_db();
+    seed_org_state(&db, STABLE_ORG_ID);
+    db.insert_org_share("share-repair", STABLE_ORG_ID, None, Some("source"), "note",
+        Some("Title"), 2, 1, &sha32(2), "t").unwrap();
+    db.lock().execute(
+        "UPDATE org_shares SET state='failed',last_error='projection_pending',item_id='head-r2',
+          doc_id=?2,access='edit',dispatch_id='dispatch-r2',expected_actor_user_id='owner',
+          expected_owner_user_id='owner' WHERE id=?1",
+        rusqlite::params!["share-repair",STABLE_DOC_ID],
+    ).unwrap();
+    let prepared = Db::prepare_org_item_index("Title", "t", "body", None).unwrap();
+    db.upsert_org_item("head-r2", STABLE_ORG_ID, 2, "owner", "Title", "body", "t",
+        2, 1, &sha32(2), None, Some("owner"), None).unwrap();
+    db.set_org_item_document_metadata("head-r2", Some(STABLE_DOC_ID), "edit", Some("owner")).unwrap();
+    db.replace_org_item_attachment_bundle("head-r2", &[crate::storage::IncomingAttachment {
+        id: "stale".into(), mime_type: "image/png".into(), extension: "png".into(),
+        width: 1, height: 1, sha256: [1;32], data: vec![1],
+    }]).unwrap();
+    db.lock().execute("UPDATE org_items SET projection_sha256=NULL WHERE item_id='head-r2'", []).unwrap();
+    let exact = crate::storage::IncomingAttachment {
+        id: "exact".into(), mime_type: "image/png".into(), extension: "png".into(),
+        width: 2, height: 2, sha256: [2;32], data: vec![2,2],
+    };
+    let exact_attachments = vec![exact];
+    let projection = crate::storage::org_store::OrgRepublishProjection {
+        item_id: "head-r2", seq: 2, author_hint: "owner", title: "Title", markdown: "body",
+        created_at: "t", source_kind: None, author_user_id: Some("owner"), prepared: &prepared,
+        attachments: &exact_attachments,
+    };
+    assert!(db.commit_org_republish_projection_if_current(
+        "share-repair","dispatch-r2",STABLE_ORG_ID,STABLE_DOC_ID,"edit",2,1,&sha32(2),
+        "owner","owner",Some("head-r2"),Some("projection_pending"),false,&projection,
+    ).unwrap().changed);
+    let conn = db.lock();
+    assert_eq!(conn.query_row("SELECT group_concat(id) FROM note_attachments WHERE org_item_id='head-r2'", [], |r| r.get::<_,String>(0)).unwrap(), "exact");
+    assert!(conn.query_row("SELECT projection_sha256=?2 FROM org_items WHERE item_id=?1",
+        rusqlite::params!["head-r2",sha32(2)], |r| r.get::<_,bool>(0)).unwrap());
+    assert_eq!(conn.query_row("SELECT state FROM org_shares WHERE id='share-repair'", [], |r| r.get::<_,String>(0)).unwrap(), "uploaded");
+}
+
+#[test]
+fn org_source_counters_are_atomic_row_local_and_debounce_only_invalidates() {
+    let db = mem_db();
+    seed_folder(&db, "f-source", "Source");
+    db.insert_note(
+        "n-source", "f-source", "source", "Title", "A", 1,
+    )
+    .unwrap();
+    for id in ["share-a", "share-b"] {
+        db.insert_org_share(
+            id, STABLE_ORG_ID, None, Some("n-source"), "note", Some("Title"), 1, 1,
+            &sha32(1), "2026-08-13T00:00:00Z",
+        )
+        .unwrap();
+        db.set_org_share_uploaded(id, &format!("item-{id}"), "t")
+            .unwrap();
+    }
+    db.update_note_row_debounced("n-source", "Title", "draft", 2)
+        .unwrap();
+    for id in ["share-a", "share-b"] {
+        assert_eq!(db.org_share_source_counters(id).unwrap(), (1, 0));
+    }
+    db.update_note_row("n-source", "Title", "committed", 3)
+        .unwrap();
+    for id in ["share-a", "share-b"] {
+        assert_eq!(db.org_share_source_counters(id).unwrap(), (2, 1));
+    }
+
+    db.lock()
+        .execute_batch(
+            "CREATE TRIGGER fail_dirty BEFORE UPDATE OF republish_dirty ON org_shares
+               BEGIN SELECT RAISE(ABORT, 'fail dirty'); END;",
+        )
+        .unwrap();
+    assert!(db
+        .update_note_row("n-source", "Title", "must-roll-back", 4)
+        .is_err());
+    assert_eq!(db.get_note_row("n-source").unwrap().unwrap().text, "committed");
+}
+
+#[test]
+fn attachment_updates_advance_old_and_new_source_witnesses_atomically() {
+    let db = mem_db();
+    seed_folder(&db, "f-attachment-update", "Attachment update");
+    db.insert_note(
+        "n-attachment-old",
+        "f-attachment-update",
+        "source",
+        "Old",
+        "body",
+        1,
+    )
+    .unwrap();
+    db.insert_note(
+        "n-attachment-new",
+        "f-attachment-update",
+        "source",
+        "New",
+        "body",
+        1,
+    )
+    .unwrap();
+    db.lock()
+        .execute(
+            "INSERT INTO note_attachments
+               (id,document_id,mime_type,extension,byte_len,width,height,sha256,data,created_at)
+             VALUES('attachment-update','n-attachment-old','image/png','png',1,1,1,?1,?2,1)",
+            rusqlite::params![sha32(1), vec![1_u8]],
+        )
+        .unwrap();
+
+    for (share_id, document_id) in [
+        ("share-attachment-old", "n-attachment-old"),
+        ("share-attachment-new", "n-attachment-new"),
+    ] {
+        db.insert_org_share(
+            share_id,
+            STABLE_ORG_ID,
+            None,
+            Some(document_id),
+            "note",
+            Some("Title"),
+            1,
+            1,
+            &sha32(1),
+            "t",
+        )
+        .unwrap();
+        db.set_org_share_uploaded(share_id, &format!("item-{share_id}"), "t")
+            .unwrap();
+    }
+
+    db.lock()
+        .execute(
+            "UPDATE note_attachments SET data=?2,sha256=?3,byte_len=2 WHERE id=?1",
+            rusqlite::params!["attachment-update", vec![2_u8, 2], sha32(2)],
+        )
+        .unwrap();
+    assert_eq!(
+        db.org_share_source_counters("share-attachment-old")
+            .unwrap(),
+        (1, 1)
+    );
+    assert_eq!(
+        db.org_share_source_counters("share-attachment-new")
+            .unwrap(),
+        (0, 0)
+    );
+
+    db.lock()
+        .execute(
+            "UPDATE note_attachments SET document_id='n-attachment-new' WHERE id='attachment-update'",
+            [],
+        )
+        .unwrap();
+    assert_eq!(
+        db.org_share_source_counters("share-attachment-old")
+            .unwrap(),
+        (2, 2)
+    );
+    assert_eq!(
+        db.org_share_source_counters("share-attachment-new")
+            .unwrap(),
+        (1, 1)
+    );
+
+    db.lock()
+        .execute_batch(
+            "CREATE TRIGGER fail_attachment_source_witness
+               BEFORE UPDATE OF source_version ON org_shares
+               WHEN NEW.id='share-attachment-new'
+               BEGIN SELECT RAISE(ABORT, 'fail attachment witness'); END;",
+        )
+        .unwrap();
+    assert!(db
+        .lock()
+        .execute(
+            "UPDATE note_attachments SET mime_type='image/jpeg' WHERE id='attachment-update'",
+            [],
+        )
+        .is_err());
+    assert_eq!(
+        db.lock()
+            .query_row(
+                "SELECT mime_type FROM note_attachments WHERE id='attachment-update'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .unwrap(),
+        "image/png"
+    );
+}
+
+#[test]
+fn storage_foundation_keeps_new_permission_and_link_fields_off_the_base_ipc_wire() {
+    let detail = crate::storage::models::OrgItemDetail {
+        item_id: "item".into(),
+        doc_id: Some(STABLE_DOC_ID.into()),
+        link_id: Some(format!("{STABLE_ORG_ID}:{STABLE_DOC_ID}")),
+        author_hint: "author".into(),
+        title: "Title".into(),
+        created_at: "t".into(),
+        rev: 1,
+        markdown: "body".into(),
+        editable: true,
+        access: "edit".into(),
+        can_edit: true,
+        can_manage: true,
+    };
+    let detail = serde_json::to_value(detail).unwrap();
+    for key in ["docId", "linkId", "access", "canEdit", "canManage"] {
+        assert!(detail.get(key).is_none(), "foundation leaked {key} onto IPC");
+    }
+    assert_eq!(detail.get("editable"), Some(&serde_json::json!(true)));
+
+    let header = crate::storage::models::OrgItemHeader {
+        item_id: "item".into(),
+        doc_id: Some(STABLE_DOC_ID.into()),
+        title: "Title".into(),
+        author_hint: "author".into(),
+        created_at: "t".into(),
+        seq: 1,
+        kind: None,
+        owned_source: None,
+    };
+    assert!(serde_json::to_value(header).unwrap().get("docId").is_none());
+
+    let edge = crate::storage::models::LinkEdge {
+        id: 1,
+        direction: "out".into(),
+        other_kind: "org".into(),
+        other_id: format!("{STABLE_ORG_ID}:{STABLE_DOC_ID}"),
+        navigation_id: Some("item".into()),
+        other_title: "Title".into(),
+        edge_type: "manual".into(),
+        created_by: "user".into(),
+        status: "active".into(),
+        score: 1.0,
+        created_at: 1,
+        manual: true,
+        manual_edges: vec![crate::storage::models::ManualLinkEdge {
+            src_kind: "note".into(),
+            src_id: "source".into(),
+            dst_kind: "org".into(),
+            dst_id: format!("{STABLE_ORG_ID}:{STABLE_DOC_ID}"),
+        }],
+    };
+    let edge = serde_json::to_value(edge).unwrap();
+    assert!(edge.get("navigationId").is_none());
+    assert!(edge.get("manualEdges").is_none());
+
+    let target = crate::storage::models::WikiTarget {
+        kind: "org".into(),
+        id: "item".into(),
+        stable_id: Some(format!("{STABLE_ORG_ID}:{STABLE_DOC_ID}")),
+    };
+    assert!(serde_json::to_value(target)
+        .unwrap()
+        .get("stableId")
+        .is_none());
+}
+
+/// RED before UUID admission: malformed stable identities advanced the feed cursor and persisted a
+/// plaintext replica whose later link identity could never be constructed. Validation must happen
+/// before either mutation, while the historical no-docId feed shape remains ingestible.
+#[test]
+fn stable_org_document_uuid_admission_precedes_storage_mutation() {
+    const ORG_ID: &str = "11111111-1111-4111-8111-111111111111";
+    const DOC_ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+    let db = mem_db();
+    seed_org_state(&db, ORG_ID);
+    let prepared = Db::prepare_org_item_index("Title", "t", "body", None).unwrap();
+    let malformed_doc = db.commit_org_feed_item_with_metadata(
+        "bad-doc-item",
+        ORG_ID,
+        1,
+        "owner",
+        "Title",
+        "body",
+        "2026-08-13T00:00:00Z",
+        1,
+        1,
+        &sha32(1),
+        None,
+        Some("owner"),
+        &prepared,
+        Some("not-a-uuid"),
+        "view",
+        Some("owner"),
+        true,
+    );
+    assert!(matches!(
+        malformed_doc,
+        Err(crate::error::AppError::InvalidArg(_))
+    ));
+    assert_eq!(db.org_last_seq_for(ORG_ID).unwrap(), 0);
+    assert!(db.org_replica_state("bad-doc-item").unwrap().is_none());
+
+    seed_org_state(&db, "not-an-org-uuid");
+    let malformed_org = db.commit_org_feed_item_with_metadata(
+        "bad-org-item",
+        "not-an-org-uuid",
+        1,
+        "owner",
+        "Title",
+        "body",
+        "2026-08-13T00:00:00Z",
+        1,
+        1,
+        &sha32(2),
+        None,
+        Some("owner"),
+        &prepared,
+        Some(DOC_ID),
+        "view",
+        Some("owner"),
+        true,
+    );
+    assert!(matches!(
+        malformed_org,
+        Err(crate::error::AppError::InvalidArg(_))
+    ));
+    assert_eq!(db.org_last_seq_for("not-an-org-uuid").unwrap(), 0);
+    assert!(db.org_replica_state("bad-org-item").unwrap().is_none());
+
+    db.insert_org_share(
+        "share-uuid-admission",
+        ORG_ID,
+        None,
+        Some("local-note"),
+        "note",
+        Some("Local"),
+        1,
+        1,
+        &sha32(3),
+        "2026-08-13T00:00:00Z",
+    )
+    .unwrap();
+    assert!(matches!(
+        db.set_org_share_document_metadata("share-uuid-admission", "not-a-uuid", "edit"),
+        Err(crate::error::AppError::InvalidArg(_))
+    ));
+    let stored_share_doc: Option<String> = db
+        .lock()
+        .query_row(
+            "SELECT doc_id FROM org_shares WHERE id = 'share-uuid-admission'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(stored_share_doc, None);
+
+    assert!(
+        db.commit_org_feed_item_with_metadata(
+            "valid-stable-item",
+            ORG_ID,
+            1,
+            "owner",
+            "Title",
+            "body",
+            "2026-08-13T00:00:00Z",
+            1,
+            1,
+            &sha32(3),
+            None,
+            Some("owner"),
+            &prepared,
+            Some(DOC_ID),
+            "view",
+            Some("owner"),
+            true,
+        )
+        .unwrap()
+        .changed
+    );
+    assert_eq!(db.org_last_seq_for(ORG_ID).unwrap(), 1);
+    assert_eq!(
+        db.org_item_edit_ctx("valid-stable-item")
+            .unwrap()
+            .unwrap()
+            .doc_id
+            .as_deref(),
+        Some(DOC_ID)
+    );
+    assert!(matches!(
+        db.set_org_item_document_metadata(
+            "valid-stable-item",
+            Some("not-a-uuid"),
+            "edit",
+            Some("owner")
+        ),
+        Err(crate::error::AppError::InvalidArg(_))
+    ));
+    let unchanged = db.org_item_edit_ctx("valid-stable-item").unwrap().unwrap();
+    assert_eq!(unchanged.doc_id.as_deref(), Some(DOC_ID));
+    assert_eq!(unchanged.access, "view");
+
+    assert!(
+        db.commit_org_feed_item_with_metadata(
+            "legacy-item",
+            "not-an-org-uuid",
+            1,
+            "owner",
+            "Legacy",
+            "body",
+            "2026-08-13T00:00:01Z",
+            1,
+            1,
+            &sha32(4),
+            None,
+            Some("owner"),
+            &Db::prepare_org_item_index("Legacy", "t", "body", None).unwrap(),
+            None,
+            "view",
+            None,
+            false,
+        )
+        .unwrap()
+        .changed
+    );
+    assert!(db.org_replica_state("legacy-item").unwrap().is_some());
+}
+
+#[test]
+fn org_link_identity_isolated_by_org_and_follows_current_revision() {
+    let db = mem_db();
+    let org_a = "11111111-1111-4111-8111-111111111111";
+    let org_b = "22222222-2222-4222-8222-222222222222";
+    let doc = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    let endpoint_a = format!("{org_a}:{doc}");
+    let endpoint_b = format!("{org_b}:{doc}");
+    seed_org_state(&db, org_a);
+    seed_org_state(&db, org_b);
+    for (item, org, title, seq) in [
+        ("a-old", org_a, "A old", 1),
+        ("a-new", org_a, "A current", 2),
+        ("b-item", org_b, "B current", 1),
+    ] {
+        db.upsert_org_item(
+            item,
+            org,
+            seq,
+            "owner",
+            title,
+            "body",
+            "2026-08-12T00:00:00Z",
+            seq as u32,
+            1,
+            &sha32(seq as u8),
+            None,
+            Some("owner"),
+            None,
+        )
+        .unwrap();
+        db.set_org_item_document_metadata(item, Some(doc), "view", Some("owner"))
+            .unwrap();
+    }
+    db.repair_org_reconcile_metadata("a-new", org_a, 1, Some(doc), "view", Some("owner"), true)
+        .unwrap();
+    db.repair_org_reconcile_metadata("b-item", org_b, 1, Some(doc), "view", Some("owner"), true)
+        .unwrap();
+
+    assert_eq!(
+        db.org_link_target_visible(&endpoint_a).unwrap(),
+        Some(("a-new".into(), "A current".into()))
+    );
+    assert_eq!(
+        db.org_link_target_visible(&endpoint_b).unwrap(),
+        Some(("b-item".into(), "B current".into()))
+    );
+
+    db.upsert_manual_link("org", &endpoint_a, "org", &endpoint_b)
+        .expect("view-only current org documents are valid private link endpoints");
+    let before_revision = db
+        .links_for_visible(crate::links::LinkKind::Org, &endpoint_b, &HashSet::new())
+        .unwrap();
+    assert_eq!(before_revision.len(), 1);
+    assert_eq!(before_revision[0].other_id, endpoint_a);
+    assert_eq!(before_revision[0].navigation_id.as_deref(), Some("a-new"));
+    assert_eq!(before_revision[0].other_title, "A current");
+
+    db.upsert_org_item(
+        "a-next",
+        org_a,
+        3,
+        "owner",
+        "A next",
+        "body",
+        "2026-08-12T00:00:01Z",
+        3,
+        1,
+        &sha32(3),
+        None,
+        Some("owner"),
+        None,
+    )
+    .unwrap();
+    db.set_org_item_document_metadata("a-next", Some(doc), "view", Some("owner"))
+        .unwrap();
+    db.repair_org_reconcile_metadata("a-next", org_a, 1, Some(doc), "view", Some("owner"), true)
+        .unwrap();
+    let after_revision = db
+        .links_for_visible(crate::links::LinkKind::Org, &endpoint_b, &HashSet::new())
+        .unwrap();
+    assert_eq!(after_revision.len(), 1);
+    assert_eq!(
+        after_revision[0].other_id, endpoint_a,
+        "the stored edge identity must remain the stable org+document composite"
+    );
+    assert_eq!(
+        after_revision[0].navigation_id.as_deref(),
+        Some("a-next"),
+        "navigation must follow the authoritative current revision"
+    );
+    assert_eq!(after_revision[0].other_title, "A next");
+    assert_eq!(
+        manual_link_tuple_count(&db, "org", &endpoint_a, "org", &endpoint_b),
+        1
+    );
+
+    db.set_org_context_enabled(org_a, false).unwrap();
+    assert_eq!(
+        db.org_link_target_visible(&endpoint_a).unwrap(),
+        None,
+        "context disable must hide the endpoint"
+    );
+    assert_eq!(
+        link_count(&db, "org", &endpoint_a, "manual"),
+        1,
+        "context disable must preserve the private edge for reversible re-enable"
+    );
+    assert!(
+        db.links_for_visible(crate::links::LinkKind::Org, &endpoint_b, &HashSet::new(),)
+            .unwrap()
+            .is_empty(),
+        "a visible endpoint must not reveal a context-disabled neighbour"
+    );
+    db.set_org_context_enabled(org_a, true).unwrap();
+    assert_eq!(
+        db.org_link_target_visible(&endpoint_a).unwrap(),
+        Some(("a-next".into(), "A next".into()))
+    );
+    db.evict_org_item("a-old").unwrap();
+    db.evict_org_item("a-new").unwrap();
+    assert_eq!(link_count(&db, "org", &endpoint_a, "manual"), 1);
+    db.evict_org_item("a-next").unwrap();
+    assert_eq!(
+        link_count(&db, "org", &endpoint_a, "manual"),
+        1,
+        "final withdrawal withholds rather than destroys a private link"
+    );
+    assert!(db.org_link_target_visible(&endpoint_a).unwrap().is_none());
+}
+
+#[test]
+fn manual_org_links_accept_view_only_same_and_cross_org_but_refuse_noncurrent_head() {
+    let db = mem_db();
+    let org_a = "11111111-1111-4111-8111-111111111111";
+    let org_b = "22222222-2222-4222-8222-222222222222";
+    let doc_a = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    let doc_same_org = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    let doc_cross_org = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+    let doc_noncurrent = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+    seed_org_state(&db, org_a);
+    seed_org_state(&db, org_b);
+
+    for (seq, item_id, org_id, doc_id, is_current) in [
+        (1, "a-view", org_a, doc_a, true),
+        (2, "a-other-view", org_a, doc_same_org, true),
+        (3, "b-view", org_b, doc_cross_org, true),
+        (4, "a-obsolete", org_a, doc_noncurrent, false),
+    ] {
+        db.upsert_org_item(
+            item_id,
+            org_id,
+            seq,
+            "owner",
+            item_id,
+            "body",
+            "2026-08-13T00:00:00Z",
+            1,
+            1,
+            &sha32(seq as u8),
+            None,
+            Some("owner"),
+            None,
+        )
+        .unwrap();
+        db.set_org_item_document_metadata(item_id, Some(doc_id), "view", Some("owner"))
+            .unwrap();
+        db.repair_org_reconcile_metadata(
+            item_id,
+            org_id,
+            1,
+            Some(doc_id),
+            "view",
+            Some("owner"),
+            is_current,
+        )
+        .unwrap();
+    }
+
+    let a = format!("{org_a}:{doc_a}");
+    let same_org = format!("{org_a}:{doc_same_org}");
+    let cross_org = format!("{org_b}:{doc_cross_org}");
+    let noncurrent = format!("{org_a}:{doc_noncurrent}");
+    db.upsert_manual_link("org", &a, "org", &same_org)
+        .expect("view permission is sufficient for a same-org private link");
+    db.upsert_manual_link("org", &same_org, "org", &cross_org)
+        .expect("view permission is sufficient for a cross-org private link");
+    assert_eq!(manual_link_tuple_count(&db, "org", &a, "org", &same_org), 1);
+    assert_eq!(
+        manual_link_tuple_count(&db, "org", &same_org, "org", &cross_org),
+        1
+    );
+
+    assert!(matches!(
+        db.upsert_manual_link("org", &noncurrent, "org", &a),
+        Err(crate::error::AppError::Locked(_))
+    ));
+    assert_eq!(
+        manual_link_tuple_count(&db, "org", &noncurrent, "org", &a),
+        0,
+        "a live but non-current revision must fail the in-transaction endpoint gate"
+    );
+}
+
+#[test]
+fn bidirectional_org_manual_links_preserve_and_delete_exact_directed_tuples() {
+    let db = mem_db();
+    let org_id = "11111111-1111-4111-8111-111111111111";
+    let left_doc = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    let right_doc = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    seed_org_state(&db, org_id);
+    for (seq, item_id, doc_id) in [
+        (1, "left-current", left_doc),
+        (2, "right-current", right_doc),
+    ] {
+        db.upsert_org_item(
+            item_id,
+            org_id,
+            seq,
+            "owner",
+            item_id,
+            "body",
+            "2026-08-13T00:00:00Z",
+            1,
+            1,
+            &sha32(seq as u8),
+            None,
+            Some("owner"),
+            None,
+        )
+        .unwrap();
+        db.set_org_item_document_metadata(item_id, Some(doc_id), "view", Some("owner"))
+            .unwrap();
+        db.repair_org_reconcile_metadata(
+            item_id,
+            org_id,
+            1,
+            Some(doc_id),
+            "view",
+            Some("owner"),
+            true,
+        )
+        .unwrap();
+    }
+    let left = format!("{org_id}:{left_doc}");
+    let right = format!("{org_id}:{right_doc}");
+    let forward = crate::storage::models::ManualLinkEdge {
+        src_kind: "org".into(),
+        src_id: left.clone(),
+        dst_kind: "org".into(),
+        dst_id: right.clone(),
+    };
+    let reverse = crate::storage::models::ManualLinkEdge {
+        src_kind: "org".into(),
+        src_id: right.clone(),
+        dst_kind: "org".into(),
+        dst_id: left.clone(),
+    };
+
+    db.upsert_manual_link("org", &left, "org", &right).unwrap();
+    db.upsert_manual_link("org", &right, "org", &left).unwrap();
+    let collapsed = db
+        .links_for_visible(crate::links::LinkKind::Org, &left, &HashSet::new())
+        .unwrap();
+    assert_eq!(collapsed.len(), 1, "two directions collapse to one chip");
+    assert!(collapsed[0].manual_edges.contains(&forward));
+    assert!(collapsed[0].manual_edges.contains(&reverse));
+
+    db.delete_manual_link("org", &left, "org", &right).unwrap();
+    assert_eq!(manual_link_tuple_count(&db, "org", &left, "org", &right), 0);
+    assert_eq!(
+        manual_link_tuple_count(&db, "org", &right, "org", &left),
+        1,
+        "deleting one direction must preserve the reverse exact tuple"
+    );
+
+    db.upsert_manual_link("org", &left, "org", &right).unwrap();
+    assert!(!db
+        .delete_manual_links(&[forward.clone(), reverse.clone()])
+        .unwrap());
+    assert_eq!(manual_link_tuple_count(&db, "org", &left, "org", &right), 0);
+    assert_eq!(manual_link_tuple_count(&db, "org", &right, "org", &left), 0);
+}
+
+#[test]
+fn leaving_org_preserves_private_composite_link_rows_but_withholds_endpoint() {
+    let db = mem_db();
+    let org_a = "11111111-1111-4111-8111-111111111111";
+    let org_b = "22222222-2222-4222-8222-222222222222";
+    let doc_a = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    let doc_b = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    seed_org_state(&db, org_a);
+    seed_org_state(&db, org_b);
+    for (item, org, doc) in [("a", org_a, doc_a), ("b", org_b, doc_b)] {
+        db.upsert_org_item(
+            item,
+            org,
+            1,
+            "owner",
+            item,
+            "body",
+            "2026-08-12T00:00:00Z",
+            1,
+            1,
+            &sha32(1),
+            None,
+            Some("owner"),
+            None,
+        )
+        .unwrap();
+        db.set_org_item_document_metadata(item, Some(doc), "view", Some("owner"))
+            .unwrap();
+        db.repair_org_reconcile_metadata(item, org, 1, Some(doc), "view", Some("owner"), true)
+            .unwrap();
+    }
+    let endpoint_a = format!("{org_a}:{doc_a}");
+    let endpoint_b = format!("{org_b}:{doc_b}");
+    db.upsert_manual_link("org", &endpoint_a, "org", &endpoint_b)
+        .unwrap();
+
+    assert!(db.delete_org_state(org_a).unwrap());
+    assert_eq!(
+        link_count(&db, "org", &endpoint_a, "manual"),
+        1,
+        "leaving must preserve the user's opaque private graph row"
+    );
+    assert!(
+        db.links_for_visible(crate::links::LinkKind::Org, &endpoint_a, &HashSet::new())
+            .unwrap()
+            .is_empty(),
+        "the preserved row must remain completely withheld without membership"
+    );
+    assert!(
+        db.links_for_visible(crate::links::LinkKind::Org, &endpoint_b, &HashSet::new())
+            .unwrap()
+            .is_empty(),
+        "a still-joined org must not reveal a neighbour from an org this device left"
+    );
+    assert_eq!(
+        db.org_link_target_visible(&endpoint_b).unwrap(),
+        Some(("b".into(), "b".into())),
+        "leaving one org must not evict another org reusing the link domain"
+    );
+}
+
+/// An item's OCK generation is a historical encryption-key witness, not a requirement that the
+/// locally cached membership generation still equal it. A rotated member may receive an older live
+/// feed cell after learning generation N. Disabling Shared Brain context hides reads, but must not
+/// stall the append-only cursor or discard ciphertext that becomes readable again on re-enable.
+#[test]
+fn historical_generation_and_disabled_context_feed_commit_converge_without_visibility() {
+    let db = mem_db();
+    seed_org_state(&db, STABLE_ORG_ID);
+    db.set_org_generation(STABLE_ORG_ID, 2).unwrap();
+    db.set_org_context_enabled(STABLE_ORG_ID, false).unwrap();
+    let prepared = Db::prepare_org_item_index("Historical", "t", "private history", None).unwrap();
+
+    let outcome = db
+        .commit_org_feed_item_with_metadata(
+            "historical-item",
+            STABLE_ORG_ID,
+            7,
+            "owner",
+            "Historical",
+            "private history",
+            "2026-08-13T00:00:00Z",
+            1,
+            1,
+            &sha32(7),
+            None,
+            Some("owner"),
+            &prepared,
+            Some(STABLE_DOC_ID),
+            "view",
+            Some("owner"),
+            true,
+        )
+        .unwrap();
+
+    assert!(
+        outcome.changed,
+        "generation N-1 must ingest under membership N"
+    );
+    assert_eq!(
+        db.org_last_seq_for(STABLE_ORG_ID).unwrap(),
+        7,
+        "context disable must not stall the durable feed cursor"
+    );
+    assert!(
+        db.get_org_item("historical-item").unwrap().is_none(),
+        "disabled context must withhold the locally converged plaintext"
+    );
+    assert!(
+        db.search_org_chunks_fts("private history", 10)
+            .unwrap()
+            .is_empty(),
+        "disabled context must also withhold retrieval"
+    );
+
+    db.set_org_context_enabled(STABLE_ORG_ID, true).unwrap();
+    assert_eq!(
+        db.get_org_item("historical-item")
+            .unwrap()
+            .map(|item| item.title),
+        Some("Historical".into()),
+        "re-enable restores the already-converged replica without a replay"
+    );
+
+    let future = Db::prepare_org_item_index("Future", "t", "future body", None).unwrap();
+    let future_outcome = db
+        .commit_org_feed_item_with_metadata(
+            "future-item",
+            STABLE_ORG_ID,
+            8,
+            "owner",
+            "Future",
+            "future body",
+            "2026-08-13T00:00:01Z",
+            1,
+            3,
+            &sha32(8),
+            None,
+            Some("owner"),
+            &future,
+            None,
+            "view",
+            None,
+            false,
+        )
+        .unwrap();
+    assert!(
+        !future_outcome.changed,
+        "a future generation is not yet admissible"
+    );
+    assert_eq!(db.org_last_seq_for(STABLE_ORG_ID).unwrap(), 7);
+}
+
+/// A predecessor tombstone can arrive before this client can open/ingest the successor. The stable
+/// endpoint must be withheld during that gap, not destructively erased from the user's private graph;
+/// once the successor lands, the exact row becomes visible again without reconstruction.
+#[test]
+fn predecessor_tombstone_withholds_stable_link_until_successor_ingest() {
+    let db = mem_db();
+    let org_id = "11111111-1111-4111-8111-111111111111";
+    let doc_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    let endpoint = format!("{org_id}:{doc_id}");
+    seed_org_state(&db, org_id);
+    let old = Db::prepare_org_item_index("Old", "t", "old body", None).unwrap();
+    db.commit_org_feed_item_with_metadata(
+        "old-item",
+        org_id,
+        1,
+        "owner",
+        "Old",
+        "old body",
+        "2026-08-13T00:00:00Z",
+        1,
+        1,
+        &sha32(1),
+        None,
+        Some("owner"),
+        &old,
+        Some(doc_id),
+        "edit",
+        Some("owner"),
+        true,
+    )
+    .unwrap();
+    db.upsert_manual_link("org", &endpoint, "meeting", "local-anchor")
+        .unwrap();
+
+    assert!(db.commit_org_feed_tombstone(org_id, "old-item", 2).unwrap());
+    assert_eq!(
+        link_count(&db, "org", &endpoint, "manual"),
+        1,
+        "the opaque user edge survives the unavailable-successor gap"
+    );
+    assert!(db.org_link_target_visible(&endpoint).unwrap().is_none());
+
+    let next = Db::prepare_org_item_index("Current", "t", "current body", None).unwrap();
+    db.commit_org_feed_item_with_metadata(
+        "current-item",
+        org_id,
+        3,
+        "owner",
+        "Current",
+        "current body",
+        "2026-08-13T00:00:02Z",
+        2,
+        1,
+        &sha32(2),
+        None,
+        Some("editor"),
+        &next,
+        Some(doc_id),
+        "edit",
+        Some("owner"),
+        true,
+    )
+    .unwrap();
+    assert_eq!(
+        db.org_link_target_visible(&endpoint).unwrap(),
+        Some(("current-item".into(), "Current".into()))
+    );
+    assert_eq!(link_count(&db, "org", &endpoint, "manual"), 1);
+}
+
+/// The narrow legacy single-edge API is a restore/retry primitive and therefore idempotent. The
+/// collapsed-chip batch API remains strict and atomic: one stale tuple rolls the complete set back.
+#[test]
+fn single_manual_delete_is_idempotent_while_collapsed_batch_stays_strict() {
+    let db = mem_db();
+    seed_folder(&db, "f1", "Notes");
+    seed_note_doc(&db, "left", "f1", "Left", "");
+    seed_note_doc(&db, "right", "f1", "Right", "");
+
+    db.upsert_manual_link("note", "left", "note", "right")
+        .unwrap();
+    db.delete_manual_link("note", "left", "note", "right")
+        .unwrap();
+    db.delete_manual_link("note", "left", "note", "right")
+        .expect("a restore/retry delete of the same single tuple is success");
+
+    let legacy_marker = crate::enrich::apply_link_markers(
+        "left prose",
+        &[crate::enrich::ContextHit {
+            source: "note".into(),
+            detail: "[[Right]]".into(),
+            url: None,
+        }],
+    );
+    db.set_document_text("left", &legacy_marker).unwrap();
+    db.set_note_doc_exported_path("left", Some("/vault/left.md"))
+        .unwrap();
+    db.delete_manual_link("note", "left", "note", "right")
+        .expect("missing-row retry still commits legacy marker cleanup");
+    let left_text: String = db
+        .lock()
+        .query_row("SELECT text FROM documents WHERE id = 'left'", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+    assert!(!left_text.contains("[[Right]]"));
+    let cleanup = db.pending_lock_marker_export_cleanup().unwrap();
+    assert!(cleanup.iter().any(|row| {
+        row.source_kind == "note"
+            && row.source_id == "left"
+            && row.exported_path == "/vault/left.md"
+    }));
+
+    db.upsert_manual_link("note", "left", "note", "right")
+        .unwrap();
+    db.upsert_manual_link("note", "right", "note", "left")
+        .unwrap();
+    db.delete_manual_link("note", "left", "note", "right")
+        .unwrap();
+    let requested = [
+        crate::storage::models::ManualLinkEdge {
+            src_kind: "note".into(),
+            src_id: "left".into(),
+            dst_kind: "note".into(),
+            dst_id: "right".into(),
+        },
+        crate::storage::models::ManualLinkEdge {
+            src_kind: "note".into(),
+            src_id: "right".into(),
+            dst_kind: "note".into(),
+            dst_id: "left".into(),
+        },
+    ];
+    assert!(db.delete_manual_links(&requested).is_err());
+    assert_eq!(
+        link_count(&db, "note", "right", "manual"),
+        1,
+        "strict batch failure rolls back the still-existing reverse tuple"
+    );
+}
+
+#[test]
+fn locked_manual_marker_cleanup_verifies_seal_before_atomic_replacement() {
+    let db = mem_db();
+    seed_folder(&db, "f-marker-seal", "Locked notes");
+    seed_note_doc(&db, "marker-left", "f-marker-seal", "Left", "");
+    seed_note_doc(&db, "marker-right", "f-marker-seal", "Right", "");
+    let marker = crate::enrich::apply_link_markers(
+        "left prose",
+        &[crate::enrich::ContextHit {
+            source: "note".into(),
+            detail: "[[Right]]".into(),
+            url: None,
+        }],
+    );
+    let stripped = crate::enrich::strip_managed_links_block(&marker);
+    db.set_document_text("marker-left", &marker).unwrap();
+    db.set_note_doc_exported_path("marker-left", Some("/vault/marker-left.md"))
+        .unwrap();
+    db.lock()
+        .execute_batch(
+            "UPDATE folders SET locked=1 WHERE id='f-marker-seal';
+             UPDATE documents SET text_blob=X'01' WHERE id='marker-left';",
+        )
+        .unwrap();
+    db.upsert_manual_link("note", "marker-left", "note", "marker-right")
+        .unwrap();
+
+    let edge = crate::storage::models::ManualLinkEdge {
+        src_kind: "note".into(),
+        src_id: "marker-left".into(),
+        dst_kind: "note".into(),
+        dst_id: "marker-right".into(),
+    };
+    let content_key = zeroize::Zeroizing::new([7_u8; 32]);
+    let aad = b"murmur:document:v1|folder=f-marker-seal|document=marker-left|type=document";
+    let blob = crate::crypto::encrypt(&content_key, stripped.as_bytes(), aad).unwrap();
+    let invalid = crate::storage::links::PreparedManualMarkerSeal {
+        note_id: "marker-left".into(),
+        folder_id: "f-marker-seal".into(),
+        stripped_text: stripped.clone(),
+        text_blob: blob.clone(),
+        content_key: zeroize::Zeroizing::new([8_u8; 32]),
+    };
+    assert!(db
+        .delete_manual_links_with_marker_seals(std::slice::from_ref(&edge), &[invalid])
+        .is_err());
+    assert_eq!(
+        db.get_note_row("marker-left").unwrap().unwrap().text,
+        marker,
+        "verification failure must preserve the only plaintext"
+    );
+    assert_eq!(link_count(&db, "note", "marker-left", "manual"), 1);
+    assert!(db.pending_lock_marker_export_cleanup().unwrap().is_empty());
+
+    let valid = crate::storage::links::PreparedManualMarkerSeal {
+        note_id: "marker-left".into(),
+        folder_id: "f-marker-seal".into(),
+        stripped_text: stripped.clone(),
+        text_blob: blob,
+        content_key: content_key.clone(),
+    };
+    assert!(db
+        .delete_manual_links_with_marker_seals(&[edge], &[valid])
+        .unwrap());
+    let stored = db.get_note_row("marker-left").unwrap().unwrap();
+    let stored_blob: Vec<u8> = db
+        .lock()
+        .query_row(
+            "SELECT text_blob FROM documents WHERE id='marker-left'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(
+        stored.text.is_empty(),
+        "a locked note must not retain plaintext beside its verified ciphertext"
+    );
+    assert_eq!(
+        crate::crypto::decrypt(&content_key, &stored_blob, aad).unwrap(),
+        stripped.as_bytes(),
+        "the committed locked representation must decrypt byte-identical"
+    );
+    assert_eq!(link_count(&db, "note", "marker-left", "manual"), 0);
+    assert_eq!(db.pending_lock_marker_export_cleanup().unwrap().len(), 1);
+}
+
+#[test]
+fn current_document_management_does_not_mutate_origin_cas_baseline() {
+    let db = mem_db();
+    seed_org_state(&db, STABLE_ORG_ID);
+    db.insert_org_share(
+        "share-1",
+        STABLE_ORG_ID,
+        None,
+        Some("local-note"),
+        "note",
+        Some("Local"),
+        1,
+        1,
+        &sha32(1),
+        "2026-08-12T00:00:00Z",
+    )
+    .unwrap();
+    db.set_org_share_uploaded("share-1", "old-item", "2026-08-12T00:00:01Z")
+        .unwrap();
+    db.set_org_share_document_metadata("share-1", STABLE_DOC_ID, "view")
+        .unwrap();
+    db.set_org_share_document_metadata("share-1", STABLE_DOC_ID, "edit")
+        .unwrap();
+    db.clear_org_share_document_metadata("share-1").unwrap();
+    let cleared = db.org_share_by_item("old-item").unwrap().unwrap();
+    assert_eq!(cleared.doc_id, None);
+    assert_eq!(cleared.access, "view");
+    db.set_org_share_document_metadata("share-1", STABLE_DOC_ID, "view")
+        .unwrap();
+
+    for (item, seq, rev, access) in [("old-item", 1, 1, "view"), ("remote-current", 2, 2, "edit")] {
+        db.upsert_org_item(
+            item,
+            STABLE_ORG_ID,
+            seq,
+            "owner",
+            item,
+            "body",
+            "2026-08-12T00:00:00Z",
+            rev,
+            1,
+            &sha32(rev as u8),
+            None,
+            Some("editor"),
+            None,
+        )
+        .unwrap();
+        db.set_org_item_document_metadata(item, Some(STABLE_DOC_ID), access, Some("owner"))
+            .unwrap();
+    }
+    db.repair_org_reconcile_metadata(
+        "remote-current",
+        STABLE_ORG_ID,
+        1,
+        Some(STABLE_DOC_ID),
+        "edit",
+        Some("owner"),
+        true,
+    )
+    .unwrap();
+    db.evict_org_item("old-item").unwrap();
+
+    // Local journal ids and relay item ids are separate namespaces. A colliding local id must not
+    // hijack a revoke request for the current relay item.
+    db.insert_org_share(
+        "remote-current",
+        STABLE_ORG_ID,
+        None,
+        Some("collision-source"),
+        "note",
+        Some("Unrelated"),
+        1,
+        1,
+        &sha32(9),
+        "2026-08-12T00:00:02Z",
+    )
+    .unwrap();
+    db.set_org_share_uploaded(
+        "remote-current",
+        "unrelated-relay-item",
+        "2026-08-12T00:00:03Z",
+    )
+    .unwrap();
+    db.set_org_share_document_metadata(
+        "remote-current",
+        "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        "view",
+    )
+    .unwrap();
+
+    assert_eq!(
+        db.current_org_document_status(STABLE_ORG_ID, STABLE_DOC_ID)
+            .unwrap(),
+        Some(("remote-current".into(), 2, "edit".into()))
+    );
+    assert!(db.org_share_by_item("remote-current").unwrap().is_none());
+    let management = db
+        .org_share_for_revoke_target("remote-current")
+        .unwrap()
+        .unwrap();
+    assert_eq!(management.id, "share-1");
+    assert_eq!(management.item_id.as_deref(), Some("old-item"));
+    assert_eq!(
+        management.rev, 1,
+        "remote feed must not rewrite expectedRev"
+    );
+
+    assert!(db.evict_org_document(STABLE_ORG_ID, STABLE_DOC_ID).unwrap());
+    assert!(db
+        .current_org_document_status(STABLE_ORG_ID, STABLE_DOC_ID)
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn org_access_attempts_are_exact_transactional_cas_across_failures_and_accounts() {
+    let db = mem_db();
+    seed_org_state(&db, STABLE_ORG_ID);
+    let actor = "c534b6d2-02c1-4c2c-a256-3af8592b1567";
+    let other_actor = "d645c7e3-13d2-4d3d-b367-4bf9603c2678";
+    db.upsert_org_item(
+        "access-head",
+        STABLE_ORG_ID,
+        1,
+        actor,
+        "Shared",
+        "body",
+        "2026-08-12T00:00:00Z",
+        1,
+        1,
+        &sha32(1),
+        None,
+        Some(actor),
+        None,
+    )
+    .unwrap();
+    db.set_org_item_document_metadata("access-head", Some(STABLE_DOC_ID), "edit", Some(actor))
+        .unwrap();
+    db.repair_org_reconcile_metadata(
+        "access-head",
+        STABLE_ORG_ID,
+        1,
+        Some(STABLE_DOC_ID),
+        "edit",
+        Some(actor),
+        true,
+    )
+    .unwrap();
+    db.insert_org_share(
+        "access-share",
+        STABLE_ORG_ID,
+        None,
+        Some("access-source"),
+        "note",
+        Some("Shared"),
+        1,
+        1,
+        &sha32(1),
+        "2026-08-12T00:00:00Z",
+    )
+    .unwrap();
+    db.set_org_share_uploaded("access-share", "access-head", "2026-08-12T00:00:01Z")
+        .unwrap();
+    db.set_org_share_document_metadata("access-share", STABLE_DOC_ID, "edit")
+        .unwrap();
+
+    let dispatch_1 = "11111111-2222-4333-8444-555555555555";
+    assert!(db
+        .persist_org_access_attempt_if_current(
+            1,
+            "relay.example",
+            dispatch_1,
+            STABLE_ORG_ID,
+            STABLE_DOC_ID,
+            "edit",
+            "view",
+            actor,
+            actor,
+            "2026-08-12T00:00:02Z",
+        )
+        .unwrap());
+    assert_eq!(db.pending_org_access_attempts().unwrap().len(), 1);
+    assert_eq!(db.count_share_egress_by_kind("org_share_access").unwrap(), 1);
+    assert!(!db
+        .persist_org_access_attempt_if_current(
+            2,
+            "relay.example",
+            dispatch_1,
+            STABLE_ORG_ID,
+            STABLE_DOC_ID,
+            "edit",
+            "view",
+            actor,
+            actor,
+            "2026-08-12T00:00:03Z",
+        )
+        .unwrap());
+    assert_eq!(
+        db.count_share_egress_by_kind("org_share_access").unwrap(),
+        1,
+        "a refused duplicate must roll its ledger insert back"
+    );
+    assert!(!db
+        .apply_org_access_attempt_if_current(
+            dispatch_1,
+            STABLE_ORG_ID,
+            STABLE_DOC_ID,
+            "edit",
+            "view",
+            other_actor,
+            actor,
+        )
+        .unwrap());
+    assert!(!db
+        .apply_org_access_attempt_if_current(
+            dispatch_1,
+            STABLE_ORG_ID,
+            "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            "edit",
+            "view",
+            actor,
+            actor,
+        )
+        .unwrap());
+
+    db.lock()
+        .execute_batch(
+            "CREATE TRIGGER abort_access_projection
+             BEFORE UPDATE OF access ON org_items
+             BEGIN SELECT RAISE(ABORT, 'access projection fault'); END;",
+        )
+        .unwrap();
+    assert!(db
+        .apply_org_access_attempt_if_current(
+            dispatch_1,
+            STABLE_ORG_ID,
+            STABLE_DOC_ID,
+            "edit",
+            "view",
+            actor,
+            actor,
+        )
+        .is_err());
+    assert_eq!(db.pending_org_access_attempts().unwrap().len(), 1);
+    assert_eq!(db.get_org_item("access-head").unwrap().unwrap().access, "edit");
+    assert_eq!(db.get_org_share("access-share").unwrap().unwrap().access, "edit");
+    db.lock()
+        .execute_batch("DROP TRIGGER abort_access_projection;")
+        .unwrap();
+
+    assert!(db
+        .apply_org_access_attempt_if_current(
+            dispatch_1,
+            STABLE_ORG_ID,
+            STABLE_DOC_ID,
+            "edit",
+            "view",
+            actor,
+            actor,
+        )
+        .unwrap());
+    assert_eq!(db.get_org_item("access-head").unwrap().unwrap().access, "view");
+    assert_eq!(db.get_org_share("access-share").unwrap().unwrap().access, "view");
+    assert!(db.pending_org_access_attempts().unwrap().is_empty());
+    assert!(!db
+        .apply_org_access_attempt_if_current(
+            dispatch_1,
+            STABLE_ORG_ID,
+            STABLE_DOC_ID,
+            "edit",
+            "view",
+            actor,
+            actor,
+        )
+        .unwrap());
+
+    let dispatch_2 = "22222222-3333-4444-8555-666666666666";
+    assert!(db
+        .persist_org_access_attempt_if_current(
+            3,
+            "relay.example",
+            dispatch_2,
+            STABLE_ORG_ID,
+            STABLE_DOC_ID,
+            "view",
+            "edit",
+            actor,
+            actor,
+            "2026-08-12T00:00:04Z",
+        )
+        .unwrap());
+    assert!(!db
+        .fail_org_access_attempt_if_current(
+            dispatch_2,
+            STABLE_ORG_ID,
+            STABLE_DOC_ID,
+            "view",
+            "edit",
+            other_actor,
+            actor,
+        )
+        .unwrap());
+    assert!(db
+        .fail_org_access_attempt_if_current(
+            dispatch_2,
+            STABLE_ORG_ID,
+            STABLE_DOC_ID,
+            "view",
+            "edit",
+            actor,
+            actor,
+        )
+        .unwrap());
+    assert!(db.pending_org_access_attempts().unwrap().is_empty());
+
+    let dispatch_3 = "33333333-4444-4555-8666-777777777777";
+    assert!(db
+        .persist_org_access_attempt_if_current(
+            4,
+            "relay.example",
+            dispatch_3,
+            STABLE_ORG_ID,
+            STABLE_DOC_ID,
+            "view",
+            "edit",
+            actor,
+            actor,
+            "2026-08-12T00:00:05Z",
+        )
+        .unwrap());
+    assert!(!db
+        .apply_org_access_attempt_if_current(
+            dispatch_2,
+            STABLE_ORG_ID,
+            STABLE_DOC_ID,
+            "view",
+            "edit",
+            actor,
+            actor,
+        )
+        .unwrap());
+    db.lock()
+        .execute(
+            "UPDATE org_shares SET state='failed',last_error='direct_put_pending'
+              WHERE id='access-share'",
+            [],
+        )
+        .unwrap();
+    assert!(!db
+        .apply_org_access_attempt_if_current(
+            dispatch_3,
+            STABLE_ORG_ID,
+            STABLE_DOC_ID,
+            "view",
+            "edit",
+            actor,
+            actor,
+        )
+        .unwrap());
+    assert_eq!(db.get_org_item("access-head").unwrap().unwrap().access, "view");
+    assert_eq!(db.pending_org_access_attempts().unwrap().len(), 1);
+}
+
+#[test]
+fn feed_repairs_stable_metadata_even_when_content_action_is_already_applied() {
+    let db = mem_db();
+    seed_org_state(&db, STABLE_ORG_ID);
+    db.upsert_org_item(
+        "local-first",
+        STABLE_ORG_ID,
+        5,
+        "owner",
+        "Title",
+        "body",
+        "2026-08-12T00:00:00Z",
+        1,
+        1,
+        &sha32(4),
+        None,
+        Some("owner"),
+        None,
+    )
+    .unwrap();
+    db.set_org_last_seq(STABLE_ORG_ID, 5).unwrap();
+    let prepared = Db::prepare_org_item_index("Title", "t", "body", None).unwrap();
+    let applied = db
+        .commit_org_feed_item_with_metadata(
+            "local-first",
+            STABLE_ORG_ID,
+            5,
+            "owner",
+            "Title",
+            "body",
+            "2026-08-12T00:00:00Z",
+            1,
+            1,
+            &sha32(4),
+            None,
+            Some("owner"),
+            &prepared,
+            Some(STABLE_DOC_ID),
+            "edit",
+            Some("owner"),
+            true,
+        )
+        .unwrap();
+    assert!(
+        applied.changed,
+        "a legacy row without the atomic projection witness must repair its full projection"
+    );
+    assert_eq!(
+        db.org_replica_state("local-first")
+            .unwrap()
+            .unwrap()
+            .projection_sha256
+            .as_deref(),
+        Some(sha32(4).as_slice())
+    );
+    let ctx = db.org_item_edit_ctx("local-first").unwrap().unwrap();
+    assert_eq!(ctx.doc_id.as_deref(), Some(STABLE_DOC_ID));
+    assert_eq!(ctx.access, "edit");
+    assert_eq!(ctx.document_owner_user_id.as_deref(), Some("owner"));
+}
+
+#[test]
+fn anti_entropy_metadata_preserves_org_link_across_supersede_and_repairs_hash_equal_row() {
+    let db = mem_db();
+    let org_id = "11111111-1111-4111-8111-111111111111";
+    let doc_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    let endpoint = format!("{org_id}:{doc_id}");
+    seed_org_state(&db, org_id);
+    db.upsert_org_item(
+        "old-rev",
+        org_id,
+        1,
+        "owner",
+        "Old",
+        "old body",
+        "2026-08-12T00:00:00Z",
+        1,
+        1,
+        &sha32(1),
+        None,
+        Some("owner"),
+        None,
+    )
+    .unwrap();
+    db.set_org_item_document_metadata("old-rev", Some(doc_id), "view", Some("owner"))
+        .unwrap();
+    db.repair_org_reconcile_metadata(
+        "old-rev",
+        org_id,
+        1,
+        Some(doc_id),
+        "view",
+        Some("owner"),
+        true,
+    )
+    .unwrap();
+    db.upsert_org_item(
+        "attacker-max-rev",
+        org_id,
+        99,
+        "attacker",
+        "Forged max rev",
+        "must never navigate",
+        "2026-08-12T00:00:00Z",
+        u32::MAX,
+        1,
+        &sha32(9),
+        None,
+        Some("attacker"),
+        None,
+    )
+    .unwrap();
+    db.set_org_item_document_metadata("attacker-max-rev", Some(doc_id), "edit", Some("attacker"))
+        .unwrap();
+    db.upsert_manual_link("org", &endpoint, "meeting", "local-anchor")
+        .unwrap();
+
+    let prepared = Db::prepare_org_item_index("Current", "t", "current body", None).unwrap();
+    assert!(
+        db.commit_org_reconcile_item_with_metadata(
+            "current-rev",
+            org_id,
+            2,
+            "owner",
+            "Current",
+            "current body",
+            "2026-08-12T00:00:00Z",
+            2,
+            1,
+            &sha32(2),
+            None,
+            Some("editor"),
+            &prepared,
+            Some(doc_id),
+            "edit",
+            Some("owner"),
+            true,
+        )
+        .unwrap()
+        .changed
+    );
+    db.evict_org_item("old-rev").unwrap();
+    assert_eq!(link_count(&db, "org", &endpoint, "manual"), 1);
+    assert_eq!(
+        db.org_link_target_visible(&endpoint).unwrap(),
+        Some(("current-rev".into(), "Current".into()))
+    );
+
+    // A later hash-converged anti-entropy pass repairs permission metadata without re-fetching or
+    // rewriting the already-correct plaintext/index.
+    db.lock()
+        .execute(
+            "UPDATE org_items SET doc_id = NULL, access = 'view', document_owner_user_id = NULL
+              WHERE item_id = 'current-rev'",
+            [],
+        )
+        .unwrap();
+    assert!(
+        db.repair_org_reconcile_metadata(
+            "current-rev",
+            org_id,
+            1,
+            Some(doc_id),
+            "edit",
+            Some("owner"),
+            true,
+        )
+        .unwrap()
+        .changed
+    );
+    let ctx = db.org_item_edit_ctx("current-rev").unwrap().unwrap();
+    assert_eq!(ctx.doc_id.as_deref(), Some(doc_id));
+    assert_eq!(ctx.access, "edit");
+    assert_eq!(ctx.document_owner_user_id.as_deref(), Some("owner"));
+}
+
+/// Every stable-head assignment can demote readable plaintext. The demotion and global-derived Ask
+/// invalidation must be one SQLCipher transaction across local publish, live feed, reconcile ingest,
+/// and metadata-only reconcile (including an explicit current→non-current repair).
+#[test]
+fn stable_current_mutations_atomically_invalidate_global_ask_history() {
+    for mode in [
+        "local",
+        "feed",
+        "reconcile",
+        "repair_assign",
+        "repair_demote",
+    ] {
+        let db = mem_db();
+        seed_org_state(&db, STABLE_ORG_ID);
+        seed_folder(&db, "f-dep", "Dependency");
+        for (item_id, seq, rev) in [("old-current", 1_u64, 1_u32), ("new-head", 2, 2)] {
+            db.upsert_org_item(
+                item_id,
+                STABLE_ORG_ID,
+                seq,
+                "owner",
+                item_id,
+                "shared body",
+                "2026-08-13T00:00:00Z",
+                rev,
+                1,
+                &sha32(rev as u8),
+                None,
+                Some("owner"),
+                None,
+            )
+            .unwrap();
+            db.set_org_item_document_metadata(item_id, Some(STABLE_DOC_ID), "view", Some("owner"))
+                .unwrap();
+        }
+        db.repair_org_reconcile_metadata(
+            "old-current",
+            STABLE_ORG_ID,
+            1,
+            Some(STABLE_DOC_ID),
+            "view",
+            Some("owner"),
+            true,
+        )
+        .unwrap();
+        db.persist_ask_exchange(
+            &crate::storage::models::AskConversationScope::Vault,
+            None,
+            "question",
+            "derived from old current org content",
+            &[],
+            &[],
+            &[],
+            &["f-dep".to_string()],
+            "2026-08-13T00:01:00Z",
+        )
+        .unwrap();
+        let generation_before: i64 = db
+            .lock()
+            .query_row(
+                "SELECT visibility_generation FROM ask_history_state WHERE singleton=1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let prepared =
+            Db::prepare_org_item_index("new-head", "2026-08-13T00:00:00Z", "shared body", None)
+                .unwrap();
+
+        match mode {
+            "local" => {
+                db.commit_local_org_replica_with_metadata(
+                    "new-head",
+                    STABLE_ORG_ID,
+                    2,
+                    "owner",
+                    "new-head",
+                    "shared body",
+                    "2026-08-13T00:00:00Z",
+                    2,
+                    1,
+                    &sha32(2),
+                    None,
+                    Some("owner"),
+                    &prepared,
+                    None,
+                    Some(STABLE_DOC_ID),
+                    "view",
+                    Some("owner"),
+                    true,
+                )
+                .unwrap();
+            }
+            "feed" => {
+                db.commit_org_feed_item_with_metadata(
+                    "new-head",
+                    STABLE_ORG_ID,
+                    3,
+                    "owner",
+                    "new-head",
+                    "shared body",
+                    "2026-08-13T00:00:00Z",
+                    3,
+                    1,
+                    &sha32(3),
+                    None,
+                    Some("owner"),
+                    &prepared,
+                    Some(STABLE_DOC_ID),
+                    "view",
+                    Some("owner"),
+                    true,
+                )
+                .unwrap();
+            }
+            "reconcile" => {
+                db.commit_org_reconcile_item_with_metadata(
+                    "new-head",
+                    STABLE_ORG_ID,
+                    3,
+                    "owner",
+                    "new-head",
+                    "shared body",
+                    "2026-08-13T00:00:00Z",
+                    3,
+                    1,
+                    &sha32(3),
+                    None,
+                    Some("owner"),
+                    &prepared,
+                    Some(STABLE_DOC_ID),
+                    "view",
+                    Some("owner"),
+                    true,
+                )
+                .unwrap();
+            }
+            "repair_assign" => {
+                db.repair_org_reconcile_metadata(
+                    "new-head",
+                    STABLE_ORG_ID,
+                    1,
+                    Some(STABLE_DOC_ID),
+                    "view",
+                    Some("owner"),
+                    true,
+                )
+                .unwrap();
+            }
+            "repair_demote" => {
+                db.repair_org_reconcile_metadata(
+                    "old-current",
+                    STABLE_ORG_ID,
+                    1,
+                    Some(STABLE_DOC_ID),
+                    "view",
+                    Some("owner"),
+                    false,
+                )
+                .unwrap();
+            }
+            _ => unreachable!(),
+        }
+
+        let conn = db.lock();
+        let generation_after: i64 = conn
+            .query_row(
+                "SELECT visibility_generation FROM ask_history_state WHERE singleton=1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(generation_after, generation_before + 1, "mode={mode}");
+        for table in [
+            "ask_conversations",
+            "ask_conversation_messages",
+            "ask_conversation_dependencies",
+        ] {
+            let count: i64 = conn
+                .query_row(&format!("SELECT COUNT(*) FROM {table}"), [], |row| {
+                    row.get(0)
+                })
+                .unwrap();
+            assert_eq!(count, 0, "mode={mode} table={table}");
+        }
+    }
 }
 
 /// Ingest round-trip: upsert an org item WITH a real (stub) embedder → both the int8 KNN leg AND
@@ -358,6 +2623,91 @@ fn org_ingest_fts_only_when_no_embedder() {
     // The re-embed backlog lists exactly this item.
     let backlog = db.org_items_needing_embed("org-1", 10).unwrap();
     assert_eq!(backlog, vec!["it-x".to_string()]);
+}
+
+/// Stable-document retrieval must follow the relay-authoritative `is_current` witness, never the
+/// largest locally observed revision. A live attacker-controlled high-rev row for the same doc is
+/// kept in the replica for reconciliation, but must stay absent from every content reader and the
+/// re-embed backlog.
+#[test]
+fn org_content_readers_expose_only_authoritative_current_revision() {
+    let db = mem_db();
+    let org_id = "11111111-1111-4111-8111-111111111111";
+    let doc_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    seed_org_state(&db, org_id);
+
+    let conn = db.lock();
+    for (item_id, title, rev, is_current) in [
+        ("attacker-high-rev", "Attacker", 999_i64, 0_i64),
+        ("authoritative-current", "Current", 2_i64, 1_i64),
+    ] {
+        conn.execute(
+            "INSERT INTO org_items
+               (item_id, org_id, seq, author_hint, title, markdown, created_at, rev, generation,
+                content_sha256, tombstoned, doc_id, is_current)
+             VALUES (?1, ?2, ?3, 'member', ?4, 'sapphire parcel body',
+                     '2026-08-13T00:00:00Z', ?3, 1, ?5, 0, ?6, ?7)",
+            rusqlite::params![
+                item_id,
+                org_id,
+                rev,
+                title,
+                sha32(if is_current == 1 { 2 } else { 9 }),
+                doc_id,
+                is_current,
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO org_chunks (item_id, chunk_idx, text)
+             VALUES (?1, 0, 'sapphire parcel body')",
+            rusqlite::params![item_id],
+        )
+        .unwrap();
+        let chunk_id = conn.last_insert_rowid();
+        let blob = crate::embed::vec_to_int8_blob(&one_hot(0));
+        conn.execute(
+            "INSERT INTO org_vec_chunks(chunk_id, embedding) VALUES (?1, vec_int8(?2))",
+            rusqlite::params![chunk_id, blob],
+        )
+        .unwrap();
+    }
+    drop(conn);
+
+    let knn_ids = db
+        .search_org_chunks_knn(&one_hot(0), 10, 0.0)
+        .unwrap()
+        .into_iter()
+        .map(|hit| hit.item_id)
+        .collect::<Vec<_>>();
+    assert_eq!(knn_ids, vec!["authoritative-current"]);
+
+    let strict_ids = db
+        .search_org_chunks_fts("sapphire parcel", 10)
+        .unwrap()
+        .into_iter()
+        .map(|hit| hit.item_id)
+        .collect::<Vec<_>>();
+    assert_eq!(strict_ids, vec!["authoritative-current"]);
+
+    let fallback_ids = db
+        .search_org_chunks_fts("missing sapphire", 10)
+        .unwrap()
+        .into_iter()
+        .map(|hit| hit.item_id)
+        .collect::<Vec<_>>();
+    assert_eq!(fallback_ids, vec!["authoritative-current"]);
+
+    db.lock()
+        .execute(
+            "DELETE FROM org_vec_chunks WHERE chunk_id IN
+                 (SELECT id FROM org_chunks WHERE item_id IN
+                     ('attacker-high-rev', 'authoritative-current'))",
+            [],
+        )
+        .unwrap();
+    let backlog = db.org_items_needing_embed(org_id, 10).unwrap();
+    assert_eq!(backlog, vec!["authoritative-current"]);
 }
 
 /// Crash boundary: fetching a page never makes its advertised tail durable. Each successful
@@ -610,7 +2960,9 @@ fn membership_withdrawal_purges_stale_history_even_with_empty_replica() {
     assert!(db.delete_org_state("org-1").unwrap());
     let count: i64 = db
         .lock()
-        .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| row.get(0))
+        .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| {
+            row.get(0)
+        })
         .unwrap();
     assert_eq!(count, 0);
 }
@@ -785,9 +3137,14 @@ fn local_org_replica_commit_reports_transactional_supersede_once() {
     assert!(db.org_replica_state("it-old").unwrap().unwrap().tombstoned);
     let ask_rows: i64 = db
         .lock()
-        .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| row.get(0))
+        .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| {
+            row.get(0)
+        })
         .unwrap();
-    assert_eq!(ask_rows, 0, "supersede atomically purges derived Ask history");
+    assert_eq!(
+        ask_rows, 0,
+        "supersede atomically purges derived Ask history"
+    );
 
     let second = db
         .commit_local_org_replica(
@@ -873,6 +3230,125 @@ fn org_vector_reindex_primitives_preserve_replica_chunks_fts_and_cursor() {
         .unwrap();
     assert_eq!(vectors_after, chunks_before);
     assert_eq!(db.org_last_seq_for("org-1").unwrap(), 15);
+}
+
+/// Global rebuild/startup-repair readers must never materialize plaintext from an obsolete stable
+/// document revision. The attacker row sorts first and has the larger revision, while the relay
+/// witness deliberately marks only the lower revision current.
+#[test]
+fn org_vector_rebuild_readers_skip_live_noncurrent_revision() {
+    let db = mem_db();
+    seed_org_state(&db, "org-1");
+    let conn = db.lock();
+    for (item_id, rev, is_current) in [
+        ("a-attacker-high-rev", 999_i64, 0_i64),
+        ("z-authoritative-current", 2_i64, 1_i64),
+    ] {
+        conn.execute(
+            "INSERT INTO org_items
+               (item_id, org_id, seq, author_hint, title, markdown, created_at, rev, generation,
+                content_sha256, tombstoned, doc_id, is_current)
+             VALUES (?1, 'org-1', ?2, 'member', ?1, 'vector repair secret', 't', ?2, 1,
+                     ?3, 0, 'doc-1', ?4)",
+            rusqlite::params![
+                item_id,
+                rev,
+                sha32(if is_current == 1 { 2 } else { 9 }),
+                is_current
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO org_chunks (item_id, chunk_idx, text)
+             VALUES (?1, 0, 'vector repair secret')",
+            rusqlite::params![item_id],
+        )
+        .unwrap();
+    }
+    drop(conn);
+
+    assert_eq!(
+        db.next_org_item_vector_batch(None)
+            .unwrap()
+            .expect("current rebuild batch")
+            .item_id,
+        "z-authoritative-current"
+    );
+    assert_eq!(
+        db.next_missing_org_item_vector_batch(None)
+            .unwrap()
+            .expect("current repair batch")
+            .item_id,
+        "z-authoritative-current"
+    );
+    assert!(db
+        .org_item_vector_batch("a-attacker-high-rev")
+        .unwrap()
+        .is_none());
+}
+
+/// Embedding runs outside the DB transaction. If a revision is current at read time but is demoted
+/// before the vector batch commits, the transaction must reject that stale batch and persist no
+/// searchable vector rows.
+#[test]
+fn org_vector_batch_commit_rejects_revision_demoted_after_read() {
+    let db = mem_db();
+    seed_org_state(&db, STABLE_ORG_ID);
+    let emb = crate::embed::StubEmbedder;
+    db.upsert_org_item(
+        "current-before-embed",
+        STABLE_ORG_ID,
+        2,
+        "member",
+        "Current",
+        "demotion race content",
+        "t",
+        2,
+        1,
+        &sha32(2),
+        None,
+        Some("author-1"),
+        None,
+    )
+    .unwrap();
+    db.set_org_item_document_metadata(
+        "current-before-embed",
+        Some(STABLE_DOC_RACE_ID),
+        "view",
+        Some("author-1"),
+    )
+    .unwrap();
+    db.repair_org_reconcile_metadata(
+        "current-before-embed",
+        STABLE_ORG_ID,
+        1,
+        Some(STABLE_DOC_RACE_ID),
+        "view",
+        Some("author-1"),
+        true,
+    )
+    .unwrap();
+
+    let batch = db
+        .org_item_vector_batch("current-before-embed")
+        .unwrap()
+        .expect("current batch before embedding");
+    let vectors = Db::prepare_org_vector_blobs(&batch.texts, &emb).unwrap();
+
+    db.lock()
+        .execute(
+            "UPDATE org_items SET is_current = 0 WHERE item_id = 'current-before-embed'",
+            [],
+        )
+        .unwrap();
+    assert!(!db
+        .commit_org_item_vectors_if_unchanged(&batch, &vectors)
+        .unwrap());
+    let persisted: i64 = db
+        .lock()
+        .query_row("SELECT COUNT(*) FROM org_vec_chunks", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(persisted, 0, "demoted revision must receive no vectors");
 }
 
 /// CAS must compare content as well as rowids: SQLite can reuse deleted max INTEGER PRIMARY KEY
@@ -1071,7 +3547,9 @@ fn org_tombstone_evicts_from_retrieval_and_viewer() {
     assert_eq!(n, 0, "org_chunks purged on tombstone");
     let ask_count: i64 = db
         .lock()
-        .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| row.get(0))
+        .query_row("SELECT COUNT(*) FROM ask_conversations", [], |row| {
+            row.get(0)
+        })
         .unwrap();
     assert_eq!(ask_count, 0, "org tombstone must purge global-derived Ask");
     // Idempotent re-tombstone.
@@ -1087,6 +3565,145 @@ fn org_tombstone_evicts_from_retrieval_and_viewer() {
 /// re-pull stays idempotent — so the CASCADE never fired and a withdrawn colleague's pictures stayed
 /// as plaintext BLOBs in SQLite. Also asserts the primitive's return value: `true` only when a LIVE
 /// row was actually evicted, so callers can count real convergence work.
+#[test]
+fn org_feed_attachment_collision_rolls_back_item_cursor_and_completeness_witness() {
+    let db = mem_db();
+    let org_id = "33333333-3333-4333-8333-333333333333";
+    seed_org_state(&db, org_id);
+    db.upsert_org_item(
+        "other", org_id, 1, "owner", "Other", "body", "t", 1, 1,
+        &sha32(1), None, Some("owner"), None,
+    ).unwrap();
+    db.replace_org_item_attachment_bundle(
+        "other",
+        &[crate::storage::IncomingAttachment {
+            id: "collision".into(), mime_type: "image/png".into(), extension: "png".into(),
+            width: 1, height: 1, sha256: [2; 32], data: vec![2],
+        }],
+    ).unwrap();
+    let prepared = Db::prepare_org_item_index("Target", "t", "private target", None).unwrap();
+    let attachment = crate::storage::IncomingAttachment {
+        id: "collision".into(), mime_type: "image/png".into(), extension: "png".into(),
+        width: 1, height: 1, sha256: [3; 32], data: vec![3],
+    };
+    let failed = db.commit_org_feed_item_with_metadata_and_attachments(
+        "target", org_id, 2, "owner", "Target", "private target", "t", 1, 1,
+        &sha32(4), None, Some("owner"), &prepared, Some("11111111-1111-4111-8111-111111111111"),
+        "view", Some("owner"), true, &[attachment],
+    );
+    assert!(failed.is_err());
+    let conn = db.lock();
+    assert_eq!(conn.query_row("SELECT last_seq FROM org_state WHERE org_id=?1", [org_id], |r| r.get::<_, i64>(0)).unwrap(), 0);
+    assert_eq!(conn.query_row("SELECT COUNT(*) FROM org_items WHERE item_id='target'", [], |r| r.get::<_, i64>(0)).unwrap(), 0);
+    drop(conn);
+    db.lock().execute("DELETE FROM note_attachments WHERE id='collision'", []).unwrap();
+    let repaired = crate::storage::IncomingAttachment {
+        id: "target-image".into(), mime_type: "image/png".into(), extension: "png".into(),
+        width: 1, height: 1, sha256: [3; 32], data: vec![3],
+    };
+    assert!(db.commit_org_feed_item_with_metadata_and_attachments(
+        "target", org_id, 2, "owner", "Target", "private target", "t", 1, 1,
+        &sha32(4), None, Some("owner"), &prepared, Some("11111111-1111-4111-8111-111111111111"),
+        "view", Some("owner"), true, &[repaired],
+    ).unwrap().changed);
+    let conn = db.lock();
+    assert!(conn.query_row("SELECT projection_sha256=?2 FROM org_items WHERE item_id=?1", rusqlite::params!["target",sha32(4)], |r| r.get::<_, bool>(0)).unwrap());
+    assert_eq!(conn.query_row("SELECT COUNT(*) FROM note_attachments WHERE org_item_id='target'", [], |r| r.get::<_, i64>(0)).unwrap(), 1);
+}
+
+#[test]
+fn org_feed_atomically_closes_projection_pending_and_preserves_newer_source_dirty() {
+    let db = mem_db();
+    let org_id = "11111111-1111-4111-8111-111111111111";
+    let doc_id = "22222222-2222-4222-8222-222222222222";
+    seed_org_state(&db, org_id);
+    db.insert_org_share(
+        "share-a", org_id, None, Some("source-b"), "note", Some("B"), 2, 1,
+        &sha32(4), "2026-08-13T00:00:00Z",
+    ).unwrap();
+    db.set_org_share_document_metadata("share-a", doc_id, "view").unwrap();
+    {
+        let conn = db.lock();
+        conn.execute(
+            "UPDATE org_shares SET state='failed',last_error='projection_pending',
+              item_id='item-a',dispatch_id='dispatch-a',expected_actor_user_id='actor',
+              expected_owner_user_id='owner',republish_dirty=1 WHERE id='share-a'", [],
+        ).unwrap();
+    }
+    let prepared = Db::prepare_org_item_index("A", "t", "remote A", None).unwrap();
+    let outcome = db.commit_org_feed_item_with_metadata_and_attachments(
+        "item-a", org_id, 2, "actor", "A", "remote A", "t", 2, 1, &sha32(4),
+        None, Some("actor"), &prepared, Some(doc_id), "view", Some("owner"), true, &[],
+    ).unwrap();
+    assert!(outcome.changed);
+    let row = db.get_org_share("share-a").unwrap().unwrap();
+    assert_eq!(row.state, "uploaded");
+    assert_eq!(row.last_error, None);
+    assert_eq!(row.republish_dirty, 1, "newer source B remains queued after A closes");
+    assert_eq!(db.org_replica_state("item-a").unwrap().unwrap().projection_sha256, Some(sha32(4)));
+}
+
+#[test]
+fn org_feed_tombstone_closes_projection_pending_journals_without_resurrection() {
+    let db = mem_db();
+    let org_id = "11111111-1111-4111-8111-111111111111";
+    seed_org_state(&db, org_id);
+    for (id, source) in [("anchored", Some("source")), ("journal", None)] {
+        db.insert_org_share(id, org_id, None, source, "note", Some("T"), 2, 1,
+            &sha32(5), "2026-08-13T00:00:00Z").unwrap();
+        db.lock().execute(
+            "UPDATE org_shares SET state='failed',last_error='projection_pending',item_id='item-a'
+              WHERE id=?1", [id],
+        ).unwrap();
+    }
+    assert!(db.commit_org_feed_tombstone(org_id, "item-a", 1).unwrap());
+    assert_eq!(db.get_org_share("anchored").unwrap().unwrap().last_error.as_deref(), Some("org_edit_conflict"));
+    assert!(db.get_org_share("journal").unwrap().is_none());
+}
+
+#[test]
+fn confirmed_document_delete_terminalizes_sibling_anchors_and_plaintext_in_one_tx() {
+    let db = mem_db();
+    let org_id = "11111111-1111-4111-8111-111111111111";
+    let doc_id = "22222222-2222-4222-8222-222222222222";
+    seed_org_state(&db, org_id);
+    for (index, item) in ["item-1", "item-2"].into_iter().enumerate() {
+        db.insert_org_share(item, org_id, None, Some(item), "note", Some("T"),
+            (index + 1) as u32, 1, &sha32(index as u8), "2026-08-13T00:00:00Z").unwrap();
+        db.set_org_share_uploaded(item, item, "2026-08-13T00:00:01Z").unwrap();
+        db.set_org_share_document_metadata(item, doc_id, "view").unwrap();
+        db.upsert_org_item(item, org_id, (index + 1) as u64, "owner", "T", "secret",
+            "t", (index + 1) as u32, 1, &sha32(index as u8), None, Some("owner"), None).unwrap();
+        db.set_org_item_document_metadata(item, Some(doc_id), "view", Some("owner")).unwrap();
+    }
+    let endpoint = format!("{org_id}:{doc_id}");
+    db.lock()
+        .execute(
+            "INSERT INTO links
+               (src_kind,src_id,dst_kind,dst_id,edge_type,created_at)
+             VALUES('org',?1,'note','local-note','manual',1)",
+            [&endpoint],
+        )
+        .unwrap();
+    assert!(db.terminalize_and_evict_org_document(org_id, doc_id, "2026-08-13T00:00:02Z").unwrap());
+    for id in ["item-1", "item-2"] {
+        assert_eq!(db.get_org_share(id).unwrap().unwrap().state, "revoked");
+        let item = db.get_org_item(id).unwrap();
+        assert!(item.is_none(), "tombstoned plaintext is not readable");
+    }
+    assert_eq!(
+        db.lock()
+            .query_row(
+                "SELECT COUNT(*) FROM links WHERE src_kind='org' AND src_id=?1",
+                [&endpoint],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+        0,
+        "confirmed stable-document destruction must purge private graph tuples"
+    );
+}
+
 #[test]
 fn evicting_an_org_item_purges_its_attachment_blobs_on_every_path() {
     let attachment_count = |db: &Db, item_id: &str| -> i64 {
@@ -1221,18 +3838,23 @@ fn reconcile_commit_writes_below_the_live_cursor_but_never_resurrects_a_tombston
     db.set_org_last_seq("org-1", 42).unwrap();
     let prepared = Db::prepare_org_item_index("Recovered", "t", "recovered body", None).unwrap();
 
-    // Below the live cursor: the feed-commit path refuses (its cursor claim fails), the reconcile
-    // commit succeeds — and leaves the live cursor exactly where it was.
-    assert!(!db
-        .commit_org_feed_item(
-            "it-below", "org-1", 5, "anna", "Recovered", "recovered body", "t", 1, 1, &sha32(6),
-            None, None, &prepared,
-        )
-        .unwrap());
+    // Below the live cursor, reconcile still installs the complete projection and leaves the live
+    // cursor exactly where it was. Feed's legacy-incomplete repair behavior has its own oracle.
     assert!(db
         .commit_org_reconcile_item(
-            "it-below", "org-1", 5, "anna", "Recovered", "recovered body", "t", 1, 1, &sha32(6),
-            None, None, &prepared,
+            "it-below",
+            "org-1",
+            5,
+            "anna",
+            "Recovered",
+            "recovered body",
+            "t",
+            1,
+            1,
+            &sha32(6),
+            None,
+            None,
+            &prepared,
         )
         .unwrap());
     assert!(db.get_org_item("it-below").unwrap().is_some());
@@ -1242,8 +3864,19 @@ fn reconcile_commit_writes_below_the_live_cursor_but_never_resurrects_a_tombston
     assert!(db.evict_org_item("it-below").unwrap());
     assert!(!db
         .commit_org_reconcile_item(
-            "it-below", "org-1", 5, "anna", "Recovered", "recovered body", "t", 2, 1, &sha32(6),
-            None, None, &prepared,
+            "it-below",
+            "org-1",
+            5,
+            "anna",
+            "Recovered",
+            "recovered body",
+            "t",
+            2,
+            1,
+            &sha32(6),
+            None,
+            None,
+            &prepared,
         )
         .unwrap());
     assert!(db.get_org_item("it-below").unwrap().is_none());
@@ -1251,8 +3884,19 @@ fn reconcile_commit_writes_below_the_live_cursor_but_never_resurrects_a_tombston
     // Withdrawn membership can never be followed by a plaintext replica resurrection.
     assert!(!db
         .commit_org_reconcile_item(
-            "it-gone-org", "org-left", 5, "anna", "Recovered", "recovered body", "t", 1, 1,
-            &sha32(6), None, None, &prepared,
+            "it-gone-org",
+            "org-left",
+            5,
+            "anna",
+            "Recovered",
+            "recovered body",
+            "t",
+            1,
+            1,
+            &sha32(6),
+            None,
+            None,
+            &prepared,
         )
         .unwrap());
     assert!(db.get_org_item("it-gone-org").unwrap().is_none());
@@ -1753,6 +4397,38 @@ fn org_shared_content_hashes_are_collected() {
     assert!(hashes.contains(&sha32(8)));
 }
 
+#[test]
+fn org_share_scrub_is_explicit_and_legacy_default_is_fail_safe() {
+    let db = mem_db();
+    let now = "2026-08-12T00:00:00Z";
+    db.lock()
+        .execute(
+            "INSERT INTO org_shares
+               (id, org_id, meeting_id, kind, title, rev, generation, content_sha256,
+                state, created_at, updated_at)
+             VALUES (?1, ?2, ?3, 'note', 'Legacy', 1, 1, ?4, 'queued', ?5, ?5)",
+            rusqlite::params!["legacy-default", "org-1", "m1", sha32(1), now],
+        )
+        .unwrap();
+    db.insert_org_share_with_scrub(
+        "explicit-off",
+        "org-1",
+        Some("m2"),
+        None,
+        "note",
+        Some("Explicit"),
+        1,
+        1,
+        &sha32(2),
+        false,
+        now,
+    )
+    .unwrap();
+
+    assert!(db.get_org_share("legacy-default").unwrap().unwrap().scrub);
+    assert!(!db.get_org_share("explicit-off").unwrap().unwrap().scrub);
+}
+
 /// `org_shares_for_source` (the re-publish-on-edit enumerator) returns EVERY uploaded row for a
 /// source ACROSS ALL orgs (a note may be shared to several), and ONLY `uploaded` rows — a
 /// `queued`/`failed`/`revoked` row is excluded (no live server item to supersede). A `None`/`None`
@@ -1924,8 +4600,8 @@ fn org_shares_for_source_includes_failed_rows_with_a_live_item_id() {
 }
 
 /// `uploaded_org_shares_for_source_in_org` is (org, source)-SCOPED and OLDEST-FIRST: only the
-/// `uploaded` rows for the EXACT (org, source), earliest `created_at` first (so `[0]` is the dedup
-/// keeper), excluding another org, another source, and any non-uploaded (queued / revoked) row.
+/// Known-live rows plus fail-closed admission blockers for the EXACT (org, source), with uploaded
+/// keepers first and blockers last. Another org/source and revoked rows remain excluded.
 #[test]
 fn uploaded_org_shares_for_source_in_org_scopes_and_orders_oldest_first() {
     let db = mem_db();
@@ -1975,7 +4651,8 @@ fn uploaded_org_shares_for_source_in_org_scopes_and_orders_oldest_first() {
     .unwrap();
     db.set_org_share_uploaded("u-c", "item-c", "2026-07-11T00:03:00Z")
         .unwrap();
-    // A still-`queued` row for the same (org, source) — EXCLUDED (no live server item).
+    // A still-`queued` row is retained as an admission blocker: NULL item identity is not proof that
+    // an older client never dispatched it.
     db.insert_org_share(
         "u-q",
         "org-1",
@@ -2046,8 +4723,8 @@ fn uploaded_org_shares_for_source_in_org_scopes_and_orders_oldest_first() {
     let ids: Vec<_> = rows.iter().map(|r| r.id.as_str()).collect();
     assert_eq!(
         ids,
-        vec!["u-a", "u-b", "u-c"],
-        "only (org-1,d1) uploaded rows, oldest-first"
+        vec!["u-a", "u-b", "u-c", "u-q"],
+        "known-live rows are first, followed by the exact-source admission blocker"
     );
     // The both-None guard returns empty (no source ⇒ nothing).
     assert!(db
@@ -2180,12 +4857,227 @@ fn duplicate_uploaded_org_shares_returns_only_the_extras() {
     );
 }
 
-/// `cancel_pending_org_shares_for_source_in_org` cancels ONLY the (org, source) `queued`/`failed`
-/// rows, leaving `uploaded` keepers and other orgs/sources untouched.
+#[test]
+fn known_uploaded_share_is_keeper_ahead_of_older_ambiguous_null_item() {
+    let db = mem_db();
+    db.insert_org_share("ambiguous", "org-1", None, Some("d1"), "note", Some("T"),
+        1, 1, &sha32(1), "2026-07-11T00:00:00Z").unwrap();
+    db.set_org_share_failed("ambiguous", "initial_post_pending", "2026-07-11T00:00:01Z").unwrap();
+    db.insert_org_share("live", "org-1", None, Some("d1"), "note", Some("T"),
+        1, 1, &sha32(2), "2026-07-11T00:01:00Z").unwrap();
+    db.set_org_share_uploaded("live", "item-live", "2026-07-11T00:01:01Z").unwrap();
+    let rows = db.uploaded_org_shares_for_source_in_org("org-1", None, Some("d1")).unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].id, "live");
+    assert_eq!(rows[1].id, "ambiguous");
+    assert!(!db.acquire_new_org_share_for_source(
+        "third", "org-1", None, Some("d1"), "note", Some("T"), 1, 1,
+        &sha32(3), true, "2026-07-11T00:02:00Z",
+    ).unwrap());
+}
+
+#[test]
+fn folder_and_source_closures_block_share_insert_and_rearm_until_reopened() {
+    let db = mem_db();
+    db.insert_folder(&Folder {
+        id: "closing-folder".into(),
+        name: "Closing".into(),
+        path: "Closing".into(),
+        parent_id: None,
+        locked: false,
+        created_at: "2026-08-14T00:00:00Z".into(),
+    })
+    .unwrap();
+    db.insert_document(
+        "closing-doc",
+        "closing-folder",
+        "doc.md",
+        "body",
+        "document",
+        1,
+    )
+    .unwrap();
+    db.begin_org_folder_closure("closing-folder").unwrap();
+    assert!(db
+        .insert_outbound_note_share(
+            "blocked-link",
+            "closing-doc",
+            "link",
+            1,
+            "2026-08-14T00:00:01Z",
+        )
+        .is_err(), "folder closure must reject link/user share admission too");
+    assert!(db
+        .insert_org_share(
+            "blocked-folder",
+            "org-1",
+            None,
+            Some("closing-doc"),
+            "note",
+            Some("T"),
+            1,
+            1,
+            &sha32(1),
+            "t",
+        )
+        .is_err());
+    db.clear_org_folder_closure("closing-folder").unwrap();
+    db.insert_org_share(
+        "share",
+        "org-1",
+        None,
+        Some("closing-doc"),
+        "note",
+        Some("T"),
+        1,
+        1,
+        &sha32(1),
+        "t",
+    )
+    .unwrap();
+    db.begin_org_source_closure("document", "closing-doc").unwrap();
+    assert!(db
+        .insert_outbound_note_share(
+            "blocked-source-link",
+            "closing-doc",
+            "link",
+            1,
+            "2026-08-14T00:00:02Z",
+        )
+        .is_err(), "source closure must reject link/user share admission too");
+    assert!(db
+        .lock()
+        .execute(
+            "UPDATE documents SET text='edited while closing' WHERE id='closing-doc'",
+            [],
+        )
+        .is_err(), "a destructive closure must freeze the source during remote revoke");
+    for sql in [
+        "UPDATE documents SET name='renamed.md' WHERE id='closing-doc'",
+        "UPDATE documents SET kind='note' WHERE id='closing-doc'",
+    ] {
+        assert!(db.lock().execute(sql, []).is_err(), "every envelope identity field is frozen");
+    }
+    assert!(db
+        .reset_org_share_for_retry_with_scrub("share", Some("T2"), 1, 1, &sha32(2), true, "t2")
+        .is_err());
+    db.clear_org_source_closure("document", "closing-doc").unwrap();
+    db.reset_org_share_for_retry_with_scrub("share", Some("T2"), 1, 1, &sha32(2), true, "t2")
+        .unwrap();
+}
+
+#[test]
+fn meeting_source_closure_blocks_provider_insert_delete_and_title_changes() {
+    let db = mem_db();
+    db.insert_folder(&Folder {
+        id: "meeting-close-folder".into(), name: "Closing".into(), path: "Closing".into(),
+        parent_id: None, locked: false, created_at: "2026-08-14T00:00:00Z".into(),
+    }).unwrap();
+    db.insert_meeting(&Meeting {
+        id: "meeting-close".into(), started_at: "t".into(), ended_at: None,
+        title: Some("Before".into()), duration_s: 0, audio_path: None,
+        status: MeetingStatus::Summarized, folder_id: Some("meeting-close-folder".into()),
+    }).unwrap();
+    db.upsert_note(&NoteRecord {
+        meeting_id: "meeting-close".into(), provider_id: "provider-a".into(),
+        markdown: "body".into(), created_at: "t".into(), exported_path: None,
+        model_requested: None, model_served: None, gateway_host: None,
+    }).unwrap();
+    db.begin_org_source_closure("meeting", "meeting-close").unwrap();
+
+    assert!(db.upsert_note(&NoteRecord {
+        meeting_id: "meeting-close".into(), provider_id: "provider-b".into(),
+        markdown: "other".into(), created_at: "t2".into(), exported_path: None,
+        model_requested: None, model_served: None, gateway_host: None,
+    }).is_err());
+    assert!(db.lock().execute(
+        "DELETE FROM notes WHERE meeting_id='meeting-close' AND provider_id='provider-a'", [],
+    ).is_err());
+    assert!(db.lock().execute(
+        "UPDATE meetings SET title='After' WHERE id='meeting-close'", [],
+    ).is_err());
+}
+
+#[test]
+fn source_closure_blocks_manual_attachment_mutation_but_allows_authorized_parent_cascade() {
+    let db = mem_db();
+    db.insert_folder(&Folder {
+        id: "attachment-folder".into(), name: "Attachments".into(), path: "Attachments".into(),
+        parent_id: None, locked: false, created_at: "2026-08-14T00:00:00Z".into(),
+    }).unwrap();
+    db.insert_document("attachment-doc", "attachment-folder", "note.md", "body", "note", 1).unwrap();
+    let owner = crate::storage::AttachmentOwner::Document { document_id: "attachment-doc".into() };
+    let hash = [3u8; 32];
+    db.insert_attachment(&crate::storage::NewAttachment {
+        id: "attachment-one", owner: &owner, mime_type: "image/png", extension: "png",
+        width: 1, height: 1, sha256: &hash, byte_len: 1, data: &[1], data_blob: None,
+        created_at: 1,
+    }).unwrap();
+    db.begin_org_source_closure("document", "attachment-doc").unwrap();
+    assert!(db.delete_attachment(&owner, "attachment-one").is_err());
+    db.delete_document("attachment-doc").unwrap();
+    assert!(db.list_attachments(&owner).unwrap().is_empty());
+    let phase: String = db.lock().query_row(
+        "SELECT phase FROM org_share_closures
+          WHERE scope_kind='document' AND scope_id='attachment-doc'", [], |row| row.get(0),
+    ).unwrap();
+    assert_eq!(phase, "closed", "parent cascade and barrier completion commit together");
+}
+
+#[test]
+fn source_delete_with_attachment_rolls_back_until_every_share_is_terminal() {
+    let db = mem_db();
+    db.insert_folder(&Folder {
+        id: "atomic-delete-folder".into(), name: "Atomic".into(), path: "Atomic".into(),
+        parent_id: None, locked: false, created_at: "2026-08-14T00:00:00Z".into(),
+    }).unwrap();
+    db.insert_document("atomic-delete-doc", "atomic-delete-folder", "note.md", "body", "note", 1).unwrap();
+    let owner = crate::storage::AttachmentOwner::Document { document_id: "atomic-delete-doc".into() };
+    db.insert_attachment(&crate::storage::NewAttachment {
+        id: "atomic-image", owner: &owner, mime_type: "image/png", extension: "png",
+        width: 1, height: 1, sha256: &[7; 32], byte_len: 1, data: &[7], data_blob: None,
+        created_at: 1,
+    }).unwrap();
+    db.insert_outbound_share_attempt(
+        "atomic-share", None, Some("atomic-delete-doc"), "link", 1,
+        "c534b6d2-02c1-4c2c-a256-3af8592b1567", "t",
+    ).unwrap();
+    db.begin_org_source_closure("document", "atomic-delete-doc").unwrap();
+
+    assert!(db.delete_document("atomic-delete-doc").is_err());
+    let exists: i64 = db.lock().query_row(
+        "SELECT EXISTS(SELECT 1 FROM documents WHERE id='atomic-delete-doc')", [],
+        |row| row.get(0),
+    ).unwrap();
+    assert_eq!(exists, 1);
+    assert_eq!(db.list_attachments(&owner).unwrap().len(), 1);
+    let phase: String = db.lock().query_row(
+        "SELECT phase FROM org_share_closures
+          WHERE scope_kind='document' AND scope_id='atomic-delete-doc'", [], |row| row.get(0),
+    ).unwrap();
+    assert_eq!(phase, "closing");
+
+    db.set_outbound_share_state("atomic-share", "revoked").unwrap();
+    db.delete_document("atomic-delete-doc").unwrap();
+    let exists: i64 = db.lock().query_row(
+        "SELECT EXISTS(SELECT 1 FROM documents WHERE id='atomic-delete-doc')", [],
+        |row| row.get(0),
+    ).unwrap();
+    assert_eq!(exists, 0);
+    assert!(db.list_attachments(&owner).unwrap().is_empty());
+    let phase: String = db.lock().query_row(
+        "SELECT phase FROM org_share_closures
+          WHERE scope_kind='document' AND scope_id='atomic-delete-doc'", [], |row| row.get(0),
+    ).unwrap();
+    assert_eq!(phase, "closed");
+}
+
+/// Duplicate collapse cancels only rows with durable proof that no remote publish exists. Legacy
+/// queued/generic-failed NULL identities are preserved because old clients dispatched while queued.
 #[test]
 fn cancel_pending_org_shares_scopes_to_org_and_source() {
     let db = mem_db();
-    // Target (org-1, d1): one queued + one failed → both cancelled.
+    // Legacy queued + generic failed are NOT safe to cancel from local state alone.
     db.insert_org_share(
         "q",
         "org-1",
@@ -2214,6 +5106,36 @@ fn cancel_pending_org_shares_scopes_to_org_and_source() {
     .unwrap();
     db.set_org_share_failed("f", "boom", "2026-07-11T00:02:30Z")
         .unwrap();
+    db.insert_org_share(
+        "too-large","org-1",None,Some("d1"),"note",Some("T"),1,1,&sha32(8),
+        "2026-07-11T00:02:35Z",
+    ).unwrap();
+    db.set_org_share_failed("too-large","too_large","2026-07-11T00:02:36Z").unwrap();
+    // Ambiguous stable-document attempts carry durable recovery witnesses and must never be
+    // collapsed as ordinary pending duplicates, even when they share this exact local source.
+    for (id, reason, byte) in [
+        ("direct", "direct_put_pending", 21u8),
+        ("republish-put", "republish_put_pending", 24u8),
+        ("edit-conflict", "org_edit_conflict", 27u8),
+        ("initial", "initial_post_pending", 22u8),
+        ("replayable", "initial_post_replayable", 23u8),
+    ] {
+        db.insert_org_share(
+            id,
+            "org-1",
+            None,
+            Some("d1"),
+            "note",
+            Some("T"),
+            1,
+            1,
+            &sha32(byte),
+            "2026-07-11T00:02:45Z",
+        )
+        .unwrap();
+        db.set_org_share_failed(id, reason, "2026-07-11T00:02:50Z")
+            .unwrap();
+    }
     // An UPLOADED row for the same (org, source) — NOT cancelled.
     db.insert_org_share(
         "u",
@@ -2266,12 +5188,23 @@ fn cancel_pending_org_shares_scopes_to_org_and_source() {
             "2026-07-11T01:00:00Z",
         )
         .unwrap();
-    assert_eq!(
-        n, 2,
-        "both the queued and failed (org-1,d1) rows are cancelled"
-    );
-    assert_eq!(db.get_org_share("q").unwrap().unwrap().state, "revoked");
-    assert_eq!(db.get_org_share("f").unwrap().unwrap().state, "revoked");
+    assert_eq!(n,2,"only authenticated-absence and exact pre-dispatch failures cancel");
+    assert_eq!(db.get_org_share("q").unwrap().unwrap().state,"queued");
+    assert_eq!(db.get_org_share("f").unwrap().unwrap().state,"failed");
+    assert_eq!(db.get_org_share("too-large").unwrap().unwrap().state,"revoked");
+    for id in [
+        "direct",
+        "republish-put",
+        "edit-conflict",
+        "initial",
+    ] {
+        assert_eq!(
+            db.get_org_share(id).unwrap().unwrap().state,
+            "failed",
+            "an ambiguous recovery witness is preserved"
+        );
+    }
+    assert_eq!(db.get_org_share("replayable").unwrap().unwrap().state,"revoked");
     assert_eq!(
         db.get_org_share("u").unwrap().unwrap().state,
         "uploaded",
@@ -2292,6 +5225,167 @@ fn cancel_pending_org_shares_scopes_to_org_and_source() {
         db.cancel_pending_org_shares_for_source_in_org("org-1", None, None, "x")
             .unwrap(),
         0
+    );
+}
+
+#[test]
+fn reusable_org_share_null_and_ambiguous_error_guards_are_fail_closed() {
+    let db = mem_db();
+    let insert = |id: &str, source: &str, byte: u8| {
+        db.insert_org_share(
+            id,
+            "org-1",
+            None,
+            Some(source),
+            "note",
+            Some("T"),
+            1,
+            1,
+            &sha32(byte),
+            "2026-07-11T00:00:00Z",
+        )
+        .unwrap();
+    };
+
+    insert("plain", "plain-source", 1);
+    assert_eq!(
+        db.find_reusable_org_share("org-1", None, Some("plain-source"))
+            .unwrap()
+            .unwrap()
+            .id,
+        "plain",
+        "a normal queued row with NULL last_error remains reusable"
+    );
+    db.reset_org_share_for_retry_with_scrub(
+        "plain",
+        Some("Changed"),
+        1,
+        1,
+        &sha32(2),
+        true,
+        "2026-07-11T00:01:00Z",
+    )
+    .unwrap();
+
+    insert("direct", "direct-source", 3);
+    db.set_org_share_failed("direct", "direct_put_pending", "2026-07-11T00:01:00Z")
+        .unwrap();
+    assert!(db
+        .find_reusable_org_share("org-1", None, Some("direct-source"))
+        .unwrap()
+        .is_none());
+    assert!(matches!(
+        db.reset_org_share_for_retry_with_scrub(
+            "direct",
+            Some("T"),
+            1,
+            1,
+            &sha32(3),
+            true,
+            "2026-07-11T00:02:00Z",
+        ),
+        Err(crate::error::AppError::Unavailable(_))
+    ));
+    assert_eq!(
+        db.get_org_share("direct")
+            .unwrap()
+            .unwrap()
+            .last_error
+            .as_deref(),
+        Some("direct_put_pending")
+    );
+
+    insert("republish-put", "republish-put-source", 6);
+    db.set_org_share_failed(
+        "republish-put",
+        "republish_put_pending",
+        "2026-07-11T00:01:00Z",
+    )
+    .unwrap();
+    assert!(db
+        .find_reusable_org_share("org-1", None, Some("republish-put-source"))
+        .unwrap()
+        .is_none());
+    assert!(matches!(
+        db.reset_org_share_for_retry_with_scrub(
+            "republish-put",
+            Some("T"),
+            1,
+            1,
+            &sha32(6),
+            true,
+            "2026-07-11T00:02:00Z",
+        ),
+        Err(crate::error::AppError::Unavailable(_))
+    ));
+
+    let (id, reason, byte) = ("edit-conflict", "org_edit_conflict", 9u8);
+        insert(id, id, byte);
+        db.set_org_share_failed(id, reason, "2026-07-11T00:01:00Z")
+            .unwrap();
+        assert!(db
+            .find_reusable_org_share("org-1", None, Some(id))
+            .unwrap()
+            .is_none());
+        assert!(matches!(
+            db.reset_org_share_for_retry_with_scrub(
+                id,
+                Some("T"),
+                1,
+                1,
+                &sha32(byte),
+                true,
+                "2026-07-11T00:02:00Z",
+            ),
+            Err(crate::error::AppError::Unavailable(_))
+        ));
+        assert_eq!(
+            db.get_org_share(id).unwrap().unwrap().last_error.as_deref(),
+            Some(reason)
+        );
+
+    insert("replay", "replay-source", 4);
+    db.set_org_share_failed("replay", "initial_post_replayable", "2026-07-11T00:01:00Z")
+        .unwrap();
+    assert_eq!(
+        db.find_reusable_org_share("org-1", None, Some("replay-source"))
+            .unwrap()
+            .unwrap()
+            .id,
+        "replay"
+    );
+    assert!(matches!(
+        db.reset_org_share_for_retry_with_scrub(
+            "replay",
+            Some("Changed"),
+            1,
+            1,
+            &sha32(5),
+            true,
+            "2026-07-11T00:02:00Z",
+        ),
+        Err(crate::error::AppError::Unavailable(_))
+    ));
+    assert!(matches!(
+        db.reset_org_share_for_retry_with_scrub(
+            "replay",
+            Some("T"),
+            1,
+            1,
+            &sha32(4),
+            true,
+            "2026-07-11T00:03:00Z",
+        ),
+        Err(crate::error::AppError::Unavailable(_))
+    ));
+    assert_eq!(
+        db.get_org_share("replay")
+            .unwrap()
+            .unwrap()
+            .last_error
+            .as_deref(),
+        Some("initial_post_replayable"),
+        "only the actor/owner/doc/access-bound replay CAS may re-arm an ambiguous initial POST"
     );
 }
 
@@ -3571,22 +6665,41 @@ fn resolve_wikilink_hides_sealed_target() {
 #[test]
 fn resolve_wikilink_falls_back_to_org_item_exact_title_match() {
     let db = mem_db();
-    seed_org_state(&db, "org-1");
+    let org_id = "11111111-1111-4111-8111-111111111111";
+    let doc_id = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    seed_org_state(&db, org_id);
     let emb = crate::embed::StubEmbedder;
-    db.upsert_org_item(
-        "it-shared",
-        "org-1",
+    for (item_id, seq, rev) in [
+        ("attacker-max-rev", 99, 99),
+        ("authoritative-current", 2, 2),
+    ] {
+        db.upsert_org_item(
+            item_id,
+            org_id,
+            seq,
+            "anna",
+            "Nebula Rollout",
+            "the nebula rollout plan for q3",
+            "2026-07-10T09:00:00Z",
+            rev,
+            1,
+            &sha32(rev as u8),
+            None,
+            None,
+            Some(&emb),
+        )
+        .unwrap();
+        db.set_org_item_document_metadata(item_id, Some(doc_id), "view", Some("owner"))
+            .unwrap();
+    }
+    db.repair_org_reconcile_metadata(
+        "authoritative-current",
+        org_id,
         1,
-        "anna",
-        "Nebula Rollout",
-        "the nebula rollout plan for q3",
-        "2026-07-10T09:00:00Z",
-        1,
-        1,
-        &sha32(9),
-        None,
-        None,
-        Some(&emb),
+        Some(doc_id),
+        "view",
+        Some("owner"),
+        true,
     )
     .unwrap();
 
@@ -3597,8 +6710,55 @@ fn resolve_wikilink_falls_back_to_org_item_exact_title_match() {
         .expect("an exact-title org item must resolve");
     assert_eq!(t.kind, "org");
     assert_eq!(
-        t.id, "it-shared",
-        "org leg must carry the ORG item id, never a local id"
+        t.id, "authoritative-current",
+        "exact-title resolution must follow the relay-authoritative current head, not max rev"
+    );
+    let expected_link_id = format!("{org_id}:{doc_id}");
+    assert_eq!(t.stable_id.as_deref(), Some(expected_link_id.as_str()));
+}
+
+/// Rows ingested before stable document identities existed remain navigable by their immutable feed
+/// item identity. They are never promoted into a durable stable-link target: autocomplete/manual
+/// graph writes still require an authenticated `(org_id, doc_id)` composite.
+#[test]
+fn resolve_wikilink_keeps_legacy_org_item_navigable_without_stable_link_identity() {
+    let db = mem_db();
+    seed_org_state(&db, "org-1");
+    db.upsert_org_item(
+        "legacy-item",
+        "org-1",
+        1,
+        "anna",
+        "Legacy Shared Note",
+        "legacy shared body",
+        "2026-07-10T09:00:00Z",
+        1,
+        1,
+        &sha32(12),
+        None,
+        Some("anna"),
+        None,
+    )
+    .unwrap();
+
+    let target = db
+        .resolve_wikilink("Legacy Shared Note", &HashSet::new())
+        .unwrap()
+        .expect("legacy shared title remains readable and navigable");
+    assert_eq!(target.kind, "org");
+    assert_eq!(target.id, "legacy-item");
+    assert_eq!(
+        target.stable_id, None,
+        "pre-docId rows must never fabricate a durable stable identity"
+    );
+    assert!(db
+        .org_link_doc_id_for_item_visible("legacy-item")
+        .unwrap()
+        .is_none());
+    assert!(
+        db.upsert_manual_link("org", "legacy-item", "meeting", "local-anchor")
+            .is_err(),
+        "a raw legacy item id cannot become an opaque persistent org endpoint"
     );
 }
 
@@ -3609,12 +6769,16 @@ fn resolve_wikilink_falls_back_to_org_item_exact_title_match() {
 #[test]
 fn resolve_wikilink_excludes_tombstoned_and_disabled_org_items() {
     let db = mem_db();
-    seed_org_state(&db, "org-1");
-    seed_org_state(&db, "org-2");
+    let org_1 = "11111111-1111-4111-8111-111111111111";
+    let org_2 = "22222222-2222-4222-8222-222222222222";
+    let doc_1 = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    let doc_2 = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+    seed_org_state(&db, org_1);
+    seed_org_state(&db, org_2);
     let emb = crate::embed::StubEmbedder;
     db.upsert_org_item(
         "it-gone",
-        "org-1",
+        org_1,
         1,
         "anna",
         "Ghost Doc",
@@ -3630,7 +6794,7 @@ fn resolve_wikilink_excludes_tombstoned_and_disabled_org_items() {
     .unwrap();
     db.upsert_org_item(
         "it-disabled",
-        "org-2",
+        org_2,
         1,
         "bob",
         "Disabled Org Doc",
@@ -3644,6 +6808,20 @@ fn resolve_wikilink_excludes_tombstoned_and_disabled_org_items() {
         Some(&emb),
     )
     .unwrap();
+    for (item_id, org_id, doc_id) in [("it-gone", org_1, doc_1), ("it-disabled", org_2, doc_2)] {
+        db.set_org_item_document_metadata(item_id, Some(doc_id), "view", Some("owner"))
+            .unwrap();
+        db.repair_org_reconcile_metadata(
+            item_id,
+            org_id,
+            1,
+            Some(doc_id),
+            "view",
+            Some("owner"),
+            true,
+        )
+        .unwrap();
+    }
 
     let nothing = std::collections::HashSet::new();
     // Sanity: both resolve before we exclude them.
@@ -3664,7 +6842,7 @@ fn resolve_wikilink_excludes_tombstoned_and_disabled_org_items() {
         "a tombstoned org item must not resolve as a wikilink target"
     );
 
-    db.set_org_context_enabled("org-2", false).unwrap();
+    db.set_org_context_enabled(org_2, false).unwrap();
     assert!(
         db.resolve_wikilink("Disabled Org Doc", &nothing)
             .unwrap()
@@ -6210,7 +9388,9 @@ fn vec_knn_orders_nearest_first() {
     insert_known_chunk(&db, "m-far", "far", &one_hot(2));
 
     let nothing = std::collections::HashSet::new();
-    let hits = db.search_semantic_visible(&query, 3, 0.0, &nothing).unwrap();
+    let hits = db
+        .search_semantic_visible(&query, 3, 0.0, &nothing)
+        .unwrap();
     let order: Vec<&str> = hits.iter().map(|h| h.meeting.id.as_str()).collect();
     assert_eq!(
         order,
@@ -6239,7 +9419,9 @@ fn vec_semantic_search_is_gated_by_visibility() {
     let query = one_hot(0);
     // Empty unlock set → excluded.
     let nothing = std::collections::HashSet::new();
-    let hidden = db.search_semantic_visible(&query, 10, 0.0, &nothing).unwrap();
+    let hidden = db
+        .search_semantic_visible(&query, 10, 0.0, &nothing)
+        .unwrap();
     assert!(
         !hidden.iter().any(|h| h.meeting.id == "sealed"),
         "sealed-not-unlocked meeting leaked through the semantic gate"
@@ -6247,7 +9429,9 @@ fn vec_semantic_search_is_gated_by_visibility() {
     // Folder session-unlocked → present.
     let mut unlocked = std::collections::HashSet::new();
     unlocked.insert("f-locked".to_string());
-    let shown = db.search_semantic_visible(&query, 10, 0.0, &unlocked).unwrap();
+    let shown = db
+        .search_semantic_visible(&query, 10, 0.0, &unlocked)
+        .unwrap();
     assert!(
         shown.iter().any(|h| h.meeting.id == "sealed"),
         "session-unlocked meeting must reappear in semantic results"
@@ -6694,7 +9878,9 @@ fn doc_chunk_search_is_gated_by_visibility() {
 
     // Seal the folder (chunk row deliberately survives) → INVISIBLE with empty unlock set.
     db.set_folder_locked("f-locked", true, None).unwrap();
-    let hidden = db.search_doc_chunks_visible(&query, 10, 0.0, &nothing).unwrap();
+    let hidden = db
+        .search_doc_chunks_visible(&query, 10, 0.0, &nothing)
+        .unwrap();
     assert!(
         !hidden.iter().any(|h| h.document_id == "d1"),
         "sealed-not-unlocked document chunk leaked through the gate"
@@ -6703,7 +9889,9 @@ fn doc_chunk_search_is_gated_by_visibility() {
     // Session-unlock → present again.
     let mut unlocked = std::collections::HashSet::new();
     unlocked.insert("f-locked".to_string());
-    let shown = db.search_doc_chunks_visible(&query, 10, 0.0, &unlocked).unwrap();
+    let shown = db
+        .search_doc_chunks_visible(&query, 10, 0.0, &unlocked)
+        .unwrap();
     assert!(
         shown.iter().any(|h| h.document_id == "d1"),
         "session-unlocked document chunk must reappear in search"
@@ -7398,6 +10586,24 @@ fn link_count(db: &Db, kind: &str, id: &str, edge_type: &str) -> i64 {
                      AND ((src_kind = ?1 AND src_id = ?2) OR (dst_kind = ?1 AND dst_id = ?2))",
             rusqlite::params![kind, id, edge_type],
             |r| r.get(0),
+        )
+        .unwrap()
+}
+
+fn manual_link_tuple_count(
+    db: &Db,
+    src_kind: &str,
+    src_id: &str,
+    dst_kind: &str,
+    dst_id: &str,
+) -> i64 {
+    db.lock()
+        .query_row(
+            "SELECT COUNT(*) FROM links
+              WHERE src_kind = ?1 AND src_id = ?2 AND dst_kind = ?3 AND dst_id = ?4
+                AND edge_type = 'manual'",
+            rusqlite::params![src_kind, src_id, dst_kind, dst_id],
+            |row| row.get(0),
         )
         .unwrap()
 }
@@ -8221,6 +11427,85 @@ fn links_for_visible_dedupes_manual_and_wikilink() {
     assert!(
         to_target[0].manual,
         "the collapsed chip is flagged as a removable manual link"
+    );
+}
+
+/// The display representative may point in the opposite direction from the exact manual row. The
+/// chip must carry that stored tuple rather than asking the FE to reconstruct it from `direction`.
+#[test]
+fn links_for_visible_preserves_opposite_manual_tuple_under_wikilink() {
+    let db = mem_db();
+    seed_folder(&db, "f1", "Notes");
+    seed_note_doc(&db, "source", "f1", "Source", "");
+    seed_note_doc(&db, "target", "f1", "Target", "");
+    let unlocked = HashSet::new();
+
+    db.index_wikilinks_for_source(
+        crate::links::LinkKind::Note,
+        "source",
+        "see [[Target]]",
+        &unlocked,
+    )
+    .unwrap();
+    db.upsert_manual_link("note", "target", "note", "source")
+        .unwrap();
+
+    let edges = db
+        .links_for_visible(crate::links::LinkKind::Note, "source", &unlocked)
+        .unwrap();
+    let chip = edges.iter().find(|edge| edge.other_id == "target").unwrap();
+    assert_eq!(chip.edge_type, "wikilink");
+    assert_eq!(chip.direction, "out");
+    // This storage-first layer keeps exact unlink handles internal. The following stacked command
+    // and frontend layer deliberately activates their IPC representation only after this schema is
+    // present, so this oracle binds durable tuple preservation rather than the future wire shape.
+    assert_eq!(
+        chip.manual_edges,
+        vec![crate::storage::models::ManualLinkEdge {
+            src_kind: "note".into(),
+            src_id: "target".into(),
+            dst_kind: "note".into(),
+            dst_id: "source".into(),
+        }],
+        "the removable chip must retain the opposite directed manual tuple"
+    );
+}
+
+/// Both directed manual rows collapse to one neighbour chip, but neither exact unlink handle may be
+/// lost: one click must be able to remove the complete hidden set atomically.
+#[test]
+fn links_for_visible_preserves_bidirectional_manual_tuples() {
+    let db = mem_db();
+    seed_folder(&db, "f1", "Notes");
+    seed_note_doc(&db, "left", "f1", "Left", "");
+    seed_note_doc(&db, "right", "f1", "Right", "");
+    db.upsert_manual_link("note", "left", "note", "right")
+        .unwrap();
+    db.upsert_manual_link("note", "right", "note", "left")
+        .unwrap();
+
+    let edges = db
+        .links_for_visible(crate::links::LinkKind::Note, "left", &HashSet::new())
+        .unwrap();
+    let chip = edges.iter().find(|edge| edge.other_id == "right").unwrap();
+    assert_eq!(edges.len(), 1, "the pair remains one displayed chip");
+    assert_eq!(
+        chip.manual_edges,
+        vec![
+            crate::storage::models::ManualLinkEdge {
+                src_kind: "note".into(),
+                src_id: "left".into(),
+                dst_kind: "note".into(),
+                dst_id: "right".into(),
+            },
+            crate::storage::models::ManualLinkEdge {
+                src_kind: "note".into(),
+                src_id: "right".into(),
+                dst_kind: "note".into(),
+                dst_id: "left".into(),
+            },
+        ],
+        "both exact directed manual tuples must survive display collapse"
     );
 }
 
@@ -9895,7 +13180,9 @@ fn transcript_chunks_are_gated_by_visibility_semantic() {
 
     let query = one_hot(0);
     let nothing = std::collections::HashSet::new();
-    let hidden = db.search_semantic_visible(&query, 10, 0.0, &nothing).unwrap();
+    let hidden = db
+        .search_semantic_visible(&query, 10, 0.0, &nothing)
+        .unwrap();
     assert!(
         !hidden.iter().any(|h| h.meeting.id == "sealed"),
         "sealed meeting's TRANSCRIPT chunk leaked through the semantic gate"
@@ -9903,7 +13190,9 @@ fn transcript_chunks_are_gated_by_visibility_semantic() {
     // Session-unlock → it reappears (proves the row + gate, not purge).
     let mut unlocked = std::collections::HashSet::new();
     unlocked.insert("f-locked".to_string());
-    let shown = db.search_semantic_visible(&query, 10, 0.0, &unlocked).unwrap();
+    let shown = db
+        .search_semantic_visible(&query, 10, 0.0, &unlocked)
+        .unwrap();
     assert!(
         shown.iter().any(|h| h.meeting.id == "sealed"),
         "session-unlocked meeting's transcript chunk must reappear in semantic results"
@@ -10263,7 +13552,9 @@ fn no_entity_match_leaves_hybrid_identical_to_two_leg_fusion() {
 
     // Expected = RRF over EXACTLY the two legs.
     let fts = db.search_visible("budget planning", 10, &nothing).unwrap();
-    let sem = db.search_semantic_visible(&query, 10, 0.0, &nothing).unwrap();
+    let sem = db
+        .search_semantic_visible(&query, 10, 0.0, &nothing)
+        .unwrap();
     let fts_ids: Vec<String> = fts.iter().map(|h| h.meeting.id.clone()).collect();
     let sem_ids: Vec<String> = sem.iter().map(|h| h.meeting.id.clone()).collect();
     let expected: Vec<String> = crate::embed::rrf_fuse(&[fts_ids, sem_ids], crate::embed::RRF_K)
@@ -11271,7 +14562,9 @@ fn s1_floor_drops_orthogonal_semantic_neighbour() {
     let query = one_hot(0);
 
     // No floor (0.0) → BOTH returned.
-    let all = db.search_semantic_visible(&query, 10, 0.0, &nothing).unwrap();
+    let all = db
+        .search_semantic_visible(&query, 10, 0.0, &nothing)
+        .unwrap();
     let ids: Vec<&str> = all.iter().map(|h| h.meeting.id.as_str()).collect();
     assert!(
         ids.contains(&"m-near") && ids.contains(&"m-far"),
@@ -11279,7 +14572,9 @@ fn s1_floor_drops_orthogonal_semantic_neighbour() {
     );
 
     // Floor 0.75 → only the near (cos 1.0) survives.
-    let floored = db.search_semantic_visible(&query, 10, 0.75, &nothing).unwrap();
+    let floored = db
+        .search_semantic_visible(&query, 10, 0.75, &nothing)
+        .unwrap();
     let fids: Vec<&str> = floored.iter().map(|h| h.meeting.id.as_str()).collect();
     assert_eq!(
         fids,
@@ -11359,7 +14654,12 @@ fn s1_floor_keeps_fts_hit_when_vector_leg_floored_empty() {
     db.insert_meeting(&sample_meeting("m-budget", "2026-06-24T10:00:00Z"))
         .unwrap();
     // FTS text carries "budget"; the ONLY chunk is orthogonal (one_hot(2)) to the query one_hot(0).
-    note_for(&db, "m-budget", "claude_code", "the quarterly budget review");
+    note_for(
+        &db,
+        "m-budget",
+        "claude_code",
+        "the quarterly budget review",
+    );
     insert_known_chunk(&db, "m-budget", "the quarterly budget review", &one_hot(2));
 
     let nothing = std::collections::HashSet::new();
@@ -11577,7 +14877,12 @@ fn org_fts_or_fallback_requires_ceil_half_exact_unique_content_terms() {
 
     // The strict phase remains the full original query: once a row matching all 65 terms exists,
     // strict AND returns it and the fallback must not also admit a row matching only the first 16.
-    ingest("strict-full-query", "Strict full query", &overlong_query, 11);
+    ingest(
+        "strict-full-query",
+        "Strict full query",
+        &overlong_query,
+        11,
+    );
     let strict_overlong = db.search_org_chunks_fts(&overlong_query, 10).unwrap();
     let strict_ids = strict_overlong
         .iter()
@@ -11658,7 +14963,9 @@ fn s2_precision_preserved_no_shared_content_word() {
     assert!(
         hits.is_empty(),
         "OR fallback must NOT match when no content word is shared, got {:?}",
-        hits.iter().map(|h| h.meeting.id.clone()).collect::<Vec<_>>()
+        hits.iter()
+            .map(|h| h.meeting.id.clone())
+            .collect::<Vec<_>>()
     );
 }
 
@@ -11672,11 +14979,15 @@ fn s2_stopword_only_overlap_does_not_hit() {
         .unwrap();
     note_for(&db, "m1", "claude_code", "the plan is done");
     let nothing = std::collections::HashSet::new();
-    let hits = db.search_visible("what is the status", 10, &nothing).unwrap();
+    let hits = db
+        .search_visible("what is the status", 10, &nothing)
+        .unwrap();
     assert!(
         hits.is_empty(),
         "stopword-only overlap must not produce a hit through the OR fallback, got {:?}",
-        hits.iter().map(|h| h.meeting.id.clone()).collect::<Vec<_>>()
+        hits.iter()
+            .map(|h| h.meeting.id.clone())
+            .collect::<Vec<_>>()
     );
 }
 
@@ -11687,7 +14998,11 @@ fn s2_stopword_only_overlap_does_not_hit() {
 fn sweep_removes_stale_fixtures_of_both_prefix_families() {
     let root = unique_temp_path("murmur-sweep-scope", "dir");
     std::fs::create_dir_all(&root).unwrap();
-    for name in ["murmur-old.sqlite", "murmur-old.sqlite-wal", "meetnotes-old.sqlite"] {
+    for name in [
+        "murmur-old.sqlite",
+        "murmur-old.sqlite-wal",
+        "meetnotes-old.sqlite",
+    ] {
         std::fs::write(root.join(name), b"x").unwrap();
     }
     // Callers pass ext = "dir"; directories must be reclaimed too, not just files.

--- a/src-tauri/src/storage/links.rs
+++ b/src-tauri/src/storage/links.rs
@@ -14,6 +14,7 @@
 use std::collections::HashSet;
 
 use rusqlite::{Connection, OptionalExtension};
+use zeroize::Zeroizing;
 
 use crate::error::{AppError, Result};
 use crate::storage::db::{
@@ -21,6 +22,23 @@ use crate::storage::db::{
     Db, LinkRowRaw,
 };
 use crate::storage::models::{BacklinkSource, SourceKind, WikiTarget};
+
+fn parse_stable_uuid(value: &str) -> Option<uuid::Uuid> {
+    uuid::Uuid::parse_str(value).ok()
+}
+
+fn org_link_id(org_id: &str, doc_id: &str) -> Option<String> {
+    parse_stable_uuid(org_id)?;
+    parse_stable_uuid(doc_id)?;
+    Some(format!("{org_id}:{doc_id}"))
+}
+
+fn parse_org_link_id(id: &str) -> Option<(&str, &str)> {
+    let (org_id, doc_id) = id.split_once(':')?;
+    parse_stable_uuid(org_id)?;
+    parse_stable_uuid(doc_id)?;
+    Some((org_id, doc_id))
+}
 
 fn parse_marker_identity(value: Option<String>, field: &str) -> Result<Option<u64>> {
     value
@@ -57,6 +75,25 @@ pub(crate) struct LockMarkerExportPublish {
     pub(crate) stage_device: Option<u64>,
     pub(crate) stage_inode: Option<u64>,
     pub(crate) state: String,
+}
+
+/// Verify-before-destroy result prepared by the command layer for a legacy marker living in a
+/// session-unlocked but durably locked note. The plaintext is included only to bind the ciphertext
+/// to the exact transaction-computed scrub; this struct never crosses IPC or leaves process memory.
+#[derive(Clone)]
+pub(crate) struct PreparedManualMarkerSeal {
+    pub(crate) note_id: String,
+    pub(crate) folder_id: String,
+    pub(crate) stripped_text: String,
+    pub(crate) text_blob: Vec<u8>,
+    pub(crate) content_key: Zeroizing<[u8; 32]>,
+}
+
+fn document_seal_aad(folder_id: &str, document_id: &str) -> Vec<u8> {
+    format!(
+        "murmur:document:v1|folder={folder_id}|document={document_id}|type=document"
+    )
+    .into_bytes()
 }
 
 /// TOCTOU seal re-check for a MEETING endpoint, run INSIDE the caller's write transaction — the
@@ -100,6 +137,29 @@ fn link_endpoint_sealed_at_rest_tx(
         // A `note` id IS a `documents` id, so both non-meeting kinds probe the documents row.
         crate::links::LinkKind::Note | crate::links::LinkKind::Document => {
             doc_sealed_at_rest_tx(tx, id)
+        }
+        // Org items have no folder seal domain. Availability is a joined+enabled+live local replica
+        // check, repeated inside the edge write transaction to close context/leave races.
+        crate::links::LinkKind::Org => {
+            let Some((org_id, doc_id)) = parse_org_link_id(id) else {
+                return Ok(true);
+            };
+            let visible = tx
+                .query_row(
+                    "SELECT 1
+                      FROM org_items oi
+                      JOIN org_state os ON os.org_id = oi.org_id
+                     WHERE oi.org_id = ?1 AND oi.doc_id = ?2
+                        AND oi.tombstoned = 0 AND oi.is_current = 1
+                        AND os.context_enabled = 1
+                      LIMIT 1",
+                    rusqlite::params![org_id, doc_id],
+                    |_| Ok(()),
+                )
+                .optional()
+                .map_err(map_err)?
+                .is_some();
+            Ok(!visible)
         }
     }
 }
@@ -285,6 +345,7 @@ impl Db {
                 return Ok(Some(WikiTarget {
                     kind: "note".to_string(),
                     id,
+                    stable_id: None,
                 }));
             }
         }
@@ -294,12 +355,14 @@ impl Db {
             return Ok(Some(WikiTarget {
                 kind: "meeting".to_string(),
                 id: m.id,
+                stable_id: None,
             }));
         }
         if let Some(m) = self.meeting_by_title_folded_visible(title, unlocked)? {
             return Ok(Some(WikiTarget {
                 kind: "meeting".to_string(),
                 id: m.id,
+                stable_id: None,
             }));
         }
         // Document leg — AFTER meetings, BEFORE org. A note that links a document materializes
@@ -343,6 +406,7 @@ impl Db {
                 return Ok(Some(WikiTarget {
                     kind: "document".to_string(),
                     id,
+                    stable_id: None,
                 }));
             }
         }
@@ -354,25 +418,38 @@ impl Db {
         // touches `org_items`.
         {
             let conn = self.lock();
-            let org_id: Option<String> = conn
+            let org_target: Option<(String, String, Option<String>)> = conn
                 .query_row(
-                    "SELECT oi.item_id
+                    "SELECT oi.item_id, oi.org_id, oi.doc_id
                        FROM org_items oi
                        JOIN org_state os ON os.org_id = oi.org_id
                       WHERE oi.tombstoned = 0
                         AND os.context_enabled = 1
+                        AND ((oi.doc_id IS NOT NULL AND oi.is_current = 1)
+                             OR oi.doc_id IS NULL)
                         AND oi.title = ?1
-                      ORDER BY oi.created_at DESC, oi.item_id ASC
+                      ORDER BY CASE WHEN oi.doc_id IS NOT NULL THEN 0 ELSE 1 END,
+                               oi.rev DESC, oi.seq DESC, oi.item_id ASC
                       LIMIT 1",
                     rusqlite::params![title],
-                    |r| r.get(0),
+                    |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
                 )
                 .optional()
                 .map_err(map_err)?;
-            if let Some(id) = org_id {
+            if let Some((item_id, org_id, doc_id)) = org_target {
+                let stable_id = match doc_id {
+                    Some(doc_id) => {
+                        let Some(stable_id) = org_link_id(&org_id, &doc_id) else {
+                            return Ok(None);
+                        };
+                        Some(stable_id)
+                    }
+                    None => None,
+                };
                 return Ok(Some(WikiTarget {
                     kind: "org".to_string(),
-                    id,
+                    id: item_id,
+                    stable_id,
                 }));
             }
         }
@@ -880,15 +957,18 @@ impl Db {
                 let kind = match target.kind.as_str() {
                     "meeting" => crate::links::LinkKind::Meeting,
                     "note" => crate::links::LinkKind::Note,
-                    // "org" targets live outside the folder-lock link domain (PR-4) — skip.
+                    // Org relationships are explicit/manual only. A title collision in a local note
+                    // must not silently create a private Shared Brain relation on save.
+                    "org" => continue,
                     _ => continue,
                 };
                 // Never self-link (a note whose title resolves to itself).
                 if kind == src_kind && target.id == src_id {
                     continue;
                 }
-                if !targets.iter().any(|(k, i)| *k == kind && i == &target.id) {
-                    targets.push((kind, target.id));
+                let endpoint_id = target.stable_id.unwrap_or(target.id);
+                if !targets.iter().any(|(k, i)| *k == kind && i == &endpoint_id) {
+                    targets.push((kind, endpoint_id));
                 }
             }
         }
@@ -1131,11 +1211,12 @@ impl Db {
     /// note↔meeting-links PR-1 — upsert ONE user-initiated DIRECTED `manual` edge (`created_by='user'`,
     /// `status='active'`, `score=1.0`). Idempotent on the table's UNIQUE key (a repeat link is a no-op
     /// refresh, never a duplicate row). Directed like wikilink/companion — endpoints are stored AS
-    /// PASSED (never canonicalized). The CALLER (`link_items_inner`) has already gated BOTH endpoints
-    /// session-visible before this write, so a `manual` row is never created behind a lock. Purged on
-    /// seal by the edge-type-agnostic `purge_links_tx`; read through the both-endpoint-gated
-    /// `links_for_visible`. This wrapper exposes the private `upsert_link_tx` to the command layer
-    /// exactly as `set_companion_link` does for the companion edge — no new SQL surface.
+    /// PASSED (never canonicalized). The CALLER (`link_items_inner`) gates BOTH endpoints
+    /// session-visible, and this transaction repeats the at-rest endpoint gate immediately before
+    /// insertion so a concurrent seal, context-disable, leave, or final withdrawal cannot race a
+    /// stale snapshot into a durable row. Local folder seals purge affected local endpoints; org
+    /// withdrawal instead withholds the opaque private row through the both-endpoint-gated
+    /// `links_for_visible` until a live successor exists again.
     pub fn upsert_manual_link(
         &self,
         src_kind: &str,
@@ -1146,6 +1227,17 @@ impl Db {
         let now = chrono::Utc::now().timestamp_millis();
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
+        let src = crate::links::LinkKind::parse(src_kind)
+            .ok_or_else(|| AppError::InvalidArg("invalid source link kind".into()))?;
+        let dst = crate::links::LinkKind::parse(dst_kind)
+            .ok_or_else(|| AppError::InvalidArg("invalid destination link kind".into()))?;
+        if link_endpoint_sealed_at_rest_tx(&tx, src, src_id)?
+            || link_endpoint_sealed_at_rest_tx(&tx, dst, dst_id)?
+        {
+            return Err(AppError::Locked(
+                "one of these items is no longer available to link".into(),
+            ));
+        }
         Self::upsert_link_tx(
             &tx, src_kind, src_id, dst_kind, dst_id, "manual", 1.0, "user", "active", now,
         )?;
@@ -1162,8 +1254,9 @@ impl Db {
     /// note↔meeting-links PR-1 — delete ONLY the DIRECTED `manual` edge for `(src → dst)`. NEVER
     /// touches a `wikilink`/`companion`/`semantic` row for the same pair (the `edge_type='manual'`
     /// predicate is exact): unlinking a manual link leaves any derived wikilink/companion/semantic
-    /// relation intact. Idempotent (0 rows for an already-absent edge). The CALLER strips the
-    /// materialized `[[Title]]` from the source note's body separately (best-effort).
+    /// relation intact. This narrow restore/retry API is idempotent for a missing exact row; the
+    /// collapsed multi-edge [`Self::delete_manual_links`] API remains strict and atomic. Legacy
+    /// marker preparation is performed transactionally by that batch primitive.
     pub fn delete_manual_link(
         &self,
         src_kind: &str,
@@ -1171,14 +1264,16 @@ impl Db {
         dst_kind: &str,
         dst_id: &str,
     ) -> Result<()> {
-        let conn = self.lock();
-        conn.execute(
-            "DELETE FROM links
-               WHERE src_kind = ?1 AND src_id = ?2 AND dst_kind = ?3 AND dst_id = ?4
-                 AND edge_type = 'manual'",
-            rusqlite::params![src_kind, src_id, dst_kind, dst_id],
-        )
-        .map_err(map_err)?;
+        let _cleanup_queued = self.delete_manual_links_with_marker_seals_mode(
+            &[crate::storage::models::ManualLinkEdge {
+                src_kind: src_kind.to_string(),
+                src_id: src_id.to_string(),
+                dst_kind: dst_kind.to_string(),
+                dst_id: dst_id.to_string(),
+            }],
+            &[],
+            false,
+        )?;
         tracing::info!(
             target: "links",
             src_kind = src_kind,
@@ -1186,6 +1281,267 @@ impl Db {
             "delete_manual_link"
         );
         Ok(())
+    }
+
+    /// Delete a collapsed chip's complete set of exact directed `manual` rows in ONE transaction.
+    /// Every endpoint is re-checked for at-rest availability before the first mutation. For every
+    /// legacy note-source marker, the same transaction strips the DB body and journals its exact
+    /// vault export BEFORE deleting the last naming edge. A preparation error rolls the whole set
+    /// back, so a concurrent seal cannot lose the only durable cleanup intent. Derived
+    /// `wikilink`/`companion`/`semantic` rows are excluded by the exact `edge_type` predicate.
+    /// Returns whether at least one vault-cleanup outbox row was queued.
+    pub fn delete_manual_links(
+        &self,
+        manual_edges: &[crate::storage::models::ManualLinkEdge],
+    ) -> Result<bool> {
+        self.delete_manual_links_with_marker_seals(manual_edges, &[])
+    }
+
+    /// Command-layer twin of [`Self::delete_manual_links`] carrying verified fresh seals for any
+    /// session-unlocked locked source whose legacy marker is mutated in the transaction.
+    pub(crate) fn delete_manual_links_with_marker_seals(
+        &self,
+        manual_edges: &[crate::storage::models::ManualLinkEdge],
+        prepared_seals: &[PreparedManualMarkerSeal],
+    ) -> Result<bool> {
+        self.delete_manual_links_with_marker_seals_mode(manual_edges, prepared_seals, true)
+    }
+
+    fn delete_manual_links_with_marker_seals_mode(
+        &self,
+        manual_edges: &[crate::storage::models::ManualLinkEdge],
+        prepared_seals: &[PreparedManualMarkerSeal],
+        strict_missing: bool,
+    ) -> Result<bool> {
+        if manual_edges.is_empty() || manual_edges.len() > 2 {
+            return Err(AppError::InvalidArg(
+                "a collapsed pair must contain one or two manual link edges".into(),
+            ));
+        }
+        for (index, edge) in manual_edges.iter().enumerate() {
+            if manual_edges[..index].contains(edge) {
+                return Err(AppError::InvalidArg(
+                    "duplicate manual link edge in unlink request".into(),
+                ));
+            }
+        }
+        for (index, seal) in prepared_seals.iter().enumerate() {
+            if seal.text_blob.is_empty()
+                || prepared_seals[..index]
+                    .iter()
+                    .any(|prior| prior.note_id == seal.note_id)
+            {
+                return Err(AppError::InvalidArg(
+                    "invalid prepared manual-marker seal set".into(),
+                ));
+            }
+        }
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        for edge in manual_edges {
+            let src = crate::links::LinkKind::parse(&edge.src_kind)
+                .ok_or_else(|| AppError::InvalidArg("invalid source link kind".into()))?;
+            let dst = crate::links::LinkKind::parse(&edge.dst_kind)
+                .ok_or_else(|| AppError::InvalidArg("invalid destination link kind".into()))?;
+            if link_endpoint_sealed_at_rest_tx(&tx, src, &edge.src_id)?
+                || link_endpoint_sealed_at_rest_tx(&tx, dst, &edge.dst_id)?
+            {
+                return Err(AppError::Locked(
+                    "one of these items is no longer available to unlink".into(),
+                ));
+            }
+        }
+        let cleanup_queued =
+            Self::prepare_manual_marker_cleanup_tx(&tx, manual_edges, prepared_seals)?;
+        for edge in manual_edges {
+            let deleted = tx
+                .execute(
+                    "DELETE FROM links
+                   WHERE src_kind = ?1 AND src_id = ?2 AND dst_kind = ?3 AND dst_id = ?4
+                     AND edge_type = 'manual'",
+                    rusqlite::params![edge.src_kind, edge.src_id, edge.dst_kind, edge.dst_id],
+                )
+                .map_err(map_err)?;
+            if strict_missing && deleted != 1 {
+                return Err(AppError::InvalidArg(
+                    "one of the selected manual link edges no longer exists".into(),
+                ));
+            }
+        }
+        tx.commit().map_err(map_err)?;
+        tracing::info!(
+            target: "links",
+            count = manual_edges.len(),
+            "delete_manual_links"
+        );
+        Ok(cleanup_queued)
+    }
+
+    /// Resolve the current marker title while holding the exact unlink transaction. This is not a
+    /// general read surface: the command already gated both endpoints, and the transaction repeats
+    /// their at-rest availability check before calling it. `None` is a fail-closed preparation
+    /// refusal for a note-source edge, never permission to delete first and guess later.
+    fn manual_marker_title_tx(
+        tx: &rusqlite::Transaction<'_>,
+        kind: crate::links::LinkKind,
+        id: &str,
+    ) -> Result<Option<String>> {
+        match kind {
+            crate::links::LinkKind::Meeting => tx
+                .query_row(
+                    "SELECT COALESCE(NULLIF(TRIM(title), ''), 'Meeting')
+                       FROM meetings WHERE id = ?1",
+                    rusqlite::params![id],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(map_err),
+            crate::links::LinkKind::Note | crate::links::LinkKind::Document => tx
+                .query_row(
+                    "SELECT COALESCE(NULLIF(TRIM(title), ''), name)
+                       FROM documents WHERE id = ?1",
+                    rusqlite::params![id],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(map_err),
+            crate::links::LinkKind::Org => {
+                let Some((org_id, doc_id)) = parse_org_link_id(id) else {
+                    return Ok(None);
+                };
+                tx.query_row(
+                    "SELECT oi.title
+                       FROM org_items oi
+                       JOIN org_state os ON os.org_id = oi.org_id
+                      WHERE oi.org_id = ?1 AND oi.doc_id = ?2
+                        AND oi.tombstoned = 0 AND oi.is_current = 1
+                        AND os.context_enabled = 1
+                      LIMIT 1",
+                    rusqlite::params![org_id, doc_id],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(map_err)
+            }
+        }
+    }
+
+    /// Prepare every legacy note-source marker cleanup in the unlink transaction. Only a real
+    /// machine-owned marker is mutated/journalled; ordinary user-authored wikilinks outside the
+    /// managed block are untouched. The returned flag tells the command whether it must drain the
+    /// durable filesystem outbox before reporting success.
+    fn prepare_manual_marker_cleanup_tx(
+        tx: &rusqlite::Transaction<'_>,
+        manual_edges: &[crate::storage::models::ManualLinkEdge],
+        prepared_seals: &[PreparedManualMarkerSeal],
+    ) -> Result<bool> {
+        let mut titles_by_note: std::collections::HashMap<
+            String,
+            std::collections::HashSet<String>,
+        > = std::collections::HashMap::new();
+        for edge in manual_edges {
+            let src = crate::links::LinkKind::parse(&edge.src_kind)
+                .ok_or_else(|| AppError::InvalidArg("invalid source link kind".into()))?;
+            if src != crate::links::LinkKind::Note {
+                continue;
+            }
+            let dst = crate::links::LinkKind::parse(&edge.dst_kind)
+                .ok_or_else(|| AppError::InvalidArg("invalid destination link kind".into()))?;
+            let title = Self::manual_marker_title_tx(tx, dst, &edge.dst_id)?.ok_or_else(|| {
+                AppError::Locked("one of these items is no longer available to unlink".into())
+            })?;
+            let title = crate::enrich::sanitize(&title);
+            if title.trim().is_empty() {
+                return Err(AppError::InvalidArg(
+                    "a linked item has no usable marker title".into(),
+                ));
+            }
+            titles_by_note
+                .entry(edge.src_id.clone())
+                .or_default()
+                .insert(title);
+        }
+
+        let mut cleanup_queued = false;
+        let mut used_seals = std::collections::HashSet::new();
+        for (note_id, titles) in titles_by_note {
+            let row: Option<(String, Option<String>, bool, String)> = tx
+                .query_row(
+                    "SELECT COALESCE(d.text, ''), d.exported_path, f.locked, d.folder_id
+                       FROM documents d
+                       JOIN folders f ON f.id = d.folder_id
+                      WHERE d.id = ?1 AND d.kind = 'note'",
+                    rusqlite::params![note_id],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                )
+                .optional()
+                .map_err(map_err)?;
+            let Some((text, exported_path, folder_locked, folder_id)) = row else {
+                return Err(AppError::Locked(
+                    "a linked note is no longer available to unlink".into(),
+                ));
+            };
+            let Some(stripped) = Self::strip_titles_from_managed_block(&text, &titles) else {
+                continue;
+            };
+            if let Some(path) = exported_path.filter(|path| !path.is_empty()) {
+                for title in &titles {
+                    Self::enqueue_marker_export_cleanup_tx(tx, false, &note_id, "", &path, title)?;
+                }
+                cleanup_queued = true;
+            }
+            let changed = if folder_locked {
+                let prepared = prepared_seals
+                    .iter()
+                    .find(|prepared| prepared.note_id == note_id)
+                    .ok_or_else(|| {
+                        AppError::Locked(
+                            "locked note marker cleanup has no verified fresh seal".into(),
+                        )
+                    })?;
+                if prepared.stripped_text != stripped {
+                    return Err(AppError::Locked(
+                        "linked note changed while its marker cleanup was prepared".into(),
+                    ));
+                }
+                if prepared.folder_id != folder_id
+                    || crate::crypto::decrypt(
+                        &prepared.content_key,
+                        &prepared.text_blob,
+                        &document_seal_aad(&folder_id, &note_id),
+                    )? != stripped.as_bytes()
+                {
+                    return Err(AppError::Locked(
+                        "locked note marker cleanup seal did not verify byte-identical".into(),
+                    ));
+                }
+                used_seals.insert(note_id.clone());
+                tx.execute(
+                    "UPDATE documents SET text = '', text_blob = ?2
+                       WHERE id = ?1 AND kind = 'note' AND text = ?3",
+                    rusqlite::params![note_id, prepared.text_blob, text],
+                )
+                .map_err(map_err)?
+            } else {
+                tx.execute(
+                    "UPDATE documents SET text = ?2
+                       WHERE id = ?1 AND kind = 'note' AND text = ?3",
+                    rusqlite::params![note_id, stripped, text],
+                )
+                .map_err(map_err)?
+            };
+            if changed != 1 {
+                return Err(AppError::Storage(
+                    "linked note changed while preparing marker cleanup".into(),
+                ));
+            }
+        }
+        if used_seals.len() != prepared_seals.len() {
+            return Err(AppError::InvalidArg(
+                "prepared manual-marker seal does not belong to this unlink".into(),
+            ));
+        }
+        Ok(cleanup_queued)
     }
 
     /// TEST-ONLY: insert one raw `links` row and return its row id, so sibling-crate test modules
@@ -1525,7 +1881,7 @@ impl Db {
 
     /// PURE: strip the `[[title]]` hits named by `titles` from the MACHINE-OWNED `murmur:links` block
     /// of `body`, via [`crate::enrich::extract_link_hits`] + `apply_link_markers` (the exact inverse
-    /// the command-layer `strip_manual_link_marker` uses). Returns `Some(new_body)` iff a hit was
+    /// the transactional manual-unlink preparation uses). Returns `Some(new_body)` iff a hit was
     /// removed (so the caller only writes on a real change), else `None`. A user-typed `[[Title]]`
     /// OUTSIDE the managed block is never in `extract_link_hits`'s output, so it is never stripped.
     pub(crate) fn strip_titles_from_managed_block(
@@ -2022,6 +2378,7 @@ impl Db {
                    JOIN doc_chunks dc ON dc.id = v.chunk_id
                   WHERE dc.document_id = ?1"
             }
+            crate::links::LinkKind::Org => return Ok(None),
         };
         let mut stmt = conn.prepare(sql).map_err(map_err)?;
         let rows = stmt
@@ -2152,6 +2509,7 @@ impl Db {
                 "AND kd.chunk_id NOT IN (SELECT id FROM doc_chunks WHERE document_id = ?3)"
                     .to_string(),
             ),
+            crate::links::LinkKind::Org => return Ok(Vec::new()),
         };
         // Each vec0 table gets its own single-MATCH CTE (vec0 allows one MATCH+k per query); the
         // meeting leg maps chunk→meeting and gates on the meeting's note folder; the doc leg maps
@@ -2462,6 +2820,16 @@ impl Db {
         };
         let mut edges: Vec<crate::storage::models::LinkEdge> = Vec::new();
         for (lid, sk, si, dk, di, et, cb, st, score, created_at) in rows {
+            let manual_edges = if et == "manual" {
+                vec![crate::storage::models::ManualLinkEdge {
+                    src_kind: sk.clone(),
+                    src_id: si.clone(),
+                    dst_kind: dk.clone(),
+                    dst_id: di.clone(),
+                }]
+            } else {
+                Vec::new()
+            };
             // Identify the OTHER endpoint (the one that is NOT the queried item) + the direction.
             let (direction, other_kind_s, other_id) = if sk == kind.as_str() && si == id {
                 ("out", dk, di)
@@ -2477,11 +2845,18 @@ impl Db {
             else {
                 continue;
             };
+            let navigation_id = if other_kind == crate::links::LinkKind::Org {
+                self.org_link_target_visible(&other_id)?
+                    .map(|(item_id, _title)| item_id)
+            } else {
+                None
+            };
             edges.push(crate::storage::models::LinkEdge {
                 id: lid,
                 direction: direction.to_string(),
                 other_kind: other_kind_s,
                 other_id,
+                navigation_id,
                 other_title,
                 edge_type: et,
                 created_by: cb,
@@ -2490,7 +2865,8 @@ impl Db {
                 created_at,
                 // Set on the base build; the collapse pass below flips it true per (other_kind,
                 // other_id) pair that carries a `manual` edge.
-                manual: false,
+                manual: !manual_edges.is_empty(),
+                manual_edges,
             });
         }
         let edges = Self::collapse_manual_duplicate_edges(edges);
@@ -2632,8 +3008,10 @@ impl Db {
     /// - PREFER the DETERMINISTIC edge (`wikilink` > `companion` > `semantic`) for the surviving
     ///   row's stable `id`/`edge_type` (its id is what accept/dismiss already key on), falling back to
     ///   the `manual` row when it is the only edge for the pair.
-    /// - Set `manual = true` on the surviving row iff ANY edge in the group is a `manual` edge — so
-    ///   the FE knows the chip is user-created + REMOVABLE regardless of which `edge_type` won.
+    /// - Preserve every exact directed manual tuple in `manual_edges` (at most two: one per direction
+    ///   under the table UNIQUE key), and set `manual = true` iff that list is non-empty. The FE can
+    ///   therefore remove the whole hidden manual set without reconstructing direction from the
+    ///   representative.
     ///
     /// Input order is already the reader's stable sort (active-then-suggested, score DESC, id ASC);
     /// this preserves the FIRST-seen group's position so the output order stays deterministic. Pairs
@@ -2664,27 +3042,23 @@ impl Db {
             (String, String),
             crate::storage::models::LinkEdge,
         > = std::collections::HashMap::new();
-        for edge in edges {
+        for mut edge in edges {
             let key = (edge.other_kind.clone(), edge.other_id.clone());
-            let has_manual = edge.edge_type == "manual";
             match groups.get_mut(&key) {
                 None => {
                     order.push(key.clone());
-                    let mut rep = edge;
-                    rep.manual = has_manual;
-                    groups.insert(key, rep);
+                    edge.manual = !edge.manual_edges.is_empty();
+                    groups.insert(key, edge);
                 }
                 Some(rep) => {
-                    // A manual edge anywhere in the group makes the surviving chip removable.
-                    if has_manual {
-                        rep.manual = true;
-                    }
+                    let mut manual_edges = std::mem::take(&mut rep.manual_edges);
+                    manual_edges.append(&mut edge.manual_edges);
                     // Promote the representative to the more-deterministic edge (lower rank wins).
                     if edge_rank(&edge.edge_type) < edge_rank(&rep.edge_type) {
-                        let manual_flag = rep.manual; // carry the group's removable flag forward.
                         *rep = edge;
-                        rep.manual = manual_flag;
                     }
+                    rep.manual = !manual_edges.is_empty();
+                    rep.manual_edges = manual_edges;
                 }
             }
         }
@@ -2722,7 +3096,7 @@ impl Db {
                 let expected_kind = match kind {
                     crate::links::LinkKind::Note => "note",
                     crate::links::LinkKind::Document => "document",
-                    crate::links::LinkKind::Meeting => unreachable!(),
+                    crate::links::LinkKind::Meeting | crate::links::LinkKind::Org => unreachable!(),
                 };
                 let sql = format!(
                     "SELECT COALESCE(NULLIF(TRIM(d.title), ''), d.name)
@@ -2737,6 +3111,54 @@ impl Db {
                 .optional()
                 .map_err(map_err)
             }
+            crate::links::LinkKind::Org => self
+                .org_link_target_visible(id)
+                .map(|target| target.map(|(_item_id, title)| title)),
         }
+    }
+
+    /// Resolve a strict stable Shared Brain `org_id:doc_id` composite to its current live feed item
+    /// and title. The SQL join is the org read gate: membership must still exist locally, context
+    /// must be enabled, and at least one non-tombstoned current replica revision must exist.
+    /// Unknown/revoked/left/disabled are all indistinguishable `None` so a private edge never becomes
+    /// an existence or title oracle.
+    pub fn org_link_target_visible(&self, link_id: &str) -> Result<Option<(String, String)>> {
+        let Some((org_id, doc_id)) = parse_org_link_id(link_id) else {
+            return Ok(None);
+        };
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT oi.item_id, oi.title
+               FROM org_items oi
+               JOIN org_state os ON os.org_id = oi.org_id
+              WHERE oi.org_id = ?1 AND oi.doc_id = ?2
+                AND oi.tombstoned = 0 AND oi.is_current = 1 AND os.context_enabled = 1
+              LIMIT 1",
+            rusqlite::params![org_id, doc_id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
+    /// Translate one current feed revision id to its stable link identity. This is used only while
+    /// building the already-gated org candidate page; legacy rows without a `doc_id` are deliberately
+    /// not offered because an item-id edge would break on the next revision.
+    pub fn org_link_doc_id_for_item_visible(&self, item_id: &str) -> Result<Option<String>> {
+        let conn = self.lock();
+        let target: Option<(String, String)> = conn
+            .query_row(
+                "SELECT oi.org_id, oi.doc_id
+               FROM org_items oi
+               JOIN org_state os ON os.org_id = oi.org_id
+              WHERE oi.item_id = ?1 AND oi.tombstoned = 0 AND os.context_enabled = 1
+                AND oi.doc_id IS NOT NULL AND oi.is_current = 1
+              LIMIT 1",
+                rusqlite::params![item_id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .optional()
+            .map_err(map_err)?;
+        Ok(target.and_then(|(org_id, doc_id)| org_link_id(&org_id, &doc_id)))
     }
 }

--- a/src-tauri/src/storage/meetings_store.rs
+++ b/src-tauri/src/storage/meetings_store.rs
@@ -175,13 +175,22 @@ impl Db {
     }
 
     pub fn set_meeting_title(&self, id: &str, title: &str) -> Result<()> {
-        let conn = self.lock();
-        conn.execute(
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let changed = tx.execute(
             "UPDATE meetings SET title = ?2 WHERE id = ?1",
             rusqlite::params![id, title],
         )
         .map_err(map_err)?;
-        Ok(())
+        if changed != 0 {
+            tx.execute(
+                "UPDATE org_shares SET republish_dirty = republish_dirty + 1
+                  WHERE meeting_id = ?1 AND state IN ('queued','uploaded','failed')",
+                rusqlite::params![id],
+            )
+            .map_err(map_err)?;
+        }
+        tx.commit().map_err(map_err)
     }
 
     /// Upsert the meeting's typed-notes plaintext. Used by the FE autosave (write the whole buffer)

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -767,31 +767,39 @@ pub struct OrgChunkHit {
 #[serde(rename_all = "camelCase")]
 pub struct OrgItemDetail {
     pub item_id: String,
+    #[serde(skip_serializing, skip_deserializing)]
+    pub doc_id: Option<String>,
+    #[serde(skip_serializing, skip_deserializing)]
+    pub link_id: Option<String>,
     pub author_hint: String,
     pub title: String,
     pub created_at: String,
     pub rev: u32,
     pub markdown: String,
-    /// True when the CALLER authored this item (their `server_user_id` matches the item's stored
-    /// `author_user_id`) — so the viewer can offer edit-in-place on ANY of the author's machines, not
-    /// just the one that first shared it (the origin machine redirects to the local source instead;
-    /// a second machine has no local `org_shares` row, so this server-authoritative author check is
-    /// what unlocks editing there). Computed by the `org_get_item` command (needs the session);
-    /// `Db::get_org_item` always sets it `false`. 2026-07-14.
+    /// Compatibility mirror of `can_edit` for older frontends. Permission-aware clients use
+    /// `can_edit`/`can_manage`, computed from stable ownership, org role, and document access.
     pub editable: bool,
+    #[serde(skip_serializing, skip_deserializing)]
+    pub access: String,
+    #[serde(skip_serializing, skip_deserializing)]
+    pub can_edit: bool,
+    #[serde(skip_serializing, skip_deserializing)]
+    pub can_manage: bool,
 }
 
-/// Internal (not FE-facing) context the `org_update_own_item` egress command needs to re-publish an
-/// edited org item the caller authored: which org to publish into, the current rev (→ rev+1 supersede),
-/// the original `created_at` + `source_kind` to preserve on the wire, and the stored `author_user_id`
-/// for the ownership gate. Resolved by [`Db::org_item_edit_ctx`] for a LIVE (non-tombstoned) item.
+/// Internal edit/management context for a live org item. It preserves immutable envelope provenance
+/// and separates the revision actor (`author_user_id`) from the stable document manager.
 #[derive(Debug, Clone)]
 pub struct OrgItemEditCtx {
     pub org_id: String,
+    pub doc_id: Option<String>,
     pub rev: u32,
     pub created_at: String,
+    pub author_hint: String,
     pub source_kind: Option<String>,
     pub author_user_id: Option<String>,
+    pub document_owner_user_id: Option<String>,
+    pub access: String,
 }
 
 /// Shared Brain v1 — a LIST-row header for one live org item (the browsable org-items list, so a
@@ -803,6 +811,8 @@ pub struct OrgItemEditCtx {
 #[serde(rename_all = "camelCase")]
 pub struct OrgItemHeader {
     pub item_id: String,
+    #[serde(skip_serializing, skip_deserializing)]
+    pub doc_id: Option<String>,
     pub title: String,
     pub author_hint: String,
     pub created_at: String,
@@ -1631,6 +1641,18 @@ pub struct BacklinkSource {
     pub timestamp: String,
 }
 
+/// One exact, directed user-created row in the `links` table. A displayed [`LinkEdge`] may collapse
+/// several rows for the same neighbour (including both `A -> B` and `B -> A`), so removability must
+/// carry the stored tuples instead of reconstructing one from the display representative.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ManualLinkEdge {
+    pub src_kind: String,
+    pub src_id: String,
+    pub dst_kind: String,
+    pub dst_id: String,
+}
+
 /// Brain v3 PR-3 — one persisted `links` row surfaced to the FE, with the OTHER endpoint's display
 /// title resolved through the SAME visibility gate as the queried endpoint (both-endpoint gating).
 /// `direction` says whether the queried item is this edge's `src` ("out") or `dst` ("in") so the FE
@@ -1640,22 +1662,28 @@ pub struct BacklinkSource {
 /// (1.0 for the deterministic wikilink/companion/manual edges). Only ever built when BOTH endpoints
 /// are VISIBLE — a sealed neighbour can never appear, and a sealed queried item yields an empty list.
 ///
-/// `manual` (note↔meeting-links PR-1) is the DISPLAY-DEDUPE flag: when a user-initiated `manual` edge
+/// `manual` (note↔meeting-links PR-1) is the backward-compatible DISPLAY-DEDUPE flag: when a
+/// user-initiated `manual` edge
 /// AND a derived `wikilink` (or another deterministic edge) exist for the SAME `(other_kind,
 /// other_id)` pair, `links_for_visible` collapses them to ONE row (preferring the deterministic
 /// `edge_type` for its stable id) but sets `manual = true` so the FE knows the chip is user-created +
 /// REMOVABLE (renders the `×` → `unlink_items`). A pair with no `manual` edge has `manual = false`
-/// (an auto wikilink/semantic chip — not user-removable). Always present, defaults `false` for any
-/// non-manual edge, so an old FE reads it as absent.
+/// (an auto wikilink/semantic chip — not user-removable). `manual_edges` is the authoritative exact
+/// directed set behind that flag (one or both directions); it lets unlink remove every collapsed row
+/// atomically even when the representative points the other way. Both fields default empty/false.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct LinkEdge {
     pub id: i64,
     /// "out" (queried item is `src`) | "in" (queried item is `dst`).
     pub direction: String,
-    /// The neighbour endpoint kind: `meeting|note|document`.
+    /// The neighbour endpoint kind: `meeting|note|document|org`.
     pub other_kind: String,
     pub other_id: String,
+    /// Current navigation id when the stable endpoint id differs from the routed id. Present for an
+    /// `org` edge (`other_id = org_id:doc_id`, `navigation_id = current item_id`) and omitted locally.
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub navigation_id: Option<String>,
     /// The neighbour's current display title, resolved through the visibility gate.
     pub other_title: String,
     pub edge_type: String,
@@ -1669,6 +1697,11 @@ pub struct LinkEdge {
     /// a `manual` chip. Defaults `false` (serde default) for every non-manual pair.
     #[serde(default)]
     pub manual: bool,
+    /// Every exact directed `manual` row folded into this displayed chip. Empty for derived-only
+    /// chips. The unlink command removes this whole set in one transaction; `manual` remains as the
+    /// backward-compatible display flag.
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub manual_edges: Vec<ManualLinkEdge>,
 }
 
 /// A resolved `[[Title]]` wikilink navigation target — the VISIBLE note, meeting, document, or
@@ -1688,6 +1721,10 @@ pub struct WikiTarget {
     /// `"meeting"` | `"note"` | `"document"` | `"org"`.
     pub kind: String,
     pub id: String,
+    /// Revision-stable endpoint id used by the private link graph. For org targets this is the
+    /// strict `org_id:doc_id` composite; `id` remains the current `item_id` for navigation.
+    #[serde(default, skip_serializing, skip_deserializing)]
+    pub stable_id: Option<String>,
 }
 
 /// note↔meeting-links PR-2 — one EXPLICIT source the user pinned in the Ask source picker: a
@@ -1894,8 +1931,16 @@ pub struct OrgShareRow {
     pub generation: u32,
     pub content_sha256: Option<Vec<u8>>,
     pub item_id: Option<String>,
+    pub doc_id: Option<String>,
+    pub access: String,
+    /// The caller's durable PII-scrub choice. Legacy rows migrate to fail-safe `true`.
+    pub scrub: bool,
     pub state: String,
     pub last_error: Option<String>,
+    pub expected_actor_user_id: Option<String>,
+    pub expected_owner_user_id: Option<String>,
+    pub source_version: u64,
+    pub republish_dirty: u64,
     pub created_at: String,
     pub updated_at: String,
 }

--- a/src-tauri/src/storage/notes_store.rs
+++ b/src-tauri/src/storage/notes_store.rs
@@ -278,14 +278,46 @@ impl Db {
         text: &str,
         updated_at: i64,
     ) -> Result<()> {
-        let conn = self.lock();
-        conn.execute(
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let changed = tx.execute(
             "UPDATE documents SET title = ?2, text = ?3, updated_at = ?4
                WHERE id = ?1 AND kind = 'note'",
             rusqlite::params![id, title, text, updated_at],
         )
         .map_err(map_err)?;
-        Ok(())
+        if changed != 0 {
+            tx.execute(
+            "UPDATE org_shares SET republish_dirty = republish_dirty + 1, republish_deferred=0
+              WHERE document_id = ?1 AND state IN ('queued','uploaded','failed')",
+            rusqlite::params![id],
+            )
+            .map_err(map_err)?;
+        }
+        tx.commit().map_err(map_err)
+    }
+
+    pub fn update_note_row_debounced(
+        &self,
+        id: &str,
+        title: &str,
+        text: &str,
+        updated_at: i64,
+    ) -> Result<()> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        tx.execute(
+            "UPDATE documents SET title = ?2, text = ?3, updated_at = ?4
+               WHERE id = ?1 AND kind = 'note'",
+            rusqlite::params![id, title, text, updated_at],
+        )
+        .map_err(map_err)?;
+        tx.execute(
+            "UPDATE org_shares SET republish_deferred=1
+              WHERE document_id=?1 AND state IN ('queued','uploaded','failed')",
+            rusqlite::params![id],
+        ).map_err(map_err)?;
+        tx.commit().map_err(map_err)
     }
 
     /// Background auto-title CAS. It changes ONLY `title` + `updated_at`, and only while the exact
@@ -302,8 +334,9 @@ impl Db {
         title: &str,
         updated_at: i64,
     ) -> Result<bool> {
-        let conn = self.lock();
-        let changed = conn
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let changed = tx
             .execute(
                 "UPDATE documents
                     SET title = ?5, updated_at = ?6
@@ -328,6 +361,15 @@ impl Db {
                 ],
             )
             .map_err(map_err)?;
+        if changed != 0 {
+            tx.execute(
+                "UPDATE org_shares SET republish_dirty = republish_dirty + 1
+                  WHERE document_id = ?1 AND state IN ('queued','uploaded','failed')",
+                rusqlite::params![id],
+            )
+            .map_err(map_err)?;
+        }
+        tx.commit().map_err(map_err)?;
         Ok(changed == 1)
     }
 
@@ -345,14 +387,47 @@ impl Db {
         text_blob: &[u8],
         updated_at: i64,
     ) -> Result<()> {
-        let conn = self.lock();
-        conn.execute(
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let changed = tx.execute(
             "UPDATE documents SET title = ?2, text = ?3, text_blob = ?4, updated_at = ?5
                WHERE id = ?1 AND kind = 'note'",
             rusqlite::params![id, title, text, text_blob, updated_at],
         )
         .map_err(map_err)?;
-        Ok(())
+        if changed != 0 {
+            tx.execute(
+            "UPDATE org_shares SET republish_dirty = republish_dirty + 1, republish_deferred=0
+              WHERE document_id = ?1 AND state IN ('queued','uploaded','failed')",
+            rusqlite::params![id],
+            )
+            .map_err(map_err)?;
+        }
+        tx.commit().map_err(map_err)
+    }
+
+    pub fn update_note_row_sealed_debounced(
+        &self,
+        id: &str,
+        title: &str,
+        text: &str,
+        text_blob: &[u8],
+        updated_at: i64,
+    ) -> Result<()> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        tx.execute(
+            "UPDATE documents SET title = ?2, text = ?3, text_blob = ?4, updated_at = ?5
+               WHERE id = ?1 AND kind = 'note'",
+            rusqlite::params![id, title, text, text_blob, updated_at],
+        )
+        .map_err(map_err)?;
+        tx.execute(
+            "UPDATE org_shares SET republish_deferred=1
+              WHERE document_id=?1 AND state IN ('queued','uploaded','failed')",
+            rusqlite::params![id],
+        ).map_err(map_err)?;
+        tx.commit().map_err(map_err)
     }
 
     /// MOVE-INTO-LOCKED twin of [`Db::update_note_row_sealed`] (2026-07-10 residual W2): reassign an
@@ -664,8 +739,9 @@ impl Db {
     }
 
     pub fn upsert_note(&self, note: &NoteRecord) -> Result<()> {
-        let conn = self.lock();
-        conn.execute(
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        tx.execute(
             "INSERT INTO notes
                (meeting_id, provider_id, markdown, created_at, exported_path,
                 model_requested, model_served, gateway_host)
@@ -689,7 +765,13 @@ impl Db {
             ],
         )
         .map_err(map_err)?;
-        Ok(())
+        tx.execute(
+            "UPDATE org_shares SET republish_dirty = republish_dirty + 1
+              WHERE meeting_id = ?1 AND state IN ('queued','uploaded','failed')",
+            rusqlite::params![note.meeting_id],
+        )
+        .map_err(map_err)?;
+        tx.commit().map_err(map_err)
     }
 
     /// SEAL-ON-WRITE twin of [`Db::upsert_note`] for a meeting whose folder is LOCKED (and
@@ -742,6 +824,12 @@ impl Db {
                 content_blob,
                 folder_id,
             ],
+        )
+        .map_err(map_err)?;
+        tx.execute(
+            "UPDATE org_shares SET republish_dirty = republish_dirty + 1
+              WHERE meeting_id = ?1 AND state IN ('queued','uploaded','failed')",
+            rusqlite::params![note.meeting_id],
         )
         .map_err(map_err)?;
         tx.commit().map_err(map_err)
@@ -798,7 +886,8 @@ impl Db {
         conn.query_row(
             "SELECT meeting_id, provider_id, markdown, created_at, exported_path,
                     model_requested, model_served, gateway_host
-               FROM notes WHERE meeting_id = ?1 ORDER BY created_at DESC LIMIT 1",
+               FROM notes WHERE meeting_id = ?1
+               ORDER BY created_at DESC, provider_id DESC LIMIT 1",
             rusqlite::params![meeting_id],
             row_to_note,
         )

--- a/src-tauri/src/storage/org_store.rs
+++ b/src-tauri/src/storage/org_store.rs
@@ -26,7 +26,8 @@ use rusqlite::OptionalExtension;
 use crate::embed::Embedder;
 use crate::error::Result;
 use crate::storage::db::{
-    fts_match_content_terms_any, fts_match_query, fts_unicode61_content_terms, map_err, Db,
+    fts_match_content_terms_any, fts_match_query, fts_unicode61_content_terms,
+    insert_share_egress_dispatch_tx, map_err, Db,
 };
 use crate::storage::models::OrgChunkHit;
 
@@ -35,6 +36,13 @@ use crate::storage::models::OrgChunkHit;
 /// also prevents an untrusted query from making SQL preparation scale without bound.
 const MAX_ORG_FTS_CONTENT_TERMS: usize = 32;
 
+fn require_stable_uuid(value: &str, error: &'static str) -> Result<()> {
+    uuid::Uuid::parse_str(value)
+        .ok()
+        .map(|_| ())
+        .ok_or_else(|| crate::error::AppError::InvalidArg(error.into()))
+}
+
 /// Chunk/vector material for one org item, prepared before entering the short feed-commit
 /// transaction. Keeping model inference on this side of the transaction is load-bearing: recording
 /// admission may invalidate the work, while a committed feed action and its cursor must remain one
@@ -42,6 +50,43 @@ const MAX_ORG_FTS_CONTENT_TERMS: usize = 32;
 pub(crate) struct PreparedOrgItemIndex {
     chunks: Vec<String>,
     vector_blobs: Option<Vec<Vec<u8>>>,
+}
+
+/// Result of a stable-document metadata commit. `changed` preserves each caller's historical
+/// boolean (feed/reconcile applied, local predecessor evicted); `visibility_reduced` independently
+/// reports that a previously readable authoritative head was demoted in the same transaction.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct OrgMetadataCommitOutcome {
+    pub(crate) changed: bool,
+    pub(crate) visibility_reduced: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct OrgAccessAttemptRow {
+    pub(crate) dispatch_id: String,
+    pub(crate) org_id: String,
+    pub(crate) doc_id: String,
+    pub(crate) old_access: String,
+    pub(crate) new_access: String,
+    pub(crate) actor_user_id: String,
+    pub(crate) owner_user_id: String,
+}
+
+/// Optional plaintext projection carried by an already-authenticated republish completion. All
+/// expensive validation/index preparation happens before the transaction; the storage seam only
+/// installs these exact bytes after the durable dispatch witness still matches.
+#[allow(dead_code)]
+pub(crate) struct OrgRepublishProjection<'a> {
+    pub(crate) item_id: &'a str,
+    pub(crate) seq: u64,
+    pub(crate) author_hint: &'a str,
+    pub(crate) title: &'a str,
+    pub(crate) markdown: &'a str,
+    pub(crate) created_at: &'a str,
+    pub(crate) source_kind: Option<&'a str>,
+    pub(crate) author_user_id: Option<&'a str>,
+    pub(crate) prepared: &'a PreparedOrgItemIndex,
+    pub(crate) attachments: &'a [crate::storage::IncomingAttachment],
 }
 
 /// What this device currently holds for ONE org item id — the minimum the anti-entropy reconcile
@@ -58,6 +103,8 @@ pub(crate) struct OrgReplicaState {
     /// before the feed carried one. Equality with the feed's hash is what lets the sweep skip an
     /// already-converged item with no blob fetch.
     pub(crate) content_sha256: Option<Vec<u8>>,
+    #[allow(dead_code)]
+    pub(crate) projection_sha256: Option<Vec<u8>>,
 }
 
 /// One live org item's existing chunk rows, loaded for a model-switch reindex. The keyset iterator
@@ -75,7 +122,88 @@ pub(crate) struct OrgItemVectorBatch {
     content_sha256: Option<Vec<u8>>,
 }
 
+#[allow(dead_code)]
 impl Db {
+    pub(crate) fn begin_org_source_closure(
+        &self,
+        source_kind: &str,
+        source_id: &str,
+    ) -> Result<()> {
+        if !matches!(source_kind, "meeting" | "document") || source_id.trim().is_empty() {
+            return Err(crate::error::AppError::InvalidArg(
+                "invalid organization share closure source".into(),
+            ));
+        }
+        let conn = self.lock();
+        conn.execute(
+            "INSERT INTO org_share_closures(scope_kind,scope_id,phase,created_at)
+             VALUES(?1,?2,'closing',?3)
+             ON CONFLICT(scope_kind,scope_id) DO NOTHING",
+            rusqlite::params![source_kind,source_id,chrono::Utc::now().to_rfc3339()],
+        ).map_err(map_err)?;
+        Ok(())
+    }
+
+    pub(crate) fn begin_org_folder_closure(&self, folder_id: &str) -> Result<bool> {
+        let conn = self.lock();
+        let changed = conn.execute(
+            "INSERT INTO org_share_closures(scope_kind,scope_id,phase,created_at)
+             VALUES('folder',?1,'closing',?2)
+             ON CONFLICT(scope_kind,scope_id) DO NOTHING",
+            rusqlite::params![folder_id,chrono::Utc::now().to_rfc3339()],
+        ).map_err(map_err)?;
+        Ok(changed == 1)
+    }
+
+    pub(crate) fn clear_org_folder_closure(&self, folder_id: &str) -> Result<()> {
+        self.lock().execute(
+            "DELETE FROM org_share_closures WHERE scope_kind='folder' AND scope_id=?1",
+            [folder_id],
+        ).map_err(map_err)?;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn clear_org_source_closure(
+        &self,
+        source_kind: &str,
+        source_id: &str,
+    ) -> Result<()> {
+        if !matches!(source_kind, "meeting" | "document") || source_id.trim().is_empty() {
+            return Err(crate::error::AppError::InvalidArg(
+                "invalid organization share closure source".into(),
+            ));
+        }
+        self.lock()
+            .execute(
+                "DELETE FROM org_share_closures WHERE scope_kind=?1 AND scope_id=?2",
+                rusqlite::params![source_kind, source_id],
+            )
+            .map_err(map_err)?;
+        Ok(())
+    }
+
+    pub(crate) fn complete_org_closure(&self, scope_kind: &str, scope_id: &str) -> Result<()> {
+        self.lock().execute(
+            "UPDATE org_share_closures SET phase='closed'
+              WHERE scope_kind=?1 AND scope_id=?2",
+            rusqlite::params![scope_kind,scope_id],
+        ).map_err(map_err)?;
+        Ok(())
+    }
+
+    pub(crate) fn org_folder_closure_exists(&self, folder_id: &str) -> Result<bool> {
+        self.lock()
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM org_share_closures
+                  WHERE scope_kind='folder' AND scope_id=?1)",
+                [folder_id],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(map_err)
+            .map(|exists| exists != 0)
+    }
+
     /// Upsert the locally-cached membership of an org (create/status). Preserves an existing row's
     /// local `consented` flag, `last_seq` cursor, AND `context_enabled` toggle (an incoming status
     /// refresh MUST NOT reset the consent flag, rewind the sync cursor, or silently re-enable an org
@@ -167,12 +295,13 @@ impl Db {
     pub fn set_org_context_enabled(&self, org_id: &str, enabled: bool) -> Result<bool> {
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
-        let changed = tx.execute(
-            "UPDATE org_state SET context_enabled = ?2
+        let changed = tx
+            .execute(
+                "UPDATE org_state SET context_enabled = ?2
                WHERE org_id = ?1 AND context_enabled != ?2",
-            rusqlite::params![org_id, enabled as i64],
-        )
-        .map_err(map_err)?;
+                rusqlite::params![org_id, enabled as i64],
+            )
+            .map_err(map_err)?;
         if !enabled && changed > 0 {
             Self::purge_all_ask_conversations_tx(&tx)?;
         }
@@ -216,11 +345,12 @@ impl Db {
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
         let items = Self::purge_org_replica_tx(&tx, org_id)?;
-        let removed = tx.execute(
-            "DELETE FROM org_state WHERE org_id = ?1",
-            rusqlite::params![org_id],
-        )
-        .map_err(map_err)?;
+        let removed = tx
+            .execute(
+                "DELETE FROM org_state WHERE org_id = ?1",
+                rusqlite::params![org_id],
+            )
+            .map_err(map_err)?;
         if removed > 0 {
             // Membership withdrawal invalidates global-derived Ask even when the decrypted org
             // replica was already empty and the durable conversation is the only derived copy.
@@ -247,12 +377,44 @@ impl Db {
         content_sha256: &[u8],
         created_at: &str,
     ) -> Result<()> {
+        self.insert_org_share_with_scrub(
+            id,
+            org_id,
+            meeting_id,
+            document_id,
+            kind,
+            title,
+            rev,
+            generation,
+            content_sha256,
+            true,
+            created_at,
+        )
+    }
+
+    /// Insert a queued share while durably recording the caller's scrub choice. Retry code must use
+    /// this value so an ambiguous successful POST is replayed with the same canonical content hash.
+    #[allow(clippy::too_many_arguments)]
+    pub fn insert_org_share_with_scrub(
+        &self,
+        id: &str,
+        org_id: &str,
+        meeting_id: Option<&str>,
+        document_id: Option<&str>,
+        kind: &str,
+        title: Option<&str>,
+        rev: u32,
+        generation: u32,
+        content_sha256: &[u8],
+        scrub: bool,
+        created_at: &str,
+    ) -> Result<()> {
         let conn = self.lock();
         conn.execute(
             "INSERT INTO org_shares
                (id, org_id, meeting_id, document_id, kind, title, rev, generation,
-                content_sha256, item_id, state, last_error, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL, 'queued', NULL, ?10, ?10)",
+                content_sha256, item_id, scrub, state, last_error, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL, ?10, 'queued', NULL, ?11, ?11)",
             rusqlite::params![
                 id,
                 org_id,
@@ -263,6 +425,7 @@ impl Db {
                 rev as i64,
                 generation as i64,
                 content_sha256,
+                scrub as i64,
                 created_at
             ],
         )
@@ -278,6 +441,51 @@ impl Db {
             "UPDATE org_shares SET state = 'uploaded', item_id = ?2, last_error = NULL,
                updated_at = ?3 WHERE id = ?1",
             rusqlite::params![id, item_id, updated_at],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    pub fn set_org_share_document_metadata(
+        &self,
+        id: &str,
+        doc_id: &str,
+        access: &str,
+    ) -> Result<()> {
+        require_stable_uuid(doc_id, "invalid org document id")?;
+        if !matches!(access, "view" | "edit") {
+            return Err(crate::error::AppError::InvalidArg(
+                "invalid org item access".into(),
+            ));
+        }
+        let conn = self.lock();
+        let org_id = conn
+            .query_row(
+                "SELECT org_id FROM org_shares WHERE id = ?1",
+                rusqlite::params![id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(map_err)?;
+        if let Some(org_id) = org_id.as_deref() {
+            require_stable_uuid(org_id, "invalid organization id")?;
+        }
+        conn.execute(
+            "UPDATE org_shares SET doc_id = ?2, access = ?3 WHERE id = ?1",
+            rusqlite::params![id, doc_id, access],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Clear server-issued stable-document metadata before retrying a publish against a relay that
+    /// rejected the prior resource. This is one storage-owned mutation so command code never opens
+    /// the SQLCipher connection or risks clearing only half of the identity/permission tuple.
+    pub fn clear_org_share_document_metadata(&self, id: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE org_shares SET doc_id = NULL, access = 'view' WHERE id = ?1",
+            rusqlite::params![id],
         )
         .map_err(map_err)?;
         Ok(())
@@ -319,16 +527,25 @@ impl Db {
             generation: r.get::<_, i64>(7)? as u32,
             content_sha256: r.get(8)?,
             item_id: r.get(9)?,
-            state: r.get(10)?,
-            last_error: r.get(11)?,
-            created_at: r.get(12)?,
-            updated_at: r.get(13)?,
+            doc_id: r.get(10)?,
+            access: r.get(11)?,
+            scrub: r.get::<_, i64>(12)? != 0,
+            state: r.get(13)?,
+            last_error: r.get(14)?,
+            expected_actor_user_id: r.get(15)?,
+            expected_owner_user_id: r.get(16)?,
+            source_version: r.get::<_, i64>(17)?.max(0) as u64,
+            republish_dirty: r.get::<_, i64>(18)?.max(0) as u64,
+            created_at: r.get(19)?,
+            updated_at: r.get(20)?,
         })
     }
 
     const ORG_SHARE_COLS: &'static str =
         "id, org_id, meeting_id, document_id, kind, title, rev, generation,
-         content_sha256, item_id, state, last_error, created_at, updated_at";
+         content_sha256, item_id, doc_id, access, scrub, state, last_error,
+         expected_actor_user_id, expected_owner_user_id, source_version, republish_dirty,
+         created_at, updated_at";
 
     /// One org share by its local id.
     pub fn get_org_share(&self, id: &str) -> Result<Option<crate::storage::OrgShareRow>> {
@@ -345,12 +562,274 @@ impl Db {
         .map_err(map_err)
     }
 
+    /// Content-free dispatch witness for exact attempt completion CAS. Kept separate from the
+    /// general UI row so the transport id is not propagated through unrelated read surfaces.
+    pub fn org_share_dispatch_id(&self, id: &str) -> Result<Option<String>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT dispatch_id FROM org_shares WHERE id = ?1",
+            rusqlite::params![id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(map_err)
+        .map(Option::flatten)
+    }
+
+    /// Persist one content-free access dispatch receipt and its complete local CAS witness in the
+    /// same SQLite transaction. A content mutation journal, stale local access/owner tuple, or an
+    /// existing pending access attempt refuses admission without leaving a phantom egress row.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn persist_org_access_attempt_if_current(
+        &self,
+        ts: i64,
+        host: &str,
+        dispatch_id: &str,
+        org_id: &str,
+        doc_id: &str,
+        old_access: &str,
+        new_access: &str,
+        actor_user_id: &str,
+        owner_user_id: &str,
+        created_at: &str,
+    ) -> Result<bool> {
+        for (value, error) in [
+            (dispatch_id, "invalid org access dispatch id"),
+            (org_id, "invalid org id"),
+            (doc_id, "invalid org document id"),
+            (actor_user_id, "invalid org access actor"),
+            (owner_user_id, "invalid org document owner"),
+        ] {
+            require_stable_uuid(value, error)?;
+        }
+        if !matches!(old_access, "view" | "edit") || !matches!(new_access, "view" | "edit") {
+            return Err(crate::error::AppError::InvalidArg(
+                "invalid org document access".into(),
+            ));
+        }
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let admissible: bool = tx
+            .query_row(
+                "SELECT EXISTS(
+                   SELECT 1 FROM org_items
+                    WHERE org_id=?1 AND doc_id=?2 AND tombstoned=0 AND is_current=1
+                      AND access=?3 AND document_owner_user_id=?4
+                 )
+                 AND NOT EXISTS(
+                   SELECT 1 FROM org_access_attempts
+                    WHERE org_id=?1 AND doc_id=?2 AND state='pending'
+                 )
+                 AND NOT EXISTS(
+                   SELECT 1 FROM org_access_attempts WHERE dispatch_id=?5
+                 )
+                 AND NOT EXISTS(
+                   SELECT 1 FROM org_shares
+                    WHERE org_id=?1 AND doc_id=?2 AND state='failed'
+                      AND last_error IN (
+                        'direct_put_pending','republish_put_pending','republish_post_pending',
+                        'initial_post_pending','initial_post_replayable','projection_pending',
+                        'recovery_witness_missing','org_edit_conflict'
+                      )
+                 )",
+                rusqlite::params![org_id, doc_id, old_access, owner_user_id, dispatch_id],
+                |row| Ok(row.get::<_, i64>(0)? != 0),
+            )
+            .map_err(map_err)?;
+        if !admissible {
+            return Ok(false);
+        }
+        insert_share_egress_dispatch_tx(
+            &tx,
+            ts,
+            host,
+            "org_share_access",
+            0,
+            dispatch_id,
+        )?;
+        tx.execute(
+            "INSERT INTO org_access_attempts
+              (dispatch_id,org_id,doc_id,old_access,new_access,actor_user_id,owner_user_id,state,created_at)
+             VALUES(?1,?2,?3,?4,?5,?6,?7,'pending',?8)",
+            rusqlite::params![
+                dispatch_id,
+                org_id,
+                doc_id,
+                old_access,
+                new_access,
+                actor_user_id,
+                owner_user_id,
+                created_at
+            ],
+        )
+        .map_err(map_err)?;
+        tx.commit().map_err(map_err)?;
+        Ok(true)
+    }
+
+    pub(crate) fn pending_org_access_attempts(&self) -> Result<Vec<OrgAccessAttemptRow>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT dispatch_id,org_id,doc_id,old_access,new_access,actor_user_id,owner_user_id
+                   FROM org_access_attempts WHERE state='pending' ORDER BY seq ASC",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(OrgAccessAttemptRow {
+                    dispatch_id: row.get(0)?,
+                    org_id: row.get(1)?,
+                    doc_id: row.get(2)?,
+                    old_access: row.get(3)?,
+                    new_access: row.get(4)?,
+                    actor_user_id: row.get(5)?,
+                    owner_user_id: row.get(6)?,
+                })
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// Apply a successful PATCH only while every immutable dispatch/document/account/access witness
+    /// still matches and no newer non-failed attempt or blocked content mutation exists. The attempt
+    /// transition and all local replica/journal metadata updates commit or roll back together.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn apply_org_access_attempt_if_current(
+        &self,
+        dispatch_id: &str,
+        org_id: &str,
+        doc_id: &str,
+        old_access: &str,
+        new_access: &str,
+        actor_user_id: &str,
+        owner_user_id: &str,
+    ) -> Result<bool> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let changed = tx
+            .execute(
+                "UPDATE org_access_attempts SET state='applied'
+                  WHERE dispatch_id=?1 AND org_id=?2 AND doc_id=?3 AND old_access=?4
+                    AND new_access=?5 AND actor_user_id=?6 AND owner_user_id=?7 AND state='pending'
+                    AND EXISTS(SELECT 1 FROM org_items
+                      WHERE org_id=?2 AND doc_id=?3 AND tombstoned=0 AND is_current=1
+                        AND access=?4 AND document_owner_user_id=?7)
+                    AND NOT EXISTS(SELECT 1 FROM org_access_attempts newer
+                      WHERE newer.org_id=?2 AND newer.doc_id=?3
+                        AND newer.seq > org_access_attempts.seq AND newer.state != 'failed')
+                    AND NOT EXISTS(SELECT 1 FROM org_shares
+                      WHERE org_id=?2 AND doc_id=?3 AND state='failed'
+                        AND last_error IN (
+                          'direct_put_pending','republish_put_pending','republish_post_pending',
+                          'initial_post_pending','initial_post_replayable','projection_pending',
+                          'recovery_witness_missing','org_edit_conflict'
+                        ))",
+                rusqlite::params![
+                    dispatch_id,
+                    org_id,
+                    doc_id,
+                    old_access,
+                    new_access,
+                    actor_user_id,
+                    owner_user_id
+                ],
+            )
+            .map_err(map_err)?;
+        if changed != 1 {
+            return Ok(false);
+        }
+        tx.execute(
+            "UPDATE org_items SET access=?3,document_owner_user_id=?4
+              WHERE org_id=?1 AND doc_id=?2 AND tombstoned=0",
+            rusqlite::params![org_id, doc_id, new_access, owner_user_id],
+        )
+        .map_err(map_err)?;
+        tx.execute(
+            "UPDATE org_shares SET access=?3 WHERE org_id=?1 AND doc_id=?2",
+            rusqlite::params![org_id, doc_id, new_access],
+        )
+        .map_err(map_err)?;
+        tx.execute(
+            "DELETE FROM org_access_attempts WHERE org_id=?1 AND doc_id=?2
+              AND seq < (SELECT seq FROM org_access_attempts WHERE dispatch_id=?3)",
+            rusqlite::params![org_id, doc_id, dispatch_id],
+        )
+        .map_err(map_err)?;
+        tx.commit().map_err(map_err)?;
+        Ok(true)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn fail_org_access_attempt_if_current(
+        &self,
+        dispatch_id: &str,
+        org_id: &str,
+        doc_id: &str,
+        old_access: &str,
+        new_access: &str,
+        actor_user_id: &str,
+        owner_user_id: &str,
+    ) -> Result<bool> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE org_access_attempts SET state='failed'
+              WHERE dispatch_id=?1 AND org_id=?2 AND doc_id=?3 AND old_access=?4
+                AND new_access=?5 AND actor_user_id=?6 AND owner_user_id=?7 AND state='pending'",
+            rusqlite::params![
+                dispatch_id,
+                org_id,
+                doc_id,
+                old_access,
+                new_access,
+                actor_user_id,
+                owner_user_id
+            ],
+        )
+        .map(|changed| changed == 1)
+        .map_err(map_err)
+    }
+
     /// The org share bearing a given server `item_id` (for revoke-by-item + self-share dedup).
     pub fn org_share_by_item(&self, item_id: &str) -> Result<Option<crate::storage::OrgShareRow>> {
         let conn = self.lock();
         conn.query_row(
             &format!(
                 "SELECT {} FROM org_shares WHERE item_id = ?1",
+                Self::ORG_SHARE_COLS
+            ),
+            rusqlite::params![item_id],
+            Self::map_org_share,
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
+    /// Resolve a revoke request arriving with the CURRENT feed item back to the origin device's
+    /// durable source-share row without changing its CAS baseline (`item_id`/`rev`/hash). Exact
+    /// Server item-id lookup remains the first leg so legacy rows keep working; the stable leg is
+    /// scoped by `(org_id, doc_id)` and is intentionally not used by `org_resolve_source`. A server
+    /// item id must never be interpreted as the local `org_shares.id` namespace.
+    pub fn org_share_for_revoke_target(
+        &self,
+        item_id: &str,
+    ) -> Result<Option<crate::storage::OrgShareRow>> {
+        if let Some(row) = self.org_share_by_item(item_id)? {
+            return Ok(Some(row));
+        }
+        let conn = self.lock();
+        conn.query_row(
+            &format!(
+                "SELECT {} FROM org_shares
+                  WHERE (org_id, doc_id) =
+                        (SELECT org_id, doc_id FROM org_items
+                          WHERE item_id = ?1 AND tombstoned = 0 AND doc_id IS NOT NULL)
+                    AND (state = 'uploaded' OR (state = 'failed' AND item_id IS NOT NULL))
+                  ORDER BY created_at ASC LIMIT 1",
                 Self::ORG_SHARE_COLS
             ),
             rusqlite::params![item_id],
@@ -388,7 +867,11 @@ impl Db {
         let mut stmt = conn
             .prepare(&format!(
                 "SELECT {} FROM org_shares
-                   WHERE (state = 'uploaded' OR (state = 'failed' AND item_id IS NOT NULL))
+                   WHERE (state = 'uploaded'
+                      OR (state = 'failed' AND (item_id IS NOT NULL OR last_error IN
+                         ('initial_post_pending','initial_post_replayable','direct_put_pending',
+                          'republish_put_pending','republish_post_pending','org_edit_conflict',
+                          'recovery_witness_missing','projection_pending','too_large'))))
                      AND ((?1 IS NOT NULL AND meeting_id = ?1)
                        OR (?2 IS NOT NULL AND document_id = ?2))
                    ORDER BY created_at ASC",
@@ -408,12 +891,44 @@ impl Db {
         Ok(out)
     }
 
-    /// Every LIVE (`uploaded`) org share of ONE exact source (`meeting_id` XOR `document_id`) in ONE
+    /// Destructive source operations must see every non-terminal journal, including legacy
+    /// queued/generic-failed NULL-identity rows whose old client may have dispatched a POST without
+    /// recording a witness. The command-layer proof classifier decides DELETE vs local cancellation
+    /// vs fail-closed; this query deliberately makes no remote-absence inference from state/item_id.
+    pub(crate) fn org_shares_for_source_revoke(
+        &self,
+        meeting_id: Option<&str>,
+        document_id: Option<&str>,
+    ) -> Result<Vec<crate::storage::OrgShareRow>> {
+        if meeting_id.is_none() && document_id.is_none() {
+            return Ok(Vec::new());
+        }
+        let conn = self.lock();
+        let mut stmt = conn.prepare(&format!(
+            "SELECT {} FROM org_shares
+              WHERE state != 'revoked'
+                AND ((?1 IS NOT NULL AND meeting_id=?1)
+                  OR (?2 IS NOT NULL AND document_id=?2))
+              ORDER BY created_at ASC,id ASC",
+            Self::ORG_SHARE_COLS,
+        )).map_err(map_err)?;
+        let rows = stmt.query_map(
+            rusqlite::params![meeting_id,document_id],Self::map_org_share,
+        ).map_err(map_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// Every LIVE org share of ONE exact source (`meeting_id` XOR `document_id`) in ONE
     /// org, OLDEST-FIRST (stable tie-break on `id`). The `(org, source)`-scoped twin of
     /// `org_shares_for_source` (which spans all orgs): powers the share IDEMPOTENCY guard + the
     /// duplicate collapse — `[0]` is the canonical KEEPER (earliest published, the identity other
-    /// members first saw), `[1..]` are accidental duplicates to tombstone. `state = 'uploaded'` only
-    /// (a queued/failed row has no live server item; a revoked one was intentionally torn down).
+    /// members first saw), `[1..]` are accidental duplicates to tombstone. A durable direct-PUT
+    /// journal remains live because its `item_id` is the still-published predecessor; treating it as
+    /// absent would let a second Share click mint a new document while reconciliation is pending.
     /// `meeting_id`/`document_id` matched NULL-safe via `IS`; both-None ⇒ empty (no source).
     pub fn uploaded_org_shares_for_source_in_org(
         &self,
@@ -428,9 +943,15 @@ impl Db {
         let mut stmt = conn
             .prepare(&format!(
                 "SELECT {} FROM org_shares
-                   WHERE org_id = ?1 AND state = 'uploaded'
+                   WHERE org_id = ?1
+                     AND (state IN ('queued','uploaded')
+                       OR (state = 'failed' AND (item_id IS NOT NULL OR last_error IN
+                         ('initial_post_pending','initial_post_replayable','direct_put_pending',
+                          'republish_put_pending','republish_post_pending','org_edit_conflict',
+                          'recovery_witness_missing','projection_pending'))))
                      AND meeting_id IS ?2 AND document_id IS ?3
-                   ORDER BY created_at ASC, id ASC",
+                   ORDER BY CASE WHEN state='uploaded' AND item_id IS NOT NULL THEN 0 ELSE 1 END,
+                            created_at ASC, id ASC",
                 Self::ORG_SHARE_COLS
             ))
             .map_err(map_err)?;
@@ -459,6 +980,7 @@ impl Db {
             .prepare(&format!(
                 "SELECT {} FROM org_shares o
                    WHERE o.state = 'uploaded'
+                     AND (o.meeting_id IS NOT NULL OR o.document_id IS NOT NULL)
                      AND EXISTS (
                        SELECT 1 FROM org_shares e
                         WHERE e.state = 'uploaded'
@@ -498,8 +1020,11 @@ impl Db {
         let conn = self.lock();
         let n = conn
             .execute(
-                "UPDATE org_shares SET state = 'revoked', updated_at = ?4
-                   WHERE org_id = ?1 AND state IN ('queued', 'failed')
+                "UPDATE org_shares SET state = 'revoked', last_error=NULL, dispatch_id=NULL,
+                     updated_at = ?4
+                   WHERE org_id = ?1 AND state='failed' AND item_id IS NULL
+                     AND ((last_error='initial_post_replayable') OR
+                       (dispatch_id IS NULL AND last_error IN ('too_large','seal_failed')))
                      AND meeting_id IS ?2 AND document_id IS ?3",
                 rusqlite::params![org_id, meeting_id, document_id, updated_at],
             )
@@ -528,6 +1053,10 @@ impl Db {
                    WHERE org_id = ?1
                      AND meeting_id IS ?2 AND document_id IS ?3
                      AND state IN ('queued', 'failed')
+                     AND (last_error IS NULL OR last_error NOT IN
+                       ('direct_put_pending', 'republish_put_pending', 'republish_post_pending',
+                        'org_edit_conflict', 'recovery_witness_missing', 'projection_pending',
+                        'initial_post_pending'))
                    ORDER BY created_at DESC LIMIT 1",
                 Self::ORG_SHARE_COLS
             ),
@@ -538,11 +1067,77 @@ impl Db {
         .map_err(map_err)
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn acquire_new_org_share_for_source(
+        &self, id: &str, org_id: &str, meeting_id: Option<&str>, document_id: Option<&str>,
+        kind: &str, title: Option<&str>, rev: u32, generation: u32,
+        content_sha256: &[u8], scrub: bool, now: &str,
+    ) -> Result<bool> {
+        let conn = self.lock();
+        let changed = conn.execute(
+            "INSERT INTO org_shares
+              (id,org_id,meeting_id,document_id,kind,title,rev,generation,content_sha256,
+               scrub,state,created_at,updated_at)
+             SELECT ?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,'queued',?11,?11
+              WHERE NOT EXISTS(SELECT 1 FROM org_shares
+                WHERE org_id=?2 AND meeting_id IS ?3 AND document_id IS ?4
+                  AND state!='revoked')",
+            rusqlite::params![id, org_id, meeting_id, document_id, kind, title, rev as i64,
+                generation as i64, content_sha256, scrub as i64, now],
+        ).map_err(map_err)?;
+        Ok(changed == 1)
+    }
+
     /// SB-3 retry re-arm: reset an EXISTING org-share row back to `queued` for a fresh publish attempt,
     /// refreshing the per-attempt fields (title/content hash/generation/timestamps) and CLEARING any
     /// item_id + last_error. Used by `share_to_org_inner` when it reuses a `find_reusable_org_share`
     /// row instead of inserting a new one — so N failed attempts stay ONE row, and a later success
     /// flips that same row to uploaded (no duplicate). Idempotent on the row id.
+    // One cohesive retry-row mutation; keeping every persisted attempt field visible prevents a
+    // caller from accidentally retaining stale scrub/hash/generation state.
+    #[allow(clippy::too_many_arguments)]
+    pub fn reset_org_share_for_retry_with_scrub(
+        &self,
+        id: &str,
+        title: Option<&str>,
+        rev: u32,
+        generation: u32,
+        content_sha256: &[u8],
+        scrub: bool,
+        updated_at: &str,
+    ) -> Result<()> {
+        let conn = self.lock();
+        let changed = conn
+            .execute(
+                "UPDATE org_shares SET state = 'queued', item_id = NULL, last_error = NULL,
+               title = ?2, rev = ?3, generation = ?4, content_sha256 = ?5, scrub = ?6,
+               updated_at = ?7
+             WHERE id = ?1
+               AND (last_error IS NULL OR last_error NOT IN
+                 ('direct_put_pending', 'republish_put_pending', 'republish_post_pending',
+                  'org_edit_conflict', 'recovery_witness_missing', 'projection_pending',
+                  'initial_post_pending', 'initial_post_replayable'))",
+                rusqlite::params![
+                    id,
+                    title,
+                    rev as i64,
+                    generation as i64,
+                    content_sha256,
+                    scrub as i64,
+                    updated_at
+                ],
+            )
+            .map_err(map_err)?;
+        if changed != 1 {
+            return Err(crate::error::AppError::Unavailable(
+                "ambiguous org publish source changed before replay".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Backward-compatible retry seam for the command layer from the stack base.
+    /// The follow-up command-layer commit switches to the scrub-bound variant above.
     pub fn reset_org_share_for_retry(
         &self,
         id: &str,
@@ -570,6 +1165,202 @@ impl Db {
         Ok(())
     }
 
+    /// A stable document with an unresolved mutation witness cannot accept a permission PATCH.
+    /// The check is content-free and runs before the PATCH dispatch receipt/socket boundary.
+    pub(crate) fn org_document_has_blocked_republish(
+        &self,
+        org_id: &str,
+        doc_id: &str,
+    ) -> Result<bool> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM org_shares
+              WHERE org_id = ?1 AND doc_id = ?2 AND state = 'failed'
+                AND last_error IN ('direct_put_pending', 'republish_put_pending',
+                                   'republish_post_pending', 'initial_post_pending',
+                                   'initial_post_replayable', 'org_edit_conflict',
+                                   'recovery_witness_missing', 'projection_pending'))",
+            rusqlite::params![org_id, doc_id],
+            |row| Ok(row.get::<_, i64>(0)? != 0),
+        )
+        .map_err(map_err)
+    }
+
+    pub(crate) fn org_share_source_counters(&self, id: &str) -> Result<(u64, u64)> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT source_version, republish_dirty FROM org_shares WHERE id = ?1",
+            rusqlite::params![id],
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?.max(0) as u64,
+                    row.get::<_, i64>(1)?.max(0) as u64,
+                ))
+            },
+        )
+        .map_err(map_err)
+    }
+
+    pub(crate) fn complete_source_less_projection_if_present(&self, share_id: &str) -> Result<bool> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let changed = tx.execute(
+            "DELETE FROM org_shares WHERE id=?1 AND state='failed'
+              AND last_error='projection_pending' AND meeting_id IS NULL AND document_id IS NULL
+              AND EXISTS(SELECT 1 FROM org_items i WHERE i.item_id=org_shares.item_id
+                AND i.org_id=org_shares.org_id AND i.doc_id=org_shares.doc_id
+                AND i.access=org_shares.access AND i.rev=org_shares.rev
+                AND i.generation=org_shares.generation AND i.content_sha256=org_shares.content_sha256
+                AND i.projection_sha256=org_shares.content_sha256
+                AND i.tombstoned=0)",
+            rusqlite::params![share_id],
+        ).map_err(map_err)?;
+        tx.commit().map_err(map_err)?;
+        Ok(changed == 1)
+    }
+
+    pub(crate) fn terminalize_and_evict_org_document(
+        &self,
+        org_id: &str,
+        doc_id: &str,
+        updated_at: &str,
+    ) -> Result<bool> {
+        require_stable_uuid(org_id, "invalid organization id")?;
+        require_stable_uuid(doc_id, "invalid org document id")?;
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let item_ids: Vec<String> = {
+            let mut stmt = tx.prepare(
+                "SELECT item_id FROM org_items WHERE org_id=?1 AND doc_id=?2 AND tombstoned=0",
+            ).map_err(map_err)?;
+            let rows = stmt.query_map(rusqlite::params![org_id,doc_id], |row| row.get(0))
+                .map_err(map_err)?;
+            let mut ids = Vec::new();
+            for row in rows { ids.push(row.map_err(map_err)?); }
+            ids
+        };
+        let mut evicted = false;
+        for item_id in item_ids {
+            evicted |= Self::tombstone_org_item_tx(&tx, &item_id)?;
+        }
+        Self::purge_org_document_links_tx(&tx, org_id, doc_id)?;
+        tx.execute(
+            "UPDATE org_shares SET state='revoked', last_error=NULL, item_id=NULL,
+                    dispatch_id=NULL, updated_at=?3
+              WHERE org_id=?1 AND doc_id=?2 AND state!='revoked'",
+            rusqlite::params![org_id,doc_id,updated_at],
+        ).map_err(map_err)?;
+        tx.execute(
+            "DELETE FROM org_access_attempts WHERE org_id=?1 AND doc_id=?2",
+            rusqlite::params![org_id,doc_id],
+        ).map_err(map_err)?;
+        tx.commit().map_err(map_err)?;
+        Ok(evicted)
+    }
+
+    pub(crate) fn org_source_version(
+        &self,
+        meeting_id: Option<&str>,
+        document_id: Option<&str>,
+    ) -> Result<u64> {
+        let (kind, id) = match (meeting_id, document_id) {
+            (Some(id), None) => ("meeting", id),
+            (None, Some(id)) => ("document", id),
+            _ => return Err(crate::error::AppError::InvalidArg(
+                "exactly one org share source is required".into(),
+            )),
+        };
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT version FROM org_source_versions WHERE source_kind=?1 AND source_id=?2",
+            rusqlite::params![kind, id],
+            |row| Ok(row.get::<_, i64>(0)?.max(0) as u64),
+        )
+        .optional()
+        .map_err(map_err)
+        .map(|value| value.unwrap_or(0))
+    }
+
+    pub(crate) fn clear_org_share_dirty_if_epoch(
+        &self,
+        id: &str,
+        source_version: u64,
+        dirty_counter: u64,
+        item_id: &str,
+        rev: u32,
+        content_sha256: &[u8],
+    ) -> Result<bool> {
+        let conn = self.lock();
+        let changed = conn
+            .execute(
+                "UPDATE org_shares SET republish_dirty = 0
+                  WHERE id = ?1 AND state = 'uploaded' AND last_error IS NULL
+                    AND source_version = ?2 AND republish_dirty = ?3 AND republish_dirty > 0
+                    AND item_id = ?4 AND rev = ?5 AND content_sha256 = ?6",
+                rusqlite::params![
+                    id,
+                    source_version as i64,
+                    dirty_counter as i64,
+                    item_id,
+                    rev as i64,
+                    content_sha256,
+                ],
+            )
+            .map_err(map_err)?;
+        Ok(changed == 1)
+    }
+
+    /// Re-arm an authenticated-absence initial POST without changing its durable actor/owner
+    /// witnesses. The equality predicates are the DB-level account-switch CAS: a stale caller can
+    /// neither overwrite the witnesses nor make the row dispatchable under another account.
+    #[allow(clippy::too_many_arguments)]
+    pub fn reset_initial_org_share_for_replay(
+        &self,
+        id: &str,
+        rev: u32,
+        generation: u32,
+        content_sha256: &[u8],
+        scrub: bool,
+        doc_id: &str,
+        access: &str,
+        expected_actor_user_id: &str,
+        expected_owner_user_id: &str,
+        current_actor_user_id: &str,
+        updated_at: &str,
+    ) -> Result<()> {
+        let conn = self.lock();
+        let changed = conn
+            .execute(
+                "UPDATE org_shares
+                    SET state = 'queued', item_id = NULL, last_error = NULL, updated_at = ?11
+                  WHERE id = ?1 AND state = 'failed' AND last_error = 'initial_post_replayable'
+                    AND rev = ?2 AND generation = ?3 AND content_sha256 = ?4 AND scrub = ?5
+                    AND doc_id = ?6 AND access = ?7
+                    AND expected_actor_user_id = ?8 AND expected_owner_user_id = ?9
+                    AND ?10 = ?8 AND ?10 = ?9",
+                rusqlite::params![
+                    id,
+                    rev as i64,
+                    generation as i64,
+                    content_sha256,
+                    scrub as i64,
+                    doc_id,
+                    access,
+                    expected_actor_user_id,
+                    expected_owner_user_id,
+                    current_actor_user_id,
+                    updated_at,
+                ],
+            )
+            .map_err(map_err)?;
+        if changed != 1 {
+            return Err(crate::error::AppError::Unavailable(
+                "ambiguous org publish actor or source changed before replay".into(),
+            ));
+        }
+        Ok(())
+    }
+
     /// All org shares in a given `state` (the launch sweep pulls `queued` + `revoke_pending`).
     pub fn list_org_shares_in_state(
         &self,
@@ -592,6 +1383,28 @@ impl Db {
         Ok(out)
     }
 
+    pub(crate) fn list_dirty_uploaded_org_shares(
+        &self,
+    ) -> Result<Vec<crate::storage::OrgShareRow>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(&format!(
+                "SELECT {} FROM org_shares
+                  WHERE state = 'uploaded' AND last_error IS NULL
+                    AND republish_dirty > 0
+                    AND (meeting_id IS NOT NULL OR document_id IS NOT NULL)
+                  ORDER BY updated_at ASC, id ASC",
+                Self::ORG_SHARE_COLS
+            ))
+            .map_err(map_err)?;
+        let rows = stmt.query_map([], Self::map_org_share).map_err(map_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
     /// Every LIVE org share across ALL sources/orgs — the un-scoped twin of `org_shares_for_source`,
     /// for callers that need the whole "is this live" set rather than one source (the Library bulk
     /// share-badge listing). Same STUCK-REPUBLISH definition of "live" as `org_shares_for_source`:
@@ -605,7 +1418,7 @@ impl Db {
         let mut stmt = conn
             .prepare(&format!(
                 "SELECT {} FROM org_shares
-                   WHERE state = 'uploaded' OR (state = 'failed' AND item_id IS NOT NULL)
+                   WHERE (state = 'uploaded' OR (state = 'failed' AND item_id IS NOT NULL))
                    ORDER BY created_at ASC",
                 Self::ORG_SHARE_COLS
             ))
@@ -659,13 +1472,13 @@ impl Db {
         let conn = self.lock();
         let mut stmt = conn
             .prepare(
-                "SELECT s.item_id, s.title
-                   FROM org_shares s
-                   LEFT JOIN notes n  ON n.meeting_id = s.meeting_id
-                   LEFT JOIN documents d ON d.id = s.document_id
-                  WHERE (s.state IN ('queued','uploaded','revoke_pending')
-                     OR (s.state = 'failed' AND s.item_id IS NOT NULL))
-                    AND (n.folder_id = ?1 OR d.folder_id = ?1)",
+                "SELECT s.item_id, s.title FROM org_shares s
+                  WHERE s.state != 'revoked'
+                    AND ((s.document_id IS NOT NULL AND EXISTS(
+                          SELECT 1 FROM documents d WHERE d.id=s.document_id AND d.folder_id=?1))
+                      OR (s.meeting_id IS NOT NULL AND EXISTS(
+                          SELECT 1 FROM notes n WHERE n.meeting_id=s.meeting_id
+                           AND n.folder_id=?1)))",
             )
             .map_err(map_err)?;
         let rows = stmt
@@ -697,13 +1510,13 @@ impl Db {
         let conn = self.lock();
         let mut stmt = conn
             .prepare(
-                "SELECT s.id, s.item_id, s.title
-                   FROM org_shares s
-                   LEFT JOIN notes n     ON n.meeting_id = s.meeting_id
-                   LEFT JOIN documents d ON d.id = s.document_id
-                  WHERE (s.state IN ('queued','uploaded','revoke_pending')
-                     OR (s.state = 'failed' AND s.item_id IS NOT NULL))
-                    AND (n.folder_id = ?1 OR d.folder_id = ?1)",
+                "SELECT s.id, s.item_id, s.title FROM org_shares s
+                  WHERE s.state != 'revoked'
+                    AND ((s.document_id IS NOT NULL AND EXISTS(
+                          SELECT 1 FROM documents d WHERE d.id=s.document_id AND d.folder_id=?1))
+                      OR (s.meeting_id IS NOT NULL AND EXISTS(
+                          SELECT 1 FROM notes n WHERE n.meeting_id=s.meeting_id
+                           AND n.folder_id=?1)))",
             )
             .map_err(map_err)?;
         let rows = stmt
@@ -855,17 +1668,75 @@ impl Db {
         prepared: &PreparedOrgItemIndex,
         superseded_item_id: Option<&str>,
     ) -> Result<bool> {
+        self.commit_local_org_replica_with_metadata(
+            item_id,
+            org_id,
+            seq,
+            author_hint,
+            title,
+            markdown,
+            created_at,
+            rev,
+            generation,
+            content_sha256,
+            source_kind,
+            author_user_id,
+            prepared,
+            superseded_item_id,
+            None,
+            "view",
+            None,
+            false,
+        )
+        .map(|outcome| outcome.changed)
+    }
+
+    /// Local publish/CAS refresh with stable document metadata stamped before predecessor eviction
+    /// in the same transaction. That ordering lets the tombstone see the new live revision and
+    /// preserve the revision-stable private link edge across supersession.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn commit_local_org_replica_with_metadata(
+        &self,
+        item_id: &str,
+        org_id: &str,
+        seq: u64,
+        author_hint: &str,
+        title: &str,
+        markdown: &str,
+        created_at: &str,
+        rev: u32,
+        generation: u32,
+        content_sha256: &[u8],
+        source_kind: Option<&str>,
+        author_user_id: Option<&str>,
+        prepared: &PreparedOrgItemIndex,
+        superseded_item_id: Option<&str>,
+        doc_id: Option<&str>,
+        access: &str,
+        document_owner_user_id: Option<&str>,
+        is_current: bool,
+    ) -> Result<OrgMetadataCommitOutcome> {
+        if let Some(doc_id) = doc_id {
+            require_stable_uuid(org_id, "invalid organization id")?;
+            require_stable_uuid(doc_id, "invalid org document id")?;
+        }
+        if !matches!(access, "view" | "edit") {
+            return Err(crate::error::AppError::InvalidArg(
+                "invalid org item access".into(),
+            ));
+        }
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
-        if !Self::org_membership_exists_tx(&tx, org_id)? {
+        if !Self::org_membership_witness_tx(&tx, org_id, generation)? {
             // The server publish may have raced a local leave/removal. The remote item remains the
             // server's concern, but withdrawn membership must never be followed by a plaintext local
             // replica resurrection.
-            return Ok(false);
+            return Ok(OrgMetadataCommitOutcome::default());
         }
         let existing = tx
             .query_row(
-                "SELECT seq, content_sha256, tombstoned FROM org_items WHERE item_id = ?1",
+                "SELECT seq, content_sha256, tombstoned, projection_sha256
+                   FROM org_items WHERE item_id = ?1",
                 rusqlite::params![item_id],
                 |r| {
                     Ok((
@@ -920,12 +1791,296 @@ impl Db {
             .map_err(map_err)?;
         }
 
+        if doc_id.is_some() || document_owner_user_id.is_some() || access != "view" {
+            Self::set_org_item_document_metadata_tx(
+                &tx,
+                item_id,
+                doc_id,
+                access,
+                document_owner_user_id,
+            )?;
+        }
+        let current_reduced =
+            Self::set_org_item_current_tx(&tx, item_id, org_id, doc_id, is_current)?;
+
         let superseded_evicted = match superseded_item_id.filter(|old| *old != item_id) {
             Some(old_item_id) => Self::tombstone_org_item_tx(&tx, old_item_id)?,
             None => false,
         };
+        // Tombstoning a live predecessor already purges in `tombstone_org_item_tx`; do not advance
+        // the durable generation twice when it is also the distinct head demoted above.
+        if current_reduced && !superseded_evicted {
+            Self::purge_all_ask_conversations_tx(&tx)?;
+        }
         tx.commit().map_err(map_err)?;
-        Ok(superseded_evicted)
+        Ok(OrgMetadataCommitOutcome {
+            changed: superseded_evicted,
+            visibility_reduced: current_reduced || superseded_evicted,
+        })
+    }
+
+    /// Install the plaintext/index/attachment projection of one completed stable PUT only while
+    /// the exact completed dispatch is still the live share head. A concurrent revoke or access
+    /// PATCH changes that witness and makes this a no-op, so a late HTTP response cannot resurrect
+    /// withdrawn content or stale permissions. Every older locally-held revision of the document is
+    /// purged in the same transaction, including revisions that were never the recorded predecessor.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn commit_org_republish_projection_if_current(
+        &self,
+        share_id: &str,
+        dispatch_id: &str,
+        org_id: &str,
+        doc_id: &str,
+        access: &str,
+        rev: u32,
+        generation: u32,
+        content_sha256: &[u8],
+        expected_actor_user_id: &str,
+        document_owner_user_id: &str,
+        expected_predecessor_item_id: Option<&str>,
+        expected_pending_reason: Option<&str>,
+        discard_source_less_anchor: bool,
+        projection: &OrgRepublishProjection<'_>,
+    ) -> Result<OrgMetadataCommitOutcome> {
+        require_stable_uuid(org_id, "invalid organization id")?;
+        require_stable_uuid(doc_id, "invalid org document id")?;
+        if !matches!(access, "view" | "edit") {
+            return Err(crate::error::AppError::InvalidArg(
+                "invalid org item access".into(),
+            ));
+        }
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let witness: bool = tx
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM org_shares
+                  WHERE id = ?1
+                    AND ((state = 'uploaded' AND last_error IS NULL AND item_id = ?2)
+                      OR (state = 'failed' AND last_error IS ?12 AND item_id IS ?13))
+                    AND org_id = ?9 AND expected_actor_user_id = ?10
+                    AND expected_owner_user_id = ?11
+                    AND doc_id = ?3 AND access = ?4 AND rev = ?5 AND generation = ?6
+                    AND content_sha256 = ?7 AND dispatch_id = ?8)",
+                rusqlite::params![
+                    share_id,
+                    projection.item_id,
+                    doc_id,
+                    access,
+                    rev as i64,
+                    generation as i64,
+                    content_sha256,
+                    dispatch_id,
+                    org_id,
+                    expected_actor_user_id,
+                    document_owner_user_id,
+                    expected_pending_reason,
+                    expected_predecessor_item_id,
+                ],
+                |row| Ok(row.get::<_, i64>(0)? != 0),
+            )
+            .map_err(map_err)?;
+        if !witness || !Self::org_membership_witness_tx(&tx, org_id, generation)? {
+            return Ok(OrgMetadataCommitOutcome::default());
+        }
+
+        let target_tombstoned = tx
+            .query_row(
+                "SELECT tombstoned FROM org_items WHERE item_id = ?1",
+                rusqlite::params![projection.item_id],
+                |row| Ok(row.get::<_, i64>(0)? != 0),
+            )
+            .optional()
+            .map_err(map_err)?
+            .unwrap_or(false);
+        if target_tombstoned {
+            return Ok(OrgMetadataCommitOutcome::default());
+        }
+        let incompatible_head: bool = tx
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM org_items
+                  WHERE org_id = ?1 AND doc_id = ?2 AND tombstoned = 0 AND is_current = 1
+                    AND item_id != ?3
+                    AND (generation > ?4 OR (generation = ?4 AND rev >= ?5)
+                      OR seq > ?6))",
+                rusqlite::params![
+                    org_id,
+                    doc_id,
+                    projection.item_id,
+                    generation as i64,
+                    rev as i64,
+                    projection.seq as i64,
+                ],
+                |row| Ok(row.get::<_, i64>(0)? != 0),
+            )
+            .map_err(map_err)?;
+        if incompatible_head {
+            return Ok(OrgMetadataCommitOutcome::default());
+        }
+
+        let existing_target = tx
+            .query_row(
+                "SELECT seq, content_sha256, tombstoned, projection_sha256
+                   FROM org_items WHERE item_id = ?1",
+                rusqlite::params![projection.item_id],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?.max(0) as u64,
+                        row.get::<_, Option<Vec<u8>>>(1)?,
+                        row.get::<_, i64>(2)? != 0,
+                        row.get::<_, Option<Vec<u8>>>(3)?,
+                    ))
+                },
+            )
+            .optional()
+            .map_err(map_err)?;
+        let replace_attachments = existing_target.as_ref().map_or(true, |(_, _, _, witness)| {
+            witness.as_deref() != Some(content_sha256)
+        });
+        let replace_target = match existing_target {
+            None => true,
+            Some((_seq, _hash, true, _projection)) => {
+                return Ok(OrgMetadataCommitOutcome::default())
+            }
+            Some((stored_seq, _, false, _projection)) if stored_seq > projection.seq => {
+                return Ok(OrgMetadataCommitOutcome::default())
+            }
+            Some((stored_seq, stored_hash, false, _projection)) if stored_seq == projection.seq => {
+                if stored_hash.as_deref() != Some(content_sha256) {
+                    return Err(crate::error::AppError::Storage(
+                        "conflicting org replica payload at the same feed sequence".into(),
+                    ));
+                }
+                false
+            }
+            Some(_) => true,
+        };
+        let replace_attachments = replace_target || replace_attachments;
+
+        if replace_target {
+            Self::upsert_org_item_prepared_tx(
+                &tx,
+                projection.item_id,
+                org_id,
+                projection.seq,
+                projection.author_hint,
+                projection.title,
+                projection.markdown,
+                projection.created_at,
+                rev,
+                generation,
+                content_sha256,
+                projection.source_kind,
+                projection.author_user_id,
+                projection.prepared,
+            )?;
+        }
+        if replace_attachments {
+            Self::replace_org_item_attachment_bundle_tx(
+                &tx,
+                projection.item_id,
+                projection.attachments,
+                content_sha256,
+            )?;
+        }
+        Self::set_org_item_document_metadata_tx(
+            &tx,
+            projection.item_id,
+            Some(doc_id),
+            access,
+            Some(document_owner_user_id),
+        )?;
+        let current_reduced =
+            Self::set_org_item_current_tx(&tx, projection.item_id, org_id, Some(doc_id), true)?;
+
+        let older_ids: Vec<String> = {
+            let mut stmt = tx
+                .prepare(
+                    "SELECT item_id FROM org_items
+                      WHERE org_id = ?1 AND doc_id = ?2 AND item_id != ?3 AND tombstoned = 0
+                        AND (generation < ?4 OR (generation = ?4 AND rev < ?5))",
+                )
+                .map_err(map_err)?;
+            let rows = stmt
+                .query_map(
+                    rusqlite::params![
+                        org_id,
+                        doc_id,
+                        projection.item_id,
+                        generation as i64,
+                        rev as i64,
+                    ],
+                    |row| row.get(0),
+                )
+                .map_err(map_err)?;
+            let mut ids = Vec::new();
+            for row in rows {
+                ids.push(row.map_err(map_err)?);
+            }
+            ids
+        };
+        let had_older = !older_ids.is_empty();
+        let mut evicted = false;
+        for item_id in older_ids {
+            evicted |= Self::tombstone_org_item_tx(&tx, &item_id)?;
+        }
+
+        let completion_changed = tx.execute(
+            "UPDATE org_shares SET state='uploaded', item_id=?2, last_error=NULL, updated_at=?11
+              WHERE id=?1 AND state='failed' AND last_error IS ?12 AND item_id IS ?13
+                AND doc_id=?3 AND access=?4 AND rev=?5 AND generation=?6
+                AND content_sha256=?7 AND dispatch_id=?8
+                AND expected_actor_user_id=?9 AND expected_owner_user_id=?10",
+            rusqlite::params![share_id, projection.item_id, doc_id, access, rev as i64,
+                generation as i64, content_sha256, dispatch_id, expected_actor_user_id,
+                document_owner_user_id, chrono::Utc::now().to_rfc3339(),
+                expected_pending_reason, expected_predecessor_item_id],
+        ).map_err(map_err)?;
+        let still_uploaded: bool = tx.query_row(
+                "SELECT EXISTS(SELECT 1 FROM org_shares WHERE id=?1 AND state='uploaded'
+                  AND last_error IS NULL AND item_id=?2 AND doc_id=?3 AND access=?4 AND rev=?5
+                  AND generation=?6 AND content_sha256=?7 AND dispatch_id=?8
+                  AND expected_actor_user_id=?9 AND expected_owner_user_id=?10)",
+                rusqlite::params![
+                    share_id,
+                    projection.item_id,
+                    doc_id,
+                    access,
+                    rev as i64,
+                    generation as i64,
+                    content_sha256,
+                    dispatch_id,
+                    expected_actor_user_id,
+                    document_owner_user_id,
+                ],
+                |row| Ok(row.get::<_, i64>(0)? != 0),
+            )
+            .map_err(map_err)?;
+        if !still_uploaded || (expected_pending_reason.is_some() && completion_changed != 1) {
+            return Ok(OrgMetadataCommitOutcome::default());
+        }
+        if discard_source_less_anchor {
+            tx.execute(
+                "DELETE FROM org_shares WHERE id=?1 AND state='uploaded' AND item_id=?2
+                  AND dispatch_id=?3 AND meeting_id IS NULL AND document_id IS NULL",
+                rusqlite::params![share_id, projection.item_id, dispatch_id],
+            )
+            .map_err(map_err)?;
+        } else {
+            tx.execute(
+                "UPDATE org_shares SET expected_actor_user_id = NULL
+                  WHERE id = ?1 AND dispatch_id = ?2 AND expected_actor_user_id = ?3",
+                rusqlite::params![share_id, dispatch_id, expected_actor_user_id],
+            )
+            .map_err(map_err)?;
+        }
+        if (current_reduced || evicted) && had_older {
+            Self::purge_all_ask_conversations_tx(&tx)?;
+        }
+        tx.commit().map_err(map_err)?;
+        Ok(OrgMetadataCommitOutcome {
+            changed: true,
+            visibility_reduced: current_reduced || evicted,
+        })
     }
 
     /// Commit one already-prepared live feed item and advance the org cursor to this action's exact
@@ -948,10 +2103,130 @@ impl Db {
         author_user_id: Option<&str>,
         prepared: &PreparedOrgItemIndex,
     ) -> Result<bool> {
+        self.commit_org_feed_item_with_metadata(
+            item_id,
+            org_id,
+            seq,
+            author_hint,
+            title,
+            markdown,
+            created_at,
+            rev,
+            generation,
+            content_sha256,
+            source_kind,
+            author_user_id,
+            prepared,
+            None,
+            "view",
+            None,
+            false,
+        )
+        .map(|outcome| outcome.changed)
+    }
+
+    /// Feed commit plus stable permission/link metadata in the same transaction. Metadata is also
+    /// repaired when the content action is already behind the cursor (`false`), provided the live
+    /// item exists; this closes the local-publish-before-feed gap without rewriting content/indexes.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn commit_org_feed_item_with_metadata(
+        &self,
+        item_id: &str,
+        org_id: &str,
+        seq: u64,
+        author_hint: &str,
+        title: &str,
+        markdown: &str,
+        created_at: &str,
+        rev: u32,
+        generation: u32,
+        content_sha256: &[u8],
+        source_kind: Option<&str>,
+        author_user_id: Option<&str>,
+        prepared: &PreparedOrgItemIndex,
+        doc_id: Option<&str>,
+        access: &str,
+        document_owner_user_id: Option<&str>,
+        is_current: bool,
+    ) -> Result<OrgMetadataCommitOutcome> {
+        self.commit_org_feed_item_with_metadata_and_attachments(
+            item_id, org_id, seq, author_hint, title, markdown, created_at, rev, generation,
+            content_sha256, source_kind, author_user_id, prepared, doc_id, access,
+            document_owner_user_id, is_current, &[],
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn commit_org_feed_item_with_metadata_and_attachments(
+        &self, item_id: &str, org_id: &str, seq: u64, author_hint: &str, title: &str,
+        markdown: &str, created_at: &str, rev: u32, generation: u32,
+        content_sha256: &[u8], source_kind: Option<&str>, author_user_id: Option<&str>,
+        prepared: &PreparedOrgItemIndex, doc_id: Option<&str>, access: &str,
+        document_owner_user_id: Option<&str>, is_current: bool,
+        attachments: &[crate::storage::IncomingAttachment],
+    ) -> Result<OrgMetadataCommitOutcome> {
+        if let Some(doc_id) = doc_id {
+            require_stable_uuid(org_id, "invalid organization id")?;
+            require_stable_uuid(doc_id, "invalid org document id")?;
+        }
+        if !matches!(access, "view" | "edit") {
+            return Err(crate::error::AppError::InvalidArg(
+                "invalid org item access".into(),
+            ));
+        }
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
-        if !Self::claim_org_feed_seq_tx(&tx, org_id, seq)? {
-            return Ok(false);
+        if !Self::org_membership_witness_tx(&tx, org_id, generation)? {
+            return Ok(OrgMetadataCommitOutcome::default());
+        }
+        let claimed_seq = Self::claim_org_feed_seq_tx(&tx, org_id, seq)?;
+        if !claimed_seq {
+            let projection_complete = tx
+                .query_row(
+                    "SELECT projection_sha256 = ?2 FROM org_items
+                      WHERE item_id = ?1 AND tombstoned = 0",
+                    rusqlite::params![item_id, content_sha256],
+                    |row| Ok(row.get::<_, Option<bool>>(0)?.unwrap_or(false)),
+                )
+                .optional()
+                .map_err(map_err)?
+                .unwrap_or(false);
+            if !projection_complete {
+                // The cursor may have committed before the authenticated attachment bundle in a
+                // legacy build. Repair the whole projection below without moving the cursor.
+            } else {
+            if doc_id.is_some() || document_owner_user_id.is_some() || access != "view" {
+                Self::set_org_item_document_metadata_tx(
+                    &tx,
+                    item_id,
+                    doc_id,
+                    access,
+                    document_owner_user_id,
+                )?;
+            }
+            let visibility_reduced =
+                Self::set_org_item_current_tx(&tx, item_id, org_id, doc_id, is_current)?;
+            Self::close_projection_pending_for_item_tx(
+                &tx,
+                item_id,
+                org_id,
+                doc_id,
+                access,
+                rev,
+                generation,
+                content_sha256,
+                author_user_id,
+                document_owner_user_id,
+            )?;
+            if visibility_reduced {
+                Self::purge_all_ask_conversations_tx(&tx)?;
+            }
+            tx.commit().map_err(map_err)?;
+            return Ok(OrgMetadataCommitOutcome {
+                changed: false,
+                visibility_reduced,
+            });
+            }
         }
         // Tombstones are permanent for an append-only item id. Even a malformed/malicious later live
         // event may advance the org cursor, but it must never restore plaintext for a withdrawn item.
@@ -966,7 +2241,7 @@ impl Db {
             .unwrap_or(false);
         if already_tombstoned {
             tx.commit().map_err(map_err)?;
-            return Ok(false);
+            return Ok(OrgMetadataCommitOutcome::default());
         }
         Self::upsert_org_item_prepared_tx(
             &tx,
@@ -984,8 +2259,38 @@ impl Db {
             author_user_id,
             prepared,
         )?;
+        Self::replace_org_item_attachment_bundle_tx(&tx, item_id, attachments, content_sha256)?;
+        if doc_id.is_some() || document_owner_user_id.is_some() || access != "view" {
+            Self::set_org_item_document_metadata_tx(
+                &tx,
+                item_id,
+                doc_id,
+                access,
+                document_owner_user_id,
+            )?;
+        }
+        let visibility_reduced =
+            Self::set_org_item_current_tx(&tx, item_id, org_id, doc_id, is_current)?;
+        Self::close_projection_pending_for_item_tx(
+            &tx,
+            item_id,
+            org_id,
+            doc_id,
+            access,
+            rev,
+            generation,
+            content_sha256,
+            author_user_id,
+            document_owner_user_id,
+        )?;
+        if visibility_reduced {
+            Self::purge_all_ask_conversations_tx(&tx)?;
+        }
         tx.commit().map_err(map_err)?;
-        Ok(true)
+        Ok(OrgMetadataCommitOutcome {
+            changed: true,
+            visibility_reduced,
+        })
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1019,7 +2324,7 @@ impl Db {
                rev=excluded.rev, generation=excluded.generation,
                content_sha256=excluded.content_sha256, source_kind=excluded.source_kind,
                author_user_id=COALESCE(excluded.author_user_id, org_items.author_user_id),
-               tombstoned=0",
+               projection_sha256=NULL, tombstoned=0",
             rusqlite::params![
                 item_id,
                 org_id,
@@ -1063,6 +2368,100 @@ impl Db {
         Ok(())
     }
 
+    fn replace_org_item_attachment_bundle_tx(
+        tx: &rusqlite::Transaction<'_>,
+        item_id: &str,
+        attachments: &[crate::storage::IncomingAttachment],
+        content_sha256: &[u8],
+    ) -> Result<()> {
+        tx.execute("DELETE FROM note_attachments WHERE org_item_id=?1", [item_id])
+            .map_err(map_err)?;
+        let created_at = chrono::Utc::now().timestamp_millis();
+        for attachment in attachments {
+            tx.execute(
+                "INSERT INTO note_attachments
+                  (id,document_id,meeting_id,provider_id,org_item_id,mime_type,extension,
+                   byte_len,width,height,sha256,data,data_blob,exported_path,created_at)
+                 VALUES(?1,NULL,NULL,NULL,?2,?3,?4,?5,?6,?7,?8,?9,NULL,NULL,?10)",
+                rusqlite::params![attachment.id, item_id, attachment.mime_type,
+                    attachment.extension, i64::try_from(attachment.data.len()).map_err(|_| {
+                        crate::error::AppError::InvalidArg("image is too large".into())
+                    })?, i64::from(attachment.width), i64::from(attachment.height),
+                    attachment.sha256.as_slice(), attachment.data, created_at],
+            ).map_err(map_err)?;
+        }
+        tx.execute(
+            "UPDATE org_items SET projection_sha256=?2
+              WHERE item_id=?1 AND tombstoned=0",
+            rusqlite::params![item_id, content_sha256],
+        ).map_err(map_err)?;
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn close_projection_pending_for_item_tx(
+        tx: &rusqlite::Transaction<'_>,
+        item_id: &str,
+        org_id: &str,
+        doc_id: Option<&str>,
+        access: &str,
+        rev: u32,
+        generation: u32,
+        content_sha256: &[u8],
+        author_user_id: Option<&str>,
+        document_owner_user_id: Option<&str>,
+    ) -> Result<()> {
+        let (Some(doc_id), Some(actor), Some(owner)) =
+            (doc_id, author_user_id, document_owner_user_id)
+        else {
+            return Ok(());
+        };
+        let now = chrono::Utc::now().to_rfc3339();
+        tx.execute(
+            "UPDATE org_shares SET state='uploaded', last_error=NULL,
+                    expected_actor_user_id=NULL, updated_at=?10
+              WHERE state='failed' AND last_error='projection_pending'
+                AND item_id=?1 AND org_id=?2 AND doc_id=?3 AND access=?4
+                AND rev=?5 AND generation=?6 AND content_sha256=?7
+                AND expected_actor_user_id=?8 AND expected_owner_user_id=?9
+                AND (meeting_id IS NOT NULL OR document_id IS NOT NULL)",
+            rusqlite::params![
+                item_id,
+                org_id,
+                doc_id,
+                access,
+                rev as i64,
+                generation as i64,
+                content_sha256,
+                actor,
+                owner,
+                now,
+            ],
+        )
+        .map_err(map_err)?;
+        tx.execute(
+            "DELETE FROM org_shares
+              WHERE state='failed' AND last_error='projection_pending'
+                AND meeting_id IS NULL AND document_id IS NULL
+                AND item_id=?1 AND org_id=?2 AND doc_id=?3 AND access=?4
+                AND rev=?5 AND generation=?6 AND content_sha256=?7
+                AND expected_actor_user_id=?8 AND expected_owner_user_id=?9",
+            rusqlite::params![
+                item_id,
+                org_id,
+                doc_id,
+                access,
+                rev as i64,
+                generation as i64,
+                content_sha256,
+                actor,
+                owner,
+            ],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
     /// TOMBSTONE an org item — the discard-the-result alias of the ONE eviction primitive
     /// [`Db::evict_org_item`]. Kept as the historical name used by `delete_org_item_as_author`.
     /// Idempotent — tombstoning an unknown/already-tombstoned id is fine.
@@ -1095,6 +2494,18 @@ impl Db {
             return Ok((false, false));
         }
         let evicted = Self::tombstone_org_item_tx(&tx, item_id)?;
+        let now = chrono::Utc::now().to_rfc3339();
+        tx.execute(
+            "UPDATE org_shares SET last_error='org_edit_conflict',updated_at=?2
+              WHERE state='failed' AND last_error='projection_pending' AND item_id=?1 AND org_id=?3
+                AND (meeting_id IS NOT NULL OR document_id IS NOT NULL)",
+            rusqlite::params![item_id,now,org_id],
+        ).map_err(map_err)?;
+        tx.execute(
+            "DELETE FROM org_shares WHERE state='failed' AND last_error='projection_pending'
+              AND item_id=?1 AND org_id=?2 AND meeting_id IS NULL AND document_id IS NULL",
+            rusqlite::params![item_id,org_id],
+        ).map_err(map_err)?;
         tx.commit().map_err(map_err)?;
         Ok((true, evicted))
     }
@@ -1130,6 +2541,55 @@ impl Db {
         Ok(evicted)
     }
 
+    /// Evict every locally-held live revision of one stable org document in one transaction. Used
+    /// after the relay confirms a stable-document DELETE, so a stale origin `item_id` cannot leave a
+    /// remotely-edited current head searchable on this device.
+    pub fn evict_org_document(&self, org_id: &str, doc_id: &str) -> Result<bool> {
+        require_stable_uuid(org_id, "invalid organization id")?;
+        require_stable_uuid(doc_id, "invalid org document id")?;
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let item_ids: Vec<String> = {
+            let mut stmt = tx
+                .prepare(
+                    "SELECT item_id FROM org_items
+                      WHERE org_id = ?1 AND doc_id = ?2 AND tombstoned = 0
+                      ORDER BY rev ASC, seq ASC, item_id ASC",
+                )
+                .map_err(map_err)?;
+            let rows = stmt
+                .query_map(rusqlite::params![org_id, doc_id], |r| r.get(0))
+                .map_err(map_err)?;
+            let mut ids = Vec::new();
+            for row in rows {
+                ids.push(row.map_err(map_err)?);
+            }
+            ids
+        };
+        let mut evicted = false;
+        for item_id in item_ids {
+            evicted |= Self::tombstone_org_item_tx(&tx, &item_id)?;
+        }
+        Self::purge_org_document_links_tx(&tx, org_id, doc_id)?;
+        tx.commit().map_err(map_err)?;
+        Ok(evicted)
+    }
+
+    fn purge_org_document_links_tx(
+        tx: &rusqlite::Transaction<'_>,
+        org_id: &str,
+        doc_id: &str,
+    ) -> Result<usize> {
+        let endpoint = format!("{org_id}:{doc_id}");
+        tx.execute(
+            "DELETE FROM links
+              WHERE (src_kind='org' AND src_id=?1)
+                 OR (dst_kind='org' AND dst_id=?1)",
+            rusqlite::params![endpoint],
+        )
+        .map_err(map_err)
+    }
+
     /// The in-transaction body of [`Db::evict_org_item`]. Returns whether a LIVE row was evicted.
     fn tombstone_org_item_tx(tx: &rusqlite::Transaction<'_>, item_id: &str) -> Result<bool> {
         let was_live: bool = tx
@@ -1148,10 +2608,15 @@ impl Db {
         // text so no reader can ever observe one half of the eviction.
         Self::purge_org_item_attachments_tx(tx, item_id)?;
         tx.execute(
-            "UPDATE org_items SET tombstoned = 1, markdown = '', title = '' WHERE item_id = ?1",
+            "UPDATE org_items SET tombstoned = 1, markdown = '', title = '',
+                 projection_sha256 = NULL WHERE item_id = ?1",
             rusqlite::params![item_id],
         )
         .map_err(map_err)?;
+        // A relay tombstone removes the readable replica, not the user's private graph choice.
+        // `links_for_visible` and every org endpoint resolver join the live membership/context/item
+        // witness, so this opaque SQLCipher row is withheld while no authoritative head exists and
+        // becomes usable again if a successor revision is later ingested.
         if was_live {
             Self::purge_all_ask_conversations_tx(tx)?;
         }
@@ -1175,10 +2640,15 @@ impl Db {
         Ok(changed == 1)
     }
 
-    fn org_membership_exists_tx(tx: &rusqlite::Transaction<'_>, org_id: &str) -> Result<bool> {
+    fn org_membership_witness_tx(
+        tx: &rusqlite::Transaction<'_>,
+        org_id: &str,
+        generation: u32,
+    ) -> Result<bool> {
         tx.query_row(
-            "SELECT EXISTS(SELECT 1 FROM org_state WHERE org_id = ?1)",
-            rusqlite::params![org_id],
+            "SELECT EXISTS(SELECT 1 FROM org_state
+              WHERE org_id = ?1 AND generation >= ?2)",
+            rusqlite::params![org_id, generation as i64],
             |r| r.get::<_, bool>(0),
         )
         .map_err(map_err)
@@ -1203,6 +2673,10 @@ impl Db {
     }
 
     fn purge_org_replica_tx(tx: &rusqlite::Transaction<'_>, org_id: &str) -> Result<usize> {
+        // Membership withdrawal purges every decrypted org artifact below, but preserves opaque
+        // user-authored `links` rows. All readers require the org_state + enabled + live-item join,
+        // so the private relation is completely withheld after leave and can reappear only after a
+        // genuine rejoin plus successor ingest. Explicit user unlink remains the sole graph delete.
         // vec0 KNN rows for every chunk of every item in this org (the FK-less mirror table).
         tx.execute(
             "DELETE FROM org_vec_chunks WHERE chunk_id IN
@@ -1274,6 +2748,7 @@ impl Db {
                    FROM org_items oi
                    JOIN org_state os ON os.org_id = oi.org_id
                   WHERE oi.tombstoned = 0
+                    AND (oi.doc_id IS NULL OR oi.is_current = 1)
                     AND (?1 IS NULL OR oi.item_id > ?1)
                     AND EXISTS (SELECT 1 FROM org_chunks oc WHERE oc.item_id = oi.item_id)
                   ORDER BY oi.item_id ASC
@@ -1339,6 +2814,7 @@ impl Db {
                    FROM org_items oi
                    JOIN org_state os ON os.org_id = oi.org_id
                   WHERE oi.tombstoned = 0
+                    AND (oi.doc_id IS NULL OR oi.is_current = 1)
                     AND (?1 IS NULL OR oi.item_id > ?1)
                     AND EXISTS (
                         SELECT 1 FROM org_chunks oc
@@ -1409,7 +2885,8 @@ impl Db {
                 "SELECT oi.seq, oi.rev, oi.generation, oi.content_sha256
                    FROM org_items oi
                    JOIN org_state os ON os.org_id = oi.org_id
-                  WHERE oi.item_id = ?1 AND oi.tombstoned = 0",
+                  WHERE oi.item_id = ?1 AND oi.tombstoned = 0
+                    AND (oi.doc_id IS NULL OR oi.is_current = 1)",
                 rusqlite::params![item_id],
                 |r| {
                     Ok((
@@ -1482,7 +2959,8 @@ impl Db {
         let current_item = tx
             .query_row(
                 "SELECT seq, rev, generation, content_sha256
-                   FROM org_items WHERE item_id = ?1 AND tombstoned = 0",
+                   FROM org_items WHERE item_id = ?1 AND tombstoned = 0
+                    AND (doc_id IS NULL OR is_current = 1)",
                 rusqlite::params![batch.item_id],
                 |r| {
                     Ok((
@@ -1658,12 +3136,13 @@ impl Db {
     pub(crate) fn org_replica_state(&self, item_id: &str) -> Result<Option<OrgReplicaState>> {
         let conn = self.lock();
         conn.query_row(
-            "SELECT tombstoned, content_sha256 FROM org_items WHERE item_id = ?1",
+            "SELECT tombstoned, content_sha256, projection_sha256 FROM org_items WHERE item_id = ?1",
             rusqlite::params![item_id],
             |r| {
                 Ok(OrgReplicaState {
                     tombstoned: r.get::<_, i64>(0)? != 0,
                     content_sha256: r.get::<_, Option<Vec<u8>>>(1)?,
+                    projection_sha256: r.get::<_, Option<Vec<u8>>>(2)?,
                 })
             },
         )
@@ -1695,10 +3174,78 @@ impl Db {
         author_user_id: Option<&str>,
         prepared: &PreparedOrgItemIndex,
     ) -> Result<bool> {
+        self.commit_org_reconcile_item_with_metadata(
+            item_id,
+            org_id,
+            seq,
+            author_hint,
+            title,
+            markdown,
+            created_at,
+            rev,
+            generation,
+            content_sha256,
+            source_kind,
+            author_user_id,
+            prepared,
+            None,
+            "view",
+            None,
+            false,
+        )
+        .map(|outcome| outcome.changed)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn commit_org_reconcile_item_with_metadata(
+        &self,
+        item_id: &str,
+        org_id: &str,
+        seq: u64,
+        author_hint: &str,
+        title: &str,
+        markdown: &str,
+        created_at: &str,
+        rev: u32,
+        generation: u32,
+        content_sha256: &[u8],
+        source_kind: Option<&str>,
+        author_user_id: Option<&str>,
+        prepared: &PreparedOrgItemIndex,
+        doc_id: Option<&str>,
+        access: &str,
+        document_owner_user_id: Option<&str>,
+        is_current: bool,
+    ) -> Result<OrgMetadataCommitOutcome> {
+        self.commit_org_reconcile_item_with_metadata_and_attachments(
+            item_id, org_id, seq, author_hint, title, markdown, created_at, rev, generation,
+            content_sha256, source_kind, author_user_id, prepared, doc_id, access,
+            document_owner_user_id, is_current, &[],
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn commit_org_reconcile_item_with_metadata_and_attachments(
+        &self, item_id: &str, org_id: &str, seq: u64, author_hint: &str, title: &str,
+        markdown: &str, created_at: &str, rev: u32, generation: u32,
+        content_sha256: &[u8], source_kind: Option<&str>, author_user_id: Option<&str>,
+        prepared: &PreparedOrgItemIndex, doc_id: Option<&str>, access: &str,
+        document_owner_user_id: Option<&str>, is_current: bool,
+        attachments: &[crate::storage::IncomingAttachment],
+    ) -> Result<OrgMetadataCommitOutcome> {
+        if let Some(doc_id) = doc_id {
+            require_stable_uuid(org_id, "invalid organization id")?;
+            require_stable_uuid(doc_id, "invalid org document id")?;
+        }
+        if !matches!(access, "view" | "edit") {
+            return Err(crate::error::AppError::InvalidArg(
+                "invalid org item access".into(),
+            ));
+        }
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
-        if !Self::org_membership_exists_tx(&tx, org_id)? {
-            return Ok(false);
+        if !Self::org_membership_witness_tx(&tx, org_id, generation)? {
+            return Ok(OrgMetadataCommitOutcome::default());
         }
         let already_tombstoned = tx
             .query_row(
@@ -1710,7 +3257,7 @@ impl Db {
             .map_err(map_err)?
             .unwrap_or(false);
         if already_tombstoned {
-            return Ok(false);
+            return Ok(OrgMetadataCommitOutcome::default());
         }
         Self::upsert_org_item_prepared_tx(
             &tx,
@@ -1728,8 +3275,110 @@ impl Db {
             author_user_id,
             prepared,
         )?;
+        Self::replace_org_item_attachment_bundle_tx(&tx, item_id, attachments, content_sha256)?;
+        Self::set_org_item_document_metadata_tx(
+            &tx,
+            item_id,
+            doc_id,
+            access,
+            document_owner_user_id,
+        )?;
+        let visibility_reduced =
+            Self::set_org_item_current_tx(&tx, item_id, org_id, doc_id, is_current)?;
+        Self::close_projection_pending_for_item_tx(
+            &tx,
+            item_id,
+            org_id,
+            doc_id,
+            access,
+            rev,
+            generation,
+            content_sha256,
+            author_user_id,
+            document_owner_user_id,
+        )?;
+        if visibility_reduced {
+            Self::purge_all_ask_conversations_tx(&tx)?;
+        }
         tx.commit().map_err(map_err)?;
-        Ok(true)
+        Ok(OrgMetadataCommitOutcome {
+            changed: true,
+            visibility_reduced,
+        })
+    }
+
+    /// Metadata-only anti-entropy repair for a hash-converged live row. No content/chunks are read or
+    /// rewritten, and an existing tombstone remains permanent.
+    // Metadata repair mirrors the authoritative feed identity tuple atomically and intentionally
+    // spells out every witness field at the call site.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn repair_org_reconcile_metadata(
+        &self,
+        item_id: &str,
+        org_id: &str,
+        generation: u32,
+        doc_id: Option<&str>,
+        access: &str,
+        document_owner_user_id: Option<&str>,
+        is_current: bool,
+    ) -> Result<OrgMetadataCommitOutcome> {
+        if let Some(doc_id) = doc_id {
+            require_stable_uuid(org_id, "invalid organization id")?;
+            require_stable_uuid(doc_id, "invalid org document id")?;
+        }
+        if !matches!(access, "view" | "edit") {
+            return Err(crate::error::AppError::InvalidArg(
+                "invalid org item access".into(),
+            ));
+        }
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        if !Self::org_membership_witness_tx(&tx, org_id, generation)? {
+            return Ok(OrgMetadataCommitOutcome::default());
+        }
+        let current = tx
+            .query_row(
+                "SELECT doc_id, access, document_owner_user_id, is_current FROM org_items
+                  WHERE item_id = ?1 AND org_id = ?2 AND tombstoned = 0",
+                rusqlite::params![item_id, org_id],
+                |r| {
+                    Ok((
+                        r.get::<_, Option<String>>(0)?,
+                        r.get::<_, String>(1)?,
+                        r.get::<_, Option<String>>(2)?,
+                        r.get::<_, i64>(3)? != 0,
+                    ))
+                },
+            )
+            .optional()
+            .map_err(map_err)?;
+        let Some((stored_doc_id, stored_access, stored_owner, stored_current)) = current else {
+            return Ok(OrgMetadataCommitOutcome::default());
+        };
+        if stored_doc_id.as_deref() == doc_id
+            && stored_access == access
+            && stored_owner.as_deref() == document_owner_user_id
+            && stored_current == is_current
+        {
+            return Ok(OrgMetadataCommitOutcome::default());
+        }
+        Self::set_org_item_document_metadata_tx(
+            &tx,
+            item_id,
+            doc_id,
+            access,
+            document_owner_user_id,
+        )?;
+        let visibility_reduced =
+            Self::set_org_item_current_tx(&tx, item_id, org_id, doc_id, is_current)?;
+        if visibility_reduced {
+            Self::purge_all_ask_conversations_tx(&tx)?;
+        }
+        tx.commit().map_err(map_err)?;
+        Ok(OrgMetadataCommitOutcome {
+            changed: true,
+            visibility_reduced,
+        })
     }
 
     /// GATED-FREE (no folder lock applies to org items) semantic KNN over the int8 org partition:
@@ -1770,6 +3419,7 @@ impl Db {
                JOIN org_items oi ON oi.item_id = oc.item_id
                JOIN org_state os ON os.org_id = oi.org_id
               WHERE oi.tombstoned = 0 AND os.context_enabled = 1
+                AND (oi.doc_id IS NULL OR oi.is_current = 1)
               ORDER BY knn.distance ASC, oi.item_id ASC";
         let blob = crate::embed::vec_to_int8_blob(query_vec);
         let mut stmt = conn.prepare(sql).map_err(map_err)?;
@@ -1830,6 +3480,7 @@ impl Db {
                JOIN org_items oi ON oi.item_id = oc.item_id
                JOIN org_state os ON os.org_id = oi.org_id
               WHERE fts_org_chunks MATCH ?1 AND oi.tombstoned = 0 AND os.context_enabled = 1
+                AND (oi.doc_id IS NULL OR oi.is_current = 1)
               ORDER BY rank ASC, oi.item_id ASC
               LIMIT ?2";
         let mut stmt = conn.prepare(sql).map_err(map_err)?;
@@ -1858,8 +3509,7 @@ impl Db {
         // query. Only an empty strict result may activate the fallback.
         let mut rows_vec = run(&mut stmt, &and_expr)?;
         if rows_vec.is_empty() {
-            let terms =
-                fts_unicode61_content_terms(&conn, q, MAX_ORG_FTS_CONTENT_TERMS)?;
+            let terms = fts_unicode61_content_terms(&conn, q, MAX_ORG_FTS_CONTENT_TERMS)?;
             let Some(any_expr) = fts_match_content_terms_any(&terms) else {
                 return Ok(Vec::new());
             };
@@ -1901,6 +3551,7 @@ impl Db {
                       WHERE fts_org_chunks MATCH ?
                         AND oi.tombstoned = 0
                         AND os.context_enabled = 1
+                        AND (oi.doc_id IS NULL OR oi.is_current = 1)
                       ORDER BY rank ASC, oi.item_id ASC
                       LIMIT ?"
                 );
@@ -1964,22 +3615,29 @@ impl Db {
     ) -> Result<Option<crate::storage::models::OrgItemDetail>> {
         let conn = self.lock();
         conn.query_row(
-            "SELECT oi.item_id, oi.author_hint, oi.title, oi.created_at, oi.rev, oi.markdown
+            "SELECT oi.item_id, oi.doc_id, oi.author_hint, oi.title, oi.created_at, oi.rev,
+                    oi.markdown, oi.access
                FROM org_items oi
                JOIN org_state os ON os.org_id = oi.org_id
-              WHERE oi.item_id = ?1 AND oi.tombstoned = 0 AND os.context_enabled = 1",
+              WHERE oi.item_id = ?1 AND oi.tombstoned = 0 AND os.context_enabled = 1
+                AND (oi.doc_id IS NULL OR oi.is_current = 1)",
             rusqlite::params![item_id],
             |r| {
                 Ok(crate::storage::models::OrgItemDetail {
                     item_id: r.get(0)?,
-                    author_hint: r.get(1)?,
-                    title: r.get(2)?,
-                    created_at: r.get(3)?,
-                    rev: r.get::<_, i64>(4)? as u32,
-                    markdown: r.get(5)?,
+                    doc_id: r.get(1)?,
+                    link_id: None,
+                    author_hint: r.get(2)?,
+                    title: r.get(3)?,
+                    created_at: r.get(4)?,
+                    rev: r.get::<_, i64>(5)? as u32,
+                    markdown: r.get(6)?,
+                    access: r.get(7)?,
                     // The DB layer has no session context — the `org_get_item` command computes the real
                     // value by comparing the stored `author_user_id` with the caller's `server_user_id`.
                     editable: false,
+                    can_edit: false,
+                    can_manage: false,
                 })
             },
         )
@@ -1998,6 +3656,217 @@ impl Db {
         )
         .map_err(map_err)?;
         Ok(())
+    }
+
+    pub fn set_org_item_document_metadata(
+        &self,
+        item_id: &str,
+        doc_id: Option<&str>,
+        access: &str,
+        document_owner_user_id: Option<&str>,
+    ) -> Result<()> {
+        if let Some(doc_id) = doc_id {
+            require_stable_uuid(doc_id, "invalid org document id")?;
+        }
+        if !matches!(access, "view" | "edit") {
+            return Err(crate::error::AppError::InvalidArg(
+                "invalid org item access".into(),
+            ));
+        }
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        if doc_id.is_some() {
+            let org_id = tx
+                .query_row(
+                    "SELECT org_id FROM org_items WHERE item_id = ?1 AND tombstoned = 0",
+                    rusqlite::params![item_id],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()
+                .map_err(map_err)?;
+            if let Some(org_id) = org_id.as_deref() {
+                require_stable_uuid(org_id, "invalid organization id")?;
+            }
+        }
+        Self::set_org_item_document_metadata_tx(
+            &tx,
+            item_id,
+            doc_id,
+            access,
+            document_owner_user_id,
+        )?;
+        tx.commit().map_err(map_err)?;
+        Ok(())
+    }
+
+    fn set_org_item_document_metadata_tx(
+        tx: &rusqlite::Transaction<'_>,
+        item_id: &str,
+        doc_id: Option<&str>,
+        access: &str,
+        document_owner_user_id: Option<&str>,
+    ) -> Result<()> {
+        if let Some(doc_id) = doc_id {
+            require_stable_uuid(doc_id, "invalid org document id")?;
+        }
+        tx.execute(
+            "UPDATE org_items SET doc_id = COALESCE(?2, doc_id), access = ?3,
+                    document_owner_user_id = COALESCE(?4, document_owner_user_id)
+              WHERE item_id = ?1 AND tombstoned = 0",
+            rusqlite::params![item_id, doc_id, access, document_owner_user_id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    fn set_org_item_current_tx(
+        tx: &rusqlite::Transaction<'_>,
+        item_id: &str,
+        org_id: &str,
+        doc_id: Option<&str>,
+        is_current: bool,
+    ) -> Result<bool> {
+        let target_was_current = tx
+            .query_row(
+                "SELECT is_current FROM org_items
+                  WHERE item_id = ?1 AND org_id = ?2 AND tombstoned = 0",
+                rusqlite::params![item_id, org_id],
+                |row| Ok(row.get::<_, i64>(0)? != 0),
+            )
+            .optional()
+            .map_err(map_err)?;
+        let Some(target_was_current) = target_was_current else {
+            return Ok(false);
+        };
+        let visibility_reduced = if is_current {
+            let doc_id = doc_id.ok_or_else(|| {
+                crate::error::AppError::InvalidArg("current org item missing doc id".into())
+            })?;
+            let distinct_current_demoted = tx
+                .query_row(
+                    "SELECT EXISTS(SELECT 1 FROM org_items
+                       WHERE org_id = ?1 AND doc_id = ?2 AND item_id != ?3
+                         AND tombstoned = 0 AND is_current = 1)",
+                    rusqlite::params![org_id, doc_id, item_id],
+                    |row| row.get(0),
+                )
+                .map_err(map_err)?;
+            tx.execute(
+                "UPDATE org_items SET is_current = 0
+                  WHERE org_id = ?1 AND doc_id = ?2 AND item_id != ?3",
+                rusqlite::params![org_id, doc_id, item_id],
+            )
+            .map_err(map_err)?;
+            distinct_current_demoted
+        } else {
+            target_was_current
+        };
+        tx.execute(
+            "UPDATE org_items SET is_current = ?2 WHERE item_id = ?1 AND tombstoned = 0",
+            rusqlite::params![item_id, is_current as i64],
+        )
+        .map_err(map_err)?;
+        Ok(visibility_reduced)
+    }
+
+    /// Current locally-ingested head metadata for a stable document. This is a content-free
+    /// management resolver: it does not mutate the origin share row's CAS baseline.
+    pub fn current_org_document_status(
+        &self,
+        org_id: &str,
+        doc_id: &str,
+    ) -> Result<Option<(String, u32, String)>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT oi.item_id, oi.rev, oi.access
+               FROM org_items oi
+               JOIN org_state os ON os.org_id = oi.org_id
+              WHERE oi.org_id = ?1 AND oi.doc_id = ?2 AND oi.tombstoned = 0
+                AND oi.is_current = 1 AND os.context_enabled = 1
+              LIMIT 1",
+            rusqlite::params![org_id, doc_id],
+            |r| Ok((r.get(0)?, r.get::<_, i64>(1)? as u32, r.get(2)?)),
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
+    pub fn set_org_share_access_for_document(
+        &self,
+        org_id: &str,
+        doc_id: &str,
+        access: &str,
+    ) -> Result<()> {
+        require_stable_uuid(org_id, "invalid organization id")?;
+        require_stable_uuid(doc_id, "invalid org document id")?;
+        if !matches!(access, "view" | "edit") {
+            return Err(crate::error::AppError::InvalidArg(
+                "invalid org item access".into(),
+            ));
+        }
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE org_shares SET access = ?3 WHERE org_id = ?1 AND doc_id = ?2",
+            rusqlite::params![org_id, doc_id, access],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Apply the relay-confirmed permission state to the complete local stable-document resource.
+    /// Every LIVE replica revision and the origin share's display metadata move together in ONE
+    /// SQLCipher transaction. The origin share's `item_id`, `rev`, and content hash are deliberately
+    /// untouched: they remain the last-published CAS witness, so a collaborator edit still produces
+    /// a real 409 on the next automatic source republish.
+    pub fn set_org_document_access_metadata(
+        &self,
+        org_id: &str,
+        doc_id: &str,
+        access: &str,
+        document_owner_user_id: &str,
+    ) -> Result<bool> {
+        require_stable_uuid(org_id, "invalid organization id")?;
+        require_stable_uuid(doc_id, "invalid org document id")?;
+        if !matches!(access, "view" | "edit") {
+            return Err(crate::error::AppError::InvalidArg(
+                "invalid org item access".into(),
+            ));
+        }
+        if document_owner_user_id.trim().is_empty() {
+            return Err(crate::error::AppError::InvalidArg(
+                "missing org document owner".into(),
+            ));
+        }
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let blocked: bool = tx
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM org_shares
+                  WHERE org_id = ?1 AND doc_id = ?2 AND state = 'failed'
+                    AND last_error IN ('direct_put_pending','republish_put_pending',
+                       'republish_post_pending','initial_post_pending','initial_post_replayable',
+                       'projection_pending','recovery_witness_missing','org_edit_conflict'))",
+                rusqlite::params![org_id, doc_id],
+                |row| Ok(row.get::<_, i64>(0)? != 0),
+            )
+            .map_err(map_err)?;
+        if blocked {
+            return Ok(false);
+        }
+        tx.execute(
+            "UPDATE org_items
+                SET access = ?3, document_owner_user_id = ?4
+              WHERE org_id = ?1 AND doc_id = ?2 AND tombstoned = 0",
+            rusqlite::params![org_id, doc_id, access, document_owner_user_id],
+        )
+        .map_err(map_err)?;
+        tx.execute(
+            "UPDATE org_shares SET access = ?3 WHERE org_id = ?1 AND doc_id = ?2",
+            rusqlite::params![org_id, doc_id, access],
+        )
+        .map_err(map_err)?;
+        tx.commit().map_err(map_err)?;
+        Ok(true)
     }
 
     /// The item ids of this org's LIVE (non-tombstoned) local replica rows that are still missing
@@ -2062,16 +3931,56 @@ impl Db {
     ) -> Result<Option<crate::storage::models::OrgItemEditCtx>> {
         let conn = self.lock();
         conn.query_row(
-            "SELECT org_id, rev, created_at, source_kind, author_user_id
-               FROM org_items WHERE item_id = ?1 AND tombstoned = 0",
+            "SELECT org_id, doc_id, rev, created_at, author_hint, source_kind, author_user_id,
+                    document_owner_user_id, access
+               FROM org_items WHERE item_id = ?1 AND tombstoned = 0
+                AND (doc_id IS NULL OR is_current = 1)",
             rusqlite::params![item_id],
             |r| {
                 Ok(crate::storage::models::OrgItemEditCtx {
                     org_id: r.get(0)?,
-                    rev: r.get::<_, i64>(1)? as u32,
-                    created_at: r.get(2)?,
-                    source_kind: r.get::<_, Option<String>>(3)?,
-                    author_user_id: r.get::<_, Option<String>>(4)?,
+                    doc_id: r.get(1)?,
+                    rev: r.get::<_, i64>(2)? as u32,
+                    created_at: r.get(3)?,
+                    author_hint: r.get(4)?,
+                    source_kind: r.get::<_, Option<String>>(5)?,
+                    author_user_id: r.get::<_, Option<String>>(6)?,
+                    document_owner_user_id: r.get::<_, Option<String>>(7)?,
+                    access: r.get(8)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
+    /// Resolve the current live revision of a stable document for permission management. The
+    /// origin `org_shares` row is deliberately left untouched so its expected revision remains an
+    /// honest CAS witness and a remote edit produces 409 on automatic republish.
+    pub fn org_item_edit_ctx_by_document(
+        &self,
+        org_id: &str,
+        doc_id: &str,
+    ) -> Result<Option<crate::storage::models::OrgItemEditCtx>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT org_id, doc_id, rev, created_at, author_hint, source_kind, author_user_id,
+                    document_owner_user_id, access
+               FROM org_items
+              WHERE org_id = ?1 AND doc_id = ?2 AND tombstoned = 0 AND is_current = 1
+              LIMIT 1",
+            rusqlite::params![org_id, doc_id],
+            |r| {
+                Ok(crate::storage::models::OrgItemEditCtx {
+                    org_id: r.get(0)?,
+                    doc_id: r.get(1)?,
+                    rev: r.get::<_, i64>(2)? as u32,
+                    created_at: r.get(3)?,
+                    author_hint: r.get(4)?,
+                    source_kind: r.get(5)?,
+                    author_user_id: r.get(6)?,
+                    document_owner_user_id: r.get(7)?,
+                    access: r.get(8)?,
                 })
             },
         )
@@ -2083,7 +3992,9 @@ impl Db {
     /// body; that's [`Db::get_org_item`]). Newest-first by feed `seq`. This is what lets a member SEE
     /// what colleagues shared into the org instead of only search-hitting it. Org items are
     /// deliberately org-disclosed content (no folder lock gate applies); the COMMAND layer re-checks
-    /// the caller is a local member of `org_id` before calling this.
+    /// the caller is a local member of `org_id` before calling this. The result is bounded to the
+    /// newest 500 headers so a malformed or unexpectedly large local replica cannot allocate an
+    /// unbounded IPC payload.
     ///
     /// `kind` is now populated DIRECTLY from the stored `source_kind` column (opened off the item's
     /// `OrgEnvelope` at ingest — see `upsert_org_item`) for EVERY item, not just ones this device
@@ -2098,23 +4009,26 @@ impl Db {
         let conn = self.lock();
         let mut stmt = conn
             .prepare(
-                "SELECT item_id, title, author_hint, created_at, seq, source_kind
+                "SELECT item_id, doc_id, title, author_hint, created_at, seq, source_kind
                    FROM org_items
                   WHERE org_id = ?1 AND tombstoned = 0
-                  ORDER BY seq DESC",
+                    AND (doc_id IS NULL OR is_current = 1)
+                  ORDER BY seq DESC
+                  LIMIT 500",
             )
             .map_err(map_err)?;
         let rows = stmt
             .query_map(rusqlite::params![org_id], |r| {
                 Ok(crate::storage::models::OrgItemHeader {
                     item_id: r.get(0)?,
-                    title: r.get(1)?,
-                    author_hint: r.get(2)?,
-                    created_at: r.get(3)?,
-                    seq: r.get::<_, i64>(4)? as u64,
+                    doc_id: r.get(1)?,
+                    title: r.get(2)?,
+                    author_hint: r.get(3)?,
+                    created_at: r.get(4)?,
+                    seq: r.get::<_, i64>(5)? as u64,
                     // Direct from storage now (see doc comment above); `list_org_items_inner` may still
                     // enrich/override for the caller's own items via the local `org_shares` resolver.
-                    kind: r.get::<_, Option<String>>(5)?,
+                    kind: r.get::<_, Option<String>>(6)?,
                     owned_source: None,
                 })
             })
@@ -2142,7 +4056,8 @@ impl Db {
             "SELECT COUNT(*)
                FROM org_items oi
                JOIN org_state os ON os.org_id = oi.org_id
-              WHERE oi.org_id = ?1 AND oi.tombstoned = 0 AND os.context_enabled = 1",
+              WHERE oi.org_id = ?1 AND oi.tombstoned = 0 AND os.context_enabled = 1
+                AND (oi.doc_id IS NULL OR oi.is_current = 1)",
             rusqlite::params![org_id],
             |r| r.get::<_, i64>(0),
         )
@@ -2181,6 +4096,7 @@ impl Db {
                    JOIN org_items oi ON oi.item_id = oc.item_id
                    JOIN org_state os ON os.org_id = oi.org_id
                   WHERE oi.org_id = ?1 AND oi.tombstoned = 0
+                    AND (oi.doc_id IS NULL OR oi.is_current = 1)
                     AND NOT EXISTS (SELECT 1 FROM org_vec_chunks v WHERE v.chunk_id = oc.id)
                   LIMIT ?2",
             )

--- a/src-tauri/src/summarize/vault_context.rs
+++ b/src-tauri/src/summarize/vault_context.rs
@@ -521,6 +521,9 @@ pub(crate) fn resolve_vault_context_pinned_visible_inputs(
             }
             LinkKind::Note => db.note_is_visible(&source.id, unlocked)?,
             LinkKind::Document => db.document_is_visible(&source.id, unlocked)?,
+            // Org context activation belongs to the following command/IPC stack. Storage-only org
+            // endpoints remain invisible to the base provider context so no egress widens early.
+            LinkKind::Org => false,
         };
         if typed_visible && explicit_keys.insert(key) {
             explicit_refs.push(source.clone());
@@ -649,6 +652,16 @@ fn resolve_pinned_source(
                 true,
                 Vec::new(),
             )
+        }
+        LinkKind::Org => {
+            return Ok(ResolvedPinnedSource {
+                source: source.clone(),
+                header: String::new(),
+                body: String::new(),
+                body_required: true,
+                manifest_digest: source_manifest_digest("", None, false, ""),
+                vault_sources: Vec::new(),
+            });
         }
     };
     let manifest_digest =


### PR DESCRIPTION
Adds the additive SQLCipher storage and migration foundation for crash-safe Org sharing and permissions. Includes exact access-attempt CAS, atomic projection and attachment completeness, durable closures, source-version witnesses, fail-closed legacy recovery, and verify-before-destroy marker cleanup.\n\nVerification: Harness PASS on exact diff 1bde6b6aa221d56f11add693548d2ab64b939c6d41cfbb199fb753c7854eaaf8; 3051 Rust library tests; clippy with warnings denied; independent combined, lock-security, and egress-security reviews PASS.\n\nThis is storage-first and does not activate new server wire behavior, UI, or Railway deployment.