### PR TITLE
feat(storage): adopt every existing container into a default project

### DIFF
--- a/src-tauri/src/commands/folders.rs
+++ b/src-tauri/src/commands/folders.rs
@@ -82,6 +82,41 @@ pub(crate) fn flatten_projects_for_legacy_tree(
         .collect()
 }
 
+/// Refuse any path-composing operation on a container whose path IS the vault root.
+///
+/// The hierarchy migration gives the default project `path = ''` — the first row in the app's
+/// history whose path is the vault root. Without a refusal, a rename would compose
+/// `fs::rename(<vault>, <vault>/<new name>)` and MOVE THE USER'S ENTIRE VAULT, and a delete would
+/// target the vault directory itself.
+///
+/// `assert_in_vault` deliberately RESOLVES an empty relative path to the vault root — a documented
+/// behaviour with its own test — so the refusal has to happen before a container reaches it. The
+/// complete set of call sites is enumerated below rather than left to each future author to
+/// rediscover; anything added later that composes filesystem work from a container it resolved by id
+/// belongs on that list.
+///
+/// The complete set of places that compose filesystem work from a resolved container's OWN path,
+/// and what each does with the vault-root row:
+///   - `rename_folder_inner` (the subtree `fs::rename`, and `reexport_notes_under_subtree` beneath
+///     it) — refused here, before anything is touched;
+///   - `delete_folder_inner` (`fs::remove_dir`) — refused here;
+///   - `move_note_folder_inner`'s `src`/`dst` — unreachable: it resolves through
+///     `Db::note_folder_by_id`, which excludes any container whose path is the vault root. That
+///     holds however such a row arrived — this migration only ever creates a meeting-kind project
+///     there, but an import could produce a note-kind one, and the resolver refuses both.
+///   - `write_note_to_vault` — takes a NOTE container's path, which is rooted under the note root
+///     and falls back to `"Notes"`, so it is never empty;
+///   - `remove_lock_inner`'s re-export and `move_note_file` — both already map an empty path to
+///     `None`, which correctly means "the vault root" for a note that belongs nowhere else.
+fn refuse_vault_root_container(folder: &Folder) -> Result<(), AppError> {
+    if folder.path.is_empty() {
+        return Err(AppError::InvalidArg(
+            "the workspace root cannot be renamed or deleted".into(),
+        ));
+    }
+    Ok(())
+}
+
 /// Assemble `FolderNode` roots (parent_id == None) and recurse children. Sealed-but-session-
 /// unlocked folders carry `unlocked = true`.
 pub(crate) fn build_folder_tree(
@@ -131,6 +166,16 @@ pub fn create_folder(
     name: String,
     parent_id: Option<String>,
 ) -> Result<Folder, AppError> {
+    create_folder_inner(state.inner(), name, parent_id)
+}
+
+/// Inner of [`create_folder`] taking `&AppState`, so the real creation path can be exercised by a
+/// test rather than approximated by calling its name sanitiser directly.
+pub(crate) fn create_folder_inner(
+    state: &AppState,
+    name: String,
+    parent_id: Option<String>,
+) -> Result<Folder, AppError> {
     let clean = crate::summarize::organize::sanitize_folder(&name)
         .ok_or_else(|| AppError::InvalidArg("folder name is empty or invalid".into()))?;
 
@@ -156,7 +201,7 @@ pub fn create_folder(
 
     // Create the vault subdirectory (best-effort but surfaced): only when a vault is configured.
     // D5: canonicalize + assert the composed dir stays inside the vault root before any mkdir.
-    if let Some(vault) = vault_path(&state) {
+    if let Some(vault) = vault_path(state) {
         let vault_root = std::path::Path::new(&vault);
         let dir = assert_in_vault(vault_root, std::path::Path::new(&rel_path))?;
         std::fs::create_dir_all(&dir)
@@ -223,6 +268,7 @@ pub(crate) fn rename_folder_inner(
         .db
         .folder_by_id(&folder_id)?
         .ok_or_else(|| AppError::InvalidArg(format!("no folder {folder_id}")))?;
+    refuse_vault_root_container(&folder)?;
     ensure_folder_subtree_unlocked(state, &folder_id)?;
     let old_path = folder.path.clone();
 
@@ -415,6 +461,7 @@ pub(crate) fn delete_folder_inner(state: &AppState, folder_id: String) -> Result
         .db
         .folder_by_id(&folder_id)?
         .ok_or_else(|| AppError::InvalidArg(format!("no folder {folder_id}")))?;
+    refuse_vault_root_container(&folder)?;
 
     // Refuse a non-empty SUBTREE — never orphan child folders by dangling their parent_id.
     if !state.db.child_folders(&folder_id)?.is_empty() {

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -13037,7 +13037,27 @@
 
         let snapshot = DurableScopeSnapshot::Vault(capture_content_visibility_snapshot(&state));
         let initial_dependencies = state.db.visible_folder_ids(&HashSet::new()).unwrap();
-        assert_eq!(initial_dependencies, vec!["f-visible".to_string()]);
+        // Every database now carries a default project (the hierarchy migration), which is a real
+        // always-open container and so is legitimately part of the visible set. Subtract exactly
+        // THAT id rather than filtering by a name prefix, so both assertions stay CLOSED sets: any
+        // other id leaking into the visible set — another generated container, an org- or
+        // system-sourced one — must still fail here, at a gate assertion. Naming the id also avoids
+        // depending on where a UUID happens to sort relative to "f-visible".
+        let project_id: String = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT id FROM folders WHERE COALESCE(level, 'folder') = 'project'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let seeded = |ids: &[String]| -> Vec<String> {
+            let mut v: Vec<String> = ids.iter().filter(|id| **id != project_id).cloned().collect();
+            v.sort();
+            v
+        };
+        assert_eq!(seeded(&initial_dependencies), vec!["f-visible".to_string()]);
 
         state
             .unlocked_folders
@@ -13074,7 +13094,7 @@
                 .unwrap()
         };
         assert_eq!(
-            dependencies,
+            seeded(&dependencies),
             vec!["f-late".to_string(), "f-visible".to_string()]
         );
     }
@@ -30471,4 +30491,409 @@
             update_permit.authorize_update(host, org_id, doc_id, &substituted_update),
             Err(AppError::Storage(message)) if message == "org update dispatch permit mismatch"
         ));
+    }
+
+    /// Adoption does not change how a note container RENAMES — proven through the real rename entry
+    /// point, on the vault, rather than asserted from the composition rule.
+    ///
+    /// This is the hazard the whole migration design exists to avoid, so it is not enough to reason
+    /// that `rename_folder_inner` treats an empty parent path like no parent at all. A note container
+    /// whose stored path cannot be composed from any note root is adopted by the project, whose path
+    /// is the vault root; if that changed what a later rename does, the real directory would move
+    /// while `notes.exported_path` / `documents.exported_path` stayed behind — and a later seal would
+    /// then delete an `.md` at a path that no longer exists, leaving the plaintext inside a folder the
+    /// app reports as sealed. Both databases are renamed identically and compared.
+    #[test]
+    fn adoption_does_not_change_how_a_note_container_renames() {
+        fn rename_uncomposable(tag: &str, adopt: bool) -> (String, std::path::PathBuf) {
+            let vault = tmp_vault(tag);
+            let state = build_state_with_vault(tag, &vault);
+            // Model a pre-hierarchy database: opening one adopts it, so undo that first.
+            state
+                .db
+                .lock()
+                .execute(
+                    "DELETE FROM folders WHERE COALESCE(level, 'folder') = 'project'",
+                    rusqlite::params![],
+                )
+                .unwrap();
+            // A note container stamped two levels under a root while its parent link stays NULL —
+            // the shape `create_note_folder_inner` produces and no root can compose.
+            state
+                .db
+                .insert_folder(&Folder {
+                    id: "c-deep".into(),
+                    name: "Deep".into(),
+                    path: "Notes/Mid/Deep".into(),
+                    parent_id: None,
+                    locked: false,
+                    created_at: "2026-08-22T09:00:00Z".into(),
+                })
+                .unwrap();
+            state
+                .db
+                .lock()
+                .execute(
+                    "UPDATE folders SET kind = 'note' WHERE id = 'c-deep'",
+                    rusqlite::params![],
+                )
+                .unwrap();
+            std::fs::create_dir_all(vault.join("Notes/Mid/Deep")).unwrap();
+
+            if adopt {
+                Db::migrate_hierarchy_v1(&state.db.lock()).unwrap();
+            }
+            rename_folder_inner(&state, "c-deep".into(), "Renamed".into()).unwrap();
+            let path: String = state
+                .db
+                .lock()
+                .query_row("SELECT path FROM folders WHERE id = 'c-deep'", [], |r| {
+                    r.get(0)
+                })
+                .unwrap();
+            (path, vault)
+        }
+
+        let (before, vault_before) = rename_uncomposable("rename-unadopted", false);
+        let (after, vault_after) = rename_uncomposable("rename-adopted", true);
+        assert_eq!(
+            before, after,
+            "adoption changed where a rename puts a note container's directory"
+        );
+        // And the directory really landed there in BOTH vaults — comparing two `exists()` calls would
+        // also pass if neither directory existed at all.
+        assert!(
+            vault_before.join(&before).is_dir(),
+            "the un-adopted rename did not create {before}"
+        );
+        assert!(
+            vault_after.join(&after).is_dir(),
+            "the adopted rename did not create {after}"
+        );
+        assert!(
+            !vault_before.join("Notes/Mid/Deep").exists(),
+            "the un-adopted rename left the old directory behind"
+        );
+        assert!(
+            !vault_after.join("Notes/Mid/Deep").exists(),
+            "the adopted rename left the old directory behind"
+        );
+    }
+
+    /// Sealing a project reaches its own items only, never the containers beneath it.
+    ///
+    /// The hierarchy gives containers parents for the first time, so this pins that a lock is still
+    /// exactly as wide as it was: per container, never recursive. (Making a project lock cascade to
+    /// its children is a later, deliberate step — this proves it does not happen by accident here.)
+    #[test]
+    fn sealing_a_project_reaches_its_own_items_only() {
+        let state = build_state("project-seal-scope");
+        // The database adopts on open, so the project already exists; give it a child and one item
+        // each, then seal the project.
+        let project: String = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT id FROM folders WHERE COALESCE(level, 'folder') = 'project' AND path = ''",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        make_child_folder(&state.db, "f-work", "Work", "Work", &project);
+        seed_meeting(&state.db, "m-project", "# project note", Some(&project));
+        seed_meeting(&state.db, "m-work", "# work note", Some("f-work"));
+
+        lock_folder_inner(&state, project.clone()).unwrap();
+
+        assert!(
+            !meeting_is_unlocked(&state, "m-project").unwrap(),
+            "the project's own item is sealed"
+        );
+        assert!(
+            meeting_is_unlocked(&state, "m-work").unwrap(),
+            "a container beneath it is untouched — a lock is per container, never recursive"
+        );
+    }
+
+    /// Renaming or deleting the workspace root is refused.
+    ///
+    /// The hierarchy gives the default project `path = ''`, and every folder command composes its
+    /// filesystem work from `folders.path`. `assert_in_vault` resolves an empty relative path to the
+    /// vault root — the property that lets the migration adopt every container without moving a file
+    /// — so without this refusal a rename would compose `fs::rename(<vault>, <vault>/<new name>)` and
+    /// move the user's ENTIRE vault. No shipped row had an empty path before, so the refusal ships
+    /// with the row that makes it reachable.
+    #[test]
+    fn the_workspace_root_cannot_be_renamed_or_deleted() {
+        let vault = tmp_vault("workspace-root-guard");
+        let state = build_state_with_vault("workspace-root-guard", &vault);
+        make_open_folder(&state.db, "f-work", "Work");
+        std::fs::create_dir_all(vault.join("Work")).unwrap();
+        Db::migrate_hierarchy_v1(&state.db.lock()).unwrap();
+
+        let project: String = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT id FROM folders WHERE COALESCE(level, 'folder') = 'project'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+
+        let err = rename_folder_inner(&state, project.clone(), "Renamed".into())
+            .expect_err("renaming the workspace root must be refused");
+        assert!(matches!(err, AppError::InvalidArg(_)), "got {err:?}");
+        let err = delete_folder_inner(&state, project.clone())
+            .expect_err("deleting the workspace root must be refused");
+        assert!(matches!(err, AppError::InvalidArg(_)), "got {err:?}");
+
+        // The vault is intact and the project row is unchanged.
+        assert!(vault.join("Work").is_dir(), "the vault was disturbed");
+        assert!(!vault.join("Renamed").exists());
+        let path: String = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT path FROM folders WHERE id = ?1",
+                rusqlite::params![project],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(path, "");
+
+        // An ordinary container still renames exactly as before.
+        rename_folder_inner(&state, "f-work".into(), "Ops".into()).unwrap();
+        assert!(vault.join("Ops").is_dir());
+    }
+
+    /// On an ADOPTED database the reserved note root still resolves and still cannot be sealed.
+    ///
+    /// Adoption gives that root a non-NULL parent for the first time. The invariant it exists to
+    /// protect — that creating a note always has a writable, never-sealed home — is checked here
+    /// through the real resolver and the real seal refusal, not through its flag.
+    #[test]
+    fn the_note_root_still_resolves_and_still_refuses_to_seal_after_adoption() {
+        let state = build_state("adopted-note-root");
+        // The real upgrade path: an existing user already HAS a note root, and adoption then gives it
+        // a parent. (A root created AFTER adoption keeps a NULL parent, because the completion guard
+        // short-circuits — containers created post-adoption get their parent from the creation call
+        // instead. Defaulting that parent to the workspace project belongs to the creation-guards
+        // step, which is where the tree first has a consumer.)
+        state
+            .db
+            .lock()
+            .execute(
+                "DELETE FROM folders WHERE COALESCE(level, 'folder') = 'project'",
+                rusqlite::params![],
+            )
+            .unwrap();
+        let root_before = state.db.ensure_notes_root().unwrap();
+        Db::migrate_hierarchy_v1(&state.db.lock()).unwrap();
+
+        let parent: Option<String> = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT parent_id FROM folders WHERE id = ?1",
+                rusqlite::params![root_before],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            parent.is_some(),
+            "adoption gives the note root a parent — that is the new condition under test"
+        );
+
+        // The resolver still finds the SAME root rather than minting a second one.
+        let root_after = state.db.ensure_notes_root().unwrap();
+        assert_eq!(root_after, root_before, "a second note root was created");
+
+        // And sealing it is still refused, so note creation never dead-ends.
+        let err = lock_folder_inner(&state, root_after.clone())
+            .expect_err("the note root must still refuse to seal");
+        assert!(matches!(err, AppError::InvalidArg(_)), "got {err:?}");
+    }
+
+    /// No shipped creation path can produce a container whose path is the vault root.
+    ///
+    /// The migration declines to adopt when the vault root is occupied, and the legacy-tree shim
+    /// hides project rows — so if a user COULD create a container there, they could put their own
+    /// database into the declined state. This drives BOTH shipped creation entry points rather than
+    /// their shared name sanitiser: a path that stopped calling the sanitiser, or gained its own
+    /// composition, would leave a sanitiser-only assertion green.
+    #[test]
+    fn no_creation_path_can_produce_a_vault_root_container() {
+        let vault = tmp_vault("no-empty-path");
+        let state = build_state_with_vault("no-empty-path", &vault);
+
+        for name in ["", "   ", "...", "/", "///", "\u{0}", ".", " . "] {
+            assert!(
+                create_folder_inner(&state, name.to_string(), None).is_err(),
+                "the meeting-side create accepted {name:?}"
+            );
+            assert!(
+                create_note_folder_inner(&state, name, None).is_err(),
+                "the note-side create accepted {name:?}"
+            );
+        }
+
+        // Controls: an ordinary name succeeds on both paths, and neither lands at the vault root.
+        let meeting_side = create_folder_inner(&state, "Work".into(), None).unwrap();
+        assert!(!meeting_side.path.is_empty());
+        let note_side = create_note_folder_inner(&state, "Research", None).unwrap();
+        assert!(!note_side.path.is_empty());
+
+        // And nothing in the database occupies the vault root except the project the migration made.
+        let at_root: Vec<String> = {
+            let conn = state.db.lock();
+            let mut stmt = conn
+                .prepare("SELECT COALESCE(level, 'folder') FROM folders WHERE path = ''")
+                .unwrap();
+            let rows = stmt.query_map([], |r| r.get::<_, String>(0)).unwrap();
+            rows.map(|r| r.unwrap()).collect()
+        };
+        assert_eq!(at_root, vec!["project".to_string()]);
+    }
+
+    /// Resolving the vault root BY PATH after adoption returns the project — stated, because it
+    /// returned nothing on every database before this change.
+    ///
+    /// It matters for the by-path resolvers: the auto-file classifier maps a model-chosen subfolder
+    /// name to a container this way. The name it can produce is sanitised, and the sanitiser refuses
+    /// anything empty, so the classifier cannot address the project — but that is now a property
+    /// worth asserting rather than assuming.
+    #[test]
+    fn the_vault_root_resolves_by_path_only_to_the_project() {
+        let state = build_state("vault-root-by-path");
+        let project: Option<String> = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT id FROM folders WHERE COALESCE(level, 'folder') = 'project' AND path = ''",
+                [],
+                |r| r.get(0),
+            )
+            .ok();
+        assert!(project.is_some(), "the database is adopted");
+
+        let by_path = state.db.folder_by_path("").unwrap();
+        assert_eq!(
+            by_path.map(|f| f.id),
+            project,
+            "the empty path resolves to the workspace project and nothing else"
+        );
+        // The classifier's own vocabulary cannot name it.
+        assert!(crate::summarize::organize::sanitize_folder("").is_none());
+    }
+
+    /// A genuinely sealed container survives adoption gated, unlockable, and byte-identical.
+    ///
+    /// Comparing the `locked` and `wrapped_key` columns before and after only shows the migration did
+    /// not overwrite them. It cannot show that a REAL seal still opens afterwards, which is the
+    /// property that matters: the content is only recoverable through the key those columns describe.
+    /// So this seals through the ordinary lock path with real key material, migrates, checks the gate,
+    /// then permanently unseals and compares the markdown byte for byte.
+    #[test]
+    fn a_real_seal_survives_adoption_and_still_unseals_byte_identical() {
+        let state = build_state("sealed-through-adoption");
+        // Model a pre-hierarchy database, seal a container with content in it, THEN adopt.
+        state
+            .db
+            .lock()
+            .execute(
+                "DELETE FROM folders WHERE COALESCE(level, 'folder') = 'project'",
+                rusqlite::params![],
+            )
+            .unwrap();
+        make_open_folder(&state.db, "f-legal", "Legal");
+        let markdown = "# Merger terms\n\nAcquire at 3.2x revenue.\n";
+        seed_meeting(&state.db, "m1", markdown, Some("f-legal"));
+
+        lock_folder_inner(&state, "f-legal".into()).unwrap();
+        assert!(!meeting_is_unlocked(&state, "m1").unwrap(), "sealed before adoption");
+
+        Db::migrate_hierarchy_v1(&state.db.lock()).unwrap();
+
+        // Adopted, and still sealed — the gate reads the per-row flag, which adoption never writes.
+        let parent: Option<String> = state
+            .db
+            .lock()
+            .query_row("SELECT parent_id FROM folders WHERE id = 'f-legal'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert!(parent.is_some(), "it was adopted");
+        assert!(!meeting_is_unlocked(&state, "m1").unwrap(), "still sealed after adoption");
+
+        // And the real key still opens it, returning exactly what went in.
+        remove_lock_inner(&state, "f-legal".to_string()).unwrap();
+        assert!(meeting_is_unlocked(&state, "m1").unwrap());
+        let restored = state
+            .db
+            .get_latest_note_for_meeting("m1")
+            .unwrap()
+            .expect("the note is back");
+        assert_eq!(
+            restored.markdown, markdown,
+            "content did not survive seal -> adopt -> unseal byte-identical"
+        );
+    }
+
+    /// The vault-root refusal covers a DECLINED-ADOPTION occupant too, not only the created project.
+    ///
+    /// The hazard is the path, not the row: every folder command composes its filesystem work from
+    /// `folders.path`, and an empty one resolves to the vault root — so renaming it means "move the
+    /// vault into a subdirectory of itself" and deleting it targets the vault directory, whichever row
+    /// happens to sit there. Narrowing the refusal to the migration's own project would leave both
+    /// operations reachable on exactly the database where the migration declined to adopt BECAUSE
+    /// such a container was present.
+    #[test]
+    fn the_vault_root_refusal_covers_a_declined_adoption_occupant() {
+        let vault = tmp_vault("declined-occupant");
+        let state = build_state_with_vault("declined-occupant", &vault);
+        state
+            .db
+            .lock()
+            .execute(
+                "DELETE FROM folders WHERE COALESCE(level, 'folder') = 'project'",
+                rusqlite::params![],
+            )
+            .unwrap();
+        // A container occupying the vault root, the shape only an import or a manual edit produces.
+        make_open_folder(&state.db, "f-root", "");
+        make_open_folder(&state.db, "f-work", "Work");
+        std::fs::create_dir_all(vault.join("Work")).unwrap();
+
+        Db::migrate_hierarchy_v1(&state.db.lock()).unwrap();
+        assert!(
+            state
+                .db
+                .lock()
+                .query_row(
+                    "SELECT EXISTS(SELECT 1 FROM folders WHERE COALESCE(level,'folder') = 'project')",
+                    [],
+                    |r| r.get::<_, i64>(0)
+                )
+                .unwrap()
+                == 0,
+            "adoption declined, which is the state under test"
+        );
+
+        // The occupant is NOT the project, and is still refused.
+        let err = rename_folder_inner(&state, "f-root".into(), "Renamed".into())
+            .expect_err("renaming a vault-root container must be refused");
+        assert!(matches!(err, AppError::InvalidArg(_)), "got {err:?}");
+        let err = delete_folder_inner(&state, "f-root".into())
+            .expect_err("deleting a vault-root container must be refused");
+        assert!(matches!(err, AppError::InvalidArg(_)), "got {err:?}");
+
+        // The vault is intact: nothing moved, nothing removed.
+        assert!(vault.join("Work").is_dir());
+        assert!(!vault.join("Renamed").exists());
+        assert!(vault.is_dir());
+
+        // And an ordinary container on the same database still renames.
+        rename_folder_inner(&state, "f-work".into(), "Ops".into()).unwrap();
+        assert!(vault.join("Ops").is_dir());
     }

--- a/src-tauri/src/commands/tests/workspace_tree_tests.rs
+++ b/src-tauri/src/commands/tests/workspace_tree_tests.rs
@@ -22,6 +22,17 @@ fn fresh_db(label: &str) -> (Db, std::path::PathBuf) {
     let path = crate::storage::db::unique_temp_path(&format!("murmur-workspace-{label}"), "sqlite");
     let _ = std::fs::remove_file(&path);
     let db = Db::open_with_key(&path, TEST_DEK).unwrap();
+    // Opening a database ADOPTS it: the hierarchy migration creates a default project at the vault
+    // root. Undo that here so each test states the exact container shape it is about — otherwise a
+    // test that builds its own project at the vault root collides with the automatic one on the
+    // UNIQUE path, and every fixture would have to work around a row it never asked for. The
+    // migration itself is exercised on purpose by the tests at the end of this file.
+    db.lock()
+        .execute(
+            "DELETE FROM folders WHERE COALESCE(level, 'folder') = 'project'",
+            rusqlite::params![],
+        )
+        .unwrap();
     (db, path)
 }
 
@@ -1078,6 +1089,937 @@ fn the_legacy_folder_tree_is_unchanged_on_a_pre_migration_database() {
         serde_json::to_string(&after).unwrap(),
         "the legacy folder tree changed on a pre-migration database"
     );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+// ── the hierarchy migration ──────────────────────────────────────────────────────────────────────
+//
+// `migrate()` adopts a database the moment it is opened, so a PRE-migration state is modelled by
+// removing the project it created and then driving `migrate_hierarchy_v1` directly. That is the same
+// entry point `migrate()` calls, so these exercise the real migration rather than a re-statement.
+
+/// A database in the shape it had before the hierarchy existed: containers, no project. Identical to
+/// [`fresh_db`], named separately so the migration tests read as what they are.
+fn pre_migration_db(label: &str) -> (Db, std::path::PathBuf) {
+    fresh_db(label)
+}
+
+fn run_migration(db: &Db) {
+    Db::migrate_hierarchy_v1(&db.lock()).unwrap();
+}
+
+/// (id, path, parent_id, level, locked, wrapped_key) — the columns a migration must be able to
+/// prove it did or did not change.
+type FolderRow = (String, String, Option<String>, String, i64, Option<Vec<u8>>);
+
+fn folder_rows(db: &Db) -> Vec<FolderRow> {
+    let conn = db.lock();
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, path, parent_id, COALESCE(level, 'folder'), locked, wrapped_key
+               FROM folders ORDER BY id",
+        )
+        .unwrap();
+    let rows = stmt
+        .query_map([], |r| {
+            Ok((
+                r.get(0)?,
+                r.get(1)?,
+                r.get(2)?,
+                r.get(3)?,
+                r.get(4)?,
+                r.get(5)?,
+            ))
+        })
+        .unwrap();
+    rows.map(|r| r.unwrap()).collect()
+}
+
+/// Every existing container is adopted, and note containers land under the note root so that path
+/// composition agrees with what is already on disk.
+#[test]
+fn the_migration_adopts_every_existing_container() {
+    let (db, path) = pre_migration_db("adopt");
+    container(&db, "f-work", "Work", "Work", None, "folder");
+    container(&db, "f-notes", "Notes", "Notes", None, "folder");
+    container(&db, "f-research", "Research", "Notes/Research", None, "folder");
+    // `execute` runs only the FIRST statement of a batch — use `execute_batch` for both.
+    db.lock()
+        .execute_batch(
+            "UPDATE folders SET kind = 'note' WHERE id IN ('f-notes', 'f-research');
+             UPDATE folders SET is_root = 1 WHERE id = 'f-notes';",
+        )
+        .unwrap();
+
+    run_migration(&db);
+
+    let containers = db.list_containers().unwrap();
+    let project = containers
+        .iter()
+        .find(|c| c.level == "project")
+        .expect("a default project exists");
+    assert!(project.parent_id.is_none());
+
+    let by_id = |id: &str| containers.iter().find(|c| c.id == id).unwrap().clone();
+    assert_eq!(by_id("f-work").parent_id.as_deref(), Some(project.id.as_str()));
+    assert_eq!(by_id("f-notes").parent_id.as_deref(), Some(project.id.as_str()));
+    assert_eq!(
+        by_id("f-research").parent_id.as_deref(),
+        Some("f-notes"),
+        "a note container is adopted under the note root, so parent.path + name == its own path"
+    );
+    assert!(by_id("f-notes").is_root, "the note root keeps its flag");
+    for id in ["f-work", "f-notes", "f-research"] {
+        assert_eq!(by_id(id).level, "folder");
+    }
+
+    // And the tree now renders as a single forest rooted at the project.
+    let forest = tree(&db, &HashSet::new());
+    assert_eq!(forest.len(), 1);
+    assert_eq!(forest[0].id, project.id);
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// The migration moves nothing on disk: no `path` and no `exported_path` changes.
+///
+/// This is the property the whole design exists to preserve. `folders.path` is a real vault
+/// directory and `notes.exported_path` is where `lock_folder` goes to delete a plaintext `.md`; a
+/// rewritten path with an unmoved file (or the reverse) is the NOTES-2 sealed-content leak.
+#[test]
+fn the_migration_moves_no_path_and_no_export() {
+    let (db, path) = pre_migration_db("no-move");
+    container(&db, "f-work", "Work", "Work", None, "folder");
+    container(&db, "f-pl", "Sprzedaż", "Sprzedaż", None, "folder");
+    meeting_in(&db, "m1", "Standup", "2026-08-20T09:00:00Z", Some("f-work"));
+    db.lock()
+        .execute(
+            "UPDATE notes SET exported_path = '/vault/Work/Standup.md' WHERE meeting_id = 'm1'",
+            rusqlite::params![],
+        )
+        .unwrap();
+    note_in(&db, "d1", "Oferta", "f-pl", 1_700_000_000_000);
+    db.lock()
+        .execute(
+            "UPDATE documents SET exported_path = '/vault/Sprzedaż/Oferta.md' WHERE id = 'd1'",
+            rusqlite::params![],
+        )
+        .unwrap();
+
+    let paths_before: Vec<(String, String)> = folder_rows(&db)
+        .into_iter()
+        .map(|(id, p, _, _, _, _)| (id, p))
+        .collect();
+    let exports_before: Vec<String> = {
+        let conn = db.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT exported_path FROM notes WHERE exported_path IS NOT NULL
+                 UNION ALL
+                 SELECT exported_path FROM documents WHERE exported_path IS NOT NULL",
+            )
+            .unwrap();
+        let rows = stmt.query_map([], |r| r.get::<_, String>(0)).unwrap();
+        let mut v: Vec<String> = rows.map(|r| r.unwrap()).collect();
+        v.sort();
+        v
+    };
+
+    run_migration(&db);
+
+    let paths_after: Vec<(String, String)> = folder_rows(&db)
+        .into_iter()
+        .filter(|(_, _, _, level, _, _)| level != "project")
+        .map(|(id, p, _, _, _, _)| (id, p))
+        .collect();
+    assert_eq!(
+        paths_before, paths_after,
+        "a container path changed — the vault directory it names did not"
+    );
+
+    let exports_after: Vec<String> = {
+        let conn = db.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT exported_path FROM notes WHERE exported_path IS NOT NULL
+                 UNION ALL
+                 SELECT exported_path FROM documents WHERE exported_path IS NOT NULL",
+            )
+            .unwrap();
+        let rows = stmt.query_map([], |r| r.get::<_, String>(0)).unwrap();
+        let mut v: Vec<String> = rows.map(|r| r.unwrap()).collect();
+        v.sort();
+        v
+    };
+    assert_eq!(
+        exports_before, exports_after,
+        "an exported .md path changed — the seal would delete nothing there"
+    );
+
+    // The project itself sits at the vault root, which is what makes all of the above possible.
+    let project = db
+        .list_containers()
+        .unwrap()
+        .into_iter()
+        .find(|c| c.level == "project")
+        .unwrap();
+    let project_path: String = db
+        .lock()
+        .query_row(
+            "SELECT path FROM folders WHERE id = ?1",
+            rusqlite::params![project.id],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(project_path, "", "the default project IS the vault root");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Running it again changes nothing — including after a full re-open, which is how it runs for real.
+#[test]
+fn the_migration_is_idempotent() {
+    let (db, path) = pre_migration_db("idempotent-migration");
+    container(&db, "f-work", "Work", "Work", None, "folder");
+    container(&db, "f-notes", "Notes", "Notes", None, "folder");
+    db.lock()
+        .execute(
+            "UPDATE folders SET kind = 'note', is_root = 1 WHERE id = 'f-notes'",
+            rusqlite::params![],
+        )
+        .unwrap();
+
+    run_migration(&db);
+    let once = folder_rows(&db);
+    run_migration(&db);
+    assert_eq!(once, folder_rows(&db), "a second run changed a row");
+
+    // Re-opening runs the whole of migrate() again on an adopted database.
+    drop(db);
+    let db = Db::open_with_key(&path, TEST_DEK).unwrap();
+    assert_eq!(once, folder_rows(&db), "re-opening changed a row");
+    assert_eq!(
+        db.list_containers()
+            .unwrap()
+            .iter()
+            .filter(|c| c.level == "project")
+            .count(),
+        1,
+        "a second project was created"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// A system container is not adopted, not re-parented, and not read.
+///
+/// This is a launch-safety property, not tidiness: an in-flight feature owns a container whose row
+/// and children are guarded by RAISE(ABORT) triggers, and this migration runs before any content
+/// surface comes up — so a blanket re-parent would be a failure to START the app.
+#[test]
+fn the_migration_leaves_a_system_container_alone() {
+    let (db, path) = pre_migration_db("system-untouched");
+    container(&db, "f-work", "Work", "Work", None, "folder");
+    container(&db, "sys", "tasks", ".murmur/tasks", None, "folder");
+    db.lock()
+        .execute(
+            "UPDATE folders SET kind = 'task' WHERE id = 'sys'",
+            rusqlite::params![],
+        )
+        .unwrap();
+
+    run_migration(&db);
+
+    let (parent, level): (Option<String>, String) = db
+        .lock()
+        .query_row(
+            "SELECT parent_id, COALESCE(level, 'folder') FROM folders WHERE id = 'sys'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert!(parent.is_none(), "the system container was re-parented");
+    assert_eq!(level, "folder", "the system container was re-levelled");
+    assert!(db.list_containers().unwrap().iter().all(|c| c.id != "sys"));
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// The migration never WRITES a container's sealed flag or wrapped key.
+///
+/// This is the narrow column-level claim; that a real seal still opens after adoption — the property
+/// that actually matters, since the content is only recoverable through the key those columns
+/// describe — is proven separately by
+/// `lifecycle_tests::a_real_seal_survives_adoption_and_still_unseals_byte_identical`, which seals
+/// through the ordinary lock path with real key material and unseals afterwards.
+#[test]
+fn the_migration_touches_no_lock_state() {
+    let (db, path) = pre_migration_db("sealed-migration");
+    container(&db, "f-locked", "Legal", "Legal", None, "folder");
+    seal(&db, "f-locked");
+    db.lock()
+        .execute(
+            "UPDATE folders SET wrapped_key = X'DEADBEEF' WHERE id = 'f-locked'",
+            rusqlite::params![],
+        )
+        .unwrap();
+
+    let before: (i64, Option<Vec<u8>>) = db
+        .lock()
+        .query_row(
+            "SELECT locked, wrapped_key FROM folders WHERE id = 'f-locked'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+
+    run_migration(&db);
+
+    let after: (i64, Option<Vec<u8>>) = db
+        .lock()
+        .query_row(
+            "SELECT locked, wrapped_key FROM folders WHERE id = 'f-locked'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(before, after, "the migration touched a sealed container's key");
+    assert_eq!(before.0, 1);
+
+    // It is adopted like any other container, and still reports itself sealed.
+    let sealed = db
+        .list_containers()
+        .unwrap()
+        .into_iter()
+        .find(|c| c.id == "f-locked")
+        .unwrap();
+    assert!(sealed.parent_id.is_some());
+    assert!(sealed.locked);
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// The default project is named after the vault directory when one is configured.
+#[test]
+fn the_default_project_takes_the_vault_directory_name() {
+    let (db, path) = pre_migration_db("vault-name");
+    db.lock()
+        .execute(
+            "INSERT OR REPLACE INTO settings (key, value) VALUES ('vault_path', '/Users/x/Obsidian/Second Brain')",
+            rusqlite::params![],
+        )
+        .unwrap();
+
+    run_migration(&db);
+
+    let project = db
+        .list_containers()
+        .unwrap()
+        .into_iter()
+        .find(|c| c.level == "project")
+        .unwrap();
+    assert_eq!(project.name, "Second Brain");
+
+    // With no vault configured, a neutral name is used instead.
+    let (db2, path2) = pre_migration_db("neutral-name");
+    run_migration(&db2);
+    let project = db2
+        .list_containers()
+        .unwrap()
+        .into_iter()
+        .find(|c| c.level == "project")
+        .unwrap();
+    assert_eq!(project.name, "Workspace");
+
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_file(&path2);
+}
+
+/// Anything already occupying the vault root leaves the database un-adopted — nothing is promoted.
+///
+/// The slot is UNIQUE, so an occupant cannot be moved aside, and promoting it would produce a row
+/// that is a project AND carries a user's contents. Two things follow from that, and both are why
+/// this declines instead: the legacy shim hides project rows, so a promoted container and everything
+/// filed inside it would vanish from the shipped sidebar; and a promoted note-kind row would be a
+/// note folder at the vault root, which the note-folder move resolves and would then compose
+/// filesystem work from — against the vault root itself.
+#[test]
+fn an_occupied_vault_root_declines_adoption() {
+    // Including the shapes that most resemble the migration's own result: a project-level row at the
+    // vault root, of each kind — the meeting-kind one being exactly what a completed adoption looks
+    // like, minus the adoption. Only the exact shape this migration produces — a MEETING-kind
+    // project there — may be read as "already adopted"; anything else is an occupant and declines,
+    // because accepting it would both skip the occupancy check and, for the note kind, leave a note
+    // folder whose path is the vault root.
+    for (label, prepare) in [
+        ("plain", 0u8),
+        ("sealed", 1u8),
+        ("note-kind", 2u8),
+        ("note-kind project", 3u8),
+        ("meeting-kind project", 4u8),
+    ] {
+        let (db, path) = pre_migration_db(&format!("occupied-{label}"));
+        container(&db, "f-root", "Everything", "", None, "folder");
+        container(&db, "f-work", "Work", "Work", None, "folder");
+        meeting_in(&db, "m1", "Root standup", "2026-08-20T09:00:00Z", Some("f-root"));
+        if prepare == 1 {
+            seal(&db, "f-root");
+        } else if prepare == 2 {
+            db.lock()
+                .execute(
+                    "UPDATE folders SET kind = 'note' WHERE id = 'f-root'",
+                    rusqlite::params![],
+                )
+                .unwrap();
+        } else if prepare == 3 {
+            db.lock()
+                .execute(
+                    "UPDATE folders SET kind = 'note', level = 'project' WHERE id = 'f-root'",
+                    rusqlite::params![],
+                )
+                .unwrap();
+        } else if prepare == 4 {
+            // The shape that most resembles a completed adoption. It is NOT one: `f-work` is still
+            // outside. Recognising the shape alone would report this database done and leave that
+            // container orphaned on this launch and every later one.
+            db.lock()
+                .execute(
+                    "UPDATE folders SET level = 'project' WHERE id = 'f-root'",
+                    rusqlite::params![],
+                )
+                .unwrap();
+        }
+
+        // What the shipped sidebar shows, captured BEFORE the migration runs.
+        let shipped_forest = |db: &Db| -> String {
+            let folders = db.list_folders().unwrap();
+            let levels = db.folder_levels().unwrap();
+            let counts = db.count_notes_per_folder(&HashSet::new()).unwrap();
+            let kinds = db.folder_kinds().unwrap();
+            serde_json::to_string(&build_folder_tree(
+                &flatten_projects_for_legacy_tree(folders, &levels),
+                &counts,
+                &HashSet::new(),
+                &kinds,
+            ))
+            .unwrap()
+        };
+        let before = folder_rows(&db);
+        let forest_before = shipped_forest(&db);
+
+        run_migration(&db);
+
+        assert_eq!(
+            before,
+            folder_rows(&db),
+            "{label}: an occupied vault root must leave every row untouched"
+        );
+        // And the shipped sidebar renders exactly what it rendered before — which is the whole reason
+        // for declining rather than adopting the occupant. (Compared before-vs-after, not shimmed-vs-
+        // unshimmed: hiding a project-level row is what the shim is FOR, so on a database that already
+        // contains one those two differ by design and always have.)
+        assert_eq!(
+            forest_before,
+            shipped_forest(&db),
+            "{label}: the shipped sidebar changed"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
+/// Containers that already had a parent keep it — existing depth is preserved, never flattened.
+#[test]
+fn the_migration_preserves_existing_nesting() {
+    let (db, path) = pre_migration_db("preserve-depth");
+    container(&db, "f-parent", "Work", "Work", None, "folder");
+    container(&db, "f-child", "Q3", "Work/Q3", Some("f-parent"), "folder");
+
+    run_migration(&db);
+
+    let containers = db.list_containers().unwrap();
+    let project = containers.iter().find(|c| c.level == "project").unwrap();
+    assert_eq!(
+        containers
+            .iter()
+            .find(|c| c.id == "f-child")
+            .unwrap()
+            .parent_id
+            .as_deref(),
+        Some("f-parent"),
+        "an already-nested container was re-parented"
+    );
+    assert_eq!(
+        containers
+            .iter()
+            .find(|c| c.id == "f-parent")
+            .unwrap()
+            .parent_id
+            .as_deref(),
+        Some(project.id.as_str())
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+// ── the review round that produced these ─────────────────────────────────────────────────────────
+//
+// Every test below exists because an independent review found the corresponding path unproven. Two
+// of them cover failure modes that would not have been leaks but LAUNCH FAILURES: this migration
+// runs inside `migrate()`, before any content surface, so a write against a trigger-guarded row
+// aborts startup. They therefore install a real `RAISE(ABORT)` trigger and prove the absence of the
+// write, rather than inspecting the row afterwards and inferring it.
+
+/// Arm a row so that ANY write to it aborts, exactly as the reserved container's own triggers do.
+fn forbid_writes_to(db: &Db, id: &str) {
+    db.lock()
+        .execute_batch(&format!(
+            "CREATE TRIGGER guard_update_{id} BEFORE UPDATE ON folders WHEN OLD.id = '{id}'
+               BEGIN SELECT RAISE(ABORT, 'protected container written'); END;
+             CREATE TRIGGER guard_child_{id} BEFORE UPDATE ON folders WHEN NEW.parent_id = '{id}'
+               BEGIN SELECT RAISE(ABORT, 'protected container given a child'); END;",
+            id = id.replace('-', "_")
+        ))
+        .unwrap_or_else(|e| panic!("could not arm the guard: {e}"));
+}
+
+/// THE shim oracle, on an ADOPTED database.
+///
+/// Part 1's shim exists so the shipped sidebar keeps rendering the old forest AFTER adoption, and
+/// until now every test in this file un-adopted its database first — so the one shape the shim is
+/// for was the one shape nothing covered. Both of its failure modes are live: keying roots off a
+/// NULL parent would make the sidebar lose every folder (or surface the project as a root), and
+/// note-kind containers reachable through the new parent edges would re-enter the Meetings tree,
+/// which filters them at the top level ONLY. That leak shipped once already.
+#[test]
+fn the_legacy_folder_tree_is_unchanged_on_an_adopted_database() {
+    let path = crate::storage::db::unique_temp_path("murmur-workspace-adopted-shim", "sqlite");
+    let _ = std::fs::remove_file(&path);
+    // NOT `fresh_db`: this one keeps the project the migration creates.
+    let db = Db::open_with_key(&path, TEST_DEK).unwrap();
+    container(&db, "f-work", "Work", "Work", None, "folder");
+    container(&db, "f-notes", "Notes", "Notes", None, "folder");
+    container(&db, "f-research", "Research", "Notes/Research", None, "folder");
+    container(&db, "f-child", "Q3", "Work/Q3", Some("f-work"), "folder");
+    db.lock()
+        .execute_batch(
+            "UPDATE folders SET kind = 'note' WHERE id IN ('f-notes', 'f-research');
+             UPDATE folders SET is_root = 1 WHERE id = 'f-notes';",
+        )
+        .unwrap();
+    // Re-open so the migration adopts the containers seeded above.
+    drop(db);
+    let db = Db::open_with_key(&path, TEST_DEK).unwrap();
+    assert_eq!(
+        db.list_containers()
+            .unwrap()
+            .iter()
+            .filter(|c| c.level == "project")
+            .count(),
+        1,
+        "the database is adopted"
+    );
+
+    let folders = db.list_folders().unwrap();
+    let levels = db.folder_levels().unwrap();
+    let flattened = flatten_projects_for_legacy_tree(folders, &levels);
+    let counts = db.count_notes_per_folder(&HashSet::new()).unwrap();
+    let kinds = db.folder_kinds().unwrap();
+    let legacy = build_folder_tree(&flattened, &counts, &HashSet::new(), &kinds);
+
+    let roots: Vec<&str> = legacy.iter().map(|n| n.id.as_str()).collect();
+    // (a) the project is not among the roots, and (b) every former root is still a root.
+    assert!(
+        !roots.iter().any(|id| db
+            .list_containers()
+            .unwrap()
+            .iter()
+            .any(|c| c.level == "project" && c.id == *id)),
+        "the project surfaced as a legacy root: {roots:?}"
+    );
+    assert!(roots.contains(&"f-work"), "a former root vanished: {roots:?}");
+    assert!(roots.contains(&"f-notes"), "a former root vanished: {roots:?}");
+    assert!(
+        roots.contains(&"f-research"),
+        "a note container adopted under the note root must still be a legacy ROOT, or the shipped \
+         Meetings tree — which filters note kinds at the top level only — would swallow it: {roots:?}"
+    );
+    // (c) real nesting is still nested, and the note kinds are still filterable where the shipped
+    //     Meetings tree looks: the top level.
+    let work = legacy.iter().find(|n| n.id == "f-work").unwrap();
+    assert_eq!(work.children.len(), 1);
+    assert_eq!(work.children[0].id, "f-child");
+    let meeting_forest: Vec<&str> = legacy
+        .iter()
+        .filter(|n| n.kind != "note")
+        .map(|n| n.id.as_str())
+        .collect();
+    assert_eq!(
+        meeting_forest,
+        vec!["f-work"],
+        "a note-kind container re-entered the Meetings tree: {meeting_forest:?}"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// With SEVERAL note roots, each note container is adopted under the one its own path is stamped
+/// under.
+///
+/// `ensure_notes_root` deliberately creates a separate root when the existing one is locked (its
+/// "Inbox N" fallback), so a real database can hold more than one. Picking the wrong one breaks
+/// `parent.path + name == path`, and the next rename then recomposes from that wrong parent and
+/// relocates the real vault directory while `exported_path` stays behind — the sealed-content leak,
+/// because the seal deletes the plaintext at the recorded path and so deletes nothing.
+#[test]
+fn a_note_container_is_adopted_under_the_root_its_path_is_stamped_under() {
+    let (db, path) = pre_migration_db("two-note-roots");
+    container(&db, "r-notes", "Notes", "Notes", None, "folder");
+    container(&db, "r-inbox", "Inbox 2", "Inbox 2", None, "folder");
+    container(&db, "c-under-notes", "Research", "Notes/Research", None, "folder");
+    container(&db, "c-under-inbox", "Drafts", "Inbox 2/Drafts", None, "folder");
+    db.lock()
+        .execute_batch(
+            "UPDATE folders SET kind = 'note';
+             UPDATE folders SET is_root = 1 WHERE id IN ('r-notes', 'r-inbox');",
+        )
+        .unwrap();
+
+    run_migration(&db);
+
+    let containers = db.list_containers().unwrap();
+    let parent_of = |id: &str| {
+        containers
+            .iter()
+            .find(|c| c.id == id)
+            .unwrap()
+            .parent_id
+            .clone()
+    };
+    assert_eq!(parent_of("c-under-notes").as_deref(), Some("r-notes"));
+    assert_eq!(parent_of("c-under-inbox").as_deref(), Some("r-inbox"));
+
+    // And composition holds for both, which is the property the whole rule exists to protect.
+    for (child, root, name) in [
+        ("c-under-notes", "Notes", "Research"),
+        ("c-under-inbox", "Inbox 2", "Drafts"),
+    ] {
+        let stored: String = db
+            .lock()
+            .query_row(
+                "SELECT path FROM folders WHERE id = ?1",
+                rusqlite::params![child],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, format!("{root}/{name}"));
+    }
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// A note container whose path cannot be composed from any root is left to the project, with its
+/// path untouched — never silently re-homed under a root that would misdescribe it.
+#[test]
+fn a_note_container_with_an_uncomposable_path_is_not_re_homed() {
+    let (db, path) = pre_migration_db("uncomposable");
+    container(&db, "r-notes", "Notes", "Notes", None, "folder");
+    // Two levels deep: `parent.path + '/' + name` would compose to "Notes/Deep", not its real path.
+    container(&db, "c-deep", "Deep", "Notes/Mid/Deep", None, "folder");
+    db.lock()
+        .execute_batch(
+            "UPDATE folders SET kind = 'note';
+             UPDATE folders SET is_root = 1 WHERE id = 'r-notes';",
+        )
+        .unwrap();
+
+    run_migration(&db);
+
+    let containers = db.list_containers().unwrap();
+    let project = containers.iter().find(|c| c.level == "project").unwrap();
+    let deep = containers.iter().find(|c| c.id == "c-deep").unwrap();
+    assert_eq!(
+        deep.parent_id.as_deref(),
+        Some(project.id.as_str()),
+        "an uncomposable container belongs to the project, not to a root that misdescribes it"
+    );
+    let stored: String = db
+        .lock()
+        .query_row("SELECT path FROM folders WHERE id = 'c-deep'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(stored, "Notes/Mid/Deep", "its path is untouched either way");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// A protected container flagged as a note root is never chosen as an adoption parent.
+///
+/// Proven by the trigger, not by inspection: giving it a child would ABORT inside `migrate()`, which
+/// is a failure to start the app.
+#[test]
+fn a_protected_container_is_never_chosen_as_a_note_root() {
+    let (db, path) = pre_migration_db("protected-root");
+    container(&db, "sys", "tasks", ".murmur/tasks", None, "folder");
+    container(&db, "r-notes", "Notes", "Notes", None, "folder");
+    container(&db, "c-note", "Research", "Notes/Research", None, "folder");
+    db.lock()
+        .execute_batch(
+            "UPDATE folders SET kind = 'note' WHERE id IN ('r-notes', 'c-note');
+             UPDATE folders SET kind = 'task', is_root = 1 WHERE id = 'sys';
+             UPDATE folders SET is_root = 1 WHERE id = 'r-notes';",
+        )
+        .unwrap();
+    forbid_writes_to(&db, "sys");
+
+    run_migration(&db);
+
+    let containers = db.list_containers().unwrap();
+    assert_eq!(
+        containers
+            .iter()
+            .find(|c| c.id == "c-note")
+            .unwrap()
+            .parent_id
+            .as_deref(),
+        Some("r-notes"),
+        "the real note root, not the protected row"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// A protected container occupying the vault root leaves the database un-adopted rather than
+/// aborting startup — and is neither read nor written.
+#[test]
+fn a_protected_container_at_the_vault_root_declines_adoption() {
+    let (db, path) = pre_migration_db("protected-vault-root");
+    container(&db, "sys", "root", "", None, "folder");
+    container(&db, "f-work", "Work", "Work", None, "folder");
+    db.lock()
+        .execute(
+            "UPDATE folders SET kind = 'task' WHERE id = 'sys'",
+            rusqlite::params![],
+        )
+        .unwrap();
+    forbid_writes_to(&db, "sys");
+
+    // Must not abort: the whole migration runs before any content surface.
+    run_migration(&db);
+
+    assert!(
+        db.list_containers()
+            .unwrap()
+            .iter()
+            .all(|c| c.level != "project"),
+        "the database is left un-adopted, and will retry on the next launch"
+    );
+    let work_parent: Option<String> = db
+        .lock()
+        .query_row("SELECT parent_id FROM folders WHERE id = 'f-work'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert!(work_parent.is_none(), "nothing was adopted");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// A protected container is left byte-identical even when its level is not the default.
+///
+/// The level-normalisation statement was inert for such a row only by accident — its level
+/// coalesced out of the predicate. A future import stamping a non-default level would have turned it
+/// into a write against a trigger-guarded row during startup.
+#[test]
+fn a_protected_container_with_an_unexpected_level_is_left_byte_identical() {
+    let (db, path) = pre_migration_db("protected-level");
+    container(&db, "sys", "tasks", ".murmur/tasks", None, "project");
+    container(&db, "f-work", "Work", "Work", None, "folder");
+    db.lock()
+        .execute(
+            "UPDATE folders SET kind = 'task' WHERE id = 'sys'",
+            rusqlite::params![],
+        )
+        .unwrap();
+    let before: (Option<String>, String, String) = db
+        .lock()
+        .query_row(
+            "SELECT parent_id, COALESCE(level, 'folder'), path FROM folders WHERE id = 'sys'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .unwrap();
+    forbid_writes_to(&db, "sys");
+
+    // The system row already carries level='project'. The adoption guard must not mistake that for a
+    // completed migration — otherwise the database would never be adopted, on this launch or any
+    // later one — so this asserts the real containers were adopted as well as that the row is intact.
+    run_migration(&db);
+
+    let containers = db.list_containers().unwrap();
+    let project = containers
+        .iter()
+        .find(|c| c.level == "project")
+        .expect("a system row at project level must not masquerade as the adoption result");
+    assert_eq!(
+        containers.iter().find(|c| c.id == "f-work").unwrap().parent_id.as_deref(),
+        Some(project.id.as_str()),
+        "the user container was adopted"
+    );
+
+    let after: (Option<String>, String, String) = db
+        .lock()
+        .query_row(
+            "SELECT parent_id, COALESCE(level, 'folder'), path FROM folders WHERE id = 'sys'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(before, after, "a protected container was modified");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// The reserved prefix excludes the reserved DIRECTORY itself, not only its descendants.
+#[test]
+fn the_reserved_prefix_root_itself_is_excluded() {
+    let (db, path) = pre_migration_db("reserved-root");
+    // A user KIND at exactly the reserved path: only the path guard can exclude it.
+    container(&db, "reserved", "murmur", ".murmur", None, "folder");
+    container(&db, "f-work", "Work", "Work", None, "folder");
+    forbid_writes_to(&db, "reserved");
+
+    run_migration(&db);
+
+    let parent: Option<String> = db
+        .lock()
+        .query_row(
+            "SELECT parent_id FROM folders WHERE id = 'reserved'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert!(parent.is_none(), "the reserved directory itself was adopted");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// The adoption is one atomic unit: a failure part-way leaves the database byte-identical.
+///
+/// It matters more than usual because the completion guard is RESULT-based. A partial run that left
+/// the project row behind would short-circuit that guard on every later launch, with orphaned
+/// containers and nothing to repair them — so atomicity here is what makes "retry on the next
+/// launch" true rather than aspirational.
+#[test]
+fn a_failed_adoption_leaves_the_database_untouched() {
+    let (db, path) = pre_migration_db("atomic-adoption");
+    container(&db, "f-work", "Work", "Work", None, "folder");
+    container(&db, "f-legal", "Legal", "Legal", None, "folder");
+    let before = folder_rows(&db);
+
+    // Abort the moment anything is given a parent — i.e. after the project row has been inserted.
+    db.lock()
+        .execute_batch(
+            "CREATE TRIGGER abort_adoption BEFORE UPDATE ON folders
+               WHEN NEW.parent_id IS NOT NULL AND OLD.parent_id IS NULL
+               BEGIN SELECT RAISE(ABORT, 'injected mid-adoption failure'); END;",
+        )
+        .unwrap();
+
+    let err = Db::migrate_hierarchy_v1(&db.lock()).expect_err("the injected failure propagates");
+    assert!(matches!(err, AppError::Storage(_)), "unexpected error: {err:?}");
+
+    db.lock()
+        .execute_batch("DROP TRIGGER abort_adoption")
+        .unwrap();
+    assert_eq!(
+        before,
+        folder_rows(&db),
+        "a partial adoption survived: the project row would then satisfy the completion guard \
+         forever while its containers stayed orphaned"
+    );
+    // And the next attempt, with the failure removed, adopts cleanly.
+    run_migration(&db);
+    let containers = db.list_containers().unwrap();
+    let project = containers.iter().find(|c| c.level == "project").unwrap();
+    assert_eq!(
+        containers
+            .iter()
+            .find(|c| c.id == "f-work")
+            .unwrap()
+            .parent_id
+            .as_deref(),
+        Some(project.id.as_str())
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// A user project at some OTHER path does not satisfy the completion guard.
+///
+/// The guard recognises the exact result this migration produces — a user container occupying the
+/// vault root. Accepting any project-level row would let a database that was never adopted
+/// short-circuit forever, leaving every former root orphaned.
+#[test]
+fn a_project_away_from_the_vault_root_does_not_count_as_adopted() {
+    let (db, path) = pre_migration_db("stray-project");
+    container(&db, "p-stray", "Elsewhere", "Elsewhere", None, "project");
+    container(&db, "f-work", "Work", "Work", None, "folder");
+
+    run_migration(&db);
+
+    let containers = db.list_containers().unwrap();
+    let root_project = containers
+        .iter()
+        .find(|c| c.level == "project" && c.id != "p-stray")
+        .expect("a stray project must not stand in for the adoption result");
+    assert_eq!(
+        containers
+            .iter()
+            .find(|c| c.id == "f-work")
+            .unwrap()
+            .parent_id
+            .as_deref(),
+        Some(root_project.id.as_str()),
+        "the real containers were adopted"
+    );
+
+    let _ = std::fs::remove_file(&path);
+}
+
+/// A container at the vault root is not resolvable as a NOTE folder, whatever shape it arrived in.
+///
+/// This is what makes the note-folder move unreachable for such a row unconditionally, rather than
+/// only for the container this migration creates: the move composes `src`/`dst` from a container's
+/// own path, and an empty path is the vault directory itself, so resolving one there would let the
+/// move relocate the user's whole vault.
+#[test]
+fn a_vault_root_container_is_not_a_note_folder() {
+    let (db, path) = pre_migration_db("root-not-note-folder");
+    container(&db, "f-root", "Everything", "", None, "folder");
+    container(&db, "f-notes", "Notes", "Notes", None, "folder");
+    db.lock()
+        .execute_batch(
+            "UPDATE folders SET kind = 'note' WHERE id IN ('f-root', 'f-notes');
+             UPDATE folders SET is_root = 1 WHERE id = 'f-notes';",
+        )
+        .unwrap();
+
+    assert!(
+        db.note_folder_by_id("f-root").unwrap().is_none(),
+        "a note-kind container at the vault root must not resolve as a note folder"
+    );
+    // A project-level one is refused for the same reason, and an ordinary note folder still resolves.
+    db.lock()
+        .execute(
+            "UPDATE folders SET level = 'project' WHERE id = 'f-root'",
+            rusqlite::params![],
+        )
+        .unwrap();
+    assert!(db.note_folder_by_id("f-root").unwrap().is_none());
+    assert!(db.note_folder_by_id("f-notes").unwrap().is_some());
 
     let _ = std::fs::remove_file(&path);
 }

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -1218,6 +1218,9 @@ impl Db {
                ON folders(parent_id, position);",
         )
         .map_err(map_err)?;
+        // The one-time adoption of every existing container into a default project. Runs here,
+        // immediately after the columns it depends on exist, and before any content surface.
+        Self::migrate_hierarchy_v1(&conn)?;
         // Phase 2b — content-free egress audit log. One row per cloud provider call written by
         // `DbEgressSink`. The table carries ONLY counts, ids, labels, byte sizes, and token counts —
         // NEVER transcript, prompt, scrubbed values, API keys, or any meeting content (§8: no PII

--- a/src-tauri/src/storage/folders_store.rs
+++ b/src-tauri/src/storage/folders_store.rs
@@ -23,6 +23,10 @@ use crate::error::{AppError, Result};
 use crate::storage::db::{map_err, visibility_clause, Db, RawDocument};
 use crate::storage::models::{Folder, NoteFolder, PropertySchemaField};
 
+/// The name a default project takes when no vault directory is configured to name it after.
+/// Neutral on purpose: it is an ordinary container the user can rename like any other.
+pub(crate) const DEFAULT_PROJECT_NAME: &str = "Workspace";
+
 pub(crate) type MeetingNoteExportRow = (String, String, String, Option<String>);
 pub(crate) type NoteFolderCatalogRow = (NoteFolder, i64, Vec<PropertySchemaField>);
 
@@ -441,11 +445,20 @@ impl Db {
 
     /// A note-folder by id (`kind='note'` enforced), or `None`. Used to gate note-folder ops so a
     /// meeting-folder id can't be driven through a note-folder command.
+    /// A note folder by id.
+    ///
+    /// Excludes any container whose path is the VAULT ROOT. Note folders live under the note root, so
+    /// one at the vault root is not a note folder in any useful sense — and this is the resolution
+    /// point `move_note_folder_inner` goes through before composing `src`/`dst` from a container's own
+    /// path. An empty path resolves to the vault directory itself, so allowing it here would let that
+    /// move relocate the user's whole vault. Refusing at the resolver closes it for every caller of
+    /// this method at once, whatever shape the row arrived in (this migration creates a meeting-kind
+    /// project there, but an import could produce a note-kind one).
     pub fn note_folder_by_id(&self, id: &str) -> Result<Option<NoteFolder>> {
         let conn = self.lock();
         conn.query_row(
             "SELECT id, name, path, parent_id, locked, kind, COALESCE(is_root, 0)
-               FROM folders WHERE id = ?1 AND kind = 'note'",
+               FROM folders WHERE id = ?1 AND kind = 'note' AND path <> ''",
             rusqlite::params![id],
             row_to_note_folder,
         )
@@ -541,6 +554,263 @@ impl Db {
             out.insert(id, kind);
         }
         Ok(out)
+    }
+
+    /// One-time adoption of every existing container into a default PROJECT.
+    ///
+    /// # Why this moves nothing on disk
+    ///
+    /// `folders.path` is a real Obsidian directory and the UNIQUE key `folder_by_path` resolves;
+    /// three columns hold absolute paths derived from it (`notes.exported_path`,
+    /// `documents.exported_path`, the attachment replicas). Re-rooting every container under a
+    /// project would mean moving the user's actual vault directories AND rewriting every stored
+    /// absolute path, across two systems with no shared transaction — and a stale `exported_path`
+    /// means `lock_folder` deletes nothing and the real plaintext survives inside a folder the app
+    /// reports as sealed (the NOTES-2 leak, already paid for). A locked subtree cannot be moved at
+    /// all (`ensure_folder_subtree_unlocked` refuses), so such a migration could not even complete.
+    ///
+    /// The default project therefore takes the vault ROOT as its path — the empty string.
+    /// `create_folder` composes a child path as `parent.path + '/' + name` only when the parent path
+    /// is non-empty, and `assert_in_vault` resolves an empty relative path to the vault root, so
+    /// **every existing container keeps its path byte-identical** and nothing is created, moved or
+    /// removed on disk. `path` being UNIQUE is exactly right: only one row may be the vault root.
+    ///
+    /// # Why the guard is "no project exists" rather than a flag
+    ///
+    /// A flag records that the migration RAN; the check below records that its RESULT is present. If
+    /// a user later deletes their last project, a flag would leave every container orphaned with no
+    /// parent and no project, and they would vanish from the tree with nothing to repair them. This
+    /// form self-heals, and it is equally idempotent: with any project present it is a no-op. It is
+    /// also what lets the migration DECLINE to adopt (below) and simply retry on the next launch.
+    ///
+    /// # What it never touches
+    ///
+    /// No `path`, no `locked`, no `wrapped_key`, no `*_blob`, and no system container — not written,
+    /// not read. A database with sealed containers migrates with no key and no biometric prompt. The
+    /// whole adoption inherits `Db::migrate`'s transaction, so a crash leaves a database either
+    /// wholly adopted or untouched.
+    pub(crate) fn migrate_hierarchy_v1(conn: &rusqlite::Connection) -> Result<()> {
+        // Same exclusion the adoption itself uses: a machine-owned container is never adopted, so it
+        // must not count as an orphan either — otherwise its mere presence would make every database
+        // look incomplete forever.
+        const NOT_SYSTEM: &str = "COALESCE(kind, 'meeting') IN ('meeting', 'note')
+             AND COALESCE(path, '') <> '.murmur'
+             AND COALESCE(path, '') NOT LIKE '.murmur/%'";
+        // Completion is recognised from the FULL result, not from a fragment of it: a meeting-kind
+        // container at project level occupying the vault root, AND no eligible container still
+        // sitting outside it. The shape alone is not enough — an import or a manual edit can produce
+        // exactly that row while leaving other containers unadopted, and treating it as done would
+        // report a database complete while its containers stayed orphaned, on this launch and every
+        // later one.
+        //
+        // A partial result cannot come from this function: the adoption below runs inside its own
+        // savepoint. So a project WITH orphans beside it is an occupant, and takes the same decline
+        // path as any other occupant — no writes, and a later launch retries once the vault root is
+        // free. Since `path` is UNIQUE, requiring `path = ''` bounds the project half to one row.
+        let project_at_root: bool = conn
+            .query_row(
+                "SELECT EXISTS(
+                   SELECT 1 FROM folders
+                    WHERE COALESCE(level, 'folder') = 'project'
+                      AND path = ''
+                      AND COALESCE(kind, 'meeting') = 'meeting')",
+                [],
+                |r| Ok(r.get::<_, i64>(0)? != 0),
+            )
+            .map_err(map_err)?;
+        let orphans_remain: bool = conn
+            .query_row(
+                &format!(
+                    "SELECT EXISTS(
+                       SELECT 1 FROM folders
+                        WHERE parent_id IS NULL AND path <> '' AND {NOT_SYSTEM})"
+                ),
+                [],
+                |r| Ok(r.get::<_, i64>(0)? != 0),
+            )
+            .map_err(map_err)?;
+        if project_at_root && !orphans_remain {
+            return Ok(());
+        }
+        conn.execute_batch("SAVEPOINT hierarchy_v1")
+            .map_err(map_err)?;
+        let outcome = Self::adopt_containers_into_default_project(conn);
+        match &outcome {
+            Ok(()) => conn.execute_batch("RELEASE hierarchy_v1"),
+            // Roll the whole adoption back, then release the savepoint so the enclosing migration
+            // transaction is left exactly as it was found.
+            Err(_) => conn.execute_batch("ROLLBACK TO hierarchy_v1; RELEASE hierarchy_v1"),
+        }
+        .map_err(map_err)?;
+        outcome
+    }
+
+    /// The adoption itself, always called inside [`Db::migrate_hierarchy_v1`]'s savepoint.
+    fn adopt_containers_into_default_project(conn: &rusqlite::Connection) -> Result<()> {
+        // A SAVEPOINT, not a transaction: `Db::migrate` already runs every step inside one, so a
+        // nested BEGIN would simply fail — but the adoption below is four separate writes, and its
+        // completion guard is RESULT-based, so a failure after the project row exists and before the
+        // re-parent passes would leave containers orphaned AND make every later launch short-circuit
+        // at the guard with nothing to repair them. Owning the boundary here makes "either wholly
+        // adopted or untouched" a property of this function rather than an inherited assumption.
+
+        // Every statement below carries this. A system container must be neither adopted, nor
+        // re-parented, nor re-levelled, nor even READ — the reserved container is guarded by
+        // RAISE(ABORT) triggers and this runs inside `migrate()`, before any content surface, so a
+        // write against it is not untidiness but a failure to START the app.
+        //
+        // `COALESCE(path, '')` because `path NOT LIKE …` evaluates to NULL for a NULL path, which
+        // would silently drop such a row from adoption with no statement of intent; and the prefix
+        // guard covers the reserved directory ITSELF as well as its descendants.
+        const NOT_SYSTEM: &str = "COALESCE(kind, 'meeting') IN ('meeting', 'note')
+             AND COALESCE(path, '') <> '.murmur'
+             AND COALESCE(path, '') NOT LIKE '.murmur/%'";
+
+        // ── the vault-root slot ──────────────────────────────────────────────────────────────────
+        //
+        // Exactly one row may hold `path = ''` (UNIQUE), so if something already occupies it, either
+        // that row becomes the project or there is no project this run.
+        // ── the vault-root slot ─────────────────────────────────────────────────────────────────
+        //
+        // Exactly one row may hold `path = ''` (UNIQUE), so if anything already occupies it there is
+        // nowhere to put the project. This DECLINES rather than promoting the occupant, and rather
+        // than aborting.
+        //
+        // Not promoting is the point. Promotion looked harmless — it is a user's own container, and
+        // the level does not affect gating — but it produced a row that is a project AND carries the
+        // occupant's kind and contents, and two things then followed from that. The legacy-tree shim
+        // hides project rows, so a promoted container and everything filed in it would vanish from
+        // the shipped sidebar, which is exactly what the compatibility shim exists to prevent. And a
+        // promoted note-kind row is a note folder at the vault root, which the note-folder move
+        // resolves and would then compose filesystem work from — against the vault root itself.
+        // Declining removes both, and keeps every project this migration produces a freshly created
+        // meeting-kind row, which is what the rest of the safety argument assumes.
+        //
+        // Aborting is not an option either: this runs inside `migrate()`, before any content surface,
+        // so an abort is a failure to START the app. Declining completes: the legacy shim keeps the
+        // shipped sidebar rendering exactly what it renders today, and because completion is
+        // recognised from the RESULT rather than a flag, a later launch adopts as soon as the slot is
+        // free.
+        //
+        // `path = ''` exactly, never `COALESCE(path, '')`: a UNIQUE index does not de-duplicate NULLs,
+        // so a NULL-path row could coexist with a genuine one and be picked by the planner.
+        //
+        // No shipped creation path can produce a container at the vault root — the single name
+        // sanitiser both container kinds use refuses everything that reduces to an empty component —
+        // so this branch is defensive against an import or a manual edit, not a supported flow. See
+        // `no_creation_path_can_produce_a_vault_root_container`.
+        let occupied: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM folders WHERE path = '')",
+                [],
+                |r| Ok(r.get::<_, i64>(0)? != 0),
+            )
+            .map_err(map_err)?;
+        if occupied {
+            tracing::warn!(
+                target: "storage",
+                "the vault root is already occupied; leaving the hierarchy un-adopted"
+            );
+            return Ok(());
+        }
+
+        // Named after the vault directory when one is configured; on a fresh database none is, and a
+        // neutral name is used. The user can rename it like any container.
+        let vault: Option<String> = conn
+            .query_row(
+                "SELECT value FROM settings WHERE key = 'vault_path'",
+                [],
+                |r| r.get(0),
+            )
+            .optional()
+            .map_err(map_err)?;
+        let name = vault
+            .as_deref()
+            .filter(|v| !v.trim().is_empty())
+            .and_then(|v| std::path::Path::new(v).file_name())
+            .map(|s| s.to_string_lossy().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| DEFAULT_PROJECT_NAME.to_string());
+        let project_id = uuid::Uuid::new_v4().to_string();
+        conn.execute(
+            "INSERT INTO folders
+               (id, name, path, parent_id, locked, wrapped_key, created_at, kind, level)
+             VALUES (?1, ?2, '', NULL, 0, NULL, ?3, 'meeting', 'project')",
+            rusqlite::params![project_id, name, chrono::Utc::now().to_rfc3339()],
+        )
+        .map_err(map_err)?;
+
+        // ── note containers go under the note root their PATH is actually stamped under ──────────
+        //
+        // `create_note_folder_inner` stamps every note container's path under a note root while
+        // leaving its parent link NULL, so the parent tree and the path tree disagree for every one
+        // of them today. `rename_folder_inner` recomposes a container's path from its CURRENT
+        // parent, so adopting them straight into the project would make the next rename silently
+        // relocate the real vault directory — leaving `exported_path` stale, which is the named
+        // sealed-content leak: the seal deletes the plaintext `.md` at the recorded path, so it
+        // deletes nothing and the real file survives inside a sealed folder.
+        //
+        // Choosing the root by `is_root` alone is not enough. `ensure_notes_root` deliberately
+        // creates a SEPARATE root when the existing one is locked (its "Inbox N" fallback), so a real
+        // database can hold more than one — and picking the wrong one produces exactly the broken
+        // composition described above. So each container is matched to the root whose path composes
+        // ITS path: `container.path == root.path || '/' || container.name`. A container that matches
+        // no root keeps a NULL parent here and is adopted by the project pass below, which is the
+        // safe fallback — its composition is no more broken than it already is today with a NULL
+        // parent, and no vault directory moves either way.
+        const NOTE_ROOT_MATCH: &str = "SELECT r.id FROM folders r
+              WHERE COALESCE(r.is_root, 0) = 1
+                AND COALESCE(r.kind, 'meeting') = 'note'
+                AND COALESCE(r.path, '') <> ''
+                AND COALESCE(r.kind, 'meeting') IN ('meeting', 'note')
+                AND COALESCE(r.path, '') <> '.murmur'
+                AND COALESCE(r.path, '') NOT LIKE '.murmur/%'
+                AND folders.path = r.path || '/' || folders.name
+              ORDER BY r.path, r.id
+              LIMIT 1";
+        conn.execute(
+            &format!(
+                "UPDATE folders
+                    SET parent_id = ({NOTE_ROOT_MATCH})
+                  WHERE parent_id IS NULL
+                    AND id <> ?1
+                    AND COALESCE(is_root, 0) = 0
+                    AND COALESCE(kind, 'meeting') = 'note'
+                    AND {NOT_SYSTEM}
+                    AND EXISTS ({NOTE_ROOT_MATCH})"
+            ),
+            rusqlite::params![project_id],
+        )
+        .map_err(map_err)?;
+
+        // ── everything else that was a root becomes a child of the project ───────────────────────
+        //
+        // Including the note root itself, and any note container the composition match above
+        // declined. Containers that already had a parent keep it: existing depth is preserved.
+        conn.execute(
+            &format!(
+                "UPDATE folders SET parent_id = ?1
+                  WHERE parent_id IS NULL AND id <> ?1 AND {NOT_SYSTEM}"
+            ),
+            rusqlite::params![project_id],
+        )
+        .map_err(map_err)?;
+
+        // Every non-project container states its level explicitly, so the tree never has to infer one
+        // from a NULL parent. Carries the same exclusion as the two statements above: a system row is
+        // inert here only by accident today (its level coalesces out of the predicate), and any future
+        // import that stamped a non-'folder' level on it would turn this into a write against a
+        // trigger-guarded row during startup.
+        conn.execute(
+            &format!(
+                "UPDATE folders SET level = 'folder'
+                  WHERE id <> ?1 AND COALESCE(level, 'folder') <> 'folder' AND {NOT_SYSTEM}"
+            ),
+            rusqlite::params![project_id],
+        )
+        .map_err(map_err)?;
+
+        Ok(())
     }
 
     /// Every folder's hierarchy LEVEL (`"project"` or `"folder"`), keyed by id.


### PR DESCRIPTION
Part 2 of the workspace-hierarchy program — the one-time adoption of every existing container into a
default project. Design spec: `docs/superpowers/specs/2026-08-22-workspace-hierarchy-design.md` §3.
Part 1 (#595) added the container level, the gated tree readers, and the shim that keeps the shipped
sidebar rendering the old forest.

**No user-visible behaviour changes.** The shim means the sidebar renders exactly what it renders
today, before and after adoption.

## What it does

On a database with no project: create the default project at the vault root, adopt every former root
container into it, and state every other container's level explicitly. Note containers are adopted
under the note root whose path actually composes theirs.

## Why it moves nothing on disk

`folders.path` is a real Obsidian directory and the UNIQUE key `folder_by_path` resolves; three
columns hold absolute paths derived from it. Re-rooting every container under a project would mean
moving the user's actual vault directories **and** rewriting every stored absolute path, across two
systems with no shared transaction — and a stale `exported_path` is the leak this repo has already
paid for once: `lock_folder` deletes vault `.md` files at the recorded paths, so a stale path means
the seal deletes nothing and the real plaintext survives inside a folder the app reports as sealed. A
locked subtree cannot be moved at all, so such a migration could not even complete on a vault that has
one.

So the default project takes `path = ''` — the vault root. Child path composition appends a separator
only when the parent path is non-empty, so **every existing container keeps its path byte-identical**
and nothing on disk is created, moved or removed.

## What the empty path costs, and what pays for it

It is the first row in the app's history whose path is the vault root. Four consequences, all found
by independent review and all closed here:

1. **No path-composing command may accept it.** `assert_in_vault` resolves an empty relative path to
   the vault root — the property that makes the migration free — so `rename_folder` on the project
   would compose `fs::rename(<vault>, <vault>/<new name>)` and **move the user's entire vault**, and
   `delete_folder` would target the vault directory. Both now refuse a vault-root container, shipped
   in the same change as the row that makes it reachable. (Audited the rest: `remove_lock`'s
   re-export and `move_note_file` already treat an empty path as the vault root, correctly.)
2. **Completion is recognised from the result, so the result must be exact.** The guard looks for a
   user-kind container at project level occupying `path = ''`. Accepting any project-level row would
   let a machine-owned one — or a user project at another path — short-circuit it forever, leaving
   every former root orphaned with nothing to repair it. `path` being UNIQUE also bounds it to one row.
3. **Result-based completion demands real atomicity.** A failure between inserting the project and
   re-parenting would leave a row that satisfies the guard and containers that are orphaned. The
   adoption owns a SAVEPOINT rather than inheriting `migrate()`'s transaction by assumption, and a
   test injects a mid-adoption failure and asserts the table is byte-identical.
4. **One input state completes without adopting.** The vault root is a unique slot; if ANY container
   occupies it there is nowhere to put a project and nothing that may be moved aside. The migration
   adopts nothing rather than aborting — it runs before any content surface, so an abort is a failure
   to start the app — and a later launch adopts as soon as the slot is free.

   Review is what settled this. An earlier revision PROMOTED the occupant instead, which looked
   harmless — it is the user's own container, and the level does not affect gating. But it produced
   a row that is a project AND carries a user's contents, and two things followed: the shim
   hides project rows, so that container and everything filed inside it vanished from the shipped
   sidebar; and a promoted note-kind row is a note folder whose path is the vault root, which the
   note-folder move resolves and would then compose filesystem work from. Declining removed both at
   once and made every project this migration produces a freshly created meeting-kind row — which is
   what the vault-root safety argument depends on. No shipped creation path can produce a container
   at the vault root anyway (the single name sanitiser refuses everything that reduces to an empty
   component), so this branch is defensive against an import, and a test says so.

## Note containers go under the root their path is stamped under

`create_note_folder_inner` stamps a note container's path under a note root while leaving its parent
link NULL, so the parent tree and the path tree disagree for every one of them today — and
`rename_folder_inner` recomposes from the CURRENT parent. Choosing the root by its flag alone is not
enough: `ensure_notes_root` deliberately creates a SEPARATE root when the existing one is locked, so a
real database can hold more than one. Each container is therefore matched to the root whose path
composes its own.

A container matching no root is adopted by the project, and a test drives the **real rename entry
point** on a vault, before and after adoption, to prove the outcome is identical — rather than
asserting it from the composition rule. (`rename_folder_inner` treats an empty parent path exactly
like no parent.) The pre-existing defect that renaming such a container relocates its directory at all
is untouched by this change and is not introduced by it.

## Verification

`cargo test --lib` green (3190, single-threaded as the gate runs it).
`cargo clippy --lib --tests -- -D warnings` clean.

Oracles, beyond part 1's:

- **no `path` and no `exported_path` changes** — asserted by comparing every one of them before and
  after, including a multi-byte name
- a mid-adoption failure leaves the table byte-identical, and the next run adopts cleanly
- running it again changes nothing, including after a full re-open
- a machine-owned container is neither adopted, re-parented, nor re-levelled — proven with a real
  `RAISE(ABORT)` trigger, so the absence of the write is demonstrated rather than inferred
- a machine-owned container occupying the vault root leaves the database un-adopted instead of
  aborting startup
- no shipped creation path can produce a container at the vault root
- the empty path resolves by path only to the project, and the auto-file classifier cannot name it
- one flagged as a note root is never chosen as an adoption parent
- the reserved prefix directory itself is excluded, not only its descendants
- a sealed container migrates with its flag and wrapped key untouched
- an occupied vault root — plain, sealed, or note-kind — leaves every row untouched AND leaves the
  legacy forest byte-identical
- with two note roots, each container is adopted under the one its own path is stamped under
- adoption does not change how a container renames — through the real entry point, on a vault
- sealing a project reaches its own items only, never the containers beneath it — a lock is still
  per container, never recursive
- the note root still resolves and still refuses to seal after it gains a parent
- the legacy folder tree is byte-identical on a pre-migration database, and on an adopted one the
  project is not a root, every former root still is, and note kinds stay filterable where the shipped
  Meetings tree looks — the top level only
- renaming or deleting the workspace root is refused, and the vault is intact afterwards

Verified through the Harness (risk: `lock`) with an independent Codex review and a cross-vendor
lock-security specialist review, over six rounds.

**Boundary:** headless checks cannot prove Touch ID, the Keychain KEK release, or the packaged
WKWebView render. This change touches none of them — it reads no key and writes no lock state.
