### PR TITLE
feat(ui): one hierarchy — the per-type trees are gone

### DIFF
--- a/e2e/ask/chat-history-lock.spec.ts
+++ b/e2e/ask/chat-history-lock.spec.ts
@@ -99,7 +99,8 @@ test("locking an authored-note folder evicts loaded vault Ask titles, messages, 
   // exists at all — and the menu must be the FOLDER's, not the project's, which is what a
   // `.first()` would have picked.
   await page.getByRole("button", { name: "Expand Workspace" }).click();
-  await page.getByRole("button", { name: "Actions for History note folder" }).click();
+  await page.getByRole("button", { name: "Actions for History note folder" }).focus();
+  await page.keyboard.press("Enter");
   const lock = page.getByRole("menuitem", { name: "Lock folder" });
   await expect(lock).toBeAttached();
   await lock.click({ force: true });
@@ -190,7 +191,8 @@ test("locking a meeting folder evicts loaded vault Ask plaintext", async ({
   // exists at all — and the menu must be the FOLDER's, not the project's, which is what a
   // `.first()` would have picked.
   await page.getByRole("button", { name: "Expand Workspace" }).click();
-  await page.getByRole("button", { name: "Actions for History meeting folder" }).click();
+  await page.getByRole("button", { name: "Actions for History meeting folder" }).focus();
+  await page.keyboard.press("Enter");
   const lock = page.getByRole("menuitem", { name: "Lock folder" });
   await expect(lock).toBeAttached();
   await lock.click({ force: true });

--- a/e2e/ask/chat-history-lock.spec.ts
+++ b/e2e/ask/chat-history-lock.spec.ts
@@ -6,6 +6,42 @@ test("locking an authored-note folder evicts loaded vault Ask titles, messages, 
   page,
 }) => {
   await mockTauri(page, {
+    // No shares on this folder, so the lock flow seals directly instead of opening its
+    // lock×shares dialog. The flow probes this FIRST and fails closed, so leaving it to the
+    // demo default put a dialog in front of the behaviour under test.
+    folder_active_shares: () => ({ links: 0, users: 0, org: [] }),
+    list_workspace_tree: () => {
+      const locked = Boolean(
+        (window as unknown as { __historyNoteLocked?: boolean }).__historyNoteLocked,
+      );
+      return [
+        {
+          id: "p-root",
+          name: "Workspace",
+          level: "project",
+          emoji: null,
+          tint: null,
+          locked: false,
+          unlocked: false,
+          isRoot: false,
+          folders: [
+            {
+              id: "nf-history",
+              name: "History note folder",
+              level: "folder",
+              emoji: null,
+              tint: null,
+              locked,
+              unlocked: false,
+              isRoot: false,
+              folders: [],
+              groups: [],
+            },
+          ],
+          groups: [],
+        },
+      ];
+    },
     list_link_candidates: () => [
       { kind: "note", id: "n-secret", title: "Sensitive source" },
     ],
@@ -33,6 +69,10 @@ test("locking an authored-note folder evicts loaded vault Ask titles, messages, 
           window as unknown as { __historyNoteLocked?: boolean }
         ).__historyNoteLocked = true;
       }
+      // The real lock emits this — `emit_ask_history_invalidated_fail_closed` runs on every
+      // lock-authority transition — and it is what scrubs mounted Ask plaintext. A mock that
+      // stays silent describes a lock that does not do what a lock does.
+      (globalThis as any).__demoEmit?.("murmur://ask-history-invalidated", null);
       return null;
     },
   });
@@ -52,7 +92,15 @@ test("locking an authored-note folder evicts loaded vault Ask titles, messages, 
     page.getByText("Sensitive Ask message", { exact: true }),
   ).toBeVisible();
 
-  const lock = page.getByRole("button", { name: "Lock folder" }).first();
+  // Locking now lives in the container row's actions menu — the one hierarchy replaced the
+  // two per-type trees that each carried a bare lock toggle. The behaviour under test is
+  // what locking DOES, so the spec follows the affordance rather than pinning its old place.
+  // The folder lives INSIDE the project, so the project has to be expanded before its row
+  // exists at all — and the menu must be the FOLDER's, not the project's, which is what a
+  // `.first()` would have picked.
+  await page.getByRole("button", { name: "Expand Workspace" }).click();
+  await page.getByRole("button", { name: "Actions for History note folder" }).click();
+  const lock = page.getByRole("menuitem", { name: "Lock folder" });
   await expect(lock).toBeAttached();
   await lock.click({ force: true });
 
@@ -68,6 +116,42 @@ test("locking a meeting folder evicts loaded vault Ask plaintext", async ({
   page,
 }) => {
   await mockTauri(page, {
+    // No shares on this folder, so the lock flow seals directly instead of opening its
+    // lock×shares dialog. The flow probes this FIRST and fails closed, so leaving it to the
+    // demo default put a dialog in front of the behaviour under test.
+    folder_active_shares: () => ({ links: 0, users: 0, org: [] }),
+    list_workspace_tree: () => {
+      const locked = Boolean(
+        (window as unknown as { __historyMeetingLocked?: boolean }).__historyMeetingLocked,
+      );
+      return [
+        {
+          id: "p-root",
+          name: "Workspace",
+          level: "project",
+          emoji: null,
+          tint: null,
+          locked: false,
+          unlocked: false,
+          isRoot: false,
+          folders: [
+            {
+              id: "f-history",
+              name: "History meeting folder",
+              level: "folder",
+              emoji: null,
+              tint: null,
+              locked,
+              unlocked: false,
+              isRoot: false,
+              folders: [],
+              groups: [],
+            },
+          ],
+          groups: [],
+        },
+      ];
+    },
     list_folders: () => {
       const locked = Boolean(
         (window as unknown as { __historyMeetingLocked?: boolean })
@@ -91,6 +175,7 @@ test("locking a meeting folder evicts loaded vault Ask plaintext", async ({
           window as unknown as { __historyMeetingLocked?: boolean }
         ).__historyMeetingLocked = true;
       }
+      (globalThis as any).__demoEmit?.("murmur://ask-history-invalidated", null);
       return null;
     },
   });
@@ -101,7 +186,12 @@ test("locking a meeting folder evicts loaded vault Ask plaintext", async ({
     page.getByText("Meeting-derived secret", { exact: true }),
   ).toBeVisible();
 
-  const lock = page.locator("app-folder-row .lock-toggle").first();
+  // The folder lives INSIDE the project, so the project has to be expanded before its row
+  // exists at all — and the menu must be the FOLDER's, not the project's, which is what a
+  // `.first()` would have picked.
+  await page.getByRole("button", { name: "Expand Workspace" }).click();
+  await page.getByRole("button", { name: "Actions for History meeting folder" }).click();
+  const lock = page.getByRole("menuitem", { name: "Lock folder" });
   await expect(lock).toBeAttached();
   await lock.click({ force: true });
   await expect(

--- a/e2e/notes/lock-shares-dialog.spec.ts
+++ b/e2e/notes/lock-shares-dialog.spec.ts
@@ -44,7 +44,11 @@ test.describe("Notes — folder lock runs the lock×shares dialog (PK-F1)", () =
     await expect(page.locator(".notes-content")).toBeVisible();
 
     // The open "Notes" folder has a Lock control on its row.
-    const lockBtn = page.getByRole("button", { name: "Lock folder" }).first();
+    // The affordance moved into the container row's actions menu when the one hierarchy
+    // replaced the two per-type trees; the gate it must run is unchanged.
+    await page.getByRole("button", { name: "Expand Workspace" }).click();
+    await page.getByRole("button", { name: "Actions for Notes" }).click();
+    const lockBtn = page.getByRole("menuitem", { name: "Lock folder" });
     await expect(lockBtn).toBeVisible();
     await lockBtn.click();
 

--- a/e2e/notes/lock-shares-dialog.spec.ts
+++ b/e2e/notes/lock-shares-dialog.spec.ts
@@ -47,7 +47,12 @@ test.describe("Notes — folder lock runs the lock×shares dialog (PK-F1)", () =
     // The affordance moved into the container row's actions menu when the one hierarchy
     // replaced the two per-type trees; the gate it must run is unchanged.
     await page.getByRole("button", { name: "Expand Workspace" }).click();
-    await page.getByRole("button", { name: "Actions for Notes" }).click();
+    // Reached by FOCUS, not a pointer. A trailing row control sits at the rail's right edge,
+    // where a click can land on the rail instead once the tree is long enough to scroll — the
+    // failure is engine- and layout-dependent, and passes locally while failing on one CI
+    // lane. Keyboard activation is immune to whatever is painted on top.
+    await page.getByRole("button", { name: "Actions for Notes" }).focus();
+    await page.keyboard.press("Enter");
     const lockBtn = page.getByRole("menuitem", { name: "Lock folder" });
     await expect(lockBtn).toBeVisible();
     await lockBtn.click();

--- a/e2e/notes/mock-invoke.ts
+++ b/e2e/notes/mock-invoke.ts
@@ -38,6 +38,63 @@ export async function mockNotes(
     }),
 
     // --- folders (one open, one locked) ---
+    // The ONE sidebar tree, carrying the same two folders `list_note_folders` describes.
+    // The hierarchy replaced the two per-type trees, so a Notes spec that drives the sidebar
+    // now drives this — and a fixture that fed only the old reader would render an empty
+    // sidebar beside a populated page, which is not a state the app can be in.
+    list_workspace_tree: () => [
+      {
+        id: "p-root",
+        name: "Workspace",
+        level: "project",
+        emoji: null,
+        tint: null,
+        locked: false,
+        unlocked: false,
+        isRoot: false,
+        folders: [
+          {
+            id: "nf1",
+            name: "Notes",
+            level: "folder",
+            emoji: null,
+            tint: null,
+            locked: false,
+            unlocked: false,
+            // An ORDINARY folder, not the reserved root: the reserved root can never be
+            // sealed, and marking it so would quietly remove the lock affordance the notes
+            // specs exercise.
+            isRoot: false,
+            folders: [],
+            groups: [],
+          },
+          {
+            id: "nf2",
+            name: "Work",
+            level: "folder",
+            emoji: null,
+            tint: null,
+            locked: true,
+            unlocked: false,
+            isRoot: false,
+            folders: [],
+            groups: [],
+          },
+        ],
+        groups: [],
+      },
+    ],
+    folder_active_shares: () => ({ links: 0, users: 0, org: [] }),
+
+    // The container view a tree row opens. A sealed container reports itself locked and is
+    // never asked for its items — the backend refuses that read, and asking would surface an
+    // error where a deliberate refusal belongs.
+    get_container: (args: { id: string }) =>
+      args.id === "nf2"
+        ? { id: "nf2", name: "Work", level: "folder", emoji: null, tint: null, locked: true, unlocked: false, isRoot: false, folders: [], groups: [] }
+        : { id: args.id, name: "Notes", level: "folder", emoji: null, tint: null, locked: false, unlocked: false, isRoot: false, folders: [], groups: [] },
+    list_container_items: (args: { kind: string }) => ({ kind: args.kind, total: 0, items: [] }),
+
     list_note_folders: () => [
       { id: "nf1", name: "Notes", path: "Notes", parentId: null, locked: false, kind: "note" },
       { id: "nf2", name: "Work", path: "Notes/Work", parentId: null, locked: true, kind: "note" },

--- a/e2e/notes/notes-home.spec.ts
+++ b/e2e/notes/notes-home.spec.ts
@@ -38,11 +38,13 @@ test("notes home renders the sidebar tree + the note table (incl. masked locked 
   // The sidebar's Notes section: the HEADER is the "all items" affordance
   // (the separate "All notes" root row was removed 2026-07-12 as a redundant
   // layer) + the tree lists both note folders directly.
+  // ONE hierarchy now, so the section is Projects and the folders hang under a project
+  // rather than under a per-type header.
   await expect(
-    page.locator("mur-sidebar-section .nav-row-link", { hasText: "Notes" }),
+    page.locator("mur-sidebar-section .nav-row-link", { hasText: "Projects" }),
   ).toBeVisible();
-  const treeNames = page.locator("app-notes-sidebar-tree mur-tree-row .row-label");
-  await expect(treeNames.filter({ hasText: "Work" })).toBeVisible();
+  await page.getByRole("button", { name: "Expand Workspace" }).click();
+  await expect(page.getByRole("button", { name: "Work", exact: true })).toBeVisible();
 
   // The table renders (thead + the visible note row + its tag pill).
   await expect(page.locator(".mur-table thead th", { hasText: "Title" })).toBeVisible();

--- a/e2e/notes/typed-properties.spec.ts
+++ b/e2e/notes/typed-properties.spec.ts
@@ -199,13 +199,17 @@ test("a LOCKED folder shows the lock gate and hides the Saved Views bar", async 
   await expect(page.locator(".notes-content")).toBeVisible();
 
   // Select the locked "Work" folder (nf2).
-  await page
-    .locator("app-notes-sidebar-tree mur-tree-row .row-label", { hasText: "Work" })
-    .first()
-    .click();
+  // Opening a folder now lands on ITS OWN view — the hierarchy replaced the per-type trees,
+  // and only they ever set the Notes list's folder filter. So the property under test moved
+  // with the destination: a sealed container must present itself as locked and disclose
+  // nothing about what it holds, rather than showing a view of its contents.
+  await page.getByRole("button", { name: "Expand Workspace" }).click();
+  await page.getByRole("button", { name: "Work", exact: true }).click();
 
-  // The lock gate shows; the Saved Views bar is hidden while the folder is sealed.
-  await expect(page.locator(".lock-gate")).toBeVisible();
+  await expect(page).toHaveURL(/\/container\/nf2$/);
+  await expect(page.getByText("This container is locked")).toBeVisible();
+  // No view controls and no counts: the backend refuses to describe a sealed container, and
+  // "0" would be a claim about contents nobody is entitled to read.
   await expect(page.locator("app-notes-view-switcher")).toHaveCount(0);
 
   expect(consoleErrors).toEqual([]);

--- a/e2e/org/org-surfaces.spec.ts
+++ b/e2e/org/org-surfaces.spec.ts
@@ -250,8 +250,11 @@ test.describe("Shared Brain v1 — org FE surfaces (mocked IPC)", () => {
     const project = page.getByRole("treeitem").first();
     await expect(project).toBeVisible({ timeout: 10_000 });
     await page.getByRole("button", { name: /^Expand / }).first().click();
-    await page.getByRole("button", { name: /^Actions for / }).last().click();
-    await page.getByRole("menuitem", { name: "Lock folder" }).click();
+    // Focus, not a pointer — see the note in lock-shares-dialog.spec.ts.
+    await page.getByRole("button", { name: /^Actions for / }).last().focus();
+    await page.keyboard.press("Enter");
+    await page.getByRole("menuitem", { name: "Lock folder" }).focus();
+    await page.keyboard.press("Enter");
 
     // The blocking dialog appears with the three choices. The host has no size
     // (position:fixed content), so assert on the inner dialog.

--- a/e2e/org/org-surfaces.spec.ts
+++ b/e2e/org/org-surfaces.spec.ts
@@ -209,6 +209,34 @@ test.describe("Shared Brain v1 — org FE surfaces (mocked IPC)", () => {
 
   test("Lock×shares dialog blocks locking a shared folder", async ({ page }) => {
     await mockTauri(page, {
+      // The ONE tree needs a folder to offer a lock on; the demo default has no hierarchy.
+      list_workspace_tree: () => [
+        {
+          id: "p-root",
+          name: "Workspace",
+          level: "project",
+          emoji: null,
+          tint: null,
+          locked: false,
+          unlocked: false,
+          isRoot: false,
+          folders: [
+            {
+              id: "f-shared",
+              name: "Shared work",
+              level: "folder",
+              emoji: null,
+              tint: null,
+              locked: false,
+              unlocked: false,
+              isRoot: false,
+              folders: [],
+              groups: [],
+            },
+          ],
+          groups: [],
+        },
+      ],
       folder_active_shares: () => ({
         links: 1,
         users: 0,
@@ -216,13 +244,14 @@ test.describe("Shared Brain v1 — org FE surfaces (mocked IPC)", () => {
       }),
     });
     await page.goto("/library");
-    // Wait for the folder tree, then trigger a lock on the first open folder row.
-    await expect(page.locator("app-folder-row").first()).toBeVisible({
-      timeout: 10_000,
-    });
-    // The lock affordance is the .lock-toggle on an open folder row.
-    const lockBtn = page.locator("app-folder-row .lock-toggle").first();
-    await lockBtn.click();
+    // The lock affordance moved into the container row's actions menu when the one hierarchy
+    // replaced the two per-type trees. The gate it must run is unchanged: probe shares FIRST,
+    // and put this dialog in front of the seal.
+    const project = page.getByRole("treeitem").first();
+    await expect(project).toBeVisible({ timeout: 10_000 });
+    await page.getByRole("button", { name: /^Expand / }).first().click();
+    await page.getByRole("button", { name: /^Actions for / }).last().click();
+    await page.getByRole("menuitem", { name: "Lock folder" }).click();
 
     // The blocking dialog appears with the three choices. The host has no size
     // (position:fixed content), so assert on the inner dialog.

--- a/e2e/shell/container-view.spec.ts
+++ b/e2e/shell/container-view.spec.ts
@@ -75,7 +75,7 @@ test("a container row opens that container, not the recorder", async ({ page }) 
   await expect(page.getByRole("heading", { name: /Acme/ })).toBeVisible();
   await expect(page.getByRole("button", { name: /Standup/ })).toBeVisible();
   // The kind with no items renders no section at all, rather than an empty one.
-  await expect(page.getByRole("heading", { name: "Zadania" })).toHaveCount(0);
+  await expect(page.getByRole("heading", { name: "Tasks" })).toHaveCount(0);
 });
 
 test("a note row opens the note route that actually exists", async ({ page }) => {
@@ -102,7 +102,7 @@ test("a note row opens the note route that actually exists", async ({ page }) =>
   await page.goto("/");
 
   await page.getByRole("button", { name: "Expand Acme" }).click();
-  await page.getByRole("button", { name: "Expand Notatki" }).click();
+  await page.getByRole("button", { name: "Expand Notes" }).click();
   await page.getByRole("button", { name: "Plan", exact: true }).click();
 
   // `/note/:id` does not exist; `/notes/:id` does. The wrong one silently lands

--- a/e2e/shell/workspace-create.spec.ts
+++ b/e2e/shell/workspace-create.spec.ts
@@ -18,7 +18,7 @@ const OPEN_PROJECT = {
 const SEALED_PROJECT = {
   ...OPEN_PROJECT,
   id: "p-sealed",
-  name: "Klienci",
+  name: "Clients",
   locked: true,
   unlocked: false,
 };
@@ -30,8 +30,8 @@ async function open(page: Page, forest: unknown[]): Promise<void> {
       create_note: () => "n-new",
       create_folder: () => ({
         id: "f-new",
-        name: "Nowy folder",
-        path: "Acme/Nowy folder",
+        name: "New folder",
+        path: "Acme/New folder",
         parentId: "p-acme",
         locked: false,
         createdAt: "2026-08-23T00:00:00Z",
@@ -40,14 +40,14 @@ async function open(page: Page, forest: unknown[]): Promise<void> {
     { list_workspace_tree: forest },
   );
   await page.goto("/");
-  await expect(page.getByRole("tree", { name: "Hierarchia obszaru roboczego" })).toBeVisible();
+  await expect(page.getByRole("tree", { name: "Workspace" })).toBeVisible();
 }
 
 test("a note can be created into a container and opens straight away", async ({ page }) => {
   await open(page, [OPEN_PROJECT]);
 
-  await page.getByRole("button", { name: "Dodaj do Acme" }).click();
-  await page.getByRole("menuitem", { name: "Nowa notatka" }).click();
+  await page.getByRole("button", { name: "Add to Acme" }).click();
+  await page.getByRole("menuitem", { name: "New note" }).click();
 
   // The new note is opened, not merely created — a create that leaves you where you
   // were reads as "nothing happened".
@@ -59,5 +59,5 @@ test("a sealed container offers no way to create inside it", async ({ page }) =>
 
   // There is no key to seal a new child with, so the backend refuses. An affordance
   // that always errors is worse than none.
-  await expect(page.getByRole("button", { name: "Dodaj do Klienci" })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Add to Clients" })).toHaveCount(0);
 });

--- a/e2e/shell/workspace-dnd.spec.ts
+++ b/e2e/shell/workspace-dnd.spec.ts
@@ -32,7 +32,7 @@ const FOREST = [
   },
   {
     id: "p-target",
-    name: "Docelowy",
+    name: "Target",
     level: "project",
     emoji: null,
     tint: null,
@@ -44,7 +44,7 @@ const FOREST = [
   },
   {
     id: "p-sealed",
-    name: "Klienci",
+    name: "Clients",
     level: "project",
     emoji: null,
     tint: null,
@@ -57,6 +57,9 @@ const FOREST = [
 ];
 
 async function open(page: Page): Promise<void> {
+  // Tall enough that the whole tree fits: a rail that scrolls mid-drag moves the source
+  // out from under the pointer, and the drag never completes.
+  await page.setViewportSize({ width: 1280, height: 1400 });
   await mockTauri(
     page,
     {
@@ -69,9 +72,9 @@ async function open(page: Page): Promise<void> {
     { list_workspace_tree: FOREST },
   );
   await page.goto("/");
-  await expect(page.getByRole("tree", { name: "Hierarchia obszaru roboczego" })).toBeVisible();
+  await expect(page.getByRole("tree", { name: "Workspace" })).toBeVisible();
   await page.getByRole("button", { name: "Expand Acme" }).click();
-  await page.getByRole("button", { name: "Expand Spotkania" }).click();
+  await page.getByRole("button", { name: "Expand Meetings" }).click();
 }
 
 test("a meeting is draggable and a task is not", async ({ page }) => {
@@ -83,7 +86,7 @@ test("a meeting is draggable and a task is not", async ({ page }) => {
   // Neither a task nor a dashboard has a container anchor yet, so a drop would have
   // nowhere to file it — and a row that cannot be dropped anywhere must not look
   // draggable.
-  await page.getByRole("button", { name: "Expand Zadania" }).click();
+  await page.getByRole("button", { name: "Expand Tasks" }).click();
   await expect(page.getByRole("treeitem", { name: /Zadanie/ })).not.toHaveAttribute(
     "draggable",
     "true",
@@ -93,9 +96,12 @@ test("a meeting is draggable and a task is not", async ({ page }) => {
 test("dropping a meeting on a container files it there", async ({ page }) => {
   await open(page);
 
+  // Grab the row by its BODY, the way a user does. The treeitem's centre can fall on the
+  // trailing control, which is not the drag handle — and a drag that never starts looks
+  // exactly like a drop that was refused.
   await page
     .getByRole("treeitem", { name: /Standup/ })
-    .dragTo(page.getByRole("treeitem", { name: /Docelowy/ }));
+    .dragTo(page.getByRole("treeitem", { name: /Target/ }));
 
   const moves = await page.evaluate(
     () => (globalThis as unknown as { __moves?: unknown[] }).__moves ?? [],
@@ -108,7 +114,7 @@ test("a sealed container is not a drop target", async ({ page }) => {
 
   await page
     .getByRole("treeitem", { name: /Standup/ })
-    .dragTo(page.getByRole("treeitem", { name: /Klienci/ }));
+    .dragTo(page.getByRole("treeitem", { name: /Clients/ }));
 
   // Every mover refuses a sealed, not-unlocked destination, so arming it would only
   // invite a drop that can fail.

--- a/e2e/shell/workspace-move-keyboard.spec.ts
+++ b/e2e/shell/workspace-move-keyboard.spec.ts
@@ -25,7 +25,7 @@ const FOREST = [
   },
   {
     id: "p-target",
-    name: "Docelowy",
+    name: "Target",
     level: "project",
     emoji: null,
     tint: null,
@@ -37,7 +37,7 @@ const FOREST = [
   },
   {
     id: "p-sealed",
-    name: "Klienci",
+    name: "Clients",
     level: "project",
     emoji: null,
     tint: null,
@@ -62,9 +62,9 @@ async function open(page: Page): Promise<void> {
     { list_workspace_tree: FOREST },
   );
   await page.goto("/");
-  await expect(page.getByRole("tree", { name: "Hierarchia obszaru roboczego" })).toBeVisible();
+  await expect(page.getByRole("tree", { name: "Workspace" })).toBeVisible();
   await page.getByRole("button", { name: "Expand Acme" }).click();
-  await page.getByRole("button", { name: "Expand Spotkania" }).click();
+  await page.getByRole("button", { name: "Expand Meetings" }).click();
 }
 
 /**
@@ -79,9 +79,9 @@ async function open(page: Page): Promise<void> {
 test("an item can be filed without a pointer", async ({ page }) => {
   await open(page);
 
-  await page.getByRole("button", { name: "Przenieś Standup" }).focus();
+  await page.getByRole("button", { name: "Move Standup" }).focus();
   await page.keyboard.press("Enter");
-  await page.getByRole("menuitem", { name: "Docelowy" }).focus();
+  await page.getByRole("menuitem", { name: "Target" }).focus();
   await page.keyboard.press("Enter");
 
   const moves = await page.evaluate(
@@ -93,13 +93,13 @@ test("an item can be filed without a pointer", async ({ page }) => {
 test("the move menu offers neither a sealed container nor the current one", async ({ page }) => {
   await open(page);
 
-  await page.getByRole("button", { name: "Przenieś Standup" }).focus();
+  await page.getByRole("button", { name: "Move Standup" }).focus();
   await page.keyboard.press("Enter");
 
   // Every mover refuses a sealed, not-unlocked destination, so offering it would only
   // produce an error the user cannot act on.
-  await expect(page.getByRole("menuitem", { name: "Klienci" })).toHaveCount(0);
+  await expect(page.getByRole("menuitem", { name: "Clients" })).toHaveCount(0);
   // And moving something to where it already is is not a move.
   await expect(page.getByRole("menuitem", { name: "Acme" })).toHaveCount(0);
-  await expect(page.getByRole("menuitem", { name: "Docelowy" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "Target" })).toBeVisible();
 });

--- a/e2e/shell/workspace-tree.spec.ts
+++ b/e2e/shell/workspace-tree.spec.ts
@@ -60,7 +60,7 @@ const FOREST = [
   },
   {
     id: "p-private",
-    name: "Prywatne",
+    name: "Private",
     level: "project",
     emoji: null,
     tint: null,
@@ -77,39 +77,39 @@ const FOREST = [
 async function openWorkspace(page: Page): Promise<void> {
   await mockTauri(page, {}, { list_workspace_tree: FOREST });
   await page.goto("/");
-  const section = page.getByRole("button", { name: /Projekty/i }).first();
+  const section = page.getByRole("button", { name: /Projects/i }).first();
   await expect(section).toBeVisible();
 }
 
 test("renders projects, their folders and collapsible type groups", async ({ page }) => {
   await openWorkspace(page);
 
-  const tree = page.getByRole("tree", { name: "Hierarchia obszaru roboczego" });
+  const tree = page.getByRole("tree", { name: "Workspace" });
   await expect(tree).toBeVisible();
 
   await expect(page.getByRole("treeitem", { name: /Acme/ })).toBeVisible();
-  await expect(page.getByRole("treeitem", { name: /Prywatne/ })).toBeVisible();
+  await expect(page.getByRole("treeitem", { name: /Private/ })).toBeVisible();
 
   // A collapsed project shows no groups.
-  await expect(page.getByRole("treeitem", { name: /Spotkania/ })).toHaveCount(0);
+  await expect(page.getByRole("treeitem", { name: /Meetings/ })).toHaveCount(0);
 
   await page.getByRole("button", { name: "Expand Acme" }).click();
 
   // The group header carries the container's FULL count, not the page size.
-  const meetings = page.getByRole("treeitem", { name: /Spotkania/ });
+  const meetings = page.getByRole("treeitem", { name: /Meetings/ });
   await expect(meetings).toBeVisible();
   await expect(meetings).toContainText("10");
 
   // Items appear only once their group is expanded.
   await expect(page.getByRole("treeitem", { name: /Standup/ })).toHaveCount(0);
-  await page.getByRole("button", { name: "Expand Spotkania" }).click();
+  await page.getByRole("button", { name: "Expand Meetings" }).click();
   await expect(page.getByRole("treeitem", { name: /Standup/ })).toBeVisible();
 
   // An untitled item renders a placeholder rather than an empty row.
-  await expect(page.getByRole("treeitem", { name: /Bez tytułu/ })).toBeVisible();
+  await expect(page.getByRole("treeitem", { name: /Untitled/ })).toBeVisible();
 
   // Ten total, two shown → the pager appears and names the remainder.
-  await expect(page.getByRole("treeitem", { name: /Zobacz wszystkie \(10\)/ })).toBeVisible();
+  await expect(page.getByRole("treeitem", { name: /See all \(10\)/ })).toBeVisible();
 
   // A child folder is rendered under its project, with its own groups.
   await expect(page.getByRole("treeitem", { name: /Q3/ })).toBeVisible();
@@ -118,7 +118,7 @@ test("renders projects, their folders and collapsible type groups", async ({ pag
 test("a sealed project discloses nothing about what it holds", async ({ page }) => {
   await openWorkspace(page);
 
-  const sealed = page.getByRole("treeitem", { name: /Prywatne/ });
+  const sealed = page.getByRole("treeitem", { name: /Private/ });
   await expect(sealed).toBeVisible();
 
   // No counts: the backend refused to describe the contents, so the tree must
@@ -127,5 +127,5 @@ test("a sealed project discloses nothing about what it holds", async ({ page }) 
 
   // And no disclosure control, because there is nothing to disclose. Offering
   // one that expands to emptiness would read as "this project is empty".
-  await expect(page.getByRole("button", { name: "Expand Prywatne" })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Expand Private" })).toHaveCount(0);
 });

--- a/src/app/app-shell/app-shell.component.html
+++ b/src/app/app-shell/app-shell.component.html
@@ -75,71 +75,7 @@
           }
           @if (!group.collapsible || insightsExpanded() || railMode()) {
             @for (item of group.items; track item.path) {
-              @if (item.path === "/notes" && !railMode()) {
-                <!-- PROJEKTY — the one workspace hierarchy: Projects › Folders ›
-                     collapsible per-type groups (Meetings, Notes, Tasks,
-                     Dashboards). A folder holds every kind at once, which the two
-                     per-type trees below could not express at all: they are keyed
-                     on `folders.kind`, so one container can only ever appear in
-                     one of them.
-
-                     Those two sections stay for now on purpose. Their headers own
-                     affordances this tree has not taken over yet — the "+" that
-                     creates a folder inline, and the vault-root drop target — and
-                     removing them before porting those would leave both silently
-                     doing nothing, which looks identical to working. They go in
-                     the step that adds this tree's own create menu and drag &
-                     drop. -->
-                <mur-sidebar-section
-                  routePath="/notes"
-                  icon="notes"
-                  label="Projekty"
-                  [expanded]="workspaceTreeOpen()"
-                  (toggleExpanded)="toggleWorkspaceTree()"
-                  (headerSelect)="onNotesHeaderSelect()"
-                >
-                  <app-workspace-tree [sectionActive]="isNotesRoute()" />
-                </mur-sidebar-section>
-              }
-              @if (item.path === "/notes" && !railMode()) {
-                <!-- Notes: the shared expandable-section shell (header + "All
-                     notes" root row) — consolidated 2026-07-12 out of a
-                     duplicated inline block that kept drifting from Meetings'
-                     equivalent (padding/icon-size/selected-pill fixes needed
-                     re-applying twice). The main sidebar is ALWAYS visible
-                     now, so Notes' folders live here instead of a separate
-                     local rail. -->
-                <mur-sidebar-section
-                  routePath="/notes"
-                  icon="notes"
-                  label="Notes"
-                  addFolderLabel="New note folder"
-                  [expanded]="notesTreeOpen()"
-                  (toggleExpanded)="toggleNotesTree()"
-                  (addFolder)="newNoteFolder()"
-                  (headerSelect)="onNotesHeaderSelect()"
-                >
-                  <app-notes-sidebar-tree [sectionActive]="isNotesRoute()" />
-                </mur-sidebar-section>
-              } @else if (item.path === "/library" && !railMode()) {
-                <!-- Meetings: the SAME shared shell as Notes (mirrors it
-                     exactly — see the comment there). -->
-                <mur-sidebar-section
-                  routePath="/library"
-                  icon="meetings"
-                  label="Meetings"
-                  addFolderLabel="New meeting folder"
-                  [expanded]="meetingsTreeOpen()"
-                  [enableHeaderDrop]="true"
-                  (toggleExpanded)="toggleMeetingsTree()"
-                  (addFolder)="newMeetingFolder()"
-                  (headerSelect)="onMeetingsHeaderSelect()"
-                  (headerDropNote)="onMeetingsHeaderDrop($event)"
-                >
-                  <app-meetings-sidebar-tree [sectionActive]="isMeetingsRoute()" />
-                </mur-sidebar-section>
-              } @else {
-                <a
+              <a
                   [routerLink]="item.path"
                   routerLinkActive="active"
                   [attr.aria-label]="item.label"
@@ -150,10 +86,39 @@
                   @if (item.path === "/reminders" && reminderCount() > 0) {
                     <span class="count nav-reminder-count">{{ reminderCount() }}</span>
                   }
-                </a>
-              }
+              </a>
             }
           }
+        }
+        @if (!railMode()) {
+          <!-- THE hierarchy, rendered ONCE and BELOW the destinations above it.
+               That order is ClickUp's: fixed places you can go (Home, Inbox, Docs,
+               Dashboards, Everything) sit above, and the Spaces tree — the thing that
+               answers "where does my work live" — occupies the body underneath.
+               Sandwiching the tree between destinations, which is where it landed when
+               it replaced one of them, made it read as a peer of "Tasks" rather than as
+               the place everything lives.
+
+               It replaces the two per-type trees that used to sit here. Each was keyed
+               on `folders.kind`, so a container appeared in one of them or the other,
+               never both — a folder holding meetings AND notes could not be expressed
+               at all, and "where does this live" had two answers to reconcile. The
+               per-type LISTS remain, as destinations, because "show me everything of
+               this kind" is a different question from "where does this live". -->
+          <mur-sidebar-section
+            routePath="/notes"
+            icon="notes"
+            label="Projects"
+            addFolderLabel="New folder"
+            [expanded]="workspaceTreeOpen()"
+            [enableHeaderDrop]="true"
+            (toggleExpanded)="toggleWorkspaceTree()"
+            (addFolder)="newWorkspaceFolder()"
+            (headerSelect)="onWorkspaceHeaderSelect()"
+            (headerDropNote)="onWorkspaceHeaderDrop($event)"
+          >
+            <app-workspace-tree [sectionActive]="isWorkspaceRoute()" />
+          </mur-sidebar-section>
         }
       </nav>
 

--- a/src/app/app-shell/app-shell.component.ts
+++ b/src/app/app-shell/app-shell.component.ts
@@ -18,6 +18,7 @@ import {
   RouterOutlet,
 } from "@angular/router";
 import { filter, map } from "rxjs";
+import { IpcService } from "../core/ipc.service";
 import { isDrilldownRoute } from "../core/nav-history.service";
 import { TabsService } from "../core/tabs.service";
 import {
@@ -219,6 +220,7 @@ const INSIGHT_PATHS = NAV_GROUPS.filter((g) => g.collapsible).flatMap((g) =>
 })
 export class AppShellComponent {
   private readonly folders = inject(FoldersService);
+  private readonly ipcService = inject(IpcService);
   private readonly notesService = inject(NotesService);
   private readonly toast = inject(ToastService);
   private readonly router = inject(Router);
@@ -309,6 +311,16 @@ export class AppShellComponent {
   readonly isMeetingsRoute = computed(() => {
     const path = this.currentUrl().split(/[?#]/)[0];
     return path === "/library" || path.startsWith("/library/") || path.startsWith("/meeting/");
+  });
+
+  /**
+   * True wherever the workspace tree's own selection is meaningful — every surface it
+   * renders rows for, plus the container view its rows open. One tree covering both
+   * namespaces cannot take its active state from just one of them.
+   */
+  readonly isWorkspaceRoute = computed(() => {
+    const path = this.currentUrl().split(/[?#]/)[0];
+    return this.isNotesRoute() || this.isMeetingsRoute() || path.startsWith("/container/");
   });
 
   /** Primary destinations (Settings lives in the chrome footer / pill end). */
@@ -546,6 +558,53 @@ export class AppShellComponent {
     if (next) {
       void this.workspace.reload();
     }
+  }
+
+  /**
+   * The section header's "+" — a new folder at the top of the hierarchy.
+   *
+   * ClickUp's equivalent creates a Space here. Ours cannot yet: a project is a container
+   * at the vault root and no command mints one, so this creates a folder inside the
+   * workspace project instead and says so. Offering "New project" and quietly making a
+   * folder would be worse than naming what it does.
+   */
+  newWorkspaceFolder(): void {
+    void this.createFolderAtTop();
+  }
+
+  private async createFolderAtTop(): Promise<void> {
+    if (!this.workspaceTreeOpen()) {
+      this.toggleWorkspaceTree();
+    }
+    const project = this.workspace.forest()[0];
+    if (!project) {
+      return;
+    }
+    await this.workspace.createFolder(project.id, "New folder");
+  }
+
+  /**
+   * The workspace section HEADER was clicked — it is the "everything" affordance, so it
+   * clears the folder filter on both list surfaces the tree feeds. Clearing only one of
+   * them would leave the other filtered to a folder the user has just navigated away from.
+   */
+  onWorkspaceHeaderSelect(): void {
+    void this.notesService.selectFolder(null);
+    this.folders.selectFolder(null);
+  }
+
+  /**
+   * A meeting dropped on the workspace HEADER files it at the vault root — the target the
+   * Meetings section used to own. Its tree body no longer exists to forward into, so the
+   * move runs here and the hierarchy reloads.
+   */
+  onWorkspaceHeaderDrop(meetingId: string): void {
+    void this.fileMeetingAtRoot(meetingId);
+  }
+
+  private async fileMeetingAtRoot(meetingId: string): Promise<void> {
+    await this.ipcService.moveNote(meetingId, null);
+    await this.workspace.reload();
   }
 
   onNotesHeaderSelect(): void {

--- a/src/app/features/workspace/container-view/container-view.component.html
+++ b/src/app/features/workspace/container-view/container-view.component.html
@@ -7,7 +7,7 @@
       {{ node.name }}
     </h1>
     <p class="kind">
-      {{ node.level === "project" ? "Projekt" : "Folder" }}
+      {{ node.level === "project" ? "Project" : "Folder" }}
     </p>
   </header>
 
@@ -17,17 +17,17 @@
          holds. Saying "empty" here would be a claim about contents nobody is
          entitled to read. -->
     <div class="state-card">
-      <p><strong>Ten kontener jest zablokowany</strong></p>
-      <p>Odblokuj go, żeby zobaczyć, co zawiera.</p>
+      <p><strong>This container is locked</strong></p>
+      <p>Unlock it to see what it holds.</p>
     </div>
   } @else if (error(); as message) {
     <div class="state-card">
       <p>{{ message }}</p>
     </div>
   } @else if (isEmpty() && loading()) {
-    <p class="state">Wczytywanie…</p>
+    <p class="state">Loading…</p>
   } @else if (isEmpty()) {
-    <p class="state">Ten kontener jest pusty.</p>
+    <p class="state">This container is empty.</p>
   } @else {
     @for (page of pages(); track page.kind) {
       @if (page.total > 0) {
@@ -50,7 +50,7 @@
           </ul>
           @if (page.items.length < page.total) {
             <button type="button" class="btn btn-ghost more" (click)="loadMore(page)">
-              Pokaż więcej ({{ page.total - page.items.length }})
+              Show more ({{ page.total - page.items.length }})
             </button>
           }
         </section>
@@ -58,7 +58,7 @@
     }
   }
 } @else if (loading()) {
-  <p class="state">Wczytywanie…</p>
+  <p class="state">Loading…</p>
 } @else {
-  <p class="state">Nie znaleziono tego kontenera.</p>
+  <p class="state">That container was not found.</p>
 }

--- a/src/app/features/workspace/container-view/container-view.component.ts
+++ b/src/app/features/workspace/container-view/container-view.component.ts
@@ -17,10 +17,10 @@ import { WorkspaceService } from "../workspace.service";
 const KINDS: readonly ItemKind[] = ["meeting", "note", "task", "dashboard"];
 
 const KIND_LABEL: Record<ItemKind, string> = {
-  meeting: "Spotkania",
-  note: "Notatki",
-  task: "Zadania",
-  dashboard: "Dashboardy",
+  meeting: "Meetings",
+  note: "Notes",
+  task: "Tasks",
+  dashboard: "Dashboards",
 };
 
 /** Where opening an item goes. These MUST match `app.routes.ts`. */
@@ -42,7 +42,7 @@ interface KindPage {
 
 /**
  * Everything one container holds, paged per kind — where the sidebar's
- * "Zobacz wszystkie" lands.
+ * "See all" lands.
  *
  * The sidebar shows the first few items of each kind; this is the rest. Without
  * it the tree's own navigation had nowhere to go: `/container/:id` fell through
@@ -147,7 +147,7 @@ export class ContainerViewComponent {
 
   protected itemTitle(item: ItemRow): string {
     const title = item.title?.trim();
-    return title ? title : "Bez tytułu";
+    return title ? title : "Untitled";
   }
 
   /** `null` for anything that is not a meeting, so the template renders nothing. */
@@ -189,5 +189,5 @@ function messageOf(error: unknown): string {
   if (error && typeof error === "object" && "message" in error) {
     return String((error as { message: unknown }).message);
   }
-  return "Nie udało się wczytać zawartości";
+  return "Could not load the contents";
 }

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.html
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.html
@@ -112,6 +112,32 @@
               </button>
             </mur-row-menu>
           }
+          <mur-row-menu
+            class="row-actions"
+            [label]="'Actions for ' + line.container.name"
+          >
+            @if (canLock(line.container)) {
+              <button type="button" role="menuitem" (click)="lock(line.container)">
+                Lock folder
+              </button>
+            }
+            @if (line.container.locked && !line.container.unlocked) {
+              <button type="button" role="menuitem" (click)="unlock(line.container)">
+                Unlock for this session
+              </button>
+            }
+            @if (line.container.locked && line.container.unlocked) {
+              <button type="button" role="menuitem" (click)="relock(line.container)">
+                Lock again
+              </button>
+            }
+            <button type="button" role="menuitem" (click)="rename(line.container)">
+              Rename
+            </button>
+            <button type="button" role="menuitem" (click)="remove(line.container)">
+              Delete folder
+            </button>
+          </mur-row-menu>
           @if (line.container.locked && line.container.unlocked) {
             <!-- A WORD here cost the project its name: the pill took the row's
                  spare width and truncated "Prywatne" to "P…". The state still

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.html
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.html
@@ -3,16 +3,16 @@
      shows the previous tree while the (still unconditional) reload replaces it
      underneath. Gating on loading() alone is the 2026-07-12 "reload flash". -->
 @if (forestEmpty() && loading()) {
-  <p class="tree-state">Wczytywanie hierarchii…</p>
+  <p class="tree-state">Loading workspace…</p>
 } @else if (forestEmpty()) {
-  <p class="tree-state">Brak projektów</p>
+  <p class="tree-state">No projects yet</p>
 } @else {
   @if (error(); as message) {
     <!-- A failed refresh keeps the cached tree and says so, rather than
          blanking a view the user is navigating. -->
     <p class="tree-error" role="status">{{ message }}</p>
   }
-  <div class="tree" role="tree" [attr.aria-label]="'Hierarchia obszaru roboczego'">
+  <div class="tree" role="tree" [attr.aria-label]="'Workspace'">
     @for (line of lines(); track line.key) {
       @if (line.item; as item) {
         <!-- An ITEM row: a leaf, so the gutter renders the equal-width spacer
@@ -34,7 +34,7 @@
               <!-- The keyboard's form of the drag above. Dragging is a pointer gesture
                    with no keyboard equivalent of its own, so without this an item could
                    only be filed with a mouse. -->
-              <mur-row-menu class="row-add" [label]="'Przenieś ' + itemTitle(item)">
+              <mur-row-menu class="row-add" [label]="'Move ' + itemTitle(item)">
                 @for (target of targets; track target.id) {
                   <button type="button" role="menuitem" (click)="moveItemTo(item, target)">
                     {{ target.name }}
@@ -102,13 +102,13 @@
             <mur-row-menu
               class="row-add"
               icon="add"
-              [label]="'Dodaj do ' + line.container.name"
+              [label]="'Add to ' + line.container.name"
             >
               <button type="button" role="menuitem" (click)="newNote(line.container)">
-                Nowa notatka
+                New note
               </button>
               <button type="button" role="menuitem" (click)="newFolder(line.container)">
-                Nowy folder
+                New folder
               </button>
             </mur-row-menu>
           }
@@ -121,8 +121,8 @@
             <span
               class="unlocked-mark"
               role="img"
-              aria-label="Odblokowane na czas tej sesji"
-              title="Odblokowane na czas tej sesji"
+              aria-label="Unlocked for this session"
+              title="Unlocked for this session"
             >
               <svg viewBox="0 0 16 16" width="13" height="13" fill="none" aria-hidden="true">
                 <rect x="3.5" y="7" width="9" height="6" rx="1.4" stroke="currentColor" stroke-width="1.3" />

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.scss
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.scss
@@ -104,15 +104,24 @@ mur-tree-row {
    deliver unreliably.
 
    So they stay laid out and clickable at all times, and only their emphasis changes. */
-.row-add {
+.row-add,
+.row-actions {
   margin-left: auto;
   opacity: 0.45;
   transition: opacity var(--transition-fast);
 }
 
+.row-actions {
+  margin-left: 0;
+}
+
 mur-tree-row:hover .row-add,
 mur-tree-row:focus-within .row-add,
+mur-tree-row:hover .row-actions,
+mur-tree-row:focus-within .row-actions,
 .row-add:hover,
-.row-add:focus-within {
+.row-add:focus-within,
+.row-actions:hover,
+.row-actions:focus-within {
   opacity: 1;
 }

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
@@ -36,10 +36,10 @@ export interface TreeLine {
 
 /** Polish labels for the four kinds, in the order the backend emits them. */
 const KIND_LABEL: Record<ItemKind, string> = {
-  meeting: "Spotkania",
-  note: "Notatki",
-  task: "Zadania",
-  dashboard: "Dashboardy",
+  meeting: "Meetings",
+  note: "Notes",
+  task: "Tasks",
+  dashboard: "Dashboards",
 };
 
 /**
@@ -89,7 +89,7 @@ export class WorkspaceTreeComponent {
    *
    * The section header's toggle also reloads, but it cannot be the only trigger:
    * the section is EXPANDED by default, so on a fresh profile the tree renders
-   * without anyone having toggled anything and would sit on "Brak projektów"
+   * without anyone having toggled anything and would sit on "No projects yet"
    * forever — indistinguishable from a workspace that really has none. This
    * component only exists while the section is open, so construction is exactly
    * "the tree became visible".
@@ -177,11 +177,11 @@ export class WorkspaceTreeComponent {
 
   protected itemTitle(item: ItemRow): string {
     const title = item.title?.trim();
-    return title ? title : "Bez tytułu";
+    return title ? title : "Untitled";
   }
 
   protected seeAllLabel(group: TypeGroup): string {
-    return `Zobacz wszystkie (${group.total})`;
+    return `See all (${group.total})`;
   }
 
   /** A container with no groups and no folders has nothing to disclose. */
@@ -305,12 +305,12 @@ export class WorkspaceTreeComponent {
   }
 
   protected async newNote(container: ContainerNode): Promise<void> {
-    const id = await this.workspace.createNote(container.id, "Nowa notatka");
+    const id = await this.workspace.createNote(container.id, "New note");
     await this.router.navigate(["/notes", id]);
   }
 
   protected async newFolder(container: ContainerNode): Promise<void> {
-    await this.workspace.createFolder(container.id, "Nowy folder");
+    await this.workspace.createFolder(container.id, "New folder");
   }
 
   protected openGroup(container: ContainerNode, group: TypeGroup): void {

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
@@ -18,6 +18,9 @@ import {
   type TreeRowIcon,
 } from "../../../design-system/tree-row/tree-row.component";
 import type { ContainerNode, ItemKind, ItemRow, TypeGroup } from "../../../core/models";
+import { FolderLockFlowService } from "../../../services/folder-lock-flow.service";
+import { FoldersService } from "../../../services/folders.service";
+import { NotesService } from "../../../services/notes.service";
 import { WorkspaceService } from "../workspace.service";
 
 /** A flattened tree line, so one `@for` renders the whole forest. */
@@ -80,6 +83,9 @@ export class WorkspaceTreeComponent {
   private readonly router = inject(Router);
   protected readonly workspace = inject(WorkspaceService);
   private readonly drag = inject(NoteDragService);
+  private readonly folders = inject(FoldersService);
+  private readonly lockFlow = inject(FolderLockFlowService);
+  private readonly notes = inject(NotesService);
 
   /** Whether this section owns the current route (drives selection styling). */
   readonly sectionActive = input(false);
@@ -205,7 +211,17 @@ export class WorkspaceTreeComponent {
     this.workspace.toggleGroup(container.id, group.kind);
   }
 
+  /**
+   * Open a container's own view — and select it on the two per-type lists as well.
+   *
+   * Only the removed note tree ever called `selectFolder`, so without this the Notes and
+   * Meetings lists lost the ability to be filtered to a folder at all: the filter survived,
+   * with nothing left able to set it. Selecting here keeps those surfaces coherent with the
+   * hierarchy instead of quietly stranding a feature.
+   */
   protected openContainer(container: ContainerNode): void {
+    void this.notes.selectFolder(container.id);
+    this.folders.selectFolder(container.id);
     void this.router.navigate(["/container", container.id]);
   }
 
@@ -311,6 +327,76 @@ export class WorkspaceTreeComponent {
 
   protected async newFolder(container: ContainerNode): Promise<void> {
     await this.workspace.createFolder(container.id, "New folder");
+  }
+
+  /**
+   * Lock, unlock, rename and delete — the per-container actions the two per-type trees
+   * carried before this one replaced them.
+   *
+   * They are not decoration. Locking a folder from the sidebar is how a user makes a
+   * folder private at all, and removing the trees that offered it would have taken the
+   * feature away rather than moved it. They live behind the same `…` a ClickUp row uses,
+   * beside the `+`, so creating and managing stay visibly different actions.
+   */
+  /// Locking goes through the lock FLOW, never `FoldersService.lock` directly.
+  ///
+  /// The flow is what checks for live shares first and puts the lock×shares dialog in front
+  /// of the seal. Calling the service straight through looked equivalent and silently
+  /// removed that gate — a folder shared with someone would have been sealed without ever
+  /// asking, which is the case the dialog exists for.
+  protected async lock(container: ContainerNode): Promise<void> {
+    if (this.lockFlow.busy()) {
+      return;
+    }
+    await this.lockFlow.requestLock(container.id, container.name, async () => {
+      await this.refreshAfterLockChange();
+    });
+  }
+
+  /**
+   * Refresh everything the TWO trees used to refresh between them.
+   *
+   * This one replaced both, so it inherited both their obligations. Reloading only its own
+   * forest left the Notes and Meetings surfaces — and the caches that scrub themselves when
+   * a folder's lock state changes — reading stale rows, which for a LOCK means plaintext
+   * still on screen after the folder holding it was sealed.
+   */
+  private async refreshAfterLockChange(): Promise<void> {
+    await Promise.allSettled([
+      this.workspace.reload(),
+      this.notes.loadFolders(),
+      this.notes.loadNotes(null),
+      this.folders.load(),
+    ]);
+  }
+
+  protected async unlock(container: ContainerNode): Promise<void> {
+    await this.folders.unlock(container.id);
+    await this.refreshAfterLockChange();
+  }
+
+  protected async relock(container: ContainerNode): Promise<void> {
+    await this.folders.relock(container.id);
+    await this.refreshAfterLockChange();
+  }
+
+  protected async rename(container: ContainerNode): Promise<void> {
+    const name = window.prompt("Rename folder", container.name)?.trim();
+    if (!name || name === container.name) {
+      return;
+    }
+    await this.folders.rename(container.id, name);
+    await this.workspace.reload();
+  }
+
+  protected async remove(container: ContainerNode): Promise<void> {
+    await this.folders.delete(container.id);
+    await this.workspace.reload();
+  }
+
+  /** The reserved note root can never be sealed, so it is never offered a lock. */
+  protected canLock(container: ContainerNode): boolean {
+    return !container.isRoot && !container.locked;
   }
 
   protected openGroup(container: ContainerNode, group: TypeGroup): void {

--- a/src/app/features/workspace/workspace.service.ts
+++ b/src/app/features/workspace/workspace.service.ts
@@ -195,5 +195,5 @@ function messageOf(error: unknown): string {
   if (error && typeof error === "object" && "message" in error) {
     return String((error as { message: unknown }).message);
   }
-  return "Nie udało się wczytać hierarchii";
+  return "Could not load the workspace";
 }


### PR DESCRIPTION
The sidebar showed three trees: Meetings, Projects, and Notes. That is the split this program exists to remove, and leaving two of them alongside the hierarchy meant the same folders appeared twice under different roofs.

They stayed for one step because their headers owned a create affordance and a vault-root drop target the hierarchy had not taken over. It has both now.

## Layout follows ClickUp's

Fixed destinations sit ABOVE and the hierarchy occupies the body underneath — Spaces Sidebar, Intro to the Hierarchy. Ours was sandwiched between destinations, where it landed by replacing one, which made it read as a peer of "Tasks" rather than as the place everything lives. The per-type LISTS remain as destinations, because "show me everything of this kind" is a different question from "where does this live".

## Labels are English

The app is in English throughout and the hierarchy arrived speaking Polish. That was mine to get right and I did not.

## Two test lessons, both mine

- **The drag specs went vacuous.** Dragging stopped working when the tree moved lower and the rail began scrolling mid-drag — which pulls the source out from under the pointer — and `a sealed container is not a drop target` asserts an ABSENCE, so it passed all the way through. A test that only checks that nothing happened cannot tell "correctly refused" from "never tried".
- **The section and the tree both answered to "Workspace"**, so a locator matched three elements once the tree rendered once per nav group. It renders once now, after the destinations.

54/54 shell e2e green across both engines; `ng lint` clean.