### PR TITLE
fix(commands): stop filing plaintext into sealed containers

### DIFF
--- a/src-tauri/src/commands/folders.rs
+++ b/src-tauri/src/commands/folders.rs
@@ -590,6 +590,27 @@ fn reexport_notes_under_subtree(state: &AppState, folder_id: &str) -> Result<(),
         )?;
     }
 
+    // AUTHORED notes live in a different table with their own `exported_path`, and this walk
+    // used to skip them entirely — so after a rename every one of them named a file that had
+    // just been moved. The seal removes plaintext BY RECORDED PATH ONLY
+    // (`note_exported_path_rows_in_folder` → `remove_note_export_if_unchanged`), with no
+    // directory sweep behind it, so it removed nothing and the real `.md` stayed readable
+    // inside a sealed folder. That is the 2026-07-11 NOTES-2 leak, on the path that never
+    // called its fix.
+    //
+    // Rebuilt from basename + the folder's new directory, exactly like the meeting notes
+    // above, which stays correct under `/var` vs `/private/var` canonicalisation drift in the
+    // stored absolute path.
+    for (document_id, old) in state.db.note_exported_path_rows_in_folder(folder_id)? {
+        let Some(name) = std::path::Path::new(&old).file_name() else {
+            continue;
+        };
+        let new_path = new_dir.join(name);
+        state
+            .db
+            .set_note_doc_exported_path(&document_id, Some(&new_path.to_string_lossy()))?;
+    }
+
     // Recurse into descendant folders (their dirs moved with the same single `fs::rename`).
     for child in state.db.child_folders(folder_id)? {
         reexport_notes_under_subtree(state, &child.id)?;
@@ -772,7 +793,17 @@ fn reparent_authored_notes_to_default(state: &AppState, folder_id: &str) -> Resu
     if note_ids.is_empty() {
         return Ok(());
     }
-    let default_id = state.db.ensure_default_note_folder()?;
+    // The RESERVED note root — the one `lock_folder` refuses to seal — not
+    // `ensure_default_note_folder`, which returns whatever row holds the path "Notes",
+    // creating it if absent and returning it EVEN WHEN IT IS SEALED. On a database where the
+    // user has locked a container at that path, resolving through it filed these notes into a
+    // sealed container and exported their plaintext into its directory: unsealed content
+    // inside a sealed tree, which the at-rest re-blank sweep never visits because it keys off
+    // the container being marked locked.
+    //
+    // Orphaned notes belong in the always-open home for unfiled notes, which is exactly what
+    // the reserved root is for.
+    let default_id = state.db.ensure_notes_root()?;
     if default_id == folder_id {
         // Deleting the default note-folder while it still holds authored notes: reparenting to
         // itself is a no-op and the row-delete would then destroy them. Fail closed.
@@ -786,8 +817,10 @@ fn reparent_authored_notes_to_default(state: &AppState, folder_id: &str) -> Resu
         .note_folder_by_id(&default_id)?
         .ok_or_else(|| AppError::Storage("default note-folder missing after ensure".into()))?;
     for id in &note_ids {
-        // Reassign the row to the default note-folder (the gate/seal anchor). The default folder is
-        // OPEN (root "Notes" is never locked), so a plain reassign is correct — no reseal needed.
+        // Reassign the row to the reserved note root (the gate/seal anchor). That root is
+        // structurally open — `lock_folder` refuses to seal an `is_root` container — so a plain
+        // reassign is correct and no reseal is needed. This used to say the same thing about
+        // "the default folder", which was a claim about a resolver that did not honour it.
         state.db.set_note_doc_folder(id, &default_id)?;
         // Move the plaintext `.md` into the default folder's vault subdir + re-point exported_path.
         if let Some(row) = state.db.get_note_row(id)? {

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -31538,6 +31538,134 @@
         );
     }
 
+    /// Deleting a folder must not move its authored notes into a LOCKED container.
+    ///
+    /// `reparent_authored_notes_to_default` USED TO resolve its destination with
+    /// `ensure_default_note_folder`, whose comment asserted the result was safe: "the default
+    /// folder is OPEN (root Notes is never locked), so a plain reassign is correct". That is
+    /// not what the resolver does — it returns whatever row holds the path "Notes", creating
+    /// it if absent and returning it REGARDLESS of `locked`, and it never consults `is_root`.
+    ///
+    /// So on a database where the user has locked a container at "Notes", deleting any note
+    /// folder reassigns its notes there and exports their plaintext into its directory:
+    /// unsealed content inside a sealed tree, which the at-rest re-blank sweep never visits
+    /// because it keys off the container being marked locked.
+    #[test]
+    fn deleting_a_folder_never_files_its_notes_into_a_locked_container() {
+        let vault = tmp_vault("delete-into-locked");
+        let state = build_state_with_vault("delete-into-locked", &vault);
+
+        // The user's own locked container sitting on the "Notes" path.
+        make_open_folder(&state.db, "f-notes-taken", "Notes");
+        state
+            .db
+            .lock()
+            .execute(
+                "UPDATE folders SET kind = 'note' WHERE id = 'f-notes-taken'",
+                rusqlite::params![],
+            )
+            .unwrap();
+        std::fs::create_dir_all(vault.join("Notes")).unwrap();
+        lock_folder_inner(&state, "f-notes-taken".into()).unwrap();
+
+        // A note folder holding one authored note with a real exported .md.
+        let doomed = create_note_folder_inner(&state, "Drafts", None).unwrap();
+        let note = create_note_inner(&state, Some(&doomed.id), "Roadmap").unwrap();
+        update_note_doc_inner(&state, &note, "Roadmap", "# Roadmap\nShip Q3.").unwrap();
+
+        delete_folder_inner(&state, doomed.id.clone()).unwrap();
+
+        let landed: Option<String> = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT folder_id FROM documents WHERE id = ?1",
+                rusqlite::params![note],
+                |r| r.get(0),
+            )
+            .unwrap();
+        // Not merely "somewhere else": the RESERVED root, which is the always-open home for
+        // unfiled notes and the only destination that cannot later be sealed out from under
+        // them. Asserting only "not the locked one" would accept any folder at all.
+        let root = state.db.ensure_notes_root().unwrap();
+        assert_eq!(
+            landed.as_deref(),
+            Some(root.as_str()),
+            "an orphaned note must land in the reserved note root"
+        );
+        assert!(
+            !vault.join("Notes/Roadmap.md").exists(),
+            "plaintext was exported into a sealed container's directory"
+        );
+    }
+
+    /// Renaming a note container must not strand its authored notes' `.md` outside the seal.
+    ///
+    /// The rename physically moves the vault subtree, so every recorded export path under it
+    /// is stale the moment it returns. Meeting notes are re-derived by
+    /// `reexport_notes_under_subtree`; authored notes live in `documents.exported_path`, which
+    /// nothing on that path rewrites. The seal then removes plaintext BY RECORDED PATH ONLY
+    /// (`note_exported_path_rows_in_folder` → `remove_note_export_if_unchanged`) with no
+    /// directory sweep to catch what it missed — so the note the user just sealed stays
+    /// readable on disk under its new name.
+    ///
+    /// This is the 2026-07-11 NOTES-2 leak reappearing on the path that never called its fix.
+    #[test]
+    fn renaming_a_note_container_still_seals_its_authored_notes_md() {
+        let vault = tmp_vault("rename-then-seal");
+        let state = build_state_with_vault("rename-then-seal", &vault);
+        let fid = create_note_folder_inner(&state, "Ideas", None).unwrap().id;
+        let id = create_note_inner(&state, Some(&fid), "Roadmap").unwrap();
+        update_note_doc_inner(&state, &id, "Roadmap", "# Roadmap\nShip Q3.").unwrap();
+
+        let before = get_note_inner(&state, &id)
+            .unwrap()
+            .exported_path
+            .expect("note exported to vault");
+        assert!(std::path::Path::new(&before).exists());
+
+        rename_folder_inner(&state, fid.clone(), "Plans".into()).unwrap();
+        assert!(
+            !std::path::Path::new(&before).exists(),
+            "control: the rename must actually move the file, or this oracle proves nothing"
+        );
+
+        lock_folder_inner(&state, fid.clone()).unwrap();
+
+        // Nothing readable may survive anywhere under the vault.
+        fn walk(dir: &std::path::Path, out: &mut Vec<String>) {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    walk(&path, out);
+                } else if path.extension().and_then(|e| e.to_str()) == Some("md") {
+                    out.push(path.to_string_lossy().into_owned());
+                }
+            }
+        }
+        let mut survivors = Vec::new();
+        walk(&vault, &mut survivors);
+        assert!(
+            survivors.is_empty(),
+            "plaintext survived the seal after a rename: {survivors:?}"
+        );
+
+        // And the RECORDED path is cleared. An empty vault with a stale path still pointing at
+        // a file is the state a later relock would chase and miss; the disk and the row have to
+        // agree that nothing is exported.
+        assert!(
+            state
+                .db
+                .note_exported_path_rows_in_folder(&fid)
+                .unwrap()
+                .is_empty(),
+            "exported_path survived the seal"
+        );
+    }
+
     /// A note root created AFTER adoption is inside the project, not beside it.
     #[test]
     fn a_note_root_created_after_adoption_is_inside_the_project() {


### PR DESCRIPTION
Two SHIPPED sealed-content leaks, found while building the workspace hierarchy. Both are reachable
from ordinary UI actions, both are silent, and both have a RED-before-GREEN oracle that fails on
today's code.

They share one shape: **a write picks a default destination, and the resolver it uses can hand back a
sealed container.**

## Deleting a folder moved its authored notes into a LOCKED container

`reparent_authored_notes_to_default` resolved through `Db::ensure_default_note_folder`, and its
comment stated the assumption that made this safe:

> The default folder is OPEN (root "Notes" is never locked), so a plain reassign is correct — no
> reseal needed.

That is not what the resolver does. It returns whatever row holds the path `"Notes"` — creating it if
absent, and returning it **regardless of `locked`** — and it never consults `is_root`. The reserved
root is a different thing: `ensure_notes_root` deliberately places it elsewhere (`Inbox N`) when
`"Notes"` is already held by a locked container.

So on a database where the user has locked a container at `"Notes"`, deleting **any** note folder
reassigned its authored notes there and exported their plaintext into that container's directory. The
at-rest re-blank sweep never finds them: it keys off the container being marked locked, and reads
recorded paths that now point inside a container whose seal already ran.

Orphaned notes now go to the reserved root — the always-open home for unfiled notes, and the only
destination that cannot later be sealed out from under them.

## Renaming a note container stranded its authored notes' `.md`

The rename physically moves the vault subtree, so every recorded export path under it is stale the
moment it returns. `reexport_notes_under_subtree` re-derived paths only for the `notes` table (meeting
notes). Authored notes live in `documents.exported_path`, and nothing on that path rewrote it.

`finish_folder_lock_after_seal` then removes authored-note plaintext **by recorded path only**
(`note_exported_path_rows_in_folder` → `remove_note_export_if_unchanged`), with no directory sweep
behind it. It removed nothing, and the real `.md` stayed readable inside a sealed folder.

This is the 2026-07-11 NOTES-2 leak on the path that never called its fix — the MOVE path calls it,
and even has its own oracle for it, one function away.

## Oracles

Both were written first and **failed on the unpatched code**:

- deleting a folder while `"Notes"` is held by a locked container lands its notes in the RESERVED
  ROOT — not merely "somewhere else", which would accept any folder — and exports no plaintext into
  the locked container's directory;
- renaming a container then locking it leaves **no `.md` anywhere under the vault** (a whole-vault
  sweep, because per-path assertions are exactly what missed this) and clears the recorded
  `exported_path`, since an empty vault with a stale path is what a later relock would chase and miss.

`cargo test --lib` green (3208); `cargo clippy --lib --tests -- -D warnings` clean.

Verified through the Harness (risk: `lock`) with an independent Codex review and a cross-vendor
egress-security specialist review.

**Note on process:** an earlier attempt bundled a fix to an unrelated test whose 2s probe budget
failed inside the harness's own sandbox. Review was right to send it away; it shipped separately as
#601, and this change rebased onto it.
