### PR TITLE
feat(record): file a finished recording into a project or folder

### DIFF
--- a/e2e/record/recording-placement.spec.ts
+++ b/e2e/record/recording-placement.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * A finished recording can be filed into a project or folder, and a SEALED
+ * destination cannot receive it.
+ *
+ * A meeting is the one kind a user cannot create into a container — it creates
+ * itself when recording stops — so the placement decision has to happen after
+ * the fact. This pins two things the UI cannot get wrong:
+ *
+ *  1. Picking a destination calls `move_note` with THAT container id. The mock
+ *     records the real argument in the page, so a card that renders a list but
+ *     files somewhere else (or nowhere) fails rather than merely looking right.
+ *  2. A sealed-and-not-session-unlocked container is not clickable. The backend
+ *     refuses that move with `AppError::Locked` and is right to — there is no
+ *     content key to seal the arriving meeting with — but a destination a click
+ *     cannot reach must not look reachable.
+ *
+ * RED contract: drop the `[disabled]` binding and the locked row takes the
+ * click, so `move_note` is invoked for `f-sealed` and the last assertion fails;
+ * make `file()` ignore its argument and the first one fails.
+ */
+test.describe("Record — filing a finished recording", () => {
+  const container = (
+    id: string,
+    name: string,
+    level: "project" | "folder",
+    locked: boolean,
+    folders: unknown[] = [],
+  ) => ({
+    id,
+    name,
+    level,
+    emoji: null,
+    tint: null,
+    locked,
+    unlocked: false,
+    isRoot: false,
+    folders,
+    groups: [],
+  });
+
+  const forest = [
+    container("p-acme", "Acme", "project", false, [
+      container("f-weekly", "Weekly", "folder", false),
+      container("f-sealed", "Board", "folder", true),
+    ]),
+  ];
+
+  test("picking a destination files the meeting there, and a sealed one is refused", async ({
+    page,
+  }) => {
+    await mockTauri(
+      page,
+      {
+        // The override is stringified into the page, so the recorder lives on
+        // `window` — a closure over a Node-side array would never be written to.
+        move_note: (args: unknown) => {
+          const w = window as unknown as { __moves?: unknown[] };
+          (w.__moves ??= []).push(args);
+          return null;
+        },
+      },
+      {
+        model_present: true,
+        start_recording: {
+          meetingId: "m-rec",
+          startedAt: "2026-07-01T09:00:00Z",
+        },
+        stop_recording: {
+          meetingId: "m-rec",
+          markdown: "# Notes",
+          exportedPath: "/vault/Notes/m-rec.md",
+        },
+        list_workspace_tree: forest,
+      },
+    );
+
+    await page.goto("/record");
+    await page.locator("button.start-btn").click();
+    await page.locator("button.stop-btn").click();
+
+    const card = page.locator("[data-testid='recording-placement']");
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    // The sealed folder is offered but not reachable.
+    const sealed = page.locator("[data-testid='placement-destination-f-sealed']");
+    await expect(sealed).toBeVisible();
+    await expect(sealed).toBeDisabled();
+
+    // The open folder files the meeting — and the call carries ITS id.
+    await page.locator("[data-testid='placement-destination-f-weekly']").click();
+    await expect(page.locator("[data-testid='placement-filed']")).toContainText(
+      "Weekly",
+    );
+
+    const moves = await page.evaluate(
+      () => (window as unknown as { __moves?: unknown[] }).__moves ?? [],
+    );
+    expect(moves).toEqual([{ meetingId: "m-rec", folderId: "f-weekly" }]);
+  });
+});

--- a/src/app/app-shell/app-shell.component.ts
+++ b/src/app/app-shell/app-shell.component.ts
@@ -2,12 +2,10 @@ import {
   ChangeDetectionStrategy,
   Component,
   Injector,
-  afterNextRender,
   computed,
   effect,
   inject,
   signal,
-  viewChild,
 } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
 import {
@@ -33,8 +31,6 @@ import { MurTabStripComponent } from "../design-system/tab-strip/tab-strip.compo
 import { DocumentPreviewComponent } from "../features/brain/document-preview/document-preview.component";
 import { TilePaletteComponent } from "../features/dashboards/tile-palette/tile-palette.component";
 import { LockSharesDialogComponent } from "../features/folders/lock-shares-dialog/lock-shares-dialog.component";
-import { MeetingsSidebarTreeComponent } from "../features/folders/meetings-sidebar-tree/meetings-sidebar-tree.component";
-import { NotesSidebarTreeComponent } from "../features/notes/notes-sidebar-tree/notes-sidebar-tree.component";
 import { WorkspaceService } from "../features/workspace/workspace.service";
 import { WorkspaceTreeComponent } from "../features/workspace/workspace-tree/workspace-tree.component";
 import { ReminderComposerComponent } from "../features/reminders/reminder-composer/reminder-composer.component";
@@ -177,8 +173,6 @@ const INSIGHT_PATHS = NAV_GROUPS.filter((g) => g.collapsible).flatMap((g) =>
     MurQuickSearchComponent,
     MurSidebarComponent,
     MurTabStripComponent,
-    MeetingsSidebarTreeComponent,
-    NotesSidebarTreeComponent,
     WorkspaceTreeComponent,
     MurSidebarSectionComponent,
     LockSharesDialogComponent,
@@ -358,17 +352,6 @@ export class AppShellComponent {
   private readonly workspace = inject(WorkspaceService);
 
   /**
-   * References to the two FOLDER-TREE-BODY components — resolve to
-   * `undefined` while their section is collapsed (each only renders inside
-   * `<mur-sidebar-section>`'s own `@if (expanded())`, projected as content).
-   * The section header's compact "+" icon forwards into
-   * {@link newNoteFolder}/{@link newMeetingFolder}; the header's vault-root
-   * drop target forwards into {@link onMeetingsHeaderDrop}.
-   */
-  private readonly notesSidebarTree = viewChild(NotesSidebarTreeComponent);
-  private readonly meetingsSidebarTree = viewChild(MeetingsSidebarTreeComponent);
-
-  /**
    * Whether the Insights group renders expanded: the stored preference, OR
    * forced open while the CURRENT route lives inside it (the active pill must
    * never be hidden by a collapsed group).
@@ -505,37 +488,6 @@ export class AppShellComponent {
   }
 
   /**
-   * The "Notes" section header's compact "+" icon — opens the note-folder
-   * tree's inline "New folder" field. Expands the tree first if it's
-   * collapsed (the tree component only exists in the DOM while open, so
-   * {@link notesSidebarTree} resolves to `undefined` until then) —
-   * `afterNextRender` defers the forward to AFTER that `@if` flips and the
-   * component actually mounts.
-   */
-  newNoteFolder(): void {
-    if (this.notesTreeOpen()) {
-      this.notesSidebarTree()?.startCreateFolder();
-      return;
-    }
-    this._notesTreeOpen.set(true);
-    afterNextRender(() => this.notesSidebarTree()?.startCreateFolder(), {
-      injector: this.injector,
-    });
-  }
-
-  /** The "Meetings" section header's compact "+" icon — mirrors {@link newNoteFolder}. */
-  newMeetingFolder(): void {
-    if (this.meetingsTreeOpen()) {
-      this.meetingsSidebarTree()?.openCreateFolder();
-      return;
-    }
-    this._meetingsTreeOpen.set(true);
-    afterNextRender(() => this.meetingsSidebarTree()?.openCreateFolder(), {
-      injector: this.injector,
-    });
-  }
-
-  /**
    * The "Notes" section HEADER was clicked (2026-07-12: the header IS the
    * "all items" affordance now — the separate "All notes" root row was
    * removed as a redundant layer). Clears the note-folder filter; the
@@ -614,32 +566,6 @@ export class AppShellComponent {
   /** The "Meetings" section header was clicked — mirrors {@link onNotesHeaderSelect}. */
   onMeetingsHeaderSelect(): void {
     this.folders.selectFolder(null);
-  }
-
-  /**
-   * A note was dropped onto the Meetings section HEADER (the vault-root drop
-   * target moved onto the header when the "All meetings" root row was
-   * removed, 2026-07-12) — forwards into
-   * `MeetingsSidebarTreeComponent.onDropNote` (which owns the toast +
-   * folder-name lookup) the same way the "+" forwarding does. Unlike the
-   * "+", the header renders even while the tree is COLLAPSED — expand it
-   * first in that case so the tree-body component exists to run the move
-   * (and so the user sees where the note landed).
-   */
-  onMeetingsHeaderDrop(meetingId: string): void {
-    if (this.meetingsTreeOpen()) {
-      void this.meetingsSidebarTree()?.onDropNote({ meetingId, folderId: null });
-      return;
-    }
-    this._meetingsTreeOpen.set(true);
-    afterNextRender(
-      () =>
-        void this.meetingsSidebarTree()?.onDropNote({
-          meetingId,
-          folderId: null,
-        }),
-      { injector: this.injector },
-    );
   }
 
   /** Open the ⌘K spotlight. */

--- a/src/app/features/record/record/record.component.html
+++ b/src/app/features/record/record/record.component.html
@@ -197,6 +197,10 @@
        and the facts this note supersedes at the TOP, beside the "Saved ✓ in Murmur"
        strip — not buried below a full-height note. Gated on stage = done. ─────────── -->
   @if (store.stage() === "done") {
+    <!-- A meeting is the one kind that cannot be created INTO a container: it
+         creates itself when recording stops. The placement decision therefore
+         happens here or not at all. -->
+    <app-recording-placement [meetingId]="store.meetingId()" />
     <app-brain-reveal-card [active]="!!store.lastNote()" />
     <app-re-truth-card
       [active]="!!store.lastNote()"

--- a/src/app/features/record/record/record.component.ts
+++ b/src/app/features/record/record/record.component.ts
@@ -18,6 +18,7 @@ import { MicMuteToggleComponent } from "../mic-mute-toggle/mic-mute-toggle.compo
 import { MeetingConversationComponent } from "../meeting-conversation/meeting-conversation.component";
 import { BrainRevealCardComponent } from "../brain-reveal-card/brain-reveal-card.component";
 import { ReTruthCardComponent } from "../re-truth-card/re-truth-card.component";
+import { RecordingPlacementComponent } from "../recording-placement/recording-placement.component";
 import { MeetingConversationStore } from "../../../core/meeting-conversation.store";
 import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 import {
@@ -58,6 +59,7 @@ type LiveCaptionsState =
     MicMuteToggleComponent,
     MeetingConversationComponent,
     BrainRevealCardComponent,
+    RecordingPlacementComponent,
     ReTruthCardComponent,
   ],
   host: { "(document:keydown)": "onKey($event)" },

--- a/src/app/features/record/recording-placement/recording-placement.component.html
+++ b/src/app/features/record/recording-placement/recording-placement.component.html
@@ -1,0 +1,131 @@
+@if (meetingId() && !dismissed()) {
+  <section
+    class="placement card"
+    aria-labelledby="placement-heading"
+    data-testid="recording-placement"
+  >
+    @if (filedIn(); as filed) {
+      <div class="filed" data-testid="placement-filed">
+        <svg class="filed-glyph" viewBox="0 0 16 16" aria-hidden="true">
+          <path
+            d="M3 8.5 6.2 12 13 4.5"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+        <p class="filed-line">
+          Filed in
+          <strong>{{ filed.emoji ? filed.emoji + " " : "" }}{{ filed.name }}</strong>
+        </p>
+        <button type="button" class="btn-ghost change" (click)="change()">
+          Change
+        </button>
+      </div>
+    } @else {
+      <header class="placement-head">
+        <h2 id="placement-heading" class="placement-title">
+          Where should this recording live?
+        </h2>
+        <button
+          type="button"
+          class="btn-ghost later"
+          (click)="dismiss()"
+          data-testid="placement-later"
+        >
+          Later
+        </button>
+      </header>
+
+      @if (empty()) {
+        <p class="placement-empty">
+          No projects yet — create one in the sidebar and this recording can go
+          straight into it.
+        </p>
+      } @else {
+        @if (destinations().length > 6) {
+          <input
+            type="search"
+            class="placement-search"
+            placeholder="Filter projects and folders"
+            aria-label="Filter destinations"
+            [value]="query()"
+            (input)="query.set($any($event.target).value)"
+            data-testid="placement-search"
+          />
+        }
+
+        <ul class="placement-list" role="list">
+          @for (destination of visible(); track destination.id) {
+            <li>
+              <button
+                type="button"
+                class="destination"
+                [class.is-blocked]="destination.blocked"
+                [class.is-last]="destination.id === lastDestinationId()"
+                [style.--depth]="destination.depth"
+                [disabled]="destination.blocked || filing()"
+                [attr.title]="
+                  destination.blocked
+                    ? 'Unlock this folder before filing a recording into it'
+                    : null
+                "
+                (click)="file(destination)"
+                [attr.data-testid]="'placement-destination-' + destination.id"
+              >
+                <span class="destination-glyph" aria-hidden="true">
+                  @if (destination.blocked) {
+                    <svg viewBox="0 0 16 16">
+                      <path
+                        d="M4.5 7V5.2a3.5 3.5 0 0 1 7 0V7M3.6 7h8.8v6H3.6z"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="1.4"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  } @else if (destination.emoji) {
+                    {{ destination.emoji }}
+                  } @else if (destination.level === "project") {
+                    <svg viewBox="0 0 16 16">
+                      <rect
+                        x="2.5"
+                        y="3.5"
+                        width="11"
+                        height="9"
+                        rx="2"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="1.4"
+                      />
+                    </svg>
+                  } @else {
+                    <svg viewBox="0 0 16 16">
+                      <path
+                        d="M2.5 5.2A1.7 1.7 0 0 1 4.2 3.5h2l1.3 1.7h4.3a1.7 1.7 0 0 1 1.7 1.7v4.4a1.2 1.2 0 0 1-1.2 1.2H3.7a1.2 1.2 0 0 1-1.2-1.2z"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="1.4"
+                        stroke-linejoin="round"
+                      />
+                    </svg>
+                  }
+                </span>
+                <span class="destination-name">{{ destination.name }}</span>
+                @if (destination.blocked) {
+                  <span class="destination-note">Locked</span>
+                } @else if (destination.id === lastDestinationId()) {
+                  <span class="destination-note">Last used</span>
+                }
+              </button>
+            </li>
+          } @empty {
+            <li class="placement-empty">Nothing matches that filter.</li>
+          }
+        </ul>
+      }
+    }
+  </section>
+}

--- a/src/app/features/record/recording-placement/recording-placement.component.scss
+++ b/src/app/features/record/recording-placement/recording-placement.component.scss
@@ -1,0 +1,140 @@
+:host {
+  display: block;
+}
+
+.placement {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+}
+
+.placement-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.placement-title {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.later,
+.change {
+  flex: none;
+}
+
+.placement-search {
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-input);
+  color: var(--text-primary);
+  font: inherit;
+}
+
+.placement-search:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.placement-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  max-height: 15rem;
+  overflow-y: auto;
+  list-style: none;
+}
+
+.destination {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  padding-inline-start: calc(var(--space-3) + var(--depth, 0) * var(--space-4));
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.destination:hover:not(:disabled) {
+  background: var(--surface-hover);
+}
+
+.destination:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.destination:disabled {
+  cursor: not-allowed;
+  color: var(--text-muted);
+}
+
+.destination-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  width: 1.1rem;
+  height: 1.1rem;
+  color: var(--text-secondary);
+}
+
+.destination-glyph svg {
+  width: 100%;
+  height: 100%;
+}
+
+.destination-name {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.destination-note {
+  flex: none;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.placement-empty {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.filed {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.filed-glyph {
+  width: 1rem;
+  height: 1rem;
+  flex: none;
+  color: var(--accent);
+}
+
+.filed-line {
+  flex: 1 1 auto;
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 0.9rem;
+}

--- a/src/app/features/record/recording-placement/recording-placement.component.ts
+++ b/src/app/features/record/recording-placement/recording-placement.component.ts
@@ -1,0 +1,202 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  signal,
+} from "@angular/core";
+
+import { IpcService } from "../../../core/ipc.service";
+import type { ContainerNode } from "../../../core/models";
+import { ToastService } from "../../../services/toast.service";
+import { WorkspaceService } from "../../workspace/workspace.service";
+
+/** One selectable destination, flattened out of the container forest. */
+interface Destination {
+  id: string;
+  name: string;
+  emoji: string | null;
+  /** 0 for a project, 1 for a folder inside one. Drives the indent only. */
+  depth: number;
+  level: "project" | "folder";
+  /** Sealed and NOT unlocked for this session — cannot receive plaintext. */
+  blocked: boolean;
+}
+
+/** localStorage key for the destination the user filed into last. */
+const LAST_DESTINATION_KEY = "murmur.recording.lastDestination";
+
+/**
+ * Where the recording that just finished should live.
+ *
+ * A meeting is the one kind a user cannot create INTO a container: it creates
+ * itself the moment recording stops, so the placement decision has to happen
+ * after the fact or it never happens at all — which is how a vault ends up with
+ * every meeting in one undifferentiated pile. The card therefore appears on
+ * every resolved recording rather than only on unfiled ones: "you already filed
+ * this one" is a judgement this component cannot make honestly (a meeting lands
+ * in a DEFAULT destination, which is not the same as a chosen one), and asking
+ * once is cheaper than a wrong guess in either direction.
+ *
+ * Filing routes through `move_note`, which is the ONLY mover that carries the
+ * lock transitions: an open target moves the vault `.md`, a sealed target that
+ * is session-unlocked seals the meeting on arrival so plaintext never lands
+ * inside a sealed container, and a sealed target that is not unlocked is
+ * refused outright. Those rows are therefore rendered disabled here rather than
+ * offered and then rejected — the refusal is correct backend behaviour, but a
+ * destination a click cannot reach should not look clickable.
+ */
+@Component({
+  selector: "app-recording-placement",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: "./recording-placement.component.html",
+  styleUrl: "./recording-placement.component.scss",
+})
+export class RecordingPlacementComponent {
+  private readonly workspace = inject(WorkspaceService);
+  private readonly ipc = inject(IpcService);
+  private readonly toast = inject(ToastService);
+
+  /** The meeting to file. Null while nothing has resolved yet. */
+  readonly meetingId = input<string | null>(null);
+
+  /** Where this recording ended up, once the user has picked. */
+  private readonly _filedIn = signal<Destination | null>(null);
+  readonly filedIn = this._filedIn.asReadonly();
+
+  /** True while a move is in flight, so the list cannot be double-clicked. */
+  private readonly _filing = signal(false);
+  readonly filing = this._filing.asReadonly();
+
+  /** Set when the user chooses to keep the default destination for now. */
+  private readonly _dismissed = signal(false);
+  readonly dismissed = this._dismissed.asReadonly();
+
+  /** Free-text filter over destination names. */
+  readonly query = signal("");
+
+  /**
+   * Reset the card for each new recording.
+   *
+   * Without this the "Filed in X" confirmation from the PREVIOUS recording would
+   * still be showing when the next one resolves, and the user would believe a
+   * meeting had been filed that never was.
+   */
+  private readonly _resetPerMeeting = effect(() => {
+    this.meetingId();
+    this._filedIn.set(null);
+    this._dismissed.set(false);
+    this.query.set("");
+  });
+
+  /** Load the forest once, so the card has somewhere to offer. */
+  private readonly _load = effect(() => {
+    if (this.meetingId() && this.workspace.forestEmpty()) {
+      void this.workspace.reload();
+    }
+  });
+
+  readonly destinations = computed<Destination[]>(() => {
+    const flat: Destination[] = [];
+    const push = (node: ContainerNode, depth: number): void => {
+      flat.push({
+        id: node.id,
+        name: node.name,
+        emoji: node.emoji,
+        depth,
+        level: node.level,
+        blocked: node.locked && !node.unlocked,
+      });
+      for (const child of node.folders) {
+        push(child, depth + 1);
+      }
+    };
+    for (const project of this.workspace.forest()) {
+      push(project, 0);
+    }
+    return flat;
+  });
+
+  /**
+   * The filtered list, with the last-used destination hoisted to the top.
+   *
+   * Meetings cluster: the folder you filed the last one into is overwhelmingly
+   * the folder you want for this one, and making the user re-find it in a long
+   * list is what turns a two-second decision into one they stop making.
+   */
+  readonly visible = computed<Destination[]>(() => {
+    const needle = this.query().trim().toLowerCase();
+    const matches = needle
+      ? this.destinations().filter((d) => d.name.toLowerCase().includes(needle))
+      : this.destinations();
+    const last = readLastDestination();
+    if (!last) {
+      return matches;
+    }
+    const hoisted = matches.find((d) => d.id === last && !d.blocked);
+    return hoisted ? [hoisted, ...matches.filter((d) => d !== hoisted)] : matches;
+  });
+
+  readonly lastDestinationId = computed(() => readLastDestination());
+
+  readonly empty = computed(() => this.destinations().length === 0);
+
+  async file(destination: Destination): Promise<void> {
+    const meetingId = this.meetingId();
+    if (!meetingId || destination.blocked || this._filing()) {
+      return;
+    }
+    this._filing.set(true);
+    try {
+      await this.workspace.moveItem("meeting", meetingId, destination.id);
+      writeLastDestination(destination.id);
+      this._filedIn.set(destination);
+    } catch (error) {
+      this.toast.push(
+        `Could not file this recording: ${messageOf(error)}`,
+        "danger",
+      );
+    } finally {
+      this._filing.set(false);
+    }
+  }
+
+  /** Re-open the list after a successful file, so a mis-click is recoverable. */
+  change(): void {
+    this._filedIn.set(null);
+  }
+
+  dismiss(): void {
+    this._dismissed.set(true);
+  }
+}
+
+function readLastDestination(): string | null {
+  try {
+    return localStorage.getItem(LAST_DESTINATION_KEY);
+  } catch {
+    // A private window, cleared site data, or a browser blocking storage. The
+    // card works without the hoist; it must not fail to render over it.
+    return null;
+  }
+}
+
+function writeLastDestination(id: string): void {
+  try {
+    localStorage.setItem(LAST_DESTINATION_KEY, id);
+  } catch {
+    // Non-fatal — see readLastDestination.
+  }
+}
+
+function messageOf(error: unknown): string {
+  if (typeof error === "string") {
+    return error;
+  }
+  if (error && typeof error === "object" && "message" in error) {
+    return String((error as { message: unknown }).message);
+  }
+  return String(error);
+}


### PR DESCRIPTION
## What

A meeting is the one kind a user cannot create INTO a container — it creates itself the moment
recording stops. So the placement decision has to happen after the fact or it never happens at
all, which is how a vault ends up with every meeting in one undifferentiated pile.

When a recording resolves, a card asks where it should live and lists every project and folder.

- **Appears on every resolved recording.** "You already filed this one" is a judgement the
  component cannot make honestly: a meeting lands in a DEFAULT destination, which is not the same
  as a chosen one. Asking once is cheaper than a wrong guess in either direction.
- **Last-used destination first.** Meetings cluster; the folder you filed the last one into is
  overwhelmingly the one you want for this one.
- **Sealed destinations are visible but not clickable.** `move_note` refuses a sealed,
  not-session-unlocked target — there is no content key to seal the arriving meeting with — and is
  right to. But a destination a click cannot reach should not look clickable.
- **Filing routes through `move_note`**, the only mover carrying the lock transitions: an open
  target moves the vault `.md`; a sealed-but-session-unlocked target seals the meeting on arrival
  so plaintext never lands inside a sealed container.

## Also: dead code the single-hierarchy sidebar left in the app shell

`#600` removed the per-type trees from the shell template but left two `viewChild`s pointing at
them and three commands that existed only to forward into those children. Every forward was
`?.`-guarded, so each had become a command that looks like it runs and does nothing. None was
reachable from the template — the hierarchy owns all three actions now — so they are removed
along with the two NG8113 warnings they were producing.

## Verification

- `npx ng build` / `npx ng lint` green.
- `npx playwright test e2e/record/ e2e/shell/` — 124 passed (chromium + webkit).
- New spec `e2e/record/recording-placement.spec.ts` asserts against the real invoke path: picking
  a destination calls `move_note` with THAT container id (recorded in the page, because mock
  overrides are stringified into it), and the sealed row is disabled.
- **RED verified**: dropping the `[disabled]` binding makes the locked row clickable and the spec
  fails with `Expected: disabled / Received: enabled`.
