### PR TITLE
feat(workspace): create dashboards in a container, and drag every kind

### DIFF
--- a/e2e/shell/workspace-dnd.spec.ts
+++ b/e2e/shell/workspace-dnd.spec.ts
@@ -25,7 +25,14 @@ const FOREST = [
         kind: "task",
         total: 1,
         items: [
-          { kind: "task", id: "t-1", title: "Zadanie", durationS: null, sortAt: 1 },
+          { kind: "task", id: "t-1", title: "Ship the thing", durationS: null, sortAt: 1 },
+        ],
+      },
+      {
+        kind: "dashboard",
+        total: 1,
+        items: [
+          { kind: "dashboard", id: "d-1", title: "Q3 board", durationS: null, sortAt: 0 },
         ],
       },
     ],
@@ -64,8 +71,23 @@ async function open(page: Page): Promise<void> {
     page,
     {
       move_note: (args: unknown) => {
-        (globalThis as unknown as { __moves: unknown[] }).__moves ??= [];
-        (globalThis as unknown as { __moves: unknown[] }).__moves.push(args);
+        const w = globalThis as unknown as { __moves?: unknown[] };
+        (w.__moves ??= []).push({ cmd: "move_note", args });
+        return null;
+      },
+      move_note_doc: (args: unknown) => {
+        const w = globalThis as unknown as { __moves?: unknown[] };
+        (w.__moves ??= []).push({ cmd: "move_note_doc", args });
+        return null;
+      },
+      move_dashboard_to_container: (args: unknown) => {
+        const w = globalThis as unknown as { __moves?: unknown[] };
+        (w.__moves ??= []).push({ cmd: "move_dashboard_to_container", args });
+        return null;
+      },
+      set_task_container: (args: unknown) => {
+        const w = globalThis as unknown as { __moves?: unknown[] };
+        (w.__moves ??= []).push({ cmd: "set_task_container", args });
         return null;
       },
     },
@@ -77,20 +99,62 @@ async function open(page: Page): Promise<void> {
   await page.getByRole("button", { name: "Expand Meetings" }).click();
 }
 
-test("a meeting is draggable and a task is not", async ({ page }) => {
+test("every kind the tree renders is draggable", async ({ page }) => {
   await open(page);
 
-  const meeting = page.getByRole("treeitem", { name: /Standup/ });
-  await expect(meeting).toHaveAttribute("draggable", "true");
-
-  // Neither a task nor a dashboard has a container anchor yet, so a drop would have
-  // nowhere to file it — and a row that cannot be dropped anywhere must not look
-  // draggable.
-  await page.getByRole("button", { name: "Expand Tasks" }).click();
-  await expect(page.getByRole("treeitem", { name: /Zadanie/ })).not.toHaveAttribute(
+  // This test used to assert the OPPOSITE for tasks and dashboards, and was right to: neither
+  // had a container anchor, so a drag would have been a gesture with nothing behind it. Both
+  // gained a backend mover, and a row a user can see under a project is a row they will try to
+  // drag out of it.
+  await expect(page.getByRole("treeitem", { name: /Standup/ })).toHaveAttribute(
     "draggable",
     "true",
   );
+
+  await page.getByRole("button", { name: "Expand Tasks" }).click();
+  await expect(page.getByRole("treeitem", { name: /Ship the thing/ })).toHaveAttribute(
+    "draggable",
+    "true",
+  );
+
+  await page.getByRole("button", { name: "Expand Dashboards" }).click();
+  await expect(page.getByRole("treeitem", { name: /Q3 board/ })).toHaveAttribute(
+    "draggable",
+    "true",
+  );
+});
+
+test("each kind is filed through its OWN backend mover", async ({ page }) => {
+  await open(page);
+
+  // The four kinds do NOT share a command, and the id alone cannot say which one to call — a
+  // single mover for all of them would file a board through the note path and lose it. Each
+  // drag is checked for the command AND its argument shape, against the real invoke path.
+  await page
+    .getByRole("treeitem", { name: /Standup/ })
+    .dragTo(page.getByRole("treeitem", { name: /Target/ }));
+
+  await page.getByRole("button", { name: "Expand Dashboards" }).click();
+  await page
+    .getByRole("treeitem", { name: /Q3 board/ })
+    .dragTo(page.getByRole("treeitem", { name: /Target/ }));
+
+  await page.getByRole("button", { name: "Expand Tasks" }).click();
+  await page
+    .getByRole("treeitem", { name: /Ship the thing/ })
+    .dragTo(page.getByRole("treeitem", { name: /Target/ }));
+
+  const moves = await page.evaluate(
+    () => (globalThis as unknown as { __moves?: unknown[] }).__moves ?? [],
+  );
+  expect(moves).toEqual([
+    { cmd: "move_note", args: { meetingId: "m-1", folderId: "p-target" } },
+    {
+      cmd: "move_dashboard_to_container",
+      args: { id: "d-1", folderId: "p-target" },
+    },
+    { cmd: "set_task_container", args: { id: "t-1", containerId: "p-target" } },
+  ]);
 });
 
 test("dropping a meeting on a container files it there", async ({ page }) => {
@@ -106,7 +170,9 @@ test("dropping a meeting on a container files it there", async ({ page }) => {
   const moves = await page.evaluate(
     () => (globalThis as unknown as { __moves?: unknown[] }).__moves ?? [],
   );
-  expect(moves).toEqual([{ meetingId: "m-1", folderId: "p-target" }]);
+  expect(moves).toEqual([
+    { cmd: "move_note", args: { meetingId: "m-1", folderId: "p-target" } },
+  ]);
 });
 
 test("a sealed container is not a drop target", async ({ page }) => {

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -3050,6 +3050,53 @@ export class IpcService {
   }
 
   /**
+   * Create a dashboard, optionally INSIDE a container.
+   *
+   * `folderId` is the board's container anchor and its LOCK anchor: a board with no folder
+   * cannot be sealed, because there is no folder whose key would seal it. The backend refuses a
+   * container that is sealed and not session-unlocked, for the same reason it refuses filing a
+   * note there — a board created inside a sealed tree would be born readable.
+   */
+  createDashboardIn(
+    title: string,
+    folderId: string | null,
+    emoji?: string | null,
+    tint?: string | null,
+  ): Promise<Dashboard> {
+    return invoke<Dashboard>("create_dashboard", {
+      title,
+      emoji: emoji ?? null,
+      tint: tint ?? null,
+      folderId,
+    });
+  }
+
+  /**
+   * File a task into a local container, or unfile it with `containerId: null`.
+   *
+   * Placement is LOCAL and never egresses — it is not part of the task envelope that reaches an
+   * org, so a user's private folder structure stays on the device. Sealing a container unfiles
+   * the tasks in it, because a task's content lives in the org's E2EE store and a folder key
+   * cannot seal it; leaving one inside would mean the lock said sealed while the task stayed as
+   * readable as before.
+   */
+  setTaskContainer(id: string, containerId: string | null): Promise<void> {
+    return invoke<void>("set_task_container", { id, containerId });
+  }
+
+  /**
+   * Re-file a dashboard into a container, or unfile it with `folderId: null`.
+   *
+   * Refused at BOTH ends when sealed, for different reasons: a sealed TARGET would receive the
+   * board in plaintext inside a tree the user believes is unreadable, and a sealed SOURCE holds
+   * that board as ciphertext bound to its current container — moving the row without unsealing
+   * first would carry blobs somewhere no key can open them.
+   */
+  moveDashboardToContainer(id: string, folderId: string | null): Promise<void> {
+    return invoke<void>("move_dashboard_to_container", { id, folderId });
+  }
+
+  /**
    * ESCAPE HATCH for a folder whose master key is genuinely unrecoverable: the backend FIRST
    * proves no key can unwrap it (else it refuses with a "key was found — unlock normally" error),
    * then discards ONLY that folder's UNRECOVERABLE sealed contents (never-sealed readable content is

--- a/src/app/features/folders/note-drag.service.ts
+++ b/src/app/features/folders/note-drag.service.ts
@@ -6,7 +6,16 @@ import { Injectable, computed, signal } from "@angular/core";
  * Tasks and dashboards are absent on purpose: neither has a container anchor yet,
  * so a drop would have nowhere to file it. They join when their backend halves do.
  */
-export type DraggableKind = "meeting" | "note";
+/**
+ * What can be dragged into a container.
+ *
+ * All four kinds the hierarchy renders, because a row a user can see under a project is a row
+ * they will try to drag out of it — and the three that silently ignored the gesture were the
+ * ones that had no mover behind them, not the ones that were meant to sit still. Each kind
+ * moves through its OWN backend command (see `WorkspaceService.moveItem`); the kind travels with
+ * the payload precisely because the id alone cannot say which one.
+ */
+export type DraggableKind = "meeting" | "note" | "dashboard" | "task";
 
 /** The in-flight drag: an id is not enough, because the two kinds move differently. */
 interface DragPayload {

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.html
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.html
@@ -110,6 +110,13 @@
               <button type="button" role="menuitem" (click)="newFolder(line.container)">
                 New folder
               </button>
+              <button
+                type="button"
+                role="menuitem"
+                (click)="newDashboard(line.container)"
+              >
+                New dashboard
+              </button>
             </mur-row-menu>
           }
           <mur-row-menu

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
@@ -243,8 +243,26 @@ export class WorkspaceTreeComponent {
    * container anchor yet, so a drop would have nowhere to file it. A row that
    * cannot be dropped anywhere must not look draggable.
    */
+  /**
+   * Every kind the tree renders is draggable, because every one now has a mover behind it.
+   *
+   * This used to admit only meetings and notes — correctly, at the time: a dashboard had no
+   * container to move between and a task had no local placement at all, so a drag would have
+   * been a gesture with nothing to do. Both gained a backend half, and a row a user can see
+   * under a project is a row they will try to drag out of it. `ItemKind` and `DraggableKind` are
+   * kept as separate types on purpose: they agree today, and the day a kind is renderable but
+   * not movable, this function is where that is said.
+   */
   protected draggableKind(item: ItemRow): DraggableKind | null {
-    return item.kind === "meeting" || item.kind === "note" ? item.kind : null;
+    switch (item.kind) {
+      case "meeting":
+      case "note":
+      case "dashboard":
+      case "task":
+        return item.kind;
+      default:
+        return null;
+    }
   }
 
   protected onDragStart(event: DragEvent, item: ItemRow): void {
@@ -327,6 +345,11 @@ export class WorkspaceTreeComponent {
 
   protected async newFolder(container: ContainerNode): Promise<void> {
     await this.workspace.createFolder(container.id, "New folder");
+  }
+
+  protected async newDashboard(container: ContainerNode): Promise<void> {
+    const id = await this.workspace.createDashboard(container.id, "New dashboard");
+    await this.router.navigate(["/dashboards", id]);
   }
 
   /**

--- a/src/app/features/workspace/workspace.service.ts
+++ b/src/app/features/workspace/workspace.service.ts
@@ -80,10 +80,11 @@ export class WorkspaceService {
   /**
    * Create a note inside a container and return its id.
    *
-   * Only NOTES and FOLDERS can be created into a container today. Dashboards have
-   * no container anchor yet and tasks are org-scoped, so offering either here would
-   * create something that does not land where the user asked — worse than not
-   * offering it. They arrive with their backend halves.
+   * Notes, folders and dashboards can be created into a container. Tasks cannot, and that is
+   * not an oversight: a task belongs to an ORGANIZATION, so creating one needs an org and an
+   * assignee that a container cannot supply. A task reaches a container by being FILED into one
+   * afterwards ({@link fileTask}), which is the same shape a meeting uses and for the same
+   * reason — the thing exists first, the placement is a second, separate decision.
    */
   async createNote(containerId: string, title: string): Promise<string> {
     const id = await this.ipc.createNote(containerId, title);
@@ -97,6 +98,19 @@ export class WorkspaceService {
     await this.reload();
   }
 
+  /** Create a dashboard inside a container and return its id. */
+  async createDashboard(containerId: string, title: string): Promise<string> {
+    const board = await this.ipc.createDashboardIn(title, containerId);
+    await this.reload();
+    return board.id;
+  }
+
+  /** File an existing task into a container (or unfile it with `null`). */
+  async fileTask(taskId: string, containerId: string | null): Promise<void> {
+    await this.ipc.setTaskContainer(taskId, containerId);
+    await this.reload();
+  }
+
   /**
    * Move an item into a container.
    *
@@ -107,10 +121,18 @@ export class WorkspaceService {
    * that is sealed and not unlocked is refused.
    */
   async moveItem(kind: DraggableKind, id: string, containerId: string): Promise<void> {
-    if (kind === "meeting") {
-      await this.ipc.moveNote(id, containerId);
-    } else {
-      await this.ipc.moveNoteDoc(id, containerId);
+    switch (kind) {
+      case "meeting":
+        await this.ipc.moveNote(id, containerId);
+        break;
+      case "dashboard":
+        await this.ipc.moveDashboardToContainer(id, containerId);
+        break;
+      case "task":
+        await this.ipc.setTaskContainer(id, containerId);
+        break;
+      default:
+        await this.ipc.moveNoteDoc(id, containerId);
     }
     await this.reload();
   }


### PR DESCRIPTION
> **Depends on the container-anchor backend.** This branch calls
> `move_dashboard_to_container` and `set_task_container`, which do not exist on `murmur` yet.
> CI here is green regardless — the e2e mocks the transport, and Rust never sees an FE call — so
> **do not merge this before the backend PR.** That gap is precisely the trap
> `.claude/rules/angular-zoneless.md` T6 records: a hand-written mock DEFINES a contract, it does
> not verify one. Held as a draft for that reason.

## What

The container's `+` menu offered "New note" and "New folder" and stopped there, and only meetings
and notes were draggable. Both were correct at the time — a dashboard had no container to be
created into or moved between, and a task had no local placement at all — so the missing entries
were missing backends, not missing UI. Both gained their backend halves, so the UI catches up.

- **"New dashboard"** joins the `+` menu and opens the new board.
- **All four kinds are draggable.** A row a user can see under a project is a row they will try to
  drag out of it, and three of the four silently ignored the gesture.
- **Each kind is filed through its OWN command** — `move_note`, `move_note_doc`,
  `move_dashboard_to_container`, `set_task_container`. The id alone cannot say which one to call,
  which is why the kind travels with the drag payload; one shared mover would file a board through
  the note path and lose it.

`DraggableKind` and `ItemKind` stay separate types on purpose. They agree today, and
`draggableKind()` is where it gets said on the day a kind is renderable but not movable.

## Verification

- `npx ng build` / `npx ng lint` green.
- `npx playwright test e2e/shell/` — 56 passed (chromium + webkit).
- The dnd spec's "a meeting is draggable and a task is not" asserted a reason that no longer
  holds, so it is replaced by what is now true, plus a routing test pinning each kind to its own
  command **and** argument shape.
- **RED verified**: removing the dashboard case from `moveItem` files a board through
  `move_note_doc`, and the routing test fails on exactly that substitution
  (`- "move_dashboard_to_container" / + "move_note_doc"`).

Also renames a Polish fixture title in an English app.
