### PR TITLE
feat(workspace): organize a project or folder with AI, from its own menu

### DIFF
--- a/e2e/shell/container-organize.spec.ts
+++ b/e2e/shell/container-organize.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+const FOREST = [
+  {
+    id: "p-acme",
+    name: "Acme",
+    level: "project",
+    emoji: null,
+    tint: null,
+    locked: false,
+    unlocked: false,
+    isRoot: false,
+    folders: [],
+    groups: [],
+  },
+  {
+    id: "p-sealed",
+    name: "Clients",
+    level: "project",
+    emoji: null,
+    tint: null,
+    locked: true,
+    unlocked: false,
+    isRoot: false,
+    folders: [],
+    groups: [],
+  },
+];
+
+const PLAN = {
+  moves: [
+    {
+      noteId: "n-1",
+      title: "Standup 14 Aug",
+      fromFolder: "Acme",
+      toFolder: "Standups",
+      toFolderId: null,
+    },
+  ],
+};
+
+async function open(page: Page): Promise<void> {
+  await page.setViewportSize({ width: 1280, height: 1000 });
+  await mockTauri(
+    page,
+    {
+      plan_organize_notes: (args: unknown) => {
+        const w = globalThis as unknown as { __planned?: unknown[]; __plan: unknown };
+        (w.__planned ??= []).push(args);
+        return w.__plan;
+      },
+      apply_organize_plan: (args: unknown) => {
+        const w = globalThis as unknown as { __applied?: unknown[] };
+        (w.__applied ??= []).push(args);
+        return null;
+      },
+    },
+    { list_workspace_tree: FOREST },
+  );
+  await page.addInitScript((plan) => {
+    (globalThis as unknown as { __plan: unknown }).__plan = plan;
+  }, PLAN);
+  await page.goto("/");
+  await expect(page.getByRole("tree", { name: "Workspace" })).toBeVisible();
+}
+
+/**
+ * The AI organizer is scoped to the CONTAINER the user asked about.
+ *
+ * The planner and its review sheet already existed, reachable only from the Notes home header and
+ * scoped to whichever note-folder happened to be active. The thing a user wants to tidy is a
+ * project or a folder, and the hierarchy is where those are named — so the action moved to the
+ * container's own actions menu, and the container id has to travel with it. A planner called with
+ * the wrong scope reads the wrong notes and proposes moves for files the user was not looking at.
+ */
+test("organizing a container plans for THAT container", async ({ page }) => {
+  await open(page);
+
+  await page.getByRole("button", { name: "Actions for Acme" }).click();
+  await page.locator("[data-testid='organize-container']").click();
+
+  const planned = await page.evaluate(
+    () => (globalThis as unknown as { __planned?: unknown[] }).__planned ?? [],
+  );
+  expect(planned).toEqual([{ folderId: "p-acme" }]);
+
+  // Non-destructive: the review sheet is up and NOTHING has moved yet. An AI that silently
+  // re-filed a vault would be a feature nobody could trust twice.
+  await expect(page.getByText("Standups")).toBeVisible();
+  const appliedBeforeConfirm = await page.evaluate(
+    () => (globalThis as unknown as { __applied?: unknown[] }).__applied ?? [],
+  );
+  expect(appliedBeforeConfirm).toEqual([]);
+});
+
+/**
+ * A SEALED container does not offer the action.
+ *
+ * The planner reads titles and body excerpts to classify them, and those reads are gated — so for
+ * a sealed container it can only ever return an empty plan. Offering an action that cannot do
+ * anything is worse than not offering it: the user reads the empty result as the feature failing.
+ */
+test("a sealed container does not offer the organizer", async ({ page }) => {
+  await open(page);
+
+  await page.getByRole("button", { name: "Actions for Clients" }).click();
+  await expect(page.locator("[data-testid='organize-container']")).toHaveCount(0);
+});

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.html
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.html
@@ -131,6 +131,17 @@
                 Lock again
               </button>
             }
+            @if (canOrganize(line.container)) {
+              <button
+                type="button"
+                role="menuitem"
+                [disabled]="organizePlanning()"
+                (click)="organize(line.container)"
+                data-testid="organize-container"
+              >
+                {{ organizePlanning() ? "Reading this folder…" : "Organize with AI" }}
+              </button>
+            }
             <button type="button" role="menuitem" (click)="rename(line.container)">
               Rename
             </button>
@@ -160,4 +171,16 @@
       }
     }
   </div>
+}
+
+<!-- The auto-organize review sheet — ONE instance for the whole tree, not one per row: it is a
+     modal, only one container is ever being organized, and a per-row instance would build a
+     dialog for every container in the vault. Its own opaque overlay (T3). -->
+@if (organizePlan()) {
+  <app-organize-sheet
+    [plan]="organizePlan()"
+    [busy]="organizeApplying()"
+    (apply)="applyOrganize($event)"
+    (cancelled)="closeOrganize()"
+  />
 }

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
@@ -4,6 +4,7 @@ import {
   computed,
   inject,
   input,
+  signal,
 } from "@angular/core";
 import { Router } from "@angular/router";
 
@@ -17,7 +18,17 @@ import {
   MurTreeRowComponent,
   type TreeRowIcon,
 } from "../../../design-system/tree-row/tree-row.component";
-import type { ContainerNode, ItemKind, ItemRow, TypeGroup } from "../../../core/models";
+import type {
+  ContainerNode,
+  ItemKind,
+  ItemRow,
+  OrganizeMove,
+  OrganizePlan,
+  TypeGroup,
+} from "../../../core/models";
+import { IpcService } from "../../../core/ipc.service";
+import { OrganizeSheetComponent } from "../../notes/organize-sheet/organize-sheet.component";
+import { ToastService } from "../../../services/toast.service";
 import { FolderLockFlowService } from "../../../services/folder-lock-flow.service";
 import { FoldersService } from "../../../services/folders.service";
 import { NotesService } from "../../../services/notes.service";
@@ -37,7 +48,7 @@ export interface TreeLine {
   seeAll?: boolean;
 }
 
-/** Polish labels for the four kinds, in the order the backend emits them. */
+/** Group headings for the four kinds, in the order the backend emits them. */
 const KIND_LABEL: Record<ItemKind, string> = {
   meeting: "Meetings",
   note: "Notes",
@@ -75,12 +86,19 @@ const KIND_ROUTE: Record<ItemKind, string> = {
 @Component({
   selector: "app-workspace-tree",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [FolderDropDirective, MurRowMenuComponent, MurTreeRowComponent],
+  imports: [
+    FolderDropDirective,
+    MurRowMenuComponent,
+    MurTreeRowComponent,
+    OrganizeSheetComponent,
+  ],
   templateUrl: "./workspace-tree.component.html",
   styleUrl: "./workspace-tree.component.scss",
 })
 export class WorkspaceTreeComponent {
   private readonly router = inject(Router);
+  private readonly ipc = inject(IpcService);
+  private readonly toast = inject(ToastService);
   protected readonly workspace = inject(WorkspaceService);
   private readonly drag = inject(NoteDragService);
   private readonly folders = inject(FoldersService);
@@ -397,6 +415,74 @@ export class WorkspaceTreeComponent {
   /** The reserved note root can never be sealed, so it is never offered a lock. */
   protected canLock(container: ContainerNode): boolean {
     return !container.isRoot && !container.locked;
+  }
+
+  // ── AI organize, per container ────────────────────────────────────────────
+  //
+  // The planner and the review sheet already existed; they were reachable only
+  // from the Notes home header, scoped to whichever note-folder happened to be
+  // active. That is the wrong place for them now: the thing a user wants to
+  // tidy is a PROJECT or a FOLDER, and the hierarchy is where those are named.
+  //
+  // Two-step and non-destructive, unchanged: `plan_organize_notes` PROPOSES,
+  // the sheet lets the user drop individual moves, and nothing moves until
+  // `apply_organize_plan`. An AI that silently re-filed a vault would be a
+  // feature nobody could trust twice.
+
+  /** The proposed plan; `null` means the sheet is closed. */
+  protected readonly organizePlan = signal<OrganizePlan | null>(null);
+  /** True while the plan is being fetched (the menu entry says so). */
+  protected readonly organizePlanning = signal(false);
+  /** True while the apply is in flight (the sheet's own spinner). */
+  protected readonly organizeApplying = signal(false);
+
+  /**
+   * A sealed container cannot be organized, and the reason is the planner's:
+   * it reads titles and body excerpts to classify them, and those reads are
+   * gated. Offering the action would produce an empty plan and look broken.
+   */
+  protected canOrganize(container: ContainerNode): boolean {
+    return !container.locked || container.unlocked;
+  }
+
+  protected async organize(container: ContainerNode): Promise<void> {
+    if (this.organizePlanning() || this.organizePlan()) {
+      return;
+    }
+    this.organizePlanning.set(true);
+    try {
+      const plan = await this.ipc.planOrganizeNotes(container.id);
+      if (plan.moves.length === 0) {
+        this.toast.info(`Nothing to re-file in ${container.name}.`);
+        return;
+      }
+      this.organizePlan.set(plan);
+    } catch {
+      this.toast.danger("Couldn't plan an auto-organize. Please try again.");
+    } finally {
+      this.organizePlanning.set(false);
+    }
+  }
+
+  protected async applyOrganize(moves: OrganizeMove[]): Promise<void> {
+    if (moves.length === 0) {
+      this.closeOrganize();
+      return;
+    }
+    this.organizeApplying.set(true);
+    try {
+      await this.ipc.applyOrganizePlan({ moves });
+      await this.workspace.reload();
+      this.closeOrganize();
+    } catch {
+      this.toast.danger("Couldn't apply the plan. Nothing was moved.");
+    } finally {
+      this.organizeApplying.set(false);
+    }
+  }
+
+  protected closeOrganize(): void {
+    this.organizePlan.set(null);
   }
 
   protected openGroup(container: ContainerNode, group: TypeGroup): void {


### PR DESCRIPTION
## What

The AI organizer already existed — planner command, review sheet, plan/apply flow. It was
reachable only from the Notes home header, scoped to whichever note-folder happened to be active.

That is the wrong place for it now. The thing a user wants to tidy is a **project** or a
**folder**, and the hierarchy is where those are named. So the action moves to the container's own
actions menu, and the container id travels with it.

**The scope is the whole point.** A planner called without a container reads the entire vault and
proposes moves for files the user was not looking at.

## What stays exactly as it was

- **Two-step and non-destructive.** `plan_organize_notes` PROPOSES; the sheet lets the user drop
  individual moves; nothing moves until `apply_organize_plan`. An AI that silently re-filed a
  vault would be a feature nobody could trust twice.
- The planner's own gating, redaction and provider selection are untouched — this reaches the same
  command from a different button.

## What is new

- **A sealed container does not offer the action.** The planner reads titles and body excerpts to
  classify them, and those reads are gated — so for a sealed container it can only ever return an
  empty plan. An action that cannot do anything is worse than no action: the user reads the empty
  result as the feature failing.
- **One sheet instance for the whole tree**, not one per row. Only one container is ever being
  organized, and a per-row instance would build a dialog for every container in the vault.
- An empty plan says so in a toast instead of opening an empty sheet.

## Verification

- `npx ng build` / `npx ng lint` green.
- `npx playwright test e2e/shell/` — 58 passed (chromium + webkit).
- New spec asserts the planner is called with THAT container's id, that nothing is applied before
  the user confirms, and that a sealed container has no menu entry.
- **RED verified**: dropping the container id makes the planner run vault-wide, and the scoping
  test fails on exactly that substitution (`- "p-acme" / + null`).

Also corrects a stale comment that described the English group headings as Polish.
