### PR TITLE
fix(cli): give the process-group proof its own teardown budget

### DIFF
--- a/src-tauri/src/summarize/claude_code.rs
+++ b/src-tauri/src/summarize/claude_code.rs
@@ -320,7 +320,24 @@ async fn kill_and_reap_external_cli(
     let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
     match tokio::time::timeout(remaining, child.wait()).await {
         Ok(Ok(_)) => {
-            kill_and_prove_group_dead(group.pgid(), deadline).await?;
+            // A FRESH budget, not the remainder of the one `child.wait()` just spent. These are
+            // two different waits on two different things: reaping OUR direct child, and then
+            // proving the whole isolated group empty — which depends on the OS reaping
+            // grandchildren the CLI spawned and that our kill orphaned. `kill(-pgid, 0)` reports
+            // a zombie as alive, so the group can look occupied for a moment after every process
+            // in it is dead, and that moment is not ours to control.
+            //
+            // Sharing one deadline meant a slow child reap silently ate the group proof's entire
+            // budget: `child.wait()` taking 4.9s of 5s left the proof 100ms, it timed out, and
+            // the group was marked Unproven — permanently, since that marker is sticky. That is
+            // not a cosmetic failure. `perf::…` refuses recording admission while any group is
+            // unproven, so a teardown that merely ran late could leave a user unable to start
+            // recording until the app restarted.
+            kill_and_prove_group_dead(
+                group.pgid(),
+                tokio::time::Instant::now() + CLAUDE_REAP_TIMEOUT,
+            )
+            .await?;
             group.mark_proven_dead();
             Ok(())
         }
@@ -1289,6 +1306,78 @@ mod tests {
             Some("claude-opus-4-8".to_string()),
             "the --model override rides the shared seam: {args:?}"
         );
+    }
+
+    /// A timed-out child is torn down and leaves NO unproven process group.
+    ///
+    /// SCOPE, stated plainly because the name of this test used to overclaim: it is a smoke test
+    /// for the teardown path, NOT a regression test for the budget split below it. It passes both
+    /// with and without that change, and it was verified to do so rather than assumed.
+    ///
+    /// The reason is that the coupling cannot be driven from a test. Teardown does two different
+    /// waits — reaping OUR direct child, then proving the isolated group empty, which depends on
+    /// the OS reaping grandchildren our kill orphaned. Sharing one deadline means a slow child
+    /// reap eats the group proof's budget. But the kill is SIGKILL, which cannot be trapped or
+    /// delayed, so there is no way to make the first wait slow on demand and no way to reach the
+    /// failing branch deterministically. The fix (a fresh budget for the second wait) rests on
+    /// reading the code, not on a red test, and that is recorded here rather than papered over
+    /// with a green one that proves something else.
+    ///
+    /// What this test DOES pin, and what would have caught a real regression in it: a wedged child
+    /// with a grandchild is killed, reaped, and its group proven dead — so `has_unproven_process_group`
+    /// stays false. That marker is sticky and recording admission refuses while any group carries
+    /// it, so a teardown that stopped proving groups dead would silently cost the user the ability
+    /// to record until they restarted the app.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_timed_out_child_leaves_no_unproven_process_group() {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+
+        let script = crate::storage::db::unique_temp_path("murmur-teardown-budget", "sh");
+        let mut file = std::fs::File::create(&script).unwrap();
+        // A grandchild, so the group holds more than the direct child: that is the shape whose
+        // reaping the app does not control, and the reason the second wait exists at all.
+        writeln!(file, "#!/bin/sh").unwrap();
+        writeln!(file, "/bin/sleep 30 &").unwrap();
+        writeln!(file, "/bin/sleep 30").unwrap();
+        drop(file);
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let mut command = Command::new(&script);
+        command.stdin(std::process::Stdio::piped());
+        command.stdout(std::process::Stdio::piped());
+        command.stderr(std::process::Stdio::piped());
+        isolate_process_group(&mut command);
+        let child = command.spawn().unwrap();
+
+        let result = run_external_cli_child_with_timeout(
+            child,
+            b"",
+            "teardown budget probe",
+            Duration::from_millis(200),
+        )
+        .await;
+
+        // The probe itself must fail as a timeout — otherwise the fixture never reached the
+        // teardown path and this oracle proves nothing at all.
+        let Err(AppError::Summarize(reason)) = result else {
+            panic!("a wedged child must time out");
+        };
+        assert!(
+            reason.contains("timed out after"),
+            "the fixture must reach the timeout path: {reason}"
+        );
+        assert!(
+            !reason.contains("teardown failed"),
+            "teardown must complete inside its budget: {reason}"
+        );
+        assert!(
+            !has_unproven_process_group(),
+            "a timed-out child left an unproven process group"
+        );
+
+        let _ = std::fs::remove_file(script);
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## What

External-CLI teardown does two different waits on two different things: reaping **our direct
child**, then proving the **isolated process group** empty. The second depends on the OS reaping
grandchildren the CLI spawned and our kill orphaned, and `kill(-pgid, 0)` reports a zombie as
alive — so a group can look occupied for a moment after every process in it is dead, and that
moment is not ours to control.

They shared one five-second deadline. A `child.wait()` taking 4.9s of it left the group proof
100ms; the proof timed out and the group was marked `Unproven`.

**That marker is sticky, and `perf::…` refuses recording admission while any group carries it.** So
a teardown that merely ran late could cost a user the ability to start recording until they
restarted the app.

The fix gives the group proof its own budget. Worst case a teardown takes 10s instead of 5s.

## What this does NOT fix — corrected

This change was written after `availability_version_probe_has_a_short_deadline_and_reaps_its_group`
failed on CI, and the first version of this description implied the two were connected.

**They are not.** That test has now failed **three times** on CI, and the third time was on THIS
branch, with this fix applied. A fix present while the failure recurs is a fix that does not
address it. The earlier "intermittent, mechanism unproven" framing was too generous to the change;
this is a disproof, not an open question.

So: the flake is real, recurring, CI-only (never reproduced locally), and **unexplained**. It is
not this. Whoever picks it up should start from that, rather than from the budget coupling.

## What the fix rests on

Its own reasoning: two independent waits should not share one budget, and the consequence of the
second one losing is a sticky marker that blocks recording. That argument stands on reading the
code, and **there is no red test behind it**.

An earlier draft of the accompanying test was named
`a_slow_child_reap_does_not_consume_the_group_proof_budget` and claimed "RED against the shared
deadline, GREEN once the proof gets its own". Running it against the unfixed code showed it
**passed** — a green test decorating a change it never exercised. SIGKILL cannot be trapped or
delayed, so there is no way to make the first wait slow on demand. It is renamed to
`a_timed_out_child_leaves_no_unproven_process_group`, which is what it actually pins, and its
comment records that it passes either way and that this was verified rather than assumed.

What the test does cover: a wedged child with a grandchild is killed, reaped, and its group proven
dead, so `has_unproven_process_group` stays false.

## Verification

- `cargo test --lib` for the affected tests: green.
- Verified the test passes with AND without the fix — which is the point of the rename.
