### PR TITLE
feat(hierarchy): container anchors for dashboards and tasks

### DIFF
--- a/src-tauri/src/commands/dashboards.rs
+++ b/src-tauri/src/commands/dashboards.rs
@@ -360,15 +360,49 @@ fn iso_to_epoch_secs(iso: &str) -> Option<i64> {
 
 // ── board CRUD ─────────────────────────────────────────────────────────────────────────────────
 
-/// Every board with its layout metadata. No gated read happens here — a summary carries only the
-/// user's own chrome (title/emoji/tint) plus tile kinds, never a source's title.
+/// Every board with its layout metadata — GATED.
+///
+/// The doc here used to say no gated read happens, because a summary carries only the user's own
+/// chrome. That was true while a board could not live in a folder: with no container there was no
+/// lock that could cover it. Now that a board can be filed, its own title is content — "Q3 layoffs"
+/// names the thing whether or not a single tile is readable — so a board whose container is sealed
+/// and not session-unlocked comes back masked.
 #[tauri::command]
 pub fn list_dashboards(state: State<'_, AppState>) -> Result<Vec<DashboardSummaryDto>, AppError> {
-    let boards = state.db.list_dashboards()?;
+    list_dashboards_inner(state.inner())
+}
+
+/// Body of [`list_dashboards`], taking `&AppState`.
+///
+/// Split out because the sealed-board masking below lives HERE, at the command layer, and a gate
+/// no test can reach is a gate whose tests end up aimed one layer down — which is exactly what
+/// happened: the first round asserted on `Db::list_dashboards_visible`, which masks the row, and
+/// stayed green while the tile count and kinds assembled here still shipped.
+pub(crate) fn list_dashboards_inner(
+    state: &AppState,
+) -> Result<Vec<DashboardSummaryDto>, AppError> {
+    // Hold the lifecycle guard across the gate AND the tile read, for the same reason
+    // `get_dashboard` does: a relock landing between the two would judge tiles against a
+    // snapshot that is already stale.
+    let _lifecycle = super::lifecycle_guard(state);
+    let unlocked = crate::commands::unlocked_snapshot(state)?;
+    let boards = state.db.list_dashboards_visible(&unlocked)?;
     let kinds = state.db.dashboard_tile_kinds()?;
     let out = boards
         .into_iter()
         .map(|d| {
+            // A sealed board discloses NO tiles — not their kinds and not their number.
+            // `list_dashboards_visible` masks the row, but the summary is assembled from a
+            // SEPARATE ungated read, so masking the row alone still shipped "this locked board
+            // is built from three meetings and a note". Tile shape is exactly the kind of
+            // structural fact a lock exists to withhold.
+            if d.locked {
+                return DashboardSummaryDto {
+                    tile_count: 0,
+                    tile_kinds: Vec::new(),
+                    dashboard: d,
+                };
+            }
             let tile_kinds: Vec<TilePreviewDto> = kinds
                 .iter()
                 .filter(|(board_id, _, _)| board_id == &d.id)
@@ -393,6 +427,7 @@ pub fn create_dashboard(
     title: String,
     emoji: Option<String>,
     tint: Option<String>,
+    folder_id: Option<String>,
 ) -> Result<Dashboard, AppError> {
     let _lifecycle = super::lifecycle_guard(state.inner());
     if state.db.dashboard_count()? >= MAX_DASHBOARDS {
@@ -403,11 +438,30 @@ pub fn create_dashboard(
     let title = clean_title(&title, "title")?;
     let id = uuid::Uuid::new_v4().to_string();
     let now = now_iso();
-    state.db.insert_dashboard(
+    // A board created INTO a sealed container would be born readable inside a sealed tree —
+    // the same hazard the container-creation guard closes for folders. The seal is per
+    // container and runs on lock, so refuse rather than create something the existing lock
+    // will not cover.
+    if let Some(folder) = folder_id.as_deref() {
+        // EXISTENCE first. `folder_is_unlocked` answers "is this folder sealed", and an id that
+        // names nothing is not sealed — so the guard passed and the board was inserted with a
+        // dangling `folder_id`: invisible in the tree (the LEFT JOIN finds no row) and outside
+        // any future lock, which is precisely the state the container anchor exists to prevent.
+        if state.db.folder_by_id(folder)?.is_none() {
+            return Err(AppError::InvalidArg(format!("no such container: {folder}")));
+        }
+        if !crate::commands::folder_is_unlocked(state.inner(), folder)? {
+            return Err(AppError::Locked(
+                "unlock this folder before creating a dashboard in it".into(),
+            ));
+        }
+    }
+    state.db.insert_dashboard_in_folder(
         &id,
         &title,
         clean_emoji(emoji).as_deref(),
         clean_tint(tint).as_deref(),
+        folder_id.as_deref(),
         &now,
     )?;
     state
@@ -425,13 +479,33 @@ pub fn update_dashboard(
     tint: Option<String>,
     pinned: Option<bool>,
 ) -> Result<Dashboard, AppError> {
-    let _lifecycle = super::lifecycle_guard(state.inner());
+    update_dashboard_inner(
+        state.inner(),
+        &id,
+        title.as_deref(),
+        emoji,
+        tint,
+        pinned,
+    )
+}
+
+pub(crate) fn update_dashboard_inner(
+    state: &AppState,
+    id: &str,
+    title: Option<&str>,
+    emoji: Option<String>,
+    tint: Option<String>,
+    pinned: Option<bool>,
+) -> Result<Dashboard, AppError> {
+    let _lifecycle = super::lifecycle_guard(state);
+    require_board_writable(state, id)?;
+    let title = title.map(str::to_string);
     let title = match title {
         Some(t) => Some(clean_title(&t, "title")?),
         None => None,
     };
     let found = state.db.update_dashboard(
-        &id,
+        id,
         title.as_deref(),
         clean_emoji(emoji).as_deref(),
         clean_tint(tint).as_deref(),
@@ -443,20 +517,40 @@ pub fn update_dashboard(
     }
     state
         .db
-        .get_dashboard(&id)?
+        .get_dashboard(id)?
         .ok_or_else(|| AppError::Storage("dashboard vanished after update".into()))
 }
 
 #[tauri::command]
 pub fn delete_dashboard(state: State<'_, AppState>, id: String) -> Result<bool, AppError> {
-    let _lifecycle = super::lifecycle_guard(state.inner());
-    state.db.delete_dashboard(&id)
+    delete_dashboard_inner(state.inner(), &id)
+}
+
+pub(crate) fn delete_dashboard_inner(state: &AppState, id: &str) -> Result<bool, AppError> {
+    let _lifecycle = super::lifecycle_guard(state);
+    // Deleting is a write like any other, and it is the one that cannot be undone: a sealed
+    // board's plaintext lives only in its blobs, and the row carries the pointer to them.
+    require_board_writable(state, id)?;
+    state.db.delete_dashboard(id)
 }
 
 #[tauri::command]
 pub fn reorder_dashboards(state: State<'_, AppState>, ids: Vec<String>) -> Result<(), AppError> {
-    let _lifecycle = super::lifecycle_guard(state.inner());
-    state.db.reorder_dashboards(&ids)
+    reorder_dashboards_inner(state.inner(), &ids)
+}
+
+pub(crate) fn reorder_dashboards_inner(
+    state: &AppState,
+    ids: &[String],
+) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state);
+    // Ordering is board-level position, not content, so this refuses only if the CALLER named a
+    // board it may not touch — a sealed board must not be draggable into a new position by a
+    // caller that cannot see it.
+    for id in ids {
+        require_board_writable(state, id)?;
+    }
+    state.db.reorder_dashboards(ids)
 }
 
 // ── tile CRUD ──────────────────────────────────────────────────────────────────────────────────
@@ -471,7 +565,20 @@ pub fn add_dashboard_tile(
     span: Option<i64>,
     config: Option<String>,
 ) -> Result<(), AppError> {
-    let _lifecycle = super::lifecycle_guard(state.inner());
+    add_dashboard_tile_inner(state.inner(), dashboard_id, kind, ref_id, title, span, config)
+}
+
+pub(crate) fn add_dashboard_tile_inner(
+    state: &AppState,
+    dashboard_id: String,
+    kind: String,
+    ref_id: Option<String>,
+    title: Option<String>,
+    span: Option<i64>,
+    config: Option<String>,
+) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state);
+    require_board_writable(state, &dashboard_id)?;
     if !TILE_KINDS.contains(&kind.as_str()) {
         return Err(AppError::InvalidArg(format!("unknown tile kind: {kind}")));
     }
@@ -499,7 +606,7 @@ pub fn add_dashboard_tile(
     }
     let mut question_provenance = None;
     let config = if kind == "living_answer" {
-        let unlocked = super::unlocked_snapshot(state.inner())?;
+        let unlocked = super::unlocked_snapshot(state)?;
         let readable = readable_folder_ids(&state.db, &unlocked)?;
         let encoded = sanitize_living_answer_config_for_add(config.as_deref(), &readable)?;
         let question = parse_config(Some(&encoded)).question.unwrap_or_default();
@@ -551,7 +658,18 @@ pub fn update_dashboard_tile(
     span: Option<i64>,
     config: Option<String>,
 ) -> Result<(), AppError> {
-    let _lifecycle = super::lifecycle_guard(state.inner());
+    update_dashboard_tile_inner(state.inner(), id, title, span, config)
+}
+
+pub(crate) fn update_dashboard_tile_inner(
+    state: &AppState,
+    id: String,
+    title: Option<String>,
+    span: Option<i64>,
+    config: Option<String>,
+) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state);
+    require_tile_writable(state, &id)?;
     let Some((dashboard_id, existing_kind)) = state.db.dashboard_tile_metadata(&id)? else {
         return Err(AppError::InvalidArg(format!("no tile with id {id}")));
     };
@@ -583,7 +701,15 @@ pub fn update_dashboard_tile(
 
 #[tauri::command]
 pub fn delete_dashboard_tile(state: State<'_, AppState>, id: String) -> Result<bool, AppError> {
-    let _lifecycle = super::lifecycle_guard(state.inner());
+    delete_dashboard_tile_inner(state.inner(), id)
+}
+
+pub(crate) fn delete_dashboard_tile_inner(
+    state: &AppState,
+    id: String,
+) -> Result<bool, AppError> {
+    let _lifecycle = super::lifecycle_guard(state);
+    require_tile_writable(state, &id)?;
     let board = state
         .db
         .dashboard_tile_metadata(&id)?
@@ -601,28 +727,160 @@ pub fn reorder_dashboard_tiles(
     dashboard_id: String,
     tile_ids: Vec<String>,
 ) -> Result<(), AppError> {
-    let _lifecycle = super::lifecycle_guard(state.inner());
+    reorder_dashboard_tiles_inner(state.inner(), dashboard_id, tile_ids)
+}
+
+pub(crate) fn reorder_dashboard_tiles_inner(
+    state: &AppState,
+    dashboard_id: String,
+    tile_ids: Vec<String>,
+) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state);
+    require_board_writable(state, &dashboard_id)?;
     state.db.reorder_dashboard_tiles(&dashboard_id, &tile_ids)?;
     state.db.touch_dashboard(&dashboard_id, &now_iso())
 }
 
 // ── the board, resolved ────────────────────────────────────────────────────────────────────────
 
+/// Refuse any WRITE against a board whose container is sealed and not session-unlocked.
+///
+/// Before this change a board could not live in a folder at all, so no dashboard mutation needed a
+/// lock gate and none had one — the reads were the whole surface. Giving boards a container made
+/// every one of those writes a way to put user content inside a sealed tree: a renamed board, a
+/// new tile, a reordered layout. Each would be written in PLAINTEXT into a folder the user has
+/// been told is unreadable, and the seal has already run, so nothing would come back to encrypt
+/// it. The next unseal would then overwrite it from the stored blob, so the write is also lost.
+///
+/// A board with no container is unaffected: there is no folder whose key would seal it, so there
+/// is nothing to be inside of.
+fn require_board_writable(state: &AppState, dashboard_id: &str) -> Result<(), AppError> {
+    let Some(board) = state.db.get_dashboard(dashboard_id)? else {
+        return Ok(()); // absent board — the caller's own not-found path reports it.
+    };
+    let Some(folder) = board.folder_id.as_deref() else {
+        return Ok(());
+    };
+    if !crate::commands::folder_is_unlocked(state, folder)? {
+        return Err(AppError::Locked(
+            "unlock this board's container before changing it".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// The tile twin of [`require_board_writable`], resolving the tile's board first.
+fn require_tile_writable(state: &AppState, tile_id: &str) -> Result<(), AppError> {
+    let Some((dashboard_id, _kind)) = state.db.dashboard_tile_metadata(tile_id)? else {
+        return Ok(()); // absent tile — the caller reports not-found.
+    };
+    require_board_writable(state, &dashboard_id)
+}
+
+/// Move a board into a container, or unfile it with `folderId: null`.
+///
+/// Both ends are gated, and they refuse for different reasons.
+///
+/// The TARGET must be unlocked, because a board arriving in a sealed container would land in
+/// plaintext inside a tree the user has been told is unreadable — the same hazard
+/// `create_dashboard` refuses, and the reason `move_note` refuses a sealed destination it has no
+/// key for.
+///
+/// The SOURCE must be unlocked too, and that one is easy to miss: a board sitting in a sealed
+/// container has its title and tiles in ciphertext, bound by `aad_document` to THAT container's
+/// id. Moving the row without unsealing it would carry blobs into a container whose key cannot
+/// open them and whose unseal enumerates them — content that can never be recovered. Unlock the
+/// source first and the ordinary session-unlock has already restored the plaintext, so the move
+/// is a plain re-parent.
+#[tauri::command]
+pub fn move_dashboard_to_container(
+    state: State<'_, AppState>,
+    id: String,
+    folder_id: Option<String>,
+) -> Result<(), AppError> {
+    move_dashboard_to_container_inner(state.inner(), &id, folder_id.as_deref())
+}
+
+/// Body of [`move_dashboard_to_container`], taking `&AppState` so the two refusals above can be
+/// driven directly. A gate whose only caller needs a Tauri `State` is a gate no test can bind.
+pub(crate) fn move_dashboard_to_container_inner(
+    state: &AppState,
+    id: &str,
+    folder_id: Option<&str>,
+) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state);
+    let unlocked = super::unlocked_snapshot(state)?;
+    let Some(board) = state.db.get_dashboard_visible(id, &unlocked)? else {
+        return Err(AppError::InvalidArg(format!("no such dashboard: {id}")));
+    };
+    if board.locked {
+        return Err(AppError::Locked(
+            "unlock this board's container before moving it".into(),
+        ));
+    }
+    if let Some(folder) = folder_id {
+        if state.db.folder_by_id(folder)?.is_none() {
+            return Err(AppError::InvalidArg(format!("no such container: {folder}")));
+        }
+        if !crate::commands::folder_is_unlocked(state, folder)? {
+            return Err(AppError::Locked(
+                "unlock this container before moving a dashboard into it".into(),
+            ));
+        }
+    }
+    if !state.db.set_dashboard_folder(id, folder_id)? {
+        return Err(AppError::InvalidArg(format!("no such dashboard: {id}")));
+    }
+    Ok(())
+}
+
 /// One board with every tile resolved through the gated readers.
 #[tauri::command]
 pub fn get_dashboard(state: State<'_, AppState>, id: String) -> Result<Response, AppError> {
+    let payload = get_dashboard_inner(state.inner(), &id)?;
+    serde_json::to_string(&payload)
+        .map(Response::new)
+        .map_err(|_| AppError::Unavailable("dashboard response encoding failed".into()))
+}
+
+/// Body of [`get_dashboard`], returning the DTO rather than its serialization.
+///
+/// Split for the same reason as [`list_dashboards_inner`]: the sealed-board gate below is a
+/// command-layer decision, and a gate reachable only through a `Response` string is one whose
+/// tests end up asserting on the storage layer instead — where the masking it performs does not
+/// live.
+pub(crate) fn get_dashboard_inner(
+    state: &AppState,
+    id: &str,
+) -> Result<Option<DashboardDetailDto>, AppError> {
     // TOCTOU: hold the lock lifecycle guard across the gate AND every tile read, exactly like
     // `commands/meetings.rs::get_meeting_detail`. Without it a relock landing between the
     // `unlocked_snapshot` below and a later tile's read would resolve that tile against a stale
     // "unlocked" view and return content from a folder that is sealed by the time it ships.
-    let _lifecycle = super::lifecycle_guard(state.inner());
-    let Some(dashboard) = state.db.get_dashboard(&id)? else {
-        return serde_json::to_string(&Option::<DashboardDetailDto>::None)
-            .map(Response::new)
-            .map_err(|_| AppError::Unavailable("dashboard response encoding failed".into()));
+    let _lifecycle = super::lifecycle_guard(state);
+    let unlocked_for_board = super::unlocked_snapshot(state)?;
+    let Some(dashboard) = state.db.get_dashboard_visible(id, &unlocked_for_board)? else {
+        return Ok(None);
     };
-    let tiles = state.db.list_dashboard_tile_structures(&id)?;
-    let unlocked = super::unlocked_snapshot(state.inner())?;
+    // A sealed board returns its MASKED row and NO tiles at all.
+    //
+    // Masking the row alone was not enough, and `list_dashboards` was changed in this same diff
+    // for exactly this reason: the tile columns are blank at rest, but the tile ROWS still exist,
+    // so resolving them shipped one entry per tile — the count, and each tile's span and position.
+    // "This locked board is built from three things, laid out like this" is a fact about sealed
+    // content, and shape is one of the easier things to recognise a board by.
+    if dashboard.locked {
+        return Ok(Some(DashboardDetailDto {
+            dashboard,
+            tiles: Vec::new(),
+            // The Work projection goes too. It is the board's task references, so it discloses
+            // both how many there are and which tasks a sealed board is about — the same class of
+            // fact as the tile shape, reached by a different field.
+            work: Vec::new(),
+        }));
+    }
+    let tiles = state.db.list_dashboard_tile_structures(id)?;
+    let unlocked = super::unlocked_snapshot(state)?;
     let resolved = tiles
         .into_iter()
         .map(|tile| {
@@ -635,15 +893,12 @@ pub fn get_dashboard(state: State<'_, AppState>, id: String) -> Result<Response,
             Ok(ResolvedTileDto { tile, data })
         })
         .collect::<Result<Vec<_>, AppError>>()?;
-    let work = dashboard_work_inner(state.inner(), &id)?;
-    let payload = Some(DashboardDetailDto {
+    let work = dashboard_work_inner(state, id)?;
+    Ok(Some(DashboardDetailDto {
         dashboard,
         tiles: resolved,
         work,
-    });
-    serde_json::to_string(&payload)
-        .map(Response::new)
-        .map_err(|_| AppError::Unavailable("dashboard response encoding failed".into()))
+    }))
 }
 
 pub(crate) fn dashboard_work_inner(
@@ -720,14 +975,38 @@ pub(crate) fn redact_tile_chrome(mut tile: DashboardTile, data: &TileData) -> Da
 /// dashboard Ask resolves material and derived context together through `dashboard_composite_context`.
 #[tauri::command]
 pub fn get_dashboard_sources(state: State<'_, AppState>, id: String) -> Result<Response, AppError> {
-    // Same TOCTOU discipline as `get_dashboard`: gate and read under one lifecycle guard.
-    let _lifecycle = super::lifecycle_guard(state.inner());
-    let tiles = state.db.list_dashboard_tile_structures(&id)?;
-    let unlocked = super::unlocked_snapshot(state.inner())?;
-    let payload = dashboard_sources_inner(&state.db, tiles, &unlocked)?;
+    let payload = get_dashboard_sources_inner(state.inner(), &id)?;
     serde_json::to_string(&payload)
         .map(Response::new)
         .map_err(|_| AppError::Unavailable("dashboard response encoding failed".into()))
+}
+
+/// Body of [`get_dashboard_sources`], returning the list rather than its serialization.
+///
+/// Split for the same reason as its siblings: the board-level gate below is the thing worth
+/// testing, and a gate reachable only through a `Response` string is one whose test ends up
+/// aimed at the resolver instead — which withholds source CONTENT, not the list.
+pub(crate) fn get_dashboard_sources_inner(
+    state: &AppState,
+    id: &str,
+) -> Result<Vec<SourceRef>, AppError> {
+    // Same TOCTOU discipline as `get_dashboard`: gate and read under one lifecycle guard.
+    let _lifecycle = super::lifecycle_guard(state);
+    let unlocked = super::unlocked_snapshot(state)?;
+    // And the same BOARD-level gate. Each source below is resolved through the visibility set, so
+    // no individual source leaks — but the LIST itself is a fact about a sealed board: how many
+    // things it is built from, and that it is built from anything at all. `get_dashboard` was
+    // given this early return in the same diff; a second read path that skipped it would be the
+    // hole the first one closed.
+    let sealed = state
+        .db
+        .get_dashboard_visible(id, &unlocked)?
+        .is_some_and(|board| board.locked);
+    if sealed {
+        return Ok(Vec::new());
+    }
+    let tiles = state.db.list_dashboard_tile_structures(id)?;
+    dashboard_sources_inner(&state.db, tiles, &unlocked)
 }
 
 /// The header the board brief is packed under. Instructional on purpose: without

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -9175,6 +9175,16 @@ fn permanent_unseal_audio(
 /// `lock_folder`'s note seal: each blob is verified-decryptable BEFORE the plaintext is blanked /
 /// the plaintext WAV is removed — content (transcript / audio) is never lost.
 pub(crate) fn seal_folder_extras(db: &Db, folder_id: &str, ck: &[u8; 32]) -> Result<(), AppError> {
+    seal_dashboards_in_folder(db, folder_id, ck)?;
+    // TASKS LEAVE. A task's content lives in an org's E2EE store, so this folder's content key
+    // cannot seal it — and a task left inside would stay exactly as readable as it was while the
+    // user was told the folder is locked. Unfiling is the only outcome that keeps the lock's
+    // promise literally true, and it loses nothing: the task is intact, unfiled, and still in the
+    // Tasks view — the state it was in before anyone filed it.
+    let unfiled = db.unfile_tasks_in_container(folder_id)?;
+    if unfiled > 0 {
+        tracing::info!(target: "lock", folder_id, unfiled, "unfiled tasks on seal");
+    }
     let meeting_ids = db.meeting_ids_in_folder(folder_id)?;
     for mid in &meeting_ids {
         seal_meeting_extras(db, folder_id, mid, ck)?;
@@ -9692,6 +9702,126 @@ fn unseal_meeting_extras(
     Ok(())
 }
 
+/// Seal every board filed in this folder: its title, and each tile's pointer + config.
+///
+/// A board is content twice over. Its title names the thing — "Q3 layoffs" is a disclosure on its
+/// own — and its tiles say which meeting or note it is built from, which is precisely what a locked
+/// folder exists to stop revealing. A container that could hold a board but never sealed one would
+/// be a lock with a hole in it.
+///
+/// Verify-before-destroy throughout, exactly as the note and document seals do: encrypt, decrypt the
+/// ciphertext back, compare byte-for-byte, and only then blank the plaintext.
+fn seal_dashboards_in_folder(db: &Db, folder_id: &str, ck: &[u8; 32]) -> Result<(), AppError> {
+    for board in db.dashboards_in_folder(folder_id)? {
+        // Title, emoji AND tint, as one payload. The read path masks all three with the
+        // rationale that "an emoji and an accent are weak signals, but they are still signals
+        // about a thing the user asked to be unreadable" — and the seal used to cover only the
+        // title, so those two sat in plaintext at rest. That is the gap the lock exists to close:
+        // the promise is that a sealed folder is unreadable EVEN WITH THE DATABASE OPEN, and a
+        // reader going straight to the row got the emoji and the accent every time. Masking on
+        // read while leaving the columns at rest is protection against the app, not against an
+        // attacker.
+        // Whatever this condition covers, `Db::folder_has_plaintext_dashboards` must cover
+        // too — it is the predicate the keyless relock refusal uses to decide whether anything
+        // is still readable, and the two drifting apart is a silent leak, not a failed check.
+        let cosmetics = serde_json::json!({
+            "title": board.title,
+            "emoji": board.emoji,
+            "tint": board.tint,
+        })
+        .to_string();
+        if !board.title.is_empty() || board.emoji.is_some() || board.tint.is_some() {
+            let aad = aad_document(folder_id, &board.id);
+            let blob = crate::crypto::encrypt(ck, cosmetics.as_bytes(), &aad)?;
+            if crate::crypto::decrypt(ck, &blob, &aad)? != cosmetics.as_bytes() {
+                return Err(AppError::Storage(
+                    "dashboard title seal verification failed (blob mismatch)".into(),
+                ));
+            }
+            db.seal_dashboard_title(&board.id, &blob)?;
+        }
+        for (tile_id, payload) in db.dashboard_tile_payloads(&board.id)? {
+            let aad = aad_document(folder_id, &tile_id);
+            let blob = crate::crypto::encrypt(ck, payload.as_bytes(), &aad)?;
+            if crate::crypto::decrypt(ck, &blob, &aad)? != payload.as_bytes() {
+                return Err(AppError::Storage(
+                    "dashboard tile seal verification failed (blob mismatch)".into(),
+                ));
+            }
+            db.seal_dashboard_tile(&tile_id, &blob)?;
+        }
+    }
+    Ok(())
+}
+
+/// Restore every sealed board in this folder — the mirror of [`seal_dashboards_in_folder`].
+///
+/// A seal that cannot be undone is content loss, so this runs on both the session unlock and the
+/// permanent one. It is idempotent: a board with no title blob is one that was never sealed (or was
+/// already restored), and skipping it lets an interrupted unseal be retried without harm.
+fn unseal_dashboards_in_folder(db: &Db, folder_id: &str, ck: &[u8; 32]) -> Result<(), AppError> {
+    for (board_id, title_blob, tiles) in db.sealed_dashboard_blobs(folder_id)? {
+        // The title and the tiles are restored INDEPENDENTLY. An earlier version skipped the
+        // whole board when its title blob was absent, which is a real shape — a board titled
+        // "" is never title-sealed — and it meant every sealed tile under such a board stayed
+        // blanked forever. That is content loss, not a missed cosmetic.
+        let cosmetics = match &title_blob {
+            Some(blob) => {
+                let bytes = crate::crypto::decrypt(ck, blob, &aad_document(folder_id, &board_id))?;
+                let text = String::from_utf8(bytes).map_err(|_| {
+                    AppError::Storage("sealed dashboard title is not UTF-8".into())
+                })?;
+                let parsed: serde_json::Value = serde_json::from_str(&text).map_err(|_| {
+                    AppError::Storage("sealed dashboard cosmetics are not valid JSON".into())
+                })?;
+                let field = |name: &str| {
+                    parsed
+                        .get(name)
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string)
+                };
+                Some((
+                    field("title").unwrap_or_default(),
+                    field("emoji"),
+                    field("tint"),
+                ))
+            }
+            None => None,
+        };
+        let mut restored = Vec::with_capacity(tiles.len());
+        for (tile_id, blob) in tiles {
+            let bytes = crate::crypto::decrypt(ck, &blob, &aad_document(folder_id, &tile_id))?;
+            let payload = String::from_utf8(bytes).map_err(|_| {
+                AppError::Storage("sealed dashboard tile payload is not UTF-8".into())
+            })?;
+            let parsed: serde_json::Value = serde_json::from_str(&payload).map_err(|_| {
+                AppError::Storage("sealed dashboard tile payload is not valid JSON".into())
+            })?;
+            // `None` for a JSON null, so a column that was NULL comes back NULL. There is no
+            // older-payload case to defend against: `config_blob` and the `kind` field of this
+            // payload were introduced together, so every blob that exists carries the key.
+            let field = |name: &str| {
+                parsed
+                    .get(name)
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            };
+            restored.push(crate::storage::dashboards_store::RestoredTile {
+                id: tile_id,
+                title: field("title"),
+                ref_id: field("refId"),
+                config: field("config"),
+                kind: field("kind"),
+            });
+        }
+        if cosmetics.is_none() && restored.is_empty() {
+            continue;
+        }
+        db.unseal_dashboard(&board_id, cosmetics.as_ref(), &restored)?;
+    }
+    Ok(())
+}
+
 /// `meeting_embedder` is the model-gated embedder for the MEETING re-index, resolved by the CALLER
 /// (`embed_model_present().then(active_embedder)`) and passed in — `Some(real e5)` re-indexes the
 /// folder's meetings, `None` (model absent) writes nothing (never a stub vector). It is injected
@@ -9740,6 +9870,13 @@ pub(crate) fn unseal_folder_extras(
     // BEFORE this call). The caller supplies the model-gated `meeting_embedder` — never a stub
     // vector; mirrors the document re-embed above and the meeting half of `reindex_embeddings_inner`.
     reindex_meetings_after_unseal(state, &meeting_ids, meeting_embedder);
+
+    // Boards LAST, deliberately. This used to run first, which made one undecryptable board blob
+    // abort the whole unlock before a single meeting, note, document or audio file was restored —
+    // a board is the least load-bearing kind in the folder, and it was gating access to every
+    // other one. Running it last keeps the failure loud (the unlock still errors, nothing is
+    // silently skipped) while everything that CAN be restored already has been.
+    unseal_dashboards_in_folder(&state.db, folder_id, ck)?;
 
     Ok(())
 }
@@ -10269,6 +10406,14 @@ fn reblank_folder_extras_after_verification(
         None
     };
     let seal_ck = verified_ck.or(resolved_ck.as_deref());
+    // Boards, on the same terms as every other kind. A relock destroys the session plaintext of
+    // a folder that is already durably locked; a kind the re-blank does not enumerate is a kind
+    // whose plaintext SURVIVES that relock, readable in an open database. Seal and unseal
+    // covering dashboards while this one did not would have made the very first relock after a
+    // session-unlock leave a board's title and its tiles in the clear.
+    // Boards are handled AFTER the loop below, deliberately — see the note there. Returning the
+    // keyless refusal here first would have made a keyless relock blank NOTHING, when before this
+    // diff it still blanked every segment.
     for mid in state.db.meeting_ids_in_folder(folder_id)? {
         for s in state.db.raw_segments(&mid)? {
             if s.text_blob.is_some() && !s.text.is_empty() {
@@ -10363,6 +10508,40 @@ fn reblank_folder_extras_after_verification(
         state.db.set_note_doc_exported_path(&doc_id, None)?;
     }
     reblank_attachments_in_folder(state, folder_id)?;
+
+    // TASKS LEAVE HERE TOO. `seal_folder_extras` unfiles them on the initial lock, but that is not
+    // the only way a task gets into a sealed container: a folder that is durably locked and
+    // SESSION-unlocked passes `folder_is_unlocked`, so `set_task_container` accepts it, and the
+    // user can file a task into it. The relock then runs THIS function — which knew nothing about
+    // tasks — and the task stayed inside a container reported as locked, which is exactly the
+    // state the unfiling exists to prevent. Sealing and relocking are two doors into the same
+    // room; fixing one of them is not fixing it.
+    let unfiled = state.db.unfile_tasks_in_container(folder_id)?;
+    if unfiled > 0 {
+        tracing::info!(target: "lock", folder_id, unfiled, "unfiled tasks on relock");
+    }
+
+    // BOARDS LAST, and the position is the point. Every re-blank above works WITHOUT a content
+    // key, because each row still holds its own ciphertext to fall back on. A board does not: the
+    // unlock cleared `title_blob` / `config_blob`, so it must be re-encrypted to be blanked at all.
+    //
+    // So the keyless case can only be REFUSED, never skipped — skipping would report the folder
+    // locked while its boards stayed readable, which is the leak this whole function exists to
+    // prevent. Refusing EARLY, though, was its own regression: it returned before the segment and
+    // document re-blanks, which need no key, so a keyless relock went from blanking everything it
+    // could to blanking nothing at all. Doing the key-free work first and reporting the gap last
+    // keeps both properties — nothing recoverable is skipped, and nothing unsealed is quietly left
+    // readable.
+    match seal_ck {
+        Some(ck) => seal_dashboards_in_folder(&state.db, folder_id, ck)?,
+        None => {
+            if state.db.folder_has_plaintext_dashboards(folder_id)? {
+                return Err(AppError::Locked(
+                    "cannot relock: no content key available to reseal this folder's boards".into(),
+                ));
+            }
+        }
+    }
     Ok(())
 }
 
@@ -10480,6 +10659,15 @@ pub(crate) fn unseal_folder_extras_permanent(
     // again. Mirrors the document re-embed above and the meeting half of `reindex_embeddings_inner`.
     let meeting_ids = state.db.meeting_ids_in_folder(folder_id)?;
     reindex_meetings_after_unseal(state, &meeting_ids, meeting_embedder);
+
+    // Boards LAST here too. The session path was changed to run them last so one undecryptable
+    // board blob could not abort an unlock before a single meeting, note, document or audio file
+    // was restored — and this path is where that matters MORE, not less: a permanent unlock is the
+    // one the user runs to get their content back for good, and aborting it early leaves the
+    // folder half-restored with the lock still on. Fixing only the session path and leaving the
+    // permanent one running boards first would have been a fix that looked complete and covered
+    // the less important half.
+    unseal_dashboards_in_folder(&state.db, folder_id, ck)?;
 
     Ok(sealed_audio_to_retire)
 }

--- a/src-tauri/src/commands/tasks.rs
+++ b/src-tauri/src/commands/tasks.rs
@@ -47,6 +47,13 @@ pub struct TaskDto {
     pub can_edit: bool,
     pub can_manage: bool,
     pub local_refs: Vec<TaskLocalRefDto>,
+    /// The LOCAL container this task is filed in, or `None` when it is unfiled.
+    ///
+    /// Local-only, and it stays that way: it is read from `org_tasks.container_id`, which is not a
+    /// field of [`TaskEnvelope`] and so is not part of the bytes that reach an org. The DTO is what
+    /// this device renders, not what it publishes — `#[serde(flatten)] envelope` is the published
+    /// half, and this field sits outside it.
+    pub container_id: Option<String>,
     pub updated_at: String,
 }
 
@@ -111,6 +118,7 @@ pub(crate) fn task_dto(state: &AppState, row: OrgTaskRow) -> Result<TaskDto, App
     let mut envelope = TaskEnvelope::from_json(&row.envelope_json, &row.org_id)?;
     envelope.org_refs = state.db.visible_task_org_refs(&row.id)?;
     let (can_edit, can_manage) = org_item_permissions(state, &row.item_id)?;
+    let row_id_for_container = row.id.clone();
     let local_refs = state
         .db
         .task_local_refs(&row.id)?
@@ -130,6 +138,9 @@ pub(crate) fn task_dto(state: &AppState, row: OrgTaskRow) -> Result<TaskDto, App
         can_edit,
         can_manage,
         local_refs,
+        container_id: state
+            .db
+            .task_container_visible(&row_id_for_container, &super::unlocked_snapshot(state)?)?,
         updated_at: row.updated_at,
     })
 }
@@ -163,6 +174,7 @@ mod tests {
             can_edit: true,
             can_manage: true,
             local_refs: Vec::new(),
+            container_id: None,
             updated_at: "2026-08-22T09:00:00Z".into(),
         };
 
@@ -171,6 +183,56 @@ mod tests {
             json.matches("\"orgId\":").count(),
             1,
             "TaskDto must expose the envelope organization without duplicate JSON keys"
+        );
+    }
+
+    /// The task's LOCAL placement reaches the FE, and reaches it as `containerId`.
+    ///
+    /// A placement the UI cannot read back is not a feature — the sidebar has to know which
+    /// container a task is filed in to draw it there, and a snake_case key would resolve to
+    /// `undefined` and read as "unfiled". Asserted against the real serializer, because the
+    /// hand-written e2e fixtures are typed against the FE's own interface and so cannot disagree
+    /// with it (`.claude/rules/angular-zoneless.md` T6).
+    #[test]
+    fn task_dto_ships_container_id_as_camel_case() {
+        let org_id = "11111111-1111-4111-8111-111111111111";
+        let dto = TaskDto {
+            id: format!("{org_id}:22222222-2222-4222-8222-222222222222"),
+            doc_id: "22222222-2222-4222-8222-222222222222".into(),
+            item_id: "33333333-3333-4333-8333-333333333333".into(),
+            source_document_id: None,
+            envelope: TaskEnvelope {
+                version: TASK_ENVELOPE_VERSION,
+                org_id: org_id.into(),
+                title: "Task".into(),
+                description: String::new(),
+                status: TaskStatus::Todo,
+                due_at: None,
+                assignee_user_id: None,
+                created_at: "2026-08-22T09:00:00Z".into(),
+                subtasks: Vec::new(),
+                org_refs: Vec::new(),
+                images: Vec::new(),
+            },
+            access: "edit".into(),
+            can_edit: true,
+            can_manage: true,
+            local_refs: Vec::new(),
+            container_id: Some("f-weekly".into()),
+            updated_at: "2026-08-22T09:00:00Z".into(),
+        };
+
+        let value = serde_json::to_value(&dto).unwrap();
+        assert_eq!(
+            value.get("containerId").and_then(|v| v.as_str()),
+            Some("f-weekly"),
+            "the task's container must reach the FE as camelCase `containerId`"
+        );
+        // And it must NOT have leaked into the envelope half, which is the part that egresses.
+        let envelope_json = serde_json::to_string(&dto.envelope).unwrap();
+        assert!(
+            !envelope_json.contains("f-weekly"),
+            "a task's local container must never appear in the envelope that reaches the org"
         );
     }
 }
@@ -481,4 +543,45 @@ pub(crate) async fn validate_task_assignee(
             "task assignee is not an active member of this organization".into(),
         ))
     }
+}
+
+/// File a task into a local container, or unfile it with `containerId: null`.
+///
+/// Placement is LOCAL and never egresses: it is stored in `org_tasks.container_id`, which is not a
+/// field of `TaskEnvelope` and is therefore not part of the bytes that reach an org. A user's
+/// private folder structure stays on the device.
+///
+/// The container must exist and must not be sealed. Both refusals matter for different reasons: an
+/// id that names nothing would file the task into a container the tree cannot show, and a sealed
+/// container cannot hold a task at all — `seal_folder_extras` unfiles the tasks it finds, because
+/// an org-owned task is not sealable by a folder key and must never sit inside a container the
+/// user has been told is locked.
+#[tauri::command]
+pub fn set_task_container(
+    state: State<'_, AppState>,
+    id: String,
+    container_id: Option<String>,
+) -> Result<(), AppError> {
+    let _lifecycle = super::lifecycle_guard(state.inner());
+    // Read authorization first: the caller must be allowed to see this task at all before being
+    // allowed to move it. `load_task_row_for_read` is the same gate `get_task` uses.
+    let Some(_row) = load_task_row_for_read(state.inner(), &id)? else {
+        return Err(AppError::InvalidArg(format!("no such task: {id}")));
+    };
+    if let Some(container) = container_id.as_deref() {
+        if state.db.folder_by_id(container)?.is_none() {
+            return Err(AppError::InvalidArg(format!(
+                "no such container: {container}"
+            )));
+        }
+        if !crate::commands::folder_is_unlocked(state.inner(), container)? {
+            return Err(AppError::Locked(
+                "unlock this container before filing a task into it".into(),
+            ));
+        }
+    }
+    if !state.db.set_task_container(&id, container_id.as_deref())? {
+        return Err(AppError::InvalidArg(format!("no such task: {id}")));
+    }
+    Ok(())
 }

--- a/src-tauri/src/commands/tests/dashboard_cmd_tests.rs
+++ b/src-tauri/src/commands/tests/dashboard_cmd_tests.rs
@@ -606,3 +606,38 @@ fn a_note_tile_ships_updated_at_as_camel_case() {
         "the FE reads `updatedAt`: {json}"
     );
 }
+
+/// The board ROW own wire shape — `folderId` and `locked`, not `folder_id`.
+///
+/// The tile oracle above covers `TileData`; the `Dashboard` row is a separate type with its own
+/// attribute, and it is the one the sidebar reads to decide where a board is filed and whether to
+/// draw it locked. A snake_case `folder_id` would resolve to `undefined` in the FE, which reads as
+/// "unfiled" — a sealed board would then be rendered at the top level with a title the masking
+/// already blanked. The `locked` flag has the same failure mode in reverse. Asserted against the
+/// REAL serializer, because a hand-written fixture cannot disagree with the FE.
+#[test]
+fn a_dashboard_row_ships_folder_id_and_locked_as_camel_case() {
+    let row = crate::storage::models::Dashboard {
+        id: "d-1".into(),
+        title: "Q3".into(),
+        emoji: None,
+        tint: None,
+        pinned: false,
+        position: 0,
+        folder_id: Some("f-1".into()),
+        created_at: "2026-08-23T10:00:00Z".into(),
+        updated_at: "2026-08-23T10:00:00Z".into(),
+        locked: true,
+    };
+    let value = serde_json::to_value(&row).unwrap();
+    let object = value.as_object().expect("a board row serializes to an object");
+
+    assert_eq!(object.get("folderId").and_then(|v| v.as_str()), Some("f-1"));
+    assert_eq!(object.get("locked").and_then(|v| v.as_bool()), Some(true));
+    for key in object.keys() {
+        assert!(
+            !key.contains('_'),
+            "board row key `{key}` is snake_case on the wire while the FE reads camelCase"
+        );
+    }
+}

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -2905,6 +2905,1469 @@
         db.set_meeting_folder(mid, folder_id).unwrap();
     }
 
+    /// One `org_tasks` row, minimal but real: the workspace leg reads its title out of
+    /// `envelope_json` with `json_extract`, so the envelope has to be genuine JSON with a
+    /// `title` — a stub string would make the leg return NULL and the test vacuous.
+    fn insert_fixture_task(db: &Db, id: &str, title: &str) {
+        insert_fixture_task_for_org(db, id, title, "org-1", true)
+    }
+
+    /// The same fixture with the org membership spelled out, so a test can withdraw it.
+    ///
+    /// `context_enabled` is the per-device org read toggle the tree leg joins on. A task is org
+    /// content: filing it into a local folder cannot be allowed to outlive membership in the org
+    /// that owns it, and this parameter is how that gets tested rather than assumed.
+    fn insert_fixture_task_for_org(
+        db: &Db,
+        id: &str,
+        title: &str,
+        org_id: &str,
+        context_enabled: bool,
+    ) {
+        db.upsert_org_state(&crate::storage::OrgState {
+            org_id: org_id.into(),
+            name: "Acme".into(),
+            role: "member".into(),
+            joined_at: "2026-08-23T09:00:00Z".into(),
+            consented: true,
+            last_seq: 0,
+            generation: 1,
+            context_enabled,
+        })
+        .unwrap();
+        insert_fixture_task_row_with_head(db, id, title, org_id, true, false)
+    }
+
+    /// The `org_tasks` row plus its LIVE item head — but no membership. Used to prove the
+    /// membership join gates independently of the tombstone join.
+    fn insert_fixture_task_row(db: &Db, id: &str, title: &str, org_id: &str) {
+        insert_fixture_task_row_with_head(db, id, title, org_id, true, false)
+    }
+
+    /// The same, with the item head's liveness spelled out so a test can tombstone or supersede it.
+    fn insert_fixture_task_row_with_head(
+        db: &Db,
+        id: &str,
+        title: &str,
+        org_id: &str,
+        is_current: bool,
+        tombstoned: bool,
+    ) {
+        db.lock()
+            .execute(
+                "INSERT INTO org_items
+                   (item_id, org_id, seq, author_hint, title, markdown, created_at, rev,
+                    generation, content_sha256, is_current, tombstoned)
+                 VALUES (?1, ?2, 0, '', ?3, '', '2026-08-23T09:00:00Z', 1, 1, NULL, ?4, ?5)",
+                rusqlite::params![id, org_id, title, is_current as i64, tombstoned as i64],
+            )
+            .unwrap();
+        insert_fixture_task_only(db, id, title, org_id)
+    }
+
+    /// The bare `org_tasks` row, with no item head at all.
+    fn insert_fixture_task_only(db: &Db, id: &str, title: &str, org_id: &str) {
+        let envelope = serde_json::json!({
+            "version": 1,
+            "orgId": org_id,
+            "title": title,
+            "description": "",
+            "status": "todo",
+            "dueAt": null,
+            "assigneeUserId": null,
+            "createdAt": "2026-08-23T10:00:00Z",
+            "subtasks": [],
+            "orgRefs": [],
+            "images": [],
+        })
+        .to_string();
+        db.lock()
+            .execute(
+                "INSERT INTO org_tasks
+                   (id, org_id, doc_id, item_id, source_document_id, envelope_json, status,
+                    due_at, assignee_user_id, access, author_user_id, owner_user_id, rev,
+                    generation, seq, updated_at, container_id)
+                 VALUES (?1, ?3, ?1, ?1, NULL, ?2, 'todo', NULL, NULL, 'edit', NULL, NULL,
+                         1, 1, 0, '2026-08-23T10:00:00Z', NULL)",
+                rusqlite::params![id, envelope, org_id],
+            )
+            .unwrap();
+    }
+
+    /// A board in a sealed folder discloses nothing, and comes back byte-identical.
+    ///
+    /// A board is content twice over: its title names the thing — "Q3 layoffs" is a disclosure on
+    /// its own — and its tiles record which meeting or note it is built from, which is exactly
+    /// what a locked folder exists to stop revealing. Before boards could be filed at all, the
+    /// list reader returned every title unconditionally and was right to; the moment a board can
+    /// live in a container, that same reader is a leak.
+    ///
+    /// Round-trip, not just masking: a seal that cannot be undone is content loss.
+    #[test]
+    fn a_dashboard_in_a_sealed_folder_is_masked_and_restored_byte_identical() {
+        let vault = tmp_vault("dashboard-seal");
+        let state = build_state_with_vault("dashboard-seal", &vault);
+        make_open_folder(&state.db, "f-secret", "Secret");
+        std::fs::create_dir_all(vault.join("Secret")).unwrap();
+
+        let now = "2026-08-23T10:00:00Z";
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboards (id, title, emoji, tint, pinned, position, folder_id,
+                                         created_at, updated_at)
+                 VALUES ('d-1', 'Q3 layoffs', '📊', 'indigo', 0, 0, 'f-secret', ?1, ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboard_tiles (id, dashboard_id, kind, ref_id, title, span,
+                                              position, config, created_at)
+                 VALUES ('t-1', 'd-1', 'meeting', 'm-1', 'Standup', 1, 0, '{\"q\":\"headcount\"}', ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+
+        let before_title: String = state
+            .db
+            .lock()
+            .query_row("SELECT title FROM dashboards WHERE id = 'd-1'", [], |r| r.get(0))
+            .unwrap();
+        let before_config: String = state
+            .db
+            .lock()
+            .query_row("SELECT config FROM dashboard_tiles WHERE id = 't-1'", [], |r| r.get(0))
+            .unwrap();
+
+        lock_folder_inner(&state, "f-secret".into()).unwrap();
+
+        // The plaintext is gone from the row, and the gated reader shows a locked board rather
+        // than omitting it — a user who sealed a folder should see that the board is still there.
+        let sealed_title: String = state
+            .db
+            .lock()
+            .query_row("SELECT title FROM dashboards WHERE id = 'd-1'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(sealed_title, "", "the board's title survived the seal in plaintext");
+        // The tile's own TITLE and REF are content too: the title is a copy of the source
+        // meeting's title, and `ref_id` names which meeting the board is built from. Sealing
+        // only `config` left a lock with a hole exactly where someone would look.
+        let (sealed_tile_title, sealed_ref, sealed_config): (String, String, String) = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT title, ref_id, config FROM dashboard_tiles WHERE id = 't-1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(sealed_config, "", "a tile's config survived the seal in plaintext");
+        assert_eq!(sealed_tile_title, "", "a tile's title survived the seal in plaintext");
+        assert_eq!(sealed_ref, "", "a tile's source id survived the seal in plaintext");
+
+        let unlocked = std::collections::HashSet::new();
+        let listed = state.db.list_dashboards_visible(&unlocked).unwrap();
+        let board = listed.iter().find(|b| b.id == "d-1").expect("board still listed");
+        assert!(board.locked, "a sealed board must report itself locked");
+        assert_ne!(board.title, before_title, "a sealed board disclosed its title");
+        assert!(board.emoji.is_none(), "a sealed board disclosed its emoji");
+
+        // And it comes back exactly as it went in. Mirrors `unlock_folder`'s internals, the
+        // idiom every seal round-trip test in this file uses: KEK → unwrap CK → unseal extras.
+        let kek = secrets::get_or_create_master_kek().unwrap();
+        let wrapped = state.db.folder_wrapped_key("f-secret").unwrap().unwrap();
+        let ck_vec =
+            crate::crypto::decrypt(&kek, &wrapped, &aad_wrapped_ck("f-secret")).unwrap();
+        let ck: [u8; 32] = ck_vec.try_into().expect("CK is 32 bytes");
+        unseal_folder_extras(&state, "f-secret", &ck, None).unwrap();
+        let after_title: String = state
+            .db
+            .lock()
+            .query_row("SELECT title FROM dashboards WHERE id = 'd-1'", [], |r| r.get(0))
+            .unwrap();
+        let (after_tile_title, after_ref, after_config): (String, String, String) = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT title, ref_id, config FROM dashboard_tiles WHERE id = 't-1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(after_title, before_title, "the board's title did not survive the seal");
+        assert_eq!(after_config, before_config, "a tile's config did not survive the seal");
+        assert_eq!(after_tile_title, "Standup", "a tile's title did not survive the seal");
+        assert_eq!(after_ref, "m-1", "a tile's source id did not survive the seal");
+    }
+
+    /// Sealing a folder that is ALREADY sealed must not overwrite the ciphertext it finds.
+    ///
+    /// This is the relock shape, and it is the one that loses content silently.
+    /// `reblank_folder_extras_after_verification` re-runs the seal over a folder whose rows are
+    /// already blank-plus-blob; a seal that does not skip those rows encrypts three empty strings
+    /// and writes the result over the good blob. Nothing errors, nothing looks wrong — the board
+    /// is already displaying as locked — and the content is gone at the next unlock, with no
+    /// second copy anywhere. RED before the `config_blob IS NULL` filter in
+    /// `Db::dashboard_tile_payloads`, GREEN after.
+    #[test]
+    fn resealing_an_already_sealed_folder_does_not_destroy_its_boards() {
+        let vault = tmp_vault("dashboard-reseal");
+        let state = build_state_with_vault("dashboard-reseal", &vault);
+        make_open_folder(&state.db, "f-secret", "Secret");
+        std::fs::create_dir_all(vault.join("Secret")).unwrap();
+
+        let now = "2026-08-23T10:00:00Z";
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboards (id, title, emoji, tint, pinned, position, folder_id,
+                                         created_at, updated_at)
+                 VALUES ('d-4', 'Q3 layoffs', NULL, NULL, 0, 0, 'f-secret', ?1, ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboard_tiles (id, dashboard_id, kind, ref_id, title, span,
+                                              position, config, created_at)
+                 VALUES ('t-4', 'd-4', 'meeting', 'm-4', 'Standup', 1, 0, '{\"q\":\"heads\"}', ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+
+        lock_folder_inner(&state, "f-secret".into()).unwrap();
+
+        let kek = secrets::get_or_create_master_kek().unwrap();
+        let wrapped = state.db.folder_wrapped_key("f-secret").unwrap().unwrap();
+        let ck_vec = crate::crypto::decrypt(&kek, &wrapped, &aad_wrapped_ck("f-secret")).unwrap();
+        let ck: [u8; 32] = ck_vec.try_into().expect("CK is 32 bytes");
+
+        // The relock: seal again over rows that are already sealed.
+        seal_dashboards_in_folder(&state.db, "f-secret", &ck).unwrap();
+
+        unseal_folder_extras(&state, "f-secret", &ck, None).unwrap();
+        let (title, tile_title, ref_id, config): (String, String, String, String) = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT d.title, t.title, t.ref_id, t.config
+                   FROM dashboards d JOIN dashboard_tiles t ON t.dashboard_id = d.id
+                  WHERE d.id = 'd-4'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(title, "Q3 layoffs", "a relock destroyed the board's title");
+        assert_eq!(tile_title, "Standup", "a relock destroyed a tile's title");
+        assert_eq!(ref_id, "m-4", "a relock destroyed a tile's source id");
+        assert_eq!(config, "{\"q\":\"heads\"}", "a relock destroyed a tile's config");
+    }
+
+    /// A board whose title was never sealed still gets its TILES back.
+    ///
+    /// A board titled "" is not title-sealed — there is nothing to encrypt — and the unseal used
+    /// to skip such a board entirely, which left every sealed tile under it blanked forever.
+    /// Invisible from the board's own row: its title column looks exactly as it should.
+    #[test]
+    fn a_board_with_no_sealed_title_still_restores_its_tiles() {
+        let vault = tmp_vault("dashboard-untitled");
+        let state = build_state_with_vault("dashboard-untitled", &vault);
+        make_open_folder(&state.db, "f-secret", "Secret");
+        std::fs::create_dir_all(vault.join("Secret")).unwrap();
+
+        let now = "2026-08-23T10:00:00Z";
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboards (id, title, emoji, tint, pinned, position, folder_id,
+                                         created_at, updated_at)
+                 VALUES ('d-2', '', NULL, NULL, 0, 0, 'f-secret', ?1, ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboard_tiles (id, dashboard_id, kind, ref_id, title, span,
+                                              position, config, created_at)
+                 VALUES ('t-2', 'd-2', 'meeting', 'm-9', 'Retro', 1, 0, '{}', ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+
+        lock_folder_inner(&state, "f-secret".into()).unwrap();
+        let kek = secrets::get_or_create_master_kek().unwrap();
+        let wrapped = state.db.folder_wrapped_key("f-secret").unwrap().unwrap();
+        let ck_vec = crate::crypto::decrypt(&kek, &wrapped, &aad_wrapped_ck("f-secret")).unwrap();
+        let ck: [u8; 32] = ck_vec.try_into().expect("CK is 32 bytes");
+        unseal_folder_extras(&state, "f-secret", &ck, None).unwrap();
+
+        let (title, ref_id): (String, String) = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT title, ref_id FROM dashboard_tiles WHERE id = 't-2'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(title, "Retro", "a tile under an untitled board was never restored");
+        assert_eq!(ref_id, "m-9", "a tile's source id was never restored");
+    }
+
+    /// An unseal that cannot decrypt keeps the ciphertext. Verify BEFORE destroy, unseal side.
+    ///
+    /// The seal's own read-back check cannot be made to fail from a test — it decrypts what it
+    /// just encrypted under the same key and AAD — so the ordering is pinned where it IS
+    /// reachable: the unseal drops `title_blob`/`config_blob` only after every decrypt has
+    /// succeeded. Driven by moving a sealed board to a different folder, so the `aad_document`
+    /// binding no longer matches: the shape a mis-bound or corrupted blob has. Non-vacuous by
+    /// construction — the test asserts the failure actually happened before asserting survival.
+    #[test]
+    fn an_unseal_that_cannot_decrypt_does_not_drop_the_ciphertext() {
+        let vault = tmp_vault("dashboard-aad");
+        let state = build_state_with_vault("dashboard-aad", &vault);
+        make_open_folder(&state.db, "f-secret", "Secret");
+        make_open_folder(&state.db, "f-other", "Other");
+        std::fs::create_dir_all(vault.join("Secret")).unwrap();
+
+        let now = "2026-08-23T10:00:00Z";
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboards (id, title, emoji, tint, pinned, position, folder_id,
+                                         created_at, updated_at)
+                 VALUES ('d-5', 'Keep me', NULL, NULL, 0, 0, 'f-secret', ?1, ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+
+        lock_folder_inner(&state, "f-secret".into()).unwrap();
+        let sealed_blob: Vec<u8> = state
+            .db
+            .lock()
+            .query_row("SELECT title_blob FROM dashboards WHERE id = 'd-5'", [], |r| r.get(0))
+            .unwrap();
+        assert!(!sealed_blob.is_empty(), "the fixture must actually be sealed");
+
+        let kek = secrets::get_or_create_master_kek().unwrap();
+        let wrapped = state.db.folder_wrapped_key("f-secret").unwrap().unwrap();
+        let ck_vec = crate::crypto::decrypt(&kek, &wrapped, &aad_wrapped_ck("f-secret")).unwrap();
+        let ck: [u8; 32] = ck_vec.try_into().expect("CK is 32 bytes");
+
+        // Re-file the sealed board, so its blob's AAD names a folder it no longer lives in.
+        state
+            .db
+            .lock()
+            .execute(
+                "UPDATE dashboards SET folder_id = 'f-other' WHERE id = 'd-5'",
+                [],
+            )
+            .unwrap();
+
+        let err = unseal_dashboards_in_folder(&state.db, "f-other", &ck)
+            .expect_err("the mis-bound blob must fail to decrypt, or this oracle proves nothing");
+        // `AppError::Locked` is what a failed AES-GCM open is, and the variant matters: the FE
+        // must show a locked board, not a storage fault the user is invited to retry into.
+        assert!(matches!(err, AppError::Locked(_)), "got {err:?}");
+
+        let after_blob: Vec<u8> = state
+            .db
+            .lock()
+            .query_row("SELECT title_blob FROM dashboards WHERE id = 'd-5'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            after_blob, sealed_blob,
+            "a failed unseal dropped the only copy of the board's title"
+        );
+    }
+
+    /// EVERY changed read sink refuses a sealed board — the list, the detail, and the tree.
+    ///
+    /// Three sinks changed in this diff and each is gated separately, so each needs its own
+    /// negative: masking the list while `get_dashboard` still returns the row is not a lock, it
+    /// is a lock with one door open. The tree leg matters most of the three because it is the
+    /// one a sidebar walks without ever naming a board id.
+    #[test]
+    fn every_dashboard_read_sink_withholds_a_sealed_board() {
+        let vault = tmp_vault("dashboard-sinks");
+        let state = build_state_with_vault("dashboard-sinks", &vault);
+        make_open_folder(&state.db, "f-secret", "Secret");
+        std::fs::create_dir_all(vault.join("Secret")).unwrap();
+
+        let now = "2026-08-23T10:00:00Z";
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboards (id, title, emoji, tint, pinned, position, folder_id,
+                                         created_at, updated_at)
+                 VALUES ('d-6', 'Q3 layoffs', '📊', 'indigo', 0, 0, 'f-secret', ?1, ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboard_tiles (id, dashboard_id, kind, ref_id, title, span,
+                                              position, config, created_at)
+                 VALUES ('t-6', 'd-6', 'meeting', 'm-6', 'Standup', 1, 0, '{}', ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+
+        // Unfiled control: a board outside any container stays fully readable, so a green run
+        // cannot come from a reader that withholds everything.
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboards (id, title, emoji, tint, pinned, position, folder_id,
+                                         created_at, updated_at)
+                 VALUES ('d-open', 'Roadmap', NULL, NULL, 0, 0, NULL, ?1, ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+
+        lock_folder_inner(&state, "f-secret".into()).unwrap();
+        let nothing_unlocked = std::collections::HashSet::new();
+
+        // SINK 1 — the list.
+        let listed = state.db.list_dashboards_visible(&nothing_unlocked).unwrap();
+        let sealed = listed.iter().find(|b| b.id == "d-6").expect("still listed");
+        assert!(sealed.locked, "the list did not mark a sealed board locked");
+        assert_ne!(sealed.title, "Q3 layoffs", "the list disclosed a sealed title");
+        let open = listed.iter().find(|b| b.id == "d-open").expect("control listed");
+        assert_eq!(open.title, "Roadmap", "the control board was masked too");
+        assert!(!open.locked, "the control board was marked locked");
+
+        // SINK 2 — the detail read.
+        let detail = state
+            .db
+            .get_dashboard_visible("d-6", &nothing_unlocked)
+            .unwrap()
+            .expect("the row still exists");
+        assert!(detail.locked, "the detail read did not mark a sealed board locked");
+        assert_ne!(detail.title, "Q3 layoffs", "the detail read disclosed a sealed title");
+        assert!(detail.emoji.is_none(), "the detail read disclosed a sealed emoji");
+        let open_detail = state
+            .db
+            .get_dashboard_visible("d-open", &nothing_unlocked)
+            .unwrap()
+            .expect("the control row exists");
+        assert_eq!(open_detail.title, "Roadmap", "the control board was masked too");
+
+        // SINK 3 — the workspace tree leg.
+        let (rows, total) = state
+            .db
+            .container_items_page(
+                Some("f-secret"),
+                crate::storage::models::ItemKind::Dashboard,
+                0,
+                50,
+                &nothing_unlocked,
+            )
+            .unwrap();
+        assert!(
+            !rows.iter().any(|row| row.id == "d-6"),
+            "the tree listed a board from a sealed container"
+        );
+        assert_eq!(total, 0, "the tree disclosed the COUNT of a sealed container's boards");
+
+        // The Inbox leg still returns the unfiled control, so the assertion above cannot be
+        // passing on a leg that returns nothing for anyone.
+        let (inbox, _) = state
+            .db
+            .container_items_page(
+                None,
+                crate::storage::models::ItemKind::Dashboard,
+                0,
+                50,
+                &nothing_unlocked,
+            )
+            .unwrap();
+        assert!(
+            inbox.iter().any(|row| row.id == "d-open"),
+            "the Inbox leg withheld an unfiled board"
+        );
+
+        // And the sealed container's board DOES come back once the session unlocks it.
+        let unlocked: std::collections::HashSet<String> =
+            std::iter::once("f-secret".to_string()).collect();
+        let (rows, total) = state
+            .db
+            .container_items_page(
+                Some("f-secret"),
+                crate::storage::models::ItemKind::Dashboard,
+                0,
+                50,
+                &unlocked,
+            )
+            .unwrap();
+        assert!(
+            rows.iter().any(|row| row.id == "d-6"),
+            "the tree withheld a board from a session-unlocked container"
+        );
+        assert_eq!(total, 1, "the unlocked total is wrong");
+    }
+
+    /// The COMMAND-layer summary withholds a sealed board's tile count and kinds.
+    ///
+    /// This is the branch the previous round of tests missed, and the miss was instructive: they
+    /// asserted on `Db::list_dashboards_visible`, which masks the ROW. The tile count and kinds are
+    /// assembled one layer up, in `commands::list_dashboards`, from a SEPARATE ungated
+    /// `dashboard_tile_kinds()` read — so every assertion passed while "this locked board is built
+    /// from three meetings" still shipped. A test aimed at the wrong layer is not weaker evidence,
+    /// it is evidence for a different claim.
+    ///
+    /// RED contract: delete the `if d.locked` branch in `commands::list_dashboards` and the
+    /// tile_count assertion fails while every Db-layer test stays green.
+    #[test]
+    fn the_dashboard_summary_command_withholds_a_sealed_boards_tile_shape() {
+        let vault = tmp_vault("dashboard-summary-cmd");
+        let state = build_state_with_vault("dashboard-summary-cmd", &vault);
+        make_open_folder(&state.db, "f-secret", "Secret");
+        make_open_folder(&state.db, "f-open", "Open");
+        std::fs::create_dir_all(vault.join("Secret")).unwrap();
+
+        let now = "2026-08-23T10:00:00Z";
+        for (board, folder) in [("d-sealed", "f-secret"), ("d-open", "f-open")] {
+            state
+                .db
+                .lock()
+                .execute(
+                    "INSERT INTO dashboards (id, title, emoji, tint, pinned, position, folder_id,
+                                             created_at, updated_at)
+                     VALUES (?1, 'Q3 layoffs', NULL, NULL, 0, 0, ?2, ?3, ?3)",
+                    rusqlite::params![board, folder, now],
+                )
+                .unwrap();
+            for n in 0..3 {
+                state
+                    .db
+                    .lock()
+                    .execute(
+                        "INSERT INTO dashboard_tiles (id, dashboard_id, kind, ref_id, title, span,
+                                                      position, config, created_at)
+                         VALUES (?1, ?2, 'meeting', 'm-1', 'Standup', 1, ?3, '{}', ?4)",
+                        rusqlite::params![format!("{board}-t{n}"), board, n, now],
+                    )
+                    .unwrap();
+            }
+        }
+
+        lock_folder_inner(&state, "f-secret".into()).unwrap();
+
+        let summaries = crate::commands::dashboards::list_dashboards_inner(&state).unwrap();
+        let sealed = summaries
+            .iter()
+            .find(|s| s.dashboard.id == "d-sealed")
+            .expect("a sealed board is still listed");
+        assert!(sealed.dashboard.locked, "the sealed board must report itself locked");
+        assert_eq!(
+            sealed.tile_count, 0,
+            "the summary disclosed how many tiles a sealed board has"
+        );
+        assert!(
+            sealed.tile_kinds.is_empty(),
+            "the summary disclosed what a sealed board is built from"
+        );
+
+        // The CONTROL: an open board still reports its shape, so the assertions above cannot be
+        // passing on a reader that blanks everything.
+        let open = summaries
+            .iter()
+            .find(|s| s.dashboard.id == "d-open")
+            .expect("the open board is listed");
+        assert_eq!(open.tile_count, 3, "an open board must report its tiles");
+        assert_eq!(open.tile_kinds.len(), 3, "an open board must report its tile kinds");
+    }
+
+    /// The COMMAND-layer detail read returns a masked board with NO tiles and NO work.
+    ///
+    /// Same lesson as the summary: `get_dashboard_visible` masks the row, but the tile ROWS still
+    /// exist, so resolving them shipped the count and each tile's span and position. Shape is one
+    /// of the easier things to recognise a board by.
+    #[test]
+    fn the_dashboard_detail_command_returns_no_tiles_for_a_sealed_board() {
+        let vault = tmp_vault("dashboard-detail-cmd");
+        let state = build_state_with_vault("dashboard-detail-cmd", &vault);
+        make_open_folder(&state.db, "f-secret", "Secret");
+        std::fs::create_dir_all(vault.join("Secret")).unwrap();
+
+        let now = "2026-08-23T10:00:00Z";
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboards (id, title, emoji, tint, pinned, position, folder_id,
+                                         created_at, updated_at)
+                 VALUES ('d-1', 'Q3 layoffs', NULL, NULL, 0, 0, 'f-secret', ?1, ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboard_tiles (id, dashboard_id, kind, ref_id, title, span,
+                                              position, config, created_at)
+                 VALUES ('t-1', 'd-1', 'meeting', 'm-1', 'Standup', 2, 5, '{}', ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+
+        lock_folder_inner(&state, "f-secret".into()).unwrap();
+
+        let detail = crate::commands::dashboards::get_dashboard_inner(&state, "d-1")
+            .unwrap()
+            .expect("the row still exists");
+        assert!(detail.dashboard.locked, "the detail read must mark it locked");
+        assert_ne!(detail.dashboard.title, "Q3 layoffs", "the title leaked");
+        assert!(detail.tiles.is_empty(), "a sealed board disclosed its tile shape");
+        assert!(detail.work.is_empty(), "a sealed board disclosed its task references");
+
+        // The positive CONTROL, which this test was missing: a reader that returned empty tiles
+        // for every board would have passed every assertion above. Its sibling summary test
+        // carries one and this one did not — an omission worth naming, because a negative without
+        // a control is the shape that lets a broken reader look like a working gate.
+        make_open_folder(&state.db, "f-open", "Open");
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboards (id, title, emoji, tint, pinned, position, folder_id,
+                                         created_at, updated_at)
+                 VALUES ('d-open', 'Roadmap', NULL, NULL, 0, 0, 'f-open', ?1, ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboard_tiles (id, dashboard_id, kind, ref_id, title, span,
+                                              position, config, created_at)
+                 VALUES ('t-open', 'd-open', 'meeting', 'm-1', 'Standup', 1, 0, '{}', ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+        let open = crate::commands::dashboards::get_dashboard_inner(&state, "d-open")
+            .unwrap()
+            .expect("the open board exists");
+        assert!(!open.dashboard.locked, "the control board must not read as locked");
+        assert_eq!(open.dashboard.title, "Roadmap", "the control board was masked");
+        assert_eq!(open.tiles.len(), 1, "the control board must return its tile");
+    }
+
+    /// Deleting a container demotes its BOARDS, and refuses while any still holds ciphertext.
+    ///
+    /// The demotion is what stops a board becoming a row the user can open but cannot find —
+    /// invisible in the tree because its `LEFT JOIN folders` yields nothing, yet still in the flat
+    /// list, and outside any future lock. The refusal is the other half: a board whose blobs
+    /// survive is one whose content key is about to be discarded with the folder.
+    #[test]
+    fn deleting_a_container_demotes_its_boards_and_refuses_sealed_ones() {
+        let vault = tmp_vault("dashboard-delete");
+        let state = build_state_with_vault("dashboard-delete", &vault);
+        make_open_folder(&state.db, "f-gone", "Gone");
+        make_open_folder(&state.db, "f-sealed", "Sealed");
+        std::fs::create_dir_all(vault.join("Sealed")).unwrap();
+
+        let now = "2026-08-23T10:00:00Z";
+        for (board, folder) in [("d-plain", "f-gone"), ("d-sealed", "f-sealed")] {
+            state
+                .db
+                .lock()
+                .execute(
+                    "INSERT INTO dashboards (id, title, emoji, tint, pinned, position, folder_id,
+                                             created_at, updated_at)
+                     VALUES (?1, 'Board', NULL, NULL, 0, 0, ?2, ?3, ?3)",
+                    rusqlite::params![board, folder, now],
+                )
+                .unwrap();
+        }
+
+        // The open container's board is demoted, not stranded.
+        state.db.delete_folder("f-gone").unwrap();
+        assert_eq!(
+            state.db.get_dashboard("d-plain").unwrap().unwrap().folder_id,
+            None,
+            "a board was left pointing at a deleted container"
+        );
+
+        // The sealed container's board still holds ciphertext, so the delete is refused rather
+        // than stranding a board whose key is about to go away with the folder.
+        lock_folder_inner(&state, "f-sealed".into()).unwrap();
+        let err = state
+            .db
+            .delete_folder("f-sealed")
+            .expect_err("deleting a container with sealed boards must be refused");
+        assert!(matches!(err, AppError::Storage(_)), "got {err:?}");
+        assert_eq!(
+            state.db.get_dashboard("d-sealed").unwrap().unwrap().folder_id,
+            Some("f-sealed".to_string()),
+            "the refused delete still moved the board"
+        );
+    }
+
+    /// EVERY write against a board in a sealed container is refused.
+    ///
+    /// This is a whole category that had no gate, and the reason is worth keeping: before boards
+    /// could be filed, a dashboard could not be inside a locked folder, so no mutation NEEDED one
+    /// and none had one. Giving boards a container turned each of those writes into a way to put
+    /// plaintext into a sealed tree — a renamed board, a new tile, a reordered layout — after the
+    /// seal has already run and with nothing left to encrypt it. The next unseal then overwrites
+    /// the write from the stored blob, so the user loses the edit too.
+    ///
+    /// Enumerated rather than sampled on purpose: a gate applied to four of six mutations is not a
+    /// gate, and "the ones I remembered" is exactly how the category came to be missed.
+    ///
+    /// RED contract: drop any single `require_board_writable` / `require_tile_writable` call and
+    /// its line here fails.
+    #[test]
+    fn every_write_against_a_sealed_boards_container_is_refused() {
+        let vault = tmp_vault("dashboard-writes");
+        let state = build_state_with_vault("dashboard-writes", &vault);
+        make_open_folder(&state.db, "f-secret", "Secret");
+        std::fs::create_dir_all(vault.join("Secret")).unwrap();
+
+        let now = "2026-08-23T10:00:00Z";
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboards (id, title, emoji, tint, pinned, position, folder_id,
+                                         created_at, updated_at)
+                 VALUES ('d-1', 'Q3 layoffs', NULL, NULL, 0, 0, 'f-secret', ?1, ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboard_tiles (id, dashboard_id, kind, ref_id, title, span,
+                                              position, config, created_at)
+                 VALUES ('t-1', 'd-1', 'meeting', 'm-1', 'Standup', 1, 0, '{}', ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+
+        lock_folder_inner(&state, "f-secret".into()).unwrap();
+
+        // Board-level writes.
+        assert!(
+            matches!(
+                crate::commands::dashboards::update_dashboard_inner(
+                    &state, "d-1", Some("renamed"), None, None, None
+                ),
+                Err(AppError::Locked(_))
+            ),
+            "renaming a sealed board was allowed"
+        );
+        assert!(
+            matches!(
+                crate::commands::dashboards::delete_dashboard_inner(&state, "d-1"),
+                Err(AppError::Locked(_))
+            ),
+            "deleting a sealed board was allowed"
+        );
+        assert!(
+            matches!(
+                crate::commands::dashboards::reorder_dashboards_inner(&state, &["d-1".into()]),
+                Err(AppError::Locked(_))
+            ),
+            "reordering a sealed board was allowed"
+        );
+
+        // Tile-level writes.
+        assert!(
+            matches!(
+                crate::commands::dashboards::add_dashboard_tile_inner(
+                    &state,
+                    "d-1".into(),
+                    "meeting".into(),
+                    Some("m-9".into()),
+                    None,
+                    None,
+                    None,
+                ),
+                Err(AppError::Locked(_))
+            ),
+            "adding a tile to a sealed board was allowed"
+        );
+        assert!(
+            matches!(
+                crate::commands::dashboards::update_dashboard_tile_inner(
+                    &state,
+                    "t-1".into(),
+                    Some("new".into()),
+                    None,
+                    None,
+                ),
+                Err(AppError::Locked(_))
+            ),
+            "editing a sealed board's tile was allowed"
+        );
+        assert!(
+            matches!(
+                crate::commands::dashboards::delete_dashboard_tile_inner(&state, "t-1".into()),
+                Err(AppError::Locked(_))
+            ),
+            "deleting a sealed board's tile was allowed"
+        );
+        assert!(
+            matches!(
+                crate::commands::dashboards::reorder_dashboard_tiles_inner(
+                    &state,
+                    "d-1".into(),
+                    vec!["t-1".to_string()],
+                ),
+                Err(AppError::Locked(_))
+            ),
+            "reordering a sealed board's tiles was allowed"
+        );
+
+        // Nothing was written: the row still holds exactly what the seal left.
+        let (title, tile_title): (String, String) = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT d.title, t.title FROM dashboards d
+                   JOIN dashboard_tiles t ON t.dashboard_id = d.id WHERE d.id = 'd-1'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(title, "", "a refused write still touched the board");
+        assert_eq!(tile_title, "", "a refused write still touched the tile");
+
+        // The CONTROL: the same writes succeed on an UNFILED board, so these refusals are the
+        // container gate and not a reader that refuses everything.
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboards (id, title, emoji, tint, pinned, position, folder_id,
+                                         created_at, updated_at)
+                 VALUES ('d-free', 'Roadmap', NULL, NULL, 0, 0, NULL, ?1, ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+        crate::commands::dashboards::update_dashboard_inner(
+            &state, "d-free", Some("Renamed"), None, None, None,
+        )
+        .expect("an unfiled board must still be editable");
+    }
+
+    /// A RELOCK unfiles tasks too, not just the initial seal.
+    ///
+    /// `seal_folder_extras` unfiles on the first lock, but that is not the only way in. A folder
+    /// that is durably locked and SESSION-unlocked passes `folder_is_unlocked`, so
+    /// `set_task_container` accepts it and the user can file a task into it. The relock then runs
+    /// `reblank_folder_extras_after_verification`, which knew nothing about tasks — leaving the
+    /// task inside a container reported as locked, which is the state unfiling exists to prevent.
+    ///
+    /// RED contract: remove `unfile_tasks_in_container` from the re-blank and the task is still
+    /// filed after the relock.
+    #[test]
+    fn a_relock_unfiles_a_task_filed_while_the_container_was_session_unlocked() {
+        let vault = tmp_vault("task-relock");
+        let state = build_state_with_vault("task-relock", &vault);
+        make_open_folder(&state.db, "f-secret", "Secret");
+        std::fs::create_dir_all(vault.join("Secret")).unwrap();
+        insert_fixture_task(&state.db, "task-1", "Ship the thing");
+
+        // Durably lock, then SESSION-unlock: the state in which the folder accepts new content.
+        lock_folder_inner(&state, "f-secret".into()).unwrap();
+        let kek = secrets::get_or_create_master_kek().unwrap();
+        let wrapped = state.db.folder_wrapped_key("f-secret").unwrap().unwrap();
+        let ck_vec = crate::crypto::decrypt(&kek, &wrapped, &aad_wrapped_ck("f-secret")).unwrap();
+        let ck: [u8; 32] = ck_vec.try_into().expect("CK is 32 bytes");
+        unseal_folder_extras(&state, "f-secret", &ck, None).unwrap();
+        state
+            .unlocked_folders
+            .lock()
+            .unwrap()
+            .insert("f-secret".to_string());
+
+        state.db.set_task_container("task-1", Some("f-secret")).unwrap();
+        assert_eq!(
+            state.db.task_container("task-1").unwrap(),
+            Some("f-secret".to_string()),
+            "the fixture must start with the task filed"
+        );
+
+        reblank_folder_extras_after_verification(&state, "f-secret", Some(&ck)).unwrap();
+
+        assert_eq!(
+            state.db.task_container("task-1").unwrap(),
+            None,
+            "a relock left a task inside a container it reports as locked"
+        );
+    }
+
+    /// The keyless-relock predicate covers EVERYTHING the seal covers.
+    ///
+    /// These two are a pair: the seal decides what to encrypt, and
+    /// `Db::folder_has_plaintext_dashboards` decides whether a keyless relock may proceed without
+    /// encrypting anything. They must agree, and they stopped agreeing the moment the seal was
+    /// widened to cover `emoji`/`tint` and the predicate was not — one side of a paired invariant
+    /// moved on its own.
+    ///
+    /// The board below is the exact shape that fell through: EMPTY title, an emoji and a tint, no
+    /// tiles. The old predicate answered "nothing here is plaintext", so a keyless relock
+    /// succeeded and left both cosmetics readable in a folder it had just reported as locked.
+    ///
+    /// RED contract: drop `emoji IS NOT NULL OR tint IS NOT NULL` from the predicate and the
+    /// refusal below does not happen.
+    #[test]
+    fn the_keyless_relock_predicate_covers_every_column_the_seal_takes() {
+        let vault = tmp_vault("dashboard-cosmetics");
+        let state = build_state_with_vault("dashboard-cosmetics", &vault);
+        make_open_folder(&state.db, "f-secret", "Secret");
+        std::fs::create_dir_all(vault.join("Secret")).unwrap();
+
+        let now = "2026-08-23T10:00:00Z";
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboards (id, title, emoji, tint, pinned, position, folder_id,
+                                         created_at, updated_at)
+                 VALUES ('d-cos', '', '📊', 'indigo', 0, 0, 'f-secret', ?1, ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+
+        // The predicate must see this board as still holding plaintext.
+        assert!(
+            state.db.folder_has_plaintext_dashboards("f-secret").unwrap(),
+            "a board with only cosmetics read as having nothing to seal"
+        );
+
+        // And the keyless relock must therefore refuse rather than report the folder locked.
+        lock_folder_inner(&state, "f-secret".into()).unwrap();
+        let kek = secrets::get_or_create_master_kek().unwrap();
+        let wrapped = state.db.folder_wrapped_key("f-secret").unwrap().unwrap();
+        let ck_vec = crate::crypto::decrypt(&kek, &wrapped, &aad_wrapped_ck("f-secret")).unwrap();
+        let ck: [u8; 32] = ck_vec.try_into().expect("CK is 32 bytes");
+        unseal_folder_extras(&state, "f-secret", &ck, None).unwrap();
+        *state.master_kek.lock().unwrap() = None;
+
+        let err = reblank_folder_extras_after_verification(&state, "f-secret", None)
+            .expect_err("a keyless relock must refuse while cosmetics are readable");
+        assert!(matches!(err, AppError::Locked(_)), "got {err:?}");
+
+        // And the seal ROUND-TRIPS them, so refusing is not hiding a loss.
+        seal_dashboards_in_folder(&state.db, "f-secret", &ck).unwrap();
+        let (title, emoji, tint): (String, Option<String>, Option<String>) = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT title, emoji, tint FROM dashboards WHERE id = 'd-cos'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(title, "", "the title column must be blank at rest");
+        assert_eq!(emoji, None, "the emoji stayed readable at rest");
+        assert_eq!(tint, None, "the tint stayed readable at rest");
+
+        unseal_folder_extras(&state, "f-secret", &ck, None).unwrap();
+        let (emoji, tint): (Option<String>, Option<String>) = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT emoji, tint FROM dashboards WHERE id = 'd-cos'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(emoji.as_deref(), Some("📊"), "the emoji did not survive the seal");
+        assert_eq!(tint.as_deref(), Some("indigo"), "the tint did not survive the seal");
+    }
+
+    /// The board-SOURCES read withholds a sealed board's source list.
+    ///
+    /// SCOPE, stated because running the RED check showed this test does NOT capture the gate it
+    /// was written for: it passes with AND without the early return in
+    /// `get_dashboard_sources_inner`, and that was verified rather than assumed.
+    ///
+    /// The reason is that the seal blanks `ref_id` on every tile at rest, so the resolver already
+    /// returns nothing for a sealed board and the gate is defence-in-depth over an
+    /// already-blanked row. That is worth having — it does not depend on the seal having run, and
+    /// the row-masking gate beside it rests on the same argument — but it is not something this
+    /// test can prove, and a green test whose comment claims otherwise is worse than no test.
+    ///
+    /// What it DOES pin: the command returns an empty list for a sealed board and a non-empty one
+    /// for an open board, so a future change that made the sources path return content for a
+    /// sealed board — by reading tiles some other way, or before the seal — would fail here.
+    #[test]
+    fn the_dashboard_sources_command_withholds_a_sealed_boards_sources() {
+        let vault = tmp_vault("dashboard-sources");
+        let state = build_state_with_vault("dashboard-sources", &vault);
+        make_open_folder(&state.db, "f-secret", "Secret");
+        make_open_folder(&state.db, "f-open", "Open");
+        std::fs::create_dir_all(vault.join("Secret")).unwrap();
+
+        let now = "2026-08-23T10:00:00Z";
+        seed_meeting(&state.db, "m-src", "Body", Some("f-open"));
+        for (board, folder) in [("d-sealed", "f-secret"), ("d-open", "f-open")] {
+            state
+                .db
+                .lock()
+                .execute(
+                    "INSERT INTO dashboards (id, title, emoji, tint, pinned, position, folder_id,
+                                             created_at, updated_at)
+                     VALUES (?1, 'Board', NULL, NULL, 0, 0, ?2, ?3, ?3)",
+                    rusqlite::params![board, folder, now],
+                )
+                .unwrap();
+            state
+                .db
+                .lock()
+                .execute(
+                    "INSERT INTO dashboard_tiles (id, dashboard_id, kind, ref_id, title, span,
+                                                  position, config, created_at)
+                     VALUES (?1, ?2, 'meeting', 'm-src', 'Standup', 1, 0, '{}', ?3)",
+                    rusqlite::params![format!("{board}-t"), board, now],
+                )
+                .unwrap();
+        }
+
+        lock_folder_inner(&state, "f-secret".into()).unwrap();
+
+        let sealed =
+            crate::commands::dashboards::get_dashboard_sources_inner(&state, "d-sealed").unwrap();
+        assert!(
+            sealed.is_empty(),
+            "a sealed board disclosed its source list: {sealed:?}"
+        );
+
+        // The CONTROL: an open board still returns its sources, so a green run cannot come from a
+        // command that withholds everything.
+        let open =
+            crate::commands::dashboards::get_dashboard_sources_inner(&state, "d-open").unwrap();
+        assert!(
+            !open.is_empty(),
+            "the control board must return its sources"
+        );
+    }
+
+    /// A relock with no resolvable content key REFUSES rather than leaving boards readable.
+    ///
+    /// Every other kind the at-rest re-blank handles can be blanked without a key, because its
+    /// ciphertext is still in the row. A board's is not: `Db::unseal_dashboard` clears
+    /// `title_blob` on unlock, so an unlocked board must be re-encrypted to be blanked at all.
+    /// Skipping quietly — which is what `if let Some(ck)` did — reported the folder locked while
+    /// its boards stayed in plaintext. The refusal keeps the relock retryable.
+    #[test]
+    fn a_relock_without_a_key_refuses_instead_of_leaving_boards_readable() {
+        let vault = tmp_vault("dashboard-nokey");
+        let state = build_state_with_vault("dashboard-nokey", &vault);
+        make_open_folder(&state.db, "f-secret", "Secret");
+        std::fs::create_dir_all(vault.join("Secret")).unwrap();
+
+        let now = "2026-08-23T10:00:00Z";
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboards (id, title, emoji, tint, pinned, position, folder_id,
+                                         created_at, updated_at)
+                 VALUES ('d-7', 'Q3 layoffs', NULL, NULL, 0, 0, 'f-secret', ?1, ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+
+        // The folder is durably locked and session-unlocked: plaintext is present, and the
+        // re-blank is the thing that must take it away again.
+        lock_folder_inner(&state, "f-secret".into()).unwrap();
+        let kek = secrets::get_or_create_master_kek().unwrap();
+        let wrapped = state.db.folder_wrapped_key("f-secret").unwrap().unwrap();
+        let ck_vec = crate::crypto::decrypt(&kek, &wrapped, &aad_wrapped_ck("f-secret")).unwrap();
+        let ck: [u8; 32] = ck_vec.try_into().expect("CK is 32 bytes");
+        unseal_folder_extras(&state, "f-secret", &ck, None).unwrap();
+        let plaintext: String = state
+            .db
+            .lock()
+            .query_row("SELECT title FROM dashboards WHERE id = 'd-7'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(plaintext, "Q3 layoffs", "the fixture must start from plaintext");
+
+        // No verified key, and no cached KEK to derive one from — the shape the guard is for.
+        *state.master_kek.lock().unwrap() = None;
+        let err = reblank_folder_extras_after_verification(&state, "f-secret", None)
+            .expect_err("a keyless relock must refuse while boards hold plaintext");
+        assert!(matches!(err, AppError::Locked(_)), "got {err:?}");
+
+        let after: String = state
+            .db
+            .lock()
+            .query_row("SELECT title FROM dashboards WHERE id = 'd-7'", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(after, "Q3 layoffs", "the refusal must not have destroyed anything");
+    }
+
+    /// A tile column that was NULL comes back NULL, not "".
+    ///
+    /// The payload used to coalesce every column to a string, so the unseal wrote "" over what
+    /// had been NULL. Nothing visible changes — and every `IS NULL` predicate downstream now
+    /// answers differently for a row that merely went through a lock cycle.
+    #[test]
+    fn a_null_tile_column_survives_the_seal_as_null() {
+        let vault = tmp_vault("dashboard-null");
+        let state = build_state_with_vault("dashboard-null", &vault);
+        make_open_folder(&state.db, "f-secret", "Secret");
+        std::fs::create_dir_all(vault.join("Secret")).unwrap();
+
+        let now = "2026-08-23T10:00:00Z";
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboards (id, title, emoji, tint, pinned, position, folder_id,
+                                         created_at, updated_at)
+                 VALUES ('d-8', 'Board', NULL, NULL, 0, 0, 'f-secret', ?1, ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+        state
+            .db
+            .lock()
+            .execute(
+                "INSERT INTO dashboard_tiles (id, dashboard_id, kind, ref_id, title, span,
+                                              position, config, created_at)
+                 VALUES ('t-8', 'd-8', 'meeting', NULL, 'Standup', 2, 3, NULL, ?1)",
+                rusqlite::params![now],
+            )
+            .unwrap();
+
+        lock_folder_inner(&state, "f-secret".into()).unwrap();
+        let kek = secrets::get_or_create_master_kek().unwrap();
+        let wrapped = state.db.folder_wrapped_key("f-secret").unwrap().unwrap();
+        let ck_vec = crate::crypto::decrypt(&kek, &wrapped, &aad_wrapped_ck("f-secret")).unwrap();
+        let ck: [u8; 32] = ck_vec.try_into().expect("CK is 32 bytes");
+        unseal_folder_extras(&state, "f-secret", &ck, None).unwrap();
+
+        let (ref_kind, config_kind, kind, span, position): (String, String, String, i64, i64) =
+            state
+                .db
+                .lock()
+                .query_row(
+                    "SELECT typeof(ref_id), typeof(config), kind, span, position
+                       FROM dashboard_tiles WHERE id = 't-8'",
+                    [],
+                    |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+                )
+                .unwrap();
+        assert_eq!(ref_kind, "null", "a NULL ref_id came back as a string");
+        assert_eq!(config_kind, "null", "a NULL config came back as a string");
+        assert_eq!(kind, "meeting", "the tile kind did not survive the seal");
+        // Geometry is deliberately never sealed — an unsealed board must come back in the
+        // layout it had, not collapsed to a default.
+        assert_eq!(span, 2, "the tile span was disturbed by the seal");
+        assert_eq!(position, 3, "the tile position was disturbed by the seal");
+    }
+
+    /// Moving a board refuses a sealed container at BOTH ends, for different reasons.
+    ///
+    /// A sealed TARGET would receive a board in plaintext inside a tree the user believes is
+    /// unreadable. A sealed SOURCE is the subtler one: that board's title and tiles are ciphertext
+    /// bound by `aad_document` to the container it currently lives in, so re-parenting the row
+    /// without unsealing first would carry blobs into a container whose key cannot open them and
+    /// whose unseal enumerates them — content nothing could recover afterwards.
+    ///
+    /// RED contract for each half separately: drop the target check and the move into `f-sealed`
+    /// succeeds; drop the `board.locked` check and the move OUT of a sealed container succeeds.
+    #[test]
+    fn moving_a_board_refuses_a_sealed_container_at_either_end() {
+        let vault = tmp_vault("dashboard-move");
+        let state = build_state_with_vault("dashboard-move", &vault);
+        make_open_folder(&state.db, "f-open", "Open");
+        make_open_folder(&state.db, "f-sealed", "Sealed");
+        make_open_folder(&state.db, "f-secret", "Secret");
+        std::fs::create_dir_all(vault.join("Sealed")).unwrap();
+        std::fs::create_dir_all(vault.join("Secret")).unwrap();
+
+        let now = "2026-08-23T10:00:00Z";
+        for (board, folder) in [("d-open", "f-open"), ("d-inside", "f-secret")] {
+            state
+                .db
+                .lock()
+                .execute(
+                    "INSERT INTO dashboards (id, title, emoji, tint, pinned, position, folder_id,
+                                             created_at, updated_at)
+                     VALUES (?1, 'Board', NULL, NULL, 0, 0, ?2, ?3, ?3)",
+                    rusqlite::params![board, folder, now],
+                )
+                .unwrap();
+        }
+
+        lock_folder_inner(&state, "f-sealed".into()).unwrap();
+        lock_folder_inner(&state, "f-secret".into()).unwrap();
+
+        // TARGET sealed → refused, and the board has not moved.
+        let err = move_dashboard_to_container_inner(&state, "d-open", Some("f-sealed"))
+            .expect_err("a sealed container must not accept a board");
+        assert!(matches!(err, AppError::Locked(_)), "got {err:?}");
+        assert_eq!(
+            state.db.get_dashboard("d-open").unwrap().unwrap().folder_id,
+            Some("f-open".to_string()),
+            "the refused move still re-parented the board"
+        );
+
+        // SOURCE sealed → refused, and the board has not moved.
+        let err = move_dashboard_to_container_inner(&state, "d-inside", Some("f-open"))
+            .expect_err("a board in a sealed container must not be moved out of it");
+        assert!(matches!(err, AppError::Locked(_)), "got {err:?}");
+        assert_eq!(
+            state.db.get_dashboard("d-inside").unwrap().unwrap().folder_id,
+            Some("f-secret".to_string()),
+            "the refused move still re-parented the board"
+        );
+
+        // An id that names no container is refused too — otherwise a board lands with a dangling
+        // anchor: invisible in the tree, and outside any future lock.
+        let err = move_dashboard_to_container_inner(&state, "d-open", Some("f-nope"))
+            .expect_err("an unknown container must be refused");
+        assert!(matches!(err, AppError::InvalidArg(_)), "got {err:?}");
+
+        // The CONTROL: open → open works, so the refusals above are not a reader that refuses
+        // everything.
+        make_open_folder(&state.db, "f-elsewhere", "Elsewhere");
+        move_dashboard_to_container_inner(&state, "d-open", Some("f-elsewhere")).unwrap();
+        assert_eq!(
+            state.db.get_dashboard("d-open").unwrap().unwrap().folder_id,
+            Some("f-elsewhere".to_string()),
+            "an open-to-open move did not land"
+        );
+    }
+
+    /// A filed task appears in its container's tree, and SEALING that container unfiles it.
+    ///
+    /// The lock model's promise is that a sealed container discloses nothing. A task's content
+    /// lives in an org's E2EE store, so a container's content key cannot seal it — which means a
+    /// task left inside a sealed container would stay exactly as readable as before while the user
+    /// was told the container was locked. Unfiling on seal is what makes the promise literally
+    /// true, and it loses nothing: the task is intact and back where it was before it was filed.
+    ///
+    /// RED contract: drop the `unfile_tasks_in_container` call from `seal_folder_extras` and the
+    /// task is still filed in a sealed container after the lock.
+    #[test]
+    fn sealing_a_container_unfiles_the_tasks_inside_it() {
+        let vault = tmp_vault("task-placement");
+        let state = build_state_with_vault("task-placement", &vault);
+        make_open_folder(&state.db, "f-secret", "Secret");
+        std::fs::create_dir_all(vault.join("Secret")).unwrap();
+        insert_fixture_task(&state.db, "task-1", "Ship the thing");
+
+        // Filed: the tree shows it under that container.
+        assert!(
+            state.db.set_task_container("task-1", Some("f-secret")).unwrap(),
+            "the task should have been filed"
+        );
+        let nothing_unlocked = std::collections::HashSet::new();
+        let (rows, total) = state
+            .db
+            .container_items_page(
+                Some("f-secret"),
+                crate::storage::models::ItemKind::Task,
+                0,
+                50,
+                &nothing_unlocked,
+            )
+            .unwrap();
+        assert_eq!(total, 1, "a filed task did not appear in its container");
+        assert_eq!(rows[0].id, "task-1");
+        assert_eq!(
+            rows[0].title.as_deref(),
+            Some("Ship the thing"),
+            "the tree read the wrong title out of the envelope"
+        );
+
+        // Sealed: the task leaves the container rather than sitting inside a lock that cannot
+        // reach it.
+        lock_folder_inner(&state, "f-secret".into()).unwrap();
+        assert_eq!(
+            state.db.task_container("task-1").unwrap(),
+            None,
+            "a task survived the seal of the container it was filed in"
+        );
+        let (_, total) = state
+            .db
+            .container_items_page(
+                Some("f-secret"),
+                crate::storage::models::ItemKind::Task,
+                0,
+                50,
+                &nothing_unlocked,
+            )
+            .unwrap();
+        assert_eq!(total, 0, "a sealed container still lists a task");
+    }
+
+    /// An UNFILED task belongs to the Tasks view, not the tree's Inbox.
+    ///
+    /// The Inbox leg is empty on purpose. `commands::tasks::list_tasks` gates on session and org
+    /// read context; mirroring every unfiled org task into the hierarchy would be a second route
+    /// to the same rows that does not pass through that gate.
+    #[test]
+    fn an_unfiled_task_is_not_mirrored_into_the_tree_inbox() {
+        let state = build_state("task-inbox");
+        insert_fixture_task(&state.db, "task-2", "Unfiled work");
+
+        let (rows, total) = state
+            .db
+            .container_items_page(
+                None,
+                crate::storage::models::ItemKind::Task,
+                0,
+                50,
+                &std::collections::HashSet::new(),
+            )
+            .unwrap();
+        assert!(rows.is_empty() && total == 0, "the Inbox mirrored an unfiled task");
+
+        // The control: once filed, the SAME row is reachable — so the assertion above cannot be
+        // passing on a leg that returns nothing for anyone.
+        make_open_folder(&state.db, "f-open", "Open");
+        state.db.set_task_container("task-2", Some("f-open")).unwrap();
+        let (rows, _) = state
+            .db
+            .container_items_page(
+                Some("f-open"),
+                crate::storage::models::ItemKind::Task,
+                0,
+                50,
+                &std::collections::HashSet::new(),
+            )
+            .unwrap();
+        assert_eq!(rows.len(), 1, "a filed task did not become reachable");
+    }
+
+    /// A filed task vanishes from the tree when its ORG is gone or switched off.
+    ///
+    /// This is the BLOCKER a reviewer found, and it was mine: the tree leg selected task titles
+    /// out of `org_tasks` with only the folder's `visibility_clause` — no membership predicate, no
+    /// context-enabled predicate. Filing a task locally then survived leaving the org, losing the
+    /// seat, or turning that org's context off on this device, and the title kept rendering.
+    ///
+    /// What makes it worth a test rather than a one-line fix is that the reasoning was already
+    /// written and then contradicted: the Inbox arm's own comment says mirroring org tasks into
+    /// the hierarchy "would be a SECOND, ungated route to the same rows" — and the Container arm
+    /// one branch later was exactly that route.
+    ///
+    /// RED contract: drop the `JOIN org_state ... context_enabled = 1` and both halves below
+    /// return the task.
+    #[test]
+    fn a_filed_task_needs_a_live_org_membership_to_appear_in_the_tree() {
+        let state = build_state("task-org-gate");
+        make_open_folder(&state.db, "f-open", "Open");
+        let nothing_unlocked = std::collections::HashSet::new();
+
+        // (a) org context DISABLED on this device.
+        insert_fixture_task_for_org(&state.db, "task-off", "Disabled org", "org-off", false);
+        state.db.set_task_container("task-off", Some("f-open")).unwrap();
+
+        // (b) NO local membership row at all — the shape after leaving an org.
+        insert_fixture_task_row(&state.db, "task-gone", "Former org", "org-gone");
+        state.db.set_task_container("task-gone", Some("f-open")).unwrap();
+
+        // (c) TOMBSTONED in the org — deleted for everyone else, but its `org_tasks` row
+        // survives locally, so without the item-head join its old title kept rendering under the
+        // container it was filed in.
+        insert_fixture_task_for_org(&state.db, "task-dead", "Deleted", "org-dead", true);
+        state
+            .db
+            .lock()
+            .execute(
+                "UPDATE org_items SET tombstoned = 1 WHERE item_id = 'task-dead'",
+                [],
+            )
+            .unwrap();
+        state.db.set_task_container("task-dead", Some("f-open")).unwrap();
+
+        // (d) SUPERSEDED — not the current head any more.
+        insert_fixture_task_for_org(&state.db, "task-old", "Superseded", "org-old", true);
+        state
+            .db
+            .lock()
+            .execute(
+                "UPDATE org_items SET is_current = 0 WHERE item_id = 'task-old'",
+                [],
+            )
+            .unwrap();
+        state.db.set_task_container("task-old", Some("f-open")).unwrap();
+
+        // (e) the CONTROL: a live membership, context on, live current head.
+        insert_fixture_task_for_org(&state.db, "task-live", "Live org", "org-live", true);
+        state.db.set_task_container("task-live", Some("f-open")).unwrap();
+
+        let (rows, total) = state
+            .db
+            .container_items_page(
+                Some("f-open"),
+                crate::storage::models::ItemKind::Task,
+                0,
+                50,
+                &nothing_unlocked,
+            )
+            .unwrap();
+
+        let ids: Vec<&str> = rows.iter().map(|r| r.id.as_str()).collect();
+        assert!(
+            !ids.contains(&"task-off"),
+            "a task from an org whose context is disabled was rendered: {ids:?}"
+        );
+        assert!(
+            !ids.contains(&"task-gone"),
+            "a task from an org this device is not a member of was rendered: {ids:?}"
+        );
+        assert!(
+            !ids.contains(&"task-dead"),
+            "a task tombstoned in its org was rendered: {ids:?}"
+        );
+        assert!(
+            !ids.contains(&"task-old"),
+            "a superseded task revision was rendered: {ids:?}"
+        );
+        assert!(
+            ids.contains(&"task-live"),
+            "the control task must still appear, or this proves nothing: {ids:?}"
+        );
+        assert_eq!(total, 1, "the disclosed total counted ungated tasks: {total}");
+    }
+
+    /// Deleting a container unfiles its tasks instead of stranding them.
+    #[test]
+    fn deleting_a_container_unfiles_the_tasks_inside_it() {
+        let state = build_state("task-delete");
+        make_open_folder(&state.db, "f-gone", "Gone");
+        insert_fixture_task(&state.db, "task-3", "Orphan me");
+        state.db.set_task_container("task-3", Some("f-gone")).unwrap();
+
+        state.db.delete_folder("f-gone").unwrap();
+        assert_eq!(
+            state.db.task_container("task-3").unwrap(),
+            None,
+            "a task was left pointing at a deleted container"
+        );
+    }
+
     fn make_open_folder(db: &Db, id: &str, path: &str) {
         db.insert_folder(&Folder {
             id: id.to_string(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -321,6 +321,8 @@ pub fn run() {
             commands::revoke_shares_for_folder,
             commands::list_tasks,
             commands::get_task,
+            commands::set_task_container,
+            commands::move_dashboard_to_container,
             commands::create_task,
             commands::update_task,
             commands::delete_task,

--- a/src-tauri/src/storage/dashboards_store.rs
+++ b/src-tauri/src/storage/dashboards_store.rs
@@ -18,11 +18,14 @@
 //! The methods below are an inherent-impl split of [`crate::storage::db::Db`] across files, the
 //! same pattern the other `*_store.rs` modules use.
 
+use std::collections::HashSet;
+
 use rusqlite::{OptionalExtension, Row, Transaction};
 
 use crate::error::{AppError, Result};
 use crate::storage::db::{map_err, Db};
 use crate::storage::models::{Dashboard, DashboardTile};
+use crate::storage::visibility_clause;
 
 /// Tile kinds Murmur knows how to render. Anything else is refused at the command layer, so a
 /// malformed row can never reach the renderer as an unhandled variant.
@@ -63,9 +66,39 @@ fn row_to_dashboard(row: &Row<'_>) -> rusqlite::Result<Dashboard> {
         tint: row.get(3)?,
         pinned: row.get::<_, i64>(4)? != 0,
         position: row.get(5)?,
-        created_at: row.get(6)?,
-        updated_at: row.get(7)?,
+        folder_id: row.get(6)?,
+        created_at: row.get(7)?,
+        updated_at: row.get(8)?,
+        // The raw mapper never claims a board is locked: it has not consulted the session
+        // unlock set and cannot. Only the GATED readers set this, so a caller that skips them
+        // gets `false` — which is why they are the only ones that may return a board at all.
+        locked: false,
     })
+}
+
+/// Blank a board that is sealed and not unlocked for this session.
+///
+/// Title, emoji and tint all go: an emoji and an accent are weak signals, but they are still
+/// signals about a thing the user asked to be unreadable.
+/// Blank a board the caller has already decided is sealed-and-not-unlocked.
+///
+/// The ONE masking rule, so the row-at-a-time reader and the SQL-side list reader cannot drift
+/// into masking different fields.
+fn mask_board(board: Dashboard) -> Dashboard {
+    Dashboard {
+        title: "🔒 Locked".to_string(),
+        emoji: None,
+        tint: None,
+        locked: true,
+        // The CONTAINER goes too. Keeping it let a caller group masked boards by folder and count
+        // how many a sealed container holds — the exact fact the tree leg withholds on purpose
+        // (`every_dashboard_read_sink_withholds_a_sealed_board` asserts `total == 0` there). Two
+        // readers changed in one diff cannot take opposite positions on the same disclosure; the
+        // board's own row is the weaker one, because nothing downstream needs a sealed board's
+        // container to render it as locked.
+        folder_id: None,
+        ..board
+    }
 }
 
 fn row_to_tile(row: &Row<'_>) -> rusqlite::Result<DashboardTile> {
@@ -82,7 +115,30 @@ fn row_to_tile(row: &Row<'_>) -> rusqlite::Result<DashboardTile> {
     })
 }
 
-const DASHBOARD_COLS: &str = "id, title, emoji, tint, pinned, position, created_at, updated_at";
+/// A tile's plaintext, recovered from its sealed payload.
+///
+/// Every field is `Option` so a column that was NULL before the seal is NULL after the unseal.
+/// Collapsing NULL to "" would make the round-trip lossy in a way no equality check on the
+/// visible text would catch.
+#[derive(Debug, Clone)]
+pub(crate) struct RestoredTile {
+    pub id: String,
+    pub title: Option<String>,
+    pub ref_id: Option<String>,
+    pub config: Option<String>,
+    pub kind: Option<String>,
+}
+
+/// One sealed board's ciphertext: its title blob (absent when the board was never sealed) and a
+/// blob per tile that has one. The unseal's whole input.
+pub(crate) type SealedDashboardBlobs = (String, Option<Vec<u8>>, Vec<(String, Vec<u8>)>);
+
+const DASHBOARD_COLS: &str =
+    "id, title, emoji, tint, pinned, position, folder_id, created_at, updated_at";
+/// The same columns, qualified — required by any read that JOINs `folders`, which brings a second
+/// `id` (and a `locked`) into scope and makes the bare list ambiguous.
+const DASHBOARD_COLS_D: &str = "d.id, d.title, d.emoji, d.tint, d.pinned, d.position, d.folder_id,
+     d.created_at, d.updated_at";
 const TILE_COLS: &str = "id, dashboard_id, kind, ref_id, title, span, position, config, created_at";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -140,6 +196,307 @@ impl Db {
         Ok(rows)
     }
 
+    /// Every board, with a SEALED board's title and cosmetics masked.
+    ///
+    /// A board filed in a container inherits that container's lock, and its title is content:
+    /// "Q3 layoffs" names the thing whether or not the tiles are readable. The ungated
+    /// `list_dashboards` returned every title unconditionally, which was correct only while a
+    /// board could not live in a folder at all.
+    ///
+    /// Masked rather than omitted, for the reason the meeting detail is masked rather than
+    /// omitted: a user who locked a folder should still see that the board exists and can be
+    /// unlocked, not wonder whether it was deleted.
+    pub fn list_dashboards_visible(&self, unlocked: &HashSet<String>) -> Result<Vec<Dashboard>> {
+        // ONE statement on ONE connection, and the sealed-ness rule is the SHARED
+        // `visibility_clause` every other reader uses. The first version took two separate
+        // `self.lock()`s — rows, then a hand-rolled `SELECT id FROM folders WHERE locked = 1` —
+        // which is two defects at once: a relock landing between them yields plaintext rows
+        // judged against a stale sealed set, and any predicate `visibility_clause` grows beyond
+        // `locked = 1` would silently not apply here.
+        let visible = visibility_clause("f", unlocked);
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(&format!(
+                "SELECT {DASHBOARD_COLS_D},
+                        CASE WHEN d.folder_id IS NULL OR {visible} THEN 0 ELSE 1 END AS sealed
+                   FROM dashboards d
+                   LEFT JOIN folders f ON f.id = d.folder_id
+                  ORDER BY d.pinned DESC, d.position ASC, d.updated_at DESC"
+            ))
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |r| {
+                let board = row_to_dashboard(r)?;
+                let sealed: i64 = r.get("sealed")?;
+                Ok(if sealed == 1 { mask_board(board) } else { board })
+            })
+            .map_err(map_err)?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(map_err)?;
+        Ok(rows)
+    }
+
+    /// One board, masked on the same terms as [`Db::list_dashboards_visible`].
+    pub fn get_dashboard_visible(
+        &self,
+        id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Option<Dashboard>> {
+        let visible = visibility_clause("f", unlocked);
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(&format!(
+                "SELECT {DASHBOARD_COLS_D},
+                        CASE WHEN d.folder_id IS NULL OR {visible} THEN 0 ELSE 1 END AS sealed
+                   FROM dashboards d
+                   LEFT JOIN folders f ON f.id = d.folder_id
+                  WHERE d.id = ?1"
+            ))
+            .map_err(map_err)?;
+        let board = stmt
+            .query_row(rusqlite::params![id], |r| {
+                let board = row_to_dashboard(r)?;
+                let sealed: i64 = r.get("sealed")?;
+                Ok(if sealed == 1 { mask_board(board) } else { board })
+            })
+            .optional()
+            .map_err(map_err)?;
+        Ok(board)
+    }
+
+    /// Re-file a board into a container, or unfile it with `None`.
+    ///
+    ///
+    /// Returns false when no board carries that id, so the caller refuses rather than reporting a
+    /// success that moved nothing.
+    pub(crate) fn set_dashboard_folder(&self, id: &str, folder_id: Option<&str>) -> Result<bool> {
+        let conn = self.lock();
+        let n = conn
+            .execute(
+                "UPDATE dashboards SET folder_id = ?2 WHERE id = ?1",
+                rusqlite::params![id, folder_id],
+            )
+            .map_err(map_err)?;
+        Ok(n > 0)
+    }
+
+    /// True when any board in this folder still holds PLAINTEXT.
+    ///
+    /// Asked by the at-rest re-blank when no content key could be resolved: skipping the seal
+    /// silently would report the folder locked while its boards stayed readable, so the re-blank
+    /// refuses instead.
+    ///
+    /// THIS PREDICATE MUST MATCH THE SEAL'S, and an earlier revision of it did not. The seal asks
+    /// `!board.title.is_empty() || board.emoji.is_some() || board.tint.is_some()`; this one asked
+    /// about the title alone. A board with an empty title, an emoji or a tint, and no plaintext
+    /// tiles therefore answered "nothing to seal" — so a keyless relock SUCCEEDED and left the
+    /// emoji and the accent readable in a folder it had just reported as locked. The gap opened
+    /// the moment the seal was widened to cover the two cosmetic columns and this half was not:
+    /// one side of a paired invariant moved. `seal_dashboards_in_folder` names this function as
+    /// its twin, and any future column that becomes sealable has to arrive in both.
+    pub(crate) fn folder_has_plaintext_dashboards(&self, folder_id: &str) -> Result<bool> {
+        let conn = self.lock();
+        let found: i64 = conn
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM dashboards d
+                     WHERE d.folder_id = ?1
+                       AND (COALESCE(d.title, '') <> ''
+                            OR d.emoji IS NOT NULL
+                            OR d.tint IS NOT NULL
+                            OR EXISTS(SELECT 1 FROM dashboard_tiles t
+                                       WHERE t.dashboard_id = d.id AND t.config_blob IS NULL)))",
+                rusqlite::params![folder_id],
+                |r| r.get(0),
+            )
+            .map_err(map_err)?;
+        Ok(found == 1)
+    }
+
+
+    /// Every board filed in a folder — the seal's enumeration.
+    pub(crate) fn dashboards_in_folder(&self, folder_id: &str) -> Result<Vec<Dashboard>> {
+        let conn = self.lock();
+        let sql = format!("SELECT {DASHBOARD_COLS} FROM dashboards WHERE folder_id = ?1");
+        let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![folder_id], row_to_dashboard)
+            .map_err(map_err)?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(map_err)?;
+        Ok(rows)
+    }
+
+    /// `(tile id, sealable payload)` for one board — the seal's per-tile enumeration.
+    ///
+    /// Only tiles that still hold PLAINTEXT — `config_blob IS NULL` — are returned, and that
+    /// predicate is load-bearing rather than an optimisation. `seal_dashboards_in_folder` runs
+    /// again on every relock of an already-sealed folder, and an already-sealed tile's columns
+    /// are blank by construction; without this filter that second pass would encrypt three empty
+    /// strings and overwrite the good ciphertext with them, destroying the tile's content on the
+    /// first relock and leaving nothing to recover. The title half is covered by its own
+    /// `!board.title.is_empty()` guard, which is the same predicate spelled differently.
+    ///
+    /// The payload is the tile's `title`, `ref_id` and `config` together, encoded as one JSON
+    /// object so a single blob restores all three. Sealing only `config` left the other two in
+    /// plaintext, and both are disclosures: `title` is a COPY of the source meeting's or note's
+    /// title, and `ref_id` names which one the board is built from. A lock that hid the board's
+    /// own name while leaving "Standup" and its meeting id readable would be a lock with a hole
+    /// exactly where someone would look.
+    pub(crate) fn dashboard_tile_payloads(
+        &self,
+        dashboard_id: &str,
+    ) -> Result<Vec<(String, String)>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, title, ref_id, config, kind
+                   FROM dashboard_tiles WHERE dashboard_id = ?1 AND config_blob IS NULL",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![dashboard_id], |r| {
+                // The columns go in as `Option<String>`, NOT coalesced to "". A tile whose
+                // `ref_id` was NULL and came back as "" is not a byte-identical restore — it is
+                // a silent type change that any `IS NULL` predicate downstream then reads
+                // differently. JSON null round-trips; the empty string does not stand in for it.
+                let payload = serde_json::json!({
+                    "title": r.get::<_, Option<String>>(1)?,
+                    "refId": r.get::<_, Option<String>>(2)?,
+                    "config": r.get::<_, Option<String>>(3)?,
+                    "kind": r.get::<_, Option<String>>(4)?,
+                })
+                .to_string();
+                Ok((r.get::<_, String>(0)?, payload))
+            })
+            .map_err(map_err)?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(map_err)?;
+        Ok(rows)
+    }
+
+    /// Store the sealed title and blank the plaintext — called only after the caller has proved
+    /// the blob decrypts back byte-identical.
+    pub(crate) fn seal_dashboard_title(&self, id: &str, blob: &[u8]) -> Result<()> {
+        let conn = self.lock();
+        // `emoji` and `tint` go with the title, because the blob now carries all three. The read
+        // path masked them from the start on the grounds that they are "still signals about a
+        // thing the user asked to be unreadable" — and leaving the COLUMNS populated made that
+        // masking protection against the app rather than against anyone reading the database,
+        // which is the threat the seal is for.
+        conn.execute(
+            "UPDATE dashboards SET title = '', emoji = NULL, tint = NULL, title_blob = ?2
+              WHERE id = ?1",
+            rusqlite::params![id, blob],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// The tile twin of [`Db::seal_dashboard_title`]: blanks title, ref, config and kind.
+    ///
+    /// `kind` goes with them because "this locked board contains three MEETING tiles" is a
+    /// disclosure about a thing the user asked to be unreadable. `span` and `position` stay:
+    /// they are the grid geometry, carry no reference to any content, and keeping them means an
+    /// unsealed board comes back in the layout it had rather than collapsed to a default.
+    pub(crate) fn seal_dashboard_tile(&self, id: &str, blob: &[u8]) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE dashboard_tiles
+                SET title = '', ref_id = '', config = '', kind = '', config_blob = ?2
+              WHERE id = ?1",
+            rusqlite::params![id, blob],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Restore a sealed board: decrypt its cosmetics and every tile payload back into place.
+    ///
+    /// The mirror of the seal, and the reason the seal is allowed to blank anything. Runs under
+    /// the same CK and CLEARS the blob — the earlier version of this sentence claimed the opposite
+    /// ("leaves the blob in place so an interrupted unseal can be retried"), which was not what
+    /// the SQL did and not what the rest of the system assumes. `folder_has_plaintext_dashboards`
+    /// and the keyless-relock refusal in `reblank_folder_extras_after_verification` both depend on
+    /// the blob being gone after an unlock: that absence is precisely why a board, unlike a
+    /// transcript segment, cannot be re-blanked without a key. A comment asserting the reverse on
+    /// a crypto-destructive path is worse than no comment, because it is the thing a later reader
+    /// trusts instead of the code.
+    pub(crate) fn unseal_dashboard(
+        &self,
+        id: &str,
+        cosmetics: Option<&(String, Option<String>, Option<String>)>,
+        tiles: &[RestoredTile],
+    ) -> Result<()> {
+        let conn = self.lock();
+        // `None` means this board was never cosmetics-sealed (one with no title, emoji or tint is
+        // not), so those columns are already correct and must be left alone — writing over them
+        // would make the unseal destroy what the seal deliberately did not take.
+        if let Some((title, emoji, tint)) = cosmetics {
+            conn.execute(
+                "UPDATE dashboards SET title = ?2, emoji = ?3, tint = ?4, title_blob = NULL
+                  WHERE id = ?1",
+                rusqlite::params![id, title, emoji, tint],
+            )
+            .map_err(map_err)?;
+        }
+        for tile in tiles {
+            // Plain `?5`, NOT `COALESCE(?5, kind)`. An earlier revision coalesced, reasoning
+            // about a blob written before `kind` joined the payload — but `title_blob` and
+            // `config_blob` are introduced in the same change that added `kind` to it, so no such
+            // blob can exist. Worse, the seal blanks `kind` to '', so the fallback value would
+            // always have been that empty string rather than anything worth keeping, and the
+            // coalesce silently broke the NULL-round-trips-as-NULL property every other column
+            // here holds.
+            conn.execute(
+                "UPDATE dashboard_tiles
+                    SET title = ?2, ref_id = ?3, config = ?4, kind = ?5, config_blob = NULL
+                  WHERE id = ?1",
+                rusqlite::params![tile.id, tile.title, tile.ref_id, tile.config, tile.kind],
+            )
+            .map_err(map_err)?;
+        }
+        Ok(())
+    }
+
+    /// The sealed title blob and every sealed tile blob for one board — the unseal's source.
+    pub(crate) fn sealed_dashboard_blobs(
+        &self,
+        folder_id: &str,
+    ) -> Result<Vec<SealedDashboardBlobs>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare("SELECT id, title_blob FROM dashboards WHERE folder_id = ?1")
+            .map_err(map_err)?;
+        let boards = stmt
+            .query_map(rusqlite::params![folder_id], |r| {
+                Ok((r.get::<_, String>(0)?, r.get::<_, Option<Vec<u8>>>(1)?))
+            })
+            .map_err(map_err)?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(map_err)?;
+        drop(stmt);
+
+        let mut out = Vec::new();
+        for (board_id, title_blob) in boards {
+            let mut tile_stmt = conn
+                .prepare(
+                    "SELECT id, config_blob FROM dashboard_tiles
+                      WHERE dashboard_id = ?1 AND config_blob IS NOT NULL",
+                )
+                .map_err(map_err)?;
+            let tiles = tile_stmt
+                .query_map(rusqlite::params![board_id], |r| {
+                    Ok((r.get::<_, String>(0)?, r.get::<_, Vec<u8>>(1)?))
+                })
+                .map_err(map_err)?
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .map_err(map_err)?;
+            out.push((board_id, title_blob, tiles));
+        }
+        Ok(out)
+    }
+
     pub fn get_dashboard(&self, id: &str) -> Result<Option<Dashboard>> {
         let conn = self.lock();
         let sql = format!("SELECT {DASHBOARD_COLS} FROM dashboards WHERE id = ?1");
@@ -188,12 +545,27 @@ impl Db {
     }
 
     /// Insert a board. `position` is appended after the current maximum so a new board lands last.
+    /// Insert an UNFILED board — the shape every caller had before containers existed, kept so
+    /// forty-five call sites do not have to say "no folder" to mean what they already meant.
     pub fn insert_dashboard(
         &self,
         id: &str,
         title: &str,
         emoji: Option<&str>,
         tint: Option<&str>,
+        now: &str,
+    ) -> Result<()> {
+        self.insert_dashboard_in_folder(id, title, emoji, tint, None, now)
+    }
+
+    /// Insert a board, optionally FILED in a container.
+    pub fn insert_dashboard_in_folder(
+        &self,
+        id: &str,
+        title: &str,
+        emoji: Option<&str>,
+        tint: Option<&str>,
+        folder_id: Option<&str>,
         now: &str,
     ) -> Result<()> {
         let mut conn = self.lock();
@@ -206,9 +578,10 @@ impl Db {
             )
             .map_err(map_err)?;
         tx.execute(
-            "INSERT INTO dashboards (id, title, emoji, tint, pinned, position, created_at, updated_at)
-             VALUES (?1, ?2, ?3, ?4, 0, ?5, ?6, ?6)",
-            rusqlite::params![id, title, emoji, tint, next, now],
+            "INSERT INTO dashboards (id, title, emoji, tint, pinned, position, folder_id,
+                                     created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, 0, ?5, ?7, ?6, ?6)",
+            rusqlite::params![id, title, emoji, tint, next, now, folder_id],
         )
         .map_err(map_err)?;
         advance_context_generation(&tx, id, true)?;

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -1567,6 +1567,33 @@ impl Db {
             "dashboard_context_generation",
             "INTEGER",
         )?;
+
+        // A dashboard's container, and the blobs its seal writes. Added HERE, after the
+        // dashboards DDL above, because `add_column_if_missing` inspects a table that must
+        // already exist — placing them with the `folders` columns made the very first launch
+        // fail with "no such table: dashboards", which is a refusal to START, not a bad column.
+        //
+        // `folder_id` is NULLABLE on purpose: every board that exists today is unfiled, and
+        // unfiled is a normal state for a board rather than a defect to repair. It is also the
+        // board's LOCK anchor — before it, a board had no folder, so no lock could cover it.
+        //
+        // The blobs hold what the seal takes: the title names the thing, and a tile's `ref_id`
+        // plus `config` say which meeting or note the board is built from, which is exactly
+        // what a locked folder exists to stop disclosing.
+        Self::add_column_if_missing(conn, "dashboards", "folder_id", "TEXT")?;
+        // A task's LOCAL placement. Nullable because placement is optional and because every task
+        // that predates the hierarchy has none.
+        //
+        // LOCAL-ONLY, and that is load-bearing: an `org_tasks` row is the SQLCipher projection of
+        // an E2EE envelope, and the bytes that egress are `envelope_json`, built from
+        // `TaskEnvelope`. This column is not a field of that struct and no code path copies it in,
+        // so a user's private folder structure — which is exactly the kind of thing a shared task
+        // must not carry to an org — cannot leave the device. Adding it to `TaskEnvelope` would
+        // silently make it egress; do not.
+        Self::add_column_if_missing(conn, "org_tasks", "container_id", "TEXT")?;
+        Self::add_column_if_missing(conn, "dashboards", "title_blob", "BLOB")?;
+        Self::add_column_if_missing(conn, "dashboard_tiles", "config_blob", "BLOB")?;
+
         Self::add_column_if_missing(
             conn,
             "ask_conversations",
@@ -6816,6 +6843,45 @@ impl Db {
         // to non-authored documents — authored notes were reparented out above (and refused if not).
         tx.execute(
             "DELETE FROM documents WHERE folder_id = ?1 AND kind != 'note'",
+            rusqlite::params![id],
+        )
+        .map_err(map_err)?;
+        // BOARDS: demote to unfiled in the SAME transaction, exactly as authored notes are
+        // reparented above. A board left pointing at a deleted folder is invisible in the tree
+        // (its `LEFT JOIN folders` yields no row, so neither the unfiled branch nor the visible
+        // branch holds) while still appearing in the flat list — a row the user can open but
+        // cannot find, outside any future lock.
+        //
+        // Refuse first if a board here still holds CIPHERTEXT. The command layer removes the lock
+        // before deleting, so by this point boards should be plaintext; a blob surviving means the
+        // unseal did not run, and demoting would strand a board whose content key is about to be
+        // discarded with the folder. Losing content is worse than refusing a delete.
+        let sealed_boards: i64 = tx
+            .query_row(
+                "SELECT COUNT(*) FROM dashboards d
+                  WHERE d.folder_id = ?1
+                    AND (d.title_blob IS NOT NULL
+                         OR EXISTS(SELECT 1 FROM dashboard_tiles t
+                                    WHERE t.dashboard_id = d.id AND t.config_blob IS NOT NULL))",
+                rusqlite::params![id],
+                |r| r.get(0),
+            )
+            .map_err(map_err)?;
+        if sealed_boards > 0 {
+            return Err(AppError::Storage(format!(
+                "refusing to delete folder {id}: {sealed_boards} board(s) still hold sealed \
+                 content — remove the lock first (never strand a sealed board)"
+            )));
+        }
+        tx.execute(
+            "UPDATE dashboards SET folder_id = NULL WHERE folder_id = ?1",
+            rusqlite::params![id],
+        )
+        .map_err(map_err)?;
+        // TASKS: same demotion, same reason — a task pointing at a deleted container is a row the
+        // tree cannot show and the user cannot find. Unfiled, it is back in the Tasks view.
+        tx.execute(
+            "UPDATE org_tasks SET container_id = NULL WHERE container_id = ?1",
             rusqlite::params![id],
         )
         .map_err(map_err)?;

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -2342,8 +2342,15 @@ pub struct Dashboard {
     pub tint: Option<String>,
     pub pinned: bool,
     pub position: i64,
+    /// The container this board is filed in; `None` means unfiled, which every board that
+    /// predates the hierarchy is. It is also the board's LOCK anchor: a board with no folder
+    /// cannot be sealed, because there is no folder whose key would seal it.
+    pub folder_id: Option<String>,
     pub created_at: String,
     pub updated_at: String,
+    /// True when this board's folder is sealed and NOT unlocked for this session. The title
+    /// and tiles are then masked rather than returned — see `Db::list_dashboards_visible`.
+    pub locked: bool,
 }
 
 /// One tile on a board — a pointer plus its layout, never content.

--- a/src-tauri/src/storage/tasks_store.rs
+++ b/src-tauri/src/storage/tasks_store.rs
@@ -4,6 +4,8 @@
 //! stores only an origin device's editable source payload so the existing stable org-document CAS
 //! machinery can recover and republish it. `task_local_refs` never egresses.
 
+use std::collections::HashSet;
+
 use rusqlite::{OptionalExtension, Transaction};
 
 use crate::error::{AppError, Result};
@@ -164,6 +166,94 @@ impl Db {
         .map_err(map_err)?;
         tx.commit().map_err(map_err)?;
         Ok(())
+    }
+
+    /// File a task into a local container, or clear its placement with `None`.
+    ///
+    /// Returns false when no task carries that id, so the caller can refuse rather than report a
+    /// success that moved nothing.
+    pub(crate) fn set_task_container(&self, task_id: &str, container_id: Option<&str>) -> Result<bool> {
+        let conn = self.lock();
+        let n = conn
+            .execute(
+                "UPDATE org_tasks SET container_id = ?2 WHERE id = ?1",
+                rusqlite::params![task_id, container_id],
+            )
+            .map_err(map_err)?;
+        Ok(n > 0)
+    }
+
+    /// Unfile every task in a container, returning how many moved.
+    ///
+    /// Called when the container is SEALED. A task's content lives in an org's E2EE store, so a
+    /// container's content key cannot seal it — which means a task left inside a sealed container
+    /// would stay exactly as readable as before while the user was told the container was locked.
+    /// That is the one outcome the lock model must never produce, so the task leaves the container
+    /// instead. Nothing is lost: the task is intact and unfiled, precisely where it was before
+    /// anyone filed it, and it is still listed in the Tasks view.
+    pub(crate) fn unfile_tasks_in_container(&self, container_id: &str) -> Result<usize> {
+        let conn = self.lock();
+        let n = conn
+            .execute(
+                "UPDATE org_tasks SET container_id = NULL WHERE container_id = ?1",
+                rusqlite::params![container_id],
+            )
+            .map_err(map_err)?;
+        Ok(n)
+    }
+
+    /// The container a task is filed in, or `None` when it is unfiled. TESTS ONLY.
+    ///
+    /// RAW: no visibility predicate. An earlier version of this comment justified that by saying
+    /// the seal and relock paths use it — they do not; they use
+    /// [`Db::unfile_tasks_in_container`], which needs no per-task read at all.
+    ///
+    /// It survives because the unfiling tests need it and CANNOT use the gated variant. They
+    /// assert that a task is no longer filed after a container is sealed, and
+    /// `task_container_visible` returns `None` for a sealed container whether the task is filed
+    /// there or not — so asserting `None` through it would pass on a relock that unfiled nothing.
+    /// The raw read is what makes that assertion mean something.
+    #[cfg(test)]
+    pub(crate) fn task_container(&self, task_id: &str) -> Result<Option<String>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT container_id FROM org_tasks WHERE id = ?1",
+            rusqlite::params![task_id],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .optional()
+        .map_err(map_err)
+        .map(Option::flatten)
+    }
+
+    /// The container a task is filed in, as the FE may see it.
+    ///
+    /// A sealed-and-not-unlocked container yields `None`. "Which sealed container is this item
+    /// in" is a disclosure this diff already decided to withhold elsewhere: `mask_board` drops
+    /// `folder_id` for exactly this reason, because keeping it lets a caller group items by
+    /// sealed folder and count them. Tasks are normally unfiled by both the seal and the relock,
+    /// so the window is narrow — but "narrow" is not the same as closed, and two readers in one
+    /// change should not take opposite positions on the same fact.
+    pub(crate) fn task_container_visible(
+        &self,
+        task_id: &str,
+        unlocked: &HashSet<String>,
+    ) -> Result<Option<String>> {
+        let visible = crate::storage::visibility_clause("f", unlocked);
+        let conn = self.lock();
+        conn.query_row(
+            &format!(
+                "SELECT t.container_id
+                   FROM org_tasks t
+                   LEFT JOIN folders f ON f.id = t.container_id
+                  WHERE t.id = ?1 AND (t.container_id IS NULL OR {visible})"
+            ),
+            rusqlite::params![task_id],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .optional()
+        .map_err(map_err)
+        .map(Option::flatten)
     }
 
     pub fn task_source(&self, source_id: &str) -> Result<Option<(String, String, i64)>> {

--- a/src-tauri/src/storage/workspace_store.rs
+++ b/src-tauri/src/storage/workspace_store.rs
@@ -367,23 +367,90 @@ fn visible_items_sql(kind: ItemKind, unlocked: &HashSet<String>, scope: ItemScop
                 ),
             }
         }
-        // SEAMS — filled by later steps of the hierarchy program. Tasks are org-scoped E2EE
-        // documents today (`org_tasks`, gated on org membership) with no local container anchor, and
-        // dashboards gain `folder_id` + a real seal in their own step. Until then both legs are
-        // empty, and the "hide an empty type group" rule keeps them out of the UI entirely.
+        ItemKind::Task => {
+            // A task appears in the tree ONLY once it has been filed. `container_id` is the local
+            // anchor, and the Inbox leg is deliberately empty rather than "every task with no
+            // container": the top-level Tasks view is org-scoped and gated on org read context
+            // (`commands::tasks::list_tasks`), and mirroring every unfiled org task into the
+            // hierarchy would be a SECOND, ungated route to the same rows. Filing is an explicit
+            // local act; nothing is hidden by requiring it, because the unfiled tasks are exactly
+            // where they always were.
+            //
+            // The title comes from the decrypted envelope via `json_extract` — the same string the
+            // Tasks view shows, read from the projection this device already holds in the clear
+            // inside its SQLCipher database.
+            let visible = visibility_clause("f", unlocked);
+            let scope_sql = match scope {
+                ItemScope::All => "t.container_id IS NOT NULL",
+                ItemScope::Container => "t.container_id = ?1",
+                // Unfiled tasks belong to the Tasks view, not the tree — see above.
+                ItemScope::Inbox => "1 = 0",
+            };
+            ItemQuery {
+                binds_container: matches!(scope, ItemScope::Container),
+                // The ORG gate is joined here, in SQL, exactly as `search_org_chunks_knn` /
+                // `get_org_item` / `count_org_items` do it: an org row must EXIST locally (the
+                // membership record) and have `context_enabled = 1`. Filing a task locally cannot
+                // be allowed to outlive membership in the org that owns it — a leaver, a revoked
+                // seat, or a device where the user turned that org's context off must all stop
+                // this leg dead, and the folder's `visibility_clause` says nothing about any of
+                // them.
+                //
+                // The comment on the Inbox arm above already spelled out why this matters: the
+                // Tasks view "gates on session and org read context; mirroring every unfiled org
+                // task into the hierarchy would be a SECOND, ungated route to the same rows".
+                // Without the join, the Container arm was that second route — the reasoning was
+                // written and then contradicted one branch later.
+                //
+                // `INNER JOIN`, deliberately: a task whose org row is absent has no membership
+                // this device can attest, so it must vanish rather than default to visible.
+                //
+                // The `org_items` join is the repo's own idiom for "live, current head" — the same
+                // `tombstoned = 0 AND is_current = 1` pair `dashboard_task_rows` and the Task
+                // reference resolvers use. Membership alone was not enough: a task DELETED in the
+                // org, or superseded by a newer revision, still had its `org_tasks` row and would
+                // have kept rendering its old title under the container it was filed in, long
+                // after it stopped existing for everyone else.
+                sql: format!(
+                    "SELECT t.container_id AS container_id, t.id AS item_id,
+                            json_extract(t.envelope_json, '$.title') AS title,
+                            NULL AS duration_s, t.updated_at AS sort_text, NULL AS sort_ms
+                       FROM org_tasks t
+                       JOIN org_state os ON os.org_id = t.org_id AND os.context_enabled = 1
+                       JOIN org_items i
+                         ON i.item_id = t.item_id AND i.tombstoned = 0 AND i.is_current = 1
+                       LEFT JOIN folders f ON f.id = t.container_id
+                      WHERE {scope_sql} AND t.container_id IS NOT NULL AND {visible}"
+                ),
+            }
+        }
+        // SEAM — dashboards gained `folder_id` + a real seal in their own step; this comment marks
+        // where a future kind would join.
         //
         // An always-false select rather than an absent arm on purpose: the wrappers stay
         // kind-agnostic, the column projection is pinned for the future implementation, and a caller
-        // asking for a task page gets a truthful empty page instead of an error. `binds_container`
-        // is FALSE for every scope precisely because this arm ignores the scope — see [`ItemQuery`].
-        ItemKind::Task | ItemKind::Dashboard => {
-            let _ = (unlocked, scope);
+        // asking for such a page gets a truthful empty page instead of an error. `binds_container`
+        // is FALSE for every scope precisely because such an arm ignores the scope — see [`ItemQuery`].
+        ItemKind::Dashboard => {
+            // Boards now carry a container, so this leg reads real rows — through the SAME
+            // visibility clause every other kind uses rather than a second rule of its own.
+            // `updated_at` is the sort key: a board has no single moment it happened, and the
+            // last time it changed is the closest thing to one.
+            let visible = visibility_clause("f", unlocked);
+            let scope_sql = match scope {
+                ItemScope::All => "1 = 1",
+                ItemScope::Container => "d.folder_id = ?1",
+                ItemScope::Inbox => "d.folder_id IS NULL",
+            };
             ItemQuery {
-                binds_container: false,
-                sql: "SELECT NULL AS container_id, '' AS item_id, NULL AS title,
-                             NULL AS duration_s, NULL AS sort_text, NULL AS sort_ms
-                        FROM folders WHERE 1 = 0"
-                    .to_string(),
+                binds_container: matches!(scope, ItemScope::Container),
+                sql: format!(
+                    "SELECT d.folder_id AS container_id, d.id AS item_id, d.title AS title,
+                            NULL AS duration_s, d.updated_at AS sort_text, NULL AS sort_ms
+                       FROM dashboards d
+                       LEFT JOIN folders f ON f.id = d.folder_id
+                      WHERE {scope_sql} AND (d.folder_id IS NULL OR {visible})"
+                ),
             }
         }
     }


### PR DESCRIPTION
Gives the two kinds that had no place in the hierarchy a real one, with the lock model intact. The
workspace tree's Dashboard and Task legs were always-false selects — honest at the time, but it
meant a user could see type groups that could never contain anything.

Harness: **PASSED** (combined + lock-security), four rounds of review, 16 findings, 4 proof gaps
recorded below rather than papered over.

## Dashboards — a container anchor and a real seal

`dashboards.folder_id` is also the board's **lock anchor**: a board with no folder cannot be
sealed, because there is no folder whose key would seal it.

**Gating the row was not enough, three separate times.** Each was a second reader assembling facts
the masked row withheld:

| Sink | What it shipped for a sealed board |
|---|---|
| `list_dashboards` | tile kinds and COUNT, from a separate ungated read |
| `get_dashboard` | one entry per tile — the count, each tile's span and position |
| `get_dashboard` `work` | the board's task references |
| `get_dashboard_sources` | the source list |

**Every WRITE is gated too — a category with no gate at all.** Before this change a board could not
live in a folder, so `update_dashboard`, the four tile mutations and both reorders needed none.
Giving boards a container turned each into a way to write plaintext into a sealed tree, after the
seal has run and with nothing left to encrypt it. The next unseal then overwrites the write from
the blob, so the user loses the edit too.

**The seal** covers the board's title, emoji and tint as one payload, and each tile's `title`,
`ref_id`, `config` and `kind`, verify-before-destroy throughout. `span`/`position` stay in the
clear deliberately — grid geometry referencing no content, and keeping it means an unsealed board
returns in the layout it had.

**Three enumeration sites, not two:** seal, unseal, and the at-rest re-blank. A keyless relock
REFUSES while boards hold plaintext (a board, unlike a segment, has no ciphertext to fall back on
once an unlock cleared its blob) — and refuses LAST, after the key-free re-blanks, so it still does
everything it can before reporting what it cannot.

**Boards unseal LAST on both paths.** One undecryptable board blob must not abort an unlock before
a single meeting, note, document or audio file is restored, and the permanent unlock is where that
matters more.

## Tasks — local placement that never egresses

`org_tasks.container_id` is not a field of `TaskEnvelope`, so a user's private folder structure
stays on the device.

The tree leg shows only **filed** tasks, gated on live org membership, `context_enabled = 1`, and a
live current item head (`tombstoned = 0 AND is_current = 1`). Without that, filing a task locally
survived leaving the org, losing the seat, or turning that org's context off — and the title kept
rendering.

**Sealing a container unfiles its tasks, and so does relocking one.** A task's content lives in an
org's E2EE store, so a folder key cannot seal it; one left inside would stay exactly as readable as
before while the user was told the container was locked. Nothing is lost — the task is intact and
back in the Tasks view.

## Verification

- `cargo test --lib` 3229 green · `cargo clippy --lib --tests -- -D warnings` clean.
- Every changed read sink has a negative **with a positive control**.
- The write gate is **enumerated per command**, not sampled: a gate applied to four of six
  mutations is not a gate.
- **RED-verified** — each fails on exactly its own removal: the org membership join, the summary
  masking, the write gate, the relock unfiling, the keyless-relock predicate, and the re-seal guard.

## Residuals, stated

1. The seal's own read-back check cannot be driven to its failure branch from a test — it decrypts
   what it just encrypted under the same key and AAD. The ordering is pinned on the reachable
   unseal side instead.
2. `the_dashboard_sources_command_withholds_a_sealed_boards_sources` passes **with and without** its
   gate, because the seal already blanks the tile columns, so the gate is defence-in-depth over an
   already-blanked row. The test's own comment says so, and this was verified rather than assumed.
3. Two more gaps are recorded in the harness receipt: whether any remaining ungated raw reader
   could serialize a sealed board's `folder_id`, and whether `context_enabled` is the full local
   membership predicate for an org read.
