### PR TITLE
fix(lock): locking a project seals the folders inside it

### DIFF
--- a/e2e/ask/chat-history-lock.spec.ts
+++ b/e2e/ask/chat-history-lock.spec.ts
@@ -101,7 +101,7 @@ test("locking an authored-note folder evicts loaded vault Ask titles, messages, 
   await page.getByRole("button", { name: "Expand Workspace" }).click();
   await page.getByRole("button", { name: "Actions for History note folder" }).focus();
   await page.keyboard.press("Enter");
-  const lock = page.getByRole("menuitem", { name: "Lock folder" });
+  const lock = page.getByRole("menuitem", { name: /^Lock (folder|project)/ });
   await expect(lock).toBeAttached();
   await lock.click({ force: true });
 
@@ -193,7 +193,7 @@ test("locking a meeting folder evicts loaded vault Ask plaintext", async ({
   await page.getByRole("button", { name: "Expand Workspace" }).click();
   await page.getByRole("button", { name: "Actions for History meeting folder" }).focus();
   await page.keyboard.press("Enter");
-  const lock = page.getByRole("menuitem", { name: "Lock folder" });
+  const lock = page.getByRole("menuitem", { name: /^Lock (folder|project)/ });
   await expect(lock).toBeAttached();
   await lock.click({ force: true });
   await expect(

--- a/e2e/notes/lock-shares-dialog.spec.ts
+++ b/e2e/notes/lock-shares-dialog.spec.ts
@@ -53,7 +53,7 @@ test.describe("Notes — folder lock runs the lock×shares dialog (PK-F1)", () =
     // lane. Keyboard activation is immune to whatever is painted on top.
     await page.getByRole("button", { name: "Actions for Notes" }).focus();
     await page.keyboard.press("Enter");
-    const lockBtn = page.getByRole("menuitem", { name: "Lock folder" });
+    const lockBtn = page.getByRole("menuitem", { name: /^Lock (folder|project)/ });
     await expect(lockBtn).toBeVisible();
     await lockBtn.click();
 

--- a/e2e/org/org-surfaces.spec.ts
+++ b/e2e/org/org-surfaces.spec.ts
@@ -253,7 +253,12 @@ test.describe("Shared Brain v1 — org FE surfaces (mocked IPC)", () => {
     // Focus, not a pointer — see the note in lock-shares-dialog.spec.ts.
     await page.getByRole("button", { name: /^Actions for / }).last().focus();
     await page.keyboard.press("Enter");
-    await page.getByRole("menuitem", { name: "Lock folder" }).focus();
+    // The lock entry names the CASCADE now: locking a container seals every container inside it,
+    // so a project holding folders says so rather than calling itself "Lock folder". This test is
+    // about the shares gate, not the wording, so it matches the affordance rather than one label —
+    // and the project is the case where the gate matters most, since the seal reaches its
+    // descendants too.
+    await page.getByRole("menuitem", { name: /^Lock (folder|project)/ }).focus();
     await page.keyboard.press("Enter");
 
     // The blocking dialog appears with the three choices. The host has no size

--- a/src-tauri/src/commands/lock.rs
+++ b/src-tauri/src/commands/lock.rs
@@ -37,6 +37,75 @@ use super::*;
 /// Atomicity: each note's blob is verified decryptable BEFORE we blank/delete; a crash after the
 /// DB write but before the `.md` delete leaves a stale plaintext `.md` (reconcilable) — never
 /// lost content.
+/// TWO-LEVEL LOCK — seal `folder_id` AND every container inside it, deepest first.
+///
+/// Before containers could nest, every lockable thing was a leaf, and sealing exactly one folder
+/// was exactly right. The moment a project can hold folders, that same behaviour means a user
+/// locks a project, watches it render locked, and every note in every folder underneath is still
+/// sitting in the database in plaintext — reachable through the tree, through search, through MCP.
+/// The UI says sealed and the bytes say otherwise, which is the worst combination available,
+/// because it is precisely when the user stops being careful.
+///
+/// Each container seals under its OWN content key, through the ordinary per-container path, so
+/// every guard, epoch bump and verify-before-destroy that path owns applies to all of them — and
+/// the per-container key separation that lets a single folder be unlocked on its own is untouched.
+/// One MCP revocation, held by the caller, covers the whole cascade.
+///
+/// A container that is ALREADY sealed is skipped rather than re-sealed: locking a project with one
+/// folder already locked is an ordinary thing to do, and re-minting that folder's key would orphan
+/// the ciphertext already written under the old one.
+fn lock_container_subtree(
+    state: &AppState,
+    folder_id: &str,
+    allow_live_remote_shares: bool,
+    visibility_revoked: impl FnOnce(),
+) -> Result<(), AppError> {
+    for id in container_subtree_deepest_first(state, folder_id)? {
+        if id == folder_id {
+            continue; // the target is sealed last, below, so its notice fires once at the end.
+        }
+        if state
+            .db
+            .folder_by_id(&id)?
+            .is_some_and(|folder| folder.locked)
+        {
+            continue;
+        }
+        lock_folder_inner_with_visibility_notice_policy(
+            state,
+            id,
+            allow_live_remote_shares,
+            || {},
+        )?;
+    }
+    lock_folder_inner_with_visibility_notice_policy(
+        state,
+        folder_id.to_string(),
+        allow_live_remote_shares,
+        visibility_revoked,
+    )
+}
+
+/// Every container in `folder_id`'s subtree, DEEPEST FIRST, with the folder itself last.
+///
+/// The order is the whole point. Locking is not atomic across containers — each seals under its
+/// own content key, in its own pass — so a failure part-way through leaves some sealed and some
+/// not, and the ORDER decides which. Deepest-first can only ever leave an OUTER container still
+/// open around sealed children: an over-lock the user can see and retry. Parent-first would leave
+/// a container marked locked with a child still holding plaintext inside it, which is the exact
+/// shape of a leak: the UI says sealed, the bytes say otherwise.
+fn container_subtree_deepest_first(
+    state: &AppState,
+    folder_id: &str,
+) -> Result<Vec<String>, AppError> {
+    let mut out = Vec::new();
+    for child in state.db.child_folders(folder_id)? {
+        out.extend(container_subtree_deepest_first(state, &child.id)?);
+    }
+    out.push(folder_id.to_string());
+    Ok(out)
+}
+
 #[tauri::command]
 pub async fn lock_folder(
     app: AppHandle,
@@ -49,15 +118,25 @@ pub async fn lock_folder(
         ));
     }
     let _org_mutation = state.org_share_mutation_lock.lock().await;
-    let closure_created = state.db.begin_org_folder_closure(&folder_id)?;
-    if state.db.folder_has_active_remote_share(&folder_id)? {
-        if closure_created {
-            state.db.clear_org_folder_closure(&folder_id)?;
+    // PRE-FLIGHT the whole subtree before anything seals. A container can hold containers now, so
+    // locking one seals everything inside it (see `lock_container_subtree`) — and this refusal is
+    // a property the caller can fix and would want to fix before any container changed state.
+    // Discovering it half-way through would leave a partial lock for a reason knowable up front.
+    for id in container_subtree_deepest_first(state.inner(), &folder_id)? {
+        if state.db.folder_has_active_remote_share(&id)? {
+            return Err(AppError::Unavailable(if id == folder_id {
+                "revoke this folder's shares before locking it".into()
+            } else {
+                let name = state
+                    .db
+                    .folder_by_id(&id)?
+                    .map(|f| f.name)
+                    .unwrap_or_else(|| id.clone());
+                format!("revoke the shares on {name} before locking this project")
+            }));
         }
-        return Err(AppError::Unavailable(
-            "revoke this folder's shares before locking it".into(),
-        ));
     }
+    let closure_created = state.db.begin_org_folder_closure(&folder_id)?;
     // Initial sealing revokes content just as a session relock does. Shut down every registered
     // MCP content socket BEFORE waiting on the lifecycle mutex, otherwise a slow reader can keep
     // receiving a pre-lock payload after the command has made the folder private.
@@ -186,9 +265,9 @@ fn lock_folder_with_visibility_revocation_and_notice_policy(
     allow_live_remote_shares: bool,
     visibility_revoked: impl FnOnce(),
 ) -> Result<(), AppError> {
-    let result = lock_folder_inner_with_visibility_notice_policy(
+    let result = lock_container_subtree(
         state,
-        folder_id.to_string(),
+        folder_id,
         allow_live_remote_shares,
         visibility_revoked,
     );
@@ -860,7 +939,126 @@ pub async fn unlock_folder(
     })
     .await?;
     state.db.clear_org_folder_closure(&folder_id)?;
+
+    // TWO-LEVEL UNLOCK — the other half of the cascading lock. Locking a project seals every
+    // container beneath it, so unlocking one has to open them again, or the two actions are
+    // asymmetric in the way users actually notice: one click sealed six folders, and six clicks
+    // are needed to get them back.
+    //
+    // Each descendant is opened with its OWN content key, unwrapped from the master KEK the
+    // restore above has now cached — so this costs no second Touch ID prompt, and the per-container
+    // key separation that makes a single-folder unlock possible is untouched.
+    //
+    // Best-effort per descendant: a container that cannot be opened is logged and skipped rather
+    // than failing the unlock that already succeeded. The failure direction matters — a descendant
+    // left sealed stays unreadable, which is the safe side, and the user can retry it alone.
+    let descendants: Vec<String> = container_subtree_deepest_first(state.inner(), &folder_id)?
+        .into_iter()
+        .filter(|id| *id != folder_id)
+        .collect();
+    for id in descendants {
+        let Some(child) = state.db.folder_by_id(&id)? else {
+            continue;
+        };
+        if !child.locked || folder_is_unlocked(state.inner(), &id)? {
+            continue;
+        }
+        if let Err(error) = unlock_container_with_cached_kek(&app, state.inner(), &id).await {
+            tracing::warn!(
+                target: "lock",
+                folder = %id,
+                error = %error,
+                "unlock_folder: a descendant container stayed sealed"
+            );
+        }
+    }
+
     Ok(restored)
+}
+
+/// Session-unlock ONE already-sealed container using the master KEK cached by an earlier unlock.
+///
+/// The cascading unlock's per-descendant step. It deliberately does NOT contain the biometric
+/// release, the candidate-recovery ladder, or the org-closure bookkeeping: those belong to the
+/// container the user actually asked for, ran once there, and their result — the cached KEK — is
+/// what makes this cheap. With no cached KEK there is nothing to do here, and saying so is better
+/// than quietly prompting for Touch ID once per folder in a subtree.
+async fn unlock_container_with_cached_kek(
+    app: &AppHandle,
+    state: &AppState,
+    folder_id: &str,
+) -> Result<(), AppError> {
+    let kek: Zeroizing<[u8; 32]> = {
+        let guard = state
+            .master_kek
+            .lock()
+            .map_err(|_| AppError::Storage("master-kek mutex poisoned".into()))?;
+        guard
+            .clone()
+            .ok_or_else(|| AppError::Auth("no cached master key for the cascading unlock".into()))?
+    };
+    let wrapped = state
+        .db
+        .folder_wrapped_key(folder_id)?
+        .ok_or_else(|| AppError::Storage("locked folder has no wrapped key".into()))?;
+    let ck_bytes = Zeroizing::new(crate::crypto::decrypt(
+        &kek,
+        &wrapped,
+        &aad_wrapped_ck(folder_id),
+    )?);
+    let ck: Zeroizing<[u8; 32]> = Zeroizing::new(
+        ck_bytes
+            .as_slice()
+            .try_into()
+            .map_err(|_| AppError::Storage("unwrapped content key has wrong length".into()))?,
+    );
+
+    let heavy_inference = state.heavy_inference.clone();
+    let app_for_restore = app.clone();
+    let folder_id_owned = folder_id.to_string();
+    crate::perf::run_heavy(&heavy_inference, move || -> Result<(), AppError> {
+        let state = app_for_restore.state::<AppState>();
+        let folder_id = folder_id_owned;
+        // Same lifecycle guard as the primary restore, for the same reason: this mutates plaintext
+        // columns, and a concurrent relock must not blank them mid-restore.
+        let _lifecycle = lifecycle_guard(&state);
+
+        for n in &state.db.notes_in_folder(&folder_id)? {
+            let Some(blob) = &n.content_blob else {
+                continue;
+            };
+            let aad = aad_content(&folder_id, &n.meeting_id, &n.provider_id, "note");
+            let markdown = String::from_utf8(crate::crypto::decrypt(&ck, blob, &aad)?)
+                .map_err(|_| AppError::Storage("decrypted note is not valid UTF-8".into()))?;
+            state
+                .db
+                .restore_note_markdown(&n.meeting_id, &n.provider_id, &markdown)?;
+        }
+
+        let meeting_embedder = crate::embed::active_persistence_embedder_if_available();
+        unseal_folder_extras(&state, &folder_id, &ck, meeting_embedder.as_deref())?;
+
+        {
+            let mut g = state
+                .unlocked_folders
+                .lock()
+                .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?;
+            g.insert(folder_id.clone());
+        }
+        reexport_notes_in_folder(&state, &folder_id);
+        let unlocked = {
+            state
+                .unlocked_folders
+                .lock()
+                .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?
+                .clone()
+        };
+        rederive_links_for_folder(&state, &folder_id, &unlocked);
+        tracing::info!(target: "lock", folder = %folder_id, "cascading unlock: container opened");
+        Ok(())
+    })
+    .await?;
+    Ok(())
 }
 
 /// Re-seal a session-unlocked folder for the rest of this session: re-blank the plaintext

--- a/src-tauri/src/commands/lock.rs
+++ b/src-tauri/src/commands/lock.rs
@@ -98,7 +98,10 @@ fn lock_container_subtree(
 /// A cascade multiplies that window by the size of the subtree, so every container in it needs the
 /// same marker — a descendant sealed without one is exactly the hole the target has been protected
 /// from all along.
-fn open_subtree_closures(state: &AppState, subtree: &[String]) -> Result<Vec<String>, AppError> {
+pub(crate) fn open_subtree_closures(
+    state: &AppState,
+    subtree: &[String],
+) -> Result<Vec<String>, AppError> {
     let mut created = Vec::new();
     for id in subtree {
         if state.db.begin_org_folder_closure(id)? {
@@ -116,7 +119,7 @@ fn open_subtree_closures(state: &AppState, subtree: &[String]) -> Result<Vec<Str
 /// open around sealed children: an over-lock the user can see and retry. Parent-first would leave
 /// a container marked locked with a child still holding plaintext inside it, which is the exact
 /// shape of a leak: the UI says sealed, the bytes say otherwise.
-fn container_subtree_deepest_first(
+pub(crate) fn container_subtree_deepest_first(
     state: &AppState,
     folder_id: &str,
 ) -> Result<Vec<String>, AppError> {

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -2905,6 +2905,109 @@
         db.set_meeting_folder(mid, folder_id).unwrap();
     }
 
+    /// An open container nested inside another — the shape the hierarchy made possible and the
+    /// lock had never seen.
+    /// Locking a PROJECT seals the folders inside it. This is the leak the hierarchy created.
+    ///
+    /// Before containers could nest, every lockable thing was a leaf and `lock_folder` sealing
+    /// exactly one folder was exactly right. The moment a project can hold folders, that same
+    /// behaviour means a user locks a project, watches it render locked, and every note in every
+    /// folder underneath is still sitting in the database in plaintext — reachable through the
+    /// tree, through search, through MCP. The UI says sealed; the bytes say otherwise, which is
+    /// the worst possible combination because the user stops being careful.
+    ///
+    /// RED contract: remove the descendant loop from `lock_folder` and the child's note is still
+    /// plaintext, and still visible, after the project is locked.
+    #[test]
+    fn locking_a_project_seals_the_folders_inside_it() {
+        let vault = tmp_vault("project-cascade");
+        let state = build_state_with_vault("project-cascade", &vault);
+        make_open_folder(&state.db, "p-acme", "Acme");
+        make_open_child_folder(&state.db, "f-weekly", "Acme/Weekly", "p-acme");
+        std::fs::create_dir_all(vault.join("Acme/Weekly")).unwrap();
+
+        seed_meeting(&state.db, "m-top", "Board notes", Some("p-acme"));
+        seed_meeting(&state.db, "m-deep", "Layoff plan", Some("f-weekly"));
+
+        // The test entry onto the SAME path both lock commands take. The cascade lives in
+        // `lock_container_subtree`, below the async command's org/MCP bookkeeping and above the
+        // single-container `lock_folder_inner`, precisely so one call covers every entry point
+        // and can still be driven from here.
+        let revocation = crate::mcp::begin_visibility_revocation_for_gate(
+            None,
+            crate::mcp::VisibilityRevokingEntrypoint::LockFolder,
+        );
+        crate::commands::lock_folder_with_visibility_revocation(&state, "p-acme", revocation)
+            .unwrap();
+
+        // BOTH containers are durably sealed.
+        assert!(
+            state.db.folder_by_id("p-acme").unwrap().unwrap().locked,
+            "the project itself was not sealed"
+        );
+        assert!(
+            state.db.folder_by_id("f-weekly").unwrap().unwrap().locked,
+            "a folder inside the locked project stayed open"
+        );
+
+        // And the child's note is not readable — neither in its row nor through the gate.
+        let markdown: String = state
+            .db
+            .lock()
+            .query_row(
+                "SELECT COALESCE(markdown, '') FROM notes WHERE meeting_id = 'm-deep'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            markdown, "",
+            "a note inside a folder inside a locked project stayed in plaintext"
+        );
+        let nothing_unlocked = std::collections::HashSet::new();
+        assert!(
+            state
+                .db
+                .get_note_if_visible("m-deep", &nothing_unlocked)
+                .unwrap()
+                .is_none(),
+            "the gated reader still returns a note from inside a locked project"
+        );
+    }
+
+    /// The cascade is DEEPEST-FIRST, so a failure can only over-lock, never under-lock.
+    ///
+    /// Locking is not atomic across containers. Whichever order the cascade takes decides what a
+    /// part-way failure leaves behind: deepest-first leaves an open container around sealed
+    /// children, which is visible and retryable; parent-first leaves a container marked locked
+    /// with plaintext inside it, which is a leak wearing a lock's clothes.
+    #[test]
+    fn the_lock_cascade_visits_the_deepest_container_first() {
+        let state = build_state("cascade-order");
+        make_open_folder(&state.db, "p-root", "Root");
+        make_open_child_folder(&state.db, "f-mid", "Root/Mid", "p-root");
+        make_open_child_folder(&state.db, "f-leaf", "Root/Mid/Leaf", "f-mid");
+
+        let order = container_subtree_deepest_first(&state, "p-root").unwrap();
+        assert_eq!(
+            order,
+            vec!["f-leaf".to_string(), "f-mid".to_string(), "p-root".to_string()],
+            "the cascade must reach a container only after everything inside it"
+        );
+    }
+
+    fn make_open_child_folder(db: &Db, id: &str, path: &str, parent_id: &str) {
+        db.insert_folder(&Folder {
+            id: id.to_string(),
+            name: path.rsplit('/').next().unwrap_or(path).to_string(),
+            path: path.to_string(),
+            parent_id: Some(parent_id.to_string()),
+            locked: false,
+            created_at: "2026-06-27T08:00:00Z".to_string(),
+        })
+        .unwrap();
+    }
+
     fn make_open_folder(db: &Db, id: &str, path: &str) {
         db.insert_folder(&Folder {
             id: id.to_string(),

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -1461,7 +1461,7 @@ pub(crate) fn begin_visibility_revocation(
     begin_visibility_revocation_for_gate(gate, entrypoint)
 }
 
-fn begin_visibility_revocation_for_gate(
+pub(crate) fn begin_visibility_revocation_for_gate(
     gate: Option<Arc<McpResponseGate>>,
     _entrypoint: VisibilityRevokingEntrypoint,
 ) -> VisibilityRevocation {

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.html
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.html
@@ -118,12 +118,12 @@
           >
             @if (canLock(line.container)) {
               <button type="button" role="menuitem" (click)="lock(line.container)">
-                Lock folder
+                {{ lockLabel(line.container) }}
               </button>
             }
             @if (line.container.locked && !line.container.unlocked) {
               <button type="button" role="menuitem" (click)="unlock(line.container)">
-                Unlock for this session
+                {{ unlockLabel(line.container) }}
               </button>
             }
             @if (line.container.locked && line.container.unlocked) {

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
@@ -399,6 +399,33 @@ export class WorkspaceTreeComponent {
     return !container.isRoot && !container.locked;
   }
 
+  /**
+   * What locking this container will actually do.
+   *
+   * Locking cascades: a container holding containers seals every one of them, because a project
+   * that rendered locked while the folders inside it stayed readable would be a label, not a
+   * lock. The menu has to say so — "Lock folder" on a project with six folders under it describes
+   * a much smaller action than the one about to happen, and a user who finds out afterwards has
+   * been surprised by a security control, which is the worst place to be surprised.
+   */
+  protected lockLabel(container: ContainerNode): string {
+    const nested = container.folders.length;
+    if (nested === 0) {
+      return "Lock folder";
+    }
+    return nested === 1
+      ? "Lock project and the folder inside it"
+      : `Lock project and the ${nested} folders inside it`;
+  }
+
+  /** The unlock half of {@link lockLabel} — it cascades too. */
+  protected unlockLabel(container: ContainerNode): string {
+    const nested = container.folders.length;
+    return nested === 0
+      ? "Unlock for this session"
+      : "Unlock this project and its folders for this session";
+  }
+
   protected openGroup(container: ContainerNode, group: TypeGroup): void {
     void this.router.navigate(["/container", container.id], {
       queryParams: { kind: group.kind },


### PR DESCRIPTION
## The leak

Before containers could nest, every lockable thing was a leaf, and `lock_folder` sealing exactly
one folder was exactly right.

The single hierarchy made a project a container that holds containers, and that same behaviour
became a leak: **a user locks a project, watches it render locked, and every note in every folder
underneath is still in the database in plaintext** — reachable through the tree, through search,
through MCP. The UI says sealed and the bytes say otherwise, which is the worst combination
available, because it is exactly when a user stops being careful.

`meeting_ids_in_folder` is `WHERE folder_id = ?1`, and `visibility_clause` only ever consults an
item's own folder. Neither has any notion of an ancestor, so nothing about the old lock reached one
level down.

## Lock cascades, deepest-first

The order is the whole point. Locking is not atomic across containers, so a part-way failure leaves
some sealed and some not — and **the order decides which**:

- **Deepest-first** can only leave an OUTER container open around sealed children: an over-lock the
  user can see and retry.
- **Parent-first** would leave a container marked locked with plaintext inside it — the leak
  wearing a lock's clothes.

Each container seals under its **own** content key, through the ordinary per-container path, so
every guard, epoch bump and verify-before-destroy that path owns applies to all of them — and the
per-container key separation that lets one folder be unlocked alone is untouched. One MCP
revocation, held by the caller, covers the whole cascade.

A container that is **already sealed is skipped**, not re-sealed: locking a project with one folder
already locked is an ordinary thing to do, and re-minting that folder's key would orphan the
ciphertext already written under the old one.

The share refusal is **pre-flighted across the whole subtree before anything seals** — it is a
property the caller can fix and would want to fix before any container changed state; discovering
it half-way through would leave a partial lock for a reason that was knowable up front.

The cascade lives in `lock_container_subtree`, below the async command's org/MCP bookkeeping and
above the single-container `lock_folder_inner`, so one implementation covers both lock commands and
is still drivable from a test.

## Unlock cascades back

Using the master KEK the first restore cached, so a project unlock costs **no second Touch ID
prompt** and no second candidate-recovery ladder. Best-effort per descendant: a container that
cannot be opened is logged and skipped rather than failing an unlock that already succeeded — a
descendant left sealed stays unreadable, which is the safe direction, and it can be retried alone.

## The menu says what will happen

"Lock folder" on a project with six folders under it describes a much smaller action than the one
about to run, and a user who finds out afterwards has been surprised by a security control — which
is the worst place to be surprised. The label now names the cascade, on both lock and unlock.

## Verification

- `cargo test --lib` and `cargo clippy --lib --tests -- -D warnings` green.
- `npx ng build` / `npx ng lint` green; `npx playwright test e2e/shell/` — 54 passed.
- New oracle: locking a project seals a folder inside it, its note's plaintext column is blank, and
  the gated reader withholds it — with the ordering pinned separately, so the deepest-first
  guarantee is a checked property rather than a comment.
