### PR TITLE
feat(brain): a local-MCP view of the workspace hierarchy

### DIFF
--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -1671,6 +1671,11 @@ fn tools_spec() -> Value {
             "inputSchema": { "type": "object", "properties": {} }
         },
         {
+            "name": "list_workspace_hierarchy",
+            "description": "The WORKSPACE HIERARCHY: every visible project, the folders inside it, and how many meetings / notes / tasks / dashboards each holds. This is where things LIVE, which is a different fact from what they say — a meeting in 'Acme / Weekly' and one in 'Personal' mean different things. Call it to ground a question about a project or a client in the container the user actually keeps it in, and to get the exact container id other tools accept. A sealed-and-not-session-unlocked container appears by name but reports no counts and no contents.",
+            "inputSchema": { "type": "object", "properties": {} }
+        },
+        {
             "name": "list_dashboards",
             "description": "List the user's DASHBOARDS — boards they composed BY HAND out of meetings, notes, documents, people and derived views (drift lanes, promise ledgers, pulses). Returns title + id + tile kinds only, no content. A board is the user's own declaration of what belongs together, so it is better scope than a search guess: check here first for questions about a project, deal or topic they track.",
             "inputSchema": { "type": "object", "properties": {} }
@@ -1838,6 +1843,7 @@ fn dispatch_tool(
                 .clamp(1, 100) as usize,
         },
         "list_note_folders" => ToolCall::ListNoteFolders,
+        "list_workspace_hierarchy" => ToolCall::ListWorkspaceHierarchy,
         "list_dashboards" => ToolCall::ListDashboards,
         "get_dashboard" => ToolCall::GetDashboard {
             dashboard_id: args
@@ -2080,10 +2086,18 @@ mod tests {
     }
 
     #[test]
-    fn tools_list_has_seventeen_tools() {
+    fn tools_list_has_eighteen_tools() {
         let r = rpc(r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#).unwrap();
         let tools = r["result"]["tools"].as_array().unwrap();
-        assert_eq!(tools.len(), 17);
+        // Eighteen since `list_workspace_hierarchy` joined. The count is deliberately pinned: the
+        // MCP catalogue is the loopback surface's whole contract, and a tool arriving or leaving
+        // it unnoticed is precisely what this guard exists to make impossible. It did its job
+        // here — the new tool was added and this test failed until the number was reconsidered.
+        assert_eq!(tools.len(), 18);
+        assert!(
+            tools.iter().any(|t| t["name"] == "list_workspace_hierarchy"),
+            "the hierarchy must be discoverable over local MCP"
+        );
         assert!(
             tools.iter().any(|t| t["name"] == "list_dashboards")
                 && tools.iter().any(|t| t["name"] == "get_dashboard"),
@@ -4589,6 +4603,112 @@ mod tests {
                 && unlocked_list.contains("compensation:select"),
             "session-unlocked folder must become discoverable: {unlocked_list}"
         );
+        let _ = std::fs::remove_file(&p);
+    }
+
+    /// The hierarchy tool names a sealed container but discloses NOTHING inside it.
+    ///
+    /// A container's existence is not the secret — a lock the user cannot see is worse than one
+    /// they can, and hiding the row entirely would make a locked project look deleted. What must
+    /// not escape is what is INSIDE: the titles, and the counts that say how much there is.
+    ///
+    /// The tool reads the same gated assembly the sidebar does, which already empties a sealed
+    /// container's type groups. This pins that dependency: if the reader ever started reporting
+    /// totals for a sealed container, the sidebar would look no different and this is the only
+    /// place that would notice.
+    #[test]
+    fn workspace_hierarchy_names_a_sealed_container_but_never_its_contents() {
+        let p = crate::storage::db::unique_temp_path("murmur-mcp-hierarchy", "db");
+        let db = Db::open_with_key(&p, TEST_DEK).unwrap();
+
+        // Under the ADOPTED project, not beside it. A fresh database is never projectless — the
+        // hierarchy migration adopts pre-existing folders into a default "Workspace" project —
+        // and a folder with no parent is not part of the forest the tree renders. Getting this
+        // wrong made the first run of this test assert against a vault it had not actually built.
+        let project = db.workspace_project_id().unwrap().expect("a project is adopted");
+        db.insert_folder(&crate::storage::models::Folder {
+            id: "p-open".into(),
+            name: "Acme".into(),
+            path: "Acme".into(),
+            parent_id: Some(project.clone()),
+            locked: false,
+            created_at: "2026-08-23T10:00:00Z".into(),
+        })
+        .unwrap();
+        db.insert_folder(&crate::storage::models::Folder {
+            id: "p-secret".into(),
+            name: "Layoffs Q3".into(),
+            path: "Layoffs Q3".into(),
+            parent_id: Some(project),
+            locked: true,
+            created_at: "2026-08-23T10:00:00Z".into(),
+        })
+        .unwrap();
+
+        // One meeting in each, so a leak would have something concrete to leak.
+        for (mid, title, folder) in [
+            ("m-open", "Standup", "p-open"),
+            ("m-secret", "Severance list", "p-secret"),
+        ] {
+            db.insert_meeting(&crate::storage::models::Meeting {
+                id: mid.into(),
+                started_at: "2026-08-23T09:00:00Z".into(),
+                ended_at: None,
+                title: Some(title.into()),
+                duration_s: 600,
+                audio_path: None,
+                status: crate::storage::models::MeetingStatus::Summarized,
+                folder_id: None,
+            })
+            .unwrap();
+            db.upsert_note(&crate::storage::models::NoteRecord {
+                meeting_id: mid.into(),
+                provider_id: "claude_code".into(),
+                markdown: "body".into(),
+                created_at: "2026-08-23T09:05:00Z".into(),
+                exported_path: None,
+                model_requested: None,
+                model_served: None,
+                gateway_host: None,
+            })
+            .unwrap();
+            db.set_meeting_folder(mid, Some(folder)).unwrap();
+        }
+
+        let listed =
+            dispatch_tool(&db, "list_workspace_hierarchy", &json!({}), &HashSet::new()).unwrap();
+
+        // The open container reports itself AND what it holds.
+        assert!(
+            listed.contains("Acme") && listed.contains("id:p-open"),
+            "a visible container must be discoverable: {listed}"
+        );
+        assert!(
+            listed.contains("meeting:1"),
+            "an open container must report its counts: {listed}"
+        );
+
+        // The sealed one reports itself, and that it is locked, and nothing else.
+        assert!(
+            listed.contains("Layoffs Q3") && listed.contains("locked"),
+            "a sealed container must still be visible as locked: {listed}"
+        );
+        assert!(
+            !listed.contains("Severance list"),
+            "a sealed container disclosed a title: {listed}"
+        );
+
+        // The COUNT is the subtle half: "meeting:1" beside a locked project tells a reader there
+        // is exactly one meeting in there, which is a fact about sealed content.
+        let sealed_line = listed
+            .lines()
+            .find(|line| line.contains("Layoffs Q3"))
+            .expect("the sealed container must appear");
+        assert!(
+            sealed_line.contains("empty"),
+            "a sealed container disclosed how much it holds: {sealed_line}"
+        );
+
         let _ = std::fs::remove_file(&p);
     }
 

--- a/src-tauri/src/orchestrate.rs
+++ b/src-tauri/src/orchestrate.rs
@@ -232,6 +232,7 @@ fn tool_label(call: &ToolCall) -> &'static str {
         // labels keep the shared transport enum compile-safe without advertising either to a model.
         ToolCall::ListEntities { .. } => "Entities",
         ToolCall::ListNoteFolders => "Note folders",
+        ToolCall::ListWorkspaceHierarchy => "Workspace hierarchy",
         // Dashboards — the user's own composed boards. `ListDashboards` is metadata; `GetDashboard`
         // resolves each tile through the gated resolver, so it labels like any other vault read.
         ToolCall::ListDashboards => "Dashboards",

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -102,7 +102,9 @@ pub enum AssistantScope {
 }
 
 impl AssistantScope {
-    /// Is `tool` reachable at THIS scope? The tiered gate, applied on top of the per-surface flags
+    /// One hierarchy line: indent, name, id, lock state, and the per-kind counts.
+
+/// Is `tool` reachable at THIS scope? The tiered gate, applied on top of the per-surface flags
     /// (`has_app`/`note_drafts`/`allow_writes`) in [`GatedToolExecutor::specs`]. The vault READ tools
     /// and the connector tools are partitioned here; `propose_note` / write tools are governed by the
     /// surface flags, not the tier, so they are allowed through the tier gate and left to those flags.
@@ -114,7 +116,10 @@ impl AssistantScope {
         // scope. They can be dispatched only by the loopback MCP mapper into `execute_tool`.
         if matches!(
             tool,
-            "list_entities" | "list_note_folders" | "knowledge_diff"
+            "list_entities"
+                | "list_note_folders"
+                | "list_workspace_hierarchy"
+                | "knowledge_diff"
         ) {
             return false;
         }
@@ -176,6 +181,36 @@ impl AssistantScope {
             AssistantScope::Full | AssistantScope::DurableAsk => true,
         }
     }
+}
+
+///
+/// Counts come from the container's own type groups, which the gated reader has already emptied
+/// for a sealed container — so a locked project reports `locked` and nothing else, rather than
+/// disclosing how much is inside it.
+fn render_container_line(out: &mut String, node: &crate::storage::models::ContainerNode, depth: usize) {
+    let indent = "  ".repeat(depth);
+    let state = if node.locked && !node.unlocked {
+        " · locked"
+    } else if node.locked {
+        " · locked (unlocked this session)"
+    } else {
+        ""
+    };
+    let counts = node
+        .groups
+        .iter()
+        .filter(|group| group.total > 0)
+        .map(|group| format!("{:?}:{}", group.kind, group.total).to_lowercase())
+        .collect::<Vec<_>>();
+    let counts = if counts.is_empty() {
+        "empty".to_string()
+    } else {
+        counts.join(",")
+    };
+    out.push_str(&format!(
+        "{indent}- {} · {} · id:{} · {counts}{state}\n",
+        node.name, node.level, node.id
+    ));
 }
 
 /// A single read-only tool INVOCATION. This enum holds the read-only calls the brain can run
@@ -275,6 +310,21 @@ pub enum ToolCall {
     /// Local-MCP-only discovery of visible note folders, visible row counts, and typed columns.
     /// Intentionally absent from [`tool_specs`] and [`GatedToolExecutor`].
     ListNoteFolders,
+    /// Local-MCP-only view of the WORKSPACE HIERARCHY — every visible project, the folders inside
+    /// it, and how many items of each kind each one holds.
+    ///
+    /// This is what makes the brain aware of where things LIVE, rather than only what they say. A
+    /// meeting in "Acme / Weekly" and a meeting in "Personal" are different facts about the same
+    /// vault, and until now nothing on any tool surface could tell them apart.
+    ///
+    /// Local-MCP-only, and deliberately so: it is the same class of data as [`Self::ListNoteFolders`]
+    /// — a user's private folder NAMES, which are frequently the most sensitive strings in a vault
+    /// ("Layoffs Q3", a client's name, a diagnosis). Those names have never been allowed into a
+    /// cloud-capable assistant scope, and adding a second door for them would be a new cloud egress
+    /// wearing a feature's clothes. It carries no note or transcript CONTENT, and every row it
+    /// reports comes from the same gated reader the sidebar uses, so a sealed container contributes
+    /// its existence and nothing else.
+    ListWorkspaceHierarchy,
     /// The user's DASHBOARDS — boards they composed by hand. Metadata only (title, tile count,
     /// tile kinds): no board reads a source here, so this carries no gated content and is safe at
     /// every scope. It exists so an agent can DISCOVER the boards before scoping to one.
@@ -1220,6 +1270,25 @@ pub fn execute_tool(
                 })
                 .collect::<Vec<_>>()
                 .join("\n"))
+        }
+        ToolCall::ListWorkspaceHierarchy => {
+            // The SAME gated assembly the sidebar reads — not a second query with its own idea of
+            // what is visible. A sealed-and-not-unlocked container still appears (its existence is
+            // not the secret; a lock the user cannot see is worse than one they can) but its type
+            // groups come back empty from that reader, so it contributes no titles and no counts.
+            let forest = crate::commands::workspace_tree_inner(db, unlocked)
+                .map_err(|e| AppError::Storage(format!("workspace hierarchy read failed: {e}")))?;
+            if forest.is_empty() {
+                return Ok("No visible projects.".to_string());
+            }
+            let mut out = String::new();
+            for project in &forest {
+                render_container_line(&mut out, project, 0);
+                for folder in &project.folders {
+                    render_container_line(&mut out, folder, 1);
+                }
+            }
+            Ok(out.trim_end().to_string())
         }
         ToolCall::KnowledgeDiff { entity, from, to } => {
             // EGRESS-FREE + GATED: resolve the entity through the SAME gated resolver as the dossier
@@ -7679,7 +7748,12 @@ mod tests {
                 && !names.contains("knowledge_diff"),
             "local MCP helpers must never become agent/cloud prompt input"
         );
-        for tool in ["list_entities", "list_note_folders", "knowledge_diff"] {
+        for tool in [
+            "list_entities",
+            "list_note_folders",
+            "list_workspace_hierarchy",
+            "knowledge_diff",
+        ] {
             for scope in [
                 AssistantScope::CurrentMeeting,
                 AssistantScope::Vault,
@@ -7730,6 +7804,18 @@ mod tests {
                 "the local-only ToolCall variant must remain executable on the loopback seam"
             );
         }
+
+        // The hierarchy tool is checked separately because an empty vault is NOT projectless: the
+        // hierarchy migration adopts every pre-existing folder into a default "Workspace"
+        // project, so there is always at least one, and its id is a fresh uuid. An exact-string
+        // expectation like the ones above is therefore unwritable — what matters here is the same
+        // property they assert, that the variant still EXECUTES on the loopback seam.
+        let hierarchy =
+            execute_tool(&ToolCall::ListWorkspaceHierarchy, &db, &nothing, &cfg).unwrap();
+        assert!(
+            hierarchy.contains(" · project · "),
+            "the hierarchy variant must remain executable on the loopback seam: {hierarchy}"
+        );
 
         // Exercise BOTH ToolExecutor entry points (`specs` and `run`) across every scope and both
         // surface gates. `run` must return the exact allowlist refusal, never either successful

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -102,9 +102,7 @@ pub enum AssistantScope {
 }
 
 impl AssistantScope {
-    /// One hierarchy line: indent, name, id, lock state, and the per-kind counts.
-
-/// Is `tool` reachable at THIS scope? The tiered gate, applied on top of the per-surface flags
+    /// Is `tool` reachable at THIS scope? The tiered gate, applied on top of the per-surface flags
     /// (`has_app`/`note_drafts`/`allow_writes`) in [`GatedToolExecutor::specs`]. The vault READ tools
     /// and the connector tools are partitioned here; `propose_note` / write tools are governed by the
     /// surface flags, not the tier, so they are allowed through the tier gate and left to those flags.
@@ -187,7 +185,16 @@ impl AssistantScope {
 /// Counts come from the container's own type groups, which the gated reader has already emptied
 /// for a sealed container — so a locked project reports `locked` and nothing else, rather than
 /// disclosing how much is inside it.
-fn render_container_line(out: &mut String, node: &crate::storage::models::ContainerNode, depth: usize) {
+/// One hierarchy line: indent, name, id, lock state, and the per-kind counts.
+///
+/// Counts come from the container's own type groups, which the gated reader has already emptied
+/// for a sealed container — so a locked project reports `locked` and nothing else, rather than
+/// disclosing how much is inside it.
+fn render_container_line(
+    out: &mut String,
+    node: &crate::storage::models::ContainerNode,
+    depth: usize,
+) {
     let indent = "  ".repeat(depth);
     let state = if node.locked && !node.unlocked {
         " · locked"


### PR DESCRIPTION
The brain could read what a note SAYS but not where it LIVES. A meeting in "Acme / Weekly" and one
in "Personal" are different facts about the same vault, and nothing on any tool surface could tell
them apart. This is the last piece of the hierarchy work.

## What

`list_workspace_hierarchy` reports every visible project, the folders inside it, and how many items
of each kind each holds — reading the **same gated assembly the sidebar uses**
(`commands::workspace_tree_inner`), not a second query with its own idea of what is visible.

## Local-MCP-only, deliberately

This is the same class of data as `list_note_folders`: a user's private folder **names**, which are
frequently the most sensitive strings in a vault ("Layoffs Q3", a client, a diagnosis). Those names
have never been allowed into a cloud-capable assistant scope, and adding a second door for them
would be a new cloud egress wearing a feature's clothes.

`AssistantScope::allows` excludes it alongside the existing three, and the catalogue test pins that
exclusion. **RED-verified**: remove it from the tier gate and it appears in every cloud scope,
failing `local_mcp_only_tools_remain_outside_cloud_agent_catalogs`.

## A sealed container is named, but discloses nothing inside it

Hiding the row entirely would make a locked project look deleted — a lock the user cannot see is
worse than one they can. So it reports its name and that it is locked, and `empty` in place of its
counts.

The count is the subtle half: `meeting:1` beside a locked project is a fact about sealed content.
The oracle asserts exactly that line.

## Two wrong assumptions, found by running it

Both were about the data model, and neither would have surfaced from reading:

1. **A fresh vault is not projectless.** The hierarchy migration adopts pre-existing folders into a
   default "Workspace" project, so `"No visible projects."` is unreachable. The catalogue test now
   asserts the property it actually cares about — that the variant still executes on the loopback
   seam — instead of an exact string it can never see.
2. **The leak oracle's fixture built a vault it wasn't measuring.** It created folders with
   `parent_id: None`, which are not part of the forest the tree renders, so the test asserted
   against an empty forest. Its **positive control** is what caught this — the negative assertions
   would all have passed.

I also checked whether `workspace_tree_inner` writes on read, which would make a read-only MCP
surface mutate. It does not: `list_containers` is a pure SELECT.

## Verification

- `cargo test --lib` 3230 green · `cargo clippy --lib --tests -- -D warnings` clean.
- The MCP tool-count guard did its job: adding the eighteenth tool failed the pinned count until
  the number was reconsidered — the opposite of a test that can be passed by accident.
