### PR TITLE
feat(shell): add contextual spaces navigation

### DIFF
--- a/e2e/analytics/stale-while-revalidate.spec.ts
+++ b/e2e/analytics/stale-while-revalidate.spec.ts
@@ -115,20 +115,20 @@ test("Analytics dashboard shows cached data instantly on a return visit, not a L
   // being tested). This is a plain SPA route swap to a route NOT covered by
   // `TabRouteReuseStrategy`, so `/analytics` and its children are genuinely
   // destroyed.
-  await page.getByRole("link", { name: "Meetings", exact: true }).click();
+  const browseSidebar = page.getByRole("complementary", {
+    name: "Browse sidebar",
+  });
+  await browseSidebar
+    .getByRole("link", { name: "Meetings", exact: true })
+    .click();
   await expect(page.getByText("Total meetings")).toBeHidden();
 
-  // Navigate BACK, again via the in-app link. The "Insights" sidebar
-  // section (which holds the Analytics link) auto-collapses once its route
-  // is no longer active, so expand it first.
-  const insightsToggle = page.getByRole("button", { name: "Expand Insights" });
-  if (await insightsToggle.isVisible()) {
-    await insightsToggle.click();
-  }
   // Navigate BACK — the cached numbers/threads/ledger must render INSTANTLY,
   // i.e. before the freshly-delayed IPC promises above have any chance to
   // resolve (they take 400ms; assert well inside that window).
-  await page.getByRole("link", { name: "Analytics", exact: true }).click();
+  await browseSidebar
+    .getByRole("link", { name: "Analytics", exact: true })
+    .click();
   await expect(page.getByText("Total meetings")).toBeVisible({
     timeout: 250,
   });

--- a/e2e/ask/chat-history-lock.spec.ts
+++ b/e2e/ask/chat-history-lock.spec.ts
@@ -92,14 +92,29 @@ test("locking an authored-note folder evicts loaded vault Ask titles, messages, 
     page.getByText("Sensitive Ask message", { exact: true }),
   ).toBeVisible();
 
-  // Locking now lives in the container row's actions menu — the one hierarchy replaced the
-  // two per-type trees that each carried a bare lock toggle. The behaviour under test is
-  // what locking DOES, so the spec follows the affordance rather than pinning its old place.
-  // The folder lives INSIDE the project, so the project has to be expanded before its row
-  // exists at all — and the menu must be the FOLDER's, not the project's, which is what a
-  // `.first()` would have picked.
-  await page.getByRole("button", { name: "Expand Workspace" }).click();
-  await page.getByRole("button", { name: "Actions for History note folder" }).focus();
+  // Open the hierarchy without leaving the mounted Ask route. The loaded
+  // conversation and its sensitive source must remain present until locking
+  // publishes the invalidation that scrubs them.
+  await page
+    .getByRole("navigation", { name: "Global navigation" })
+    .getByRole("button", { name: "Spaces", exact: true })
+    .click();
+  await expect(page).toHaveURL(/\/ask$/);
+  await expect(page.locator("mur-chat-history")).toBeVisible();
+  await expect(
+    page.getByText("Sensitive Ask message", { exact: true }),
+  ).toBeVisible();
+
+  const spacesSidebar = page.getByRole("complementary", {
+    name: "Spaces sidebar",
+  });
+  await expect(spacesSidebar).toBeVisible();
+  await spacesSidebar
+    .getByRole("button", { name: "Expand Workspace" })
+    .click();
+  await spacesSidebar
+    .getByRole("button", { name: "Actions for History note folder" })
+    .focus();
   await page.keyboard.press("Enter");
   const lock = page.getByRole("menuitem", { name: /^Lock (folder|project)/ });
   await expect(lock).toBeAttached();
@@ -187,11 +202,27 @@ test("locking a meeting folder evicts loaded vault Ask plaintext", async ({
     page.getByText("Meeting-derived secret", { exact: true }),
   ).toBeVisible();
 
-  // The folder lives INSIDE the project, so the project has to be expanded before its row
-  // exists at all — and the menu must be the FOLDER's, not the project's, which is what a
-  // `.first()` would have picked.
-  await page.getByRole("button", { name: "Expand Workspace" }).click();
-  await page.getByRole("button", { name: "Actions for History meeting folder" }).focus();
+  // Opening Spaces is contextual navigation: it must not unmount Ask or scrub
+  // the message before the actual lock transition occurs.
+  await page
+    .getByRole("navigation", { name: "Global navigation" })
+    .getByRole("button", { name: "Spaces", exact: true })
+    .click();
+  await expect(page).toHaveURL(/\/ask$/);
+  await expect(
+    page.getByText("Meeting-derived secret", { exact: true }),
+  ).toBeVisible();
+
+  const spacesSidebar = page.getByRole("complementary", {
+    name: "Spaces sidebar",
+  });
+  await expect(spacesSidebar).toBeVisible();
+  await spacesSidebar
+    .getByRole("button", { name: "Expand Workspace" })
+    .click();
+  await spacesSidebar
+    .getByRole("button", { name: "Actions for History meeting folder" })
+    .focus();
   await page.keyboard.press("Enter");
   const lock = page.getByRole("menuitem", { name: /^Lock (folder|project)/ });
   await expect(lock).toBeAttached();

--- a/e2e/notes/lock-shares-dialog.spec.ts
+++ b/e2e/notes/lock-shares-dialog.spec.ts
@@ -43,15 +43,30 @@ test.describe("Notes — folder lock runs the lock×shares dialog (PK-F1)", () =
     await page.goto("/notes");
     await expect(page.locator(".notes-content")).toBeVisible();
 
-    // The open "Notes" folder has a Lock control on its row.
-    // The affordance moved into the container row's actions menu when the one hierarchy
-    // replaced the two per-type trees; the gate it must run is unchanged.
-    await page.getByRole("button", { name: "Expand Workspace" }).click();
+    // Open the hierarchy without navigating away from the mounted Notes list.
+    // Its plaintext stays visible until the user actually confirms a lock.
+    await page
+      .getByRole("navigation", { name: "Global navigation" })
+      .getByRole("button", { name: "Spaces", exact: true })
+      .click();
+    await expect(page).toHaveURL(/\/notes$/);
+    await expect(page.locator(".notes-content")).toBeVisible();
+    await expect(page.getByText("My First Note", { exact: true })).toBeVisible();
+
+    const spacesSidebar = page.getByRole("complementary", {
+      name: "Spaces sidebar",
+    });
+    await expect(spacesSidebar).toBeVisible();
+    await spacesSidebar
+      .getByRole("button", { name: "Expand Workspace" })
+      .click();
     // Reached by FOCUS, not a pointer. A trailing row control sits at the rail's right edge,
     // where a click can land on the rail instead once the tree is long enough to scroll — the
     // failure is engine- and layout-dependent, and passes locally while failing on one CI
     // lane. Keyboard activation is immune to whatever is painted on top.
-    await page.getByRole("button", { name: "Actions for Notes" }).focus();
+    await spacesSidebar
+      .getByRole("button", { name: "Actions for Notes" })
+      .focus();
     await page.keyboard.press("Enter");
     const lockBtn = page.getByRole("menuitem", { name: /^Lock (folder|project)/ });
     await expect(lockBtn).toBeVisible();

--- a/e2e/notes/notes-home.spec.ts
+++ b/e2e/notes/notes-home.spec.ts
@@ -2,17 +2,13 @@ import { test, expect } from "@playwright/test";
 import { mockNotes } from "./mock-invoke";
 
 /**
- * Notes home — a normal in-flow route beside the ALWAYS-VISIBLE main sidebar
- * (2026-07-12; was a [note-folder rail | note list] drill-down that hid the
- * primary sidebar). The note-folder tree now lives IN the main sidebar
- * (`NotesSidebarTreeComponent`, nested under "Notes" — `AppShellComponent`);
- * this test confirms BOTH render: the sidebar tree (folders + "All notes")
- * AND the content pane's TABLE (2026-07-12, replaces the card grid — incl.
- * the masked locked row + a tag pill + the "New note" control), with NO
- * console/page errors — the runtime check that catches NG0600 / ɵcmp /
+ * Notes home is an exact-list route: the persistent global rail chooses the
+ * product surface while the adjacent Browse panel owns list navigation. The
+ * content pane still renders the note table, including the sealed row, with
+ * no console/page errors — the runtime check that catches NG0600 / ɵcmp /
  * forwardRef regressions a green `ng build` misses.
  */
-test("notes home renders the sidebar tree + the note table (incl. masked locked row) with no console errors", async ({
+test("notes home renders Browse navigation + the note table (incl. masked locked row) with no console errors", async ({
   page,
 }) => {
   const consoleErrors: string[] = [];
@@ -29,22 +25,26 @@ test("notes home renders the sidebar tree + the note table (incl. masked locked 
   // The content pane proves the route resolved.
   await expect(page.locator(".notes-content")).toBeVisible();
 
-  // The ALWAYS-VISIBLE main sidebar renders too (Stage 1's whole point).
-  await expect(page.locator("mur-sidebar.app-sidebar")).toBeVisible();
+  const globalNavigation = page.getByRole("navigation", {
+    name: "Global navigation",
+  });
+  await expect(globalNavigation).toBeVisible();
+
+  const browseSidebar = page.getByRole("complementary", {
+    name: "Browse sidebar",
+  });
+  await expect(browseSidebar).toBeVisible();
+  await expect(
+    browseSidebar.getByRole("link", { name: "Notes", exact: true }),
+  ).toHaveClass(/active/);
 
   // The prominent "New note" action.
   await expect(page.locator(".new-note-btn")).toBeVisible();
 
-  // The sidebar's Notes section: the HEADER is the "all items" affordance
-  // (the separate "All notes" root row was removed 2026-07-12 as a redundant
-  // layer) + the tree lists both note folders directly.
-  // ONE hierarchy now, so the section is Projects and the folders hang under a project
-  // rather than under a per-type header.
-  await expect(
-    page.locator("mur-sidebar-section .nav-row-link", { hasText: "Projects" }),
-  ).toBeVisible();
-  await page.getByRole("button", { name: "Expand Workspace" }).click();
-  await expect(page.getByRole("button", { name: "Work", exact: true })).toBeVisible();
+  // Exact list routes do not mount the hierarchy panel or its former section
+  // wrapper. The hierarchy is reserved for Space and leaf routes.
+  await expect(page.locator("mur-sidebar.spaces-sidebar")).toHaveCount(0);
+  await expect(page.locator("mur-sidebar-section")).toHaveCount(0);
 
   // The table renders (thead + the visible note row + its tag pill).
   await expect(page.locator(".mur-table thead th", { hasText: "Title" })).toBeVisible();

--- a/e2e/notes/overlay-dismiss-escape.spec.ts
+++ b/e2e/notes/overlay-dismiss-escape.spec.ts
@@ -31,7 +31,8 @@ async function backgroundAndReturnToCachedNote(
   page: import("@playwright/test").Page,
 ): Promise<void> {
   await page
-    .getByRole("link", { name: "Record", exact: true })
+    .getByRole("navigation", { name: "Global navigation" })
+    .getByRole("link", { name: "Capture", exact: true })
     .dispatchEvent("click");
   await expect(page).toHaveURL(/\/record$/);
   await expectNoTransientNoteUi(page);
@@ -79,7 +80,10 @@ test("note selection overlays stay interactive and dismiss when the pointer leav
   await expect(popover).toBeVisible();
 
   // Leaving the owning editor for app chrome dismisses the transient overlay.
-  await page.getByRole("link", { name: "Record", exact: true }).click();
+  await page
+    .getByRole("navigation", { name: "Global navigation" })
+    .getByRole("link", { name: "Capture", exact: true })
+    .click();
   await expect(page).toHaveURL(/\/record$/);
   await expect(popover).toHaveCount(0);
   await expect(toolbar).toHaveCount(0);
@@ -172,7 +176,10 @@ test("main-shell Escape is consumed after its document-level overlay handler run
   await mockNotes(page);
   await page.goto("/notes/n1");
 
-  await page.getByRole("button", { name: "Search (⌘K)" }).first().click();
+  await page
+    .getByRole("navigation", { name: "Global navigation" })
+    .getByRole("button", { name: "Search", exact: true })
+    .click();
   await expect(page.locator(".qs-scrim")).toBeVisible();
 
   const prevented = await page.evaluate(() => {

--- a/e2e/notes/tab-strip-drilldown-clearance.spec.ts
+++ b/e2e/notes/tab-strip-drilldown-clearance.spec.ts
@@ -2,17 +2,11 @@ import { test, expect } from "@playwright/test";
 import { mockNotes } from "./mock-invoke";
 
 /**
- * Drill-down routes (/settings, /org-item) render NO sidebar/pill chrome, so
- * `mur-tab-strip` starts flush at the window's LEFT edge — exactly where the
- * overlay macOS traffic lights float (trafficLightPosition 32,30 → buttons
- * span ≈ x 32..84, vertically inside the 48px strip). The strip must reserve
- * left clearance there (`app-shell.drilldown` host class + the `:host-context`
- * rule in tab-strip.component.scss) while keeping its normal padding in
- * sidebar mode, where it sits right of the sidebar panel. Headless Playwright
- * has no real macOS window chrome, so this pins the CSS contract (the computed
- * clearance), not the OS pixels.
+ * Settings keeps the persistent global rail. The tab strip therefore retains
+ * its normal 24px inset instead of switching to a flush-left drill-down
+ * clearance, and the fixed settings surface must begin after the rail.
  */
-test("the tab strip clears the traffic-light zone on drill-down routes", async ({
+test("settings keeps normal tab-strip padding and clears the global rail", async ({
   page,
 }) => {
   const consoleErrors: string[] = [];
@@ -31,18 +25,29 @@ test("the tab strip clears the traffic-light zone on drill-down routes", async (
   await page.getByRole("button", { name: "My First Note" }).click();
   await expect(page.locator(".tab-strip .tab-item")).toHaveCount(1);
 
-  // Sidebar mode: the strip sits right of the sidebar panel — normal padding
-  // (--space-5 = 24px), no traffic lights anywhere near it.
+  // Browse mode uses the normal inset (--space-5 = 24px).
   const strip = page.locator(".tab-strip");
   await expect(strip).toHaveCSS("padding-left", "24px");
 
-  // Enter the Settings drill-down through the real sidebar affordance: the
-  // chrome unmounts, the strip now starts at the window edge → clearance on.
-  await page.getByRole("link", { name: "Settings", exact: true }).click();
+  const globalNavigation = page.getByRole("navigation", {
+    name: "Global navigation",
+  });
+  await globalNavigation
+    .getByRole("link", { name: "Settings", exact: true })
+    .click();
   await expect(page).toHaveURL(/\/settings/);
-  await expect(strip).toHaveCSS("padding-left", "96px");
+  await expect(globalNavigation).toBeVisible();
+  await expect(strip).toHaveCSS("padding-left", "24px");
 
-  // Leaving the drill-down restores the normal padding.
+  const [railBox, settingsBox] = await Promise.all([
+    globalNavigation.boundingBox(),
+    page.locator("app-settings .settings-shell").boundingBox(),
+  ]);
+  expect(railBox).not.toBeNull();
+  expect(settingsBox).not.toBeNull();
+  expect(settingsBox!.x).toBeGreaterThanOrEqual(railBox!.x + railBox!.width);
+
+  // Leaving Settings preserves the same shell-level inset.
   await page.getByRole("button", { name: "Back to Murmur" }).click();
   await expect(strip).toHaveCSS("padding-left", "24px");
 

--- a/e2e/notes/typed-properties.spec.ts
+++ b/e2e/notes/typed-properties.spec.ts
@@ -203,8 +203,23 @@ test("a LOCKED folder shows the lock gate and hides the Saved Views bar", async 
   // and only they ever set the Notes list's folder filter. So the property under test moved
   // with the destination: a sealed container must present itself as locked and disclose
   // nothing about what it holds, rather than showing a view of its contents.
-  await page.getByRole("button", { name: "Expand Workspace" }).click();
-  await page.getByRole("button", { name: "Work", exact: true }).click();
+  await page
+    .getByRole("navigation", { name: "Global navigation" })
+    .getByRole("button", { name: "Spaces", exact: true })
+    .click();
+  await expect(page).toHaveURL(/\/notes$/);
+  await expect(page.locator(".notes-content")).toBeVisible();
+
+  const spacesSidebar = page.getByRole("complementary", {
+    name: "Spaces sidebar",
+  });
+  await expect(spacesSidebar).toBeVisible();
+  await spacesSidebar
+    .getByRole("button", { name: "Expand Workspace" })
+    .click();
+  await spacesSidebar
+    .getByRole("button", { name: "Work", exact: true })
+    .click();
 
   await expect(page).toHaveURL(/\/container\/nf2$/);
   await expect(page.getByText("This container is locked")).toBeVisible();

--- a/e2e/org/org-surfaces.spec.ts
+++ b/e2e/org/org-surfaces.spec.ts
@@ -244,14 +244,33 @@ test.describe("Shared Brain v1 — org FE surfaces (mocked IPC)", () => {
       }),
     });
     await page.goto("/library");
-    // The lock affordance moved into the container row's actions menu when the one hierarchy
-    // replaced the two per-type trees. The gate it must run is unchanged: probe shares FIRST,
-    // and put this dialog in front of the seal.
-    const project = page.getByRole("treeitem").first();
+
+    await expect(page.locator("app-library .library")).toBeVisible();
+    await page
+      .getByRole("navigation", { name: "Global navigation" })
+      .getByRole("button", { name: "Spaces", exact: true })
+      .click();
+    await expect(page).toHaveURL(/\/library$/);
+    await expect(page.locator("app-library .library")).toBeVisible();
+
+    // The contextual tree exposes the lock menu without replacing the mounted
+    // meetings surface. The shares gate remains unchanged: probe first, then
+    // put the blocking dialog in front of the seal.
+    const spacesSidebar = page.getByRole("complementary", {
+      name: "Spaces sidebar",
+    });
+    await expect(spacesSidebar).toBeVisible();
+    const project = spacesSidebar.getByRole("treeitem").first();
     await expect(project).toBeVisible({ timeout: 10_000 });
-    await page.getByRole("button", { name: /^Expand / }).first().click();
+    await spacesSidebar
+      .getByRole("button", { name: /^Expand / })
+      .first()
+      .click();
     // Focus, not a pointer — see the note in lock-shares-dialog.spec.ts.
-    await page.getByRole("button", { name: /^Actions for / }).last().focus();
+    await spacesSidebar
+      .getByRole("button", { name: /^Actions for / })
+      .last()
+      .focus();
     await page.keyboard.press("Enter");
     // The lock entry names the CASCADE now: locking a container seals every container inside it,
     // so a project holding folders says so rather than calling itself "Lock folder". This test is

--- a/e2e/reminders/reminders.spec.ts
+++ b/e2e/reminders/reminders.spec.ts
@@ -40,8 +40,14 @@ test("Reminders: a live count cannot be lost or overwritten by a stale startup s
     target.__resolveReminderSummary?.({ dueInboxCount: 2 });
   });
 
-  const reminderNav = page.getByRole("link", { name: "Reminders" }).first();
-  await expect(reminderNav.locator(".nav-reminder-count")).toHaveText("4");
+  await page
+    .getByRole("navigation", { name: "Global navigation" })
+    .getByRole("button", { name: "Browse", exact: true })
+    .click();
+  const reminderNav = page
+    .getByRole("complementary", { name: "Browse sidebar" })
+    .getByRole("link", { name: "Reminders" });
+  await expect(reminderNav.locator(".count")).toHaveText("4");
 });
 
 test("Reminders: a listener resolving after root teardown is immediately unregistered", async ({
@@ -224,9 +230,9 @@ test("Reminders: an event supersedes the first in-flight list snapshot", async (
   await expect(page.getByText("Stale first row 1")).toHaveCount(0);
   await expect(
     page
+      .getByRole("complementary", { name: "Browse sidebar" })
       .getByRole("link", { name: "Reminders" })
-      .first()
-      .locator(".nav-reminder-count"),
+      .locator(".count"),
   ).toHaveText("4");
 });
 
@@ -738,9 +744,9 @@ test("Reminders: a newer list count beats a delayed startup summary", async ({
   await page.goto("/reminders");
   await expect(page.getByText("Newest list row 1")).toBeVisible();
   const reminderCount = page
+    .getByRole("complementary", { name: "Browse sidebar" })
     .getByRole("link", { name: "Reminders" })
-    .first()
-    .locator(".nav-reminder-count");
+    .locator(".count");
   await expect(reminderCount).toHaveText("3");
 
   await page.evaluate(async () => {
@@ -2194,7 +2200,9 @@ test("Reminders: route, composer, inbox, Smart review, context, and event refres
 
   await page.goto("/reminders");
 
-  const reminderNav = page.getByRole("link", { name: "Reminders" }).first();
+  const reminderNav = page
+    .getByRole("complementary", { name: "Browse sidebar" })
+    .getByRole("link", { name: "Reminders" });
   await expect(reminderNav).toBeVisible();
   await expect(reminderNav.locator(".count")).toHaveText("2");
   await expect(page.getByRole("heading", { name: "Reminders" })).toBeVisible();
@@ -2394,7 +2402,14 @@ test("Reminders: route, composer, inbox, Smart review, context, and event refres
   ).toBe(true);
 
   // Routed authored-note context carries the note source into the same composer.
-  await page.getByRole("link", { name: "Notes" }).first().click();
+  await page
+    .getByRole("navigation", { name: "Global navigation" })
+    .getByRole("button", { name: "Browse", exact: true })
+    .click();
+  await page
+    .getByRole("complementary", { name: "Browse sidebar" })
+    .getByRole("link", { name: "Notes", exact: true })
+    .click();
   await page
     .getByRole("button", { name: /Atlas — PRD v3/ })
     .first()
@@ -2463,7 +2478,7 @@ test("Reminders: route, composer, inbox, Smart review, context, and event refres
     noteCard.getByText("Resolve the PRD open question"),
   ).toBeVisible();
   await page
-    .getByRole("button", { name: /Re-seal all 1 unlocked folder now/ })
+    .getByRole("button", { name: /Re-seal all 1 unlocked folders? now/ })
     .click();
   await expect(page.getByText("Resolve the PRD open question")).toHaveCount(0);
   await expect(noteCard).toHaveCount(0);

--- a/e2e/settings-notes/glossary-round-trip.spec.ts
+++ b/e2e/settings-notes/glossary-round-trip.spec.ts
@@ -56,7 +56,7 @@ test("workspace glossary loads and saves only after blur, then survives a Settin
     .toEqual([UPDATED_GLOSSARY]);
 
   await page.getByRole("button", { name: "Back to Murmur" }).click();
-  await page.getByLabel("Settings", { exact: true }).click();
+  await page.getByRole("link", { name: "Settings", exact: true }).click();
   await openNotesSettings(page);
   await expect(page.getByLabel("Workspace glossary")).toHaveValue(
     UPDATED_GLOSSARY,

--- a/e2e/shell/container-organize.spec.ts
+++ b/e2e/shell/container-organize.spec.ts
@@ -63,7 +63,8 @@ async function open(page: Page): Promise<void> {
     (globalThis as unknown as { __plan: unknown }).__plan = plan;
   }, PLAN);
   await page.goto("/");
-  await expect(page.getByRole("tree", { name: "Workspace" })).toBeVisible();
+  await page.getByRole("button", { name: "Spaces" }).click();
+  await expect(page.getByRole("tree", { name: "Spaces" })).toBeVisible();
 }
 
 /**

--- a/e2e/shell/container-view.spec.ts
+++ b/e2e/shell/container-view.spec.ts
@@ -57,6 +57,7 @@ async function open(page: Page): Promise<void> {
     { list_workspace_tree: FOREST, get_container: CONTAINER },
   );
   await page.goto("/");
+  await page.getByRole("button", { name: "Spaces" }).click();
 }
 
 /**
@@ -73,7 +74,9 @@ test("a container row opens that container, not the recorder", async ({ page }) 
 
   await expect(page).toHaveURL(/\/container\/p-acme$/);
   await expect(page.getByRole("heading", { name: /Acme/ })).toBeVisible();
-  await expect(page.getByRole("button", { name: /Standup/ })).toBeVisible();
+  await expect(
+    page.locator(".app-main").getByRole("button", { name: /Standup/ }),
+  ).toBeVisible();
   // The kind with no items renders no section at all, rather than an empty one.
   await expect(page.getByRole("heading", { name: "Tasks" })).toHaveCount(0);
 });
@@ -100,9 +103,9 @@ test("a note row opens the note route that actually exists", async ({ page }) =>
     },
   );
   await page.goto("/");
+  await page.getByRole("button", { name: "Spaces" }).click();
 
   await page.getByRole("button", { name: "Expand Acme" }).click();
-  await page.getByRole("button", { name: "Expand Notes" }).click();
   await page.getByRole("button", { name: "Plan", exact: true }).click();
 
   // `/note/:id` does not exist; `/notes/:id` does. The wrong one silently lands

--- a/e2e/shell/quick-search-account.spec.ts
+++ b/e2e/shell/quick-search-account.spec.ts
@@ -17,7 +17,10 @@ test.afterEach(({ page }) => {
 });
 
 async function openPalette(page: Page): Promise<void> {
-  await page.getByRole("button", { name: "Search (⌘K)" }).click();
+  await page
+    .getByRole("navigation", { name: "Global navigation" })
+    .getByRole("button", { name: "Search", exact: true })
+    .click();
   await expect(page.getByRole("dialog", { name: "Quick search" })).toBeVisible();
 }
 

--- a/e2e/shell/spaces-shell.spec.ts
+++ b/e2e/shell/spaces-shell.spec.ts
@@ -1,0 +1,156 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+const FOREST = [
+  {
+    id: "p-acme",
+    name: "Acme",
+    level: "project",
+    emoji: "🟣",
+    tint: null,
+    locked: false,
+    unlocked: false,
+    isRoot: false,
+    folders: [],
+    groups: [
+      {
+        kind: "task",
+        total: 1,
+        items: [
+          { kind: "task", id: "t-ship", title: "Ship release", durationS: null, sortAt: 2 },
+        ],
+      },
+      {
+        kind: "dashboard",
+        total: 1,
+        items: [
+          { kind: "dashboard", id: "d-release", title: "Release dashboard", durationS: null, sortAt: 1 },
+        ],
+      },
+    ],
+  },
+];
+
+const SEALED_FIRST_FOREST = [
+  {
+    ...FOREST[0],
+    id: "p-sealed",
+    name: "Private",
+    locked: true,
+    unlocked: false,
+    groups: [],
+  },
+  FOREST[0],
+];
+
+async function boot(page: Page, path = "/record"): Promise<void> {
+  await mockTauri(page, {}, { list_workspace_tree: FOREST });
+  await page.goto(path);
+}
+
+test("uses a persistent global rail beside a contextual Spaces panel", async ({ page }) => {
+  await boot(page);
+
+  const rail = page.getByRole("navigation", { name: "Global navigation" });
+  await expect(rail).toBeVisible();
+  await expect(page.getByRole("complementary", { name: "Spaces sidebar" })).toHaveCount(0);
+  await expect(rail.getByRole("link", { name: "Capture" })).toHaveAttribute(
+    "aria-current",
+    "page",
+  );
+
+  await rail.getByRole("button", { name: "Spaces" }).click();
+  const spaces = page.getByRole("complementary", { name: "Spaces sidebar" });
+  await expect(spaces).toBeVisible();
+  await expect(spaces.getByRole("tree", { name: "Spaces" })).toBeVisible();
+  await expect(page.getByRole("navigation", { name: "Primary" })).toHaveCount(0);
+  await expect(page.locator(".pill-bar")).toHaveCount(0);
+
+  const railBox = await rail.boundingBox();
+  const spacesBox = await spaces.boundingBox();
+  const mainBox = await page.locator(".main-col").boundingBox();
+  expect(railBox).not.toBeNull();
+  expect(spacesBox).not.toBeNull();
+  expect(mainBox).not.toBeNull();
+  expect(railBox!.width).toBeGreaterThanOrEqual(68);
+  expect(railBox!.width).toBeLessThanOrEqual(74);
+  expect(spacesBox!.width).toBeGreaterThanOrEqual(252);
+  expect(spacesBox!.width).toBeLessThanOrEqual(258);
+  expect(spacesBox!.x - (railBox!.x + railBox!.width)).toBe(8);
+  expect(railBox!.x + railBox!.width).toBeLessThan(spacesBox!.x);
+  expect(spacesBox!.x + spacesBox!.width).toBeLessThan(mainBox!.x);
+
+  await expect(rail.getByRole("button", { name: "Search" })).toBeVisible();
+  await expect(rail.getByRole("link", { name: "Capture" })).toBeVisible();
+  await expect(rail.getByRole("button", { name: "Spaces" })).toBeVisible();
+  await expect(rail.getByRole("link", { name: "Ask" })).toBeVisible();
+  await expect(rail.getByRole("button", { name: "Browse" })).toBeVisible();
+  await expect(rail.getByRole("link", { name: "Settings" })).toBeVisible();
+});
+
+test("task and dashboard leaves keep Spaces visible and select the matching row", async ({
+  page,
+}) => {
+  await boot(page, "/tasks/t-ship");
+  await expect(page).toHaveURL(/\/tasks\/t-ship$/);
+  await expect(page.getByRole("complementary", { name: "Spaces sidebar" })).toBeVisible();
+  await expect(page.getByRole("treeitem", { name: /Ship release/ })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+
+  await page.getByRole("treeitem", { name: /Release dashboard/ }).click();
+  await expect(page).toHaveURL(/\/dashboards\/d-release$/);
+  await expect(page.getByRole("complementary", { name: "Spaces sidebar" })).toBeVisible();
+  await expect(page.getByRole("treeitem", { name: /Release dashboard/ })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+});
+
+test("rail surfaces switch from deep content and Settings through real routes", async ({
+  page,
+}) => {
+  await boot(page, "/settings");
+  await page.getByRole("button", { name: "Spaces" }).click();
+  await expect(page).toHaveURL(/\/container\/p-acme$/);
+  await expect(page.getByRole("complementary", { name: "Spaces sidebar" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Browse" }).click();
+  await expect(page).toHaveURL(/\/library$/);
+  await expect(page.getByRole("complementary", { name: "Browse sidebar" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Spaces" }).click();
+  await expect(page).toHaveURL(/\/container\/p-acme$/);
+  await expect(page.getByRole("complementary", { name: "Spaces sidebar" })).toBeVisible();
+});
+
+test("does not offer or dispatch top-level folder creation into a sealed first Space", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {
+      create_folder: (args: unknown) => {
+        const target = window as unknown as { __shellFolderCalls?: unknown[] };
+        (target.__shellFolderCalls ??= []).push(args);
+        return null;
+      },
+    },
+    { list_workspace_tree: SEALED_FIRST_FOREST },
+  );
+  await page.goto("/container/p-sealed");
+
+  const create = page.getByRole("button", { name: "New folder in first Space" });
+  await expect.soft(create).toHaveCount(0);
+  if ((await create.count()) > 0) {
+    await create.click();
+  }
+  const calls = await page.evaluate(
+    () =>
+      (window as unknown as { __shellFolderCalls?: unknown[] })
+        .__shellFolderCalls ?? [],
+  );
+  expect(calls).toEqual([]);
+});

--- a/e2e/shell/spaces-shell.spec.ts
+++ b/e2e/shell/spaces-shell.spec.ts
@@ -44,6 +44,44 @@ const SEALED_FIRST_FOREST = [
   FOREST[0],
 ];
 
+const TASK = {
+  id: "t-ship",
+  orgId: "org-acme",
+  docId: "doc-ship",
+  itemId: "item-ship",
+  sourceDocumentId: null,
+  version: 1,
+  title: "Ship release",
+  description: "Keep the task route usable on a narrow window.",
+  status: "todo",
+  dueAt: null,
+  assigneeUserId: null,
+  createdAt: "2026-08-24T09:00:00Z",
+  subtasks: [],
+  orgRefs: [],
+  images: [],
+  access: "edit",
+  canEdit: true,
+  canManage: true,
+  localRefs: [],
+  updatedAt: "2026-08-24T09:00:00Z",
+};
+
+const ORGS = [
+  {
+    orgId: "org-acme",
+    name: "Acme",
+    role: "owner",
+    memberCount: 1,
+    consented: true,
+    lastSeq: 1,
+    itemCount: 1,
+    receivedCount: 0,
+    pendingShares: 0,
+    contextEnabled: true,
+  },
+];
+
 async function boot(page: Page, path = "/record"): Promise<void> {
   await mockTauri(page, {}, { list_workspace_tree: FOREST });
   await page.goto(path);
@@ -61,6 +99,7 @@ test("uses a persistent global rail beside a contextual Spaces panel", async ({ 
   );
 
   await rail.getByRole("button", { name: "Spaces" }).click();
+  await expect(page).toHaveURL(/\/record$/);
   const spaces = page.getByRole("complementary", { name: "Spaces sidebar" });
   await expect(spaces).toBeVisible();
   await expect(spaces.getByRole("tree", { name: "Spaces" })).toBeVisible();
@@ -122,8 +161,79 @@ test("rail surfaces switch from deep content and Settings through real routes", 
   await expect(page.getByRole("complementary", { name: "Browse sidebar" })).toBeVisible();
 
   await page.getByRole("button", { name: "Spaces" }).click();
-  await expect(page).toHaveURL(/\/container\/p-acme$/);
+  await expect(page).toHaveURL(/\/library$/);
   await expect(page.getByRole("complementary", { name: "Spaces sidebar" })).toBeVisible();
+});
+
+test("opens Spaces without unmounting desktop Ask content", async ({ page }) => {
+  await boot(page, "/ask");
+  const askHeading = page.getByRole("heading", { name: "Ask your meetings" });
+  await expect(askHeading).toBeVisible();
+
+  await page.getByRole("button", { name: "Spaces" }).click();
+
+  await expect(page).toHaveURL(/\/ask$/);
+  await expect(askHeading).toBeVisible();
+  await expect(page.getByRole("complementary", { name: "Spaces sidebar" })).toBeVisible();
+});
+
+for (const [count, label] of [
+  [1, "Re-seal all 1 unlocked folder now"],
+  [2, "Re-seal all 2 unlocked folders now"],
+] as const) {
+  test(`names the re-seal action correctly for ${count} unlocked folder${count === 1 ? "" : "s"}`, async ({
+    page,
+  }) => {
+    const folders = Array.from({ length: count }, (_, index) => ({
+      id: `f-${index}`,
+      name: `Private ${index + 1}`,
+      path: `Private ${index + 1}`,
+      parentId: null,
+      noteCount: 1,
+      locked: true,
+      unlocked: true,
+      kind: "note",
+      children: [],
+    }));
+    await mockTauri(
+      page,
+      {},
+      { list_workspace_tree: FOREST, list_folders: folders },
+    );
+    await page.goto("/tasks/t-ship");
+
+    await expect(page.getByRole("button", { name: label })).toBeVisible();
+  });
+}
+
+test("keeps task navigation usable at 390px without a side-by-side context panel", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await mockTauri(
+    page,
+    {},
+    {
+      list_workspace_tree: FOREST,
+      list_tasks: [TASK],
+      org_list_statuses: ORGS,
+    },
+  );
+  await page.goto("/tasks");
+
+  await expect(page.locator(".app-sidebar")).toBeHidden();
+  const mainBox = await page.locator(".main-col").boundingBox();
+  expect(mainBox).not.toBeNull();
+  expect(mainBox!.width).toBeGreaterThan(250);
+
+  await page.locator('[data-task-id="t-ship"]').click();
+  await expect(page).toHaveURL(/\/tasks\/t-ship$/);
+  await expect(page.getByLabel("Task title")).toHaveValue("Ship release");
+  await expect(page.locator(".app-sidebar")).toBeHidden();
+
+  await page.getByRole("button", { name: "Spaces" }).click();
+  await expect(page).toHaveURL(/\/container\/p-acme$/);
+  await expect(page.locator(".app-sidebar")).toBeHidden();
 });
 
 test("does not offer or dispatch top-level folder creation into a sealed first Space", async ({

--- a/e2e/shell/workspace-create.spec.ts
+++ b/e2e/shell/workspace-create.spec.ts
@@ -40,7 +40,8 @@ async function open(page: Page, forest: unknown[]): Promise<void> {
     { list_workspace_tree: forest },
   );
   await page.goto("/");
-  await expect(page.getByRole("tree", { name: "Workspace" })).toBeVisible();
+  await page.getByRole("button", { name: "Spaces" }).click();
+  await expect(page.getByRole("tree", { name: "Spaces" })).toBeVisible();
 }
 
 test("a note can be created into a container and opens straight away", async ({ page }) => {

--- a/e2e/shell/workspace-dnd.spec.ts
+++ b/e2e/shell/workspace-dnd.spec.ts
@@ -94,9 +94,9 @@ async function open(page: Page): Promise<void> {
     { list_workspace_tree: FOREST },
   );
   await page.goto("/");
-  await expect(page.getByRole("tree", { name: "Workspace" })).toBeVisible();
+  await page.getByRole("button", { name: "Spaces" }).click();
+  await expect(page.getByRole("tree", { name: "Spaces" })).toBeVisible();
   await page.getByRole("button", { name: "Expand Acme" }).click();
-  await page.getByRole("button", { name: "Expand Meetings" }).click();
 }
 
 test("every kind the tree renders is draggable", async ({ page }) => {
@@ -111,13 +111,11 @@ test("every kind the tree renders is draggable", async ({ page }) => {
     "true",
   );
 
-  await page.getByRole("button", { name: "Expand Tasks" }).click();
   await expect(page.getByRole("treeitem", { name: /Ship the thing/ })).toHaveAttribute(
     "draggable",
     "true",
   );
 
-  await page.getByRole("button", { name: "Expand Dashboards" }).click();
   await expect(page.getByRole("treeitem", { name: /Q3 board/ })).toHaveAttribute(
     "draggable",
     "true",
@@ -134,12 +132,10 @@ test("each kind is filed through its OWN backend mover", async ({ page }) => {
     .getByRole("treeitem", { name: /Standup/ })
     .dragTo(page.getByRole("treeitem", { name: /Target/ }));
 
-  await page.getByRole("button", { name: "Expand Dashboards" }).click();
   await page
     .getByRole("treeitem", { name: /Q3 board/ })
     .dragTo(page.getByRole("treeitem", { name: /Target/ }));
 
-  await page.getByRole("button", { name: "Expand Tasks" }).click();
   await page
     .getByRole("treeitem", { name: /Ship the thing/ })
     .dragTo(page.getByRole("treeitem", { name: /Target/ }));

--- a/e2e/shell/workspace-move-keyboard.spec.ts
+++ b/e2e/shell/workspace-move-keyboard.spec.ts
@@ -62,9 +62,9 @@ async function open(page: Page): Promise<void> {
     { list_workspace_tree: FOREST },
   );
   await page.goto("/");
-  await expect(page.getByRole("tree", { name: "Workspace" })).toBeVisible();
+  await page.getByRole("button", { name: "Spaces" }).click();
+  await expect(page.getByRole("tree", { name: "Spaces" })).toBeVisible();
   await page.getByRole("button", { name: "Expand Acme" }).click();
-  await page.getByRole("button", { name: "Expand Meetings" }).click();
 }
 
 /**

--- a/e2e/shell/workspace-tree.spec.ts
+++ b/e2e/shell/workspace-tree.spec.ts
@@ -3,8 +3,8 @@ import { expect, test, type Page } from "@playwright/test";
 import { mockTauri } from "../settings-ai/mock-invoke";
 
 /**
- * The workspace hierarchy in the sidebar: Projects › Folders › collapsible
- * per-type groups.
+ * The workspace hierarchy in the contextual sidebar: Spaces › Folders ›
+ * mixed content rows.
  *
  * The forest below is written as the BACKEND serializes it (`ContainerNode` /
  * `TypeGroup` / `ItemRow` carry `rename_all = "camelCase"`), not as the
@@ -48,12 +48,35 @@ const FOREST = [
     groups: [
       {
         kind: "meeting",
-        // Ten in the container, two on the first page — so the group header must
-        // show 10 and a "see all" line must appear.
-        total: 10,
+        total: 5,
         items: [
-          { kind: "meeting", id: "m-standup", title: "Standup", durationS: 900, sortAt: 2 },
-          { kind: "meeting", id: "m-retro", title: null, durationS: 1800, sortAt: 1 },
+          { kind: "meeting", id: "m-standup", title: "Standup", durationS: 900, sortAt: 90 },
+          { kind: "meeting", id: "m-retro", title: null, durationS: 1800, sortAt: 40 },
+          { kind: "meeting", id: "m-old", title: "Old sync", durationS: 600, sortAt: 10 },
+        ],
+      },
+      {
+        kind: "note",
+        total: 3,
+        items: [
+          { kind: "note", id: "n-brief", title: "Launch brief", durationS: null, sortAt: 100 },
+          { kind: "note", id: "n-risks", title: "Risks", durationS: null, sortAt: 60 },
+        ],
+      },
+      {
+        kind: "task",
+        total: 2,
+        items: [
+          { kind: "task", id: "t-ship", title: "Ship release", durationS: null, sortAt: 80 },
+          { kind: "task", id: "t-copy", title: "Review copy", durationS: null, sortAt: 30 },
+        ],
+      },
+      {
+        kind: "dashboard",
+        total: 2,
+        items: [
+          { kind: "dashboard", id: "d-release", title: "Release dashboard", durationS: null, sortAt: 70 },
+          { kind: "dashboard", id: "d-metrics", title: "Metrics", durationS: null, sortAt: 50 },
         ],
       },
     ],
@@ -77,42 +100,74 @@ const FOREST = [
 async function openWorkspace(page: Page): Promise<void> {
   await mockTauri(page, {}, { list_workspace_tree: FOREST });
   await page.goto("/");
-  const section = page.getByRole("button", { name: /Projects/i }).first();
-  await expect(section).toBeVisible();
+  await page.getByRole("button", { name: "Spaces" }).click();
+  await expect(page.getByRole("complementary", { name: "Spaces sidebar" })).toBeVisible();
 }
 
-test("renders projects, their folders and collapsible type groups", async ({ page }) => {
+test("renders one flat mixed stream below each expanded container", async ({ page }) => {
   await openWorkspace(page);
 
-  const tree = page.getByRole("tree", { name: "Workspace" });
+  const tree = page.getByRole("tree", { name: "Spaces" });
   await expect(tree).toBeVisible();
 
   await expect(page.getByRole("treeitem", { name: /Acme/ })).toBeVisible();
   await expect(page.getByRole("treeitem", { name: /Private/ })).toBeVisible();
 
-  // A collapsed project shows no groups.
-  await expect(page.getByRole("treeitem", { name: /Meetings/ })).toHaveCount(0);
-
+  // A selected Space can still be collapsed by the user.
+  await expect(page.getByRole("treeitem", { name: /Launch brief/ })).toHaveCount(0);
   await page.getByRole("button", { name: "Expand Acme" }).click();
 
-  // The group header carries the container's FULL count, not the page size.
-  const meetings = page.getByRole("treeitem", { name: /Meetings/ });
-  await expect(meetings).toBeVisible();
-  await expect(meetings).toContainText("10");
-
-  // Items appear only once their group is expanded.
-  await expect(page.getByRole("treeitem", { name: /Standup/ })).toHaveCount(0);
-  await page.getByRole("button", { name: "Expand Meetings" }).click();
-  await expect(page.getByRole("treeitem", { name: /Standup/ })).toBeVisible();
+  // No synthetic kind headers: direct children are globally newest-first.
+  await expect(tree.locator(".line--group")).toHaveCount(0);
+  const mixedRows = tree.locator(".line--item");
+  await expect(mixedRows).toHaveCount(8);
+  await expect(mixedRows).toHaveText([
+    "Launch brief",
+    "Standup",
+    "Ship release",
+    "Release dashboard",
+    "Risks",
+    "Metrics",
+    "Untitled",
+    "Review copy",
+  ]);
+  for (const row of await mixedRows.all()) {
+    await expect(row).toHaveAttribute("aria-level", "2");
+  }
 
   // An untitled item renders a placeholder rather than an empty row.
   await expect(page.getByRole("treeitem", { name: /Untitled/ })).toBeVisible();
 
-  // Ten total, two shown → the pager appears and names the remainder.
-  await expect(page.getByRole("treeitem", { name: /See all \(10\)/ })).toBeVisible();
+  // All kinds share one total and one continuation row.
+  await expect(page.getByRole("treeitem", { name: /View all \(12\)/ })).toHaveCount(1);
 
   // A child folder is rendered under its project, with its own groups.
   await expect(page.getByRole("treeitem", { name: /Q3/ })).toBeVisible();
+});
+
+test("keeps an older selected leaf within the eight-row cap", async ({ page }) => {
+  await mockTauri(page, {}, { list_workspace_tree: FOREST });
+  await page.goto("/meeting/m-old");
+
+  const tree = page.getByRole("tree", { name: "Spaces" });
+  await expect(tree).toBeVisible();
+  const mixedRows = tree.locator(".line--item");
+  await expect(mixedRows).toHaveCount(8);
+  await expect(mixedRows).toHaveText([
+    "Launch brief",
+    "Standup",
+    "Ship release",
+    "Release dashboard",
+    "Risks",
+    "Metrics",
+    "Untitled",
+    "Old sync",
+  ]);
+  await expect(page.getByRole("treeitem", { name: "Old sync" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  await expect(page.getByRole("treeitem", { name: /View all \(12\)/ })).toHaveCount(1);
 });
 
 test("a sealed project discloses nothing about what it holds", async ({ page }) => {

--- a/e2e/shell/workspace-tree.spec.ts
+++ b/e2e/shell/workspace-tree.spec.ts
@@ -184,3 +184,168 @@ test("a sealed project discloses nothing about what it holds", async ({ page }) 
   // one that expands to emptiness would read as "this project is empty".
   await expect(page.getByRole("button", { name: "Expand Private" })).toHaveCount(0);
 });
+
+test("treats a sealed container as an intrinsic leaf even when a stale payload includes content", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {},
+    {
+      list_workspace_tree: [
+        {
+          id: "p-sealed-stale",
+          name: "Private",
+          level: "project",
+          emoji: "🔒",
+          tint: "violet",
+          locked: true,
+          unlocked: false,
+          isRoot: false,
+          folders: [
+            {
+              id: "f-secret",
+              name: "Secret child",
+              level: "folder",
+              emoji: null,
+              tint: null,
+              locked: true,
+              unlocked: false,
+              isRoot: false,
+              folders: [],
+              groups: [],
+            },
+          ],
+          groups: [
+            {
+              kind: "note",
+              total: 1,
+              items: [
+                {
+                  kind: "note",
+                  id: "n-secret",
+                  title: "Secret launch title",
+                  durationS: null,
+                  sortAt: 1,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  );
+  await page.goto("/container/p-sealed-stale");
+
+  const sealed = page.getByRole("treeitem", { name: "Private" });
+  await expect(sealed).toBeVisible();
+  await expect(page.getByRole("button", { name: "Expand Private" })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Add to Private" })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Actions for Private" })).toHaveCount(1);
+  await page.getByRole("button", { name: "Actions for Private" }).click();
+  await expect(page.getByRole("menuitem", { name: "Unlock for this session" })).toBeVisible();
+  await expect(page.getByRole("menuitem")).toHaveCount(1);
+  await expect(page.getByText("Secret child", { exact: true })).toHaveCount(0);
+  await expect(page.getByText("Secret launch title", { exact: true })).toHaveCount(0);
+});
+
+test("scrubs cached hierarchy titles when relock succeeds even if every refresh rejects", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {
+      list_workspace_tree: () => {
+        const target = window as unknown as { __workspaceTreeCalls?: number };
+        target.__workspaceTreeCalls = (target.__workspaceTreeCalls ?? 0) + 1;
+        if (target.__workspaceTreeCalls > 1) {
+          return Promise.reject(new Error("workspace refresh unavailable"));
+        }
+        return [
+          {
+            id: "p-private",
+            name: "Private",
+            level: "project",
+            emoji: null,
+            tint: null,
+            locked: true,
+            unlocked: true,
+            isRoot: false,
+            folders: [],
+            groups: [
+              {
+                kind: "note",
+                total: 1,
+                items: [
+                  {
+                    kind: "note",
+                    id: "n-secret",
+                    title: "Acquisition codename",
+                    durationS: null,
+                    sortAt: 1,
+                  },
+                ],
+              },
+              {
+                kind: "meeting",
+                total: 1,
+                items: [
+                  {
+                    kind: "meeting",
+                    id: "m-secret",
+                    title: "Board compensation",
+                    durationS: 600,
+                    sortAt: 2,
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+      },
+      relock_all: () => {
+        (
+          window as unknown as {
+            __demoEmit: (event: string, payload: unknown) => void;
+          }
+        ).__demoEmit("murmur://reminder-visibility-invalidated", null);
+        return null;
+      },
+    },
+    {
+      list_folders: [
+        {
+          id: "p-private",
+          name: "Private",
+          path: "Private",
+          parentId: null,
+          noteCount: 2,
+          locked: true,
+          unlocked: true,
+          kind: "meeting",
+          children: [],
+        },
+      ],
+    },
+  );
+  await page.goto("/meeting/m-secret");
+
+  await expect(page.getByText("Board compensation", { exact: true })).toBeVisible();
+  await expect(page.getByText("Acquisition codename", { exact: true })).toBeVisible();
+
+  await page.getByRole("button", { name: "Re-seal all 1 unlocked folder now" }).click();
+
+  await expect(page.getByText("Board compensation", { exact: true })).toHaveCount(0);
+  await expect(page.getByText("Acquisition codename", { exact: true })).toHaveCount(0);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as unknown as { __workspaceTreeCalls?: number })
+            .__workspaceTreeCalls ?? 0,
+      ),
+    )
+    .toBeGreaterThan(1);
+  await expect(page.getByText("Board compensation", { exact: true })).toHaveCount(0);
+  await expect(page.getByText("Acquisition codename", { exact: true })).toHaveCount(0);
+});

--- a/src/app/app-shell/app-shell.component.html
+++ b/src/app/app-shell/app-shell.component.html
@@ -125,9 +125,7 @@
           class="unlocked-pill"
           [disabled]="relockingAll()"
           (click)="relockAll()"
-          [attr.aria-label]="
-            'Re-seal all ' + unlockedCount() + ' unlocked folders now'
-          "
+          [attr.aria-label]="relockAllAriaLabel()"
         >
           <mur-icon icon="lock" />
           <span>{{ unlockedCount() }} unlocked</span>

--- a/src/app/app-shell/app-shell.component.html
+++ b/src/app/app-shell/app-shell.component.html
@@ -1,304 +1,180 @@
-<!-- Chrome is HIDDEN under any drill-down route (/settings, /library):
-     each drills down to its own two-column [rail | content] layout. -->
-@if (!inDrilldown()) {
-  @if (!barMode()) {
-    @if (railMode()) {
-      <!-- Rail mode: the traffic lights sit ABOVE the slim rail — keep the
-           window draggable along the top edge, like pill mode does. -->
-      <div class="pill-drag" data-tauri-drag-region></div>
-    }
-    <!-- Full sidebar, or (rail collapse style) the slim icon-only variant. -->
-    <mur-sidebar class="app-sidebar" [class.is-rail]="railMode()">
-      <!-- Top drag strip: reserves room for the overlay traffic lights and
-           lets the user move the window. -->
-      <div class="sidebar-drag" data-tauri-drag-region></div>
+<div class="shell-drag" data-tauri-drag-region></div>
 
-      <!-- Quick actions (Apple TV puts Search first in the rail). -->
-      <div class="sidebar-quick">
+<nav class="global-rail" aria-label="Global navigation">
+  <div class="rail-drag" data-tauri-drag-region></div>
+  <div class="rail-brand" aria-hidden="true">M</div>
+
+  <a
+    class="rail-item"
+    [class.active]="isCaptureActive()"
+    [attr.aria-current]="isCaptureActive() ? 'page' : null"
+    routerLink="/record"
+    (click)="clearContextOverride()"
+    aria-label="Capture"
+    title="Capture"
+  >
+    <mur-icon icon="record" />
+  </a>
+  <button
+    type="button"
+    class="rail-item"
+    (click)="openSearch()"
+    aria-label="Search"
+    title="Search (⌘K)"
+  >
+    <mur-icon icon="search" />
+  </button>
+  <button
+    type="button"
+    class="rail-item"
+    [class.active]="contextPanel() === 'spaces'"
+    [attr.aria-pressed]="contextPanel() === 'spaces'"
+    (click)="showSpaces()"
+    aria-label="Spaces"
+    title="Spaces"
+  >
+    <mur-icon icon="spaces" />
+  </button>
+  <a
+    class="rail-item"
+    [class.active]="isAskActive()"
+    [attr.aria-current]="isAskActive() ? 'page' : null"
+    routerLink="/ask"
+    (click)="clearContextOverride()"
+    aria-label="Ask"
+    title="Ask"
+  >
+    <mur-icon icon="ask" />
+  </a>
+  <button
+    type="button"
+    class="rail-item"
+    [class.active]="contextPanel() === 'browse'"
+    [attr.aria-pressed]="contextPanel() === 'browse'"
+    (click)="showBrowse()"
+    aria-label="Browse"
+    title="Browse"
+  >
+    <mur-icon icon="browse" />
+  </button>
+
+  <span class="rail-spacer"></span>
+
+  <button
+    type="button"
+    class="rail-item"
+    (click)="newNote()"
+    aria-label="New note"
+    title="New note (⌘N)"
+  >
+    <mur-icon icon="plus" />
+  </button>
+  <a
+    class="rail-item"
+    [class.active]="isSettingsActive()"
+    [attr.aria-current]="isSettingsActive() ? 'page' : null"
+    routerLink="/settings"
+    (click)="clearContextOverride()"
+    aria-label="Settings"
+    title="Settings"
+  >
+    <mur-icon icon="settings" />
+  </a>
+</nav>
+
+@if (contextPanel() === "spaces") {
+  <mur-sidebar
+    class="app-sidebar spaces-sidebar"
+    role="complementary"
+    aria-label="Spaces sidebar"
+  >
+    <div class="context-header">
+      <h2>Spaces</h2>
+      <div class="context-actions">
         <button
           type="button"
-          class="quick-row"
+          class="context-action"
           (click)="openSearch()"
-          aria-label="Search (⌘K)"
-          [attr.title]="railMode() ? 'Search (⌘K)' : null"
+          aria-label="Search Spaces"
+          title="Search"
         >
           <mur-icon icon="search" />
-          <span class="nav-label">Search</span>
-          <mur-kbd class="quick-kbd">⌘K</mur-kbd>
         </button>
-        <button
-          type="button"
-          class="quick-row"
-          (click)="newNote()"
-          aria-label="New note (⌘N)"
-          [attr.title]="railMode() ? 'New note (⌘N)' : null"
-        >
-          <mur-icon icon="plus" />
-          <span class="nav-label">New note</span>
-          <mur-kbd class="quick-kbd">⌘N</mur-kbd>
-        </button>
-      </div>
-
-      <nav class="sidebar-nav" aria-label="Primary">
-        @for (group of navGroups; track group.label ?? "top") {
-          @if (group.label; as label) {
-            @if (group.collapsible) {
-              <button
-                type="button"
-                class="sidebar-group-toggle"
-                (click)="toggleInsights()"
-                [attr.aria-expanded]="insightsExpanded()"
-                [attr.aria-label]="
-                  (insightsExpanded() ? 'Collapse ' : 'Expand ') + label
-                "
-              >
-                <span class="sidebar-group-label">{{ label }}</span>
-                <svg
-                  class="group-chev"
-                  [class.open]="insightsExpanded()"
-                  viewBox="0 0 16 16"
-                  width="11"
-                  height="11"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.6"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  aria-hidden="true"
-                >
-                  <path d="m6 4.5 3.5 3.5L6 11.5" />
-                </svg>
-              </button>
-            } @else {
-              <span class="sidebar-group-label">{{ label }}</span>
-            }
-          }
-          @if (!group.collapsible || insightsExpanded() || railMode()) {
-            @for (item of group.items; track item.path) {
-              <a
-                  [routerLink]="item.path"
-                  routerLinkActive="active"
-                  [attr.aria-label]="item.label"
-                  [attr.title]="railMode() ? item.label : null"
-                >
-                  <mur-icon [icon]="item.icon" />
-                  <span class="nav-label">{{ item.label }}</span>
-                  @if (item.path === "/reminders" && reminderCount() > 0) {
-                    <span class="count nav-reminder-count">{{ reminderCount() }}</span>
-                  }
-              </a>
-            }
-          }
-        }
-        @if (!railMode()) {
-          <!-- THE hierarchy, rendered ONCE and BELOW the destinations above it.
-               That order is ClickUp's: fixed places you can go (Home, Inbox, Docs,
-               Dashboards, Everything) sit above, and the Spaces tree — the thing that
-               answers "where does my work live" — occupies the body underneath.
-               Sandwiching the tree between destinations, which is where it landed when
-               it replaced one of them, made it read as a peer of "Tasks" rather than as
-               the place everything lives.
-
-               It replaces the two per-type trees that used to sit here. Each was keyed
-               on `folders.kind`, so a container appeared in one of them or the other,
-               never both — a folder holding meetings AND notes could not be expressed
-               at all, and "where does this live" had two answers to reconcile. The
-               per-type LISTS remain, as destinations, because "show me everything of
-               this kind" is a different question from "where does this live". -->
-          <mur-sidebar-section
-            routePath="/notes"
-            icon="notes"
-            label="Projects"
-            addFolderLabel="New folder"
-            [expanded]="workspaceTreeOpen()"
-            [enableHeaderDrop]="true"
-            (toggleExpanded)="toggleWorkspaceTree()"
-            (addFolder)="newWorkspaceFolder()"
-            (headerSelect)="onWorkspaceHeaderSelect()"
-            (headerDropNote)="onWorkspaceHeaderDrop($event)"
-          >
-            <app-workspace-tree [sectionActive]="isWorkspaceRoute()" />
-          </mur-sidebar-section>
-        }
-      </nav>
-
-      <div class="sidebar-footer">
-        <!-- Session-privacy: the sidebar's SINGLE accent focal point + its only
-             "Lock all" action (2026-07-14 declutter — the former top-of-tree
-             pill was removed). Status (N unlocked) + action (Lock all now) in
-             one control; only shown while something is actually exposed. -->
-        @if (unlockedCount() > 0) {
+        @if (canCreateWorkspaceFolder()) {
           <button
             type="button"
-            class="unlocked-pill"
-            [disabled]="relockingAll()"
-            (click)="relockAll()"
-            [attr.aria-label]="
-              'Re-seal all ' +
-              unlockedCount() +
-              ' unlocked folder' +
-              (unlockedCount() === 1 ? '' : 's') +
-              ' now'
-            "
-            [attr.title]="
-              'These folders are decrypted into plaintext until you re-lock or a screen share starts. Click to re-seal all now.'
-            "
+            class="context-action"
+            (click)="newWorkspaceFolder()"
+            aria-label="New folder in first Space"
+            title="New folder"
           >
-            <svg
-              class="unlocked-glyph"
-              viewBox="0 0 16 16"
-              width="12"
-              height="12"
-              fill="none"
-              aria-hidden="true"
-            >
-              <rect x="3.5" y="7" width="9" height="6" rx="1.4" stroke="currentColor" stroke-width="1.3" />
-              <path d="M5.5 7V5.4a2.5 2.5 0 0 1 4.9-0.65" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
-            </svg>
-            <span class="unlocked-count">{{ unlockedCount() }}</span>
-            <span class="nav-label unlocked-label">unlocked</span>
-            <span class="nav-label unlocked-action">Lock all</span>
+            <mur-icon icon="plus" />
           </button>
         }
-
-        <a
-          class="sidebar-settings"
-          routerLink="/settings"
-          routerLinkActive="active"
-          aria-label="Settings"
-          [attr.title]="railMode() ? 'Settings' : null"
-        >
-          <mur-icon icon="settings" />
-          <span class="nav-label">Settings</span>
-        </a>
-
-        <button
-          type="button"
-          class="sidebar-collapse"
-          (click)="togglePillMode()"
-          [attr.aria-label]="
-            railMode()
-              ? 'Expand the sidebar'
-              : collapseStyle() === 'rail'
-                ? 'Collapse the sidebar into an icon rail'
-                : 'Collapse the sidebar into the top bar'
-          "
-          [attr.title]="
-            railMode()
-              ? 'Expand sidebar'
-              : collapseStyle() === 'rail'
-                ? 'Collapse to icon rail'
-                : 'Collapse into the top bar'
-          "
-        >
-          <mur-icon icon="sidebar" />
-          <span class="nav-label">{{
-            collapseStyle() === "rail" ? "Collapse to rail" : "Collapse to bar"
-          }}</span>
-        </button>
       </div>
-    </mur-sidebar>
-  } @else {
-    <!-- Pill mode: window-drag strip along the top edge, BEHIND the pill. -->
-    <div class="pill-drag" data-tauri-drag-region></div>
+    </div>
 
-    <nav class="pill-bar" aria-label="Primary">
-      <button
-        type="button"
-        class="pill-item"
-        (click)="togglePillMode()"
-        aria-label="Show sidebar"
-        title="Show sidebar"
-      >
-        <mur-icon icon="sidebar" />
-      </button>
+    <div class="context-body">
+      <app-workspace-tree [currentPath]="currentPath()" />
+    </div>
 
-      <span class="pill-sep" aria-hidden="true"></span>
-
-      @for (item of navItems; track item.path) {
-        <a
-          class="pill-item"
-          [routerLink]="item.path"
-          routerLinkActive="active"
-          [attr.aria-label]="item.label"
-          [attr.title]="item.label"
-        >
-          <mur-icon [icon]="item.icon" />
-          <span class="nav-label">{{ item.label }}</span>
-          @if (item.path === "/reminders" && reminderCount() > 0) {
-            <span class="count nav-reminder-count">{{ reminderCount() }}</span>
-          }
-        </a>
-      }
-
-      <span class="pill-sep" aria-hidden="true"></span>
-
-      <button
-        type="button"
-        class="pill-item"
-        (click)="openSearch()"
-        aria-label="Search (⌘K)"
-        title="Search (⌘K)"
-      >
-        <mur-icon icon="search" />
-      </button>
-      <button
-        type="button"
-        class="pill-item"
-        (click)="newNote()"
-        aria-label="New note (⌘N)"
-        title="New note (⌘N)"
-      >
-        <mur-icon icon="plus" />
-      </button>
-      <a
-        class="pill-item"
-        routerLink="/settings"
-        routerLinkActive="active"
-        aria-label="Settings"
-        title="Settings"
-      >
-        <mur-icon icon="settings" />
-      </a>
-
-      @if (unlockedCount() > 0) {
+    @if (unlockedCount() > 0) {
+      <div class="context-footer">
         <button
           type="button"
-          class="pill-unlocked"
+          class="unlocked-pill"
           [disabled]="relockingAll()"
           (click)="relockAll()"
           [attr.aria-label]="
             'Re-seal all ' + unlockedCount() + ' unlocked folders now'
           "
-          title="Locked folders decrypted for this session — click to re-seal all now"
         >
-          <svg viewBox="0 0 16 16" width="12" height="12" fill="none" aria-hidden="true">
-            <rect x="3.5" y="7" width="9" height="6" rx="1.4" stroke="currentColor" stroke-width="1.3" />
-            <path d="M5.5 7V5.4a2.5 2.5 0 0 1 4.9-0.65" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
-          </svg>
-          <span class="unlocked-count">{{ unlockedCount() }}</span>
+          <mur-icon icon="lock" />
+          <span>{{ unlockedCount() }} unlocked</span>
+          <span class="unlocked-action">Lock all</span>
         </button>
+      </div>
+    }
+  </mur-sidebar>
+} @else if (contextPanel() === "browse") {
+  <mur-sidebar
+    class="app-sidebar browse-sidebar"
+    role="complementary"
+    aria-label="Browse sidebar"
+  >
+    <div class="context-header">
+      <h2>Browse</h2>
+      <button
+        type="button"
+        class="context-action"
+        (click)="openSearch()"
+        aria-label="Search"
+        title="Search"
+      >
+        <mur-icon icon="search" />
+      </button>
+    </div>
+    <nav class="browse-nav" aria-label="Browse destinations">
+      @for (group of browseGroups; track group) {
+        <span class="context-group-label">{{ group }}</span>
+        @for (item of itemsForGroup(group); track item.path) {
+          <a
+            [routerLink]="item.path"
+            [class.active]="isBrowseItemActive(item.path)"
+            (click)="clearContextOverride()"
+          >
+            <mur-icon [icon]="item.icon" />
+            <span>{{ item.label }}</span>
+            @if (item.path === "/reminders" && reminderCount() > 0) {
+              <span class="count">{{ reminderCount() }}</span>
+            }
+          </a>
+        }
       }
     </nav>
-  }
+  </mur-sidebar>
 }
 
-<!-- Real in-flow layout, not a floating overlay (fixed 2026-07-12 — a
-     `position: fixed` strip could never make the page underneath aware
-     space was taken, so every route needed its own pixel-guess clearance,
-     forever fragile). `.main-col` is the flex COLUMN [tab strip, app-main]
-     occupying the SAME row-item slot `.app-main` used to occupy directly
-     (beside the sidebar in sidebar/rail mode; full width in pill/drill-down
-     mode) — `mur-tab-strip` now genuinely PUSHES `.app-main` down by its
-     real rendered height when tabs are open, and contributes ZERO height
-     when `tabs().length === 0` (its own `@if`). The one remaining wrinkle:
-     drill-down routes (library / notes home / note editor / settings) render
-     their OWN `position: fixed; inset: 0` full-window host, which ignores
-     normal DOM flow and would paint over this strip regardless — those hosts
-     read `top: var(--tabs-strip-height, 0px)` (set on `:root` by
-     `AppShellComponent`, see its ctor) instead of `inset: 0`, so they
-     structurally leave the strip's real height uncovered rather than
-     floating a guess on top of it. -->
 <div class="main-col">
   <mur-tab-strip />
   <main class="app-main">
@@ -306,15 +182,12 @@
   </main>
 </div>
 
-<!-- ⌘K quick-search spotlight (works from every route, drill-downs too). -->
 @if (searchOpen()) {
   <mur-quick-search (closed)="searchOpen.set(false)" />
 }
 
-<!-- Account session notice: keeps optional sharing auth visible outside Settings. -->
 <app-account-session-banner />
 
-<!-- Toast viewport: renders the app-wide queue from ToastService. -->
 @if (toasts().length > 0) {
   <div class="toast-viewport" aria-live="polite" aria-atomic="false">
     @for (t of toasts(); track t.id) {
@@ -349,8 +222,6 @@
   </div>
 }
 
-<!-- Lock×shares blocking dialog (PK-F1) — rendered ONCE for the whole app
-     (2026-07-12 fix; see the `lockFlow` field doc). Opaque overlay (T3). -->
 @if (lockFlow.pending(); as pending) {
   <app-lock-shares-dialog
     [folderName]="pending.folderName"
@@ -363,24 +234,13 @@
   />
 }
 
-<!-- Read-only document/note content-preview modal — the SINGLE app-wide host
-     (see the `docPreview` field doc). Reachable from every route: a Related /
-     Suggested chip, a `[[wikilink]]`, or a full-brain-graph node opens it via
-     `DocumentPreviewService.open`; the component renders nothing while its
-     `target` is null. Opaque overlay (T3), owned by the component. -->
 <app-document-preview
   [doc]="docPreview.target()"
   (dismiss)="docPreview.close()"
 />
 
-<!-- The one opaque app-wide Murmur reminder composer host. -->
 <app-reminder-composer />
 
-<!-- Add-a-tile palette (Dashboards). Hosted HERE, not by the board, for the same
-     reason as every overlay above it: a `position: fixed` layer whose only
-     ancestors are <body>/<html> cannot be pushed, clipped, covered or offset by
-     anything a feature view does. The board only flips the service's signal.
-     See TilePaletteService for the five fixes that bought this. -->
 @if (tilePalette.open()) {
   <app-tile-palette
     (dismiss)="tilePalette.dismiss()"

--- a/src/app/app-shell/app-shell.component.ts
+++ b/src/app/app-shell/app-shell.component.ts
@@ -55,6 +55,7 @@ const BROWSE_ITEMS: readonly BrowseItem[] = [
 ];
 
 const BROWSE_GROUPS = ["Work", "Intelligence", "Insights"] as const;
+const NARROW_SHELL_QUERY = "(max-width: 760px)";
 
 @Component({
   selector: "app-shell",
@@ -150,6 +151,11 @@ export class AppShellComponent {
     const firstSpace = this.workspace.forest()[0];
     return Boolean(firstSpace && (!firstSpace.locked || firstSpace.unlocked));
   });
+  readonly relockAllAriaLabel = computed(() => {
+    const count = this.unlockedCount();
+    const noun = count === 1 ? "folder" : "folders";
+    return `Re-seal all ${count} unlocked ${noun} now`;
+  });
 
   private readonly _syncTabsStripHeight = effect(() => {
     const height = this.tabs.tabs().length > 0 ? "48px" : "0px";
@@ -165,13 +171,17 @@ export class AppShellComponent {
       await this.workspace.reload();
     }
     const firstSpace = this.workspace.forest()[0];
-    if (firstSpace) {
+    const path = this.currentPath();
+    const fixedDrilldown =
+      path.startsWith("/settings") || path.startsWith("/org-item/");
+    const narrowViewport = window.matchMedia(NARROW_SHELL_QUERY).matches;
+    if ((fixedDrilldown || narrowViewport) && firstSpace) {
       this._contextOverride.set(null);
       await this.router.navigate(["/container", firstSpace.id]);
       return;
     }
     this._contextOverride.set("spaces");
-    if (this.currentPath().startsWith("/settings")) {
+    if (fixedDrilldown) {
       await this.router.navigate(["/record"]);
     }
   }

--- a/src/app/app-shell/app-shell.component.ts
+++ b/src/app/app-shell/app-shell.component.ts
@@ -1,180 +1,72 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  Injector,
   computed,
   effect,
   inject,
   signal,
 } from "@angular/core";
 import { toSignal } from "@angular/core/rxjs-interop";
-import {
-  NavigationEnd,
-  Router,
-  RouterLink,
-  RouterLinkActive,
-  RouterOutlet,
-} from "@angular/router";
+import { NavigationEnd, Router, RouterLink, RouterOutlet } from "@angular/router";
 import { filter, map } from "rxjs";
-import { IpcService } from "../core/ipc.service";
-import { isDrilldownRoute } from "../core/nav-history.service";
+
 import { TabsService } from "../core/tabs.service";
 import {
   MurIconComponent,
   type ShellIcon,
 } from "../design-system/icon/icon.component";
-import { MurKbdComponent } from "../design-system/kbd/kbd.component";
 import { MurQuickSearchComponent } from "../design-system/quick-search/quick-search.component";
 import { MurSidebarComponent } from "../design-system/sidebar/sidebar.component";
-import { MurSidebarSectionComponent } from "../design-system/sidebar-section/sidebar-section.component";
 import { MurTabStripComponent } from "../design-system/tab-strip/tab-strip.component";
 import { DocumentPreviewComponent } from "../features/brain/document-preview/document-preview.component";
 import { TilePaletteComponent } from "../features/dashboards/tile-palette/tile-palette.component";
 import { LockSharesDialogComponent } from "../features/folders/lock-shares-dialog/lock-shares-dialog.component";
-import { WorkspaceService } from "../features/workspace/workspace.service";
-import { WorkspaceTreeComponent } from "../features/workspace/workspace-tree/workspace-tree.component";
 import { ReminderComposerComponent } from "../features/reminders/reminder-composer/reminder-composer.component";
 import { RemindersStore } from "../features/reminders/reminders.store";
-import { ChromeService } from "../services/chrome.service";
+import { AccountSessionBannerComponent } from "../features/sharing/account-session-banner/account-session-banner.component";
+import { WorkspaceService } from "../features/workspace/workspace.service";
+import { WorkspaceTreeComponent } from "../features/workspace/workspace-tree/workspace-tree.component";
 import { DocumentPreviewService } from "../services/document-preview.service";
 import { FolderLockFlowService } from "../services/folder-lock-flow.service";
 import { FoldersService } from "../services/folders.service";
 import { NotesService } from "../services/notes.service";
 import { TilePaletteService } from "../services/tile-palette.service";
 import { ToastService, type Toast } from "../services/toast.service";
-import { AccountSessionBannerComponent } from "../features/sharing/account-session-banner/account-session-banner.component";
 
-/** localStorage key for the chrome mode: "1" = pill bar, "0" = sidebar. */
-const SIDEBAR_KEY = "murmur-sidebar-collapsed";
-
-/** localStorage key for the Insights sidebar group: "1" = expanded. */
-const INSIGHTS_KEY = "murmur-sidebar-insights";
-
-/**
- * localStorage key for the Notes nav row's note-folder tree: "1" = expanded.
- * Default OPEN (Obsidian shows its vault tree by default) — unlike Insights,
- * which defaults collapsed.
- */
-const NOTES_TREE_KEY = "murmur-sidebar-notes-tree";
-
-/**
- * localStorage key for the Meetings nav row's folder tree: "1" = expanded.
- * Default OPEN — mirrors `NOTES_TREE_KEY` (Stage 2 of the always-visible-
- * sidebar work, 2026-07-12).
- */
-const MEETINGS_TREE_KEY = "murmur-sidebar-meetings-tree";
-
-/** Persisted expansion of the workspace hierarchy section. */
-const WORKSPACE_TREE_KEY = "murmur-sidebar-workspace-tree";
-
-/** A primary navigation destination. `icon` selects the inline SVG. */
-interface NavItem {
+interface BrowseItem {
   readonly path: string;
   readonly label: string;
   readonly icon: ShellIcon;
+  readonly group: "Work" | "Intelligence" | "Insights";
 }
 
-/** A labeled cluster of destinations in the EXPANDED sidebar only. */
-interface NavGroup {
-  readonly label: string | null;
-  readonly collapsible?: boolean;
-  readonly items: readonly NavItem[];
-}
+type ContextPanel = "spaces" | "browse" | "none";
 
-/**
- * QUIET GLASS sidebar grouping: Record (the app's primary act) solo on top,
- * then labeled clusters; the analytical destinations collapse under Insights.
- * The PILL BAR is untouched — it keeps the flat item list (NAV_ITEMS below).
- */
-const NAV_GROUPS: readonly NavGroup[] = [
-  {
-    label: null,
-    items: [{ path: "/record", label: "Record", icon: "record" }],
-  },
-  {
-    label: "Workspace",
-    items: [
-      { path: "/library", label: "Meetings", icon: "meetings" },
-      { path: "/notes", label: "Notes", icon: "notes" },
-      { path: "/dashboards", label: "Dashboards", icon: "dashboards" },
-      { path: "/tasks", label: "Tasks", icon: "tasks" },
-      { path: "/reminders", label: "Reminders", icon: "reminders" },
-    ],
-  },
-  {
-    label: "Assistant",
-    items: [
-      { path: "/ask", label: "Ask", icon: "ask" },
-      { path: "/brain", label: "Brain", icon: "brain" },
-    ],
-  },
-  {
-    label: "Insights",
-    collapsible: true,
-    items: [
-      { path: "/analytics", label: "Analytics", icon: "analytics" },
-      { path: "/graph", label: "Graph", icon: "graph" },
-      { path: "/people", label: "People", icon: "people" },
-    ],
-  },
+const BROWSE_ITEMS: readonly BrowseItem[] = [
+  { path: "/library", label: "Meetings", icon: "meetings", group: "Work" },
+  { path: "/notes", label: "Notes", icon: "notes", group: "Work" },
+  { path: "/tasks", label: "Tasks", icon: "tasks", group: "Work" },
+  { path: "/dashboards", label: "Dashboards", icon: "dashboards", group: "Work" },
+  { path: "/reminders", label: "Reminders", icon: "reminders", group: "Work" },
+  { path: "/brain", label: "Brain", icon: "brain", group: "Intelligence" },
+  { path: "/analytics", label: "Analytics", icon: "analytics", group: "Insights" },
+  { path: "/graph", label: "Graph", icon: "graph", group: "Insights" },
+  { path: "/people", label: "People", icon: "people", group: "Insights" },
 ];
 
-/**
- * The flat destination list for the PILL BAR — kept in the pill bar's
- * PRE-EXISTING order (the grouping above reorders only the expanded sidebar;
- * the collapsed chrome must not silently reshuffle).
- */
-const NAV_ITEMS: readonly NavItem[] = [
-  { path: "/record", label: "Record", icon: "record" },
-  { path: "/library", label: "Meetings", icon: "meetings" },
-  { path: "/notes", label: "Notes", icon: "notes" },
-  { path: "/dashboards", label: "Dashboards", icon: "dashboards" },
-  { path: "/tasks", label: "Tasks", icon: "tasks" },
-  { path: "/reminders", label: "Reminders", icon: "reminders" },
-  { path: "/analytics", label: "Analytics", icon: "analytics" },
-  { path: "/graph", label: "Graph", icon: "graph" },
-  { path: "/people", label: "People", icon: "people" },
-  { path: "/brain", label: "Brain", icon: "brain" },
-  { path: "/ask", label: "Ask", icon: "ask" },
-];
+const BROWSE_GROUPS = ["Work", "Intelligence", "Insights"] as const;
 
-/** Routes that live inside the collapsible Insights group. */
-const INSIGHT_PATHS = NAV_GROUPS.filter((g) => g.collapsible).flatMap((g) =>
-  g.items.map((i) => i.path),
-);
-
-/**
- * PROTOTYPE (Apple TV iPadOS shell) — the app chrome in two liquid-glass modes:
- *
- * - **Sidebar mode** — a FLOATING rounded glass panel (inset from the window
- *   edges, Apple TV's opened sidebar), with quick actions (Search ⌘K, New
- *   note ⌘N) pinned under the brand.
- * - **Pill mode** — the sidebar collapses into a floating top-center pill bar
- *   (Apple TV's collapsed state): sidebar toggle · icon nav (the active route
- *   shows its label) · search · new note · settings.
- *
- * ⌘K opens the quick-search spotlight and ⌘N starts a new note from anywhere
- * (both also on Ctrl for completeness). Light/dark ride the existing theme
- * tokens untouched.
- *
- * Why this is a separate child component (and not just AppComponent's
- * template): it is the Tauri WKWebView FOUC fix — see the original rationale
- * below; the shell CSS stays GLOBAL in styles.css, matched by class.
- */
 @Component({
   selector: "app-shell",
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     RouterOutlet,
     RouterLink,
-    RouterLinkActive,
     MurIconComponent,
-    MurKbdComponent,
     MurQuickSearchComponent,
     MurSidebarComponent,
     MurTabStripComponent,
     WorkspaceTreeComponent,
-    MurSidebarSectionComponent,
     LockSharesDialogComponent,
     DocumentPreviewComponent,
     ReminderComposerComponent,
@@ -182,30 +74,7 @@ const INSIGHT_PATHS = NAV_GROUPS.filter((g) => g.collapsible).flatMap((g) =>
     AccountSessionBannerComponent,
   ],
   host: {
-    // Scoped to !inDrilldown so the pill-clearance padding never leaks onto
-    // drill-down routes (which render no pill bar). Rail-style collapse keeps
-    // the sidebar in the flex row, so it needs no clearance either.
-    "[class.pill-mode]": "barMode() && !inDrilldown()",
-    // True exactly when the floating sidebar/rail actually renders (mirrors
-    // the template's own `@if (!inDrilldown()) { @if (!barMode()) { … } }`
-    // gate) — drives `.main-col`'s top offset (styles.css) so the tab strip
-    // lines up with the sidebar's first content row instead of sitting
-    // noticeably higher (2026-07-12 fix). Deliberately excludes drill-down
-    // AND pill/bar mode: neither renders the floating sidebar this alignment
-    // targets, and drill-down routes read `--tabs-strip-height` (a literal,
-    // not this margin) for their own fixed-host offset — adding the margin
-    // there too would desync the two.
-    "[class.sidebar-visible]": "!inDrilldown() && !barMode()",
-    // True on drill-down routes (/settings, /org-item), where NO sidebar/pill
-    // chrome renders and `.main-col` spans from the window's LEFT edge —
-    // `mur-tab-strip` reads this via `:host-context` to reserve clearance for
-    // the overlay macOS traffic lights, which otherwise sit on the first tab
-    // (2026-07-17 fix; see tab-strip.component.scss).
-    "[class.drilldown]": "inDrilldown()",
-    // (The former `notes-wide-route` binding is GONE, 2026-07-12: `.app-main`
-    // is `max-width: none; width: 100%` for EVERY main route now — see the
-    // `.app-main` comment in styles.css. Views that want a narrower reading
-    // column own that cap in their own component scss.)
+    "[class.context-visible]": "contextPanel() !== 'none'",
     "(document:keydown)": "onGlobalKeydown($event)",
     "(window:keydown.escape)": "onWindowEscape($event)",
   },
@@ -214,379 +83,150 @@ const INSIGHT_PATHS = NAV_GROUPS.filter((g) => g.collapsible).flatMap((g) =>
 })
 export class AppShellComponent {
   private readonly folders = inject(FoldersService);
-  private readonly ipcService = inject(IpcService);
   private readonly notesService = inject(NotesService);
   private readonly toast = inject(ToastService);
   private readonly router = inject(Router);
-  private readonly chrome = inject(ChromeService);
   private readonly tabs = inject(TabsService);
-  private readonly injector = inject(Injector);
   private readonly reminders = inject(RemindersStore);
+  protected readonly workspace = inject(WorkspaceService);
+
   readonly reminderCount = this.reminders.dueInboxCount;
-
-  /**
-   * Shared lock×shares flow (probe → warn/revoke dialog → lock) — rendered
-   * exactly ONCE here (2026-07-12 fix), regardless of which sidebar tree
-   * (`NotesSidebarTreeComponent` / `MeetingsSidebarTreeComponent`'s folder
-   * rows) triggered it. Both used to render their OWN `<app-lock-shares-
-   * dialog>` bound to this same root-singleton service — harmless while only
-   * one tree existed, but the main sidebar now ALWAYS mounts both
-   * simultaneously, so a single lock request rendered TWO dialogs (caught by
-   * `e2e/org/org-surfaces.spec.ts`'s strict-mode-violation failure).
-   */
   readonly lockFlow = inject(FolderLockFlowService);
-
-  /**
-   * The app-wide read-only document/note preview modal, hosted ONCE here so it's
-   * reachable from every route (a Related/Suggested chip, a `[[wikilink]]`, a
-   * full-brain-graph node — none of which have a document route). The template
-   * binds its `target` into the SINGLE `<app-document-preview>` host below; every
-   * "open a document" surface calls {@link DocumentPreviewService.open}.
-   */
   readonly docPreview = inject(DocumentPreviewService);
-
-  /**
-   * The Add-a-tile palette's open state. The palette is rendered HERE (see the
-   * template) rather than by the board — `TilePaletteService` documents why.
-   */
   readonly tilePalette = inject(TilePaletteService);
 
-  constructor() {
-    void this.reminders.initSummary();
-  }
-
-  /**
-   * The current URL, updated on every completed navigation. Seeded from
-   * `router.url` so `inDrilldown` is correct on a cold deep-link.
-   */
   private readonly currentUrl = toSignal(
     this.router.events.pipe(
-      filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+      filter((event): event is NavigationEnd => event instanceof NavigationEnd),
       map(() => this.router.url),
     ),
     { initialValue: this.router.url },
   );
 
-  /** True while on any drill-down route (`/settings*`, `/library*`). */
-  readonly inDrilldown = computed(() => isDrilldownRoute(this.currentUrl()));
+  readonly currentPath = computed(() => this.currentUrl().split(/[?#]/)[0]);
 
-  /**
-   * True on EVERY Notes route: `/notes` (the table list) and
-   * `/notes/:id`/`/notes/new` (the editor). Drives
-   * `NotesSidebarTreeComponent`'s `sectionActive` input — see
-   * {@link isMeetingsRoute} for the full rationale (the two are symmetric).
-   * Covers `/notes/new` too (`NoteEditorComponent` handles that path
-   * directly, `app.routes.ts`). (Its former second job — the
-   * `notes-wide-route` width escape — is gone: `.app-main` is uncapped on
-   * every main route now, see styles.css.)
-   */
-  readonly isNotesRoute = computed(() => {
-    // Strip a query/fragment before comparing so `/notes?x=y` still counts as
-    // the exact list route rather than falling through to neither branch.
-    const path = this.currentUrl().split(/[?#]/)[0];
-    return path === "/notes" || path.startsWith("/notes/");
+  private readonly _contextOverride = signal<ContextPanel | null>(null);
+
+  private readonly isSpaceLeafRoute = computed(() => {
+    const path = this.currentPath();
+    return (
+      path.startsWith("/container/") ||
+      path.startsWith("/meeting/") ||
+      (path.startsWith("/notes/") && path !== "/notes/new") ||
+      (path.startsWith("/tasks/") && path !== "/tasks/new") ||
+      path.startsWith("/dashboards/")
+    );
   });
 
-  /**
-   * True on EVERY Meetings route: `/library` (the list) and `/meeting/:id`
-   * (the detail view) — mirrors {@link isNotesRoute}. Drives
-   * `MeetingsSidebarTreeComponent`'s `sectionActive` input (2026-07-12 fix):
-   * the tree's folder rows remembered the last-selected folder via the SHARED
-   * `FoldersService.activeFolderId` regardless of which page was open, so
-   * "All meetings"/a folder kept showing the active/selected pill even while
-   * looking at `/notes` or `/record` — misleadingly claiming something was
-   * "current" when nothing about Meetings was. Gating the VISUAL selected
-   * state on this (while still remembering the folder internally so
-   * returning to `/library` reselects it) makes both trees symmetric: fused
-   * header+root pill while that section is the current route, fully plain
-   * otherwise — never "sometimes fused, sometimes disconnected" depending on
-   * which page happens to be open.
-   */
-  readonly isMeetingsRoute = computed(() => {
-    const path = this.currentUrl().split(/[?#]/)[0];
-    return path === "/library" || path.startsWith("/library/") || path.startsWith("/meeting/");
+  private readonly isBrowseRoute = computed(() =>
+    BROWSE_ITEMS.some((item) => this.currentPath() === item.path),
+  );
+
+  readonly contextPanel = computed<ContextPanel>(() => {
+    const path = this.currentPath();
+    if (path.startsWith("/settings") || path.startsWith("/org-item/")) {
+      return "none";
+    }
+    const override = this._contextOverride();
+    if (override) {
+      return override;
+    }
+    if (this.isSpaceLeafRoute()) {
+      return "spaces";
+    }
+    if (this.isBrowseRoute()) {
+      return "browse";
+    }
+    return "none";
   });
 
-  /**
-   * True wherever the workspace tree's own selection is meaningful — every surface it
-   * renders rows for, plus the container view its rows open. One tree covering both
-   * namespaces cannot take its active state from just one of them.
-   */
-  readonly isWorkspaceRoute = computed(() => {
-    const path = this.currentUrl().split(/[?#]/)[0];
-    return this.isNotesRoute() || this.isMeetingsRoute() || path.startsWith("/container/");
-  });
-
-  /** Primary destinations (Settings lives in the chrome footer / pill end). */
-  readonly navItems: readonly NavItem[] = NAV_ITEMS;
-
-  /** Sidebar-only grouping of the same destinations (pill bar stays flat). */
-  readonly navGroups: readonly NavGroup[] = NAV_GROUPS;
-
-  /** Persisted Insights-group preference (default collapsed). */
-  private readonly _insightsOpen = signal(this.readStoredInsightsOpen());
-
-  /**
-   * Persisted Notes note-folder-tree preference (default EXPANDED — Obsidian
-   * always shows its vault tree). Nested under the "Notes" nav row via
-   * {@link NotesSidebarTreeComponent}.
-   */
-  private readonly _notesTreeOpen = signal(this.readStoredNotesTreeOpen());
-  readonly notesTreeOpen = this._notesTreeOpen.asReadonly();
-
-  /**
-   * Persisted Meetings folder-tree preference (default EXPANDED). Nested
-   * under the "Meetings" nav row via {@link MeetingsSidebarTreeComponent}
-   * (Stage 2, 2026-07-12 — mirrors the Notes tree above).
-   */
-  private readonly _meetingsTreeOpen = signal(this.readStoredMeetingsTreeOpen());
-  readonly meetingsTreeOpen = this._meetingsTreeOpen.asReadonly();
-
-  /**
-   * Persisted "Projekty" (workspace hierarchy) preference — default EXPANDED,
-   * matching the two per-type trees it will eventually replace.
-   */
-  private readonly _workspaceTreeOpen = signal(this.readStoredWorkspaceTreeOpen());
-  readonly workspaceTreeOpen = this._workspaceTreeOpen.asReadonly();
-
-  private readonly workspace = inject(WorkspaceService);
-
-  /**
-   * Whether the Insights group renders expanded: the stored preference, OR
-   * forced open while the CURRENT route lives inside it (the active pill must
-   * never be hidden by a collapsed group).
-   */
-  readonly insightsExpanded = computed(
-    () =>
-      this._insightsOpen() ||
-      INSIGHT_PATHS.some((p) => this.currentUrl().startsWith(p)),
-  );
-
-  /**
-   * Chrome mode: false = floating sidebar, true = top pill bar. Persisted
-   * under the pre-existing key (old "collapsed" preference maps naturally
-   * onto the compact pill chrome).
-   */
-  private readonly _pillMode = signal(this.readStoredPillMode());
-  readonly pillMode = this._pillMode.asReadonly();
-
-  /**
-   * How a COLLAPSED sidebar renders (Settings → Appearance → Sidebar):
-   * `bar` (default) = the floating top pill bar; `rail` = a slim icon-only
-   * rail docked at the left edge. The collapsed FLAG and its persistence
-   * (murmur-sidebar-collapsed) are unchanged — only the rendering differs.
-   */
-  readonly collapseStyle = this.chrome.collapseStyle;
-
-  /** Collapsed AND the top-bar style — render the pill bar. */
-  readonly barMode = computed(
-    () => this.pillMode() && this.collapseStyle() === "bar",
-  );
-
-  /** Collapsed AND the rail style — render the icon-only sidebar rail. */
-  readonly railMode = computed(
-    () => this.pillMode() && this.collapseStyle() === "rail",
-  );
-
-  /** Whether the ⌘K quick-search spotlight is open. */
+  readonly browseItems = BROWSE_ITEMS;
+  readonly browseGroups = BROWSE_GROUPS;
   readonly searchOpen = signal(false);
-
-  /**
-   * How many locked folders are unlocked (plaintext-exposed) this session —
-   * drives the footer "N unlocked · Lock all" button. `FoldersService`'s tree
-   * comes from `list_folders`, which returns EVERY folder (meeting AND note —
-   * no `kind` filter in the SQL), each with its session `unlocked` flag, so this
-   * one count already covers both trees. (Do NOT add `NotesService`'s note-folder
-   * count on top — note folders are already in this tree, so that double-counts.)
-   */
   readonly unlockedCount = this.folders.unlockedCount;
-
-  /** True while the footer "Lock all" re-seal is in flight (guards double-clicks). */
   readonly relockingAll = signal(false);
-
-  /** The app-wide toast queue, rendered in the main-window viewport. */
   readonly toasts = this.toast.toasts;
-
-  /** Persist the chrome-mode choice whenever it changes. */
-  private readonly _persistPillMode = effect(() => {
-    const value = this._pillMode();
-    try {
-      localStorage.setItem(SIDEBAR_KEY, value ? "1" : "0");
-    } catch {
-      // Private-mode / storage-disabled — the preference is not persisted.
-    }
+  readonly canCreateWorkspaceFolder = computed(() => {
+    const firstSpace = this.workspace.forest()[0];
+    return Boolean(firstSpace && (!firstSpace.locked || firstSpace.unlocked));
   });
 
-  /** Persist the Insights-group preference whenever it changes. */
-  private readonly _persistInsightsOpen = effect(() => {
-    const value = this._insightsOpen();
-    try {
-      localStorage.setItem(INSIGHTS_KEY, value ? "1" : "0");
-    } catch {
-      // Private-mode / storage-disabled — the preference is not persisted.
-    }
-  });
-
-  /** Persist the Notes-tree preference whenever it changes. */
-  private readonly _persistNotesTreeOpen = effect(() => {
-    const value = this._notesTreeOpen();
-    try {
-      localStorage.setItem(NOTES_TREE_KEY, value ? "1" : "0");
-    } catch {
-      // Private-mode / storage-disabled — the preference is not persisted.
-    }
-  });
-
-  /** Persist the Meetings-tree preference whenever it changes. */
-  private readonly _persistMeetingsTreeOpen = effect(() => {
-    const value = this._meetingsTreeOpen();
-    try {
-      localStorage.setItem(MEETINGS_TREE_KEY, value ? "1" : "0");
-    } catch {
-      // Private-mode / storage-disabled — the preference is not persisted.
-    }
-  });
-
-  /**
-   * `--tabs-strip-height` on `<html>` — the ONE signal-driven source of
-   * truth every drill-down's fixed `position: fixed` host (library / notes
-   * home / note editor / settings) reads for its own `top` offset, so it
-   * structurally leaves `mur-tab-strip`'s real height uncovered instead of
-   * floating a per-route pixel guess on top of it (fixed 2026-07-12). A
-   * fixed design constant, not content-measured — `mur-tab-strip`'s own
-   * rendered height never varies (one row, no wrapping), so this is a plain
-   * signal-driven toggle, same directness `GlassService` already uses for
-   * `--glass-user-alpha`, not a `ResizeObserver`. MUST stay in px-sync with
-   * `tab-strip.component.scss`'s `.tab-strip { height: … }`. */
   private readonly _syncTabsStripHeight = effect(() => {
     const height = this.tabs.tabs().length > 0 ? "48px" : "0px";
     document.documentElement.style.setProperty("--tabs-strip-height", height);
   });
 
-  /** Toggle between the floating sidebar and the top pill bar. */
-  togglePillMode(): void {
-    this._pillMode.update((c) => !c);
+  constructor() {
+    void this.reminders.initSummary();
   }
 
-  /**
-   * Toggle the Insights group. Uses the RENDERED state as the base so a click
-   * always visibly inverts what the user sees (the group may be auto-expanded
-   * by the active route while the stored preference says collapsed).
-   */
-  toggleInsights(): void {
-    this._insightsOpen.set(!this.insightsExpanded());
-  }
-
-  /** Toggle the Notes nav row's nested note-folder tree. */
-  toggleNotesTree(): void {
-    this._notesTreeOpen.update((v) => !v);
-  }
-
-  /** Toggle the Meetings nav row's nested folder tree. */
-  toggleMeetingsTree(): void {
-    this._meetingsTreeOpen.update((v) => !v);
-  }
-
-  /**
-   * The "Notes" section HEADER was clicked (2026-07-12: the header IS the
-   * "all items" affordance now — the separate "All notes" root row was
-   * removed as a redundant layer). Clears the note-folder filter; the
-   * header's own routerLink handles the `/notes` navigation.
-   */
-  /**
-   * Expand/collapse the workspace hierarchy, loading it when it opens.
-   *
-   * The forest lives in a root service, so a return visit renders the cached
-   * tree immediately while this reload replaces it underneath.
-   */
-  toggleWorkspaceTree(): void {
-    const next = !this._workspaceTreeOpen();
-    this._workspaceTreeOpen.set(next);
-    try {
-      localStorage.setItem(WORKSPACE_TREE_KEY, next ? "1" : "0");
-    } catch {
-      // A remembered expansion is a convenience; losing it must not break the nav.
+  async showSpaces(): Promise<void> {
+    if (this.workspace.forestEmpty()) {
+      await this.workspace.reload();
     }
-    if (next) {
-      void this.workspace.reload();
+    const firstSpace = this.workspace.forest()[0];
+    if (firstSpace) {
+      this._contextOverride.set(null);
+      await this.router.navigate(["/container", firstSpace.id]);
+      return;
+    }
+    this._contextOverride.set("spaces");
+    if (this.currentPath().startsWith("/settings")) {
+      await this.router.navigate(["/record"]);
     }
   }
 
-  /**
-   * The section header's "+" — a new folder at the top of the hierarchy.
-   *
-   * ClickUp's equivalent creates a Space here. Ours cannot yet: a project is a container
-   * at the vault root and no command mints one, so this creates a folder inside the
-   * workspace project instead and says so. Offering "New project" and quietly making a
-   * folder would be worse than naming what it does.
-   */
+  showBrowse(): void {
+    this._contextOverride.set(null);
+    void this.router.navigate(["/library"]);
+  }
+
+  clearContextOverride(): void {
+    this._contextOverride.set(null);
+  }
+
+  isCaptureActive(): boolean {
+    return this.currentPath() === "/record" && this.contextPanel() === "none";
+  }
+
+  isAskActive(): boolean {
+    return this.currentPath().startsWith("/ask") && this.contextPanel() === "none";
+  }
+
+  isSettingsActive(): boolean {
+    return this.currentPath().startsWith("/settings");
+  }
+
+  isBrowseItemActive(path: string): boolean {
+    return this.currentPath() === path;
+  }
+
+  itemsForGroup(group: BrowseItem["group"]): readonly BrowseItem[] {
+    return this.browseItems.filter((item) => item.group === group);
+  }
+
+  openSearch(): void {
+    this.searchOpen.set(true);
+  }
+
+  newNote(): void {
+    this.searchOpen.set(false);
+    this._contextOverride.set(null);
+    void this.router.navigate(["/notes/new"]);
+  }
+
   newWorkspaceFolder(): void {
     void this.createFolderAtTop();
   }
 
   private async createFolderAtTop(): Promise<void> {
-    if (!this.workspaceTreeOpen()) {
-      this.toggleWorkspaceTree();
-    }
     const project = this.workspace.forest()[0];
-    if (!project) {
+    if (!project || (project.locked && !project.unlocked)) {
       return;
     }
     await this.workspace.createFolder(project.id, "New folder");
   }
 
-  /**
-   * The workspace section HEADER was clicked — it is the "everything" affordance, so it
-   * clears the folder filter on both list surfaces the tree feeds. Clearing only one of
-   * them would leave the other filtered to a folder the user has just navigated away from.
-   */
-  onWorkspaceHeaderSelect(): void {
-    void this.notesService.selectFolder(null);
-    this.folders.selectFolder(null);
-  }
-
-  /**
-   * A meeting dropped on the workspace HEADER files it at the vault root — the target the
-   * Meetings section used to own. Its tree body no longer exists to forward into, so the
-   * move runs here and the hierarchy reloads.
-   */
-  onWorkspaceHeaderDrop(meetingId: string): void {
-    void this.fileMeetingAtRoot(meetingId);
-  }
-
-  private async fileMeetingAtRoot(meetingId: string): Promise<void> {
-    await this.ipcService.moveNote(meetingId, null);
-    await this.workspace.reload();
-  }
-
-  onNotesHeaderSelect(): void {
-    void this.notesService.selectFolder(null);
-  }
-
-  /** The "Meetings" section header was clicked — mirrors {@link onNotesHeaderSelect}. */
-  onMeetingsHeaderSelect(): void {
-    this.folders.selectFolder(null);
-  }
-
-  /** Open the ⌘K spotlight. */
-  openSearch(): void {
-    this.searchOpen.set(true);
-  }
-
-  /** Quick action: create a new standalone note and open its editor (⌘N). */
-  newNote(): void {
-    this.searchOpen.set(false);
-    void this.router.navigate(["/notes/new"]);
-  }
-
-  /**
-   * The footer "N unlocked · Lock all" button (2026-07-14): re-seal EVERY
-   * session-unlocked folder now and zeroize the cached key — the sidebar's
-   * single privacy action (the former top-of-tree "Lock all" pill was removed).
-   * `FoldersService.relockAll` reloads the meetings tree; we then reload the
-   * Notes tree too so a re-sealed note-folder's per-row state updates as well
-   * (the backend `relock_all` re-seals both — folder ids share one session set).
-   */
   async relockAll(): Promise<void> {
     if (this.relockingAll()) {
       return;
@@ -595,6 +235,7 @@ export class AppShellComponent {
     try {
       await this.folders.relockAll();
       await this.notesService.loadFolders();
+      await this.workspace.reload();
       this.toast.success("All folders re-sealed");
     } catch {
       this.toast.danger("Couldn’t re-seal folders. Please try again.");
@@ -603,125 +244,45 @@ export class AppShellComponent {
     }
   }
 
-  /**
-   * Global shortcuts: ⌘K/Ctrl+K toggles search, ⌘N/Ctrl+N new note, ⌘T/Ctrl+T
-   * a new note TAB (same target as ⌘N — the browser-tab-bar convention, kept
-   * as a distinct shortcut from ⌘N since the tab strip is its own mental
-   * model), ⌘W/Ctrl+W closes the active tab (mirrors `mur-tab-strip`'s own ×
-   * button) and is a NO-OP — never a window-close — when no tab is open
-   * (`preventDefault()` only fires once a tab is actually found to close).
-   * NOTE: no native macOS window/app menu is registered anywhere in
-   * `src-tauri` (grepped `lib.rs` for `Menu`/`Accelerator` — the only `Menu`
-   * usage is the unrelated tray/status-bar icon), so there is no known
-   * competing native ⌘W accelerator for this JS handler to lose a race
-   * against; this was NOT verified against the real signed/packaged app
-   * (only `ng serve` + Playwright, which never exercises native window-menu
-   * chrome at all) — confirm empirically in a live dev/signed build before
-   * relying on this. Escape closes the spotlight at the DOCUMENT level — the
-   * scrim's own handler only fires while focus sits inside it (e.g. it dies
-   * once focus falls to <body>).
-   */
-  onGlobalKeydown(e: KeyboardEvent): void {
-    if (e.key === "Escape" && this.searchOpen()) {
+  onGlobalKeydown(event: KeyboardEvent): void {
+    if (event.key === "Escape" && this.searchOpen()) {
       this.searchOpen.set(false);
       return;
     }
-    if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
-    const key = e.key.toLowerCase();
+    if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey) {
+      return;
+    }
+    const key = event.key.toLowerCase();
     if (key === "k") {
-      e.preventDefault();
-      this.searchOpen.update((v) => !v);
+      event.preventDefault();
+      this.searchOpen.update((value) => !value);
     } else if (key === "n" || key === "t") {
-      e.preventDefault();
+      event.preventDefault();
       this.newNote();
     } else if (key === "w") {
       const activeId = this.tabs.activeTabId();
       if (activeId) {
-        e.preventDefault();
+        event.preventDefault();
         void this.tabs.closeTab(activeId);
       }
     }
   }
 
-  /**
-   * Consume Escape at the main-window shell boundary after document-level
-   * overlay handlers have run. In native macOS fullscreen, an unconsumed Escape
-   * falls through to window chrome (which can hide/minimize Murmur); the app's
-   * own transient UI still receives the event first during normal bubbling.
-   * The separate `/bar` window is outside this shell and keeps its intentional
-   * Escape-to-hide behavior.
-   */
   onWindowEscape(event: Event): void {
     event.preventDefault();
   }
 
-  /**
-   * Fires on every `<router-outlet>` DETACH-for-reuse (a tab switch away from
-   * a `/meeting/:id` or `/notes/:id` route kept alive by
-   * `TabRouteReuseStrategy` — NOT just a real destroy). Notifies the
-   * backgrounded component so it can pause audio (tabs plan risk #3) and
-   * collapse unbounded transcript DOM (perf-audit fix 2). Duck-typed, since
-   * the shell (eagerly loaded) can't import a lazily-loaded feature
-   * component's type — see `DetailComponent.onTabBackgrounded`.
-   */
   onOutletDetach(component: unknown): void {
     const tabAware = component as { onTabBackgrounded?: () => void } | null;
     tabAware?.onTabBackgrounded?.();
   }
 
-  /** Dismiss a toast by id (also cancels its auto-dismiss timer). */
   dismissToast(id: number): void {
     this.toast.dismiss(id);
   }
 
-  /** Run a toast's inline action, then dismiss the toast. */
-  runToastAction(t: Toast): void {
-    t.action?.run();
-    this.dismissToast(t.id);
-  }
-
-  /** Read the persisted chrome-mode preference; default sidebar. */
-  private readStoredPillMode(): boolean {
-    try {
-      return localStorage.getItem(SIDEBAR_KEY) === "1";
-    } catch {
-      return false;
-    }
-  }
-
-  /** Read the persisted Insights-group preference; default collapsed. */
-  private readStoredInsightsOpen(): boolean {
-    try {
-      return localStorage.getItem(INSIGHTS_KEY) === "1";
-    } catch {
-      return false;
-    }
-  }
-
-  /** Read the persisted Notes-tree preference; default EXPANDED. */
-  private readStoredNotesTreeOpen(): boolean {
-    try {
-      return localStorage.getItem(NOTES_TREE_KEY) !== "0";
-    } catch {
-      return true;
-    }
-  }
-
-  /** Read the persisted Meetings-tree preference; default EXPANDED. */
-  private readStoredMeetingsTreeOpen(): boolean {
-    try {
-      return localStorage.getItem(MEETINGS_TREE_KEY) !== "0";
-    } catch {
-      return true;
-    }
-  }
-
-  /** Read the persisted workspace-tree preference; default EXPANDED. */
-  private readStoredWorkspaceTreeOpen(): boolean {
-    try {
-      return localStorage.getItem(WORKSPACE_TREE_KEY) !== "0";
-    } catch {
-      return true;
-    }
+  runToastAction(toast: Toast): void {
+    toast.action?.run();
+    this.dismissToast(toast.id);
   }
 }

--- a/src/app/core/nav-history.service.ts
+++ b/src/app/core/nav-history.service.ts
@@ -7,27 +7,14 @@ import { filter, map, scan, startWith } from "rxjs";
 const DEFAULT_APP_ROUTE = "/record";
 
 /**
- * A "drill-down" is a route that HIDES the primary rail so the current flow
- * owns the window with its own back-affordance. The "← Murmur" back target
- * must be a NON-drill-down route, so both this service and app-shell's
- * rail-hide gate share this single predicate. Keep the two in lockstep — a
- * new drill-down route added here is also hidden in app-shell.
+ * A "drill-down" is a route with its own "← Murmur" back affordance. The
+ * persistent global rail remains visible; this predicate only decides which
+ * routes may become that Back button's target. A drill-down cannot target
+ * another drill-down, otherwise Back could bounce between nested flows.
  *
- * Notes (`/notes` home + `/notes/:id` editor, Stage 1, 2026-07-12) and
- * Meetings/meeting-detail (`/library`, `/meeting/:id`, Stage 2, same day) are
- * DELIBERATELY NOT drill-downs — Notion/Obsidian-style always-visible
- * sidebar: the primary rail now hosts BOTH folder trees directly
- * (`NotesSidebarTreeComponent`, `MeetingsSidebarTreeComponent`), so
- * `NotesHomeComponent`/`NoteEditorComponent`/`LibraryComponent` render as
- * normal in-flow content beside the sidebar, like `/record`, with no local
- * back-affordance (`DetailComponent`, `/meeting/:id`, never had one to begin
- * with — its own "← Meetings" is a plain in-page breadcrumb link, not the
- * rail-hiding drill-down chrome, so it needed no structural change here).
- *
- * `/settings` and the org-item viewer (`/org-item`, reached from an org card
- * inside Notes) are STILL drill-downs for now — each retains its own
- * "← Murmur" back button and hides the primary rail, until a later stage
- * folds them into the same model too.
+ * Settings and the org-item viewer retain local Back controls. Notes,
+ * meetings, tasks, dashboards, and their list views use normal shell
+ * navigation and therefore remain valid history targets.
  */
 export function isDrilldownRoute(url: string): boolean {
   return url.startsWith("/settings") || url.startsWith("/org-item");

--- a/src/app/design-system/icon/icon.component.html
+++ b/src/app/design-system/icon/icon.component.html
@@ -84,6 +84,22 @@
         <path d="m13.2 13.2 3.3 3.3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
       </svg>
     }
+    @case ("spaces") {
+      <svg viewBox="0 0 20 20" fill="none">
+        <rect x="3" y="3" width="6" height="6" rx="1.8" stroke="currentColor" stroke-width="1.4" />
+        <rect x="11" y="3" width="6" height="6" rx="1.8" stroke="currentColor" stroke-width="1.4" />
+        <rect x="3" y="11" width="6" height="6" rx="1.8" stroke="currentColor" stroke-width="1.4" />
+        <rect x="11" y="11" width="6" height="6" rx="1.8" stroke="currentColor" stroke-width="1.4" />
+      </svg>
+    }
+    @case ("browse") {
+      <svg viewBox="0 0 20 20" fill="none">
+        <path d="M4 5h12M4 10h12M4 15h12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+        <circle cx="4" cy="5" r="1" fill="currentColor" />
+        <circle cx="4" cy="10" r="1" fill="currentColor" />
+        <circle cx="4" cy="15" r="1" fill="currentColor" />
+      </svg>
+    }
     @case ("history") {
       <svg viewBox="0 0 20 20" fill="none">
         <path d="M3.2 9.7a6.8 6.8 0 1 0 2.2-5M3.2 3.6v4h4" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" />

--- a/src/app/design-system/icon/icon.component.ts
+++ b/src/app/design-system/icon/icon.component.ts
@@ -15,6 +15,8 @@ export type ShellIcon =
   | "ask"
   | "settings"
   | "search"
+  | "spaces"
+  | "browse"
   | "history"
   | "plus"
   | "sidebar"

--- a/src/app/design-system/tab-strip/tab-strip.component.scss
+++ b/src/app/design-system/tab-strip/tab-strip.component.scss
@@ -5,12 +5,12 @@
    `app-shell.component.html`/`.scss` for the `.main-col` wrapper this sits
    in). `height: 48px` here MUST stay in sync with
    `app-shell.component.ts`'s `_syncTabsStripHeight` effect (`--tabs-strip-
-   height`), which every drill-down's fixed host reads for its own `top`
-   offset — a mismatch between this literal and that effect's `"48px"`
+   height`), which fixed child surfaces read for their own `top` offset — a
+   mismatch between this literal and that effect's `"48px"`
    re-opens the header-overlap bug this pass fixed.
 
    VISUAL LANGUAGE: the same `--shell-glass-*` / `--shell-active-*` chrome
-   `.pill-bar` and the sidebar's active nav item already use — but applied
+   the global and contextual rails already use — but applied
    PER TAB, never to the row container. `.tab-strip` is LAYOUT ONLY — no
    background, no border, no shadow, no blur of its own (fixed 2026-07-12,
    third pass: painting the glass recipe on the whole row left a visible
@@ -33,21 +33,6 @@
   overflow-x: auto;
 }
 
-/* Drill-down routes (/settings, /org-item — `app-shell.drilldown`, a host
-   binding mirroring `inDrilldown()`) render NO sidebar/pill chrome, so
-   `.main-col` — and with it this strip — starts flush at the window's LEFT
-   edge, exactly where the overlay macOS traffic lights float
-   (trafficLightPosition 32,30 in tauri.conf.json → the three buttons span
-   ≈ x 32..84, vertically inside this 48px row). Reserve left clearance so
-   the first tab never sits beneath them (same structural-constant family as
-   `.pill-bar`'s `100vw - 170px` and `.sidebar-drag`'s 48px in styles.css).
-   Every other chrome mode already clears the lights: the full sidebar and
-   the icon rail sit left of this strip, and pill mode pushes `.main-col`
-   84px down. */
-:host-context(app-shell.drilldown) .tab-strip {
-  padding-left: 96px;
-}
-
 .tab-item {
   display: flex;
   align-items: center;
@@ -64,7 +49,7 @@
 }
 
 .tab-item.active {
-  /* The SAME neutral "glass on glass" lift the sidebar/pill-bar give their
+  /* The SAME neutral "glass on glass" lift the shell rails give their
      active nav item — a lensing highlight, not an opaque flat fill. */
   background: var(--shell-active-bg);
   box-shadow: var(--shell-active-shadow);

--- a/src/app/design-system/tab-strip/tab-strip.component.ts
+++ b/src/app/design-system/tab-strip/tab-strip.component.ts
@@ -6,7 +6,7 @@ import { TabsService } from "../../core/tabs.service";
  * Browser-style tab strip for Murmur's open meeting/note "document" tabs.
  * Renders whenever {@link TabsService.tabs} is non-empty as a REAL in-flow
  * Apple Liquid Glass tab row — the same `--shell-glass-*`/`--shell-active-*`
- * chrome language `.pill-bar` and the sidebar's active nav item already use.
+ * chrome language the global and contextual rails already use.
  *
  * IN-FLOW, NOT FLOATING (fixed 2026-07-12 — was `position: fixed`, a
  * floating overlay that could never make the page underneath aware space
@@ -15,12 +15,10 @@ import { TabsService } from "../../core/tabs.service";
  * `AppShellComponent`'s `.main-col` flex column (see its template) — when
  * tabs are open it PUSHES `.app-main` down by its real rendered height via
  * normal box flow, and contributes zero height when empty (this `@if`).
- * The one remaining wrinkle — drill-down routes (library / notes home / note
- * editor / settings) render their OWN `position: fixed` full-window host,
- * which would paint over this strip regardless of DOM order — is solved on
- * THEIR side: they read `top: var(--tabs-strip-height, 0px)` (set on
- * `<html>` by `AppShellComponent`, driven by this same tab count) instead of
- * `inset: 0`, so they structurally leave this strip's real height uncovered.
+ * A child surface that escapes normal flow with a fixed host must read
+ * `top: var(--tabs-strip-height, 0px)` (set on `<html>` by
+ * `AppShellComponent`, driven by this same tab count), so it structurally
+ * leaves this strip's real height uncovered.
  *
  * Injects `TabsService`/`Router` directly (the same pattern `mur-quick-search`
  * uses) rather than threading inputs/outputs through `AppShellComponent` —

--- a/src/app/features/settings/sections/settings-appearance-section/settings-appearance-section.component.html
+++ b/src/app/features/settings/sections/settings-appearance-section/settings-appearance-section.component.html
@@ -57,25 +57,6 @@
             </div>
           </div>
 
-          <!-- Sidebar collapse behavior: the floating top pill bar (default)
-               or a slim icon-only rail docked at the left edge. -->
-          <div class="card appearance-card">
-            <div class="appearance-copy">
-              <h3>Sidebar</h3>
-              <p class="text-secondary">
-                What the sidebar becomes when you collapse it. <b>Top bar</b>
-                floats the navigation at the top of the window; <b>Icon
-                rail</b> keeps a slim icon column at the side.
-              </p>
-            </div>
-            <mur-segmented
-              [options]="collapseOptions"
-              [value]="collapseStyle()"
-              (valueChange)="setCollapseStyle($event)"
-              ariaLabel="Sidebar collapse behavior"
-            />
-          </div>
-
           <!-- Liquid Glass intensity — how translucent the chrome panels
                (sidebar / pill bar / rails) are. Applies live, auto-saved. -->
           <div class="card appearance-card">

--- a/src/app/features/settings/sections/settings-appearance-section/settings-appearance-section.component.ts
+++ b/src/app/features/settings/sections/settings-appearance-section/settings-appearance-section.component.ts
@@ -7,7 +7,6 @@ import { MurSliderComponent } from "../../../../design-system/slider/slider.comp
 import {
   ChromeService,
   type AccentId,
-  type SidebarCollapseStyle,
 } from "../../../../services/chrome.service";
 import { GlassService } from "../../../../services/glass.service";
 import { ThemeService, type ThemeMode } from "../../../../services/theme.service";
@@ -50,20 +49,6 @@ export class SettingsAppearanceSectionComponent {
   /** Apply + persist the glass level live as the slider moves (auto-saved). */
   setGlass(value: number): void {
     this.glass.setLevel(value);
-  }
-
-  /** The two sidebar-collapse behaviors, rendered by <mur-segmented>. */
-  readonly collapseOptions: readonly SegmentOption[] = [
-    { value: "bar", label: "Top bar", icon: "topbar" },
-    { value: "rail", label: "Icon rail", icon: "sidebar" },
-  ];
-
-  /** Current collapse behavior — drives the Sidebar control. */
-  readonly collapseStyle = this.chrome.collapseStyle;
-
-  /** Apply a collapse behavior immediately (persisted in the service). */
-  setCollapseStyle(style: string): void {
-    this.chrome.setCollapseStyle(style as SidebarCollapseStyle);
   }
 
   /** The accent swatches; each maps to an `--accent-option-*` token class. */

--- a/src/app/features/settings/settings/settings.component.html
+++ b/src/app/features/settings/settings/settings.component.html
@@ -1,8 +1,7 @@
 <section class="settings-shell">
-  <!-- macOS-style left rail: Back, search over sections, then the section list. -->
+  <!-- Contextual Settings rail: Back, search over sections, then the section list. -->
   <mur-sidebar class="settings-sidebar" aria-label="Settings">
-    <!-- Drag strip mirrors the primary rail so the overlay traffic lights
-         stay clear of the Back button when the rail is flush to the edge. -->
+    <!-- Drag strip keeps the Back button below the window's draggable band. -->
     <div class="rail-drag" data-tauri-drag-region></div>
 
     <!-- Drill-down "up": returns to the last non-settings route (or /record). -->

--- a/src/app/features/settings/settings/settings.component.scss
+++ b/src/app/features/settings/settings/settings.component.scss
@@ -1,8 +1,7 @@
-/* Settings is a full drill-down (L2): the primary app rail is hidden
-   (app-shell) and this host fills the whole window as a flush-left
-   [section rail | content] layout. Fixed so it ignores .app-main's
-   centered max-width + padding and hugs the viewport edges; below the
-   toast viewport (z-index 60).
+/* Settings is a drill-down (L2) beside the persistent global rail. This fixed
+   host starts after that rail and fills the remaining window as a
+   [section rail | content] layout. Fixed so it ignores .app-main's centered
+   max-width + padding; below the toast viewport (z-index 60).
    `top: var(--tabs-strip-height, 0px)` (not `inset: 0`) — real reserved
    space for `mur-tab-strip`'s in-flow header row; see library.component.scss
    for the full rationale. */
@@ -11,7 +10,7 @@
   top: var(--tabs-strip-height, 0px);
   right: 0;
   bottom: 0;
-  left: 0;
+  left: calc(var(--space-2) + var(--space-8) + var(--space-2) + var(--space-2));
   z-index: 5;
   display: block;
   background: var(--surface-base);
@@ -27,7 +26,7 @@
    space `:host` actually reserves. */
 .settings-shell {
   display: grid;
-  grid-template-columns: 246px minmax(0, 1fr);
+  grid-template-columns: calc(var(--space-8) * 4) minmax(0, 1fr);
   height: calc(100vh - var(--tabs-strip-height, 0px));
   height: calc(100dvh - var(--tabs-strip-height, 0px));
 }
@@ -37,6 +36,8 @@
    live here). */
 .settings-sidebar {
   gap: var(--space-3);
+  height: calc(100% - var(--space-4));
+  margin: var(--space-2) 0;
   animation: settings-enter 300ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.html
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.html
@@ -12,7 +12,7 @@
          blanking a view the user is navigating. -->
     <p class="tree-error" role="status">{{ message }}</p>
   }
-  <div class="tree" role="tree" [attr.aria-label]="'Workspace'">
+  <div class="tree" role="tree" aria-label="Spaces">
     @for (line of lines(); track line.key) {
       @if (line.item; as item) {
         <!-- An ITEM row: a leaf, so the gutter renders the equal-width spacer
@@ -21,9 +21,11 @@
           class="line line--item"
           role="treeitem"
           [attr.aria-level]="line.depth + 1"
+          [attr.aria-selected]="isItemSelected(item)"
           [label]="itemTitle(item)"
           [depth]="line.depth"
           [icon]="kindIcon(item.kind)"
+          [selected]="isItemSelected(item)"
           [attr.draggable]="draggableKind(item) ? true : null"
           (dragstart)="onDragStart($event, item)"
           (dragend)="onDragEnd()"
@@ -54,27 +56,10 @@
           [style.padding-left]="
             'calc(' + line.depth + ' * var(--tree-indent) + 20px)'
           "
-          (click)="openGroup(line.container, line.group!)"
+          (click)="openAll(line.container)"
         >
-          {{ seeAllLabel(line.group!) }}
+          {{ viewAllLabel(line.total!) }}
         </button>
-      } @else if (line.group; as group) {
-        <!-- A TYPE-GROUP header: the count is the container's FULL visible total
-             for that kind, not the size of the first page below it. -->
-        <mur-tree-row
-          class="line line--group"
-          role="treeitem"
-          [attr.aria-level]="line.depth + 1"
-          [attr.aria-expanded]="isGroupExpanded(line.container, group)"
-          [label]="kindLabel(group.kind)"
-          [depth]="line.depth"
-          [icon]="kindIcon(group.kind)"
-          [count]="group.total"
-          [expandable]="group.total > 0"
-          [expanded]="isGroupExpanded(line.container, group)"
-          (toggleExpand)="toggleGroup(line.container, group)"
-          (activate)="toggleGroup(line.container, group)"
-        />
       } @else {
         <!-- A CONTAINER row: a Project or a Folder. A sealed-and-not-unlocked
              one carries no groups at all, so it is not expandable and shows no
@@ -84,12 +69,14 @@
           [class.line--project]="line.container.level === 'project'"
           role="treeitem"
           [attr.aria-level]="line.depth + 1"
+          [attr.aria-selected]="isContainerSelected(line.container)"
           [attr.aria-expanded]="containerExpandable(line.container) ? isContainerExpanded(line.container) : null"
           [attr.data-tint]="line.container.tint"
           [label]="line.container.name"
           [depth]="line.depth"
           [icon]="containerIcon(line.container)"
           [emoji]="line.container.emoji"
+          [selected]="isContainerSelected(line.container)"
           [expandable]="containerExpandable(line.container)"
           [expanded]="isContainerExpanded(line.container)"
           appFolderDrop

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.html
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.html
@@ -110,38 +110,39 @@
             class="row-actions"
             [label]="'Actions for ' + line.container.name"
           >
-            @if (canLock(line.container)) {
-              <button type="button" role="menuitem" (click)="lock(line.container)">
-                {{ lockLabel(line.container) }}
-              </button>
-            }
-            @if (line.container.locked && !line.container.unlocked) {
+            @if (isSealed(line.container)) {
               <button type="button" role="menuitem" (click)="unlock(line.container)">
                 {{ unlockLabel(line.container) }}
               </button>
-            }
-            @if (line.container.locked && line.container.unlocked) {
-              <button type="button" role="menuitem" (click)="relock(line.container)">
-                Lock again
+            } @else {
+              @if (canLock(line.container)) {
+                <button type="button" role="menuitem" (click)="lock(line.container)">
+                  {{ lockLabel(line.container) }}
+                </button>
+              }
+              @if (line.container.locked && line.container.unlocked) {
+                <button type="button" role="menuitem" (click)="relock(line.container)">
+                  Lock again
+                </button>
+              }
+              @if (canOrganize(line.container)) {
+                <button
+                  type="button"
+                  role="menuitem"
+                  [disabled]="organizePlanning()"
+                  (click)="organize(line.container)"
+                  data-testid="organize-container"
+                >
+                  {{ organizePlanning() ? "Reading this folder…" : "Organize with AI" }}
+                </button>
+              }
+              <button type="button" role="menuitem" (click)="rename(line.container)">
+                Rename
+              </button>
+              <button type="button" role="menuitem" (click)="remove(line.container)">
+                Delete folder
               </button>
             }
-            @if (canOrganize(line.container)) {
-              <button
-                type="button"
-                role="menuitem"
-                [disabled]="organizePlanning()"
-                (click)="organize(line.container)"
-                data-testid="organize-container"
-              >
-                {{ organizePlanning() ? "Reading this folder…" : "Organize with AI" }}
-              </button>
-            }
-            <button type="button" role="menuitem" (click)="rename(line.container)">
-              Rename
-            </button>
-            <button type="button" role="menuitem" (click)="remove(line.container)">
-              Delete folder
-            </button>
           </mur-row-menu>
           @if (line.container.locked && line.container.unlocked) {
             <!-- A WORD here cost the project its name: the pill took the row's

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
@@ -24,7 +24,6 @@ import type {
   ItemRow,
   OrganizeMove,
   OrganizePlan,
-  TypeGroup,
 } from "../../../core/models";
 import { IpcService } from "../../../core/ipc.service";
 import { OrganizeSheetComponent } from "../../notes/organize-sheet/organize-sheet.component";
@@ -40,21 +39,15 @@ export interface TreeLine {
   key: string;
   depth: number;
   container: ContainerNode;
-  /** Present on a type-group header line and on an item line. */
-  group?: TypeGroup;
   /** Present only on an item line. */
   item?: ItemRow;
-  /** Present only on a "see all" line. */
+  /** Present only on the shared continuation line. */
   seeAll?: boolean;
+  /** Full visible item count across every kind in this container. */
+  total?: number;
 }
 
-/** Group headings for the four kinds, in the order the backend emits them. */
-const KIND_LABEL: Record<ItemKind, string> = {
-  meeting: "Meetings",
-  note: "Notes",
-  task: "Tasks",
-  dashboard: "Dashboards",
-};
+const MAX_VISIBLE_ITEMS = 8;
 
 /**
  * Where activating an item navigates. These MUST name real entries in
@@ -70,7 +63,7 @@ const KIND_ROUTE: Record<ItemKind, string> = {
 
 /**
  * The workspace tree: Projects at the top, each holding Folders, and both
- * holding collapsible per-type groups of Notes, Meetings, Tasks and Dashboards.
+ * holding one time-ordered stream of Notes, Meetings, Tasks and Dashboards.
  *
  * Replaces the two per-type sidebar trees (`app-meetings-sidebar-tree` and
  * `app-notes-sidebar-tree`), which rendered one namespace each and could not
@@ -105,8 +98,8 @@ export class WorkspaceTreeComponent {
   private readonly lockFlow = inject(FolderLockFlowService);
   private readonly notes = inject(NotesService);
 
-  /** Whether this section owns the current route (drives selection styling). */
-  readonly sectionActive = input(false);
+  /** Current route path, used to select a container or leaf row. */
+  readonly currentPath = input("");
 
   /**
    * Load the forest when this tree first appears.
@@ -150,35 +143,52 @@ export class WorkspaceTreeComponent {
 
   private pushContainer(out: TreeLine[], container: ContainerNode, depth: number): void {
     out.push({ key: `c:${container.id}`, depth, container });
-    if (!this.workspace.isContainerExpanded(container.id)) {
+    if (!this.isContainerExpanded(container)) {
       return;
     }
-    for (const group of container.groups) {
-      const groupKey = `g:${container.id}:${group.kind}`;
-      out.push({ key: groupKey, depth: depth + 1, container, group });
-      if (!this.workspace.isGroupExpanded(container.id, group.kind)) {
-        continue;
-      }
-      for (const item of group.items) {
-        out.push({
-          key: `i:${item.kind}:${item.id}`,
-          depth: depth + 2,
-          container,
-          group,
-          item,
-        });
-      }
-      if (group.total > group.items.length) {
-        out.push({ key: `s:${groupKey}`, depth: depth + 2, container, group, seeAll: true });
-      }
+    const allItems = container.groups
+      .flatMap((group) => group.items)
+      .sort((left, right) => right.sortAt - left.sortAt);
+    const newestItems = allItems.slice(0, MAX_VISIBLE_ITEMS);
+    const selectedItem = allItems.find((item) => this.isItemSelected(item));
+    const selectedIsNewest = selectedItem
+      ? newestItems.some(
+          (item) => item.kind === selectedItem.kind && item.id === selectedItem.id,
+        )
+      : false;
+    const items =
+      selectedItem && !selectedIsNewest
+        ? [
+            ...allItems
+              .filter(
+                (item) =>
+                  item.kind !== selectedItem.kind || item.id !== selectedItem.id,
+              )
+              .slice(0, MAX_VISIBLE_ITEMS - 1),
+            selectedItem,
+          ].sort((left, right) => right.sortAt - left.sortAt)
+        : newestItems;
+    for (const item of items) {
+      out.push({
+        key: `i:${item.kind}:${item.id}`,
+        depth: depth + 1,
+        container,
+        item,
+      });
+    }
+    const total = container.groups.reduce((sum, group) => sum + group.total, 0);
+    if (total > items.length) {
+      out.push({
+        key: `s:${container.id}`,
+        depth: depth + 1,
+        container,
+        seeAll: true,
+        total,
+      });
     }
     for (const child of container.folders) {
       this.pushContainer(out, child, depth + 1);
     }
-  }
-
-  protected kindLabel(kind: ItemKind): string {
-    return KIND_LABEL[kind];
   }
 
   /**
@@ -204,8 +214,8 @@ export class WorkspaceTreeComponent {
     return title ? title : "Untitled";
   }
 
-  protected seeAllLabel(group: TypeGroup): string {
-    return `See all (${group.total})`;
+  protected viewAllLabel(total: number): string {
+    return `View all (${total})`;
   }
 
   /** A container with no groups and no folders has nothing to disclose. */
@@ -214,19 +224,36 @@ export class WorkspaceTreeComponent {
   }
 
   protected isContainerExpanded(container: ContainerNode): boolean {
-    return this.workspace.isContainerExpanded(container.id);
+    return (
+      this.workspace.isContainerExpanded(container.id) ||
+      this.containerContainsCurrentSelection(container)
+    );
   }
 
-  protected isGroupExpanded(container: ContainerNode, group: TypeGroup): boolean {
-    return this.workspace.isGroupExpanded(container.id, group.kind);
+  private containerContainsCurrentSelection(container: ContainerNode): boolean {
+    if (
+      container.groups.some((group) =>
+        group.items.some((item) => this.isItemSelected(item)),
+      )
+    ) {
+      return true;
+    }
+    return container.folders.some((folder) =>
+      this.isContainerSelected(folder) ||
+      this.containerContainsCurrentSelection(folder),
+    );
   }
 
   protected toggleContainer(container: ContainerNode): void {
     this.workspace.toggleContainer(container.id);
   }
 
-  protected toggleGroup(container: ContainerNode, group: TypeGroup): void {
-    this.workspace.toggleGroup(container.id, group.kind);
+  protected isContainerSelected(container: ContainerNode): boolean {
+    return this.currentPath() === `/container/${container.id}`;
+  }
+
+  protected isItemSelected(item: ItemRow): boolean {
+    return this.currentPath() === `${KIND_ROUTE[item.kind]}/${item.id}`;
   }
 
   /**
@@ -376,8 +403,8 @@ export class WorkspaceTreeComponent {
    *
    * They are not decoration. Locking a folder from the sidebar is how a user makes a
    * folder private at all, and removing the trees that offered it would have taken the
-   * feature away rather than moved it. They live behind the same `…` a ClickUp row uses,
-   * beside the `+`, so creating and managing stay visibly different actions.
+   * feature away rather than moved it. Creation and management remain separate
+   * controls so their consequences are not conflated.
    */
   /// Locking goes through the lock FLOW, never `FoldersService.lock` directly.
   ///
@@ -535,9 +562,7 @@ export class WorkspaceTreeComponent {
     this.organizePlan.set(null);
   }
 
-  protected openGroup(container: ContainerNode, group: TypeGroup): void {
-    void this.router.navigate(["/container", container.id], {
-      queryParams: { kind: group.kind },
-    });
+  protected openAll(container: ContainerNode): void {
+    this.openContainer(container);
   }
 }

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
@@ -143,7 +143,7 @@ export class WorkspaceTreeComponent {
 
   private pushContainer(out: TreeLine[], container: ContainerNode, depth: number): void {
     out.push({ key: `c:${container.id}`, depth, container });
-    if (!this.isContainerExpanded(container)) {
+    if (this.isSealed(container) || !this.isContainerExpanded(container)) {
       return;
     }
     const allItems = container.groups
@@ -220,14 +220,24 @@ export class WorkspaceTreeComponent {
 
   /** A container with no groups and no folders has nothing to disclose. */
   protected containerExpandable(container: ContainerNode): boolean {
-    return container.groups.length > 0 || container.folders.length > 0;
+    return (
+      !this.isSealed(container) &&
+      (container.groups.length > 0 || container.folders.length > 0)
+    );
   }
 
   protected isContainerExpanded(container: ContainerNode): boolean {
+    if (this.isSealed(container)) {
+      return false;
+    }
     return (
       this.workspace.isContainerExpanded(container.id) ||
       this.containerContainsCurrentSelection(container)
     );
+  }
+
+  protected isSealed(container: ContainerNode): boolean {
+    return container.locked && !container.unlocked;
   }
 
   private containerContainsCurrentSelection(container: ContainerNode): boolean {
@@ -488,6 +498,10 @@ export class WorkspaceTreeComponent {
 
   /** The unlock half of {@link lockLabel} — it cascades too. */
   protected unlockLabel(container: ContainerNode): string {
+    if (this.isSealed(container)) {
+      // A sealed row must not reveal whether the payload contains descendants.
+      return "Unlock for this session";
+    }
     const nested = container.folders.length;
     return nested === 0
       ? "Unlock for this session"

--- a/src/app/features/workspace/workspace.service.ts
+++ b/src/app/features/workspace/workspace.service.ts
@@ -4,9 +4,8 @@ import { IpcService } from "../../core/ipc.service";
 import type { ContainerNode, ItemKind, ItemPage } from "../../core/models";
 import type { DraggableKind } from "../folders/note-drag.service";
 
-/** Storage keys for the two persisted expansion sets. */
+/** Storage key for persisted container expansion. */
 const EXPANDED_CONTAINERS_KEY = "murmur.workspace.expandedContainers";
-const EXPANDED_GROUPS_KEY = "murmur.workspace.expandedGroups";
 
 /**
  * The workspace container forest, owned at the ROOT so it outlives the sidebar.
@@ -41,9 +40,6 @@ export class WorkspaceService {
 
   private readonly _expandedContainers = signal<ReadonlySet<string>>(
     readStoredSet(EXPANDED_CONTAINERS_KEY),
-  );
-  private readonly _expandedGroups = signal<ReadonlySet<string>>(
-    readStoredSet(EXPANDED_GROUPS_KEY),
   );
 
   /** Reload the whole forest. Safe to call repeatedly; the last write wins. */
@@ -149,24 +145,6 @@ export class WorkspaceService {
     );
   }
 
-  /**
-   * Type groups are keyed by container AND kind, so collapsing "Meetings" in one
-   * project leaves it open in another — the two are unrelated facts about
-   * unrelated containers.
-   */
-  isGroupExpanded(containerId: string, kind: ItemKind): boolean {
-    return this._expandedGroups().has(groupKey(containerId, kind));
-  }
-
-  toggleGroup(containerId: string, kind: ItemKind): void {
-    this._expandedGroups.set(
-      toggled(this._expandedGroups(), groupKey(containerId, kind), EXPANDED_GROUPS_KEY),
-    );
-  }
-}
-
-function groupKey(containerId: string, kind: ItemKind): string {
-  return `${containerId}:${kind}`;
 }
 
 function toggled(

--- a/src/app/features/workspace/workspace.service.ts
+++ b/src/app/features/workspace/workspace.service.ts
@@ -1,5 +1,6 @@
-import { Injectable, computed, inject, signal } from "@angular/core";
+import { DestroyRef, Injectable, computed, inject, signal } from "@angular/core";
 
+import { AskHistoryPrivacyBarrierService } from "../../core/ask-history-privacy-barrier.service";
 import { IpcService } from "../../core/ipc.service";
 import type { ContainerNode, ItemKind, ItemPage } from "../../core/models";
 import type { DraggableKind } from "../folders/note-drag.service";
@@ -20,6 +21,8 @@ const EXPANDED_CONTAINERS_KEY = "murmur.workspace.expandedContainers";
 @Injectable({ providedIn: "root" })
 export class WorkspaceService {
   private readonly ipc = inject(IpcService);
+  private readonly privacyBarrier = inject(AskHistoryPrivacyBarrierService);
+  private readonly destroyRef = inject(DestroyRef);
 
   private readonly _forest = signal<ContainerNode[]>([]);
   /** Projects, each with its folders and per-kind item groups. */
@@ -42,20 +45,66 @@ export class WorkspaceService {
     readStoredSet(EXPANDED_CONTAINERS_KEY),
   );
 
+  /**
+   * Invalidates an older gated read when lock authority changes underneath it.
+   * Without this token, a pre-lock response can land after the synchronous scrub
+   * and restore titles that the renderer is no longer allowed to retain.
+   */
+  private loadGeneration = 0;
+
+  constructor() {
+    const unregister = this.privacyBarrier.registerInvalidator(() => {
+      this.scrubAndReload();
+    });
+    this.destroyRef.onDestroy(unregister);
+  }
+
   /** Reload the whole forest. Safe to call repeatedly; the last write wins. */
   async reload(): Promise<void> {
+    const generation = ++this.loadGeneration;
     this._loading.set(true);
     try {
+      // Tauri events are not replayed. Refuse content-bearing hierarchy reads
+      // until the shared privacy listeners have acknowledged registration.
+      const privacyReady = await this.privacyBarrier.ensureReady();
+      if (generation !== this.loadGeneration) {
+        return;
+      }
+      if (!privacyReady) {
+        this._forest.set([]);
+        this._error.set("Workspace is unavailable securely right now");
+        return;
+      }
       const forest = await this.ipc.listWorkspaceTree();
+      if (generation !== this.loadGeneration) {
+        return;
+      }
       this._forest.set(forest);
       this._error.set(null);
     } catch (error) {
+      if (generation !== this.loadGeneration) {
+        return;
+      }
       // Keep whatever is cached: a failed refresh must not blank a tree the user
-      // is navigating. The message is surfaced, the rows are not thrown away.
+      // is navigating. A privacy transition clears that cache synchronously in
+      // `scrubAndReload`, so this fallback can retain only still-authorized rows.
       this._error.set(messageOf(error));
     } finally {
-      this._loading.set(false);
+      if (generation === this.loadGeneration) {
+        this._loading.set(false);
+      }
     }
+  }
+
+  /**
+   * Lock/move/delete authority changed. Drop every cached title synchronously,
+   * invalidate any pre-transition response, then repair from the canonical gated
+   * reader. If that refetch fails, the empty privacy-safe state remains visible.
+   */
+  private scrubAndReload(): void {
+    ++this.loadGeneration;
+    this._forest.set([]);
+    void this.reload();
   }
 
   /** One container's own metadata (never its contents); `null` when unknown. */

--- a/src/app/services/chrome.service.ts
+++ b/src/app/services/chrome.service.ts
@@ -1,12 +1,5 @@
 import { Injectable, signal } from "@angular/core";
 
-/**
- * What the sidebar becomes when the user collapses it:
- * - `bar` (default) — the floating top-center pill bar (the Apple TV pattern).
- * - `rail` — a slim icon-only rail that stays docked at the left edge.
- */
-export type SidebarCollapseStyle = "bar" | "rail";
-
 /** The user-selectable accent palettes (Settings → Appearance). `purple` is
  * the base :root ramp in colors.css; the others live in accents.css. */
 export type AccentId =
@@ -16,9 +9,6 @@ export type AccentId =
   | "green"
   | "orange"
   | "pink";
-
-const STORAGE_KEY = "murmur-sidebar-collapse-style";
-const VALID: readonly SidebarCollapseStyle[] = ["bar", "rail"];
 
 const ACCENT_KEY = "murmur-accent";
 const VALID_ACCENTS: readonly AccentId[] = [
@@ -31,18 +21,11 @@ const VALID_ACCENTS: readonly AccentId[] = [
 ];
 
 /**
- * Owns chrome-behavior preferences (Settings → Appearance). Persisted in
+ * Owns visual chrome preferences (Settings → Appearance). Persisted in
  * localStorage like ThemeService — pure webview chrome state, no IPC needed.
- * The collapsed/expanded FLAG itself stays with AppShellComponent
- * (murmur-sidebar-collapsed); this service only decides what "collapsed"
- * looks like.
  */
 @Injectable({ providedIn: "root" })
 export class ChromeService {
-  private readonly _collapseStyle = signal<SidebarCollapseStyle>(this.read());
-  /** The user's chosen collapse behavior: `bar` (default) or `rail`. */
-  readonly collapseStyle = this._collapseStyle.asReadonly();
-
   private readonly _accent = signal<AccentId>(this.readAccent());
   /** The user's chosen accent palette (default `purple`). */
   readonly accent = this._accent.asReadonly();
@@ -62,29 +45,6 @@ export class ChromeService {
       // localStorage unavailable — the in-memory signal still works.
     }
     this.applyAccent(accent);
-  }
-
-  /** Set and persist the collapse style; applies immediately (auto-saved). */
-  setCollapseStyle(style: SidebarCollapseStyle): void {
-    this._collapseStyle.set(style);
-    try {
-      localStorage.setItem(STORAGE_KEY, style);
-    } catch {
-      // localStorage unavailable (private mode / disabled) — the in-memory
-      // signal still works for this session.
-    }
-  }
-
-  private read(): SidebarCollapseStyle {
-    try {
-      const v = localStorage.getItem(STORAGE_KEY);
-      if (v && VALID.includes(v as SidebarCollapseStyle)) {
-        return v as SidebarCollapseStyle;
-      }
-    } catch {
-      // ignore — fall through to the default
-    }
-    return "bar";
   }
 
   private readAccent(): AccentId {

--- a/src/styles.css
+++ b/src/styles.css
@@ -124,8 +124,8 @@ body.bar-shell::after { display: none !important; }
   body.murmur-printing::before,
   body.murmur-printing::after { display: none !important; }
   body.murmur-printing .app-sidebar,
-  body.murmur-printing .pill-bar,
-  body.murmur-printing .pill-drag { display: none !important; }
+  body.murmur-printing .global-rail,
+  body.murmur-printing .shell-drag { display: none !important; }
   body.murmur-printing .app-main { max-width: none; margin: 0; padding: 0; }
   body.murmur-printing { background: #fff !important; color: #000 !important; }
 }
@@ -140,10 +140,8 @@ body.bar-shell::after { display: none !important; }
    work everywhere). So the shell's CSS is global here, matched by class.
    See app-shell.component.ts for the full FOUC rationale.
 
-   PROTOTYPE (Apple TV iPadOS shell): the chrome has two liquid-glass modes —
-   a FLOATING rounded sidebar panel (inset from the window edges), or a
-   floating top-center PILL BAR when collapsed. The window keeps the Overlay
-   title-bar style; the traffic lights float over `.sidebar-drag`/`.pill-drag`. */
+   The persistent product rail and contextual panel share one Liquid Glass
+   treatment; the traffic lights float over the rail's drag region. */
 app-shell {
   display: flex;
   align-items: stretch;
@@ -185,176 +183,6 @@ app-shell {
   border-bottom-left-radius: var(--radius-md);
 }
 
-/* --- Sidebar (Apple TV: a floating rounded liquid-glass panel) ------------- */
-.app-sidebar {
-  position: sticky;
-  top: 10px;
-  align-self: flex-start;
-  z-index: 10;
-  flex: none;
-  display: flex;
-  flex-direction: column;
-  width: 236px;
-  height: calc(100vh - 20px);
-  margin: 10px 0 10px 10px;
-  padding: 0 var(--space-3) var(--space-4);
-  background:
-    linear-gradient(var(--shell-glass-veil), var(--shell-glass-veil)),
-    var(--shell-glass-bg);
-  -webkit-backdrop-filter: blur(var(--shell-glass-blur)) saturate(var(--shell-glass-saturate));
-  backdrop-filter: blur(var(--shell-glass-blur)) saturate(var(--shell-glass-saturate));
-  border: 1px solid var(--shell-glass-border);
-  border-radius: var(--radius-xl);
-  box-shadow: var(--shadow-md), var(--shell-glass-inner);
-}
-
-/* Top strip that reserves room for the overlay traffic lights and moves the
-   window (data-tauri-drag-region on the element). Sized so the lights
-   (trafficLightPosition 32,30 in tauri.conf.json, inside the floating rail)
-   get their own breathing zone before the rail content starts. */
-.sidebar-drag {
-  flex: none;
-  height: 48px;
-}
-
-/* --- Quick actions (Search ⌘K / New note ⌘N) — the top of the rail --------- */
-.sidebar-quick {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  flex: none;
-  padding-bottom: var(--space-2);
-  border-bottom: 1px solid var(--border-subtle);
-}
-.quick-kbd {
-  flex: none;
-  margin-left: auto; /* chrome lives inside mur-kbd; this class only positions it */
-}
-
-/* --- Sidebar nav + footer rows (shared row shape) -------------------------- */
-.sidebar-nav {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  flex: 1 1 auto;
-  min-height: 0;
-  overflow-y: auto;
-  padding-top: var(--space-2);
-}
-.sidebar-nav a,
-.quick-row,
-.sidebar-settings,
-.sidebar-collapse {
-  display: flex;
-  flex: none;
-  align-items: center;
-  gap: var(--space-3);
-  width: 100%;
-  height: 38px;
-  padding: 0 var(--space-3);
-  border: none;
-  border-radius: var(--radius-md);
-  background: transparent;
-  color: var(--text-secondary);
-  font-family: inherit;
-  font-size: 0.9rem;
-  font-weight: 550;
-  letter-spacing: -0.01em;
-  text-align: left;
-  text-decoration: none;
-  cursor: pointer;
-  transition: color var(--transition), background var(--transition);
-}
-.sidebar-nav a:hover,
-.quick-row:hover,
-.sidebar-settings:hover,
-.sidebar-collapse:hover {
-  color: var(--text-primary);
-  background: var(--surface-hover);
-}
-.sidebar-nav a:focus-visible,
-.quick-row:focus-visible,
-.sidebar-settings:focus-visible,
-.sidebar-collapse:focus-visible {
-  outline: none;
-  color: var(--text-primary);
-  box-shadow: 0 0 0 3px var(--accent-ring);
-}
-/* Active: a NEUTRAL glass-on-glass pill; the label stays neutral and ONLY the
-   glyph takes the accent (QUIET GLASS: color = meaning, chrome stays calm). */
-.sidebar-nav a.active,
-.sidebar-settings.active {
-  color: var(--shell-active-text);
-  background: var(--shell-active-bg);
-  box-shadow: var(--shell-active-shadow);
-}
-.sidebar-nav a.active .nav-icon,
-.sidebar-settings.active .nav-icon {
-  color: var(--shell-active-icon);
-}
-/* The expandable-section shell (header row + "All meetings"/"All notes" root
-   row) that used to be duplicated here for Notes AND Meetings is now ONE
-   component, `<mur-sidebar-section>` (src/app/design-system/sidebar-section —
-   consolidated 2026-07-12 after four rounds of style drift between the two
-   copies). Its own `.nav-row-*`/`.root-row` classes live in that component's
-   scoped scss now; `.group-chev`'s rotate-on-open animation stays global
-   (shared with the Insights group toggle below, which isn't part of that
-   component). */
-/* `<mur-sidebar-section>` is a direct child of the `.sidebar-nav` flex
-   COLUMN — `flex: none` defensively pins its own box to its content's
-   natural (fixed-row-height) size, so it's never a candidate for the
-   column's default `flex-shrink: 1` to compress at a short window height
-   (investigated 2026-07-12: not reproduced empirically — `.sidebar-nav`'s
-   `min-height: 0` + `overflow-y: auto` already makes IT the sole scrolling
-   region at every tested height down to 320px — but this is the right
-   belt-and-suspenders row-height guarantee regardless). The projected tree-
-   body components pick up the SAME guarantee from their own `:host` rules. */
-mur-sidebar-section {
-  flex: none;
-}
-/* --- Sidebar groups (QUIET GLASS): labeled clusters; Insights collapses ---- */
-.sidebar-group-label {
-  display: block;
-  padding: var(--space-3) var(--space-3) var(--space-1);
-  color: var(--text-muted);
-  font-size: 0.68rem;
-  font-weight: 700;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
-  user-select: none;
-}
-.sidebar-group-toggle {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  width: 100%;
-  margin: 0;
-  padding: 0 var(--space-3) 0 0;
-  border: none;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  color: var(--text-muted);
-  font-family: inherit;
-  text-align: left;
-  cursor: pointer;
-  transition: color var(--transition-fast);
-}
-.sidebar-group-toggle .sidebar-group-label {
-  flex: 1 1 auto;
-  color: inherit;
-}
-.sidebar-group-toggle:hover { color: var(--text-secondary); }
-.sidebar-group-toggle:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px var(--accent-ring);
-}
-.group-chev {
-  flex: none;
-  margin-top: var(--space-2); /* optically centers against the label's top padding */
-  transition: transform var(--transition-fast);
-}
-.group-chev.open { transform: rotate(90deg); }
-
 .nav-icon {
   display: grid;
   place-items: center;
@@ -363,23 +191,6 @@ mur-sidebar-section {
   height: 20px;
 }
 .nav-icon svg { width: 20px; height: 20px; display: block; }
-.nav-label {
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-.sidebar-footer {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  flex: none;
-  margin-top: var(--space-2);
-  padding-top: var(--space-2);
-  border-top: 1px solid var(--border-subtle);
-}
-
 /* --- Session-privacy "N unlocked · Lock all" button (footer) ---------------
    The sidebar's SINGLE accent focal point AND its only "Lock all" action
    (2026-07-14 declutter). Full-width so it reads as an action row like the
@@ -429,157 +240,6 @@ mur-sidebar-section {
 /* The action half — pushed to the trailing edge, a touch bolder. */
 .unlocked-action { margin-left: auto; font-weight: 700; letter-spacing: 0; }
 
-/* --- Icon-rail collapse (Settings → Appearance → Sidebar → "Icon rail") ----
-   The ALTERNATIVE collapsed chrome: the same floating glass panel, shrunk to
-   a slim icon-only column docked at the left edge. Same collapsed flag and
-   toggle as the pill bar — only the rendering differs. */
-.app-sidebar.is-rail {
-  width: 64px;
-  padding: 0 var(--space-2) var(--space-4);
-  /* The rail is too narrow to contain the overlay traffic lights
-     (trafficLightPosition 32,30 assumes the 236px panel) — start BELOW them,
-     like the pill bar does, so the lights float over the window backdrop. */
-  top: 52px;
-  margin-top: 52px;
-  height: calc(100vh - 62px);
-}
-.app-sidebar.is-rail .sidebar-drag {
-  height: 10px; /* the lights live above the rail now — no reserved zone */
-}
-.app-sidebar.is-rail .nav-label,
-.app-sidebar.is-rail .quick-kbd,
-.app-sidebar.is-rail .sidebar-group-label,
-.app-sidebar.is-rail .sidebar-group-toggle,
-.app-sidebar.is-rail .unlocked-label {
-  display: none;
-}
-.app-sidebar.is-rail .sidebar-nav a,
-.app-sidebar.is-rail .quick-row,
-.app-sidebar.is-rail .sidebar-settings,
-.app-sidebar.is-rail .sidebar-collapse {
-  justify-content: center;
-  gap: 0;
-  padding: 0;
-}
-.app-sidebar.is-rail .unlocked-pill {
-  justify-content: center;
-  gap: var(--space-1);
-  padding: 0;
-}
-/* Grouped destinations read as one calm icon column; give the groups a
-   breath of separation where their labels used to sit. */
-.app-sidebar.is-rail .sidebar-nav a + a {
-  margin-top: 2px;
-}
-
-/* --- Pill bar (Apple TV collapsed chrome: floating top-center liquid pill) - */
-/* Invisible strip along the window's top edge: keeps the window draggable and
-   reserves room for the overlay traffic lights while the sidebar is away. */
-.pill-drag {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 34px;
-  z-index: 39;
-}
-.pill-bar {
-  position: fixed;
-  top: 12px;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 40;
-  display: flex;
-  align-items: center;
-  gap: 3px;
-  max-width: calc(100vw - 170px); /* clear the traffic lights on the left */
-  padding: 5px;
-  background:
-    linear-gradient(var(--shell-glass-veil), var(--shell-glass-veil)),
-    var(--shell-glass-bg);
-  -webkit-backdrop-filter: blur(var(--shell-glass-blur)) saturate(var(--shell-glass-saturate));
-  backdrop-filter: blur(var(--shell-glass-blur)) saturate(var(--shell-glass-saturate));
-  border: 1px solid var(--shell-glass-border);
-  border-radius: var(--radius-pill);
-  box-shadow: var(--shadow-md), var(--shell-glass-inner);
-}
-.pill-item {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-2);
-  height: 36px;
-  min-width: 36px;
-  padding: 0 var(--space-2);
-  border: none;
-  border-radius: var(--radius-pill);
-  background: transparent;
-  color: var(--text-secondary);
-  font-family: inherit;
-  font-size: 0.86rem;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  text-decoration: none;
-  cursor: pointer;
-  transition: color var(--transition-fast), background var(--transition-fast);
-}
-.pill-item:hover {
-  color: var(--text-primary);
-  background: var(--surface-hover);
-}
-.pill-item:focus-visible {
-  outline: none;
-  color: var(--text-primary);
-  box-shadow: 0 0 0 3px var(--accent-ring);
-}
-/* Apple TV pattern: icons only; the ACTIVE destination expands with its label. */
-.pill-item .nav-label { display: none; }
-.pill-item.active {
-  color: var(--shell-active-text);
-  background: var(--shell-active-bg);
-  box-shadow: var(--shell-active-shadow);
-  padding: 0 var(--space-3);
-}
-.pill-item.active .nav-icon { color: var(--shell-active-icon); }
-.pill-item.active .nav-label { display: block; flex: none; }
-.pill-sep {
-  flex: none;
-  width: 1px;
-  height: 20px;
-  margin: 0 3px;
-  background: var(--border-subtle);
-}
-.pill-unlocked {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  height: 28px;
-  margin-left: 3px;
-  padding: 0 var(--space-2);
-  border: 0;
-  border-radius: var(--radius-pill);
-  background: var(--accent-soft);
-  color: var(--accent-hover);
-  font-family: inherit;
-  font-size: 0.76rem;
-  font-weight: 600;
-  line-height: 1;
-  white-space: nowrap;
-  cursor: pointer;
-  transition: filter var(--transition);
-}
-.pill-unlocked:hover:not(:disabled) {
-  filter: brightness(1.12);
-}
-.pill-unlocked:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px var(--accent-ring);
-}
-.pill-unlocked:disabled {
-  opacity: 0.6;
-  cursor: default;
-}
-
 /* --- Main column: [tab strip, app-main] stacked, beside the sidebar --------
    `.main-col` is the flex ROW item that used to be `.app-main` directly —
    now a flex COLUMN so `mur-tab-strip` (when it renders, i.e. tabs are open)
@@ -592,25 +252,6 @@ mur-sidebar-section {
   display: flex;
   flex-direction: column;
 }
-/* Pill mode: no sidebar in the flex row — clear the floating pill instead.
-   Moved here (was on `.app-main`) so it also clears the tab strip, which
-   now lives ABOVE `.app-main` inside this same column. */
-app-shell.pill-mode .main-col { padding-top: 84px; }
-/* Sidebar/rail mode: align `mur-tab-strip`'s row with the sidebar PANEL's own
-   top edge (2026-07-12, second alignment fix — the first attempt matched the
-   58px offset of the sidebar's internal "Search" row, which is itself pushed
-   down by `.sidebar-drag`'s 48px traffic-light clearance. That clearance only
-   exists because the macOS traffic lights sit over the LEFT side of the
-   window, inside the sidebar's own drag region — the tab strip, over on the
-   right, has no traffic lights to clear, so matching the Search row put the
-   tabs ~48px too low and they read as floating well below the sidebar's own
-   top edge instead of level with it). The sidebar panel's visible top edge is
-   `margin-top: 10px` (`.app-sidebar`) — that is the correct alignment target.
-   `[class.sidebar-visible]` (AppShellComponent host binding) is false for
-   drill-down/pill-bar routes, so this margin never fights `--tabs-strip-height`
-   (the literal those routes' fixed hosts read for their own offset) or the
-   pill-mode padding above. */
-app-shell.sidebar-visible .main-col { margin-top: 10px; }
 /* `.app-main` fills the whole content pane on EVERY main route (2026-07-12,
    user request "W innych głównych widokach też popraw aby było jednolicie
    wszędzie" — the third and FINAL step of the width unification: Notes first,
@@ -701,3 +342,244 @@ app-shell.sidebar-visible .main-col { margin-top: 10px; }
     .app-sidebar { transition: none; }
 }
 
+/* ── Persistent product rail + contextual navigation ──────────────────
+   Shell chrome stays global because WKWebView must receive it from the initial
+   linked stylesheet. The rail chooses a surface; the adjacent panel contains
+   only that surface's navigation. */
+app-shell {
+  gap: var(--space-2);
+  height: 100vh;
+  padding: var(--space-2);
+  overflow: hidden;
+}
+
+.shell-drag {
+  position: fixed;
+  inset: 0 0 auto;
+  z-index: 8;
+  height: var(--space-6);
+}
+
+.global-rail {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  flex: 0 0 calc(var(--space-8) + var(--space-2));
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  width: calc(var(--space-8) + var(--space-2));
+  height: calc(100vh - var(--space-4));
+  padding: 0 var(--space-2) var(--space-3);
+  background:
+    linear-gradient(var(--shell-glass-veil), var(--shell-glass-veil)),
+    var(--shell-glass-bg);
+  -webkit-backdrop-filter: blur(var(--shell-glass-blur)) saturate(var(--shell-glass-saturate));
+  backdrop-filter: blur(var(--shell-glass-blur)) saturate(var(--shell-glass-saturate));
+  border: 1px solid var(--shell-glass-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md), var(--shell-glass-inner);
+}
+
+.global-rail .rail-drag {
+  flex: none;
+  width: 100%;
+  height: var(--space-7);
+}
+
+.rail-brand {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: var(--space-6);
+  height: var(--space-6);
+  margin-bottom: var(--space-1);
+  border-radius: var(--radius-md);
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+  font-size: 0.85rem;
+  font-weight: 750;
+}
+
+.rail-item {
+  position: relative;
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: var(--space-7);
+  height: var(--space-7);
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+.rail-item:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.rail-item:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+
+.rail-item.active {
+  background: var(--shell-active-bg);
+  color: var(--shell-active-icon);
+  box-shadow: var(--shell-active-shadow);
+}
+
+.rail-item.active::before {
+  content: "";
+  position: absolute;
+  left: calc(-1 * var(--space-2));
+  width: var(--space-1);
+  height: var(--space-5);
+  border-radius: var(--radius-pill);
+  background: var(--accent);
+}
+
+.rail-spacer {
+  flex: 1 1 auto;
+}
+
+.app-sidebar.spaces-sidebar,
+.app-sidebar.browse-sidebar {
+  position: sticky;
+  top: 0;
+  align-self: auto;
+  z-index: 9;
+  display: flex;
+  flex: 0 0 calc(var(--space-8) * 4);
+  flex-direction: column;
+  width: calc(var(--space-8) * 4);
+  height: calc(100vh - var(--space-4));
+  margin: 0;
+  padding: 0;
+  background:
+    linear-gradient(var(--shell-glass-veil), var(--shell-glass-veil)),
+    var(--shell-glass-bg);
+  -webkit-backdrop-filter: blur(var(--shell-glass-blur)) saturate(var(--shell-glass-saturate));
+  backdrop-filter: blur(var(--shell-glass-blur)) saturate(var(--shell-glass-saturate));
+  border: 1px solid var(--shell-glass-border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-md), var(--shell-glass-inner);
+  overflow: hidden;
+}
+
+.context-header {
+  display: flex;
+  align-items: center;
+  flex: none;
+  min-height: calc(var(--space-7) + var(--space-6));
+  padding: var(--space-7) var(--space-3) var(--space-3);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.context-header h2 {
+  flex: 1 1 auto;
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: -0.01em;
+}
+
+.context-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.context-action {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: var(--space-6);
+  height: var(--space-6);
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.context-action:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.context-action:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+
+.context-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: var(--space-2);
+}
+
+.context-footer {
+  flex: none;
+  padding: var(--space-2);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.browse-nav {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  flex-direction: column;
+  gap: 2px;
+  overflow-y: auto;
+  padding: var(--space-2);
+}
+
+.context-group-label {
+  display: block;
+  padding: var(--space-3) var(--space-3) var(--space-1);
+  color: var(--text-muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.browse-nav a {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-height: 38px;
+  padding: 0 var(--space-3);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  font-weight: 550;
+}
+
+.browse-nav a:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.browse-nav a.active {
+  background: var(--shell-active-bg);
+  color: var(--shell-active-text);
+  box-shadow: var(--shell-active-shadow);
+}
+
+.browse-nav a.active .nav-icon {
+  color: var(--shell-active-icon);
+}
+
+app-shell > .main-col {
+  height: calc(100vh - var(--space-4));
+  margin: 0;
+  overflow: auto;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -583,3 +583,10 @@ app-shell > .main-col {
   margin: 0;
   overflow: auto;
 }
+
+@media (max-width: 760px) {
+  .app-sidebar.spaces-sidebar,
+  .app-sidebar.browse-sidebar {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary

- add a persistent global rail with contextual Spaces and Browse panels
- render notes, meetings, tasks, dashboards, and folders as one mixed hierarchy
- keep deep-linked items selected within the bounded tree and retain the current route when opening desktop navigation
- align Settings, overlays, narrow-window behavior, and existing lock flows with the new shell geometry
- remove obsolete sidebar collapse modes while preserving accent preferences

## Privacy hardening

- clear cached hierarchy content synchronously whenever the shared privacy barrier invalidates it
- ignore stale in-flight hierarchy responses and stay fail-closed when a post-lock refresh fails
- treat sealed containers as intrinsic leaves, even if a stale or hostile payload contains descendants
- expose only the unlock action for sealed containers

## Verification

- GitHub Actions run `32804676450`: full release-parity gate PASS (attestation, Rust, and Web lanes)
- cloud Playwright suite: 746 passed, 2 flaky (passed on retry), 2 skipped across Chromium and WebKit
- `scripts/agent-config-audit --ci`: 152 checks, 0 warnings
- `npx ng lint`
- `npx ng build`
- `(cd src-tauri && cargo test --lib)`: 3234 passed, 0 failed, 18 ignored on a clean checkout with the exact pinned server revision
- broader shell and related Playwright suite: 134 passed across Chromium and WebKit
- changed lock-flow Playwright suite: 36 passed across Chromium and WebKit
- original cloud-failure regression set: 18 passed across Chromium and WebKit
- Settings regression package: 10 passed across Chromium and WebKit
- independent lock-security review: PASS
- independent adversarial review: PASS, including reproduction of both pre-fix privacy failures

The Playwright groups overlap and are reported separately rather than summed. Signed macOS Touch ID, ScreenCaptureKit, and live audio behavior remain outside the mocked headless runtime boundary; this change does not modify those paths.
