### PR TITLE
Fix sidebar recording visibility and row menus

### DIFF
--- a/e2e/shell/workspace-tree.spec.ts
+++ b/e2e/shell/workspace-tree.spec.ts
@@ -97,12 +97,220 @@ const FOREST = [
   },
 ];
 
+async function expectMenuItemAtHitPoint(page: Page, itemName: string): Promise<void> {
+  const item = page.getByRole("menuitem", { name: itemName });
+  await expect(item).toBeVisible();
+  await expect
+    .poll(() =>
+      item.evaluate((element) => {
+        const box = element.getBoundingClientRect();
+        const hit = document.elementFromPoint(
+          box.left + box.width / 2,
+          box.top + box.height / 2,
+        );
+        return hit === element || Boolean(hit && element.contains(hit));
+      }),
+    )
+    .toBe(true);
+}
+
 async function openWorkspace(page: Page): Promise<void> {
   await mockTauri(page, {}, { list_workspace_tree: FOREST });
   await page.goto("/");
   await page.getByRole("button", { name: "Spaces" }).click();
   await expect(page.getByRole("complementary", { name: "Spaces sidebar" })).toBeVisible();
 }
+
+test("keeps both container menus above the following tree rows", async ({ page }) => {
+  await openWorkspace(page);
+  await page.getByRole("button", { name: "Expand Acme" }).click();
+
+  await page.getByRole("button", { name: "Add to Acme" }).click();
+  await expectMenuItemAtHitPoint(page, "New note");
+  await page.keyboard.press("Escape");
+
+  await page.getByRole("button", { name: "Actions for Acme" }).click();
+  await expectMenuItemAtHitPoint(page, "Rename");
+});
+
+test("shows unfiled recordings as a real inbox and opens the complete meetings list", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {
+      list_container_items: (args: {
+        containerId: string | null;
+        kind: string;
+        offset: number;
+        limit: number;
+      }) => {
+        if (
+          args.containerId !== null ||
+          args.kind !== "meeting" ||
+          args.offset !== 0 ||
+          args.limit !== 8
+        ) {
+          throw new Error("unexpected unfiled page request");
+        }
+        return {
+          kind: "meeting",
+          total: 12,
+          items: Array.from({ length: 8 }, (_, index) => ({
+            kind: "meeting",
+            id: `m-unfiled-${12 - index}`,
+            title: `Unfiled recording ${12 - index}`,
+            durationS: 600 + index,
+            sortAt: 120 - index,
+          })),
+        };
+      },
+    },
+    { list_workspace_tree: FOREST },
+  );
+  await page.goto("/");
+  await page.getByRole("button", { name: "Spaces" }).click();
+
+  const inbox = page.getByRole("treeitem", { name: /Unfiled recordings/ });
+  await expect(inbox).toBeVisible();
+  await expect(inbox).toContainText("12");
+  await expect(inbox.getByRole("button", { name: /Add to/ })).toHaveCount(0);
+  await expect(inbox.getByRole("button", { name: /Actions for/ })).toHaveCount(0);
+  await expect(inbox).not.toHaveAttribute("appfolderdrop");
+
+  const tree = page.getByRole("tree", { name: "Spaces" });
+  const unfiledRows = tree.locator(".line--unfiled-item");
+  await expect(unfiledRows).toHaveCount(8);
+  await expect(unfiledRows).toHaveText([
+    "Unfiled recording 12",
+    "Unfiled recording 11",
+    "Unfiled recording 10",
+    "Unfiled recording 9",
+    "Unfiled recording 8",
+    "Unfiled recording 7",
+    "Unfiled recording 6",
+    "Unfiled recording 5",
+  ]);
+  const moveNewest = page.getByRole("button", {
+    name: "Move Unfiled recording 12",
+  });
+  await expect(moveNewest).toBeVisible();
+  await moveNewest.click();
+  await expect(page.getByRole("menuitem", { name: "Acme", exact: true })).toBeVisible();
+  await page.keyboard.press("Escape");
+
+  await page.getByRole("button", { name: "Collapse Unfiled recordings" }).click();
+  await expect(unfiledRows).toHaveCount(0);
+  await page.getByRole("button", { name: "Expand Unfiled recordings" }).click();
+  await expect(unfiledRows).toHaveCount(8);
+
+  // Prove the destination clears an existing meeting-folder scope instead of
+  // merely changing the URL while Library remains filtered to that Space.
+  await page
+    .getByRole("treeitem", { name: /Acme/ })
+    .getByRole("button", { name: "Acme", exact: true })
+    .click();
+  await expect(page).toHaveURL(/\/container\/p-acme$/);
+
+  await page.getByRole("treeitem", { name: "View all recordings (12)" }).click();
+  await expect(page).toHaveURL(/\/library$/);
+  await expect(page.getByRole("heading", { name: "Meetings", exact: true })).toBeVisible();
+});
+
+test("scrubs unfiled titles synchronously and drops a late pre-invalidation page", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {
+      list_container_items: () => {
+        const target = window as unknown as {
+          __unfiledCalls?: number;
+          __releaseLateUnfiled?: () => void;
+        };
+        target.__unfiledCalls = (target.__unfiledCalls ?? 0) + 1;
+        if (target.__unfiledCalls === 1) {
+          return {
+            kind: "meeting",
+            total: 1,
+            items: [
+              {
+                kind: "meeting",
+                id: "m-mounted-secret",
+                title: "Mounted private recording",
+                durationS: 300,
+                sortAt: 10,
+              },
+            ],
+          };
+        }
+        if (target.__unfiledCalls === 2) {
+          return new Promise((resolve) => {
+            target.__releaseLateUnfiled = () =>
+              resolve({
+                kind: "meeting",
+                total: 1,
+                items: [
+                  {
+                    kind: "meeting",
+                    id: "m-late-secret",
+                    title: "Late private recording",
+                    durationS: 300,
+                    sortAt: 20,
+                  },
+                ],
+              });
+          });
+        }
+        // The repair read must not hide a stale-response bug by winning the
+        // race and replacing call #2 with a safe empty page. A real privacy
+        // transition may be followed by an unavailable reader, so the
+        // generation guard itself has to keep the late secret from landing.
+        return Promise.reject(new Error("post-invalidation refresh unavailable"));
+      },
+    },
+    { list_workspace_tree: FOREST },
+  );
+  await page.goto("/");
+  await page.getByRole("button", { name: "Spaces" }).click();
+  await expect(page.getByText("Mounted private recording", { exact: true })).toBeVisible();
+
+  await page.evaluate(() => {
+    (
+      window as unknown as {
+        __demoEmit: (event: string, payload: unknown) => void;
+      }
+    ).__demoEmit("murmur://reminder-visibility-invalidated", null);
+  });
+  await expect(page.getByText("Mounted private recording", { exact: true })).toHaveCount(0);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as unknown as { __unfiledCalls?: number }).__unfiledCalls ?? 0,
+      ),
+    )
+    .toBe(2);
+
+  await page.evaluate(() => {
+    const target = window as unknown as { __releaseLateUnfiled?: () => void };
+    target.__releaseLateUnfiled?.();
+    (
+      window as unknown as {
+        __demoEmit: (event: string, payload: unknown) => void;
+      }
+    ).__demoEmit("murmur://reminder-visibility-invalidated", null);
+  });
+  await expect(page.getByText("Late private recording", { exact: true })).toHaveCount(0);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as unknown as { __unfiledCalls?: number }).__unfiledCalls ?? 0,
+      ),
+    )
+    .toBe(3);
+});
 
 test("renders one flat mixed stream below each expanded container", async ({ page }) => {
   await openWorkspace(page);

--- a/scripts/screenshots/mock-tauri.js
+++ b/scripts/screenshots/mock-tauri.js
@@ -940,6 +940,11 @@ scope to the GA-critical path only.
       case "meeting_org_shares": return [];
       case "org_live_shares_for_source": return [];
 
+      // Workspace's unfiled inbox expects a typed ItemPage, not the generic
+      // array fallback used by other `list_*` demo commands.
+      case "list_container_items":
+        return { kind: args.kind || "meeting", total: 0, items: [] };
+
       // ── Vault audit — weekly schedule + AI explain ──
       // Object-shaped (a bare `get_` name would fall through to the `[]`
       // fallback below — the FE expects an AuditSchedule, not an array).

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.html
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.html
@@ -2,9 +2,9 @@
      on emptiness AND loading, so the first visit shows it and every return
      shows the previous tree while the (still unconditional) reload replaces it
      underneath. Gating on loading() alone is the 2026-07-12 "reload flash". -->
-@if (forestEmpty() && loading()) {
+@if (workspaceEmpty() && loading()) {
   <p class="tree-state">Loading workspace…</p>
-} @else if (forestEmpty()) {
+} @else if (workspaceEmpty()) {
   <p class="tree-state">No projects yet</p>
 } @else {
   @if (error(); as message) {
@@ -13,6 +13,70 @@
     <p class="tree-error" role="status">{{ message }}</p>
   }
   <div class="tree" role="tree" aria-label="Spaces">
+    @if (unfiledRecordings(); as inbox) {
+      @if (inbox.total > 0) {
+        <!-- `container_id = NULL` is an honest inbox, not a synthetic Space:
+             it has no lock/manage/create affordances and cannot accept drops. -->
+        <mur-tree-row
+          class="line line--unfiled"
+          role="treeitem"
+          aria-level="1"
+          [attr.aria-selected]="currentPath() === '/library'"
+          [attr.aria-expanded]="unfiledExpanded()"
+          label="Unfiled recordings"
+          [depth]="0"
+          icon="meeting"
+          [count]="inbox.total"
+          [selected]="currentPath() === '/library'"
+          [expandable]="true"
+          [expanded]="unfiledExpanded()"
+          (toggleExpand)="toggleUnfiled()"
+          (activate)="openAllRecordings()"
+        />
+        @if (unfiledExpanded()) {
+          @for (item of inbox.items; track item.id) {
+            <mur-tree-row
+              class="line line--item line--unfiled-item"
+              role="treeitem"
+              aria-level="2"
+              [attr.aria-selected]="isItemSelected(item)"
+              [label]="itemTitle(item)"
+              [depth]="1"
+              icon="meeting"
+              [selected]="isItemSelected(item)"
+              [attr.draggable]="true"
+              (dragstart)="onDragStart($event, item)"
+              (dragend)="onDragEnd()"
+              (activate)="openItem(item)"
+            >
+              @if (unfiledMoveTargets(item); as targets) {
+                @if (targets.length > 0) {
+                  <mur-row-menu class="row-add" [label]="'Move ' + itemTitle(item)">
+                    @for (target of targets; track target.id) {
+                      <button type="button" role="menuitem" (click)="moveItemTo(item, target)">
+                        {{ target.name }}
+                      </button>
+                    }
+                  </mur-row-menu>
+                }
+              }
+            </mur-tree-row>
+          }
+          @if (inbox.total > inbox.items.length) {
+            <button
+              type="button"
+              class="see-all see-all--unfiled"
+              role="treeitem"
+              aria-selected="false"
+              aria-level="2"
+              (click)="openAllRecordings()"
+            >
+              {{ viewAllRecordingsLabel(inbox.total) }}
+            </button>
+          }
+        }
+      }
+    }
     @for (line of lines(); track line.key) {
       @if (line.item; as item) {
         <!-- An ITEM row: a leaf, so the gutter renders the equal-width spacer

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.scss
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.scss
@@ -28,6 +28,15 @@ mur-tree-row {
   overflow: hidden;
 }
 
+/* The closed row keeps the width guard above. While either projected row menu
+   is open, its absolute panel must escape that clip and the whole row must sit
+   above later siblings so hit-testing reaches the menu, not the next tile. */
+mur-tree-row:has(mur-row-menu.is-open) {
+  position: relative;
+  z-index: 31;
+  overflow: visible;
+}
+
 .line {
   display: flex;
   align-items: center;
@@ -53,6 +62,14 @@ mur-tree-row {
 
 .line--item {
   color: var(--text-secondary);
+}
+
+.line--unfiled {
+  margin-bottom: var(--space-1);
+}
+
+.see-all--unfiled {
+  padding-left: calc(var(--tree-indent) + 20px);
 }
 
 /* Session-unlocked is a PRIVACY state, so it carries the accent the rest of the

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
@@ -115,14 +115,16 @@ export class WorkspaceTreeComponent {
    * refetch of its own; the header's toggle owns the deliberate refresh.
    */
   constructor() {
-    if (this.workspace.forestEmpty()) {
+    if (this.workspace.workspaceEmpty()) {
       void this.workspace.reload();
     }
   }
 
   protected readonly loading = this.workspace.loading;
   protected readonly error = this.workspace.error;
-  protected readonly forestEmpty = this.workspace.forestEmpty;
+  protected readonly workspaceEmpty = this.workspace.workspaceEmpty;
+  protected readonly unfiledRecordings = this.workspace.unfiledRecordings;
+  protected readonly unfiledExpanded = signal(true);
 
   /**
    * The whole forest as flat lines.
@@ -216,6 +218,14 @@ export class WorkspaceTreeComponent {
 
   protected viewAllLabel(total: number): string {
     return `View all (${total})`;
+  }
+
+  protected viewAllRecordingsLabel(total: number): string {
+    return `View all recordings (${total})`;
+  }
+
+  protected toggleUnfiled(): void {
+    this.unfiledExpanded.update((expanded) => !expanded);
   }
 
   /** A container with no groups and no folders has nothing to disclose. */
@@ -369,6 +379,11 @@ export class WorkspaceTreeComponent {
     return this.draggableKind(item)
       ? this.moveTargets().filter((target) => target.id !== current.id)
       : [];
+  }
+
+  /** Unfiled recordings have no current container to exclude. */
+  protected unfiledMoveTargets(item: ItemRow): ContainerNode[] {
+    return this.draggableKind(item) ? this.moveTargets() : [];
   }
 
   protected async moveItemTo(item: ItemRow, target: ContainerNode): Promise<void> {
@@ -578,5 +593,11 @@ export class WorkspaceTreeComponent {
 
   protected openAll(container: ContainerNode): void {
     this.openContainer(container);
+  }
+
+  protected openAllRecordings(): void {
+    void this.notes.selectFolder(null);
+    this.folders.selectFolder(null);
+    void this.router.navigate(["/library"]);
   }
 }

--- a/src/app/features/workspace/workspace.service.ts
+++ b/src/app/features/workspace/workspace.service.ts
@@ -28,6 +28,14 @@ export class WorkspaceService {
   /** Projects, each with its folders and per-kind item groups. */
   readonly forest = this._forest.asReadonly();
 
+  private readonly _unfiledRecordings = signal<ItemPage>({
+    kind: "meeting",
+    items: [],
+    total: 0,
+  });
+  /** Newest recordings that do not belong to any lockable container. */
+  readonly unfiledRecordings = this._unfiledRecordings.asReadonly();
+
   private readonly _loading = signal(false);
   readonly loading = this._loading.asReadonly();
 
@@ -40,6 +48,11 @@ export class WorkspaceService {
    * reload replaces them underneath.
    */
   readonly forestEmpty = computed(() => this._forest().length === 0);
+
+  /** Nothing the Spaces tree can currently render. */
+  readonly workspaceEmpty = computed(
+    () => this._forest().length === 0 && this._unfiledRecordings().total === 0,
+  );
 
   private readonly _expandedContainers = signal<ReadonlySet<string>>(
     readStoredSet(EXPANDED_CONTAINERS_KEY),
@@ -72,14 +85,19 @@ export class WorkspaceService {
       }
       if (!privacyReady) {
         this._forest.set([]);
+        this._unfiledRecordings.set({ kind: "meeting", items: [], total: 0 });
         this._error.set("Workspace is unavailable securely right now");
         return;
       }
-      const forest = await this.ipc.listWorkspaceTree();
+      const [forest, unfiledRecordings] = await Promise.all([
+        this.ipc.listWorkspaceTree(),
+        this.ipc.listContainerItems(null, "meeting", 0, 8),
+      ]);
       if (generation !== this.loadGeneration) {
         return;
       }
       this._forest.set(forest);
+      this._unfiledRecordings.set(unfiledRecordings);
       this._error.set(null);
     } catch (error) {
       if (generation !== this.loadGeneration) {
@@ -104,6 +122,7 @@ export class WorkspaceService {
   private scrubAndReload(): void {
     ++this.loadGeneration;
     this._forest.set([]);
+    this._unfiledRecordings.set({ kind: "meeting", items: [], total: 0 });
     void this.reload();
   }
 


### PR DESCRIPTION
## Summary

- surface recordings without a Space or folder in an honest, non-lockable `Unfiled recordings` inbox
- show the eight newest unfiled recordings with their total and a link to the complete Meetings view
- keep `+` and actions menus above following tree rows so every menu item remains visible and clickable
- synchronously scrub the new inbox on privacy invalidation and reject stale pre-invalidation responses

## Root cause

The Meetings view reads all meetings, while the hierarchy only assembled entries with a concrete container id. Recordings with no generated note or a note whose `folder_id` is null were therefore reachable through the existing gated inbox reader but omitted from the sidebar tree.

The row menus were absolutely positioned inside a consumer-applied `overflow: hidden` row, so most of each panel was clipped and covered by later rows.

## Verification

- RED before GREEN for menu hit-testing, missing inbox, and the privacy race
- `scripts/agent-config-audit --ci` — 152 checks passed
- `(cd src-tauri && cargo test --lib)` — 3234 passed, 0 failed, 18 ignored
- `npx ng lint` — passed
- `npx ng build` — passed
- workspace-tree E2E — 16/16 across Chromium and WebKit
- shell E2E — 88/88 across Chromium and WebKit
- independent adversarial verification — PASS
- independent lock/privacy review — PASS
