### PR TITLE
Murmur 2.0 — release blockers, import Spaces, and the 2.0.0 bump

### DIFF
--- a/.claude/skills/release-murmur/SKILL.md
+++ b/.claude/skills/release-murmur/SKILL.md
@@ -66,6 +66,41 @@ scripts/agent-resource-run -- bash scripts/ci.sh  # must end "✅ CI: all gates 
 
 Do not proceed unless CI is green.
 
+### Stage 0b — the murmur-server checks (BOTH were missing until the 2.0 release, and both bit)
+
+`src-tauri/Cargo.toml` takes `murmur-protocol` as a **path dependency** into the sibling checkout
+`../murmur-server/crates/murmur-protocol`. CI clones that repo fresh at `.murmur-server-revision`,
+but YOUR LOCAL BUILD compiles whatever is checked out on disk. A green CI therefore proves nothing
+about the binary you are about to sign.
+
+```bash
+cd /Users/jakubgawronski/Projects/meetnotes
+cat .murmur-server-revision                       # the pinned 40-hex commit
+git -C ../murmur-server rev-parse HEAD            # MUST be identical
+git -C ../murmur-server status --short            # MUST be empty
+```
+
+If they differ, the sibling checkout is on someone's feature branch. **Commit that work on its own
+branch first** (never stash-and-forget, never discard), then `git -C ../murmur-server checkout main
+&& git merge --ff-only origin/main`. In the 2.0 release the checkout sat on an unmerged
+Stripe/entitlement branch whose working tree had DELETED `CAP_SHARE_OWNER_CLAIM_V1` — a symbol
+`src-tauri/src/commands/org.rs` still references — so the release build could not have compiled at
+all, while CI stayed green.
+
+Second: **the deployed relay must already advertise what this client requires.** The client refuses
+every share-create path unless `/healthz` advertises `share-owner-claim-v1`
+(`commands/org.rs::require_share_owner_claim_capability`). Deploying the server AFTER tagging the
+client ships a release whose sharing is dead on arrival.
+
+```bash
+curl -s https://murmur-server-production-b9e8.up.railway.app/healthz
+# MUST contain "capabilities":[...,"share-owner-claim-v1",...]
+```
+
+If it does not, deploy the server to the pinned revision FIRST (skill: `deploy-murmur-server`) and
+re-probe. Deploy from **clean `main`**, never from the paywall/entitlement branch the checkout
+tends to sit on.
+
 > **Also refresh the public copy before you ship.** Run **`/sync-release-copy`** now —
 > it checks the landing page (`landing/index.html`) and the GitHub repo description
 > against what the app actually does as of this release, and lands any needed edits
@@ -78,12 +113,22 @@ Do not proceed unless CI is green.
 NEW=0.4.0   # example — set to the real bump
 ```
 
-## Stage 2 — Bump version in all 3 files + sync the lock
+## Stage 2 — Bump version in all 4 files + sync the lock
 
-Edit the `version` field in each (keep `identifier` untouched in tauri.conf.json):
+Edit the `version` field in each **by hand** — never a repo-wide `sed`, which would rewrite
+unrelated dependency versions in the lockfiles (keep `identifier` untouched in tauri.conf.json):
 - `package.json` → `"version": "<NEW>"`
+- `package-lock.json` → `"version": "<NEW>"` in **BOTH** places: the top-level key (line ~3) and
+  the `""` root-package entry under `"packages"` (line ~9). Missed until the 2.0 audit, because
+  nothing builds from it — but leaving it stale makes `npm version`/`npm ci` disagree with the
+  three files below, and the next release inherits the confusion.
 - `src-tauri/tauri.conf.json` → `"version": "<NEW>"`
 - `src-tauri/Cargo.toml` → `version = "<NEW>"`
+
+`src-tauri/Cargo.toml` is the one that actually matters at runtime: the in-app About screen, the
+MCP `serverInfo`, and `src-tauri/src/update.rs` (the GitHub-release updater — the ONLY way an
+existing user learns a new version exists) all read `CARGO_PKG_VERSION`. Miss it and you ship a
+DMG that calls itself by the old version and never prompts anyone to upgrade.
 
 Then **re-pin `Cargo.lock`** (the `murmur` package entry must match, or the build/CI
 drifts):
@@ -96,7 +141,7 @@ grep -A1 '^name = "murmur"' Cargo.lock   # workspace-root lock; confirm version 
 ## Stage 3 — Commit as QueaT (no Claude trailers)
 
 ```bash
-git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml Cargo.lock
+git add package.json package-lock.json src-tauri/tauri.conf.json src-tauri/Cargo.toml Cargo.lock
 git commit -m "chore(release): bump version to $NEW"
 git log -1 --format='%an <%ae>%n%b'   # author QueaT, body has NO Co-Authored-By / Claude
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4637,7 +4637,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -62,8 +62,15 @@ zero-knowledge, no plaintext ever touching a server.
   something useful it offers a quiet **"✓ Add to notes"** — nothing enters your notes unless you say so.
 - 🔒 **Truly local-first.** The brain, transcription, and search all run on your Mac. Pick a fully-local
   stack (Ollama or the bundled GGUF model) and **nothing ever leaves the device.**
-- 📝 **A real notes product, not an afterthought.** A standalone Markdown editor with its own folders,
-  its own lock lifecycle, a 19-action AI command menu, and per-note end-to-end-encrypted sharing — for
+- 🗂️ **One hierarchy: Spaces.** Recordings and notes live in the same tree — **Spaces › folders ›
+  items** — not in two parallel folder systems. Lock a Space and everything inside it is sealed with it.
+- 📊 **Dashboards you compose.** Put notes, recordings, documents, people, promise ledgers and reminders
+  on a board, pin a **living answer** the app keeps current, and read it through Brief / Overview /
+  Commitments / Sources / People lenses. A board's sources going locked withholds the answer.
+- 📥 **Bring the notes you already have.** Import a Notion export, an Obsidian vault, or Apple Notes —
+  entirely offline, dry-run first, no token and no account.
+- 📝 **A real notes product, not an afterthought.** A standalone Markdown editor filed in the same
+  Spaces as your recordings, with the same lock lifecycle, a 19-action AI command menu, and per-note end-to-end-encrypted sharing — for
   writing that never came from a recording.
 - 🌐 **A Shared Brain for your org — free, E2EE.** Opt in and publish notes or meetings into a
   zero-knowledge shared pool your teammates' apps replicate and search locally. The server only ever
@@ -268,9 +275,9 @@ recording. Same store, same lock model, same brain.
 - **A real editor** at its own route, with collapsible YAML front-matter, a formatting toolbar, markdown
   keyboard shortcuts, an 11-type slash-`/` block-insert menu, Edit/Preview toggle, and debounced
   autosave.
-- **Note folders**, entirely separate from meeting folders, that reuse the exact same **Touch-ID-gated
-  per-folder lock** — a locked note folder masks its title to `🔒 Locked` and blanks body, tags, and
-  properties, just like a locked meeting.
+- **Filed in Spaces alongside your recordings** — one hierarchy, not a separate note-folder tree.
+  It reuses the exact same **Touch-ID-gated per-container lock**: a locked container masks its notes'
+  titles to `🔒 Locked` and blanks body, tags, and properties, just like a locked meeting.
 - **AI auto-organize** — the brain proposes a folder/tag reorganization plan, you review it, nothing
   moves until you approve.
 - **A 19-action AI command menu on selected text** — grouped into Edit / Structure / From
@@ -316,6 +323,10 @@ everyone's notes and meetings — without anyone's plaintext ever touching a ser
   index, cached keys.
 - **Per-meeting revocation** — the detail view shows any active org shares sourced from a
   meeting and lets you revoke them individually.
+- **Per-document permissions** — the document's author sets **View only** or **Can edit** on each
+  shared item; the org owner can manage it too.
+- **Shared Tasks** — assignees, due dates, subtasks, and the same per-document permissions, scoped to
+  one org. Tasks require a signed-in account.
 - **Owner-managed membership** — invite by email, remove members, from Settings → Organization.
 
 The wire format (`murmur-protocol`, MIT/Apache) is compiled into both this app and the server, so it's
@@ -542,7 +553,7 @@ axum + Postgres relay, AGPL-3.0).
 
 ## 🗺️ Status
 
-Murmur ships at **v1.0.0** — a signed, notarized macOS app, ~30 releases past the record →
+Murmur ships at **v2.0.0** — a signed, notarized macOS app, well past the record →
 transcribe → summarize MVP.
 
 **Shipped and in daily use:**
@@ -559,12 +570,31 @@ transcribe → summarize MVP.
 - **A self-building link graph** — notes, meetings, *and* imported documents are first-class
   `[[link]]` targets you pick/link/open from any surface; backlinks resolve by id, and the full-brain
   graph renders as a living neural map.
-- **Notes** as a full standalone product — editor, note folders with their own lock lifecycle, AI
+- **Spaces** — one hierarchy for everything. The separate Meetings and Notes folder trees are gone;
+  there is a single tree of **Spaces › folders › your recordings and notes**, behind a rebuilt shell
+  (a persistent icon rail plus a contextual panel). Locking a Space seals everything inside it.
+- **Dashboards** — compose a board from your notes, recordings, documents, people, promise ledgers
+  and reminders, plus pinned **living answers** (a question whose answer the app keeps up to date, and
+  withholds the moment its sources stop being readable). Read a board through **Brief / Overview /
+  Commitments / Sources / People** lenses, or ask it directly, grounded only in what's on it.
+- **Imports** — Settings → Imports pulls in a **Notion export**, an **Obsidian vault**, or **Apple
+  Notes**. Entirely offline: no API token, no account, no network call. Every import is a dry run
+  first, reporting what it would write (new vs. already imported) before anything is written. Apple
+  Notes asks macOS for permission on the first run.
+- **Ask remembers** — vault, note and meeting conversations persist, each surface with its own history
+  browser. A conversation disappears the instant any folder it drew on stops being readable.
+- **One model picker** across every AI surface, always accepting a free-text model id — so a model
+  released after this build is still selectable.
+- **Notes** as a full standalone product — editor, the shared Space/folder lock lifecycle, AI
   auto-organize, and the 19-action AI command menu.
 - **Shared Brain** — free, opt-in, end-to-end-encrypted org sharing of notes and meetings, multi-org
-  aware, auto-refreshing, with its own MCP tool.
-- The per-folder Touch ID lock model (two encryption layers, gated reads, verify-before-destroy seals),
-  the content-free egress ledger, and the read-only MCP server.
+  aware, auto-refreshing, with its own MCP tool, and **per-document permissions** (**View only** /
+  **Can edit**, set by the document's author).
+- **Tasks** — shared work inside a Shared Brain org: assignees, due dates, subtasks, and the same
+  per-document permissions. Tasks belong to an org, so — like Shared Brain and link sharing — they
+  require a signed-in account. Everything else in this list works with no account at all.
+- The per-Space / per-folder Touch ID lock model (two encryption layers, gated reads,
+  verify-before-destroy seals), the content-free egress ledger, and the read-only MCP server.
 - Per-note and per-meeting expiring E2EE link sharing.
 
 **Honest gaps, not yet shipped or only partially proven:**

--- a/docs/research/2026-08-27-murmur-2.0-release-audit.md
+++ b/docs/research/2026-08-27-murmur-2.0-release-audit.md
@@ -1,0 +1,134 @@
+# Murmur 2.0 — release audit and the nine blockers it found
+
+**Date:** 2026-08-27 · **Base:** `v1.1.0` (2026-07-31) → trunk `284caf2` · **Outcome:** shipped as 2.0.0
+
+An eleven-agent adversarial audit ran over the whole `v1.1.0..murmur` diff before this release was
+cut. It returned `DO_NOT_SHIP` on two of its three lenses. This is what it found, what was done, and
+what could not be verified without a signed build.
+
+## Why 2.0 and not 1.2
+
+253 commits, 104 merged PRs, 326 app-code files, +131k/−21k. Three new top-level product surfaces
+(**Dashboards**, **Tasks**, **Imports**), one new information architecture (**Spaces** — the separate
+Meetings and Notes trees are gone, replaced by a single Spaces › folders › items tree), a schema
+change, and per-document permissions in Shared Brain. New IA plus new surfaces plus a schema change
+is a major version.
+
+## What the audit cleared
+
+- **Migration safety: no blockers.** Every statement added to `db.rs::migrate()` since v1.1.0 is
+  additive (`add_column_if_missing` / `CREATE TABLE IF NOT EXISTS`). No `DROP`, no `ALTER … DROP
+  COLUMN`, no rewrite of user rows. An existing 1.1.0 database survives the upgrade. This was the
+  one unrecoverable risk in a release with an IA change, and it came back clean.
+- **Zero new dependencies** across the whole cycle. `Cargo.lock` moved by exactly two lines
+  (h2 0.4.15 → 0.4.16 for RUSTSEC-2026-0258, PR #590).
+
+## The nine blockers
+
+### Sealed-content leaks (3) — `27f8c81`
+
+1. **The agent/MCP dashboard tools bypassed the board-level gate.** `tools.rs`
+   `ListDashboards`/`GetDashboard` called the raw `db.list_dashboards()` / `get_dashboard()` while
+   `commands/dashboards.rs` called the `_visible` pair. Two gates for one fact, and only one applied
+   — so a board filed in a sealed folder shipped its plaintext title, tile count and tile kinds to
+   any MCP client while the UI correctly withheld all three.
+2. **Locking a project did not re-close a session-unlocked descendant.** `lock_container_subtree`
+   skipped an already-locked descendant with a bare `continue`. Not re-keying it is correct —
+   re-minting its content key would orphan existing ciphertext — but the `continue` also skipped the
+   per-container path's already-locked branch, the only place that bumps the seal epoch, revokes
+   renderer visibility and drops the folder from the session unlock set. `locked = 1` is the durable
+   seal JOURNAL, not proof the session cleanup ran.
+3. **`relock_folder` did not cascade although `unlock_folder` does.** An asymmetric open/close pair
+   is a leak by construction: whatever the open reaches, the close must reach.
+
+`relock_folder_inner_with_visibility_notice` was extracted (mirroring the existing
+`relock_all_inner_with_visibility_notice`) because the cascade was unreachable from tests behind
+`#[tauri::command]` — which is why this bug had no oracle.
+
+### Data loss (2) — `e40b7fb`, `4d22d33`
+
+4. **Durable Ask history was erased on every app launch** for any user with one locked folder, and by
+   every lock/relock vault-wide. TWO independent mechanisms, and fixing either alone leaves the user
+   with the same empty history: a global `DELETE … WHERE provenance_mode='globalDerived'` whose
+   predicate the schema CHECK makes universal, AND a bump of `ask_history_state.visibility_generation`,
+   which `list_ask_conversation_ids` requires to match — so advancing it makes all history unreadable
+   even when the rows survive.
+
+   The seal paths are now scoped to the folders actually being sealed, and survivors are carried onto
+   the new generation (only those on the immediately-preceding one, so a racing write is still
+   invalidated). Scoping is sound because the dependency snapshot is CONSERVATIVE: `ask_history.rs`
+   records `visible_folder_ids(&unlocked)` — every folder READABLE when the exchange was written, not
+   the subset the answer cited.
+
+   `purge_all_ask_conversations_tx` is KEPT for the ~20 content-deletion callers that cannot name a
+   folder set. **Known residual:** deleting a single note still clears all Ask history. Same class of
+   over-reach, not a leak, deliberately out of scope for this release.
+
+5. **Obsidian import silently overwrote notes.** Identity was the vault-RELATIVE path with no
+   discriminator, so importing a second vault containing `Area/Note.md` replaced the first vault's
+   title and body and reported it as a benign "updated". Now `<sha256(canonical root)[..16]>:<path>`.
+   Also: `run_import_inner` never re-checked `is_murmur_vault` (computed only in `scan_import`), so a
+   direct `invoke` would read Murmur's own export back in as duplicates — a frontend warning is not a
+   guard.
+
+### Dead on arrival (3) — `fa5da79`, `31c7e7a`, server deploy
+
+6. **Sharing was dead against the deployed relay.** Every share-create path requires the relay to
+   advertise `share-owner-claim-v1`; production advertised no capabilities at all. Root cause was
+   simply that **production was older than `.murmur-server-revision`** — no client change was needed.
+   Deploying the pinned `3ef670d` fixed it: `/healthz` now returns
+   `capabilities:["share-owner-claim-v1"]` and `PUT /v1/shares/{id}/reservation` answers 401 instead
+   of 404.
+
+   Separately, the journal row was committed BEFORE the capability check, so a refused precondition
+   left a `create_pending` row, the second click failed differently and untagged, and recovery needed
+   the missing capability. The check now runs first. **This changed a contract that two tests pinned**
+   — see `fa5da79` for why the new one wins and what happened to both tests.
+
+7. **Tasks errored with developer prose for the default user.** Murmur is local-first and usable with
+   no account, but Tasks is org-only and `/tasks` is an unconditional nav item, so most users got
+   `provider unavailable: not signed in to the sharing account` rendered verbatim. Now tagged
+   `sharing-account-required` (distinct from `sharing-signin-required`, which means a session lapsed)
+   and rendered as an invitation.
+
+8. **Apple Notes import could not work in the build it ships in.** The importer drives Notes.app over
+   Apple events; under hardened runtime that needs `com.apple.security.automation.apple-events` plus
+   `NSAppleEventsUsageDescription`. Neither existed. Both added, main bundle only.
+   `scripts/macos-sign-notarize.sh` now asserts both after signing and refuses to continue without
+   them — the only oracle this class can have short of shipping.
+
+### Stale public copy (1) — `eca3b9d`
+
+9. `landing/index.html` had no commits since before v1.1.0 and never mentioned Dashboards, Spaces,
+   Imports or Tasks; README claimed v1.0.0. Both refreshed, with Tasks carrying its account caveat
+   explicitly rather than being sold as local.
+
+## Also shipped
+
+**Imports land in their own Space.** An unfiled import went to the bare notes root, mixing hundreds
+of pages into the user's own notes. Each source now gets a named, badged container — 🗂️ *Imported
+from Notion*, 🔮 *Imported from Obsidian*, 🍎 *Imported from Apple Notes* — created on demand and
+reused by name across runs. Built on `create_note_folder_inner`, which is both what the importer's
+`note_folder_by_id` lookup requires and the seam that birth-seals into a locked parent.
+
+## Process notes worth keeping
+
+- **RED-before-GREEN was applied by reverting each fix in isolation**, not by trusting that a new
+  test proves anything. Every fix above has a recorded failure message from the unpatched code.
+- **A control assertion caught a bug in the fix itself.** The import feature's "an explicitly chosen
+  folder still wins" leg failed because the first draft created a meeting-kind container the importer
+  could not see. Without that control the feature would have looked correct and broken later.
+- **Agent output needed verification, twice.** Two of five delegated fixes did not compile or would
+  not have worked: Tasks was missing its errcode constant entirely (frontend classified on a code the
+  backend never sent), and its test used `unwrap_err()` on a type that deliberately has no `Debug`
+  because it holds the account master key.
+- **`clippy::incompatible_msrv` caught `std::iter::repeat_n`** (stable 1.82, crate MSRV 1.77) in the
+  Ask purge fix. `cargo test --lib` does not run clippy; only the full gate does.
+
+## Not verified here — needs a signed build and a human
+
+`cargo test --lib` cannot prove any of this: Touch ID / Security.framework KEK release, the real
+Keychain ACL, ScreenCaptureKit and TCC, the lock cascade against a real KEK, whether a sealed Space's
+boards and tasks actually round-trip, and whether the Apple Notes Automation prompt appears. The
+post-sign assertion proves the entitlement pair is present in the bundle; the prompt itself is first
+observable on the notarized DMG.

--- a/e2e/tasks/tasks-signed-out.spec.ts
+++ b/e2e/tasks/tasks-signed-out.spec.ts
@@ -1,0 +1,190 @@
+import { expect, test, type Page } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * 2.0 release blocker: Tasks is ORG-ONLY (`commands/tasks.rs::list_tasks` opens with
+ * `session_server_user_id`), but the DEFAULT Murmur user is local-first with no account — the
+ * product's headline promise. Clicking the Tasks nav item therefore rendered the raw `AppError`
+ * `Display` string in a red banner, on top of an empty state that told the user to "create shared
+ * work" and a New task button that also failed.
+ *
+ * The oracle has two legs and BOTH must hold:
+ *   RED  — a signed-out device gets a purposeful invitation and ZERO developer prose.
+ *   CONTROL — a signed-IN device still renders the real task list, so the gate cannot go vacuous
+ *             by simply swallowing Tasks for everybody.
+ */
+
+const ORG_ID = "11111111-1111-4111-8111-111111111111";
+const DOC_ID = "22222222-2222-4222-8222-222222222222";
+const TASK_ID = `${ORG_ID}:${DOC_ID}`;
+
+/** The exact wire string `share::require_login` produces once it carries its `[code]`. */
+const SIGNED_OUT_WIRE =
+  "provider unavailable: [sharing-account-required] not signed in to the sharing account";
+
+/** Vocabulary that must never reach a person, per `src-tauri/src/error.rs`. */
+const DEVELOPER_PROSE = [
+  "not signed in to the sharing account",
+  "provider unavailable",
+  "sharing-account-required",
+  "AppError",
+];
+
+const ORGS = [
+  {
+    orgId: ORG_ID,
+    name: "Acme",
+    role: "member",
+    memberCount: 2,
+    consented: true,
+    lastSeq: 7,
+    itemCount: 1,
+    receivedCount: 1,
+    pendingShares: 0,
+    contextEnabled: true,
+  },
+];
+
+const TASK = {
+  id: TASK_ID,
+  orgId: ORG_ID,
+  docId: DOC_ID,
+  itemId: "33333333-3333-4333-8333-333333333333",
+  sourceDocumentId: null,
+  version: 1,
+  title: "Finish onboarding",
+  description: "Ship the shared task view.",
+  status: "inProgress",
+  dueAt: "2026-08-28T12:00:00Z",
+  assigneeUserId: null,
+  createdAt: "2026-08-20T09:00:00Z",
+  subtasks: [],
+  orgRefs: [],
+  images: [],
+  access: "view",
+  canEdit: false,
+  canManage: false,
+  localRefs: [],
+  updatedAt: "2026-08-21T09:00:00Z",
+};
+
+function watchRuntimeErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  return errors;
+}
+
+test("a signed-out device gets a purposeful Tasks invitation, never the raw refusal", async ({
+  page,
+}) => {
+  const runtimeErrors = watchRuntimeErrors(page);
+  await mockTauri(
+    page,
+    {
+      org_refresh: () => null,
+      org_list_statuses: () => [],
+      // Exactly what the Rust seam returns for a device that has never signed in.
+      list_tasks: () => {
+        throw new Error(
+          "provider unavailable: [sharing-account-required] not signed in to the sharing account",
+        );
+      },
+      list_dashboards: () => [],
+    },
+    {},
+  );
+
+  await page.goto("/tasks");
+
+  await expect(
+    page.getByRole("heading", { name: "Tasks live in a Shared Brain", level: 1 }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Tasks are shared work inside an organization", { exact: false }),
+  ).toBeVisible();
+
+  // The two doors the account banner already offers — same vocabulary, one flow.
+  await expect(page.getByRole("button", { name: "Sign in" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Create account" })).toBeVisible();
+
+  // No error banner at all: this is an expected state, not a failure.
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  // And the misleading empty state is gone with it.
+  await expect(page.getByText("No tasks here.")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "New task" })).toHaveCount(0);
+
+  const rendered = (await page.locator("body").innerText()).toLowerCase();
+  for (const phrase of DEVELOPER_PROSE) {
+    expect(rendered).not.toContain(phrase.toLowerCase());
+  }
+
+  // The CTA is wired to the ONE existing account surface, not decorative.
+  await page.getByRole("button", { name: "Sign in" }).click();
+  await expect(page.getByRole("heading", { name: "Sign in", level: 2 })).toBeVisible();
+  await expect(page.getByPlaceholder("you@example.com")).toBeVisible();
+
+  expect(runtimeErrors).toEqual([]);
+  // The wire string the mock threw is the one the Rust seam produces — pinned here so a rename on
+  // either side fails this test instead of silently reverting the surface to prose.
+  expect(SIGNED_OUT_WIRE).toContain("[sharing-account-required]");
+});
+
+test("CONTROL: a signed-in device still renders the real task list", async ({
+  page,
+}) => {
+  const runtimeErrors = watchRuntimeErrors(page);
+  await mockTauri(
+    page,
+    {
+      org_refresh: () => null,
+      task_list_assignees: () => [],
+      list_note_attachments: () => [],
+    },
+    {
+      org_list_statuses: ORGS,
+      list_tasks: [TASK],
+      list_dashboards: [],
+    },
+  );
+
+  await page.goto("/tasks");
+
+  await expect(page.getByRole("heading", { name: "Tasks", level: 1 })).toBeVisible();
+  await expect(page.getByText("Finish onboarding")).toBeVisible();
+  await expect(page.getByRole("button", { name: "New task" }).first()).toBeVisible();
+  // The gate must NOT appear for someone who has an account.
+  await expect(
+    page.getByRole("heading", { name: "Tasks live in a Shared Brain" }),
+  ).toHaveCount(0);
+
+  expect(runtimeErrors).toEqual([]);
+});
+
+test("an UN-CODED task failure degrades to fixed copy instead of leaking Rust prose", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {
+      org_refresh: () => null,
+      org_list_statuses: () => [],
+      list_tasks: () => {
+        throw new Error("storage error: account-session mutex poisoned");
+      },
+      list_dashboards: () => [],
+    },
+    {},
+  );
+
+  await page.goto("/tasks");
+
+  const alert = page.getByRole("alert");
+  await expect(alert).toContainText("Couldn’t load shared tasks. Please try again.");
+  const rendered = (await page.locator("body").innerText()).toLowerCase();
+  expect(rendered).not.toContain("mutex poisoned");
+  expect(rendered).not.toContain("storage error");
+  // CONTROL for this leg: an un-coded failure is an ERROR, so the invitation must NOT hijack it.
+  await expect(
+    page.getByRole("heading", { name: "Tasks live in a Shared Brain" }),
+  ).toHaveCount(0);
+});

--- a/landing/index.html
+++ b/landing/index.html
@@ -604,7 +604,7 @@
             </tbody>
           </table>
         </div>
-        <div class="egress-foot">Murmur tells you, in plain language, exactly what leaves your Mac — and defaults to keeping it all on-device.</div>
+        <div class="egress-foot">Murmur tells you, in plain language, exactly what leaves your Mac — and defaults to keeping it all on-device. One model picker is used across every AI surface, and it always accepts a model id you type yourself — so a model released after this build still works.</div>
       </div>
     </div>
   </section>
@@ -618,6 +618,30 @@
         <p>One encrypted store, three ways to use it — the app, a local MCP server, and your exported Markdown files.</p>
       </div>
 
+      <!-- New in 2.0 — the structural changes, no screenshots yet -->
+      <div class="section-head reveal" style="margin-top:8px">
+        <span class="eyebrow">New in 2.0</span>
+        <h2>One hierarchy. Boards over it. And a door in.</h2>
+        <p>2.0 rebuilt the shell around a single tree, added composable boards on top of it, and opened an offline import path for the notes you already have somewhere else.</p>
+      </div>
+      <div class="steps reveal" style="margin-bottom:96px">
+        <div class="step">
+          <div class="step-n">Spaces</div>
+          <h3>One tree for everything</h3>
+          <p>The separate Meetings and Notes folder trees are gone. There's now a single tree — <b>Spaces › folders › your recordings and notes</b> — behind a persistent icon rail and a contextual panel. Lock a Space and everything inside it is sealed with it.</p>
+        </div>
+        <div class="step">
+          <div class="step-n">Dashboards</div>
+          <h3>Boards you compose</h3>
+          <p>Pull notes, recordings, documents, people, promise ledgers and reminders onto a board, then read it through <b>Brief / Overview / Commitments / Sources / People</b> lenses. Pin a <b>living answer</b> — a question the app keeps up to date, and withholds the moment its sources stop being readable. You can ask a board directly, grounded only in what's on it.</p>
+        </div>
+        <div class="step">
+          <div class="step-n">Imports</div>
+          <h3>Bring your existing notes</h3>
+          <p>Settings → Imports pulls in a <b>Notion export</b>, an <b>Obsidian vault</b>, or <b>Apple Notes</b>. Entirely offline — no API token, no account, no network call. Every import is a dry run first, so you see what it would write before it writes anything. (Apple Notes asks macOS for permission the first time.)</p>
+        </div>
+      </div>
+
       <!-- Feature 1 -->
       <div class="feature reveal">
         <div class="ftext">
@@ -628,6 +652,7 @@
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> On-device reasoner (Bielik-11B, Qwen) via Metal</li>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Grounded, not hallucinated — retrieved from your own transcripts</li>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Optional consent-gated web — off by default</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Conversations are remembered — vault, note and meeting threads persist, with a history browser on each surface. A conversation disappears the instant any folder it drew on stops being readable.</li>
           </ul>
         </div>
         <div class="shot"><img src="./assets/ask.jpg" alt="Ask Your Vault — grounded Q&A across months of meetings, every claim linked to its source" loading="lazy" /></div>
@@ -653,7 +678,7 @@
         <div class="ftext">
           <span class="eyebrow">Notes &amp; memory</span>
           <h3>Structured notes and a graph that builds itself.</h3>
-          <p>Every call becomes a clean note — summary, decisions, action items, quotes. People and projects are extracted automatically into a knowledge graph, and sealed folders stay hidden from it.</p>
+          <p>Every call becomes a clean note — summary, decisions, action items, quotes. Recordings and notes live side by side in the same Space. People and projects are extracted automatically into a knowledge graph, and sealed Spaces stay hidden from it.</p>
           <ul class="flist">
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Ask across every meeting with hybrid semantic search</li>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Entity dossiers, related meetings, weekly digests</li>
@@ -700,11 +725,11 @@
         <div class="ftext">
           <span class="eyebrow">Notes</span>
           <h3>Not just meeting notes. All your notes.</h3>
-          <p>A full Markdown editor with folders, tags, and properties — for anything you write, not just what Murmur transcribes. Select any passage and a command menu appears: refine, shorten, change tone, translate, fact-check, or just type what you want done.</p>
+          <p>A full Markdown editor with tags and properties, filed in the same Spaces as your recordings — for anything you write, not just what Murmur transcribes. Select any passage and a command menu appears: refine, shorten, change tone, translate, fact-check, or just type what you want done.</p>
           <ul class="flist">
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Nineteen Brain actions, one keystroke away</li>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Grounded in your own meetings &amp; notes, not the model's guesses</li>
-            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Paste screenshots into notes; they stay local and follow the folder lock</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Paste screenshots into notes; they stay local and follow the Space's lock</li>
           </ul>
         </div>
         <div class="shot"><img src="assets/notes-editor-brain-menu.png" alt="The standalone note editor with a text selection and the Brain command menu open, showing Refine, Shorten, Change tone and more actions" loading="lazy" /></div>
@@ -719,7 +744,9 @@
           <ul class="flist">
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> AES-256-GCM sealed under an org content key before upload</li>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Verify-before-publish — the same discipline as locking a folder</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Per-document permissions — the author sets <b>View only</b> or <b>Can edit</b> on each shared document</li>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Belong to more than one org — each gets its own encrypted feed</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Shared <b>Tasks</b> — assignees, due dates, subtasks and the same permissions. Tasks live inside an org, so they need a signed-in account.</li>
           </ul>
         </div>
         <div class="shot"><img src="assets/shared-brain-rail.png" alt="The Notes view Shared Brains rail with an organization selected, showing synced org items with author badges" loading="lazy" /></div>
@@ -747,9 +774,10 @@
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> In-meeting AI assistant + Ask Your Vault</li>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Semantic search &amp; the auto knowledge graph</li>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Standalone notes with a Brain-assisted editor</li>
-            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> E2EE sharing (account required)</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> E2EE sharing with per-document View only / Can edit (account required)</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Spaces, composable dashboards, and offline Notion / Obsidian / Apple Notes import</li>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Expiring, encrypted share links for a note or meeting</li>
-            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Per-folder Touch ID lock &amp; AES-256 encryption</li>
+            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Per-Space and per-folder Touch ID lock &amp; AES-256 encryption</li>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Screen-share auto-relock</li>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Local MCP server + Markdown export</li>
           </ul>
@@ -772,9 +800,10 @@
           <a class="btn btn-ghost" href="https://github.com/murmur-io/murmur">Follow on GitHub</a>
         </div>
 
-        <!-- Team / Enterprise — roadmap. Shared Brain org sharing itself already
-             shipped free (see the Free plan above) — this tier is only the
-             admin/governance layer on top: roles, SSO, audit log, SLA. -->
+        <!-- Team / Enterprise — roadmap. Shared Brain org sharing already shipped
+             free (see the Free plan above), and per-document View only / Can edit
+             permissions shipped in 2.0 — so this tier is only the remaining
+             admin/governance layer: SSO/SCIM, policy & audit log, SLA. -->
         <div class="plan soon reveal">
           <span class="plan-badge soon">Coming soon</span>
           <h3>Team</h3>
@@ -782,7 +811,6 @@
           <p class="tagline">Pricing and availability to be announced.</p>
           <ul>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Everything in Pro</li>
-            <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Member roles &amp; permissions for your Shared Brain org</li>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> SSO &amp; SCIM provisioning</li>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Security policy, retention &amp; audit log</li>
             <li><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg> Priority support &amp; SLA</li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murmur",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murmur",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "dependencies": {
         "@angular/common": "^22.0.8",
         "@angular/compiler": "^22.0.8",
@@ -16,7 +16,7 @@
         "@angular/router": "^22.0.8",
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-dialog": "^2.7.2",
-        "dompurify": "^3.4.12",
+        "dompurify": "^3.4.13",
         "marked": "^18.0.5",
         "rxjs": "^7.8.2",
         "tslib": "^2.8.1"
@@ -5130,9 +5130,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "scripts": {
     "start": "cargo build -p murmur-brain && ng serve --port 1420",
     "build": "ng build",
@@ -19,7 +19,7 @@
     "@angular/router": "^22.0.8",
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-dialog": "^2.7.2",
-    "dompurify": "^3.4.12",
+    "dompurify": "^3.4.13",
     "marked": "^18.0.5",
     "rxjs": "^7.8.2",
     "tslib": "^2.8.1"

--- a/scripts/macos-sign-notarize.sh
+++ b/scripts/macos-sign-notarize.sh
@@ -139,7 +139,20 @@ if ! codesign -d --entitlements :- "$APP" 2>/dev/null | grep -q "keychain-access
   echo "signed app is MISSING the keychain-access-groups entitlement — biometric lock/sharing would fail (and launch may be AMFI-killed)" >&2
   exit 1
 fi
-echo "   verified: embedded profile present + keychain-access-groups entitlement signed in"
+# POST-SIGN ASSERTION: the Apple Notes importer drives Notes.app over Apple events
+# (src-tauri/src/import/apple_notes.rs → /usr/bin/osascript). Under hardened runtime, a bundle
+# without com.apple.security.automation.apple-events gets errAEEventNotPermitted (-1743) and never
+# even appears under System Settings → Privacy & Security → Automation, so the user cannot grant it.
+# Its Info.plist counterpart (NSAppleEventsUsageDescription) is what the TCC prompt renders.
+if ! codesign -d --entitlements :- "$APP" 2>/dev/null | grep -q "com.apple.security.automation.apple-events"; then
+  echo "signed app is MISSING the apple-events automation entitlement — Apple Notes import would fail with -1743" >&2
+  exit 1
+fi
+if ! /usr/libexec/PlistBuddy -c "Print :NSAppleEventsUsageDescription" "$APP/Contents/Info.plist" >/dev/null 2>&1; then
+  echo "bundled Info.plist is MISSING NSAppleEventsUsageDescription — the Automation TCC prompt cannot be shown" >&2
+  exit 1
+fi
+echo "   verified: embedded profile present + keychain-access-groups + apple-events entitlement signed in"
 
 echo "3) Building the DMG (with Applications alias)…"
 STAGE="$(mktemp -d)/Murmur"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "1.1.0"
+version = "2.0.0"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -8,6 +8,8 @@
     <string>Murmur captures the other participants' audio playing on your Mac to transcribe meetings locally on device.</string>
     <key>NSRemindersUsageDescription</key>
     <string>Murmur can add your meeting action items to Apple Reminders.</string>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>Murmur reads your Apple Notes so it can import them.</string>
     <key>NSCalendarsUsageDescription</key>
     <string>Murmur reads your upcoming events — title, attendees, and agenda — to prepare pre-meeting context and briefs, all on your device.</string>
   </dict>

--- a/src-tauri/entitlements-app.plist
+++ b/src-tauri/entitlements-app.plist
@@ -35,6 +35,16 @@
     <key>com.apple.security.personal-information.calendars</key>
     <true/>
 
+    <!-- Apple Events automation, required so the Apple Notes importer can drive Notes.app through
+         /usr/bin/osascript (src-tauri/src/import/apple_notes.rs). Under hardened runtime an app with
+         no com.apple.security.automation.apple-events entitlement gets errAEEventNotPermitted (-1743)
+         and never appears under System Settings → Privacy & Security → Automation, so the user has no
+         way to grant it. Paired with NSAppleEventsUsageDescription in src-tauri/Info.plist, which is
+         what the TCC consent prompt shows. MAIN BUNDLE ONLY — the nested Resources/ helpers
+         (meetnotes-*) sign with entitlements.plist and must NOT get this; they send no Apple events. -->
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
+
     <!-- Data-protection keychain access group for the biometric KEK + account MK. Authorized by the
          embedded Developer-ID provisioning profile (which grants keychain-access-groups BVF778E5QD.*). -->
     <key>com.apple.application-identifier</key>

--- a/src-tauri/src/commands/import.rs
+++ b/src-tauri/src/commands/import.rs
@@ -234,6 +234,42 @@ pub fn cancel_import() -> Result<(), AppError> {
     Ok(())
 }
 
+/// Where an import lands when the user did not pick a destination themselves.
+///
+/// Previously everything went to the bare notes root, so importing a Notion export dropped several
+/// hundred pages loose among the user's own notes with nothing marking where they came from and no
+/// way to undo the mixing. Each source now gets its own named, badged container, created on demand.
+///
+/// REUSED across runs by name, so re-importing the same export updates in place instead of growing
+/// "Imported from Notion 2". Matching on the name rather than a stored id is deliberate: the
+/// container belongs to the user the moment it exists, and once they rename or move it, the next
+/// import should start a fresh one rather than reach back into somewhere they reorganised.
+fn import_destination(state: &AppState, source: ImportSource) -> Result<String, AppError> {
+    let (name, emoji) = match source {
+        ImportSource::Notion => ("Imported from Notion", "🗂️"),
+        ImportSource::Obsidian => ("Imported from Obsidian", "🔮"),
+        ImportSource::AppleNotes => ("Imported from Apple Notes", "🍎"),
+    };
+    // The notes root, not the workspace project: this holds NOTES, and `run_import_inner` resolves
+    // its destination through `note_folder_by_id`. A container created by the meeting-side
+    // `create_folder_inner` is not a note folder, so an explicit re-import into it would be refused
+    // as "no note folder" — which is exactly how the control leg of this feature's test caught it.
+    //
+    // `create_note_folder_inner` is also the seam that birth-seals into a locked parent, so an
+    // import under a sealed Notes root inherits the seal instead of writing plaintext into it.
+    let parent = state.db.ensure_notes_root()?;
+    if let Some(existing) = state.db.child_folder_by_name(&parent, name)? {
+        return Ok(existing);
+    }
+    let folder = crate::commands::create_note_folder_inner(state, name, Some(&parent))?;
+    // Cosmetic, and deliberately not fatal: an import that wrote every page correctly must not fail
+    // because a badge did not stick.
+    if let Err(error) = state.db.set_folder_emoji(&folder.id, emoji) {
+        tracing::warn!(target: "import", folder = %folder.id, %error, "could not set the import container emoji");
+    }
+    Ok(folder.id)
+}
+
 /// The synchronous body of [`run_import`], taking `&AppState` so the whole orchestration is
 /// unit-testable against a temp SQLCipher database without a Tauri runtime.
 pub(crate) fn run_import_inner(
@@ -276,7 +312,7 @@ pub(crate) fn run_import_inner(
             }
             f.to_string()
         }
-        _ => state.db.ensure_notes_root()?,
+        _ => import_destination(state, source)?,
     };
 
     let mut report = ImportReport {

--- a/src-tauri/src/commands/import.rs
+++ b/src-tauri/src/commands/import.rs
@@ -244,6 +244,20 @@ pub(crate) fn run_import_inner(
     folder_id: Option<&str>,
     mirror_hierarchy: bool,
 ) -> Result<ImportReport, AppError> {
+    // Murmur's OWN vault is not an import source: every `.md` in there is a note we exported, so
+    // reading it back would duplicate the whole library as copies of itself. `scan_import` reports
+    // this as `isMurmurVault` for the preview, but a FE warning is not a guard — a direct `invoke`
+    // skips it entirely — so the refusal has to live on this side of the IPC boundary too.
+    if matches!(source, ImportSource::Obsidian) {
+        if let (Some(chosen), Some(vault)) = (path, crate::commands::vault_path(state)) {
+            if same_dir(chosen, &vault) {
+                return Err(AppError::InvalidArg(
+                    "that folder is the Obsidian vault Murmur exports to — importing it would read your own notes back in as copies".into(),
+                ));
+            }
+        }
+    }
+
     emit(app, "scanning", 0, 0);
     let scan = scan_source(source, path)?;
     let total = scan.pages.len();

--- a/src-tauri/src/commands/import/tests.rs
+++ b/src-tauri/src/commands/import/tests.rs
@@ -390,8 +390,10 @@ fn imports_an_obsidian_vault_and_leaves_its_wikilinks_untouched() {
 }
 
 #[test]
-fn an_obsidian_re_import_matches_on_the_vault_path() {
-    // The vault has no per-note id, so the relative path is the identity. Re-import must update.
+fn an_obsidian_re_import_matches_on_the_vault_scoped_path() {
+    // The vault has no per-note id, so the identity is the VAULT-SCOPED relative path. Re-importing
+    // the same vault must update; the bare relative path must NOT be the key, because a second
+    // vault holding the same relative path would then overwrite this note.
     let state = build_state("obsidian-reimport");
     let dir = export_dir("obsidian-reimport", &[("Area/Note.md", "# Note\n")]);
     let path = dir.to_str().expect("path");
@@ -405,11 +407,26 @@ fn an_obsidian_re_import_matches_on_the_vault_path() {
     assert_eq!((second.imported, second.updated), (0, 1));
     assert_eq!(imported_notes(&state).len(), 1, "no duplicate");
 
+    let scope = crate::import::obsidian::vault_scope(&dir);
     let found = state
+        .db
+        .note_by_external_id(
+            ImportSource::Obsidian.as_str(),
+            &format!("{scope}:Area/Note"),
+        )
+        .expect("lookup");
+    assert!(
+        found.is_some(),
+        "identity is the vault fingerprint plus the vault-relative path"
+    );
+    let unscoped = state
         .db
         .note_by_external_id(ImportSource::Obsidian.as_str(), "Area/Note")
         .expect("lookup");
-    assert!(found.is_some(), "identity is the vault-relative path");
+    assert!(
+        unscoped.is_none(),
+        "the bare relative path must NOT match — that is what let a second vault overwrite this one"
+    );
     let _ = std::fs::remove_dir_all(&dir);
 }
 
@@ -423,9 +440,18 @@ fn sources_do_not_collide_on_the_same_external_id() {
 
     run_import_inner(None, &state, ImportSource::Obsidian, Some(path), None, false)
         .expect("obsidian");
+    let key = format!("{}:Note", crate::import::obsidian::vault_scope(&dir));
+    assert!(
+        state
+            .db
+            .note_by_external_id(ImportSource::Obsidian.as_str(), &key)
+            .expect("lookup")
+            .is_some(),
+        "CONTROL: the row IS reachable under its own source"
+    );
     let notion = state
         .db
-        .note_by_external_id(ImportSource::Notion.as_str(), "Note")
+        .note_by_external_id(ImportSource::Notion.as_str(), &key)
         .expect("lookup");
     assert!(
         notion.is_none(),
@@ -444,4 +470,151 @@ fn an_unknown_source_is_refused() {
         ImportSource::parse("apple-notes"),
         Some(ImportSource::AppleNotes)
     );
+}
+
+// ── the two-vault collision (BLOCKER oracle) ─────────────────────────────────
+
+#[test]
+fn a_second_vault_with_a_colliding_relative_path_does_not_overwrite_the_first() {
+    // CONTENT-LOSS ORACLE. Two DIFFERENT vaults may both hold `Area/Note.md`. If identity is the
+    // vault-RELATIVE path alone, importing the second silently REPLACES the first vault's title and
+    // body and reports it as a benign "updated" — no warning, no undo. Identity must be scoped to
+    // the vault root, so a second vault creates a NEW note.
+    let state = build_state("obsidian-two-vaults");
+    let vault_a = export_dir(
+        "obsidian-vault-a",
+        &[("Area/Note.md", "# Note\n\nvault A body\n")],
+    );
+    let vault_b = export_dir(
+        "obsidian-vault-b",
+        &[("Area/Note.md", "# Note\n\nvault B body\n")],
+    );
+
+    let first = run_import_inner(
+        None,
+        &state,
+        ImportSource::Obsidian,
+        Some(vault_a.to_str().expect("path")),
+        None,
+        false,
+    )
+    .expect("first vault");
+    assert_eq!((first.imported, first.updated), (1, 0));
+
+    let second = run_import_inner(
+        None,
+        &state,
+        ImportSource::Obsidian,
+        Some(vault_b.to_str().expect("path")),
+        None,
+        false,
+    )
+    .expect("second vault");
+    assert_eq!(
+        (second.imported, second.updated),
+        (1, 0),
+        "a second vault sharing a relative path must CREATE, never overwrite"
+    );
+
+    let rows = imported_notes(&state);
+    assert_eq!(rows.len(), 2, "both vaults' notes exist");
+    assert!(
+        rows.iter().any(|r| r.text.contains("vault A body")),
+        "the first vault's body survived the second import, got: {:?}",
+        rows.iter().map(|r| r.text.as_str()).collect::<Vec<_>>()
+    );
+    assert!(
+        rows.iter().any(|r| r.text.contains("vault B body")),
+        "the second vault's body landed"
+    );
+    let _ = std::fs::remove_dir_all(&vault_a);
+    let _ = std::fs::remove_dir_all(&vault_b);
+}
+
+#[test]
+fn re_importing_the_same_vault_through_a_trailing_slash_still_matches() {
+    // The scope must be CANONICAL: a trailing slash is the same vault, not a second identity.
+    let state = build_state("obsidian-trailing-slash");
+    let dir = export_dir("obsidian-trailing-slash", &[("Area/Note.md", "# Note\n")]);
+    let plain = dir.to_str().expect("path").to_string();
+    let slashed = format!("{plain}/");
+
+    let first = run_import_inner(None, &state, ImportSource::Obsidian, Some(&plain), None, false)
+        .expect("first");
+    assert_eq!((first.imported, first.updated), (1, 0));
+
+    let second = run_import_inner(
+        None,
+        &state,
+        ImportSource::Obsidian,
+        Some(&slashed),
+        None,
+        false,
+    )
+    .expect("second");
+    assert_eq!(
+        (second.imported, second.updated),
+        (0, 1),
+        "a trailing slash names the SAME vault"
+    );
+    assert_eq!(imported_notes(&state).len(), 1, "no duplicate");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn run_import_refuses_murmurs_own_vault_server_side() {
+    // The FE-only `isMurmurVault` warning is not a guard: a direct `invoke` bypasses it and reads
+    // Murmur's own exported notes back in as duplicates. The refusal must live server-side.
+    let state = build_state("own-vault");
+    let dir = export_dir("own-vault", &[("Note.md", "# Note\n")]);
+    let path = dir.to_str().expect("path").to_string();
+    state
+        .config
+        .lock()
+        .expect("config")
+        .vault_path
+        .replace(path.clone());
+
+    let err = run_import_inner(
+        None,
+        &state,
+        ImportSource::Obsidian,
+        Some(&path),
+        None,
+        false,
+    )
+    .expect_err("importing Murmur's own vault must be refused");
+    assert!(
+        matches!(err, AppError::InvalidArg(ref m) if m.contains("vault")),
+        "the refusal should name the vault, got {err:?}"
+    );
+    assert_eq!(imported_notes(&state).len(), 0, "nothing was written");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn a_folder_that_is_not_the_murmur_vault_still_imports() {
+    // CONTROL for the guard above: the ordinary case must keep working with a vault configured.
+    let state = build_state("own-vault-control");
+    let vault = export_dir("own-vault-control-vault", &[("Exported.md", "# Exported\n")]);
+    let other = export_dir("own-vault-control-other", &[("Note.md", "# Note\n")]);
+    state
+        .config
+        .lock()
+        .expect("config")
+        .vault_path
+        .replace(vault.to_str().expect("path").to_string());
+
+    let report = run_import_inner(
+        None,
+        &state,
+        ImportSource::Obsidian,
+        Some(other.to_str().expect("path")),
+        None,
+        false,
+    )
+    .expect("a different folder imports normally");
+    assert_eq!(report.imported, 1);
+    let _ = std::fs::remove_dir_all(&vault);
+    let _ = std::fs::remove_dir_all(&other);
 }

--- a/src-tauri/src/commands/import/tests.rs
+++ b/src-tauri/src/commands/import/tests.rs
@@ -618,3 +618,78 @@ fn a_folder_that_is_not_the_murmur_vault_still_imports() {
     let _ = std::fs::remove_dir_all(&vault);
     let _ = std::fs::remove_dir_all(&other);
 }
+
+// ── the default destination ───────────────────────────────────────────────────
+
+/// An import the user did not file lands in its OWN badged container, not loose in the notes root.
+///
+/// Dropping several hundred Notion pages straight into the root mixed them irreversibly with the
+/// user's own notes, with nothing recording where they came from. The container is created on
+/// demand, named per source, and REUSED on the next run so a re-import updates in place instead of
+/// growing "Imported from Notion 2".
+#[test]
+fn an_unfiled_import_lands_in_a_named_badged_container_and_reuses_it() {
+    let state = build_state("import-destination");
+    let dir = export_dir("import-destination", &two_linked_pages());
+    let path = dir.to_str().expect("path");
+
+    let first = run_import_inner(None, &state, ImportSource::Notion, Some(path), None, false)
+        .expect("first import");
+    assert_eq!(first.imported, 2);
+
+    let containers = state.db.list_containers().expect("containers");
+    let landed: Vec<_> = containers
+        .iter()
+        .filter(|c| c.name == "Imported from Notion")
+        .collect();
+    assert_eq!(
+        landed.len(),
+        1,
+        "exactly one destination container, got: {:?}",
+        containers.iter().map(|c| &c.name).collect::<Vec<_>>()
+    );
+    let destination = landed[0];
+    assert_eq!(
+        destination.emoji.as_deref(),
+        Some("\u{1F5C2}\u{FE0F}"),
+        "the destination carries its badge"
+    );
+
+    // REUSE: a second run of the same export updates in place and creates no second container.
+    let second = run_import_inner(None, &state, ImportSource::Notion, Some(path), None, false)
+        .expect("second import");
+    assert_eq!(
+        second.updated, 2,
+        "the re-import updated rather than duplicated"
+    );
+    assert_eq!(
+        state
+            .db
+            .list_containers()
+            .expect("containers")
+            .iter()
+            .filter(|c| c.name == "Imported from Notion")
+            .count(),
+        1,
+        "the second run reused the container instead of making another"
+    );
+
+    // CONTROL — an EXPLICIT destination still wins, so the default cannot hijack a chosen folder.
+    let chosen = crate::commands::create_note_folder_inner(&state, "Chosen", None)
+        .expect("chosen folder");
+    let third = run_import_inner(
+        None,
+        &state,
+        ImportSource::Notion,
+        Some(path),
+        Some(&chosen.id),
+        false,
+    )
+    .expect("third import");
+    assert_eq!(
+        third.updated, 2,
+        "the same pages, filed where the user asked"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/src-tauri/src/commands/lock.rs
+++ b/src-tauri/src/commands/lock.rs
@@ -51,9 +51,16 @@ use super::*;
 /// the per-container key separation that lets a single folder be unlocked on its own is untouched.
 /// One MCP revocation, held by the caller, covers the whole cascade.
 ///
-/// A container that is ALREADY sealed is skipped rather than re-sealed: locking a project with one
-/// folder already locked is an ordinary thing to do, and re-minting that folder's key would orphan
-/// the ciphertext already written under the old one.
+/// A container that is ALREADY sealed is not RE-KEYED: locking a project with one folder already
+/// locked is an ordinary thing to do, and re-minting that folder's key would orphan the ciphertext
+/// already written under the old one. It is still driven through the ordinary per-container path,
+/// whose already-locked branch is an idempotent repair tail — it bumps the seal epoch, revokes
+/// renderer visibility, drops the folder from the SESSION unlock set and repairs plaintext at rest.
+///
+/// Skipping that tail with a bare `continue` was a leak: a descendant the user had session-unlocked
+/// stayed in `state.unlocked_folders` after its parent project was locked, so every gated reader
+/// — the tree, search, MCP — kept admitting its rows while the UI said the project was sealed.
+/// `locked = 1` is the durable seal JOURNAL, not proof the session-authority cleanup ever ran.
 pub(crate) fn lock_container_subtree(
     state: &AppState,
     folder_id: &str,
@@ -70,13 +77,9 @@ pub(crate) fn lock_container_subtree(
         if id == folder_id {
             continue; // the target is sealed last, below, so its notice fires once at the end.
         }
-        if state
-            .db
-            .folder_by_id(&id)?
-            .is_some_and(|folder| folder.locked)
-        {
-            continue;
-        }
+        // An already-locked descendant is NOT skipped — see this function's doc comment. The
+        // per-container path detects `folder.locked` itself and replays only its idempotent,
+        // non-keyed repair tail, so the existing content key is never re-minted.
         lock_folder_inner_with_visibility_notice_policy(
             state,
             id,
@@ -1169,65 +1172,113 @@ pub fn relock_folder(
         &app,
         crate::mcp::VisibilityRevokingEntrypoint::RelockFolder,
     );
+    relock_folder_inner_with_visibility_notice(state.inner(), &folder_id, || {
+        // Epoch + session membership now authoritatively hide these folders. New MCP responses may
+        // be admitted against that post-revocation snapshot while physical cleanup continues.
+        crate::mcp::finish_visibility_revocation(mcp_revocation);
+        // Emitted while the lifecycle guard is still held. The FE discards cached titles
+        // synchronously; its canonical refresh cannot pass the same guard until physical reblank
+        // has completed.
+        emit_reminder_visibility_invalidated_fail_closed(&app);
+    })?;
+    // The relock purged ALL pending audit findings — ping the FE inbox (count-only).
+    emit_audit_updated_after_purge(&app, state.inner());
+    Ok(())
+}
+
+/// The relock cascade itself, with no `AppHandle` — so it is reachable from tests, exactly like its
+/// sibling [`relock_all_inner_with_visibility_notice`].
+///
+/// `visibility_revoked` runs at the ONE point where the folders have been dropped from the session
+/// unlock set and the seal epoch has advanced, but physical cleanup has not started. That ordering
+/// is load-bearing for screen-share relock: gated readers must be shut out before any fallible
+/// filesystem work, and a later failure must not re-open them.
+pub(crate) fn relock_folder_inner_with_visibility_notice(
+    state: &AppState,
+    folder_id: &str,
+    visibility_revoked: impl FnOnce(),
+) -> Result<(), AppError> {
     // BLK-1: serialize with the rest of the lock state machine (it re-blanks the same columns
     // `remove_lock` is mid-restoring).
-    let _lifecycle = lifecycle_guard(state.inner());
-    if !folder_is_unlocked(state.inner(), &folder_id)? {
+    let _lifecycle = lifecycle_guard(state);
+    if !folder_is_unlocked(state, folder_id)? {
         return Err(AppError::Locked(
             "folder visibility changed before relock preparation".into(),
         ));
     }
-    // Verify EVERY non-empty plaintext family before deleting an export or blanking the first DB
-    // column. Retained blobs must match byte-identically; missing blobs are encrypt+verified into an
-    // immutable repair plan. The lifecycle guard prevents either side changing afterward.
-    let verified = verify_relock_retained_blobs(state.inner(), &folder_id)?;
+    // CASCADE, because `unlock_folder` cascades. Unlocking a container opens its whole subtree
+    // (`preflight_unlock_subtree` + the primary restore's descent into locked descendants), so a
+    // relock that closed only the target left every descendant the unlock had opened still in the
+    // session unlock set — "Lock again" on a project reported sealed while its folders stayed
+    // readable through every gated reader. An asymmetric open/close pair is a leak by construction.
+    //
+    // Deepest-first, matching `lock_container_subtree`. Only SESSION-UNLOCKED containers are
+    // targets: a descendant that was never opened has nothing to re-blank, and `relock` is a
+    // session operation — it does not change any durable `locked` bit.
+    let targets: Vec<String> = container_subtree_deepest_first(state, folder_id)?
+        .into_iter()
+        .filter(|id| folder_is_unlocked(state, id).unwrap_or(false))
+        .collect();
+    // Verify EVERY non-empty plaintext family, for EVERY target, before deleting an export or
+    // blanking the first DB column. Retained blobs must match byte-identically; missing blobs are
+    // encrypt+verified into an immutable repair plan. The lifecycle guard prevents either side
+    // changing afterward. This whole pass is read-only, so a refusal anywhere leaves the entire
+    // subtree exactly as it was — that is why it runs before the destructive export pass below.
+    let mut verified_plans: Vec<(String, VerifiedRelockPlan)> = Vec::with_capacity(targets.len());
+    for id in &targets {
+        verified_plans.push((id.clone(), verify_relock_retained_blobs(state, id)?));
+    }
     // Remove every managed plaintext export before revoking visibility. A user-modified export or
     // collision sibling fails here while the folder is still open, never after `locked` is visible.
-    prepare_folder_exports_before_relock(state.inner(), &folder_id)?;
-    // R7: advance the seal epoch at ENTRY — see `bump_seal_epoch`.
-    bump_seal_epoch(state.inner());
-    // Revoke logical visibility FIRST. Screen-share relock must hide the folder from every gated
-    // UI/MCP reader even when a later filesystem cleanup fails. Keep the cached KEK until the
-    // physical reblank succeeds, though, so the same process retains authority to retry safely.
+    for id in &targets {
+        prepare_folder_exports_before_relock(state, id)?;
+    }
+    // R7: advance the seal epoch at ENTRY — see `bump_seal_epoch`. Once for the whole cascade.
+    bump_seal_epoch(state);
+    // Revoke logical visibility FIRST, for every target at once. Screen-share relock must hide the
+    // folders from every gated UI/MCP reader even when a later filesystem cleanup fails. Keep the
+    // cached KEK until the physical reblank succeeds, though, so the same process retains authority
+    // to retry safely.
     {
         let mut g = state
             .unlocked_folders
             .lock()
             .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?;
-        g.remove(&folder_id);
+        for id in &targets {
+            g.remove(id);
+        }
     }
-    // Epoch + session membership now authoritatively hide this folder. New MCP responses may be
-    // admitted against that post-revocation snapshot while physical cleanup continues.
-    crate::mcp::finish_visibility_revocation(mcp_revocation);
-    // Emit while the lifecycle guard is still held. The FE discards cached titles synchronously;
-    // its canonical refresh cannot pass the same guard until physical reblank has completed.
-    emit_reminder_visibility_invalidated_fail_closed(&app);
+    // Hand the caller its one revocation point — see this function's doc comment.
+    visibility_revoked();
     if let Ok(mut cache) = state.verify_cache.lock() {
         cache.clear();
     }
     // Any interrupted-fresh-seal rows now receive only ciphertexts that the preflight already
     // decrypt-verified against their exact plaintext. This is after export cleanup and logical
     // revocation, but before the first broad reblank.
-    verified.apply_repairs(&state.db)?;
-    let mut one = std::collections::HashSet::new();
-    one.insert(folder_id.clone());
+    for (_, verified) in &verified_plans {
+        verified.apply_repairs(&state.db)?;
+    }
+    let sealed: std::collections::HashSet<String> = targets.iter().cloned().collect();
     // Brain-v3 audit Fix 4: strip the just-re-sealed items' `[[Title]]` markers from VISIBLE sources
     // (in other still-open folders) + re-export their `.md`, BEFORE the relock purge drops the naming
-    // edges.
-    enqueue_marker_cleanup_for_folders(state.inner(), &one)?;
+    // edges. The whole cascade goes in one call so a marker pointing from one re-sealed folder into
+    // another is never treated as "still visible".
+    enqueue_marker_cleanup_for_folders(state, &sealed)?;
     // The re-blank tx also purges ALL memory rollups (may paraphrase the re-sealed facts) and
     // returns their exported vault paths — the files are removed here (command layer).
     remove_rollup_exports_before_seal_purge(&state.db)?;
-    let rollup_exports = state.db.blank_sealed_notes_in_folders(&one)?;
+    let rollup_exports = state.db.blank_sealed_notes_in_folders(&sealed)?;
     remove_rollup_export_files(&rollup_exports);
     // Phase 0.5 — re-blank the transcript + timeline plaintext and drop the decrypted session WAV
-    // (the .enc + the *_blob columns stay; the folder is still locked=1 on disk).
-    reblank_folder_extras_after_verification(state.inner(), &folder_id, verified.ck())?;
+    // (the .enc + the *_blob columns stay; the folders are still locked=1 on disk). Per folder,
+    // because each carries its OWN content key.
+    for (id, verified) in &verified_plans {
+        reblank_folder_extras_after_verification(state, id, verified.ck())?;
+    }
     drain_lock_marker_export_cleanup(&state.db)?;
-    // The folder has remained logically hidden throughout. A failure above retains the cached KEK
+    // The folders have remained logically hidden throughout. A failure above retains the cached KEK
     // for a repair retry; success leaves it available for other still-unlocked folders.
-    // The relock purged ALL pending audit findings — ping the FE inbox (count-only).
-    emit_audit_updated_after_purge(&app, state.inner());
     Ok(())
 }
 

--- a/src-tauri/src/commands/org.rs
+++ b/src-tauri/src/commands/org.rs
@@ -485,9 +485,21 @@ pub(crate) async fn share_note_to_link_inner(
     let share_id = crate::share::new_share_id();
     let rev = 1u32;
     require_current_org_share_snapshot(state, Some(&meeting_id), None, &source.source_version)?;
-    // Mint the exact owner-bound cleanup authority before capability discovery. An old/unavailable
-    // relay therefore leaves a visible, retryable local journal rather than losing the id. Recovery
-    // may reserve + DELETE this id, but it never redispatches the content POST.
+    // Capability discovery FIRST, then mint the owner-bound cleanup authority. Discovery is a pure
+    // read (`client.health` -> GET /healthz) that mutates nothing remote, so a journal row written
+    // ahead of it could only ever describe work that never started.
+    //
+    // Writing it first permanently locked the source out (2.0 audit). Against a relay that does not
+    // advertise the capability: the first click journalled a 'create_pending' row and then failed;
+    // the second failed EARLIER and DIFFERENTLY, on `insert_outbound_share_attempt` returning false,
+    // with the bare untagged "an interrupted link-share cleanup is already pending"; and the only
+    // recovery path, `revoke_share_inner`, needs the SAME missing capability, so it could never
+    // converge. Two clicks and that source could not be shared again without a DB repair.
+    //
+    // The guarantee the original ordering existed for is untouched: once the capability IS present
+    // the journal row is still written before the content POST, so a POST failing mid-flight still
+    // leaves a visible, retryable local journal rather than losing the id.
+    require_share_owner_claim_capability(state, &client).await?;
     if !state.db.insert_outbound_share_attempt(
         &share_id,
         Some(&meeting_id),
@@ -502,7 +514,6 @@ pub(crate) async fn share_note_to_link_inner(
                 .into(),
         ));
     }
-    require_share_owner_claim_capability(state, &client).await?;
 
     let OrgShareBodySnapshot {
         title,
@@ -658,6 +669,21 @@ pub(crate) async fn share_note_to_link_doc_inner(
     let share_id = crate::share::new_share_id();
     let rev = 1u32;
     require_current_org_share_snapshot(state, None, Some(&id), &source.source_version)?;
+    // Capability discovery FIRST, then mint the owner-bound cleanup authority. Discovery is a pure
+    // read (`client.health` -> GET /healthz) that mutates nothing remote, so a journal row written
+    // ahead of it could only ever describe work that never started.
+    //
+    // Writing it first permanently locked the source out (2.0 audit). Against a relay that does not
+    // advertise the capability: the first click journalled a 'create_pending' row and then failed;
+    // the second failed EARLIER and DIFFERENTLY, on `insert_outbound_share_attempt` returning false,
+    // with the bare untagged "an interrupted link-share cleanup is already pending"; and the only
+    // recovery path, `revoke_share_inner`, needs the SAME missing capability, so it could never
+    // converge. Two clicks and that source could not be shared again without a DB repair.
+    //
+    // The guarantee the original ordering existed for is untouched: once the capability IS present
+    // the journal row is still written before the content POST, so a POST failing mid-flight still
+    // leaves a visible, retryable local journal rather than losing the id.
+    require_share_owner_claim_capability(state, &client).await?;
     if !state.db.insert_outbound_share_attempt(
         &share_id,
         None,
@@ -672,7 +698,6 @@ pub(crate) async fn share_note_to_link_doc_inner(
                 .into(),
         ));
     }
-    require_share_owner_claim_capability(state, &client).await?;
 
     let OrgShareBodySnapshot {
         title,
@@ -1403,6 +1428,21 @@ pub(crate) async fn share_note_to_user_inner(
     let share_id = crate::share::new_share_id();
     let rev = 1u32;
     require_current_org_share_snapshot(state, Some(&meeting_id), None, &source.source_version)?;
+    // Capability discovery FIRST, then mint the owner-bound cleanup authority. Discovery is a pure
+    // read (`client.health` -> GET /healthz) that mutates nothing remote, so a journal row written
+    // ahead of it could only ever describe work that never started.
+    //
+    // Writing it first permanently locked the source out (2.0 audit). Against a relay that does not
+    // advertise the capability: the first click journalled a 'create_pending' row and then failed;
+    // the second failed EARLIER and DIFFERENTLY, on `insert_outbound_share_attempt` returning false,
+    // with the bare untagged "an interrupted link-share cleanup is already pending"; and the only
+    // recovery path, `revoke_share_inner`, needs the SAME missing capability, so it could never
+    // converge. Two clicks and that source could not be shared again without a DB repair.
+    //
+    // The guarantee the original ordering existed for is untouched: once the capability IS present
+    // the journal row is still written before the content POST, so a POST failing mid-flight still
+    // leaves a visible, retryable local journal rather than losing the id.
+    require_share_owner_claim_capability(state, &client).await?;
     if !state.db.insert_outbound_share_attempt(
         &share_id,
         Some(&meeting_id),
@@ -1417,7 +1457,6 @@ pub(crate) async fn share_note_to_user_inner(
                 .into(),
         ));
     }
-    require_share_owner_claim_capability(state, &client).await?;
 
     let OrgShareBodySnapshot {
         title,

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -31986,106 +31986,172 @@
         config.share_base_url = base.to_string();
     }
 
+    // REMOVED (2.0): `link_share_missing_owner_claim_capability_keeps_retryable_journal_without_content`
+    //
+    // It pinned the OPPOSITE contract to the regression below, and only one of them can hold: it
+    // asserted that a refused capability check LEAVES a `create_pending` journal row and that the
+    // second click is bounded by that row rather than re-probing. That bounding is what made the
+    // source permanently unshareable — the second click failed on the journal guard with a
+    // different, untagged message, and the only recovery path needed the very capability that was
+    // missing. The row was never load-bearing here: the capability proof is a bearer-free
+    // GET /healthz that leaves no remote state, so there is nothing to clean up after it refuses.
+    //
+    // What it protected against — hammering an old relay — costs one bearer-free GET per MANUAL
+    // click, which is not a rate-limiting problem worth a locked-out source. Its coverage now lives
+    // in the regression below, which additionally carries a CONTROL (the same source shares
+    // normally once the relay advertises the capability) so it cannot pass vacuously.
+
+    /// REGRESSION (2.0 blocker): a refused PRECONDITION must not permanently lock the source out.
+    ///
+    /// The relay-capability proof (`require_share_owner_claim_capability`) is a pure precondition —
+    /// it leaves no remote state (a bearer-free `GET /healthz`). Committing the durable
+    /// `outbound_shares` journal row BEFORE it meant the FIRST refused click wrote a
+    /// `create_pending` row, and every LATER click hit `insert_outbound_share_attempt`'s
+    /// "one create_pending per (mode, owner, source)" guard instead — a different, untagged
+    /// `Unavailable("… cleanup is already pending …")` the frontend cannot map, while the recovery
+    /// path (`revoke_share_inner`) needs the very capability that is missing, so it never converges.
+    /// The source became permanently unshareable without a DB repair.
+    ///
+    /// Oracle: two consecutive refusals return the SAME tagged refusal, leave NO journal row, and
+    /// the source still shares normally once the relay advertises the capability (the CONTROL —
+    /// without it this test could pass vacuously on a build where sharing is broken outright).
     #[test]
-    fn link_share_missing_owner_claim_capability_keeps_retryable_journal_without_content() {
+    fn link_share_capability_refusal_is_idempotent_and_leaves_the_source_shareable() {
         use std::io::Write;
 
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let probe = listener.try_clone().unwrap();
         let addr = listener.local_addr().unwrap();
+        let (share_tx, share_rx) = std::sync::mpsc::channel();
         let server = std::thread::spawn(move || {
+            // Two capability probes from an OLD relay (no `share-owner-claim-v1`).
+            for _ in 0..2 {
+                let (mut health, _) = accept_with_timeout(&listener);
+                let request = String::from_utf8_lossy(&read_http_request(&mut health)).to_string();
+                assert!(request.starts_with("GET /healthz "));
+                let body = r#"{"status":"ok","version":"0.1.0"}"#;
+                write!(health,"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",body.len()).unwrap();
+            }
+            // CONTROL: the relay is upgraded; the very same source must still share.
             let (mut health, _) = accept_with_timeout(&listener);
             let request = String::from_utf8_lossy(&read_http_request(&mut health)).to_string();
             assert!(request.starts_with("GET /healthz "));
-            assert!(
-                !request.to_ascii_lowercase().contains("authorization:"),
-                "health capability discovery must remain bearer-free"
-            );
-            let body = r#"{"status":"ok","version":"0.1.0"}"#;
-            write!(
-                    health,
-                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
-                    body.len()
-                )
-                .unwrap();
-        });
+            let body = r#"{"status":"ok","version":"0.1.0","capabilities":["share-owner-claim-v1"]}"#;
+            write!(health,"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",body.len()).unwrap();
 
-        let state = build_state("link-share-capability-required");
-        seed_link_share_source(
-            &state,
-            "claim-cap-folder",
-            "claim-cap-meeting",
-            &format!("http://{addr}/"),
-        );
-        let error = block_on(share_note_to_link_inner(
-            &state,
-            "claim-cap-meeting".into(),
-            None,
-            None,
-            None,
-        ))
-        .expect_err("an old relay must fail closed before share creation");
-        server.join().unwrap();
-        assert!(matches!(
-            error,
-            AppError::Unavailable(message)
-                if message.starts_with("[sharing-upgrade-required] ")
-        ));
-        probe.set_nonblocking(true).unwrap();
-        let second = block_on(share_note_to_link_inner(
-            &state,
-            "claim-cap-meeting".into(),
-            None,
-            None,
-            None,
-        ))
-        .expect_err("the existing cleanup journal bounds repeated old-relay clicks");
-        assert!(matches!(
-            second,
-            AppError::Unavailable(message) if message.contains("cleanup is already pending")
-        ));
-        assert!(matches!(
-            probe.accept(),
-            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock
-        ));
-        let journal: (i64, String, String, String) = state
-            .db
-            .lock()
-            .query_row(
-                "SELECT COUNT(*),state,mode,owner_user_id FROM outbound_shares",
-                [],
-                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            let (mut reserve, _) = accept_with_timeout(&listener);
+            let request = read_http_request(&mut reserve);
+            let request_text = String::from_utf8_lossy(&request);
+            let share_id = request_text
+                .lines()
+                .next()
+                .unwrap()
+                .strip_prefix("PUT /v1/shares/")
+                .and_then(|tail| tail.strip_suffix("/reservation HTTP/1.1"))
+                .expect("reservation path carries the exact client id")
+                .to_string();
+            write!(
+                reserve,
+                "HTTP/1.1 204 No Content\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
             )
             .unwrap();
-        assert_eq!(
-            journal.0, 1,
-            "one bounded cleanup authority survives capability failure"
+
+            let (mut create, _) = accept_with_timeout(&listener);
+            let request = read_http_request(&mut create);
+            let body_at = request.windows(4).position(|w| w == b"\r\n\r\n").unwrap() + 4;
+            let json: serde_json::Value = serde_json::from_slice(&request[body_at..]).unwrap();
+            assert_eq!(json["shareId"], share_id);
+            let body =
+                format!("{{\"shareId\":\"{share_id}\",\"shareBaseUrl\":\"http://share.invalid\"}}");
+            write!(create,"HTTP/1.1 201 Created\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",body.len()).unwrap();
+            share_tx.send(share_id).unwrap();
+        });
+
+        let state = build_state("link-share-capability-retry");
+        seed_link_share_source(
+            &state,
+            "cap-retry-folder",
+            "cap-retry-meeting",
+            &format!("http://{addr}/"),
         );
-        assert_eq!(journal.1, "create_pending");
-        assert_eq!(journal.2, "link");
-        assert_eq!(journal.3, "c534b6d2-02c1-4c2c-a256-3af8592b1567");
+
+        let mut refusals = Vec::new();
+        for _ in 0..2 {
+            let error = block_on(share_note_to_link_inner(
+                &state,
+                "cap-retry-meeting".into(),
+                None,
+                None,
+                None,
+            ))
+            .expect_err("an old relay must fail closed before share creation");
+            let AppError::Unavailable(message) = error else {
+                panic!("a refused precondition must stay Unavailable");
+            };
+            assert!(
+                message.starts_with("[sharing-upgrade-required] "),
+                "every repeated click must carry the SAME tagged refusal, got: {message}"
+            );
+            refusals.push(message);
+        }
+        assert_eq!(
+            refusals[0], refusals[1],
+            "the second click must not degrade into a different, untagged failure"
+        );
+
+        let rows: i64 = state
+            .db
+            .lock()
+            .query_row("SELECT COUNT(*) FROM outbound_shares", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(
+            rows, 0,
+            "a refused local precondition must leave NO durable journal row to recover"
+        );
+
+        // CONTROL — the same source shares normally once the capability appears.
+        let url = block_on(share_note_to_link_inner(
+            &state,
+            "cap-retry-meeting".into(),
+            None,
+            None,
+            None,
+        ))
+        .expect("the source is still shareable after the relay is upgraded");
+        server.join().unwrap();
+        let share_id = share_rx.recv().unwrap();
+        assert!(url.contains(&format!("#{}.", share_id)));
+        let stored: (i64, String) = state
+            .db
+            .lock()
+            .query_row("SELECT COUNT(*),MAX(state) FROM outbound_shares", [], |row| {
+                Ok((row.get(0)?, row.get(1)?))
+            })
+            .unwrap();
+        assert_eq!(stored.0, 1);
+        assert_eq!(stored.1, "active");
         assert_eq!(
             state
                 .db
                 .count_share_egress_by_kind("share_capability_read")
                 .unwrap(),
-            1
+            3
         );
         assert_eq!(
             state
                 .db
                 .count_share_egress_by_kind("share_reserve")
                 .unwrap(),
-            0
+            1,
+            "no reservation is dispatched while the capability is missing"
         );
         assert_eq!(
             state.db.count_share_egress_by_kind("share_create").unwrap(),
-            0
+            1
         );
     }
 
     #[test]
-    fn user_share_missing_owner_claim_capability_keeps_content_free_retry_journal() {
+    fn user_share_missing_owner_claim_capability_leaves_no_journal_and_no_recipient_pii() {
         use std::io::Write;
 
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
@@ -32124,24 +32190,20 @@
             probe.accept(),
             Err(error) if error.kind() == std::io::ErrorKind::WouldBlock
         ));
-        let journal: (String, String, Option<String>, Option<Vec<u8>>) = state
+        // The capability proof now runs BEFORE the journal write, so a refused precondition leaves
+        // NOTHING behind — see the removal note above `link_share_capability_refusal_is_idempotent…`.
+        // This used to assert the shape of a `create_pending` row (state/mode present, recipient
+        // email and content hash both NULL). The privacy property it existed for — recipient PII is
+        // never captured before the capability proof — now holds a fortiori: there is no row to
+        // capture it into. Asserting on the whole table keeps that guarantee checkable.
+        let rows: i64 = state
             .db
             .lock()
-            .query_row(
-                "SELECT state,mode,recipient_email,content_hash FROM outbound_shares",
-                [],
-                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
-            )
+            .query_row("SELECT COUNT(*) FROM outbound_shares", [], |row| row.get(0))
             .unwrap();
-        assert_eq!(journal.0, "create_pending");
-        assert_eq!(journal.1, "user");
         assert_eq!(
-            journal.2, None,
-            "recipient PII is not captured before capability proof"
-        );
-        assert_eq!(
-            journal.3, None,
-            "no ciphertext hash exists before capability proof"
+            rows, 0,
+            "a refused capability precondition must leave no journal row — and therefore no recipient PII"
         );
         assert_eq!(
             state

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -4448,6 +4448,173 @@
         );
     }
 
+    /// RELOCK MUST CASCADE, BECAUSE UNLOCK CASCADES.
+    ///
+    /// Regression for the 2.0 audit finding. `unlock_folder` opens a container's WHOLE subtree
+    /// (`preflight_unlock_subtree`, then the primary restore descends into locked descendants),
+    /// but `relock_folder` closed only the folder it was handed. So "Lock again" on a project
+    /// reported sealed while every folder the unlock had opened stayed in the session unlock set,
+    /// readable through the tree, through search and through MCP.
+    ///
+    /// An asymmetric open/close pair is a leak by construction: whatever the open reaches, the
+    /// close must reach too.
+    #[test]
+    fn relocking_a_project_re_closes_its_whole_subtree() {
+        let vault = tmp_vault("relock-cascade");
+        let state = build_state_with_vault("relock-cascade", &vault);
+        make_open_folder(&state.db, "p-acme", "Acme");
+        make_open_child_folder(&state.db, "f-weekly", "Acme/Weekly", "p-acme");
+        std::fs::create_dir_all(vault.join("Acme/Weekly")).unwrap();
+        seed_meeting(&state.db, "m-deep", "Layoff plan", Some("f-weekly"));
+
+        // Seal the project (which cascades), then open the whole subtree the way `unlock_folder`
+        // leaves it: every container in the subtree present in the session unlock set.
+        let revocation = crate::mcp::begin_visibility_revocation_for_gate(
+            None,
+            crate::mcp::VisibilityRevokingEntrypoint::LockFolder,
+        );
+        crate::commands::lock_folder_with_visibility_revocation(&state, "p-acme", revocation)
+            .unwrap();
+        {
+            let mut g = state.unlocked_folders.lock().unwrap();
+            g.insert("p-acme".to_string());
+            g.insert("f-weekly".to_string());
+        }
+
+        // Relock the PROJECT only.
+        relock_folder_inner_with_visibility_notice(&state, "p-acme", || {})
+            .unwrap();
+
+        // THE ASSERTION THAT WAS FAILING: the descendant must be closed too.
+        let still_open = state.unlocked_folders.lock().unwrap().clone();
+        assert!(
+            !still_open.contains("f-weekly"),
+            "relocking the project left its descendant session-unlocked: {still_open:?}"
+        );
+        assert!(
+            !still_open.contains("p-acme"),
+            "relocking the project left the project itself session-unlocked: {still_open:?}"
+        );
+        assert!(
+            state
+                .db
+                .get_note_if_visible("m-deep", &still_open)
+                .unwrap()
+                .is_none(),
+            "a gated reader still returns a note from inside a relocked project"
+        );
+    }
+
+    /// CONTROL for the relock cascade: it must close the subtree of the folder it was given, and
+    /// NOTHING outside it. A cascade that over-reaches would silently relock an unrelated folder
+    /// the user still has open — which reads as data disappearing.
+    #[test]
+    fn the_relock_cascade_does_not_touch_a_sibling_subtree() {
+        let vault = tmp_vault("relock-scope");
+        let state = build_state_with_vault("relock-scope", &vault);
+        make_open_folder(&state.db, "p-acme", "Acme");
+        make_open_child_folder(&state.db, "f-weekly", "Acme/Weekly", "p-acme");
+        make_open_folder(&state.db, "p-other", "Other");
+        std::fs::create_dir_all(vault.join("Acme/Weekly")).unwrap();
+        std::fs::create_dir_all(vault.join("Other")).unwrap();
+
+        for target in ["p-acme", "p-other"] {
+            let revocation = crate::mcp::begin_visibility_revocation_for_gate(
+                None,
+                crate::mcp::VisibilityRevokingEntrypoint::LockFolder,
+            );
+            crate::commands::lock_folder_with_visibility_revocation(&state, target, revocation)
+                .unwrap();
+        }
+        {
+            let mut g = state.unlocked_folders.lock().unwrap();
+            g.insert("p-acme".to_string());
+            g.insert("f-weekly".to_string());
+            g.insert("p-other".to_string());
+        }
+
+        relock_folder_inner_with_visibility_notice(&state, "p-acme", || {})
+            .unwrap();
+
+        let still_open = state.unlocked_folders.lock().unwrap().clone();
+        assert!(
+            still_open.contains("p-other"),
+            "the relock cascade reached outside its own subtree: {still_open:?}"
+        );
+        assert!(
+            !still_open.contains("p-acme") && !still_open.contains("f-weekly"),
+            "the relock cascade did not close its own subtree: {still_open:?}"
+        );
+    }
+
+    /// LOCKING A PROJECT MUST RE-CLOSE A DESCENDANT THE USER HAD SESSION-UNLOCKED.
+    ///
+    /// Regression for the 2.0 audit finding. `lock_container_subtree` used to `continue` past any
+    /// descendant whose durable `locked` bit was already set. Skipping the RE-KEY is correct —
+    /// re-minting that folder's content key would orphan the ciphertext already written under the
+    /// old one — but the bare `continue` also skipped the per-container path's already-locked
+    /// branch, which is the ONLY place that bumps the seal epoch, revokes renderer visibility and
+    /// drops the folder from `state.unlocked_folders`.
+    ///
+    /// So: lock a folder, session-unlock it, then lock its parent project. The project reports
+    /// sealed, the child's `locked` bit was already 1 — and the child stayed in the session unlock
+    /// set, so every gated reader (tree, search, MCP) kept serving its rows. `locked = 1` is the
+    /// durable seal JOURNAL, not proof the session-authority cleanup ever ran.
+    #[test]
+    fn locking_a_project_re_closes_a_session_unlocked_descendant() {
+        let vault = tmp_vault("cascade-reclose");
+        let state = build_state_with_vault("cascade-reclose", &vault);
+        make_open_folder(&state.db, "p-acme", "Acme");
+        make_open_child_folder(&state.db, "f-weekly", "Acme/Weekly", "p-acme");
+        std::fs::create_dir_all(vault.join("Acme/Weekly")).unwrap();
+        seed_meeting(&state.db, "m-deep", "Layoff plan", Some("f-weekly"));
+
+        // The child is sealed on its own first…
+        let revocation = crate::mcp::begin_visibility_revocation_for_gate(
+            None,
+            crate::mcp::VisibilityRevokingEntrypoint::LockFolder,
+        );
+        crate::commands::lock_folder_with_visibility_revocation(&state, "f-weekly", revocation)
+            .unwrap();
+        // …and then session-unlocked, exactly as `unlock_folder` leaves it.
+        state
+            .unlocked_folders
+            .lock()
+            .unwrap()
+            .insert("f-weekly".to_string());
+
+        // Now lock the PARENT project.
+        let revocation = crate::mcp::begin_visibility_revocation_for_gate(
+            None,
+            crate::mcp::VisibilityRevokingEntrypoint::LockFolder,
+        );
+        crate::commands::lock_folder_with_visibility_revocation(&state, "p-acme", revocation)
+            .unwrap();
+
+        // THE ASSERTION THAT WAS FAILING: the descendant must no longer be session-unlocked.
+        let still_open = state.unlocked_folders.lock().unwrap().clone();
+        assert!(
+            !still_open.contains("f-weekly"),
+            "locking the project left its descendant session-unlocked: {still_open:?}"
+        );
+        // And therefore the gated reader must withhold its content.
+        assert!(
+            state
+                .db
+                .get_note_if_visible("m-deep", &still_open)
+                .unwrap()
+                .is_none(),
+            "a gated reader still returns a note from a descendant of a locked project"
+        );
+
+        // CONTROL — the child's durable seal was NOT re-keyed. Its wrapped key still exists, so
+        // the existing ciphertext is still openable; a re-mint would have orphaned it.
+        assert!(
+            state.db.folder_wrapped_key("f-weekly").unwrap().is_some(),
+            "the already-sealed descendant lost its wrapped key — its ciphertext is now orphaned"
+        );
+    }
+
     /// The cascade is DEEPEST-FIRST, so a failure can only over-lock, never under-lock.
     ///
     /// Locking is not atomic across containers. Whichever order the cascade takes decides what a

--- a/src-tauri/src/errcode.rs
+++ b/src-tauri/src/errcode.rs
@@ -126,6 +126,14 @@ pub const SHARING_REJECTED: &str = "sharing-rejected";
 pub const ORG_EDIT_CONFLICT: &str = "org-edit-conflict";
 /// The sharing session is gone (401) — the user must sign in again.
 pub const SHARING_SIGNIN_REQUIRED: &str = "sharing-signin-required";
+/// An org-only surface was opened by an install that has NO sharing account at all.
+///
+/// DISTINCT from [`SHARING_SIGNIN_REQUIRED`] on purpose, and the difference is the whole point:
+/// that one means a session existed and lapsed, so "sign in again" is the right sentence. This one
+/// is the DEFAULT state of Murmur — local-first, fully usable with no account — meeting a feature
+/// that lives inside a Shared Brain org. It is not an error and must never render as one; the
+/// surface turns it into an explanation of what the feature is, plus a way in.
+pub const SHARING_ACCOUNT_REQUIRED: &str = "sharing-account-required";
 /// The configured relay has not advertised the owner-bound share reservation contract required to
 /// prevent a delayed create from resurrecting ciphertext after local deletion/lock.
 pub const SHARING_UPGRADE_REQUIRED: &str = "sharing-upgrade-required";
@@ -160,6 +168,7 @@ pub const ALL: &[&str] = &[
     SHARING_REJECTED,
     ORG_EDIT_CONFLICT,
     SHARING_SIGNIN_REQUIRED,
+    SHARING_ACCOUNT_REQUIRED,
     SHARING_UPGRADE_REQUIRED,
     REMINDERS_DENIED,
 ];
@@ -240,6 +249,12 @@ mod tests {
             "sharing-rejected",
             "org-edit-conflict",
             "sharing-signin-required",
+            // Added 2.0: the org-only Tasks surface met by an install that has no account at all.
+            // Deliberately NOT folded into `sharing-signin-required` — that one says "you were
+            // signed out", which is a lie to a user who never had an account. Landing here means
+            // updating `src/app/core/copy/error-copy.service.ts` in the same commit; that is the
+            // whole point of this test.
+            "sharing-account-required",
             "sharing-upgrade-required",
             "reminders-denied",
         ];

--- a/src-tauri/src/import/mod.rs
+++ b/src-tauri/src/import/mod.rs
@@ -15,7 +15,7 @@
 //! | Source | Identity (`external_id`) | Body | Links |
 //! |---|---|---|---|
 //! | Notion | the 32-hex page id in every filename | Markdown, verbatim | relative paths rewritten to `[[wikilinks]]` |
-//! | Obsidian | the vault-relative path | Markdown, verbatim | already `[[wikilinks]]` — left alone |
+//! | Obsidian | the vault-relative path, SCOPED to a fingerprint of the vault root | Markdown, verbatim | already `[[wikilinks]]` — left alone |
 //! | Apple Notes | the note's Core Data id | HTML rendered to text | none to speak of |
 
 use std::collections::BTreeMap;

--- a/src-tauri/src/import/obsidian.rs
+++ b/src-tauri/src/import/obsidian.rs
@@ -5,15 +5,26 @@
 //! folder, reads each file **verbatim**, and touches nothing. Rewriting links here would be actively
 //! wrong: they are already in the target form, and our own link indexer resolves them by title.
 //!
-//! IDENTITY is the vault-relative PATH. A vault has no per-note id, and the path is the only key
-//! that is stable across re-imports, which is what makes a second run update rather than duplicate.
-//! Its weakness is honest and worth stating: move a note inside the vault and the next import treats
-//! it as new. Notion's 32-hex id has no such problem, which is exactly why that source uses it.
+//! IDENTITY is the VAULT-SCOPED relative path — `<vault fingerprint>:<relative path>`. A vault has
+//! no per-note id, and the path is the only key that is stable across re-imports, which is what
+//! makes a second run update rather than duplicate. But the relative path ALONE is not an identity:
+//! two different vaults routinely both contain `Area/Note.md`, and keying on the bare relative path
+//! made importing the second vault silently OVERWRITE the first one's title and body, reported as a
+//! benign "updated", with no warning and no undo. So the key is prefixed with a fingerprint of the
+//! CANONICALIZED vault root: a second vault produces new notes, while re-importing the same vault
+//! through a trailing slash or a symlink still matches and updates.
+//!
+//! Its remaining weakness is honest and worth stating: move a note inside the vault, or move the
+//! vault itself, and the next import treats it as new. Notion's 32-hex id has no such problem,
+//! which is exactly why that source uses it.
 //!
 //! WHAT IS SKIPPED: `.obsidian/` (workspace config, plugins, hotkeys — never content), `.trash/`
 //! (deleted notes; importing them would resurrect what the user threw away), and every dotfile.
 
+use std::fmt::Write as _;
 use std::path::Path;
+
+use sha2::{Digest, Sha256};
 
 use super::{title_from_body_or_stem, ImportScan, ImportedPage, MAX_PAGES_PER_IMPORT};
 use crate::error::{AppError, Result};
@@ -32,6 +43,7 @@ pub(crate) fn scan_vault(root: &Path) -> Result<ImportScan> {
             "pick the vault FOLDER — an Obsidian vault is a directory of .md files".into(),
         ));
     }
+    let scope = vault_scope(root);
     let mut scan = ImportScan::default();
     let mut stack = vec![(root.to_path_buf(), Vec::<String>::new())];
     while let Some((dir, parents)) = stack.pop() {
@@ -78,7 +90,7 @@ pub(crate) fn scan_vault(root: &Path) -> Result<ImportScan> {
                 continue;
             };
             let stem = name.strip_suffix(".md").unwrap_or(&name).to_string();
-            let external_id = relative_id(&parents, &stem);
+            let external_id = vault_external_id(&scope, &parents, &stem);
             scan.pages.push(ImportedPage {
                 external_id: Some(external_id),
                 title: title_from_body_or_stem(&markdown, &stem),
@@ -91,12 +103,38 @@ pub(crate) fn scan_vault(root: &Path) -> Result<ImportScan> {
     Ok(scan)
 }
 
-/// The vault-relative path used as the stable identity, e.g. `Projects/Q4/Plan`.
+/// The vault-relative path, e.g. `Projects/Q4/Plan`. Half of the identity, never the whole of it.
 fn relative_id(parents: &[String], stem: &str) -> String {
     if parents.is_empty() {
         return stem.to_string();
     }
     format!("{}/{}", parents.join("/"), stem)
+}
+
+/// Length of the vault fingerprint kept in every id. 16 hex chars = 64 bits: far past the point
+/// where two vaults on one Mac could collide, and short enough that the id stays readable.
+const VAULT_SCOPE_HEX: usize = 16;
+
+/// A stable fingerprint of WHICH vault this is.
+///
+/// CANONICALIZED first, so `~/Vault`, `~/Vault/`, and a symlink pointing at it are one identity and
+/// a re-import updates rather than duplicates. Canonicalization can fail (a path that vanished
+/// between the picker and here); falling back to the path as given is the safe direction — it can
+/// only ever split one vault into two identities, never merge two vaults into one, and merging is
+/// the failure that destroys content.
+pub(crate) fn vault_scope(root: &Path) -> String {
+    let canonical = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let digest = Sha256::digest(canonical.as_os_str().as_encoded_bytes());
+    let mut out = String::with_capacity(VAULT_SCOPE_HEX);
+    for byte in digest.iter().take(VAULT_SCOPE_HEX / 2) {
+        let _ = write!(&mut out, "{byte:02x}");
+    }
+    out
+}
+
+/// The stable identity of one note: `<vault fingerprint>:<vault-relative path>`.
+pub(crate) fn vault_external_id(scope: &str, parents: &[String], stem: &str) -> String {
+    format!("{scope}:{}", relative_id(parents, stem))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/import/obsidian/tests.rs
+++ b/src-tauri/src/import/obsidian/tests.rs
@@ -3,14 +3,20 @@
 
 use super::*;
 
-/// Build a temp vault from `(relative path, contents)` pairs and scan it.
-fn vault(files: &[(&str, &str)]) -> ImportScan {
+/// Materialize a temp vault from `(relative path, contents)` pairs. The caller owns cleanup.
+fn make_vault(files: &[(&str, &str)]) -> std::path::PathBuf {
     let root = std::env::temp_dir().join(format!("murmur-vault-{}", uuid::Uuid::new_v4()));
     for (rel, body) in files {
         let path = root.join(rel);
         std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
         std::fs::write(&path, body).expect("write");
     }
+    root
+}
+
+/// Build a temp vault from `(relative path, contents)` pairs and scan it.
+fn vault(files: &[(&str, &str)]) -> ImportScan {
+    let root = make_vault(files);
     let scan = scan_vault(&root).expect("scan");
     let _ = std::fs::remove_dir_all(&root);
     scan
@@ -27,13 +33,57 @@ fn reads_notes_and_keeps_the_markdown_verbatim() {
 }
 
 #[test]
-fn the_identity_is_the_vault_relative_path() {
-    let scan = vault(&[("Projects/Q4/Plan.md", "# Plan")]);
-    assert_eq!(
-        scan.pages[0].external_id.as_deref(),
-        Some("Projects/Q4/Plan")
-    );
+fn the_identity_is_the_vault_scoped_relative_path() {
+    let root = make_vault(&[("Projects/Q4/Plan.md", "# Plan")]);
+    let scan = scan_vault(&root).expect("scan");
+    let expected = format!("{}:Projects/Q4/Plan", vault_scope(&root));
+    assert_eq!(scan.pages[0].external_id.as_deref(), Some(expected.as_str()));
     assert_eq!(scan.pages[0].parents, vec!["Projects", "Q4"]);
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn two_vaults_sharing_a_relative_path_get_different_identities() {
+    // CONTENT-LOSS ORACLE at the normalizer level. Keyed on the relative path ALONE, importing a
+    // second vault that also holds `Area/Note.md` overwrote the first one's note.
+    let a = make_vault(&[("Area/Note.md", "# Note\n\nvault A\n")]);
+    let b = make_vault(&[("Area/Note.md", "# Note\n\nvault B\n")]);
+    let id_a = scan_vault(&a).expect("scan a").pages[0]
+        .external_id
+        .clone()
+        .expect("id a");
+    let id_b = scan_vault(&b).expect("scan b").pages[0]
+        .external_id
+        .clone()
+        .expect("id b");
+    assert_ne!(id_a, id_b, "two vaults are two identities");
+    assert!(
+        id_a.ends_with(":Area/Note") && id_b.ends_with(":Area/Note"),
+        "the relative path is still the readable half, got {id_a} / {id_b}"
+    );
+    let _ = std::fs::remove_dir_all(&a);
+    let _ = std::fs::remove_dir_all(&b);
+}
+
+#[test]
+fn the_same_vault_named_two_ways_keeps_one_identity() {
+    // CONTROL. Scoping must not split a re-import of the SAME vault into a second identity just
+    // because the picker handed us a trailing slash or a symlinked path.
+    let root = make_vault(&[("Area/Note.md", "# Note")]);
+    let slashed = std::path::PathBuf::from(format!("{}/", root.to_str().expect("path")));
+    let link = std::env::temp_dir().join(format!("murmur-vault-link-{}", uuid::Uuid::new_v4()));
+    std::os::unix::fs::symlink(&root, &link).expect("symlink");
+
+    let plain_id = scan_vault(&root).expect("plain").pages[0].external_id.clone();
+    let slashed_id = scan_vault(&slashed).expect("slashed").pages[0]
+        .external_id
+        .clone();
+    let link_id = scan_vault(&link).expect("link").pages[0].external_id.clone();
+
+    assert_eq!(plain_id, slashed_id, "a trailing slash is the same vault");
+    assert_eq!(plain_id, link_id, "a symlink to it is the same vault");
+    let _ = std::fs::remove_file(&link);
+    let _ = std::fs::remove_dir_all(&root);
 }
 
 #[test]

--- a/src-tauri/src/share/mod.rs
+++ b/src-tauri/src/share/mod.rs
@@ -262,10 +262,19 @@ pub fn new_share_id() -> String {
 }
 
 /// Map an absent session to a fail-closed `Unavailable` (spec §7 inv. 8: share ops require login).
+///
+/// Tagged with [`crate::errcode::SHARING_ACCOUNT_REQUIRED`] because this refusal is REACHED BY THE
+/// DEFAULT USER: Murmur is local-first and fully usable with no account, so opening any org-only
+/// surface lands here. Untagged, the bare developer prose rendered verbatim in a red banner —
+/// exactly what `errcode.rs` says must never be what the user reads. The body after the code is
+/// still developer prose for logs; the frontend renders its own sentence from the code.
 pub(crate) fn require_login(session: &Option<AccountSession>) -> Result<&AccountSession> {
-    session
-        .as_ref()
-        .ok_or_else(|| AppError::Unavailable("not signed in to the sharing account".into()))
+    session.as_ref().ok_or_else(|| {
+        AppError::Unavailable(crate::errcode::tag(
+            crate::errcode::SHARING_ACCOUNT_REQUIRED,
+            "not signed in to the sharing account",
+        ))
+    })
 }
 
 #[cfg(test)]
@@ -292,6 +301,21 @@ mod tests {
         assert!(uuid::Uuid::parse_str(&id).is_ok());
     }
 
+    /// A minimal live session for the CONTROL leg of the gate tests. Content-free.
+    fn test_session() -> AccountSession {
+        AccountSession {
+            account_id: "a@example.com".into(),
+            email: "a@example.com".into(),
+            server_user_id: Some("00000000-0000-4000-8000-000000000000".into()),
+            device_id: "dev-1".into(),
+            mk: Zeroizing::new([0u8; 32]),
+            generation: 1,
+            access_token: "t".into(),
+            access_expires_at: None,
+            refresh_token: "r".into(),
+        }
+    }
+
     #[test]
     fn require_login_fails_closed_when_logged_out() {
         let none: Option<AccountSession> = None;
@@ -299,6 +323,32 @@ mod tests {
             require_login(&none),
             Err(AppError::Unavailable(_))
         ));
+    }
+
+    /// REGRESSION (2.0 release blocker): the DEFAULT local-first user — no account, ever — opened
+    /// the org-only Tasks surface and the frontend rendered this refusal VERBATIM, because it
+    /// carried no `[code]` and `error-copy.service.ts` is deny-by-default. The refusal must arrive
+    /// tagged with [`crate::errcode::SHARING_ACCOUNT_REQUIRED`] so the surface can render an
+    /// invitation instead of developer prose.
+    #[test]
+    fn require_login_carries_the_account_required_code() {
+        let none: Option<AccountSession> = None;
+        // `unwrap_err()` would require `&AccountSession: Debug`, and AccountSession deliberately
+        // does not derive it — it holds the account master key.
+        let wire = match require_login(&none) {
+            Err(error) => error.to_string(),
+            Ok(_) => panic!("require_login must refuse when there is no session"),
+        };
+        assert_eq!(
+            wire, "provider unavailable: [sharing-account-required] not signed in to the sharing account",
+            "the logged-out refusal must carry its code first in the body"
+        );
+        // CONTROL: the code is the NEVER-SIGNED-IN one, not the lapsed-session one. Collapsing the
+        // two would tell a first-time user they had "been signed out".
+        assert_ne!("sharing-account-required", crate::errcode::SHARING_SIGNIN_REQUIRED);
+        // CONTROL: a LIVE session is still returned, so the gate cannot go vacuous by refusing
+        // everything.
+        assert!(require_login(&Some(test_session())).is_ok());
     }
 
     #[test]

--- a/src-tauri/src/storage/ask_conversation_store.rs
+++ b/src-tauri/src/storage/ask_conversation_store.rs
@@ -896,7 +896,10 @@ impl Db {
                 "Ask history visibility generation is unavailable".into(),
             ));
         }
-        let placeholders = std::iter::repeat_n("?", folder_ids.len())
+        // `repeat(..).take(n)` rather than `repeat_n`: the latter is stable only since 1.82 and
+        // this crate's MSRV is 1.77, which `clippy::incompatible_msrv` enforces as a hard error.
+        let placeholders = std::iter::repeat("?")
+            .take(folder_ids.len())
             .collect::<Vec<_>>()
             .join(",");
         let deleted = tx

--- a/src-tauri/src/storage/ask_conversation_store.rs
+++ b/src-tauri/src/storage/ask_conversation_store.rs
@@ -814,6 +814,15 @@ impl Db {
         Ok(purged)
     }
 
+    /// Destroy EVERY durable Ask conversation, whatever it was derived from.
+    ///
+    /// Still correct — and still required — wherever the caller cannot name the folders whose
+    /// content is going away: a deleted meeting or note, an org item withdrawn, a fact retracted.
+    /// Those callers have no folder set to scope by, and a conversation may paraphrase content
+    /// whose id no longer exists, so the global sweep is the only fail-closed option there.
+    ///
+    /// It is NOT correct for the seal paths — see
+    /// [`Self::purge_ask_conversations_for_folders_tx`], which replaced it in those three.
     pub(crate) fn purge_all_ask_conversations_tx(tx: &rusqlite::Transaction<'_>) -> Result<usize> {
         let advanced = tx
             .execute(
@@ -833,6 +842,106 @@ impl Db {
             [],
         )
         .map_err(map_err)
+    }
+
+    /// Destroy every durable Ask conversation that could have drawn on one of `folder_ids`, and
+    /// leave every other conversation intact AND READABLE.
+    ///
+    /// This replaced a GLOBAL `DELETE FROM ask_conversations WHERE provenance_mode='globalDerived'`
+    /// (2.0 audit). The schema CHECK pins `provenance_mode` to that single value, so the predicate
+    /// matched every row: one locked folder anywhere in the vault wiped ALL durable history — on
+    /// every lock, every relock (including the screen-share auto-relock) and, via
+    /// `reblank_locked_folders_at_rest`, on EVERY app launch. A feature whose headline is that it
+    /// persists did not survive a restart.
+    ///
+    /// Scoping is sound because the dependency snapshot is CONSERVATIVE, not analytical:
+    /// `commands/ask_history.rs` records `db.visible_folder_ids(&unlocked)` — every folder that was
+    /// READABLE when the exchange was written, not the subset the answer happened to cite. So any
+    /// folder whose content could have reached a conversation is in that conversation's dependency
+    /// set, and sealing it destroys the conversation. A folder that was not readable could not have
+    /// contributed. (This is exactly why the sibling purges here stay GLOBAL: a pending audit
+    /// finding may cite a title with no matching id, so it has no dependency set to scope by.)
+    ///
+    /// The generation still advances, because it is the barrier against a conversation written
+    /// concurrently with the seal. Survivors are then carried onto the NEW generation — but only
+    /// those that were on the immediately-preceding one, so a row racing this transaction is not
+    /// resurrected. Advancing the generation WITHOUT carrying survivors forward would be the same
+    /// data loss by another route: `list_ask_conversation_ids` admits a row only while
+    /// `c.visibility_generation` equals the current one, so a surviving-but-unreadable row is, to
+    /// the user, an erased one.
+    pub(crate) fn purge_ask_conversations_for_folders_tx(
+        tx: &rusqlite::Transaction<'_>,
+        folder_ids: &HashSet<String>,
+    ) -> Result<usize> {
+        if folder_ids.is_empty() {
+            return Ok(0);
+        }
+        let previous: i64 = tx
+            .query_row(
+                "SELECT visibility_generation FROM ask_history_state WHERE singleton = 1",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(map_err)?;
+        let advanced = tx
+            .execute(
+                "UPDATE ask_history_state
+                    SET visibility_generation = visibility_generation + 1
+                  WHERE singleton = 1",
+                [],
+            )
+            .map_err(map_err)?;
+        if advanced != 1 {
+            return Err(AppError::Storage(
+                "Ask history visibility generation is unavailable".into(),
+            ));
+        }
+        let placeholders = std::iter::repeat_n("?", folder_ids.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let deleted = tx
+            .execute(
+                &format!(
+                    "DELETE FROM ask_conversations
+                      WHERE provenance_mode = 'globalDerived'
+                        AND id IN (SELECT d.conversation_id
+                                     FROM ask_conversation_dependencies d
+                                    WHERE d.dependency_kind = 'folder'
+                                      AND d.dependency_ref IN ({placeholders}))"
+                ),
+                rusqlite::params_from_iter(folder_ids.iter()),
+            )
+            .map_err(map_err)?;
+        tx.execute(
+            "UPDATE ask_conversations
+                SET visibility_generation =
+                      (SELECT visibility_generation FROM ask_history_state WHERE singleton = 1)
+              WHERE provenance_mode = 'globalDerived'
+                AND visibility_generation = ?1",
+            rusqlite::params![previous],
+        )
+        .map_err(map_err)?;
+        Ok(deleted)
+    }
+
+    /// The [`Self::purge_ask_conversations_for_folders_tx`] scope for a startup reconcile: every
+    /// folder that is sealed AT REST. Nothing was derived from a folder while it was sealed, so a
+    /// conversation that never saw one of these is not the reconcile's business.
+    pub(crate) fn purge_ask_conversations_for_locked_folders_tx(
+        tx: &rusqlite::Transaction<'_>,
+    ) -> Result<usize> {
+        let locked: HashSet<String> = {
+            let mut stmt = tx
+                .prepare("SELECT id FROM folders WHERE locked = 1")
+                .map_err(map_err)?;
+            let rows = stmt
+                .query_map([], |row| row.get::<_, String>(0))
+                .map_err(map_err)?
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .map_err(map_err)?;
+            rows.into_iter().collect()
+        };
+        Self::purge_ask_conversations_for_folders_tx(tx, &locked)
     }
 }
 

--- a/src-tauri/src/storage/db_tests/lock_tests.rs
+++ b/src-tauri/src/storage/db_tests/lock_tests.rs
@@ -2370,3 +2370,133 @@ fn clear_voiceprints_removes_all() {
         .unwrap()
         .is_empty());
 }
+
+/// Helper for the scoped-Ask-purge oracle: how many durable Ask conversation rows survive AT REST
+/// (not "are visible" — the row count, so a merely-hidden row still counts as surviving).
+fn ask_rows_at_rest(db: &Db) -> i64 {
+    db.lock()
+        .query_row("SELECT COUNT(*) FROM ask_conversations", [], |r| r.get(0))
+        .unwrap()
+}
+
+/// RELEASE BLOCKER (2.0) — durable Ask history must not be globally erased by a session-visibility
+/// WITHDRAWAL. `blank_sealed_notes_in_folders` (relock / relock-all — the app-quit, window-close and
+/// screen-share auto-relock hooks) and `reblank_locked_folders_at_rest` (EVERY launch, guarded only
+/// on "some folder is locked") used to run the GLOBAL
+/// `purge_all_ask_conversations_tx`, whose predicate `provenance_mode = 'globalDerived'` matches
+/// every row the schema CHECK allows — a total wipe for any user with one locked folder.
+///
+/// Both directions, one oracle:
+///   * LEAK leg (fail-closed CONTROL): a conversation whose conservative dependency snapshot
+///     contains the folder being sealed MUST be destroyed at rest by BOTH paths.
+///   * LOSS leg: a conversation that only ever saw an unrelated, still-open folder MUST survive
+///     BOTH paths and MUST STAY READABLE afterwards (a surviving-but-invisible row — e.g. one
+///     orphaned by a bumped `visibility_generation` — is the same data loss to the user).
+#[test]
+fn ask_history_purge_on_visibility_withdrawal_is_scoped_to_the_sealed_folders() {
+    let db = file_db("ask-scoped-purge");
+    seed_folder(&db, "f-open", "Open");
+    seed_folder(&db, "f-sealed", "Sealed");
+    // `f-sealed` is locked AT REST and session-unlocked right now — the exact state both paths
+    // reconcile (a relock withdraws the session unlock; the startup reconcile re-asserts at rest).
+    db.lock()
+        .execute("UPDATE folders SET locked = 1 WHERE id = 'f-sealed'", [])
+        .unwrap();
+    let session_unlocked: HashSet<String> = ["f-sealed".to_string()].into_iter().collect();
+
+    let unrelated = db
+        .persist_ask_exchange(
+            &AskConversationScope::Vault,
+            None,
+            "What did we decide about the open folder?",
+            "Derived only from content that stays visible.",
+            &[],
+            &[],
+            &[],
+            &["f-open".to_string()],
+            "2026-08-26T09:00:00Z",
+        )
+        .unwrap();
+    let derived = db
+        .persist_ask_exchange(
+            &AskConversationScope::Vault,
+            None,
+            "What did we decide in the private folder?",
+            "Derived from content that is about to be sealed.",
+            &[],
+            &[],
+            &[],
+            &["f-open".to_string(), "f-sealed".to_string()],
+            "2026-08-26T09:01:00Z",
+        )
+        .unwrap();
+
+    let visible_now = db
+        .list_ask_conversation_ids(&AskConversationScope::Vault, &session_unlocked)
+        .unwrap();
+    assert!(
+        visible_now.contains(&unrelated) && visible_now.contains(&derived),
+        "both threads start readable while the sealed folder is session-unlocked"
+    );
+    assert_eq!(ask_rows_at_rest(&db), 2);
+
+    // ── RELOCK (app quit / window close / screen-share auto-relock) ──────────────────────────────
+    db.blank_sealed_notes_in_folders(&session_unlocked).unwrap();
+    assert_eq!(
+        ask_rows_at_rest(&db),
+        1,
+        "the thread derived from the sealed folder must be DESTROYED at rest by the relock"
+    );
+    let after_relock = db
+        .list_ask_conversation_ids(&AskConversationScope::Vault, &HashSet::new())
+        .unwrap();
+    assert_eq!(
+        after_relock,
+        vec![unrelated.clone()],
+        "the unrelated thread must survive the relock AND stay readable"
+    );
+
+    // ── STARTUP RECONCILE (runs at EVERY launch while any folder is locked) ──────────────────────
+    db.reblank_locked_folders_at_rest().unwrap();
+    assert_eq!(
+        ask_rows_at_rest(&db),
+        1,
+        "the startup reconcile must not erase an unrelated thread"
+    );
+    let after_launch = db
+        .list_ask_conversation_ids(&AskConversationScope::Vault, &HashSet::new())
+        .unwrap();
+    assert_eq!(
+        after_launch,
+        vec![unrelated.clone()],
+        "durable Ask history must survive relaunch when nothing it depended on was sealed"
+    );
+
+    // ── LEAK leg for the startup path on its own (crash-while-unlocked recovery) ─────────────────
+    let crashed = db
+        .persist_ask_exchange(
+            &AskConversationScope::Vault,
+            None,
+            "What is in the private folder?",
+            "Derived during a session that crashed before relocking.",
+            &[],
+            &[],
+            &[],
+            &["f-open".to_string(), "f-sealed".to_string()],
+            "2026-08-26T09:02:00Z",
+        )
+        .unwrap();
+    assert_eq!(ask_rows_at_rest(&db), 2);
+    db.reblank_locked_folders_at_rest().unwrap();
+    assert_eq!(
+        ask_rows_at_rest(&db),
+        1,
+        "startup reconcile must DESTROY a thread that depended on a folder locked at rest"
+    );
+    assert!(
+        !db.list_ask_conversation_ids(&AskConversationScope::Vault, &HashSet::new())
+            .unwrap()
+            .contains(&crashed),
+        "the crash-derived thread is gone, not merely hidden"
+    );
+}

--- a/src-tauri/src/storage/seal_store.rs
+++ b/src-tauri/src/storage/seal_store.rs
@@ -331,7 +331,7 @@ impl Db {
         // folder's titles in its evidence with no matching id, so a scoped purge cannot cover it.
         // Cheap re-derivable rows; the next pass re-stages anything still true.
         Self::purge_all_pending_audit_findings_tx(&tx)?;
-        Self::purge_all_ask_conversations_tx(&tx)?;
+        Self::purge_ask_conversations_for_folders_tx(&tx, &HashSet::from([folder_id.to_string()]))?;
         // Smart-reminder audit candidates/cache are disposable source-derived plaintext too.
         // Accepted reminders live in separate tables and deliberately survive this purge.
         Self::purge_all_reminder_derived_tx(&tx)?;
@@ -632,7 +632,7 @@ impl Db {
             // meeting/document id can match; a relock invalidates the pass's visibility
             // snapshot). Resolved rows were blanked on resolve and survive.
             Self::purge_all_pending_audit_findings_tx(&tx)?;
-            Self::purge_all_ask_conversations_tx(&tx)?;
+            Self::purge_ask_conversations_for_folders_tx(&tx, folder_ids)?;
             // A relock withdraws the visibility snapshot that authorized every pending Smart
             // candidate. Purge the whole derived audit domain in this same re-blank transaction.
             Self::purge_all_reminder_derived_tx(&tx)?;
@@ -858,7 +858,7 @@ impl Db {
             .map_err(map_err)?;
         if any_locked {
             Self::purge_all_pending_audit_findings_tx(&tx)?;
-            Self::purge_all_ask_conversations_tx(&tx)?;
+            Self::purge_ask_conversations_for_locked_folders_tx(&tx)?;
             // Startup reconciliation must not leave candidates derived during a crashed unlocked
             // session at rest. Canonical promoted reminders remain untouched.
             Self::purge_all_reminder_derived_tx(&tx)?;

--- a/src-tauri/src/storage/workspace_store.rs
+++ b/src-tauri/src/storage/workspace_store.rs
@@ -26,6 +26,8 @@
 
 use std::collections::{HashMap, HashSet};
 
+use rusqlite::OptionalExtension;
+
 use crate::error::Result;
 use crate::storage::db::{map_err, meeting_visibility_clause, visibility_clause, Db};
 use crate::storage::models::{ContainerRow, ItemKind, ItemRow};
@@ -227,6 +229,39 @@ impl Db {
             out.push(r.map_err(map_err)?);
         }
         Ok((out, total as u32))
+    }
+
+    /// A direct child of `parent_id` with exactly this name, if one exists.
+    ///
+    /// Used by the importers to REUSE their destination container instead of creating
+    /// "Imported from Notion" again on every run. Name-matched on purpose: the container is the
+    /// user's to rename or move, and once they do, the next import should start a fresh one rather
+    /// than reach into somewhere they deliberately reorganised.
+    pub(crate) fn child_folder_by_name(
+        &self,
+        parent_id: &str,
+        name: &str,
+    ) -> Result<Option<String>> {
+        self.lock()
+            .query_row(
+                "SELECT id FROM folders WHERE parent_id = ?1 AND name = ?2 LIMIT 1",
+                rusqlite::params![parent_id, name],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(map_err)
+    }
+
+    /// Set a container's display emoji. Cosmetic only — it mirrors the `dashboards.emoji` column
+    /// and carries no behaviour.
+    pub(crate) fn set_folder_emoji(&self, folder_id: &str, emoji: &str) -> Result<()> {
+        self.lock()
+            .execute(
+                "UPDATE folders SET emoji = ?2 WHERE id = ?1",
+                rusqlite::params![folder_id, emoji],
+            )
+            .map(|_| ())
+            .map_err(map_err)
     }
 }
 

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -1188,8 +1188,13 @@ pub fn execute_tool(
                 .join("\n"))
         }
         ToolCall::ListDashboards => {
+            // GATED, on exactly the terms `commands/dashboards.rs::list_dashboards_inner` uses.
+            // This arm used to call the raw `db.list_dashboards()`, so a board filed in a sealed
+            // folder shipped its plaintext title — and its tile count and kinds — to the agent
+            // surface while the UI correctly withheld all three. Two gates for one fact drifted
+            // apart; this one now reads through the same masking query.
             let boards = db
-                .list_dashboards()
+                .list_dashboards_visible(unlocked)
                 .map_err(|e| AppError::Storage(format!("dashboard list failed: {e}")))?;
             if boards.is_empty() {
                 return Ok("No dashboards yet.".to_string());
@@ -1200,6 +1205,13 @@ pub fn execute_tool(
             Ok(boards
                 .iter()
                 .map(|b| {
+                    // A sealed board discloses NO tiles — not their number and not their kinds.
+                    // `list_dashboards_visible` masks the row, but `dashboard_tile_kinds` is a
+                    // SEPARATE ungated read, so masking the row alone still shipped "this locked
+                    // board is built from three meetings and a note".
+                    if b.locked {
+                        return format!("- {} · id:{} · tiles:0 · kinds:none", b.title, b.id);
+                    }
                     let mut tile_kinds: Vec<&str> = kinds
                         .iter()
                         .filter(|(board_id, _, _)| board_id == &b.id)
@@ -1223,12 +1235,20 @@ pub fn execute_tool(
                 .join("\n"))
         }
         ToolCall::GetDashboard { dashboard_id } => {
+            // GATED, mirroring `commands/dashboards.rs::get_dashboard_inner`. The raw
+            // `db.get_dashboard()` this used to call returned the plaintext title of a board in a
+            // sealed folder, and then enumerated its tile ROWS — disclosing the board's shape
+            // (how many tiles, laid out how) even though each tile's CONTENT was redacted by
+            // `resolve_tile`. Shape is one of the easier things to recognise a board by.
             let Some(board) = db
-                .get_dashboard(dashboard_id)
+                .get_dashboard_visible(dashboard_id, unlocked)
                 .map_err(|e| AppError::Storage(format!("dashboard read failed: {e}")))?
             else {
                 return Ok(format!("No dashboard with id {dashboard_id}."));
             };
+            if board.locked {
+                return Ok(format!("# {} (dashboard)\n(no tiles yet)", board.title));
+            }
             let tiles = db
                 .list_dashboard_tile_structures(dashboard_id)
                 .map_err(|e| AppError::Storage(format!("dashboard tiles failed: {e}")))?;
@@ -3927,6 +3947,108 @@ mod tests {
         assert!(
             matches!(reminder, Err(AppError::InvalidArg(_))),
             "durable Ask must refuse create_reminder before external write: {reminder:?}"
+        );
+    }
+
+    /// THE BOARD-LEVEL AGENT LEAK ORACLE (regression for the 2.0 audit finding).
+    ///
+    /// The sibling oracle below covers a sealed TILE. This one covers the sealed BOARD, which is a
+    /// different gate and was missing entirely: `ListDashboards`/`GetDashboard` called the raw
+    /// `db.list_dashboards()` / `db.get_dashboard()` while `commands/dashboards.rs` called the
+    /// `_visible` pair. Two gates for one fact, and only one of them was applied — so a board
+    /// filed in a sealed folder shipped its plaintext TITLE, its tile COUNT and its tile KINDS to
+    /// any MCP client, while the UI correctly withheld all three.
+    ///
+    /// The fixture is the crash-window shape deliberately: a board created while the folder was
+    /// session-unlocked, then the process dies before a relock can seal it. Its `title` column is
+    /// still plaintext and the folder is `locked = 1` and NOT in the session unlock set — so this
+    /// asserts the READ gate holds even when the at-rest seal did not finish. Content redaction
+    /// must never depend on the plaintext having already been blanked.
+    #[test]
+    fn dashboard_tools_withhold_a_sealed_board_from_agents() {
+        use crate::storage::models::Folder;
+        let db = tmp_db();
+        db.insert_folder(&Folder {
+            id: "f-sealed".to_string(),
+            name: "Legal".to_string(),
+            path: "Legal".to_string(),
+            parent_id: None,
+            locked: true,
+            created_at: "2026-08-01T00:00:00Z".to_string(),
+        })
+        .unwrap();
+        db.insert_dashboard_in_folder(
+            "b1",
+            "Q3 layoffs",
+            None,
+            None,
+            Some("f-sealed"),
+            "2026-08-03T10:00:00Z",
+        )
+        .unwrap();
+        db.insert_dashboard_tile(
+            "t1",
+            "b1",
+            "meeting",
+            Some("m-x"),
+            None,
+            4,
+            None,
+            "2026-08-03T10:00:00Z",
+        )
+        .unwrap();
+        db.insert_dashboard_tile(
+            "t2",
+            "b1",
+            "note",
+            Some("n-x"),
+            None,
+            4,
+            None,
+            "2026-08-03T10:00:00Z",
+        )
+        .unwrap();
+
+        let cfg = AppConfig::default();
+        let nothing_unlocked = HashSet::new();
+
+        let listed = execute_tool(&ToolCall::ListDashboards, &db, &nothing_unlocked, &cfg).unwrap();
+        assert!(
+            !listed.contains("Q3 layoffs"),
+            "sealed board title reached the agent surface: {listed}"
+        );
+        // Shape is a fact about sealed content too: "built from two things, a meeting and a note"
+        // is enough to recognise a board by.
+        assert!(
+            !listed.contains("tiles:2") && !listed.contains("meeting"),
+            "sealed board tile shape reached the agent surface: {listed}"
+        );
+
+        let detail = execute_tool(
+            &ToolCall::GetDashboard {
+                dashboard_id: "b1".to_string(),
+            },
+            &db,
+            &nothing_unlocked,
+            &cfg,
+        )
+        .unwrap();
+        assert!(
+            !detail.contains("Q3 layoffs"),
+            "sealed board title reached the agent surface via get_dashboard: {detail}"
+        );
+        assert!(
+            !detail.contains("m-x") && !detail.contains("n-x"),
+            "sealed board tile refs reached the agent surface: {detail}"
+        );
+
+        // CONTROL — the same board in an OPEN folder must still be fully readable, so the oracle
+        // cannot go vacuous by masking everything unconditionally.
+        let unlocked: HashSet<String> = ["f-sealed".to_string()].into_iter().collect();
+        let open = execute_tool(&ToolCall::ListDashboards, &db, &unlocked, &cfg).unwrap();
+        assert!(
+            open.contains("Q3 layoffs") && open.contains("tiles:2"),
+            "control failed — an unlocked board must still be listed in full: {open}"
         );
     }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",

--- a/src/app/core/copy/error-copy.service.ts
+++ b/src/app/core/copy/error-copy.service.ts
@@ -119,6 +119,7 @@ export const ERROR_CODES = [
   "sharing-rate-limited",
   "sharing-rejected",
   "sharing-signin-required",
+  "sharing-account-required",
   "sharing-upgrade-required",
   "org-edit-conflict",
   "reminders-denied",
@@ -145,7 +146,8 @@ export type ErrorContext =
   | "brain-delete"
   | "doc-note"
   | "unlock"
-  | "account";
+  | "account"
+  | "tasks";
 
 /**
  * The sentence for each code when no context adds anything.
@@ -195,6 +197,12 @@ const BASE_COPY: Readonly<Record<ErrorCode, string>> = {
   "sharing-rejected":
     "That didn’t work. Check the code (it may have expired) and try again.",
   "sharing-signin-required": "You’ve been signed out — sign in again to continue.",
+  // DISTINCT from `sharing-signin-required` on purpose. That one means a session EXISTED and
+  // lapsed; this one means there has never been an account on this device — the DEFAULT
+  // local-first user, who is the product's headline promise. Telling that person they have
+  // "been signed out" is a lie, and it was the second-order trap inside the 2.0 Tasks blocker.
+  "sharing-account-required":
+    "Sharing needs a Murmur account. Everything already on this Mac keeps working without one.",
   "sharing-upgrade-required":
     "Sharing is paused until the server supports crash-safe share creation. Try again after the server is updated.",
   "org-edit-conflict":
@@ -251,6 +259,12 @@ const CONTEXT_COPY: Partial<
     "note-locked":
       "That folder is locked. Unlock it, or accept into an open folder or the default one.",
   },
+  tasks: {
+    "sharing-account-required":
+      "Tasks are shared work inside an organization — sign in to your Murmur account to see them.",
+    "sharing-signin-required":
+      "Your sharing session ended — sign in again to see your organization’s tasks.",
+  },
   "org-share": {
     "note-locked":
       "This item is locked — unlock its folder before adding it to the org brain.",
@@ -297,6 +311,7 @@ const CONTEXT_FALLBACK: Partial<Record<ErrorContext, string>> = {
   "brain-delete": "Couldn’t remove that. Please try again.",
   "doc-note": "Couldn’t make a note from this document. Please try again.",
   unlock: "Couldn’t unlock. Please try again.",
+  tasks: "Couldn’t load shared tasks. Please try again.",
   recording: "Couldn’t finish that recording. Please try again.",
 };
 

--- a/src/app/features/tasks/task-view/task-view.component.html
+++ b/src/app/features/tasks/task-view/task-view.component.html
@@ -1,295 +1,347 @@
-<header class="tasks-head">
-  <div>
-    <span class="eyebrow">Shared work</span>
-    <h1>Tasks</h1>
-    <p>Encrypted work owned by one organization. Private links stay on this Mac.</p>
-  </div>
-  <button type="button" class="btn btn-primary" (click)="newTask()">New task</button>
-</header>
+<!--
+  The DEFAULT Murmur user has no sharing account — local-first with no account is the product's
+  headline promise — and Tasks is org-only, so the backend refuses every read here. That refusal
+  used to render VERBATIM in a red banner ("provider unavailable: not signed in to the sharing
+  account") on top of an empty state that told the user to "create shared work". Both are gone: the
+  store classifies the refusal by its stable `[code]` and raises `signedOut`, and this branch
+  explains what Tasks ARE and offers the same two doors the account banner offers.
 
-@if (error(); as message) {
-  <div class="banner banner-error" role="alert">
-    <span>{{ message }}</span>
-    <button type="button" class="btn btn-ghost btn-sm" (click)="store.clearError(); localError.set(null)">
-      Dismiss
-    </button>
-  </div>
-}
-
-<div class="tasks-shell" [class.show-detail]="showingDetail()">
-  <aside class="task-list" aria-label="Tasks">
-    <div class="list-tools">
-      <input
-        type="search"
-        placeholder="Find a task"
-        aria-label="Find a task"
-        [value]="query()"
-        (input)="onQuery($event)"
-      />
-      <select aria-label="Filter organization" [value]="orgFilter()" (change)="onOrgFilter($event)">
-        <option value="all">All organizations</option>
-        @for (org of store.orgs(); track org.orgId) {
-          <option [value]="org.orgId">{{ org.name }}</option>
-        }
-      </select>
-    </div>
-
-    <nav class="status-tabs" aria-label="Task status">
-      <button type="button" [class.active]="filter() === 'open'" (click)="selectFilter('open')">Open</button>
-      <button type="button" [class.active]="filter() === 'todo'" (click)="selectFilter('todo')">To do</button>
-      <button type="button" [class.active]="filter() === 'inProgress'" (click)="selectFilter('inProgress')">In progress</button>
-      <button type="button" [class.active]="filter() === 'done'" (click)="selectFilter('done')">Done</button>
-      <button type="button" [class.active]="filter() === 'all'" (click)="selectFilter('all')">All</button>
-    </nav>
-
-    <div class="task-rows">
-      @for (task of filteredTasks(); track task.id) {
-        <button
-          type="button"
-          class="task-row"
-          [class.active]="routeId() === task.id"
-          (click)="open(task)"
-          [attr.data-task-id]="task.id"
-        >
-          <span class="state-dot" [attr.data-status]="task.status"></span>
-          <span class="row-copy">
-            <strong>{{ task.title }}</strong>
-            <span>{{ orgName(task.orgId) }} · {{ formatDue(task) }}</span>
-          </span>
-          @if (task.assigneeUserId) {
-            <span class="avatar" aria-label="Assigned">A</span>
-          }
-        </button>
-      } @empty {
-        @if (store.loading()) {
-          <mur-empty-state><mur-spinner /> Syncing tasks…</mur-empty-state>
-        } @else {
-          <mur-empty-state>
-            <strong>No tasks here.</strong>
-            <p>Create shared work or change the filters.</p>
-          </mur-empty-state>
-        }
-      }
-    </div>
-  </aside>
-
-  <main class="task-detail">
-    @if (isNew() || current() !== null) {
-      @let task = current();
-      <header class="detail-head">
-        <button type="button" class="mobile-back btn btn-ghost btn-sm" (click)="backToList()">← Tasks</button>
-        <div class="detail-context">
-          <span class="eyebrow">{{ isNew() ? "New shared task" : orgName(task?.orgId ?? orgId()) }}</span>
-          @if (!isNew() && task && !task.canEdit) {
-            <span class="permission-pill">View only</span>
-          }
+  The nav item deliberately still appears for a signed-out user: `/tasks` is directly routable, so
+  hiding the chrome would leave the raw-prose route reachable while making the feature undiscoverable.
+-->
+@if (store.signedOut()) {
+  <section class="tasks-gate" aria-labelledby="tasks-gate-title">
+    <mur-empty-state>
+      <svg class="gate-mark" viewBox="0 0 44 44" fill="none" aria-hidden="true">
+        <circle cx="22" cy="22" r="20" stroke="currentColor" stroke-width="1.4" opacity="0.5" />
+        <path
+          d="M16 22.4l4 4 8.4-8.8"
+          stroke="currentColor"
+          stroke-width="1.8"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+      <h1 class="empty-title" id="tasks-gate-title">Tasks live in a Shared Brain</h1>
+      <p class="empty gate-lede">
+        Tasks are shared work inside an organization — end-to-end encrypted and kept in step with
+        the people you invite. Your meetings, notes and recordings on this Mac keep working exactly
+        as they do now, with no account.
+      </p>
+      @if (authDoor(); as door) {
+        <div class="gate-auth">
+          <app-sharing-auth-flow
+            [initialDoor]="door"
+            (completed)="onAuthCompleted()"
+            (dismissed)="closeAuth()"
+          />
         </div>
-        <div class="detail-actions">
-          @if (!isNew() && task?.canManage) {
-            <button type="button" class="btn btn-danger btn-sm" [disabled]="deleting()" (click)="remove()">
-              {{ deleting() ? "Deleting…" : "Delete" }}
-            </button>
-          }
-          <button type="button" class="btn btn-primary" [disabled]="!canSave()" (click)="save()">
-            {{ saving() ? "Saving…" : isNew() ? "Create task" : "Save" }}
+      } @else {
+        <div class="gate-actions">
+          <button type="button" class="btn btn-primary" (click)="openAuth('signin')">
+            Sign in
+          </button>
+          <button type="button" class="btn btn-ghost" (click)="openAuth('create')">
+            Create account
           </button>
         </div>
-      </header>
+      }
+    </mur-empty-state>
+  </section>
+} @else {
+  <header class="tasks-head">
+    <div>
+      <span class="eyebrow">Shared work</span>
+      <h1>Tasks</h1>
+      <p>Encrypted work owned by one organization. Private links stay on this Mac.</p>
+    </div>
+    <button type="button" class="btn btn-primary" (click)="newTask()">New task</button>
+  </header>
 
-      <section class="editor" data-testid="task-editor">
-        @if (isNew()) {
-          <label class="field compact">
-            <span>Organization</span>
-            <select [value]="orgId()" (change)="setOrg($event)">
-              @for (org of store.orgs(); track org.orgId) {
-                <option [value]="org.orgId">{{ org.name }}</option>
-              }
-            </select>
-          </label>
-        }
+  @if (error(); as message) {
+    <div class="banner banner-error" role="alert">
+      <span>{{ message }}</span>
+      <button type="button" class="btn btn-ghost btn-sm" (click)="store.clearError(); localError.set(null)">
+        Dismiss
+      </button>
+    </div>
+  }
 
+  <div class="tasks-shell" [class.show-detail]="showingDetail()">
+    <aside class="task-list" aria-label="Tasks">
+      <div class="list-tools">
         <input
-          class="title-field"
-          type="text"
-          placeholder="Task title"
-          aria-label="Task title"
-          [value]="title()"
-          [disabled]="!isNew() && !task?.canEdit"
-          (input)="setText('title', $event)"
+          type="search"
+          placeholder="Find a task"
+          aria-label="Find a task"
+          [value]="query()"
+          (input)="onQuery($event)"
         />
-        <textarea
-          class="description-field"
-          rows="6"
-          placeholder="Describe the outcome, context, or constraints…"
-          aria-label="Task description"
-          [value]="description()"
-          [disabled]="!isNew() && !task?.canEdit"
-          (input)="setText('description', $event)"
-        ></textarea>
-
-        <div class="properties">
-          <label class="field">
-            <span>Status</span>
-            <select [value]="status()" [disabled]="!isNew() && !task?.canEdit" (change)="setStatus($event)">
-              <option value="todo">To do</option>
-              <option value="inProgress">In progress</option>
-              <option value="done">Done</option>
-            </select>
-          </label>
-          <label class="field">
-            <span>Due</span>
-            <input type="datetime-local" [value]="dueAt()" [disabled]="!isNew() && !task?.canEdit" (input)="setDueAt($event)" />
-          </label>
-          <label class="field">
-            <span>Assignee</span>
-            <select [value]="assigneeUserId()" [disabled]="!isNew() && !task?.canEdit" (change)="setAssignee($event)">
-              <option value="">Unassigned</option>
-              @for (member of assignees(); track member.userId) {
-                <option [value]="member.userId">{{ member.label }}</option>
-              }
-            </select>
-          </label>
-          <label class="field">
-            <span>Members may</span>
-            <select [value]="access()" [disabled]="!isNew() && !task?.canManage" (change)="setAccess($event)">
-              <option value="edit">Edit</option>
-              <option value="view">View</option>
-            </select>
-          </label>
-        </div>
-
-        <section class="detail-section">
-          <header>
-            <div><span class="eyebrow">Checklist</span><h2>Subtasks</h2></div>
-            <span class="count">{{ subtasks().length }}</span>
-          </header>
-          <div class="subtasks">
-            @for (subtask of subtasks(); track subtask.id) {
-              <div class="subtask" [class.done]="subtask.done">
-                <input
-                  type="checkbox"
-                  [checked]="subtask.done"
-                  [disabled]="!isNew() && !task?.canEdit"
-                  (change)="toggleSubtask(subtask.id)"
-                  [attr.aria-label]="'Complete ' + subtask.title"
-                />
-                <span>{{ subtask.title }}</span>
-                @if (isNew() || task?.canEdit) {
-                  <button type="button" class="icon-button" (click)="removeSubtask(subtask.id)" aria-label="Remove subtask">×</button>
-                }
-              </div>
-            }
-          </div>
-          @if (isNew() || task?.canEdit) {
-            <form class="inline-add" (submit)="addSubtask(); $event.preventDefault()">
-              <input type="text" placeholder="Add a subtask" [value]="newSubtask()" (input)="onNewSubtask($event)" />
-              <button type="submit" class="btn btn-ghost btn-sm" [disabled]="!newSubtask().trim()">Add</button>
-            </form>
+        <select aria-label="Filter organization" [value]="orgFilter()" (change)="onOrgFilter($event)">
+          <option value="all">All organizations</option>
+          @for (org of store.orgs(); track org.orgId) {
+            <option [value]="org.orgId">{{ org.name }}</option>
           }
-        </section>
+        </select>
+      </div>
 
-        <section class="detail-section">
-          <header><div><span class="eyebrow">Encrypted</span><h2>Related org tasks</h2></div></header>
-          <div class="chips">
-            @for (ref of orgRefs(); track ref.docId) {
-              <span class="ref-chip">
-                <button type="button" (click)="openRelated(ref)">{{ relatedTitle(ref.docId) }}</button>
-                @if (isNew() || task?.canEdit) {
-                  <button type="button" class="remove-chip" (click)="removeRelated(ref.docId)" aria-label="Remove related task">×</button>
-                }
-              </span>
+      <nav class="status-tabs" aria-label="Task status">
+        <button type="button" [class.active]="filter() === 'open'" (click)="selectFilter('open')">Open</button>
+        <button type="button" [class.active]="filter() === 'todo'" (click)="selectFilter('todo')">To do</button>
+        <button type="button" [class.active]="filter() === 'inProgress'" (click)="selectFilter('inProgress')">In progress</button>
+        <button type="button" [class.active]="filter() === 'done'" (click)="selectFilter('done')">Done</button>
+        <button type="button" [class.active]="filter() === 'all'" (click)="selectFilter('all')">All</button>
+      </nav>
+
+      <div class="task-rows">
+        @for (task of filteredTasks(); track task.id) {
+          <button
+            type="button"
+            class="task-row"
+            [class.active]="routeId() === task.id"
+            (click)="open(task)"
+            [attr.data-task-id]="task.id"
+          >
+            <span class="state-dot" [attr.data-status]="task.status"></span>
+            <span class="row-copy">
+              <strong>{{ task.title }}</strong>
+              <span>{{ orgName(task.orgId) }} · {{ formatDue(task) }}</span>
+            </span>
+            @if (task.assigneeUserId) {
+              <span class="avatar" aria-label="Assigned">A</span>
+            }
+          </button>
+        } @empty {
+          @if (store.loading()) {
+            <mur-empty-state><mur-spinner /> Syncing tasks…</mur-empty-state>
+          } @else {
+            <mur-empty-state>
+              <strong>No tasks here.</strong>
+              <p>Create shared work or change the filters.</p>
+            </mur-empty-state>
+          }
+        }
+      </div>
+    </aside>
+
+    <main class="task-detail">
+      @if (isNew() || current() !== null) {
+        @let task = current();
+        <header class="detail-head">
+          <button type="button" class="mobile-back btn btn-ghost btn-sm" (click)="backToList()">← Tasks</button>
+          <div class="detail-context">
+            <span class="eyebrow">{{ isNew() ? "New shared task" : orgName(task?.orgId ?? orgId()) }}</span>
+            @if (!isNew() && task && !task.canEdit) {
+              <span class="permission-pill">View only</span>
             }
           </div>
-          @if (isNew() || task?.canEdit) {
-            <div class="inline-add">
-              <select [value]="relatedTaskId()" (change)="setRelatedTask($event)">
-                <option value="">Choose task…</option>
-                @for (candidate of relatedCandidates(); track candidate.id) {
-                  <option [value]="candidate.id">{{ candidate.title }}</option>
+          <div class="detail-actions">
+            @if (!isNew() && task?.canManage) {
+              <button type="button" class="btn btn-danger btn-sm" [disabled]="deleting()" (click)="remove()">
+                {{ deleting() ? "Deleting…" : "Delete" }}
+              </button>
+            }
+            <button type="button" class="btn btn-primary" [disabled]="!canSave()" (click)="save()">
+              {{ saving() ? "Saving…" : isNew() ? "Create task" : "Save" }}
+            </button>
+          </div>
+        </header>
+
+        <section class="editor" data-testid="task-editor">
+          @if (isNew()) {
+            <label class="field compact">
+              <span>Organization</span>
+              <select [value]="orgId()" (change)="setOrg($event)">
+                @for (org of store.orgs(); track org.orgId) {
+                  <option [value]="org.orgId">{{ org.name }}</option>
                 }
               </select>
-              <button type="button" class="btn btn-ghost btn-sm" [disabled]="!relatedTaskId()" (click)="addRelatedTask()">Link</button>
-            </div>
+            </label>
           }
-        </section>
 
-        <section class="detail-section">
-          <header>
-            <div><span class="eyebrow">E2EE bundle</span><h2>Images</h2></div>
-            @if (!isNew() && task?.canEdit) {
-              <label class="btn btn-ghost btn-sm file-button">
-                {{ uploading() ? "Adding…" : "Add image" }}
-                <input type="file" accept="image/png,image/jpeg,image/webp" multiple [disabled]="uploading()" (change)="addImages($event)" />
-              </label>
-            }
-          </header>
-          @if (isNew()) {
-            <p class="section-note">Create the task first, then add images to its encrypted document.</p>
-          }
-          <div class="image-grid">
-            @for (image of images(); track image.reference) {
-              <figure>
-                @if (imageData(image); as src) {
-                  <img [src]="src" [alt]="image.alt" />
-                } @else {
-                  <div class="image-placeholder">Encrypted image</div>
+          <input
+            class="title-field"
+            type="text"
+            placeholder="Task title"
+            aria-label="Task title"
+            [value]="title()"
+            [disabled]="!isNew() && !task?.canEdit"
+            (input)="setText('title', $event)"
+          />
+          <textarea
+            class="description-field"
+            rows="6"
+            placeholder="Describe the outcome, context, or constraints…"
+            aria-label="Task description"
+            [value]="description()"
+            [disabled]="!isNew() && !task?.canEdit"
+            (input)="setText('description', $event)"
+          ></textarea>
+
+          <div class="properties">
+            <label class="field">
+              <span>Status</span>
+              <select [value]="status()" [disabled]="!isNew() && !task?.canEdit" (change)="setStatus($event)">
+                <option value="todo">To do</option>
+                <option value="inProgress">In progress</option>
+                <option value="done">Done</option>
+              </select>
+            </label>
+            <label class="field">
+              <span>Due</span>
+              <input type="datetime-local" [value]="dueAt()" [disabled]="!isNew() && !task?.canEdit" (input)="setDueAt($event)" />
+            </label>
+            <label class="field">
+              <span>Assignee</span>
+              <select [value]="assigneeUserId()" [disabled]="!isNew() && !task?.canEdit" (change)="setAssignee($event)">
+                <option value="">Unassigned</option>
+                @for (member of assignees(); track member.userId) {
+                  <option [value]="member.userId">{{ member.label }}</option>
                 }
-                <figcaption>{{ image.alt || "Image" }}</figcaption>
-                @if (task?.canEdit) {
-                  <button type="button" class="remove-image" (click)="removeImage(image)" aria-label="Remove image">×</button>
-                }
-              </figure>
-            }
+              </select>
+            </label>
+            <label class="field">
+              <span>Members may</span>
+              <select [value]="access()" [disabled]="!isNew() && !task?.canManage" (change)="setAccess($event)">
+                <option value="edit">Edit</option>
+                <option value="view">View</option>
+              </select>
+            </label>
           </div>
-        </section>
 
-        @if (!isNew() && task) {
-          <section class="detail-section local-links">
-            <header><div><span class="eyebrow">This Mac only</span><h2>Local links</h2></div></header>
-            <p class="section-note">Note, recording and dashboard links never enter the shared task document.</p>
+          <section class="detail-section">
+            <header>
+              <div><span class="eyebrow">Checklist</span><h2>Subtasks</h2></div>
+              <span class="count">{{ subtasks().length }}</span>
+            </header>
+            <div class="subtasks">
+              @for (subtask of subtasks(); track subtask.id) {
+                <div class="subtask" [class.done]="subtask.done">
+                  <input
+                    type="checkbox"
+                    [checked]="subtask.done"
+                    [disabled]="!isNew() && !task?.canEdit"
+                    (change)="toggleSubtask(subtask.id)"
+                    [attr.aria-label]="'Complete ' + subtask.title"
+                  />
+                  <span>{{ subtask.title }}</span>
+                  @if (isNew() || task?.canEdit) {
+                    <button type="button" class="icon-button" (click)="removeSubtask(subtask.id)" aria-label="Remove subtask">×</button>
+                  }
+                </div>
+              }
+            </div>
+            @if (isNew() || task?.canEdit) {
+              <form class="inline-add" (submit)="addSubtask(); $event.preventDefault()">
+                <input type="text" placeholder="Add a subtask" [value]="newSubtask()" (input)="onNewSubtask($event)" />
+                <button type="submit" class="btn btn-ghost btn-sm" [disabled]="!newSubtask().trim()">Add</button>
+              </form>
+            }
+          </section>
+
+          <section class="detail-section">
+            <header><div><span class="eyebrow">Encrypted</span><h2>Related org tasks</h2></div></header>
             <div class="chips">
-              @for (ref of localRefs(); track ref.kind + ':' + ref.refId) {
-                <span class="ref-chip local">
-                  <button type="button" (click)="openLocalRef(ref)">{{ ref.kind }} · {{ ref.refId }}</button>
-                  <button type="button" class="remove-chip" (click)="removeLocalRef(ref)" aria-label="Remove local link">×</button>
+              @for (ref of orgRefs(); track ref.docId) {
+                <span class="ref-chip">
+                  <button type="button" (click)="openRelated(ref)">{{ relatedTitle(ref.docId) }}</button>
+                  @if (isNew() || task?.canEdit) {
+                    <button type="button" class="remove-chip" (click)="removeRelated(ref.docId)" aria-label="Remove related task">×</button>
+                  }
                 </span>
               }
             </div>
-            <div class="inline-add">
-              <select [value]="dashboardRefId()" (change)="setDashboardRef($event)">
-                <option value="">Add to dashboard…</option>
-                @for (dashboard of dashboards(); track dashboard.id) {
-                  <option [value]="dashboard.id">{{ dashboard.title }}</option>
-                }
-              </select>
-              <button type="button" class="btn btn-ghost btn-sm" [disabled]="!dashboardRefId()" (click)="addDashboardRef()">Add</button>
-            </div>
-            <div class="inline-add manual-ref">
-              <select [value]="localRefKind()" (change)="setLocalRefKind($event)">
-                <option value="note">Note</option>
-                <option value="meeting">Recording</option>
-                <option value="dashboard">Dashboard</option>
-              </select>
-              <input type="text" placeholder="Local item id" [value]="localRefId()" (input)="setLocalRefId($event)" />
-              <button type="button" class="btn btn-ghost btn-sm" [disabled]="!localRefId().trim()" (click)="addLocalRef()">Link</button>
+            @if (isNew() || task?.canEdit) {
+              <div class="inline-add">
+                <select [value]="relatedTaskId()" (change)="setRelatedTask($event)">
+                  <option value="">Choose task…</option>
+                  @for (candidate of relatedCandidates(); track candidate.id) {
+                    <option [value]="candidate.id">{{ candidate.title }}</option>
+                  }
+                </select>
+                <button type="button" class="btn btn-ghost btn-sm" [disabled]="!relatedTaskId()" (click)="addRelatedTask()">Link</button>
+              </div>
+            }
+          </section>
+
+          <section class="detail-section">
+            <header>
+              <div><span class="eyebrow">E2EE bundle</span><h2>Images</h2></div>
+              @if (!isNew() && task?.canEdit) {
+                <label class="btn btn-ghost btn-sm file-button">
+                  {{ uploading() ? "Adding…" : "Add image" }}
+                  <input type="file" accept="image/png,image/jpeg,image/webp" multiple [disabled]="uploading()" (change)="addImages($event)" />
+                </label>
+              }
+            </header>
+            @if (isNew()) {
+              <p class="section-note">Create the task first, then add images to its encrypted document.</p>
+            }
+            <div class="image-grid">
+              @for (image of images(); track image.reference) {
+                <figure>
+                  @if (imageData(image); as src) {
+                    <img [src]="src" [alt]="image.alt" />
+                  } @else {
+                    <div class="image-placeholder">Encrypted image</div>
+                  }
+                  <figcaption>{{ image.alt || "Image" }}</figcaption>
+                  @if (task?.canEdit) {
+                    <button type="button" class="remove-image" (click)="removeImage(image)" aria-label="Remove image">×</button>
+                  }
+                </figure>
+              }
             </div>
           </section>
-        }
-      </section>
-    } @else if (routeId() && store.loading()) {
-      <mur-empty-state><mur-spinner /> Opening task…</mur-empty-state>
-    } @else if (routeId()) {
-      <mur-empty-state>
-        <strong>Task unavailable.</strong>
-        <p>It may have been withdrawn, or its organization is disabled on this Mac.</p>
-        <button type="button" class="btn btn-primary" (click)="backToList()">Back to Tasks</button>
-      </mur-empty-state>
-    } @else {
-      <mur-empty-state>
-        <strong>Select a task.</strong>
-        <p>Open shared work from the list, or create a task for one organization.</p>
-        <button type="button" class="btn btn-primary" (click)="newTask()">New task</button>
-      </mur-empty-state>
-    }
-  </main>
-</div>
+
+          @if (!isNew() && task) {
+            <section class="detail-section local-links">
+              <header><div><span class="eyebrow">This Mac only</span><h2>Local links</h2></div></header>
+              <p class="section-note">Note, recording and dashboard links never enter the shared task document.</p>
+              <div class="chips">
+                @for (ref of localRefs(); track ref.kind + ':' + ref.refId) {
+                  <span class="ref-chip local">
+                    <button type="button" (click)="openLocalRef(ref)">{{ ref.kind }} · {{ ref.refId }}</button>
+                    <button type="button" class="remove-chip" (click)="removeLocalRef(ref)" aria-label="Remove local link">×</button>
+                  </span>
+                }
+              </div>
+              <div class="inline-add">
+                <select [value]="dashboardRefId()" (change)="setDashboardRef($event)">
+                  <option value="">Add to dashboard…</option>
+                  @for (dashboard of dashboards(); track dashboard.id) {
+                    <option [value]="dashboard.id">{{ dashboard.title }}</option>
+                  }
+                </select>
+                <button type="button" class="btn btn-ghost btn-sm" [disabled]="!dashboardRefId()" (click)="addDashboardRef()">Add</button>
+              </div>
+              <div class="inline-add manual-ref">
+                <select [value]="localRefKind()" (change)="setLocalRefKind($event)">
+                  <option value="note">Note</option>
+                  <option value="meeting">Recording</option>
+                  <option value="dashboard">Dashboard</option>
+                </select>
+                <input type="text" placeholder="Local item id" [value]="localRefId()" (input)="setLocalRefId($event)" />
+                <button type="button" class="btn btn-ghost btn-sm" [disabled]="!localRefId().trim()" (click)="addLocalRef()">Link</button>
+              </div>
+            </section>
+          }
+        </section>
+      } @else if (routeId() && store.loading()) {
+        <mur-empty-state><mur-spinner /> Opening task…</mur-empty-state>
+      } @else if (routeId()) {
+        <mur-empty-state>
+          <strong>Task unavailable.</strong>
+          <p>It may have been withdrawn, or its organization is disabled on this Mac.</p>
+          <button type="button" class="btn btn-primary" (click)="backToList()">Back to Tasks</button>
+        </mur-empty-state>
+      } @else {
+        <mur-empty-state>
+          <strong>Select a task.</strong>
+          <p>Open shared work from the list, or create a task for one organization.</p>
+          <button type="button" class="btn btn-primary" (click)="newTask()">New task</button>
+        </mur-empty-state>
+      }
+    </main>
+  </div>
+}

--- a/src/app/features/tasks/task-view/task-view.component.scss
+++ b/src/app/features/tasks/task-view/task-view.component.scss
@@ -527,3 +527,46 @@ select:disabled {
     flex-basis: auto;
   }
 }
+
+/* --- Signed-out gate ------------------------------------------------------
+   In-flow content, NOT a floating overlay, so it rides the frosted `.card`
+   language rather than `--surface-overlay` (trap T3 is about panels that float
+   OVER other content; this one replaces the surface). */
+.tasks-gate {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100%;
+  padding: var(--space-8) var(--space-6);
+}
+
+.tasks-gate mur-empty-state {
+  max-width: 34rem;
+}
+
+.gate-mark {
+  width: 44px;
+  height: 44px;
+  margin-bottom: var(--space-2);
+  color: var(--accent);
+}
+
+.gate-lede {
+  color: var(--text-secondary);
+  line-height: 1.55;
+}
+
+.gate-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
+.gate-auth {
+  width: 100%;
+  margin-top: var(--space-5);
+  text-align: start;
+}

--- a/src/app/features/tasks/task-view/task-view.component.ts
+++ b/src/app/features/tasks/task-view/task-view.component.ts
@@ -24,15 +24,18 @@ import { IpcService } from "../../../core/ipc.service";
 import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 import { MurEmptyStateComponent } from "../../../design-system/empty-state/empty-state.component";
 import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
+import { SharingAuthFlowComponent } from "../../sharing/sharing-auth-flow/sharing-auth-flow.component";
 import { NoteAttachmentService } from "../../../services/note-attachment.service";
 import { TaskStore } from "../task.store";
 
 type TaskFilter = "open" | TaskStatus | "all";
+/** Which door of the shared account flow the signed-out gate opened. */
+type AuthDoor = "signin" | "create";
 
 @Component({
   selector: "app-task-view",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MurEmptyStateComponent, MurSpinnerComponent],
+  imports: [MurEmptyStateComponent, MurSpinnerComponent, SharingAuthFlowComponent],
   templateUrl: "./task-view.component.html",
   styleUrl: "./task-view.component.scss",
 })
@@ -107,6 +110,15 @@ export class TaskViewComponent {
       (this.isNew() || this.current()?.canEdit === true),
   );
 
+  /**
+   * The account door the signed-out gate has opened, or `null` while it only shows the two CTAs.
+   *
+   * `SharingAuthFlowComponent` is `:host { display: contents }` and paints no surface of its own,
+   * so it is embedded INLINE in the empty state rather than in a floating panel — which keeps this
+   * clear of the opaque-overlay trap entirely instead of re-deriving a second modal.
+   */
+  readonly authDoor = signal<AuthDoor | null>(null);
+
   readonly newSubtask = signal("");
   readonly relatedTaskId = signal("");
   readonly localRefKind = signal<TaskLocalRef["kind"]>("dashboard");
@@ -153,6 +165,23 @@ export class TaskViewComponent {
       const orgId = this.orgId();
       if (orgId) untracked(() => void this.store.loadAssignees(orgId));
     });
+  }
+
+  openAuth(door: AuthDoor): void {
+    this.authDoor.set(door);
+  }
+
+  closeAuth(): void {
+    this.authDoor.set(null);
+  }
+
+  /**
+   * A finished sign-in/sign-up. Re-run the authoritative read: it is the read itself that decides
+   * whether the gate stays up, so nothing here guesses at the new session state.
+   */
+  onAuthCompleted(): void {
+    this.authDoor.set(null);
+    void this.store.reload();
   }
 
   selectFilter(value: TaskFilter): void {

--- a/src/app/features/tasks/task.store.ts
+++ b/src/app/features/tasks/task.store.ts
@@ -7,6 +7,7 @@ import type {
   TaskLocalRef,
 } from "../../core/models";
 import { IpcService } from "../../core/ipc.service";
+import { ErrorCopyService } from "../../core/copy/error-copy.service";
 
 /**
  * Root signal store for org Tasks.
@@ -19,6 +20,7 @@ import { IpcService } from "../../core/ipc.service";
 export class TaskStore {
   private readonly ipc = inject(IpcService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly errors = inject(ErrorCopyService);
 
   private readonly _tasks = signal<OrgTask[]>([]);
   private readonly _orgs = signal<OrgStatus[]>([]);
@@ -26,11 +28,22 @@ export class TaskStore {
   private readonly _error = signal<string | null>(null);
   private readonly _assignees = signal<Record<string, TaskAssignee[]>>({});
   private readonly _scrubEpoch = signal(0);
+  private readonly _signedOut = signal(false);
 
   readonly tasks = this._tasks.asReadonly();
   readonly orgs = this._orgs.asReadonly();
   readonly loading = this._loading.asReadonly();
   readonly error = this._error.asReadonly();
+  /**
+   * True when the backend refused because this device has no sharing account at all.
+   *
+   * This is a BEHAVIOUR decision, so it is bound to the stable `[code]`
+   * (`errcode::SHARING_ACCOUNT_REQUIRED`), never to the prose — see
+   * `core/copy/error-copy.service.ts`. Tasks are org-only, and the default Murmur user has no
+   * account, so this is the EXPECTED state for most installs, not a failure: the view renders
+   * an invitation instead of an error banner.
+   */
+  readonly signedOut = this._signedOut.asReadonly();
   readonly assignees = this._assignees.asReadonly();
   /** Advances before every feed-driven refetch so mounted editors can synchronously drop drafts. */
   readonly scrubEpoch = this._scrubEpoch.asReadonly();
@@ -97,8 +110,9 @@ export class TaskStore {
       this._orgs.set(orgs.filter((org) => org.contextEnabled));
       this._tasks.set(tasks);
       this._error.set(null);
+      this._signedOut.set(false);
     } catch (error) {
-      if (token === this.loadToken) this._error.set(this.message(error));
+      if (token === this.loadToken) this.publishFailure(error);
     } finally {
       if (token === this.loadToken) this._loading.set(false);
     }
@@ -110,7 +124,7 @@ export class TaskStore {
       await this.reload();
       return task;
     } catch (error) {
-      this._error.set(this.message(error));
+      this.publishFailure(error);
       return null;
     }
   }
@@ -121,7 +135,7 @@ export class TaskStore {
       await this.reload();
       return task;
     } catch (error) {
-      this._error.set(this.message(error));
+      this.publishFailure(error);
       return null;
     }
   }
@@ -132,7 +146,7 @@ export class TaskStore {
       await this.reload();
       return true;
     } catch (error) {
-      this._error.set(this.message(error));
+      this.publishFailure(error);
       return false;
     }
   }
@@ -143,7 +157,7 @@ export class TaskStore {
       await this.reload();
       return true;
     } catch (error) {
-      this._error.set(this.message(error));
+      this.publishFailure(error);
       return false;
     }
   }
@@ -154,7 +168,7 @@ export class TaskStore {
       await this.reload();
       return true;
     } catch (error) {
-      this._error.set(this.message(error));
+      this.publishFailure(error);
       return false;
     }
   }
@@ -168,7 +182,7 @@ export class TaskStore {
       this._assignees.update((all) => ({ ...all, [orgId]: rows }));
     } catch (error) {
       if (this.canCommitAssignees(orgId, token)) {
-        this._error.set(this.message(error));
+        this.publishFailure(error);
       }
     }
   }
@@ -184,8 +198,28 @@ export class TaskStore {
     this._error.set(null);
   }
 
-  private message(error: unknown): string {
-    if (error instanceof Error) return error.message;
-    return String(error);
+  /**
+   * The ONE place a backend failure becomes state this view renders.
+   *
+   * Two jobs, in this order:
+   *
+   * 1. Classify by `[code]`. `sharing-account-required` is not an error on this surface — it is the
+   *    default local-first install meeting an org-only feature — so it raises {@link signedOut}
+   *    and leaves the banner EMPTY.
+   * 2. Humanize everything else. `String(error)` used to render the raw `AppError` `Display` here,
+   *    which is exactly the developer prose `src-tauri/src/error.rs` says must never be what the
+   *    user reads. `ErrorCopyService` is deny-by-default, so an un-coded failure degrades to a
+   *    fixed sentence rather than leaking Rust vocabulary into a banner.
+   */
+  private publishFailure(error: unknown): void {
+    if (this.errors.is(error, "sharing-account-required")) {
+      this._signedOut.set(true);
+      this._error.set(null);
+      this._tasks.set([]);
+      this._orgs.set([]);
+      this._assignees.set({});
+      return;
+    }
+    this._error.set(this.errors.humanize(error, "tasks"));
   }
 }


### PR DESCRIPTION
Murmur 2.0 — the nine release blockers an adversarial pre-release audit found, plus the version bump.

An eleven-agent audit ran over the whole `v1.1.0..murmur` diff (253 commits, 104 PRs, 326 app-code
files, +131k/−21k) and returned `DO_NOT_SHIP` on two of its three lenses. Full brief:
`docs/research/2026-08-27-murmur-2.0-release-audit.md`.

## What the audit cleared

- **Migration safety: no blockers.** Every statement added to `migrate()` since v1.1.0 is additive.
  No `DROP`, no `ALTER … DROP COLUMN`, no rewrite of user rows — an existing 1.1.0 database survives.
  This was the one unrecoverable risk in a release with an IA change.
- **Zero new dependencies** across the cycle.

## Blockers fixed

**Sealed-content leaks (`27f8c81`)**
1. The agent/MCP dashboard tools bypassed the board-level gate — a board in a sealed folder shipped
   its plaintext title, tile count and kinds to any MCP client while the UI withheld all three.
2. Locking a project did not re-close a session-unlocked descendant: `lock_container_subtree`
   skipped the idempotent repair tail, the only place that drops a folder from the session unlock set.
3. `relock_folder` did not cascade although `unlock_folder` does — an asymmetric open/close pair.

**Data loss (`e40b7fb`, `4d22d33`)**

4. Durable Ask history was erased on **every app launch** for any user with one locked folder. Two
   independent mechanisms — a global DELETE whose predicate the schema CHECK makes universal, and a
   `visibility_generation` bump that makes surviving rows unreadable. Both addressed; the global
   purge is kept for the ~20 callers that cannot name a folder set.
5. Obsidian import silently overwrote notes when a second vault shared a relative path. Identity is
   now vault-scoped. Also enforces the Murmur-vault guard server-side — a frontend warning is not a guard.

**Dead on arrival (`fa5da79`, `31c7e7a`, server deploy)**

6. Sharing was dead against the deployed relay. Root cause: production was **older than
   `.murmur-server-revision`** — no client change needed. The pinned `3ef670d` is now deployed;
   `/healthz` returns `capabilities:["share-owner-claim-v1"]` and `PUT /v1/shares/{id}/reservation`
   answers 401 instead of 404. Separately, the journal row was written before the capability check,
   which locked a source out after two clicks. **This changed a contract two tests pinned** — see
   `fa5da79` for why the new one wins and what happened to both.
7. Tasks rendered `provider unavailable: not signed in to the sharing account` verbatim for the
   default account-less user. Now a tagged code (`sharing-account-required`, distinct from
   `sharing-signin-required`) and a purposeful signed-out state.
8. Apple Notes import could not work under hardened runtime — no automation entitlement, no
   `NSAppleEventsUsageDescription`. Both added; `macos-sign-notarize.sh` now asserts them after
   signing, which is the only oracle this class can have short of shipping.

**Stale public copy (`eca3b9d`)**

9. The landing page had no commits since before v1.1.0 and never mentioned Dashboards, Spaces,
   Imports or Tasks. Refreshed, with Tasks carrying its account caveat rather than being sold as local.

## Also in this PR

- **Imports land in their own Space** (`54c4164`): 🗂️ *Imported from Notion*, 🔮 *Imported from
  Obsidian*, 🍎 *Imported from Apple Notes* — created on demand, reused by name, an explicit
  destination still wins.
- **Version bump to 2.0.0** across four files + the workspace-root `Cargo.lock`; `identifier`
  `com.meetnotes.app` unchanged (asserted, not eyeballed).
- **dompurify 3.4.13** taken directly rather than by merging #580, whose rust lane is red on an
  npm-only bump. It is the app's XSS gate over LLM and transcript content.
- **Runbook `Stage 0b`** (`035b6f7`): verify `../murmur-server` sits on the pinned revision and is
  clean, and that the deployed relay already advertises the capability. Neither check existed, and
  both gaps bit during this release — the sibling checkout was on an unmerged branch whose working
  tree had deleted a symbol `commands/org.rs` still references, so the release build could not have
  compiled while CI stayed green.

## Verification

Every fix was proven **RED-before-GREEN by reverting it in isolation** and recording the failure —
not by trusting that a new test proves anything. Each leak/loss oracle carries a control so it cannot
pass vacuously. One of those controls caught a bug in a fix itself.

Local gate: `✅ CI: all gates green (stage: full)` — clippy `-D warnings`, cargo test, cargo
audit/deny, cargo build, ng lint, ng build, both headless E2E suites.
`agent-config-audit`: PASS, 152 checks, 0 warnings.

## Not verified — needs a signed build

`cargo test --lib` cannot prove Touch ID / Security.framework KEK release, the real Keychain ACL,
ScreenCaptureKit/TCC, the lock cascade against a real KEK, or whether the Apple Notes Automation
prompt appears. The post-sign assertion proves the entitlement pair is in the bundle; the prompt is
first observable on the notarized DMG.

**Known residual, deliberately out of scope:** deleting a single note still clears all Ask history
(the same over-reach, via callers that have no folder set to scope by). Not a leak; recorded in the
audit brief.
