### PR TITLE
feat(shell): rail brand tile renders the Murmur mark in the accent theme

### DIFF
--- a/src/app/app-shell/app-shell.component.html
+++ b/src/app/app-shell/app-shell.component.html
@@ -2,7 +2,7 @@
 
 <nav class="global-rail" aria-label="Global navigation">
   <div class="rail-drag" data-tauri-drag-region></div>
-  <div class="rail-brand" aria-hidden="true">M</div>
+  <div class="rail-brand" aria-hidden="true"><mur-icon icon="murmur" /></div>
 
   <a
     class="rail-item"

--- a/src/app/design-system/icon/icon.component.html
+++ b/src/app/design-system/icon/icon.component.html
@@ -1,5 +1,14 @@
 <span class="nav-icon" aria-hidden="true">
   @switch (icon()) {
+    @case ("murmur") {
+      <svg viewBox="0 0 20 20" fill="currentColor">
+        <rect x="2.4" y="7.9" width="2" height="4.2" rx="1" />
+        <rect x="5.7" y="5.8" width="2" height="8.4" rx="1" />
+        <rect x="9" y="3.7" width="2" height="12.6" rx="1" />
+        <rect x="12.3" y="5.8" width="2" height="8.4" rx="1" />
+        <rect x="15.6" y="7.9" width="2" height="4.2" rx="1" />
+      </svg>
+    }
     @case ("record") {
       <svg viewBox="0 0 20 20" fill="none">
         <circle cx="10" cy="10" r="4.5" fill="currentColor" />

--- a/src/app/design-system/icon/icon.component.ts
+++ b/src/app/design-system/icon/icon.component.ts
@@ -2,6 +2,10 @@ import { ChangeDetectionStrategy, Component, input } from "@angular/core";
 
 /** Every glyph the shell chrome can render (nav + quick actions + chrome). */
 export type ShellIcon =
+  // The Murmur brand mark itself — the five-bar waveform from
+  // `src-tauri/icons/icon.svg`, drawn in `currentColor` so the rail tile paints
+  // it in the user's accent instead of shipping a second, fixed-gradient copy.
+  | "murmur"
   | "record"
   | "meetings"
   | "notes"

--- a/src/styles.css
+++ b/src/styles.css
@@ -388,6 +388,9 @@ app-shell {
   height: var(--space-7);
 }
 
+/* The brand tile carries the Murmur waveform mark (mur-icon "murmur"), which
+   paints in `currentColor` — so the bars follow the user's accent theme rather
+   than the fixed gradient the app-icon PNG bakes in. */
 .rail-brand {
   display: grid;
   place-items: center;
@@ -398,8 +401,6 @@ app-shell {
   border-radius: var(--radius-md);
   background: var(--accent-soft);
   color: var(--accent-hover);
-  font-size: 0.85rem;
-  font-weight: 750;
 }
 
 .rail-item {


### PR DESCRIPTION
## What

The global rail's brand tile rendered a literal `M`. It now renders Murmur's own
five-bar waveform mark — the one in `src-tauri/icons/icon.svg` — added to the
`mur-icon` catalog as `"murmur"` so the glyph lives with every other icon rather
than inline in the shell template.

The mark is drawn in `currentColor`, so the bars take `--accent-hover` and follow
whichever accent the user picked in Settings, instead of shipping a second,
fixed-gradient copy of the app icon. The tile keeps its `--accent-soft` background;
`.rail-brand`'s now-dead `font-size` / `font-weight` come off.

Bar proportions are 1:1 with the app icon (bar width / mark span = 0.131), redrawn
on the 20x20 viewBox the rest of the icon set uses.

## Verification

- `npx ng lint` — clean
- `npx ng build` — exit 0
- `.agents/h/mirror-check` — `mirror OK`
- Rendered the glyph at 16/18/20/22 px next to the `record` / `search` glyphs in the
  real rail geometry (32 px tile, 48 px items): the catalog-standard 20 px keeps the
  rail's rhythm, so no size override was added.
- Ran the dev app from this tree (`npm run dev`): clean boot — `state: app state
  initialized`, `screenshare: watcher started`, no panic/abort.

FE-only; no Rust touched.
