### PR TITLE
fix(dnd): let a drag reach the page in the packaged app

### DIFF
--- a/e2e/shell/workspace-dnd.spec.ts
+++ b/e2e/shell/workspace-dnd.spec.ts
@@ -1,4 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 import { mockTauri } from "../settings-ai/mock-invoke";
 
@@ -187,4 +189,63 @@ test("a sealed container is not a drop target", async ({ page }) => {
     () => (globalThis as unknown as { __moves?: unknown[] }).__moves ?? [],
   );
   expect(moves).toEqual([]);
+});
+
+/**
+ * The half of drag-and-drop this suite is structurally blind to.
+ *
+ * # What shipped broken
+ *
+ * Every test above passed — in Chromium AND WebKit — while dragging a row in the shipped app did
+ * nothing at all. The row picked up and followed the cursor, no Space ever armed, no drop ever
+ * landed. The tests were not lying: the DOM half is correct, and Playwright dispatches the drag
+ * straight into the engine. The app has a native layer in front of the engine, and Playwright has
+ * no way to put one there.
+ *
+ * # The mechanism
+ *
+ * wry overrides `draggingEntered:`, `draggingUpdated:` and `performDragOperation:` on its WKWebView
+ * subclass (`wry/src/wkwebview/drag_drop.rs`). Each asks Tauri's drag-drop handler first and calls
+ * `super` — WKWebView's own implementation, the only path into the web content — ONLY if that
+ * handler declines. `tauri-runtime-wry` installs a handler that returns `true` unconditionally
+ * whenever the window's `dragDropEnabled` is true, and `true` is the default (`tauri-utils`
+ * `default_true`). So on a default config the native override answers every drag itself and the page
+ * is never told one happened: no `dragenter`, no `dragover`, no `drop`.
+ *
+ * `dragstart` still fires, because that is the drag SOURCE half and nothing intercepts it. A gesture
+ * that starts, follows the cursor and can never land is exactly what a user reports as "drag and
+ * drop does not work" — and exactly what no green DOM test can see.
+ *
+ * # Why the guard is a config assertion and not a browser test
+ *
+ * The defect is not reachable from a browser: it lives in the window layer of the packaged app. What
+ * IS checkable everywhere is the one line that keeps the native layer out of the way, so that is
+ * what this asserts, for every window the config declares — a second window added later would
+ * default straight back into the bug. The floating recorder bar is built in Rust
+ * (`lib.rs::create_bar_window`) and is deliberately not covered: it is a 540x58 transport control
+ * with nothing to drop onto. A future window that renders draggable content needs
+ * `.drag_drop_handler_enabled(false)` on its builder, for the same reason.
+ *
+ * The control that keeps this honest is `scripts/wkwebview-drag-probe` (`--self-test`), which builds
+ * both configurations in a real WKWebView and measures the asymmetry the way AppKit produces it:
+ *
+ *   dragDropEnabled true  → page saw {enter:0, over:0, drop:0}
+ *   dragDropEnabled false → page saw {enter:1, over:1, drop:1}, operation = move
+ *
+ * It needs a WindowServer session, so it is not part of `scripts/ci.sh`; it is how this diagnosis was
+ * made, and how to re-make it if the upstream behaviour ever changes.
+ */
+test("the native layer is kept out of the way of HTML5 drag-and-drop", async () => {
+  const conf = JSON.parse(
+    readFileSync(join(__dirname, "..", "..", "src-tauri", "tauri.conf.json"), "utf8"),
+  ) as { app: { windows: { label?: string; title?: string; dragDropEnabled?: boolean }[] } };
+
+  expect(conf.app.windows.length).toBeGreaterThan(0);
+  for (const window of conf.app.windows) {
+    expect(
+      window.dragDropEnabled,
+      `window ${window.label ?? window.title ?? "?"}: dragDropEnabled must be false, or wry's ` +
+        "NSDraggingDestination override answers every drag and the page never sees one",
+    ).toBe(false);
+  }
 });

--- a/scripts/wkwebview-drag-probe/README.md
+++ b/scripts/wkwebview-drag-probe/README.md
@@ -1,0 +1,67 @@
+# wkwebview-drag-probe
+
+Does a drag reach the **page** inside the WKWebView Murmur ships in — or does the native layer in
+front of it eat the gesture first?
+
+```bash
+swiftc -O -o /tmp/dragprobe scripts/wkwebview-drag-probe/main.swift
+
+/tmp/dragprobe               # the comparison table
+/tmp/dragprobe --self-test   # exit 1 unless the asymmetry still holds
+/tmp/dragprobe --file        # drag a file rather than text
+```
+
+```
+dragDropEnabled: true  (wry answers, WKWebView never sees it)
+  draggingEntered=1 draggingUpdated=1  page saw {"enter":0,"over":0,"drop":0}
+dragDropEnabled: false (wry declines, WKWebView handles it)
+  draggingEntered=1 draggingUpdated=16 page saw {"enter":1,"over":1,"drop":1}
+```
+
+## Why this exists
+
+Sidebar drag-and-drop worked in every gate and in neither shipped build. `e2e/shell/workspace-dnd.
+spec.ts` drove the whole gesture green in Chromium **and** WebKit — Playwright dispatches the drag
+straight into the engine, and there is no native window layer in front of it. The shipped app has
+one, and that layer was eating the drag.
+
+`scripts/wkwebview-probe` closed the "can this JS run in the engine we ship" hole and cannot answer
+this question: a drag is not an expression. It arrives through AppKit's `NSDraggingDestination`
+methods on the NSView, which is **above** the web content — in the view subclass wry installs.
+
+## The mechanism it reproduces
+
+wry 0.55 `src/wkwebview/drag_drop.rs` overrides `draggingEntered:`, `draggingUpdated:` and
+`performDragOperation:`. Each asks Tauri's drag-drop handler first and calls `super` **only if that
+handler declines**. `tauri-runtime-wry` installs a handler that returns `true` unconditionally
+whenever the window's `dragDropEnabled` is true — and `true` is the default (`tauri-utils`
+`default_true`). On a default config the overrides answer the drag themselves, WKWebView's own
+implementation never runs, and the page is never told a drag happened.
+
+`dragstart` still fires, because that is the drag **source** half and nothing intercepts it. So a
+row picks up, follows the cursor, and can never land: no target ever arms, no drop ever fires. That
+is what "drag and drop does not work" looked like from outside.
+
+The fix is one line in `src-tauri/tauri.conf.json` — `"dragDropEnabled": false` — guarded by
+`e2e/shell/workspace-dnd.spec.ts`.
+
+## What it proves and does not prove
+
+**Proves:** whether the native layer delivers or swallows a drag, in the real engine, for both
+configurations, with no mouse and no accessibility grant — it calls the dragging destination methods
+directly with a stub `NSDraggingInfo`, which is how AppKit calls them.
+
+**Also measured** while diagnosing this, and recorded in the source header: with the native handler
+off and a file dropped on a page that registers **no** drop handler at all, `draggingUpdated` answers
+`NSDragOperationNone` and `location.href` is unchanged. Turning the native handler off does not
+expose the webview to drop-to-navigate, so no global "swallow stray drops" guard is needed.
+
+**Does not prove:** that the app's own drop targets file the right thing — that is the Playwright
+spec's job, and it is a real oracle for the DOM half. It also says nothing about a signed build.
+
+## Notes
+
+- Needs a WindowServer session (the web view is attached to an off-screen window, because WebKit
+  routes drags through the view hierarchy). It is therefore **not** wired into `scripts/ci.sh`; run
+  it locally when a drag question comes up.
+- `NSDragOperation` raw values in the output: `1` copy, `16` move, `0` none.

--- a/scripts/wkwebview-drag-probe/main.swift
+++ b/scripts/wkwebview-drag-probe/main.swift
@@ -1,0 +1,224 @@
+// wkwebview-drag-probe — does a drag reach the PAGE inside a real WKWebView?
+//
+// WHY THIS EXISTS
+// ---------------
+// Murmur's sidebar drag-and-drop worked in every gate and in neither shipped
+// build. The Playwright suite (e2e/shell/workspace-dnd.spec.ts) drove the whole
+// gesture green in Chromium AND WebKit, because Playwright dispatches the drag
+// straight into the engine — there is no native window layer in front of it.
+// The shipped app has one, and that layer was eating the drag.
+//
+// `scripts/wkwebview-probe` closed the "can this JS run in the engine we ship"
+// hole. It cannot answer this question: a drag is not an expression, it arrives
+// through AppKit's NSDraggingDestination methods on the NSView, and what breaks
+// it lives ABOVE the web content, in the view subclass wry installs.
+//
+// WHAT IT REPRODUCES
+// ------------------
+// wry 0.55 `src/wkwebview/drag_drop.rs` overrides `draggingEntered:`,
+// `draggingUpdated:` and `performDragOperation:` on its WKWebView subclass. Each
+// asks Tauri's drag-drop handler first and calls `super` ONLY if that handler
+// declines. `tauri-runtime-wry` installs a handler that returns `true`
+// unconditionally whenever the window's `dragDropEnabled` is true — and true is
+// the DEFAULT. So on a default config the overrides answer the drag themselves,
+// WKWebView's own implementation never runs, and the page is never told a drag
+// happened: no dragenter, no dragover, no drop. `dragstart` still fires (that is
+// the SOURCE half, which nothing intercepts), so a row picks up and follows the
+// cursor — the gesture looks alive and can never land.
+//
+// This probe builds both configurations and reports what the page saw.
+//
+// USAGE
+//   swiftc -O -o /tmp/dragprobe scripts/wkwebview-drag-probe/main.swift
+//   /tmp/dragprobe               # print the comparison table
+//   /tmp/dragprobe --self-test   # exit 1 unless the asymmetry still holds
+//   /tmp/dragprobe --file        # drag a FILE rather than text
+//
+// Needs no accessibility grant, no signing and no mouse: it calls the dragging
+// destination methods directly with a stub NSDraggingInfo, which is exactly how
+// AppKit calls them.
+//
+// MEASURED 2026-08-28 (macOS 25.5, arm64):
+//   swallow (dragDropEnabled true)  → page saw {enter:0, over:0, drop:0}
+//   forward (dragDropEnabled false) → page saw {enter:1, over:1, drop:1}, op=move
+//   unhandled file drop, forwarding → draggingUpdated answers NONE, href unchanged
+//     (WebKit refuses a drop the page did not accept, so turning the native
+//      handler off does NOT expose the webview to drop-to-navigate)
+//
+// EXIT CODES
+//   0  ran (and, under --self-test, the asymmetry held)
+//   1  --self-test found the asymmetry broken
+//   2  a page failed to load
+
+import AppKit
+import WebKit
+
+let wantFile = CommandLine.arguments.contains("--file")
+let selfTest = CommandLine.arguments.contains("--self-test")
+
+/// The stub AppKit itself would pass in. Only the members WebKit reads matter.
+final class StubDraggingInfo: NSObject, NSDraggingInfo {
+    var draggingDestinationWindow: NSWindow?
+    var draggingSourceOperationMask: NSDragOperation = [.copy, .move]
+    var draggingLocation: NSPoint = .zero
+    var draggedImageLocation: NSPoint = .zero
+    var draggedImage: NSImage?
+    var draggingPasteboard: NSPasteboard
+    var draggingSource: Any?
+    var draggingSequenceNumber: Int = 1
+    var draggingFormation: NSDraggingFormation = .default
+    var animatesToDestination: Bool = false
+    var numberOfValidItemsForDrop: Int = 1
+    var springLoadingHighlight: NSSpringLoadingHighlight = .none
+
+    init(pasteboard: NSPasteboard, location: NSPoint, window: NSWindow?) {
+        self.draggingPasteboard = pasteboard
+        self.draggingLocation = location
+        self.draggingDestinationWindow = window
+        super.init()
+    }
+
+    func slideDraggedImage(to screenPoint: NSPoint) {}
+    override func namesOfPromisedFilesDropped(atDestination dropDestination: URL) -> [String]? { nil }
+    func enumerateDraggingItems(
+        options enumOpts: NSDraggingItemEnumerationOptions,
+        for view: NSView?,
+        classes classArray: [AnyClass],
+        searchOptions: [NSPasteboard.ReadingOptionKey: Any],
+        using block: (NSDraggingItem, Int, UnsafeMutablePointer<ObjCBool>) -> Void
+    ) {}
+    func resetSpringLoading() {}
+}
+
+/// Mirrors wry's override, with its one decision exposed as a flag.
+final class ProbeWebView: WKWebView {
+    /// true = Tauri's handler claimed the drag (dragDropEnabled true, the default).
+    var swallow = true
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        swallow ? .copy : super.draggingEntered(sender)
+    }
+    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        swallow ? .copy : super.draggingUpdated(sender)
+    }
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        swallow ? true : super.performDragOperation(sender)
+    }
+    override func draggingExited(_ sender: NSDraggingInfo?) {
+        if !swallow { super.draggingExited(sender) }
+    }
+}
+
+let page = """
+<!doctype html><html><body style="margin:0">
+<div id="t" style="width:100vw;height:100vh">drop target</div>
+<script>
+window.__seen = { enter: 0, over: 0, drop: 0 };
+const t = document.getElementById("t");
+// preventDefault is what makes a target accept a drop — the same thing
+// FolderDropDirective does.
+t.addEventListener("dragenter", e => { e.preventDefault(); window.__seen.enter++; });
+t.addEventListener("dragover",  e => { e.preventDefault(); window.__seen.over++; });
+t.addEventListener("drop",      e => { e.preventDefault(); window.__seen.drop++; });
+</script></body></html>
+"""
+
+final class LoadWatcher: NSObject, WKNavigationDelegate {
+    var finished = false
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) { finished = true }
+}
+
+func pump(_ seconds: Double) {
+    let deadline = Date().addingTimeInterval(seconds)
+    while Date() < deadline {
+        RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.02))
+    }
+}
+
+struct Result {
+    let enteredOp: UInt
+    let updatedOp: UInt
+    let seen: String
+}
+
+func run(swallow: Bool) -> Result {
+    let window = NSWindow(
+        contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),
+        styleMask: [.titled], backing: .buffered, defer: false)
+    let web = ProbeWebView(frame: NSRect(x: 0, y: 0, width: 600, height: 400),
+                           configuration: WKWebViewConfiguration())
+    web.swallow = swallow
+    let watcher = LoadWatcher()
+    web.navigationDelegate = watcher
+    window.contentView = web
+    window.orderFrontRegardless()
+    web.loadHTMLString(page, baseURL: URL(string: "http://localhost/"))
+
+    var waited = 0.0
+    while !watcher.finished && waited < 10 { pump(0.05); waited += 0.05 }
+    guard watcher.finished else {
+        FileHandle.standardError.write(Data("wkwebview-drag-probe: page load timed out\n".utf8))
+        exit(2)
+    }
+    pump(0.5)
+
+    let pasteboard = NSPasteboard(name: NSPasteboard.Name("murmur.wkwebview-drag-probe"))
+    pasteboard.clearContents()
+    if wantFile {
+        pasteboard.writeObjects([URL(fileURLWithPath: "/etc/hosts") as NSURL])
+    } else {
+        pasteboard.setString("murmur", forType: .string)
+    }
+
+    let info = StubDraggingInfo(pasteboard: pasteboard,
+                                location: NSPoint(x: 300, y: 200),
+                                window: window)
+    let entered = web.draggingEntered(info)
+    pump(0.4)
+    let updated = web.draggingUpdated(info)
+    pump(0.4)
+    _ = web.performDragOperation(info)
+    pump(0.8)
+
+    var seen = "?"
+    let done = DispatchSemaphore(value: 0)
+    web.evaluateJavaScript("JSON.stringify(window.__seen)") { value, error in
+        seen = (value as? String) ?? "error: \(String(describing: error))"
+        done.signal()
+    }
+    while done.wait(timeout: .now()) == .timedOut { pump(0.05) }
+
+    window.orderOut(nil)
+    return Result(enteredOp: entered.rawValue, updatedOp: updated.rawValue, seen: seen)
+}
+
+NSApplication.shared.setActivationPolicy(.accessory)
+
+let swallowed = run(swallow: true)
+let forwarded = run(swallow: false)
+
+print("dragging \(wantFile ? "a file" : "text") onto a page whose target accepts drops\n")
+print("  dragDropEnabled: true  (wry answers, WKWebView never sees it)")
+print("    draggingEntered=\(swallowed.enteredOp) draggingUpdated=\(swallowed.updatedOp) page saw \(swallowed.seen)")
+print("  dragDropEnabled: false (wry declines, WKWebView handles it)")
+print("    draggingEntered=\(forwarded.enteredOp) draggingUpdated=\(forwarded.updatedOp) page saw \(forwarded.seen)")
+
+if selfTest {
+    let blocked = swallowed.seen.contains("\"enter\":0")
+        && swallowed.seen.contains("\"over\":0")
+        && swallowed.seen.contains("\"drop\":0")
+    let delivered = forwarded.seen.contains("\"enter\":1")
+        && forwarded.seen.contains("\"over\":1")
+        && forwarded.seen.contains("\"drop\":1")
+    if !blocked {
+        FileHandle.standardError.write(Data(
+            "wkwebview-drag-probe: expected the swallowing config to starve the page, saw \(swallowed.seen)\n".utf8))
+        exit(1)
+    }
+    if !delivered {
+        FileHandle.standardError.write(Data(
+            "wkwebview-drag-probe: expected the forwarding config to deliver the drag, saw \(forwarded.seen)\n".utf8))
+        exit(1)
+    }
+    print("\nself-test OK — the native layer, not the page, decides whether a drag exists")
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,6 +18,7 @@
         "width": 900,
         "height": 680,
         "visible": false,
+        "dragDropEnabled": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "trafficLightPosition": {


### PR DESCRIPTION
## The bug

Dragging a row in the sidebar did nothing. It picked up, followed the cursor, and no Space ever
armed or accepted it.

Every gate was green — including the four Playwright tests in `e2e/shell/workspace-dnd.spec.ts`
that drive the entire gesture, in Chromium **and** WebKit. They were not lying: the DOM half is
correct. The defect lives in the native layer in front of the engine, and no browser test can put
one there.

## Root cause

wry overrides `draggingEntered:`, `draggingUpdated:` and `performDragOperation:` on its WKWebView
subclass (`wry/src/wkwebview/drag_drop.rs`). Each asks Tauri's drag-drop handler first and calls
`super` — WKWebView's own implementation, the only path into the web content — **only if that
handler declines**. `tauri-runtime-wry` installs a handler that returns `true` unconditionally
whenever the window's `dragDropEnabled` is true, and `true` is the default (`tauri-utils`
`default_true`; this repo never set the key).

So the native override answered every drag itself and the page was never told one happened: no
`dragenter`, no `dragover`, no `drop`. `dragstart` still fired, because that is the drag **source**
half and nothing intercepts it — which is exactly why the gesture looked alive and could never land.

## Measured, not hypothesised

`scripts/wkwebview-drag-probe` (new) reproduces both configurations in a **real WKWebView** by
calling the dragging-destination methods with a stub `NSDraggingInfo`, the way AppKit calls them —
no mouse, no accessibility grant, no signing:

```
dragDropEnabled: true  (wry answers, WKWebView never sees it)
  draggingEntered=1 draggingUpdated=1  page saw {"enter":0,"over":0,"drop":0}
dragDropEnabled: false (wry declines, WKWebView handles it)
  draggingEntered=1 draggingUpdated=16 page saw {"enter":1,"over":1,"drop":1}   # 16 = move
```

Also measured, because turning the native handler off hands stray file drops to the engine: a file
dropped on a page that registers **no** drop handler makes `draggingUpdated` answer
`NSDragOperationNone` and leaves `location.href` unchanged. WebKit refuses it on its own, so no
global "swallow stray drops" guard is needed.

Nothing in the app listens for the native drag-drop event this disables (no `onDragDropEvent`, no
Rust `DragDrop` handler). The note editor's own drop handlers (`onBodyDrop` / `onEditorDrop`) have
always expected the HTML5 shape, so they start working too.

## The oracle

The defect is unreachable from a browser, so the guard asserts the one line that keeps the native
layer out of the way, for every window the config declares — in the spec that owns this feature, so
the DOM half and the native half are read together. It is **RED before the fix and GREEN after**:

```
# conf without the line
1 failed  the native layer is kept out of the way of HTML5 drag-and-drop
# conf with the line
10 passed (chromium + webkit)
```

The probe is the control that keeps that assertion from going vacuous, and it carries the measured
numbers in its header. It needs a WindowServer session, so it is deliberately not wired into
`scripts/ci.sh`.

## Gates

- `npx playwright test e2e/shell/workspace-dnd.spec.ts` — 10 passed (chromium + webkit)
- `npx ng lint` — clean
- `npx ng build` — clean
- `.agents/h/mirror-check` — OK
- `swiftc -O scripts/wkwebview-drag-probe/main.swift` + `--self-test` — passes for text and file drags
- `cargo test --lib` — Rust source is untouched; the config change is validated by `WindowConfig`'s
  `deny_unknown_fields` + `rename_all = "camelCase"` (a wrong key fails every config parse, and
  `tauri info` parses clean). The local run was still queued behind another session on the shared
  Cargo lane when this went up; CI runs the full gate.

## What still needs a hand

The mechanism is proven in the shipping engine, but the end-to-end gesture in a rebuilt app is one
real mouse drag, and driving one needs an accessibility grant that hangs a non-interactive shell.
Worth a single confirmation drag after this merges.
