### PR TITLE
feat(ui): copyable IDs in item headers

### DIFF
--- a/e2e/detail/copy-id.spec.ts
+++ b/e2e/detail/copy-id.spec.ts
@@ -1,0 +1,193 @@
+import { expect, test, type Page } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * `<mur-copy-id>` — the header control that puts an item's stable id on the clipboard so the
+ * user can point Claude at THAT meeting/note/board over the local MCP server.
+ *
+ * The clipboard itself is stubbed rather than driven through a real permission grant: WebKit
+ * does not implement Playwright's `clipboard-read`/`clipboard-write` permissions, so a
+ * permission-based test would only ever run on one of the two projects. Stubbing
+ * `navigator.clipboard.writeText` runs on both AND is the only way to exercise the REFUSAL
+ * path, which is the half that matters — an id is not on screen anywhere, so a silently
+ * swallowed refusal would leave the user pasting whatever the clipboard held before.
+ */
+async function stubClipboard(page: Page, mode: "resolve" | "reject"): Promise<void> {
+  await page.addInitScript((behaviour: string) => {
+    const copied: string[] = [];
+    (window as unknown as { __copied: string[] }).__copied = copied;
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: (text: string) => {
+          if (behaviour === "reject") {
+            return Promise.reject(new Error("NotAllowedError"));
+          }
+          copied.push(text);
+          return Promise.resolve();
+        },
+      },
+    });
+  }, mode);
+}
+
+const copied = (page: Page) =>
+  page.evaluate(() => (window as unknown as { __copied: string[] }).__copied);
+
+test("the meeting header copies the meeting's exact id and confirms it", async ({ page }) => {
+  await stubClipboard(page, "resolve");
+  await mockTauri(page, {}, { audit_reminder_suggestions: [] });
+  await page.goto("/meeting/m-atlas-roadmap");
+
+  const button = page.getByRole("button", { name: "Copy this meeting’s ID" });
+  await expect(button).toBeVisible({ timeout: 10_000 });
+  await button.click();
+
+  // Verbatim: the string on the clipboard is exactly what `get_meeting`'s `meetingId` takes.
+  // A prefix, a label or surrounding punctuation would have to be stripped by hand first.
+  expect(await copied(page)).toEqual(["m-atlas-roadmap"]);
+  await expect(page.locator(".toast.is-success .toast-msg")).toHaveText(
+    "Meeting ID copied",
+  );
+  await expect(
+    page.getByRole("button", { name: "Meeting ID copied" }),
+  ).toBeVisible();
+});
+
+test("a refused clipboard write says so instead of flashing a false confirmation", async ({
+  page,
+}) => {
+  await stubClipboard(page, "reject");
+  await mockTauri(page, {}, { audit_reminder_suggestions: [] });
+  await page.goto("/meeting/m-atlas-roadmap");
+
+  const button = page.getByRole("button", { name: "Copy this meeting’s ID" });
+  await expect(button).toBeVisible({ timeout: 10_000 });
+  await button.click();
+
+  await expect(page.locator(".toast.is-danger .toast-msg")).toHaveText(
+    "Couldn’t copy the meeting ID — your Mac refused clipboard access.",
+  );
+  // The control must NOT claim success: no tick, and no success toast alongside the failure.
+  await expect(page.getByRole("button", { name: "Meeting ID copied" })).toHaveCount(0);
+  await expect(page.locator(".toast.is-success")).toHaveCount(0);
+});
+
+test("the note header copies the note's id", async ({ page }) => {
+  await stubClipboard(page, "resolve");
+  await mockTauri(page, {});
+  await page.goto("/notes/n1");
+
+  const button = page.getByRole("button", { name: "Copy this note’s ID" });
+  await expect(button).toBeVisible({ timeout: 10_000 });
+  await button.click();
+
+  expect(await copied(page)).toEqual(["n1"]);
+  await expect(page.locator(".toast.is-success .toast-msg")).toHaveText(
+    "Note ID copied",
+  );
+});
+
+const TASK_ORG_ID = "11111111-1111-4111-8111-111111111111";
+const TASK_DOC_ID = "22222222-2222-4222-8222-222222222222";
+const TASK_ID = `${TASK_ORG_ID}:${TASK_DOC_ID}`;
+
+/**
+ * A task id is copyable too, but the tooltip deliberately promises nothing about Claude here:
+ * no MCP tool resolves a task id yet, so this control exists to let the user refer to the task
+ * by hand. If a `get_task` tool ever lands, the copy is already in the right place.
+ */
+test("the task header copies the task's composite id", async ({ page }) => {
+  await stubClipboard(page, "resolve");
+  await mockTauri(
+    page,
+    {
+      org_refresh: () => null,
+      task_list_assignees: () => [],
+      list_note_attachments: () => [],
+      list_tasks: () => [
+        {
+          id: "11111111-1111-4111-8111-111111111111:22222222-2222-4222-8222-222222222222",
+          orgId: "11111111-1111-4111-8111-111111111111",
+          docId: "22222222-2222-4222-8222-222222222222",
+          itemId: "33333333-3333-4333-8333-333333333333",
+          sourceDocumentId: null,
+          version: 1,
+          title: "Finish onboarding",
+          description: "Body",
+          status: "inProgress",
+          dueAt: null,
+          assigneeUserId: null,
+          createdAt: "2026-08-20T09:00:00Z",
+          subtasks: [],
+          orgRefs: [],
+          images: [],
+          access: "view",
+          canEdit: false,
+          canManage: false,
+          localRefs: [],
+          updatedAt: "2026-08-21T09:00:00Z",
+        },
+      ],
+    },
+    {
+      org_list_statuses: [
+        {
+          orgId: TASK_ORG_ID,
+          name: "Acme",
+          role: "member",
+          memberCount: 2,
+          consented: true,
+          lastSeq: 7,
+          itemCount: 1,
+          receivedCount: 1,
+          pendingShares: 0,
+          contextEnabled: true,
+        },
+      ],
+    },
+  );
+  await page.goto(`/tasks/${TASK_ID}`);
+
+  const button = page.getByRole("button", { name: "Copy this task\u2019s ID" });
+  await expect(button).toBeVisible({ timeout: 10_000 });
+  await button.click();
+
+  expect(await copied(page)).toEqual([TASK_ID]);
+  await expect(page.locator(".toast.is-success .toast-msg")).toHaveText(
+    "Task ID copied",
+  );
+});
+
+test("the board header copies the board's id from the title line", async ({ page }) => {
+  await stubClipboard(page, "resolve");
+  await mockTauri(
+    page,
+    {},
+    {
+      list_dashboards: [
+        { id: "b-copy", title: "Atlas GA", emoji: "\ud83d\ude80", createdAt: 1, updatedAt: 2, tileKinds: [] },
+      ],
+      get_dashboard: {
+        id: "b-copy",
+        title: "Atlas GA",
+        emoji: "\ud83d\ude80",
+        createdAt: 1,
+        updatedAt: 2,
+        tileKinds: [],
+        tiles: [],
+      },
+      get_dashboard_sources: [],
+    },
+  );
+  await page.goto("/dashboards/b-copy");
+
+  const button = page.getByRole("button", { name: "Copy this board\u2019s ID" });
+  await expect(button).toBeVisible({ timeout: 10_000 });
+  await button.click();
+
+  expect(await copied(page)).toEqual(["b-copy"]);
+  await expect(page.locator(".toast.is-success .toast-msg")).toHaveText(
+    "Board ID copied",
+  );
+});

--- a/src/app/core/copy-id.service.ts
+++ b/src/app/core/copy-id.service.ts
@@ -1,0 +1,76 @@
+import { DestroyRef, Injectable, inject, signal } from "@angular/core";
+
+import { ToastService } from "../services/toast.service";
+
+/** How long the control keeps showing its "copied" tick before reverting (ms). */
+const COPIED_FLASH_MS = 1600;
+
+/**
+ * Copying an item's stable id to the clipboard, with the transient "copied" flash.
+ *
+ * # Why this is a service and not three lines in the component
+ *
+ * The flash needs a timer, and `angular-zoneless.md` §5 bans `setTimeout` in a component
+ * ("service timers are the only sanctioned `setTimeout`"). Owning it here keeps the handle
+ * tracked and cleared once in {@link DestroyRef.onDestroy}, the same shape
+ * `services/toast.service.ts` uses for its auto-dismiss queue.
+ *
+ * # Why the failure path is loud
+ *
+ * `navigator.clipboard.writeText` rejects when the webview refuses the write. The pre-existing
+ * copy buttons in Settings swallow that in a bare `catch {}` — they can afford to, because the
+ * text they copy is also on screen and selectable. An id is NOT on screen: a silent refusal
+ * would flash nothing, leave the clipboard holding whatever it held before, and the user would
+ * paste the wrong thing into Claude. So a refusal raises a danger toast instead.
+ */
+@Injectable({ providedIn: "root" })
+export class CopyIdService {
+  private readonly toast = inject(ToastService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  private readonly _lastCopied = signal<string | null>(null);
+  /** The id copied within the last {@link COPIED_FLASH_MS}, or `null`. */
+  readonly lastCopied = this._lastCopied.asReadonly();
+
+  private flashTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor() {
+    this.destroyRef.onDestroy(() => {
+      if (this.flashTimer !== null) {
+        clearTimeout(this.flashTimer);
+        this.flashTimer = null;
+      }
+    });
+  }
+
+  /**
+   * Copy `id` verbatim and confirm it. `label` names the kind in the toast ("Meeting", "Note").
+   *
+   * The id is copied RAW — no prefix, no punctuation — because that exact string is what the
+   * local MCP server's tools take as `meetingId` / `documentId` / `dashboardId`. Anything the
+   * user would have to strip before pasting defeats the point of the control.
+   */
+  async copy(id: string, label: string): Promise<void> {
+    const value = id.trim();
+    if (!value) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(value);
+    } catch {
+      this.toast.danger(
+        `Couldn’t copy the ${label.toLowerCase()} ID — your Mac refused clipboard access.`,
+      );
+      return;
+    }
+    this._lastCopied.set(value);
+    if (this.flashTimer !== null) {
+      clearTimeout(this.flashTimer);
+    }
+    this.flashTimer = setTimeout(() => {
+      this._lastCopied.set(null);
+      this.flashTimer = null;
+    }, COPIED_FLASH_MS);
+    this.toast.success(`${label} ID copied`);
+  }
+}

--- a/src/app/design-system/copy-id/copy-id.component.html
+++ b/src/app/design-system/copy-id/copy-id.component.html
@@ -1,0 +1,38 @@
+<button
+  type="button"
+  class="copy-id"
+  [class.is-copied]="copied()"
+  [attr.aria-label]="hint()"
+  [title]="hint()"
+  (click)="copy()"
+>
+  @if (copied()) {
+    <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path
+        d="m3.5 8.4 2.9 2.9 6.1-6.6"
+        stroke="currentColor"
+        stroke-width="1.6"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  } @else {
+    <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <rect
+        x="5.9"
+        y="5.9"
+        width="7.6"
+        height="7.6"
+        rx="1.8"
+        stroke="currentColor"
+        stroke-width="1.4"
+      />
+      <path
+        d="M10.6 3.9a1.8 1.8 0 0 0-1.8-1.4H4.3a1.8 1.8 0 0 0-1.8 1.8v4.5c0 .87.62 1.6 1.44 1.76"
+        stroke="currentColor"
+        stroke-width="1.4"
+        stroke-linecap="round"
+      />
+    </svg>
+  }
+</button>

--- a/src/app/design-system/copy-id/copy-id.component.scss
+++ b/src/app/design-system/copy-id/copy-id.component.scss
@@ -1,0 +1,41 @@
+:host {
+  display: inline-flex;
+  flex: none;
+}
+
+.copy-id {
+  display: inline-grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.copy-id svg {
+  width: 13px;
+  height: 13px;
+}
+
+.copy-id:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.copy-id:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent-ring);
+}
+
+/* The confirmed state keeps the success hue without a background, so a row of meta
+   items doesn't visibly reflow for the second and a half the tick is up. */
+.copy-id.is-copied,
+.copy-id.is-copied:hover {
+  background: transparent;
+  color: var(--success);
+}

--- a/src/app/design-system/copy-id/copy-id.component.ts
+++ b/src/app/design-system/copy-id/copy-id.component.ts
@@ -1,0 +1,66 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+} from "@angular/core";
+
+import { CopyIdService } from "../../core/copy-id.service";
+
+/**
+ * Design System — `<mur-copy-id>`: the minimal "copy this thing's id" affordance for a header.
+ *
+ * # What it is for
+ *
+ * Murmur's local MCP server addresses everything by id — `get_meeting(meetingId)`,
+ * `get_document(documentId)`, `get_dashboard(dashboardId)`. Until now the app rendered none of
+ * those ids anywhere, so a user talking to Claude over MCP had no way to say *which* recording
+ * or note they meant; they could only describe it and hope search found the right one.
+ *
+ * # Shape
+ *
+ * An icon-only ghost button that reads as chrome, not as a command: it sits at
+ * `--text-tertiary`, gains a surface only on hover/focus, and swaps its glyph to a tick for
+ * {@link CopyIdService} `COPIED_FLASH_MS` after a successful copy. The toast is the primary
+ * confirmation (it survives the pointer leaving the button); the tick is the local one.
+ *
+ * The two glyphs are inline SVG rather than `<mur-icon>` on purpose: `.nav-icon svg` is a GLOBAL
+ * 20px rule, and a parent's emulated-encapsulation style cannot reach into a child component's
+ * template to shrink it. 20px is the nav tier; this control lives in a 12px meta row.
+ */
+@Component({
+  selector: "mur-copy-id",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: "./copy-id.component.html",
+  styleUrl: "./copy-id.component.scss",
+})
+export class MurCopyIdComponent {
+  private readonly copier = inject(CopyIdService);
+
+  /** The stable id to put on the clipboard, copied verbatim. */
+  readonly id = input.required<string>();
+  /** Names the kind in the tooltip and the toast — "Meeting", "Note", "Board", "Task". */
+  readonly label = input("Item");
+
+  /** True while this exact id is the one just copied (drives the tick). */
+  readonly copied = computed(() => this.copier.lastCopied() === this.id().trim());
+
+  /**
+   * Accessible name AND tooltip.
+   *
+   * Deliberately NOT "paste it to point Claude at it". That is true of a meeting, a note and a
+   * board — the MCP server has a tool for each — and it is NOT yet true of a task, which no tool
+   * resolves by id. One promise that is false on one of four surfaces is worse than four accurate
+   * labels, so the tooltip states what the button does and stops there.
+   */
+  readonly hint = computed(() =>
+    this.copied()
+      ? `${this.label()} ID copied`
+      : `Copy this ${this.label().toLowerCase()}’s ID`,
+  );
+
+  copy(): void {
+    void this.copier.copy(this.id(), this.label());
+  }
+}

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.html
@@ -40,6 +40,12 @@
           }
           {{ board()?.title ?? "Board" }}
         </button>
+        @if (board(); as b) {
+          <!-- The board's stable id, for pointing Claude at THIS board over the local MCP
+               server (`get_dashboard`). Inside the <h1> on purpose: `.head-text` is a column,
+               so a sibling of the heading drops onto its own line. -->
+          <mur-copy-id [id]="b.id" label="Board" />
+        }
       </h1>
     }
   </div>

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.scss
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.scss
@@ -22,6 +22,9 @@
   min-width: 0;
 }
 .head h1 {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
   margin: var(--space-1) 0 0;
   font-size: 1.5rem;
   font-weight: 680;

--- a/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
+++ b/src/app/features/dashboards/dashboard-view/dashboard-view.component.ts
@@ -20,6 +20,7 @@ import type {
   SourceRef,
 } from "../../../core/models";
 import { ErrorCopyService } from "../../../core/copy/error-copy.service";
+import { MurCopyIdComponent } from "../../../design-system/copy-id/copy-id.component";
 import { MurEmptyStateComponent } from "../../../design-system/empty-state/empty-state.component";
 import { MurIconComponent } from "../../../design-system/icon/icon.component";
 import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
@@ -64,6 +65,7 @@ const LENSES: readonly { id: DashboardLens; label: string }[] = [
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     MurEmptyStateComponent,
+    MurCopyIdComponent,
     MurIconComponent,
     MurSpinnerComponent,
     DashboardComposeComponent,

--- a/src/app/features/detail/detail/detail.component.html
+++ b/src/app/features/detail/detail/detail.component.html
@@ -57,6 +57,11 @@
           <span class="meta-item">{{
             formatDuration(d.meeting.durationS)
           }}</span>
+          <!-- The recording's stable id, for pointing Claude at THIS meeting over the
+               local MCP server (`get_meeting`). Nothing about it is sensitive: it is an
+               opaque uuid, and every MCP read it enables is gated by the same
+               visibility clause the app uses, so a sealed meeting stays sealed. -->
+          <mur-copy-id [id]="d.meeting.id" label="Meeting" />
           <!-- Read-only folder + lock badge (where this note lives). -->
           @if (folderBadge(); as fb) {
             <span class="meta-sep" aria-hidden="true">·</span>

--- a/src/app/features/detail/detail/detail.component.ts
+++ b/src/app/features/detail/detail/detail.component.ts
@@ -22,6 +22,7 @@ import { IpcService } from "../../../core/ipc.service";
 import { tabKeyFor } from "../../../core/tab-keys";
 import { TabsService } from "../../../core/tabs.service";
 import { meetingStatusPillClass } from "../../../design-system/meeting-status";
+import { MurCopyIdComponent } from "../../../design-system/copy-id/copy-id.component";
 import type {
   AppConfigDto,
   AssistantInteraction,
@@ -80,6 +81,7 @@ interface ActionItem {
     SharePanelComponent,
     VerifyPanelComponent,
     MeetingCommandBarComponent,
+    MurCopyIdComponent,
   ],
   templateUrl: "./detail.component.html",
   styleUrl: "./detail.component.scss",

--- a/src/app/features/notes/note-editor/note-editor.component.html
+++ b/src/app/features/notes/note-editor/note-editor.component.html
@@ -84,6 +84,10 @@
           }
         </div>
 
+        <!-- The note's stable id, for pointing Claude at THIS note over the local MCP
+             server (`get_document` / `get_document_outline`). -->
+        <mur-copy-id [id]="doc.id" label="Note" />
+
         <span class="head-spacer"></span>
 
         <!-- Autosave indicator — shows ONLY for "saving"/"error" now (2026-07-19

--- a/src/app/features/notes/note-editor/note-editor.component.html
+++ b/src/app/features/notes/note-editor/note-editor.component.html
@@ -61,6 +61,14 @@
               <path d="M4 6l4 4 4-4" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" />
             </svg>
           </button>
+          <!-- The note's stable id, for pointing Claude at THIS note over the local MCP
+               server (`get_document` / `get_document_outline`). It sits INSIDE `.head-crumb`,
+               not beside it: `.editor-head` is `flex-wrap: wrap` and with the Ask Brain column
+               open the toolbar has under 30px of slack, so a seventh top-level flex item pushed
+               the `⋯` menu onto a second line and broke the one-shared-divider alignment the split
+               view depends on (`e2e/notes/note-chat-drawer.spec.ts`). Inside the crumb, the folder
+               name truncates instead. -->
+          <mur-copy-id [id]="doc.id" label="Note" />
           @if (menu() === "move") {
             <div class="menu head-menu" role="menu" aria-label="Move to folder">
               <p class="menu-group-label">Move to…</p>
@@ -83,10 +91,6 @@
             </div>
           }
         </div>
-
-        <!-- The note's stable id, for pointing Claude at THIS note over the local MCP
-             server (`get_document` / `get_document_outline`). -->
-        <mur-copy-id [id]="doc.id" label="Note" />
 
         <span class="head-spacer"></span>
 

--- a/src/app/features/notes/note-editor/note-editor.component.scss
+++ b/src/app/features/notes/note-editor/note-editor.component.scss
@@ -114,6 +114,17 @@
 .head-more {
   position: relative;
 }
+/* The crumb ABSORBS a cramped toolbar instead of letting the row wrap: it hosts the copy-ID
+   control and may shrink, so the folder name truncates rather than the `⋯` menu dropping to a
+   second line. A flex item only shrinks below its min-content width when `min-width: 0` says it
+   may — without this the row had no choice but to wrap, which misaligns the note header's bottom
+   from the Ask Brain pane's `.chat-head` bottom (they share ONE horizontal divider). */
+.head-crumb {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+}
 /* Privacy hint for an unfiled (always-open) note — a small 🔒-off glyph folded
    INTO the breadcrumb (2026-07-19 header slim), tooltip-only, muted + non-alarming. */
 .crumb-unsealed {
@@ -127,7 +138,10 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
+  min-width: 0;
   height: 32px;
+  overflow: hidden;
+  white-space: nowrap;
   padding: 0 var(--space-2);
   border: 1px solid transparent;
   border-radius: var(--radius-md);

--- a/src/app/features/notes/note-editor/note-editor.component.ts
+++ b/src/app/features/notes/note-editor/note-editor.component.ts
@@ -58,6 +58,7 @@ import {
 import { NoteSharePanelComponent } from "../note-share-panel/note-share-panel.component";
 import { NoteSelectionToolbarComponent } from "../note-selection-toolbar/note-selection-toolbar.component";
 import { NoteChatComponent } from "../note-chat/note-chat.component";
+import { MurCopyIdComponent } from "../../../design-system/copy-id/copy-id.component";
 import { MurToggleComponent } from "../../../design-system/toggle/toggle.component";
 import { parseDoc, serializeDoc } from "./front-matter";
 import {
@@ -187,6 +188,7 @@ const NOTE_CHAT_OPEN_KEY = "murmur-note-chat-open";
     NoteSharePanelComponent,
     NoteChatComponent,
     MurToggleComponent,
+    MurCopyIdComponent,
     SmartReminderCardComponent,
     FormsModule,
   ],

--- a/src/app/features/tasks/task-view/task-view.component.html
+++ b/src/app/features/tasks/task-view/task-view.component.html
@@ -134,6 +134,12 @@
             @if (!isNew() && task && !task.canEdit) {
               <span class="permission-pill">View only</span>
             }
+            <!-- The task's stable id. Unlike a meeting/note/board there is no MCP tool that
+                 resolves a task id yet, so this is the one surface where the id is for
+                 referring to the task by hand rather than for a tool call. -->
+            @if (!isNew() && task) {
+              <mur-copy-id [id]="task.id" label="Task" />
+            }
           </div>
           <div class="detail-actions">
             @if (!isNew() && task?.canManage) {

--- a/src/app/features/tasks/task-view/task-view.component.ts
+++ b/src/app/features/tasks/task-view/task-view.component.ts
@@ -22,6 +22,7 @@ import type {
 } from "../../../core/models";
 import { IpcService } from "../../../core/ipc.service";
 import { ErrorCopyService } from "../../../core/copy/error-copy.service";
+import { MurCopyIdComponent } from "../../../design-system/copy-id/copy-id.component";
 import { MurEmptyStateComponent } from "../../../design-system/empty-state/empty-state.component";
 import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
 import { SharingAuthFlowComponent } from "../../sharing/sharing-auth-flow/sharing-auth-flow.component";
@@ -35,7 +36,12 @@ type AuthDoor = "signin" | "create";
 @Component({
   selector: "app-task-view",
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MurEmptyStateComponent, MurSpinnerComponent, SharingAuthFlowComponent],
+  imports: [
+    MurCopyIdComponent,
+    MurEmptyStateComponent,
+    MurSpinnerComponent,
+    SharingAuthFlowComponent,
+  ],
   templateUrl: "./task-view.component.html",
   styleUrl: "./task-view.component.scss",
 })


### PR DESCRIPTION
## Why

Murmur's local MCP server addresses everything by id — `get_meeting(meetingId)`,
`get_document(documentId)`, `get_dashboard(dashboardId)` — but the app rendered none of those ids
anywhere. A user talking to Claude over MCP could only *describe* the recording or note they meant
and hope search landed on the right one.

## What

`<mur-copy-id>`, an icon-only ghost control in the header of a **meeting**, **note**, **board** and
**task**. One click copies the id **verbatim** — no prefix, no punctuation, nothing to strip before
pasting — and confirms with a toast plus a 1.6s tick.

## Three decisions worth reviewing

**The refusal path is loud.** The pre-existing copy buttons in Settings swallow a clipboard
rejection in a bare `catch {}`. They can afford to: the text they copy is also on screen and
selectable. An id is *not* on screen, so a swallowed refusal would flash nothing and leave the user
pasting whatever the clipboard held before. `CopyIdService` raises a danger toast instead.

**The tooltip promises nothing it can't keep.** It reads "Copy this meeting's ID" rather than
"paste it to point Claude at it". That promise holds for a meeting, a note and a board; **no MCP
tool resolves a task id yet**, and one label that is false on one of four surfaces is worse than
four accurate ones. (A `get_task` tool is a reasonable follow-up — the copy is already in place.)

**Inline SVG, not `<mur-icon>`.** `.nav-icon svg` is a global 20px rule and a parent's
emulated-encapsulation style cannot reach into a child component's template to shrink it. 20px is
the nav tier; this control lives in a 12px meta row.

The board's control sits *inside* the `<h1>`: `.head-text` is a column, so a sibling of the heading
dropped onto its own line (caught by screenshot, fixed).

## Verification

- `npx ng lint` — clean
- `npx ng build` — clean
- `e2e/detail/copy-id.spec.ts` — **10/10 on both Chromium and WebKit**, covering all four surfaces
  plus the refusal path.

The spec stubs `navigator.clipboard` rather than granting a Playwright permission: WebKit does not
implement `clipboard-read`/`clipboard-write`, so a permission-based test would only ever run on one
project — and stubbing is the only way to exercise the refusal at all.

Placement verified by screenshot on the meeting, note and board headers before committing.
