### PR TITLE
fix(convert): a shared sibling no longer vetoes conversion for a whole folder

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3372,12 +3372,20 @@ fn persist_converted_companion_under_snapshot_with_attachment_verifier(
             );
         }
 
-        if state.db.source_has_active_remote_share(None, Some(&id))?
-            || state.db.folder_has_active_remote_share(&folder_id)?
-            || state.db.folder_has_active_remote_share(&destination.id)?
-        {
+        // ITEM-scoped, deliberately: the hazard is rewriting the managed block of a note whose OWN
+        // ciphertext is still readable on the relay, which would leave the shared copy diverged from
+        // the canonical one. A share on a SIBLING in either container is not that hazard — the
+        // sibling's server copy is untouched by re-homing a different, unshared note past it. This
+        // used to also ask `folder_has_active_remote_share` for the source AND destination
+        // containers, which made ONE shared note anywhere in a folder refuse "Convert to note" for
+        // EVERY meeting filed there (reported 2026-08-28 against live user data; the refusal
+        // carries no `errcode`, so all the user ever saw was "Please try again"). The folder-wide
+        // question belongs to folder-wide operations — `commands/lock.rs` asks it before SEALING a
+        // container, where every item including the shared one really does change state.
+        // `notes.rs::move_note_to_folder` is the canonical item-scoped precedent.
+        if state.db.source_has_active_remote_share(None, Some(&id))? {
             return Err(AppError::Unavailable(
-                "revoke active shares before filing this converted note".into(),
+                "revoke this note's shares before filing this converted note".into(),
             ));
         }
 
@@ -3479,6 +3487,12 @@ fn persist_converted_companion_under_snapshot_with_attachment_verifier(
 /// Birth the conversion companion in the meeting's exact destination. For a locked destination the
 /// non-empty body is encrypted and verified BEFORE the one atomic insert; no blob-less plaintext
 /// row and no vault export can exist behind the lock.
+///
+/// There is deliberately NO remote-share guard here. The note being born does not exist yet, so it
+/// cannot have server ciphertext of its own; a share on a SIBLING already in this container is not
+/// affected by a new, unshared note appearing beside it. The update path keeps the item-scoped
+/// check for the case that genuinely matters (rewriting a note whose own copy is still on the
+/// relay).
 fn create_generated_companion_under_lifecycle_authorized(
     state: &AppState,
     meeting_id: &str,
@@ -3500,11 +3514,6 @@ fn create_generated_companion_under_lifecycle_authorized(
         },
         markdown,
     )?;
-    if state.db.folder_has_active_remote_share(&destination.id)? {
-        return Err(AppError::Unavailable(
-            "revoke active shares before creating a converted note in this container".into(),
-        ));
-    }
     let text_blob = if destination.locked {
         Some(sealed_document_blob(state, &destination.id, &id, markdown)?)
     } else {

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -6529,8 +6529,95 @@
         assert_eq!(after.exported_path, before.exported_path);
     }
 
+    /// A share on a SIBLING of the meeting's container must not block conversion.
+    ///
+    /// The regression this pins (reported 2026-08-28, live user data): the conversion guards asked
+    /// `folder_has_active_remote_share` for the whole destination container, so ONE shared note
+    /// anywhere in a folder made "Convert to note" fail for EVERY meeting filed there. The refusal
+    /// carries no `errcode`, so the only thing the user ever saw was the deny-by-default sentence
+    /// "Couldn't convert this meeting. Please try again."
+    ///
+    /// The hazard the guard really covers is ITEM-scoped — rewriting the managed block of a note
+    /// whose own ciphertext is still readable on the relay — and that is asserted by
+    /// `converted_companion_refuses_an_active_share_even_in_an_open_destination` above. Birthing a
+    /// different, unshared note beside a shared sibling changes nothing about the sibling's server
+    /// copy, which is why `notes.rs::move_note_to_folder` has only ever used the item-scoped check.
     #[test]
-    fn converted_companion_refuses_an_active_share_on_its_source_container_before_rehome() {
+    fn converted_companion_ignores_a_shared_sibling_in_the_meetings_container() {
+        const MEETING: &str = "m-convert-sibling-share";
+        const CONTAINER: &str = "f-convert-sibling-share";
+        const SIBLING: &str = "d-convert-shared-sibling";
+
+        let state = build_state("converted-companion-sibling-share");
+        make_open_folder(&state.db, CONTAINER, "Murmur");
+        seed_meeting(
+            &state.db,
+            MEETING,
+            "# Existing meeting note",
+            Some(CONTAINER),
+        );
+        state
+            .db
+            .insert_document(SIBLING, CONTAINER, "Shared sibling", "# Shared", "note", 1)
+            .unwrap();
+        // BOTH legs of `folder_has_active_remote_share`, because the report that found this came
+        // from an ORG share (a note shared to a Shared Brain) and the link leg is the one a test
+        // reaches for by reflex. Removing the folder-wide question has to clear both.
+        state
+            .db
+            .insert_outbound_note_share(
+                "conversion-sibling-share",
+                SIBLING,
+                "link",
+                1,
+                "2026-08-25T20:00:00Z",
+            )
+            .unwrap();
+        state
+            .db
+            .insert_org_share(
+                "conversion-sibling-org-share",
+                "org-convert-sibling",
+                None,
+                Some(SIBLING),
+                "note",
+                Some("Shared sibling"),
+                1,
+                1,
+                &[0u8; 32],
+                "2026-08-25T20:00:00Z",
+            )
+            .unwrap();
+
+        let converted = block_on(convert_meeting_to_note_inner_with(
+            None,
+            &state,
+            MEETING.into(),
+            None,
+            Some(ConversionProvider::fixed(
+                "---\ntitle: Converted\n---\n\n# Converted\n\nGenerated body.",
+            )),
+        ))
+        .unwrap();
+
+        let row = state.db.get_note_row(&converted.note_id).unwrap().unwrap();
+        assert_eq!(
+            row.folder_id, CONTAINER,
+            "the converted note is born in the meeting's own container"
+        );
+        assert!(row.text.contains("Generated body."));
+    }
+
+    /// A rehome must refuse while the companion's OWN copy is still readable on the relay, and must
+    /// leave every canonical byte, attachment and export exactly where it was.
+    ///
+    /// This used to share a SIBLING meeting in the source container and assert the same refusal,
+    /// pinning a folder-wide guard that made one shared item veto conversion for a whole folder
+    /// (see `converted_companion_ignores_a_shared_sibling_in_the_meetings_container`). The
+    /// preserved-state assertions below are the valuable half, so they now ride the item-scoped
+    /// guard that survives.
+    #[test]
+    fn converted_companion_refuses_its_own_active_share_before_rehome() {
         const MEETING: &str = "m-convert-source-shared";
         const SOURCE: &str = "f-convert-source-shared";
         const TARGET: &str = "f-convert-source-target";
@@ -6611,17 +6698,11 @@
         let attachment_twin_bytes = std::fs::read(&attachment_twin).unwrap();
 
         state.db.set_meeting_folder(MEETING, Some(TARGET)).unwrap();
-        seed_meeting(
-            &state.db,
-            "m-source-container-shared-sibling",
-            "# Shared sibling",
-            Some(SOURCE),
-        );
         state
             .db
-            .insert_outbound_share(
-                "conversion-source-container-active-share",
-                "m-source-container-shared-sibling",
+            .insert_outbound_note_share(
+                "conversion-companion-active-share",
+                &companion.note_id,
                 "link",
                 1,
                 "2026-08-25T20:00:00Z",
@@ -6653,7 +6734,7 @@
         assert_eq!(
             state.db.companion_note_for_meeting(MEETING).unwrap(),
             Some(companion.note_id.clone()),
-            "the refused source-share rehome preserves the stable companion id"
+            "the refused own-share rehome preserves the stable companion id"
         );
         assert_eq!(
             state


### PR DESCRIPTION
## The report

"Convert to note" failed with **"Couldn't convert this meeting. Please try again."** for every
meeting in one folder.

## The cause — found in real user data, not inferred

Not the provider, not the transcript. `d7ac2ec feat: unify spaces and shared brain navigation`
(2026-08-26) made two changes at once:

1. the converted note is now born in **the meeting's own container** instead of the Notes root
   (correct, and what the user wants), and
2. three new **folder-wide** guards refuse the conversion when *anything* in the source or
   destination container still has an active remote share.

Together those mean **one shared note vetoes conversion for every meeting filed beside it**. In the
reporting user's DB the meeting sits in `Notes/Murmur`, and an unrelated note in that folder carries
an org share in state `uploaded`. Reproduced as a RED test before the fix:

```
Unavailable("revoke active shares before creating a converted note in this container")
```

That refusal carries no `errcode`, so `ErrorCopyService`'s deny-by-default rendered the generic
sentence — which is why nothing about the real cause ever reached the user.

## The fix — the guard returns to the scope the rest of the repo already uses

The hazard is **item-scoped**: rewriting the managed block of a note whose *own* ciphertext is still
readable on the relay would leave the shared copy diverged. A sibling's share is not that hazard —
its server copy is untouched by an unshared note being born or re-homed past it.
`notes.rs::move_note_to_folder` has only ever asked the item-scoped question.

- **Birth path:** the folder-wide guard is removed outright. A note that does not exist yet cannot
  have server ciphertext.
- **Update path:** keeps `source_has_active_remote_share(None, Some(&id))`, drops the two
  `folder_has_active_remote_share` calls.

The folder-wide question stays where it is genuinely folder-wide: `commands/lock.rs`, before
**sealing** a container — there every item, including the shared one, really does change state.
After this change those are the only two call sites left.

## Tests

- **New** `converted_companion_ignores_a_shared_sibling_in_the_meetings_container` — the oracle for
  this bug class. Fails on trunk with the exact error above; passes after. Seeds **both** legs of
  `folder_has_active_remote_share` (link *and* org share, since the report came from an org share),
  and asserts the converted note is born in the meeting's own container.
- **Retargeted** `converted_companion_refuses_an_active_share_on_its_source_container_before_rehome`
  → `converted_companion_refuses_its_own_active_share_before_rehome`. It pinned the removed rule by
  sharing a sibling; its preserved-state assertions (canonical bytes, attachments, exports, stable
  companion id all untouched on refusal) are the valuable half, so they now ride the guard that
  survives.
- `converted_companion_refuses_an_active_share_even_in_an_open_destination` is unchanged and still
  green — a note's own share still refuses.

## Known follow-up (not in this PR)

Every lock/share refusal on the conversion path is untagged, so a user who hits *any* of them still
gets "Please try again" — including the very actionable "unlock this folder first". That is a
repo-wide pattern (~10 sibling `this meeting's folder is locked …` sites across `commands/`), so
tagging it belongs in its own change rather than bolted onto a security-guard fix.
