### PR TITLE
fix(copy): conversion refusals say what to do instead of "try again"

### DIFF
--- a/e2e/detail/convert-refusal-copy.spec.ts
+++ b/e2e/detail/convert-refusal-copy.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test, type Page } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * "Convert to note" refusals must name the ONE thing the user has to do next.
+ *
+ * Every refusal on this path used to be anonymous, so `ErrorCopyService`'s deny-by-default
+ * rendered "Couldn’t convert this meeting. Please try again." for all of them. The refusal that
+ * actually fired in production — a shared note in the meeting's folder — took a SQLCipher session
+ * against the user's own database to identify, because the app could not say it.
+ *
+ * The wire strings below are the real shape: `<AppError variant tag>: [code] <developer prose>`.
+ * The prose half must never reach the screen; the code half selects the sentence.
+ */
+async function refuseConvertWith(page: Page, wire: string): Promise<void> {
+  await mockTauri(
+    page,
+    {},
+    { audit_reminder_suggestions: [], __convertRefusal: wire },
+  );
+  // The mock's constant channel cannot throw, so the rejection is installed page-side over it.
+  await page.addInitScript((message: string) => {
+    const install = () => {
+      const internals = (window as unknown as { __TAURI_INTERNALS__?: { invoke?: unknown } })
+        .__TAURI_INTERNALS__;
+      if (!internals || typeof internals.invoke !== "function") {
+        return false;
+      }
+      const original = internals.invoke as (cmd: string, args: unknown) => Promise<unknown>;
+      internals.invoke = (cmd: string, args: unknown) =>
+        cmd === "convert_meeting_to_note"
+          ? Promise.reject(message)
+          : original(cmd, args);
+      return true;
+    };
+    if (!install()) {
+      const timer = setInterval(() => {
+        if (install()) clearInterval(timer);
+      }, 5);
+    }
+  }, wire);
+}
+
+async function convert(page: Page): Promise<void> {
+  await page.goto("/meeting/m-atlas-roadmap");
+  const button = page
+    .getByTestId("meeting-command-bar")
+    .getByRole("button", { name: "Convert to note", exact: true });
+  await expect(button).toBeVisible({ timeout: 10_000 });
+  await button.click();
+}
+
+test("a shared note in the way is named, not hidden behind “try again”", async ({ page }) => {
+  await refuseConvertWith(
+    page,
+    "provider unavailable: [share-active] revoke this note's shares before filing this converted note",
+  );
+  await convert(page);
+
+  await expect(page.locator(".toast.is-danger .toast-msg")).toHaveText(
+    "Couldn’t convert this meeting — This meeting’s note is shared. Revoke its share first, then convert again.",
+  );
+});
+
+test("a missing transcript says so instead of asking for a retry that cannot work", async ({
+  page,
+}) => {
+  await refuseConvertWith(
+    page,
+    "invalid argument: [convert-no-transcript] this meeting has no transcript to convert",
+  );
+  await convert(page);
+
+  await expect(page.locator(".toast.is-danger .toast-msg")).toHaveText(
+    "Couldn’t convert this meeting — This recording has no transcript yet, so there’s nothing to turn into a note.",
+  );
+});
+
+test("deny-by-default still holds: an un-coded failure never renders its wire string", async ({
+  page,
+}) => {
+  await refuseConvertWith(
+    page,
+    "storage error: account-session mutex poisoned at src-tauri/src/state.rs:118",
+  );
+  await convert(page);
+
+  const toast = page.locator(".toast.is-danger .toast-msg");
+  await expect(toast).toHaveText("Couldn’t convert this meeting. Please try again.");
+  // The control arm — without it the two tests above would pass even if the copy layer had been
+  // replaced by "render whatever Rust sent".
+  await expect(toast).not.toContainText("mutex");
+  await expect(toast).not.toContainText("state.rs");
+});

--- a/src-tauri/src/commands/enrich.rs
+++ b/src-tauri/src/commands/enrich.rs
@@ -142,9 +142,10 @@ pub(crate) fn apply_note_verify_markers_inner(
     // concurrent relock/seal cannot land between the unlock check and the upsert.
     let _lifecycle = lifecycle_guard(state);
     if !meeting_is_unlocked(state, &meeting_id)? {
-        return Err(AppError::Locked(
-            "this meeting's folder is locked — unlock it to edit the note".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+                crate::errcode::MEETING_LOCKED,
+                "this meeting's folder is locked — unlock it to edit the note",
+            )));
     }
     for f in &findings {
         let ok = crate::verify::extract_issue_keys(&f.key)
@@ -321,9 +322,10 @@ pub(crate) fn apply_note_enrichment_inner(
     // `link_related_notes_inner` guards). Lock order `lifecycle ⊃ db`.
     let _lifecycle = lifecycle_guard(state);
     if !meeting_is_unlocked(state, &meeting_id)? {
-        return Err(AppError::Locked(
-            "this meeting's folder is locked — unlock it to edit the note".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+                crate::errcode::MEETING_LOCKED,
+                "this meeting's folder is locked — unlock it to edit the note",
+            )));
     }
     // SEAL-SAFETY GATE (mirrors Lane A): a SEALED note (any provider row carries a content_blob) has a
     // TRANSIENT `markdown` column — blanked on relock, restored from `content_blob` on unlock. Writing
@@ -1409,9 +1411,10 @@ pub fn patch_note_tasks(
     // D4 WRITE-GATE: refuse to rewrite a sealed-and-not-unlocked meeting's note (its plaintext is
     // blanked; patching would persist the blanked value over the sealed content). Fail closed.
     if !meeting_is_unlocked(state.inner(), &meeting_id)? {
-        return Err(AppError::Locked(
-            "this meeting's folder is locked — unlock it to rewrite the note's tasks".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+                crate::errcode::MEETING_LOCKED,
+                "this meeting's folder is locked — unlock it to rewrite the note's tasks",
+            )));
     }
     let existing = state
         .db

--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -59,9 +59,10 @@ pub async fn link_meeting_entities(
     // BLK-2b READ-GATE: a sealed-and-not-unlocked meeting's note is blanked; refuse to extract
     // entities from it (would feed a cloud provider blank text + re-write vault stubs). Fail closed.
     if !meeting_is_unlocked(state.inner(), &meeting_id)? {
-        return Err(AppError::Locked(
-            "this meeting's folder is locked — unlock it to link entities".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+                crate::errcode::MEETING_LOCKED,
+                "this meeting's folder is locked — unlock it to link entities",
+            )));
     }
     let meeting = state
         .db

--- a/src-tauri/src/commands/meetings.rs
+++ b/src-tauri/src/commands/meetings.rs
@@ -217,9 +217,10 @@ pub(crate) fn rename_speaker_inner(
     // rename a speaker (would persist a near-empty plaintext timeline over the sealed blob in a
     // locked folder). Fail closed.
     if !meeting_is_unlocked(state, meeting_id)? {
-        return Err(AppError::Locked(
-            "this meeting's folder is locked — unlock it to rename a speaker".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+                crate::errcode::MEETING_LOCKED,
+                "this meeting's folder is locked — unlock it to rename a speaker",
+            )));
     }
     let json = state
         .db

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -542,9 +542,10 @@ pub(crate) fn capture_meeting_content_snapshot(
 ) -> Result<MeetingContentSnapshot, AppError> {
     let _lifecycle = lifecycle_guard(state);
     if !meeting_is_unlocked(state, meeting_id)? {
-        return Err(AppError::Locked(
-            "this meeting's folder is locked — unlock it and retry".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+                crate::errcode::MEETING_LOCKED,
+                "this meeting's folder is locked — unlock it and retry",
+            )));
     }
     Ok(MeetingContentSnapshot {
         folder_id: state.db.folder_for_meeting(meeting_id)?,
@@ -2586,9 +2587,10 @@ pub(crate) fn update_note_inner_with(
     // plaintext markdown is blanked while sealed, so an edit here would overwrite the (sealed)
     // content with the blanked value and corrupt it. Fail closed.
     if !meeting_is_unlocked(state, meeting_id)? {
-        return Err(AppError::Locked(
-            "this meeting's folder is locked — unlock it to edit the note".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+                crate::errcode::MEETING_LOCKED,
+                "this meeting's folder is locked — unlock it to edit the note",
+            )));
     }
     let existing = state
         .db
@@ -2698,9 +2700,10 @@ pub(crate) fn save_manual_notes_inner(
     // concurrent relock/seal cannot land between the unlock check and the buffer write.
     let _lifecycle = lifecycle_guard(state);
     if !meeting_is_unlocked(state, meeting_id)? {
-        return Err(AppError::Locked(
-            "this meeting's folder is locked — unlock it to edit your notes".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+                crate::errcode::MEETING_LOCKED,
+                "this meeting's folder is locked — unlock it to edit your notes",
+            )));
     }
     // Seal-on-write (audit F1): a session-unlocked LOCKED folder re-seals the fresh buffer into
     // `manual_notes_blob` in the same write; open/rootless takes the plain update. Fail-closed on a
@@ -2789,9 +2792,10 @@ fn resolve_conversion_template(
             saved: Some(saved),
         });
     }
-    Err(AppError::InvalidArg(
-        "the selected note template no longer exists".into(),
-    ))
+    Err(AppError::InvalidArg(crate::errcode::tag(
+        crate::errcode::NOTE_TEMPLATE_MISSING,
+        "the selected note template no longer exists",
+    )))
 }
 
 /// Compose a generated conversion into the companion note without ever replacing user-authored
@@ -2808,9 +2812,10 @@ fn compose_converted_companion_markdown(
     let (generated_yaml, generated_body) = crate::storage::db::split_front_matter(generated);
     let generated_body = generated_body.trim();
     if generated_body.is_empty() {
-        return Err(AppError::Unavailable(
-            "the note provider returned an empty note".into(),
-        ));
+        return Err(AppError::Unavailable(crate::errcode::tag(
+            crate::errcode::NOTE_PROVIDER_EMPTY,
+            "the note provider returned an empty note",
+        )));
     }
     if generated_body.contains(CONVERTED_NOTE_START) || generated_body.contains(CONVERTED_NOTE_END)
     {
@@ -2923,19 +2928,22 @@ fn conversion_destination_under_lifecycle(
         .into_iter()
         .find(|container| container.id == id)
         .ok_or_else(|| {
-            AppError::InvalidArg(
-                "the meeting's container is unavailable; move the meeting and retry".into(),
-            )
+            AppError::InvalidArg(crate::errcode::tag(
+                crate::errcode::CONTAINER_UNAVAILABLE,
+                "the meeting's container is unavailable; move the meeting and retry",
+            ))
         })?;
     if state.db.org_folder_closure_exists(&id)? {
-        return Err(AppError::Unavailable(
-            "the destination is closing or locked for sharing; retry after reopening it".into(),
-        ));
+        return Err(AppError::Unavailable(crate::errcode::tag(
+            crate::errcode::FOLDER_CLOSING,
+            "the destination is closing or locked for sharing; retry after reopening it",
+        )));
     }
     if row.locked && !folder_is_unlocked(state, &id)? {
-        return Err(AppError::Locked(
-            "unlock the meeting's container before converting it to a note".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+            crate::errcode::FOLDER_LOCKED,
+            "unlock the meeting's container before converting it to a note",
+        )));
     }
     Ok(ConversionDestination {
         id,
@@ -2959,20 +2967,22 @@ fn reauthorize_conversion_source_under_lifecycle(
         .into_iter()
         .find(|container| container.id == folder_id)
         .ok_or_else(|| {
-            AppError::Unavailable(
-                "the companion note's source container is unavailable; reopen it and retry".into(),
-            )
+            AppError::Unavailable(crate::errcode::tag(
+                crate::errcode::CONTAINER_UNAVAILABLE,
+                "the companion note's source container is unavailable; reopen it and retry",
+            ))
         })?;
     if state.db.org_folder_closure_exists(folder_id)? {
-        return Err(AppError::Unavailable(
-            "the companion note's source container is closing or unavailable; retry after reopening it"
-                .into(),
-        ));
+        return Err(AppError::Unavailable(crate::errcode::tag(
+            crate::errcode::FOLDER_CLOSING,
+            "the companion note's source container is closing or unavailable; retry after reopening it",
+        )));
     }
     if source.locked && !folder_is_unlocked(state, folder_id)? {
-        return Err(AppError::Locked(
-            "unlock the companion note's source container before converting this meeting".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+            crate::errcode::FOLDER_LOCKED,
+            "unlock the companion note's source container before converting this meeting",
+        )));
     }
     Ok(())
 }
@@ -3384,9 +3394,10 @@ fn persist_converted_companion_under_snapshot_with_attachment_verifier(
         // container, where every item including the shared one really does change state.
         // `notes.rs::move_note_to_folder` is the canonical item-scoped precedent.
         if state.db.source_has_active_remote_share(None, Some(&id))? {
-            return Err(AppError::Unavailable(
-                "revoke this note's shares before filing this converted note".into(),
-            ));
+            return Err(AppError::Unavailable(crate::errcode::tag(
+                crate::errcode::SHARE_ACTIVE,
+                "revoke this note's shares before filing this converted note",
+            )));
         }
 
         let (text_blob, attachment_seals) = if destination.locked {
@@ -3612,9 +3623,10 @@ async fn convert_meeting_to_note_inner_with(
             ))
         })?;
     if segments.is_empty() {
-        return Err(AppError::InvalidArg(
-            "this meeting has no transcript to convert".into(),
-        ));
+        return Err(AppError::InvalidArg(crate::errcode::tag(
+            crate::errcode::CONVERT_NO_TRANSCRIPT,
+            "this meeting has no transcript to convert",
+        )));
     }
     let selection = resolve_conversion_template(
         template_id.as_deref(),
@@ -5008,9 +5020,10 @@ fn meeting_provider_inputs_under_lifecycle(
         }
         None => {
             if !meeting_is_unlocked(state, meeting_id)? {
-                return Err(AppError::Locked(
-                    "this meeting's folder is locked — unlock it and retry".into(),
-                ));
+                return Err(AppError::Locked(crate::errcode::tag(
+                        crate::errcode::MEETING_LOCKED,
+                        "this meeting's folder is locked — unlock it and retry",
+                    )));
             }
             MeetingContentSnapshot {
                 folder_id: state.db.folder_for_meeting(meeting_id)?,
@@ -5214,9 +5227,10 @@ pub fn get_action_items(
     // D4 READ-GATE: a sealed-and-not-unlocked meeting's note markdown is blanked; refuse to parse
     // action items from it (would silently return none / leak a stale plaintext). Fail closed.
     if !meeting_is_unlocked(state.inner(), &meeting_id)? {
-        return Err(AppError::Locked(
-            "this meeting's folder is locked — unlock it to see action items".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+                crate::errcode::MEETING_LOCKED,
+                "this meeting's folder is locked — unlock it to see action items",
+            )));
     }
     let note = state.db.get_latest_note_for_meeting(&meeting_id)?;
     Ok(match note {
@@ -5257,9 +5271,10 @@ pub fn pin_moment(
     // markdown is blanked, so appending a pin would persist the blanked value over the sealed
     // content AND re-export a plaintext `.md`. Fail closed.
     if !meeting_is_unlocked(state.inner(), &meeting_id)? {
-        return Err(AppError::Locked(
-            "this meeting's folder is locked — unlock it to pin a moment".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+                crate::errcode::MEETING_LOCKED,
+                "this meeting's folder is locked — unlock it to pin a moment",
+            )));
     }
     let existing = state
         .db
@@ -7410,9 +7425,10 @@ pub async fn resummarize(
     // meeting that would (a) feed a cloud provider blank text and (b) leave plaintext markdown +
     // a vault `.md` in a locked folder. Fail closed — the FE must unlock first.
     if !meeting_is_unlocked(state.inner(), &meeting_id)? {
-        return Err(AppError::Locked(
-            "this meeting's folder is locked — unlock it to re-summarize".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+                crate::errcode::MEETING_LOCKED,
+                "this meeting's folder is locked — unlock it to re-summarize",
+            )));
     }
     // DETACHED, panic-mapped execution (the same #346 pattern as `stop_recording`): awaited
     // INLINE, a panic inside `resummarize_existing` would leave the invoke Promise unsettled
@@ -7532,9 +7548,10 @@ pub(crate) fn retry_transcription_prep(
     let _lifecycle = lifecycle_guard(state);
     // Lock gate: never re-pipeline (or decrypt) a sealed-and-not-session-unlocked meeting.
     if !meeting_is_unlocked(state, meeting_id)? {
-        return Err(AppError::Locked(
-            "this meeting's folder is locked — unlock it to retry transcription".into(),
-        ));
+        return Err(AppError::Locked(crate::errcode::tag(
+                crate::errcode::MEETING_LOCKED,
+                "this meeting's folder is locked — unlock it to retry transcription",
+            )));
     }
     reconcile_released_generation_cleanup(state, meeting_id)?;
     if state

--- a/src-tauri/src/commands/org.rs
+++ b/src-tauri/src/commands/org.rs
@@ -3805,9 +3805,10 @@ pub(crate) fn build_org_share_snapshot(
             (Some(mid), None) => {
                 // (1) READ-GATE FIRST — a sealed-not-unlocked meeting refuses before any read/egress.
                 if !meeting_is_unlocked(state, mid)? {
-                    return Err(AppError::Locked(
-                        "this meeting's folder is locked — unlock it to share to the org".into(),
-                    ));
+                    return Err(AppError::Locked(crate::errcode::tag(
+                            crate::errcode::MEETING_LOCKED,
+                            "this meeting's folder is locked — unlock it to share to the org",
+                        )));
                 }
                 let note = state
                     .db

--- a/src-tauri/src/commands/reminders.rs
+++ b/src-tauri/src/commands/reminders.rs
@@ -2956,9 +2956,10 @@ fn read_reminder_audit_source_under_lifecycle(
     match source_kind {
         "meeting" => {
             if !super::meeting_is_unlocked(state, source_id)? {
-                return Err(AppError::Locked(
-                    "this meeting's folder is locked — unlock it and retry".into(),
-                ));
+                return Err(AppError::Locked(crate::errcode::tag(
+                        crate::errcode::MEETING_LOCKED,
+                        "this meeting's folder is locked — unlock it and retry",
+                    )));
             }
             let meeting = state
                 .db

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -6480,6 +6480,92 @@
         );
     }
 
+    /// Every refusal the user can ACT ON must carry its `errcode`, so the frontend renders the
+    /// sentence that names the next step instead of the deny-by-default "Please try again".
+    ///
+    /// This is the oracle for the class, not for one message. The convert path had SIX anonymous
+    /// refusals; the one that actually fired in production ("a note in this folder is shared")
+    /// took a SQLCipher session against the user's own database to identify, because the app
+    /// could not say it. A future refactor that drops a tag puts us straight back there, and the
+    /// only thing that would notice is this test.
+    #[test]
+    fn actionable_conversion_refusals_carry_their_error_code() {
+        fn code_of(error: &AppError) -> String {
+            let rendered = error.to_string();
+            let body = rendered.split_once(": ").map_or(rendered.as_str(), |(_, b)| b);
+            body.strip_prefix('[')
+                .and_then(|rest| rest.split_once(']'))
+                .map(|(code, _)| code.to_string())
+                .unwrap_or_else(|| format!("UNCODED: {body}"))
+        }
+
+        // 1. No transcript — the meeting exists and is unlocked, but there is nothing to summarize.
+        let state = build_state("convert-code-no-transcript");
+        seed_meeting(&state.db, "m-no-transcript", "# Note", None);
+        {
+            let conn = state.db.lock();
+            conn.execute("DELETE FROM segments WHERE meeting_id='m-no-transcript'", [])
+                .unwrap();
+        }
+        let error = block_on(convert_meeting_to_note_inner_with(
+            None,
+            &state,
+            "m-no-transcript".into(),
+            None,
+            Some(ConversionProvider::fixed("---\ntitle: x\n---\n\n# x\n\nBody.")),
+        ))
+        .unwrap_err();
+        assert_eq!(code_of(&error), "convert-no-transcript");
+
+        // 2. A template id that no longer exists.
+        let error = resolve_conversion_template(Some("no-such-template"), "standard", vec![])
+            .map(|_| ())
+            .unwrap_err();
+        assert_eq!(code_of(&error), "note-template-missing");
+
+        // 3. An empty provider body must not blank a note — and must say which knob to turn.
+        let error = compose_converted_companion_markdown("", "Meeting", "---\ntitle: x\n---\n\n")
+            .map(|_| ())
+            .unwrap_err();
+        assert_eq!(code_of(&error), "note-provider-empty");
+
+        // 4. The companion's OWN live share — the guard that survives, and the exact shape of the
+        //    refusal the reporting user hit before the folder-wide guards were removed.
+        let state = build_state("convert-code-share-active");
+        seed_meeting(&state.db, "m-shared", "# Existing", None);
+        let snapshot = capture_meeting_content_snapshot(&state, "m-shared").unwrap();
+        let first = persist_converted_companion_under_snapshot_with(
+            &state,
+            "m-shared",
+            &snapshot,
+            "Shared",
+            "---\ntitle: Shared\n---\n\n# Shared\n\nOriginal.",
+            None,
+        )
+        .unwrap();
+        state
+            .db
+            .insert_outbound_note_share(
+                "convert-code-share",
+                &first.note_id,
+                "link",
+                1,
+                "2026-08-25T20:00:00Z",
+            )
+            .unwrap();
+        let snapshot = capture_meeting_content_snapshot(&state, "m-shared").unwrap();
+        let error = persist_converted_companion_under_snapshot_with(
+            &state,
+            "m-shared",
+            &snapshot,
+            "Shared",
+            "---\ntitle: Shared\n---\n\n# Shared\n\nReplacement.",
+            None,
+        )
+        .unwrap_err();
+        assert_eq!(code_of(&error), "share-active");
+    }
+
     #[test]
     fn converted_companion_refuses_an_active_share_even_in_an_open_destination() {
         let state = build_state("converted-companion-active-share");

--- a/src-tauri/src/errcode.rs
+++ b/src-tauri/src/errcode.rs
@@ -145,6 +145,25 @@ pub const SHARING_UPGRADE_REQUIRED: &str = "sharing-upgrade-required";
 /// The Reminders app refused the write — the user has not granted Reminders access.
 pub const REMINDERS_DENIED: &str = "reminders-denied";
 
+// ── Meeting → note conversion ───────────────────────────────────────────────────────────────────
+// Every refusal below was reachable in production while carrying NO code, so `ErrorCopyService`'s
+// deny-by-default rendered "Couldn't convert this meeting. Please try again." for all of them.
+// That is how a precise, actionable refusal ("a note in this folder is shared") stayed invisible
+// long enough to need a SQLCipher session against the user's own database to diagnose.
+
+/// The meeting has no transcript rows, so there is nothing to summarize into a note.
+pub const CONVERT_NO_TRANSCRIPT: &str = "convert-no-transcript";
+/// The chosen (or configured-default) note template no longer exists.
+pub const NOTE_TEMPLATE_MISSING: &str = "note-template-missing";
+/// The provider returned an empty body; nothing is written rather than blanking a note.
+pub const NOTE_PROVIDER_EMPTY: &str = "note-provider-empty";
+/// A live remote share on this exact item blocks the mutation until it is revoked.
+pub const SHARE_ACTIVE: &str = "share-active";
+/// The container is mid-close for org sharing — a transient state the user can wait out.
+pub const FOLDER_CLOSING: &str = "folder-closing";
+/// The meeting's container is not a container Murmur can write a note into.
+pub const CONTAINER_UNAVAILABLE: &str = "container-unavailable";
+
 /// Every code this crate emits, in declaration order. The frontend's allowlist mirrors it;
 /// `error_codes_are_unique_and_kebab_case` keeps the shape a machine can rely on.
 pub const ALL: &[&str] = &[
@@ -174,6 +193,12 @@ pub const ALL: &[&str] = &[
     SHARING_ACCOUNT_REQUIRED,
     SHARING_UPGRADE_REQUIRED,
     REMINDERS_DENIED,
+    CONVERT_NO_TRANSCRIPT,
+    NOTE_TEMPLATE_MISSING,
+    NOTE_PROVIDER_EMPTY,
+    SHARE_ACTIVE,
+    FOLDER_CLOSING,
+    CONTAINER_UNAVAILABLE,
 ];
 
 #[cfg(test)]
@@ -261,6 +286,15 @@ mod tests {
             "sharing-account-required",
             "sharing-upgrade-required",
             "reminders-denied",
+            // Added 2026-08-28: the meeting→note conversion refusals. Every one of these was
+            // reachable while anonymous, so the user got the generic sentence for a failure they
+            // could have fixed in one click.
+            "convert-no-transcript",
+            "note-template-missing",
+            "note-provider-empty",
+            "share-active",
+            "folder-closing",
+            "container-unavailable",
         ];
         assert_eq!(ALL, expected);
     }

--- a/src/app/core/copy/error-copy.service.ts
+++ b/src/app/core/copy/error-copy.service.ts
@@ -124,6 +124,15 @@ export const ERROR_CODES = [
   "sharing-upgrade-required",
   "org-edit-conflict",
   "reminders-denied",
+  // Added 2026-08-28 with the meeting→note conversion refusals. Each of these was reachable in
+  // production while ANONYMOUS, so deny-by-default rendered "Couldn't convert this meeting. Please
+  // try again." for a failure the user could have fixed in one click.
+  "convert-no-transcript",
+  "note-template-missing",
+  "note-provider-empty",
+  "share-active",
+  "folder-closing",
+  "container-unavailable",
 ] as const;
 
 export type ErrorCode = (typeof ERROR_CODES)[number];
@@ -148,6 +157,7 @@ export type ErrorContext =
   | "doc-note"
   | "unlock"
   | "account"
+  | "convert"
   | "tasks";
 
 /**
@@ -212,6 +222,20 @@ const BASE_COPY: Readonly<Record<ErrorCode, string>> = {
     "This shared note changed elsewhere. Your draft is still here — reload the latest version and try again.",
   "reminders-denied":
     "Grant Reminders access in System Settings ▸ Privacy & Security ▸ Reminders.",
+  "convert-no-transcript":
+    "This recording has no transcript yet, so there’s nothing to turn into a note.",
+  "note-template-missing":
+    "That note template no longer exists — pick another one in Settings ▸ Notes.",
+  "note-provider-empty":
+    "Your AI provider returned an empty note. Try again, or switch provider in Settings.",
+  // Names the ACTION, not the mechanism: "a share is active" tells the user nothing they can do.
+  // Both the link-share and the org-brain share reach this code, so the sentence covers both.
+  "share-active":
+    "This note is shared. Revoke its share first, then try again.",
+  "folder-closing":
+    "That folder is being prepared for sharing. Try again in a moment.",
+  "container-unavailable":
+    "This recording isn’t in a folder Murmur can add a note to. Move it, then try again.",
 };
 
 /**
@@ -297,6 +321,14 @@ const CONTEXT_COPY: Partial<
   recording: {
     "meeting-locked": "This meeting is locked — unlock its folder to finish the note.",
   },
+  convert: {
+    "meeting-locked": "This meeting is locked — unlock its folder to convert it.",
+    "folder-locked": "This meeting’s folder is locked — unlock it to convert it.",
+    "share-active":
+      "This meeting’s note is shared. Revoke its share first, then convert again.",
+    "cloud-consent":
+      "Converting needs your one-time permission to send a redacted transcript to your AI provider.",
+  },
   unlock: {
     "touch-id-cancelled": "Touch ID was cancelled — try again.",
     "touch-id-failed": "Touch ID didn’t recognise you — try again.",
@@ -316,6 +348,7 @@ const CONTEXT_FALLBACK: Partial<Record<ErrorContext, string>> = {
   unlock: "Couldn’t unlock. Please try again.",
   tasks: "Couldn’t load shared tasks. Please try again.",
   recording: "Couldn’t finish that recording. Please try again.",
+  convert: "Couldn’t convert this meeting. Please try again.",
 };
 
 /** Matches a leading `[kebab-code]` — strict, never a sniff. */

--- a/src/app/features/detail/detail/detail.component.ts
+++ b/src/app/features/detail/detail/detail.component.ts
@@ -1509,7 +1509,12 @@ export class DetailComponent implements OnInit {
       await this.tabsService.openNote(result.noteId, `${title} — note`);
     } catch (error) {
       if (this.isCurrentConversion(request) && this.isActiveMeeting(id)) {
-        this.toast.danger(this.errorCopy.because("Couldn’t convert this meeting", error));
+        // The "convert" context, not the default "generic": every refusal on this path now
+        // carries an errcode, and the context is what turns a locked folder or an active share
+        // into the sentence that names the ONE thing the user has to do next.
+        this.toast.danger(
+          this.errorCopy.because("Couldn’t convert this meeting", error, "convert"),
+        );
       }
     } finally {
       if (this.conversionRequest()?.sequence === request.sequence) {


### PR DESCRIPTION
## Why

Every refusal on the meeting→note path was **anonymous**, so `ErrorCopyService`'s deny-by-default
rendered the same sentence for all of them:

> Couldn’t convert this meeting. Please try again.

The refusal that actually fired in production (#624) was *"a note in this folder is shared"* — a
precise, one-click-fixable condition. Identifying it took a SQLCipher session against the reporting
user's own database, because the app could not say it. Retrying, which is what the copy advised,
could never have worked.

## What

**Six new codes** for the refusals a user can act on:

| code | sentence |
| --- | --- |
| `convert-no-transcript` | This recording has no transcript yet, so there’s nothing to turn into a note. |
| `note-template-missing` | That note template no longer exists — pick another one in Settings ▸ Notes. |
| `note-provider-empty` | Your AI provider returned an empty note. Try again, or switch provider in Settings. |
| `share-active` | This note is shared. Revoke its share first, then try again. |
| `folder-closing` | That folder is being prepared for sharing. Try again in a moment. |
| `container-unavailable` | This recording isn’t in a folder Murmur can add a note to. Move it, then try again. |

Two more conversion sites reuse the existing `folder-locked`. And **fifteen** `this meeting's folder
is locked` refusals across `commands/{enrich,links,meetings,org,reminders,mod}.rs` get the existing
`meeting-locked` — the same dead end was reachable from every other surface, not just conversion.

The frontend gains a `convert` `ErrorContext`, so a locked folder or a live share reads as the next
step *on this screen*; `detail.component.ts` passes it at the call site.

## Oracles — both RED-verified

- **`actionable_conversion_refusals_carry_their_error_code`** asserts the code on the wire for four
  refusals. I removed one tag and confirmed the test fails, then restored it — a future refactor
  that drops a tag cannot pass silently.
- **`e2e/detail/convert-refusal-copy.spec.ts`** drives the real toast through the real IPC boundary:
  two coded refusals render their actionable sentence, and a **control arm** proves an un-coded
  failure still renders the generic sentence and never leaks Rust prose (`mutex`, `state.rs`).
  Without that arm both positive tests would pass even if the copy layer had been replaced by
  "render whatever Rust sent".

## Verification

- `cargo test --lib -- errcode::` 4/4 (includes the pinned `ALL` list, which is what keeps this
  file and `error-copy.service.ts` from drifting apart).
- `cargo test --lib -- actionable_conversion_refusals` green; RED confirmed first.
- `e2e/copy/error-copy-contract.spec.ts` 8/8 and `convert-refusal-copy.spec.ts` 6/6, both engines.
- `ng lint`, `ng build`, `.agents/h/mirror-check` clean.

One note on the local suite: running the whole `commands::lifecycle_tests` module at once fails ~39
share/org tests on this machine, sandboxed or not. Each of them passes alone and in batches, and CI
(nextest, process-per-test) is green — it is parallel resource contention here, not this change.
