### PR TITLE
fix(mcp): the local server for Claude stops failing silently

### DIFF
--- a/e2e/settings/mcp-status.spec.ts
+++ b/e2e/settings/mcp-status.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test, type Page } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * Settings must not assert that the local server for Claude is running when it is not.
+ *
+ * The screen said, in the present tense, "Murmur runs a small server on this Mac … at
+ * 127.0.0.1:8765" and handed over a config to paste — unconditionally. A bind failure was a
+ * `tracing::warn!` and a dead thread; nothing else in the app knew. Found 2026-08-28 on a real
+ * machine where an unrelated `python -m http.server 8765` had held the port for two days: the
+ * SHIPPED app's own log carried the same warning, and Settings still promised a running server.
+ *
+ * The config is the load-bearing half. A config that points at a dead port does not fail loudly —
+ * it fails inside Claude, later, as "the tools just don't work", which is the hardest kind of
+ * failure to trace back here.
+ */
+/** Navigate to the Privacy & Integrations card, the same way `privacy-honesty.spec.ts` does. */
+async function openPrivacySettings(page: Page) {
+  await page.goto("/settings");
+  await page.getByText("Privacy & Integrations").first().click();
+  const section = page.locator("app-settings-privacy-section");
+  await expect(section.getByText("Local server for Claude")).toBeVisible({
+    timeout: 10_000,
+  });
+  return section;
+}
+
+const CONFIG = JSON.stringify(
+  { mcpServers: { murmur: { type: "http", url: "http://127.0.0.1:8765" } } },
+  null,
+  2,
+);
+
+test("a port held by another app is named, and the config is withheld", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {},
+    {
+      get_mcp_config: CONFIG,
+      get_mcp_status: { state: "portInUse", port: 8765 },
+    },
+  );
+  const section = await openPrivacySettings(page);
+
+  await expect(section.getByRole("status")).toContainText(
+    "another app on this Mac is using port 8765",
+  );
+  // Self-healing is promised because the listener really does retry — see mcp.rs's bind loop.
+  await expect(section.getByRole("status")).toContainText("no restart needed");
+  // Handing over a config that points at a dead port is worse than handing over none.
+  await expect(
+    section.getByRole("button", { name: /Copy config/ }),
+  ).toBeDisabled();
+});
+
+test("a listening server keeps the config copyable", async ({ page }) => {
+  await mockTauri(
+    page,
+    {},
+    {
+      get_mcp_config: CONFIG,
+      get_mcp_status: { state: "listening", port: 8765 },
+    },
+  );
+  const section = await openPrivacySettings(page);
+
+  // The CONTROL arm. Without it the test above would pass even if the copy button were disabled
+  // unconditionally, or the warning rendered always — proving nothing about the status binding.
+  await expect(section.getByRole("status")).toHaveCount(0);
+  await expect(section.getByRole("button", { name: /Copy config/ })).toBeEnabled();
+});
+
+test("an unavailable server says so rather than staying silent", async ({ page }) => {
+  await mockTauri(
+    page,
+    {},
+    {
+      get_mcp_config: CONFIG,
+      get_mcp_status: { state: "unavailable", port: 8765 },
+    },
+  );
+  const section = await openPrivacySettings(page);
+
+  await expect(section.getByRole("status")).toContainText("Not running yet");
+  // A distinct instruction from the port case: this one does NOT recover on its own.
+  await expect(section.getByRole("status")).toContainText("restart");
+  await expect(
+    section.getByRole("button", { name: /Copy config/ }),
+  ).toBeDisabled();
+});

--- a/scripts/screenshots/mock-tauri.js
+++ b/scripts/screenshots/mock-tauri.js
@@ -1801,6 +1801,12 @@ scope to the GA-critical path only.
       // doesn't match the `list_`/`get_`/`has_`/`is_` fallback prefixes below, so
       // an unhandled case would previously resolve `null` — which the FE now
       // treats as a real signed-out status, never a permanent "Loading…" state).
+      // The demo world is a HEALTHY app: the local server for Claude is up. Specs that care
+      // about a failed bind override this explicitly (`e2e/settings/mcp-status.spec.ts`).
+      // Without it the unknown-command fallback returns `[]`, and Settings correctly — but
+      // unhelpfully for every unrelated spec — renders the "not running" branch.
+      case "get_mcp_status":
+        return { state: "listening", port: 8765 };
       case "account_status":
         return {
           loggedIn: false,

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6759,6 +6759,36 @@ pub fn get_mcp_config(state: State<'_, AppState>) -> Result<String, AppError> {
     get_mcp_config_inner(state.inner())
 }
 
+/// What Settings must say about the local server for Claude, instead of asserting it is running.
+///
+/// Serialized keys are camelCase and asserted by a test (`rust-tauri.md` §2b): the FE reads
+/// `state` and `port`, and a snake_case field here would arrive as `undefined` and silently render
+/// the healthy branch — the exact failure this command exists to prevent.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpStatusDto {
+    /// `starting` | `listening` | `portInUse` | `unavailable`.
+    pub state: String,
+    /// The fixed loopback port, so the copy can name it without hardcoding it twice.
+    pub port: u16,
+}
+
+/// The listener's REAL state. Settings used to claim, in the present tense, that the server was
+/// running at `127.0.0.1:8765` and hand over a config to paste — with no way to find out that the
+/// bind had failed. Reads the status the listener thread publishes; a missing handle (the probe
+/// process that never starts MCP) reports `unavailable` rather than pretending.
+#[tauri::command]
+pub fn get_mcp_status(app: AppHandle) -> McpStatusDto {
+    let state = app
+        .try_state::<std::sync::Arc<crate::mcp::McpListenerStatus>>()
+        .map(|handle| handle.get())
+        .unwrap_or(crate::mcp::McpListenerState::Unavailable);
+    McpStatusDto {
+        state: state.as_wire().to_string(),
+        port: crate::mcp::MCP_PORT,
+    }
+}
+
 /// Headless core of [`get_mcp_config`] — testable without a Tauri `State`.
 pub(crate) fn get_mcp_config_inner(state: &AppState) -> Result<String, AppError> {
     // Read the flag the same way lib.rs does: fail CLOSED (require the token) on a poisoned lock,

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -485,6 +485,49 @@
     /// emitted (no stale/placeholder header). Runs in a debug/test build, so `get_or_create_mcp_token`
     /// mints into the dev-secrets file store — no Keychain, no `security` CLI.
     #[test]
+    /// The wire contract for the status Settings branches on.
+    ///
+    /// `rust-tauri.md` §2b exists because a snake_case field arrives as `undefined` on the FE and
+    /// the template silently takes the other branch. Here that branch is "the server is running" —
+    /// so a naming slip would restore the exact lie this command was added to remove.
+    fn mcp_status_dto_is_camel_case_on_the_wire() {
+        let dto = super::McpStatusDto {
+            state: crate::mcp::McpListenerState::PortInUse.as_wire().to_string(),
+            port: crate::mcp::MCP_PORT,
+        };
+        let value = serde_json::to_value(&dto).unwrap();
+        let object = value.as_object().unwrap();
+        for key in object.keys() {
+            assert!(
+                !key.contains('_'),
+                "IPC DTO key {key} must be camelCase, never snake_case"
+            );
+        }
+        assert_eq!(object["state"], "portInUse");
+        assert_eq!(object["port"], crate::mcp::MCP_PORT);
+    }
+
+    /// Each listener state has a DISTINCT wire value, and the round-trip through the atomic
+    /// encoding preserves it.
+    ///
+    /// `portInUse` and `unavailable` must never collapse into one: they carry different
+    /// instructions ("quit the other app" vs "restart Murmur"), and the first one recovers by
+    /// itself while the second does not.
+    #[test]
+    fn every_mcp_listener_state_has_its_own_wire_value() {
+        use crate::mcp::McpListenerState::*;
+        let all = [Starting, Listening, PortInUse, Unavailable];
+        let wires: Vec<&str> = all.iter().map(|s| s.as_wire()).collect();
+        let mut unique = wires.clone();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(unique.len(), all.len(), "wire values collided: {wires:?}");
+
+        let status = crate::mcp::McpListenerStatus::default();
+        assert_eq!(status.get(), Starting, "an unwritten status is never Listening");
+    }
+
+    #[test]
     fn get_mcp_config_carries_token_when_required_and_omits_it_when_off() {
         let state = build_state("mcp-config");
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -246,6 +246,7 @@ pub fn run() {
             commands::explain_audit_finding,
             commands::get_config,
             commands::get_mcp_config,
+            commands::get_mcp_status,
             commands::save_config,
             commands::get_storage_report,
             commands::free_up_space,
@@ -569,6 +570,9 @@ pub fn run() {
             // transport and every relock entrypoint. It contains socket clones and content-free
             // lease ids only; no meeting data or authentication material.
             app.manage(std::sync::Arc::new(crate::mcp::McpResponseGate::new()));
+            // Managed BEFORE `mcp::spawn` so the listener's first status write lands on a
+            // handle the `get_mcp_status` command can already read.
+            app.manage(std::sync::Arc::new(crate::mcp::McpListenerStatus::default()));
 
             // PRE-WINDOW legacy-recovery guard. Historical paired crash artifacts are plaintext and
             // cannot be honestly presented as protected by an already-locked folder. Publish their

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -8,7 +8,7 @@ use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{Ipv4Addr, Shutdown, SocketAddrV4, TcpListener, TcpStream};
 #[cfg(test)]
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicU8, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, TryLockError};
 use std::time::{Duration, Instant};
 
@@ -29,6 +29,86 @@ const MCP_BIND_IP: Ipv4Addr = Ipv4Addr::LOCALHOST;
 
 fn mcp_listener_addr() -> SocketAddrV4 {
     SocketAddrV4::new(MCP_BIND_IP, MCP_PORT)
+}
+
+/// How long to wait before re-attempting a bind that lost the port to another process.
+///
+/// The port is FIXED (it is baked into [`ALLOWED_HOSTS`], the `Origin` allowlist, and the config
+/// the user pastes into Claude), so "pick another port" is not available — the only recovery is to
+/// take 8765 once whoever else has it lets go. Thirty seconds is far below a user's patience for
+/// "I quit that app, why is it still broken" and far above anything that would show up as load.
+const BIND_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+
+/// What the MCP listener is actually doing, for the one screen that tells the user about it.
+///
+/// # Why this exists
+///
+/// A bind failure used to be a `tracing::warn!` and a dead thread. Nothing else in the app knew,
+/// so Settings kept saying "Murmur runs a small server on this Mac … at 127.0.0.1:8765" in the
+/// present tense and kept offering a config to paste — while the user's Claude was talking to
+/// whatever else held the port. Found 2026-08-28 on a real machine where an unrelated
+/// `python -m http.server 8765` from another project had held it for two days: the SHIPPED app's
+/// log carried the same warning, and nothing on screen said so.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum McpListenerState {
+    /// The thread is up but has not bound yet (the first attempt is in flight).
+    Starting,
+    /// Bound and serving.
+    Listening,
+    /// Another process on this Mac holds the port. Retried every [`BIND_RETRY_INTERVAL`].
+    PortInUse,
+    /// A terminal failure that retrying cannot fix (no token, no response gate, a bind error that
+    /// is not `AddrInUse`). Deliberately distinct from [`Self::PortInUse`]: the user action is
+    /// different, and telling someone to close another app when the real cause is a Keychain
+    /// refusal sends them hunting for a process that does not exist.
+    Unavailable,
+}
+
+impl McpListenerState {
+    fn as_code(self) -> u8 {
+        match self {
+            Self::Starting => 0,
+            Self::Listening => 1,
+            Self::PortInUse => 2,
+            Self::Unavailable => 3,
+        }
+    }
+
+    fn from_code(code: u8) -> Self {
+        match code {
+            1 => Self::Listening,
+            2 => Self::PortInUse,
+            3 => Self::Unavailable,
+            _ => Self::Starting,
+        }
+    }
+
+    /// The wire value the frontend branches on. camelCase to match every other IPC payload.
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            Self::Starting => "starting",
+            Self::Listening => "listening",
+            Self::PortInUse => "portInUse",
+            Self::Unavailable => "unavailable",
+        }
+    }
+}
+
+/// Tauri-managed handle to [`McpListenerState`], written by the listener thread and read by
+/// `commands::get_mcp_status`. An atomic rather than a mutex: the listener writes it from its own
+/// thread while the command reads it from the IPC thread, and a lock here could only ever add a
+/// way for the status read to block behind the retry loop.
+#[derive(Debug, Default)]
+pub struct McpListenerStatus(AtomicU8);
+
+impl McpListenerStatus {
+    pub fn get(&self) -> McpListenerState {
+        McpListenerState::from_code(self.0.load(Ordering::Relaxed))
+    }
+
+    fn set(&self, state: McpListenerState) {
+        self.0.store(state.as_code(), Ordering::Relaxed);
+    }
 }
 
 /// Max request body we will read (E5). The MCP JSON-RPC requests are tiny; cap hard so a
@@ -525,11 +605,35 @@ pub fn spawn(app: AppHandle, require_token: bool) {
 
 fn run(app: AppHandle, require_token: bool) {
     let addr = mcp_listener_addr();
-    let listener = match TcpListener::bind(addr) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::warn!(target: "mcp", error = %e, "MCP server failed to bind {addr}");
-            return;
+    let status = app
+        .try_state::<Arc<McpListenerStatus>>()
+        .map(|handle| Arc::clone(handle.inner()));
+    let report = |state: McpListenerState| {
+        if let Some(status) = status.as_ref() {
+            status.set(state);
+        }
+    };
+    report(McpListenerState::Starting);
+    // RETRY, don't give up. The port is fixed, so losing it to another local process is not a
+    // permanent condition — it lasts exactly as long as that process does. Before this loop the
+    // thread returned on the first `AddrInUse` and MCP stayed dead until the user restarted
+    // Murmur, which nothing on screen ever told them to do.
+    let listener = loop {
+        match TcpListener::bind(addr) {
+            Ok(s) => break s,
+            Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+                report(McpListenerState::PortInUse);
+                tracing::warn!(
+                    target: "mcp",
+                    "MCP server port {MCP_PORT} is held by another process on this Mac; retrying"
+                );
+                std::thread::sleep(BIND_RETRY_INTERVAL);
+            }
+            Err(e) => {
+                report(McpListenerState::Unavailable);
+                tracing::warn!(target: "mcp", error = %e, "MCP server failed to bind {addr}");
+                return;
+            }
         }
     };
     // The expected token, if enforcement is on. Minted/persisted in the Keychain on first use.
@@ -541,6 +645,7 @@ fn run(app: AppHandle, require_token: bool) {
                 // Do NOT fall back to an unauthenticated server — that would serve the whole tool
                 // surface ungated. Refuse to start the MCP listener so the gate can never be
                 // bypassed by a transient Keychain failure.
+                report(McpListenerState::Unavailable);
                 tracing::error!(target: "mcp", error = %e, "MCP token required but unavailable — refusing to start the MCP server (fail closed)");
                 return;
             }
@@ -549,12 +654,14 @@ fn run(app: AppHandle, require_token: bool) {
         None
     };
     let Some(gate) = app.try_state::<Arc<McpResponseGate>>() else {
+        report(McpListenerState::Unavailable);
         tracing::error!(target: "mcp", "MCP response gate is unavailable — refusing to start");
         return;
     };
     let gate = Arc::clone(gate.inner());
     let expected_token = expected_token.map(Arc::new);
     let active_connections = Arc::new(AtomicUsize::new(0));
+    report(McpListenerState::Listening);
     tracing::info!(target: "mcp", "MCP server listening on http://{addr}");
     loop {
         let app = app.clone();

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -173,6 +173,7 @@ import type {
   WhisperCard,
   WhisperRecommendationDto,
   WikiTarget,
+  McpStatus,
 } from "./models";
 
 export const EVENT_STATUS = "meetnotes://status";
@@ -410,6 +411,16 @@ export class IpcService {
    */
   getMcpConfig(): Promise<string> {
     return invoke<string>("get_mcp_config");
+  }
+
+  /**
+   * Whether the local server for Claude actually came up.
+   *
+   * Settings used to assert it was running and hand over a config regardless; a bind failure was
+   * a log line nobody reads. This is the read that lets the screen tell the truth.
+   */
+  getMcpStatus(): Promise<McpStatus> {
+    return invoke<McpStatus>("get_mcp_status");
   }
 
   saveConfig(config: AppConfigDto): Promise<void> {

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -3825,3 +3825,22 @@ export interface SharedWorkspace {
 
 /** What a private placement can point at. */
 export type SharedPlacementTarget = "container" | "doc";
+
+/**
+ * What the local server for Claude is actually doing.
+ *
+ * `portInUse` is deliberately its own state, not folded into a generic failure: the user action
+ * that fixes it (quit whatever else holds the port) is completely different from the one that
+ * fixes `unavailable`, and the listener retries a `portInUse` on its own, so the copy can promise
+ * recovery without a restart.
+ */
+export type McpListenerState =
+  | "starting"
+  | "listening"
+  | "portInUse"
+  | "unavailable";
+
+export interface McpStatus {
+  state: McpListenerState;
+  port: number;
+}

--- a/src/app/features/settings/sections/settings-privacy-section/settings-privacy-section.component.html
+++ b/src/app/features/settings/sections/settings-privacy-section/settings-privacy-section.component.html
@@ -225,6 +225,32 @@
                 >.
               </p>
 
+              <!--
+                The sentence above is written in the present tense, so it MUST NOT stand alone
+                when the server did not come up. A bind failure used to be a log line nobody
+                reads while this screen kept promising a running server AND handed over a config
+                to paste — found on a real machine where an unrelated process had held the port
+                for two days, in the SHIPPED app.
+                `portInUse` gets its own branch because the listener retries it on its own: the
+                user quits the other app and Murmur reconnects, with no restart to instruct.
+              -->
+              @if (mcpPortInUse()) {
+                <div class="banner is-warning" role="status">
+                  <span>
+                    Not running: another app on this Mac is using port
+                    {{ mcpStatus().port }}. Quit it and Murmur will connect on its
+                    own — no restart needed.
+                  </span>
+                </div>
+              } @else if (!mcpRunning()) {
+                <div class="banner is-warning" role="status">
+                  <span>
+                    Not running yet. If this doesn't clear on its own, restart
+                    Murmur — Claude can't read your meetings until it does.
+                  </span>
+                </div>
+              }
+
               <div class="mcp-config">
                 <div class="mcp-config-head">
                   <span class="mcp-config-label text-muted">Config</span>
@@ -232,7 +258,7 @@
                     type="button"
                     class="btn mcp-copy-btn"
                     [class.is-copied]="configCopied()"
-                    [disabled]="!mcpConfig()"
+                    [disabled]="!mcpConfig() || !mcpRunning()"
                     (click)="copyMcpConfig()"
                     [attr.aria-label]="
                       configCopied() ? 'Copied' : 'Copy config to clipboard'
@@ -298,6 +324,13 @@
                 }
               </div>
 
+              <!--
+                Gated on the CONFIG only, never on listener status. The config block above is on
+                screen whenever there is a config, and this is the sentence that says the text
+                carries a credential and what leaking it costs — hiding it behind "is the server
+                up" would trade a security disclosure for a status banner.
+                `e2e/settings/privacy-honesty.spec.ts` caught exactly that mistake here.
+              -->
               @if (mcpConfig()) {
                 <span class="mcp-hint text-muted">
                   Add this to your Claude config, then restart Claude. It contains

--- a/src/app/features/settings/sections/settings-privacy-section/settings-privacy-section.component.ts
+++ b/src/app/features/settings/sections/settings-privacy-section/settings-privacy-section.component.ts
@@ -34,6 +34,9 @@ export class SettingsPrivacySectionComponent {
   readonly configCopied = this.store.configCopied;
   readonly mcpUrl = this.store.mcpUrl;
   readonly mcpConfig = this.store.mcpConfig;
+  readonly mcpRunning = this.store.mcpRunning;
+  readonly mcpPortInUse = this.store.mcpPortInUse;
+  readonly mcpStatus = this.store.mcpStatus;
 
   // Phase D — on-device name-redaction (NER) model affordance.
   readonly nerModelPresent = this.store.nerModelPresent;

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -36,6 +36,7 @@ import type {
   StorageReport,
   VoiceprintInfo,
   ModelCatalog,
+  McpStatus,
 } from "../../core/models";
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import { NOTE_ASSIST_NEW_ACTION_IDS } from "../notes/note-brain-popover/note-assist-catalog";
@@ -496,6 +497,24 @@ export class SettingsStore {
    */
   private readonly _mcpConfig = signal<string>("");
   readonly mcpConfig = this._mcpConfig.asReadonly();
+
+  /**
+   * Whether the local server actually came up. Starts optimistic ONLY until the first read
+   * resolves — `refreshMcpStatus()` runs in `load()` alongside the config fetch.
+   */
+  private readonly _mcpStatus = signal<McpStatus>({
+    state: "starting",
+    port: 8765,
+  });
+  readonly mcpStatus = this._mcpStatus.asReadonly();
+  /** True while the server is genuinely serving — the ONLY state the healthy copy may claim. */
+  readonly mcpRunning = computed(() => this._mcpStatus().state === "listening");
+  /**
+   * True when another process on this Mac holds the port. Its own branch because the listener
+   * retries this case on its own, so the copy can tell the user to just quit the other app —
+   * no Murmur restart.
+   */
+  readonly mcpPortInUse = computed(() => this._mcpStatus().state === "portInUse");
 
   /** Flips true for ~1.6s after copying the MCP config — drives the button's confirmed state. */
   private readonly _configCopied = signal(false);
@@ -2569,6 +2588,32 @@ export class SettingsStore {
   /** Re-fetch the token-bearing MCP config into its signal (after load / config save). */
   private async refreshMcpConfig(): Promise<void> {
     this._mcpConfig.set(await this.ipc.getMcpConfig().catch(() => ""));
+    await this.refreshMcpStatus();
+  }
+
+  /**
+   * Re-read the listener's real state.
+   *
+   * A failed read degrades to `unavailable`, never to `listening`: the whole point of this signal
+   * is that the screen must not assert a running server it has not confirmed.
+   */
+  private async refreshMcpStatus(): Promise<void> {
+    // NORMALIZED, not trusted. A backend that predates this command (or a test harness that does
+    // not stub it) resolves `undefined` rather than rejecting, and `mcpStatus().port` on an
+    // undefined value throws while rendering — the T6 failure mode where one absent field takes
+    // the whole view down. A shape we cannot read degrades to `unavailable`, never to running.
+    const raw = await this.ipc.getMcpStatus().catch(() => null);
+    const state = raw?.state;
+    this._mcpStatus.set({
+      state:
+        state === "listening" ||
+        state === "portInUse" ||
+        state === "starting" ||
+        state === "unavailable"
+          ? state
+          : "unavailable",
+      port: typeof raw?.port === "number" ? raw.port : 8765,
+    });
   }
 
   async saveKey(): Promise<void> {


### PR DESCRIPTION
## The bug, found on a real machine

If anything else on the Mac holds port 8765, Murmur's MCP listener logged a `WARN`, dropped its
thread, and that was the end of it. Meanwhile Settings said, in the **present tense**:

> Murmur **runs** a small server on this Mac only … at `http://127.0.0.1:8765`.

and handed over a config to paste. So the user's Claude was pointed at whatever else owned the port,
and the only evidence was a log line nobody reads.

This was not hypothetical. On the reporting machine an unrelated `python -m http.server 8765` from a
different project had held the port **since 27 Aug 00:38**, and the **shipped** app's own log
carried the same line the whole time:

```
2026-08-27T07:48:10  WARN mcp: MCP server failed to bind 127.0.0.1:8765  error=Address already in use
```

## Three changes

**1. Retry instead of giving up.** An `AddrInUse` bind is retried every 30s. The port is fixed — it
is baked into `ALLOWED_HOSTS` (the DNS-rebinding guard), the `Origin` check, and the config the user
pastes — so "pick another port" is not available. But losing it is not permanent either: it lasts
exactly as long as the other process. Quitting that app now restores MCP with **no Murmur restart**.
A non-`AddrInUse` bind error, a missing token and a missing response gate stay terminal.

**2. The listener publishes its real state** (`starting` / `listening` / `portInUse` /
`unavailable`) through a Tauri-managed handle, read by a new `get_mcp_status` command.
`portInUse` is deliberately its own state: it recovers by itself and `unavailable` does not, so they
cannot share one sentence without lying to half the users who see it.

**3. Settings tells the truth.** A held port names the port and promises self-recovery; any other
non-running state says restart. **Copy config is disabled while nothing is listening** — a config
aimed at a dead port does not fail loudly, it fails later inside Claude as "the tools just don't
work", which is the hardest failure to trace back to this screen.

## Two things the tests caught in my own work

- **I hid a security disclosure.** My first pass gated the "this config carries a private key" hint
  on listener status, which removed it whenever the server was down — while the config text was
  still on screen. `e2e/settings/privacy-honesty.spec.ts` failed on exactly that. The hint is back on
  `mcpConfig()` alone, with a comment saying why.
- **A missing field would have taken the view down.** A backend without the new command resolves
  `undefined`, and `mcpStatus().port` on `undefined` throws while rendering — the T6 shape from
  `angular-zoneless.md`. The status read is now normalized: an unreadable shape degrades to
  `unavailable`, never to running.

## Verification

- `cargo test --lib -- mcp::` 61/61, plus two new contract tests: the DTO's serialized keys are
  camelCase (§2b — a snake_case slip here would silently render the *healthy* branch, restoring the
  exact lie) and every listener state has a distinct wire value.
- `e2e/settings/` **22/22 on Chromium and WebKit**, including a new `mcp-status.spec.ts` with a
  **control arm**: a listening server renders no banner and keeps the button enabled, so the failure
  assertions cannot pass vacuously.
- `ng lint`, `ng build`, `.agents/h/mirror-check` clean.

The shared demo mock now answers `get_mcp_status` with a healthy listener, so the default e2e world
is a working app and only the specs that care about a failed bind opt into it.
