### PR TITLE
fix: the reserved note root is an inbox, not a folder-shaped row

### DIFF
--- a/e2e/shell/unfiled-notes-inbox.spec.ts
+++ b/e2e/shell/unfiled-notes-inbox.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * The reserved note root renders as an INBOX, not a folder.
+ *
+ * `is_root` marks the one always-open note folder that backs the "Notes"
+ * section — unfiled notes land there and it can never be sealed. The migration
+ * that introduced it says the frontend hides it from the folder tree, because
+ * it IS the section rather than a nested child. The 2026-08-22 hierarchy
+ * rebuild renders every container `list_containers` returns, and that
+ * predicate filters on kind and path but NOT on `is_root`, so the root came
+ * back as a folder-shaped row on which rename, delete, lock and share are all
+ * disabled — a row that looks broken because every action is missing.
+ *
+ * These are the oracles for the fix. Without them nothing notices if the root
+ * reappears as a folder: it renders, it is clickable, and every existing spec
+ * stays green.
+ */
+const NOTE_ROOT = {
+  id: "f-notes-root",
+  name: "Notes",
+  kind: "note",
+  level: "folder",
+  emoji: null,
+  tint: null,
+  locked: false,
+  unlocked: false,
+  isRoot: true,
+  folders: [
+    {
+      id: "f-child-of-root",
+      name: "Kept child",
+      kind: "note",
+      level: "folder",
+      emoji: null,
+      tint: null,
+      locked: false,
+      unlocked: false,
+      isRoot: false,
+      folders: [],
+      groups: [],
+    },
+  ],
+  groups: [
+    {
+      kind: "note",
+      total: 12,
+      items: [
+        {
+          kind: "note",
+          id: "n-loose",
+          title: "Loose thought",
+          durationS: null,
+          sortAt: 90,
+        },
+      ],
+    },
+  ],
+};
+
+const FOREST = [
+  {
+    id: "p-acme",
+    name: "Acme",
+    kind: "note",
+    level: "project",
+    emoji: null,
+    tint: null,
+    locked: false,
+    unlocked: false,
+    isRoot: false,
+    folders: [NOTE_ROOT],
+    groups: [],
+  },
+];
+
+async function openSidebar(page: Page): Promise<void> {
+  await mockTauri(page, {}, { list_workspace_tree: FOREST });
+  await page.goto("/");
+  await page.getByRole("button", { name: "Spaces" }).click();
+  await expect(
+    page.getByRole("complementary", { name: "Spaces sidebar" }),
+  ).toBeVisible();
+  await page
+    .getByRole("treeitem", { name: /Acme/ })
+    .getByRole("button", { name: /Expand/ })
+    .click();
+}
+
+test("the reserved note root is not drawn as a folder row", async ({
+  page,
+}) => {
+  await openSidebar(page);
+  // The row itself must be absent, not merely action-free. Asserting only on the
+  // ⋯ menu passed even with the skip disabled, which made this test a witness to
+  // nothing — the menu is hover-revealed, so its absence proves neither state.
+  // Case-sensitive on purpose: the root row would be named "Notes", while the
+  // inbox row that replaces it reads "Unfiled notes". Anchoring with ^ does not
+  // work here — a tree row's accessible name also folds in its caret and menu
+  // labels ("Expand Notes …"), so the match has to be a substring.
+  await expect(page.getByRole("treeitem", { name: /Notes/ })).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Actions for Notes" }),
+  ).toHaveCount(0);
+});
+
+test("its notes render as an Unfiled notes inbox at the top level", async ({
+  page,
+}) => {
+  await openSidebar(page);
+  const inbox = page.getByRole("treeitem", { name: /Unfiled notes/ });
+  await expect(inbox).toBeVisible();
+  await expect(inbox).toHaveAttribute("aria-level", "1");
+  await expect(inbox).toContainText("12");
+  await expect(page.getByRole("treeitem", { name: /Loose thought/ })).toBeVisible();
+  // The continuation row carries an explicit role="treeitem" (matching the
+  // unfiled-recordings row it mirrors), so it is not queried as a button.
+  await expect(
+    page.getByRole("treeitem", { name: /View all \(12\)/ }),
+  ).toBeVisible();
+});
+
+test("the inbox offers no folder affordance at all", async ({ page }) => {
+  await openSidebar(page);
+  const inbox = page.getByRole("treeitem", { name: /Unfiled notes/ });
+  // An honest inbox, exactly like unfiled recordings: no lock, no manage, no
+  // create-here, and nothing to share.
+  await expect(
+    inbox.getByRole("button", { name: /Actions for/ }),
+  ).toHaveCount(0);
+});
+
+test("a folder the user created under the root stays reachable", async ({
+  page,
+}) => {
+  // The root's own row is gone, but a container the user made must never become
+  // unreachable because its parent stopped being drawn.
+  await openSidebar(page);
+  await expect(
+    page.getByRole("treeitem", { name: /Kept child/ }),
+  ).toBeVisible();
+});

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.html
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.html
@@ -81,6 +81,57 @@
         }
       }
     }
+    @if (unfiledNotes(); as inbox) {
+      @if (inbox.total > 0) {
+        <!-- The reserved note root rendered as an honest INBOX, not a folder:
+             it is the "Notes" section itself, so it carries no lock, manage or
+             create affordance and accepts no drops — exactly like the unfiled
+             recordings row above it. -->
+        <mur-tree-row
+          class="line line--unfiled"
+          role="treeitem"
+          aria-level="1"
+          [attr.aria-selected]="currentPath() === '/notes'"
+          [attr.aria-expanded]="unfiledNotesExpanded()"
+          label="Unfiled notes"
+          [depth]="0"
+          icon="note"
+          [count]="inbox.total"
+          [selected]="currentPath() === '/notes'"
+          [expandable]="true"
+          [expanded]="unfiledNotesExpanded()"
+          (toggleExpand)="toggleUnfiledNotes()"
+          (activate)="openAllNotes()"
+        />
+        @if (unfiledNotesExpanded()) {
+          @for (item of inbox.items; track item.id) {
+            <mur-tree-row
+              class="line line--item line--unfiled-item"
+              role="treeitem"
+              aria-level="2"
+              [attr.aria-selected]="isItemSelected(item)"
+              [label]="itemTitle(item)"
+              [depth]="1"
+              [icon]="kindIcon(item.kind)"
+              [selected]="isItemSelected(item)"
+              (activate)="openItem(item)"
+            />
+          }
+          @if (inbox.total > inbox.items.length) {
+            <button
+              type="button"
+              class="see-all see-all--unfiled"
+              role="treeitem"
+              aria-selected="false"
+              aria-level="2"
+              (click)="openAllNotes()"
+            >
+              {{ viewAllNotesLabel(inbox.total) }}
+            </button>
+          }
+        }
+      }
+    }
     @for (line of lines(); track line.key) {
       @if (line.item; as item) {
         <!-- An ITEM row: a leaf, so the gutter renders the equal-width spacer

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
@@ -89,6 +89,9 @@ const MAX_VISIBLE_ITEMS = 8;
 /** Persisted disclosure state for received containers, keyed like the local one. */
 const EXPANDED_SHARED_KEY = "murmur.workspace.expandedShared";
 
+/** Persisted disclosure state for the unfiled-notes inbox. */
+const UNFILED_NOTES_EXPANDED_KEY = "murmur.workspace.unfiledNotesExpanded";
+
 /**
  * Where activating an item navigates. These MUST name real entries in
  * `app.routes.ts`: an unmatched path hits the router'''s catch-all and redirects to
@@ -177,6 +180,65 @@ export class WorkspaceTreeComponent {
     if (this.sharedWorkspace.sharedBrains() === null) {
       void this.sharedWorkspace.load();
     }
+  }
+
+  /**
+   * Notes that live in the reserved note root — the ones the user never filed.
+   *
+   * Found anywhere in the forest rather than at a fixed position: the root is
+   * created inside the workspace project (`ensure_notes_root`), so its depth is
+   * an implementation detail of that migration, not something to hard-code.
+   */
+  protected readonly unfiledNotes = computed<{
+    items: ItemRow[];
+    total: number;
+  }>(() => {
+    const find = (nodes: readonly ContainerNode[]): ContainerNode | null => {
+      for (const node of nodes) {
+        if (node.isRoot) {
+          return node;
+        }
+        const inChild = find(node.folders);
+        if (inChild) {
+          return inChild;
+        }
+      }
+      return null;
+    };
+    const root = find(this.workspace.forest());
+    if (!root) {
+      return { items: [], total: 0 };
+    }
+    const items = root.groups
+      .flatMap((group) => group.items)
+      .sort((left, right) => right.sortAt - left.sortAt)
+      .slice(0, MAX_VISIBLE_ITEMS);
+    const total = root.groups.reduce((sum, group) => sum + group.total, 0);
+    return { items, total };
+  });
+
+  private readonly _unfiledNotesExpanded = signal(
+    readStoredBoolean(UNFILED_NOTES_EXPANDED_KEY, true),
+  );
+  protected readonly unfiledNotesExpanded =
+    this._unfiledNotesExpanded.asReadonly();
+
+  protected toggleUnfiledNotes(): void {
+    const next = !this._unfiledNotesExpanded();
+    this._unfiledNotesExpanded.set(next);
+    try {
+      localStorage.setItem(UNFILED_NOTES_EXPANDED_KEY, JSON.stringify(next));
+    } catch {
+      /* a private window or blocked site data: the tree still works */
+    }
+  }
+
+  protected viewAllNotesLabel(total: number): string {
+    return `View all (${total})`;
+  }
+
+  protected openAllNotes(): void {
+    void this.router.navigate(["/notes"]);
   }
 
   protected readonly loading = this.workspace.loading;
@@ -365,6 +427,24 @@ export class WorkspaceTreeComponent {
     container: ContainerNode,
     depth: number,
   ): void {
+    if (container.isRoot) {
+      // The reserved note root is the "Notes" SECTION, not a folder — the
+      // migration that introduced `is_root` says so, and every management
+      // affordance is already disabled on it (rename, delete, lock, share). The
+      // old notes tree hid it; the 2026-08-22 hierarchy rebuild renders every
+      // container from `list_containers`, whose predicate filters on kind and
+      // path but not `is_root`, so it came back as a folder-shaped row nobody
+      // can do anything with. Its notes render as an inbox instead — symmetric
+      // with unfiled recordings.
+      //
+      // Its child folders are still hoisted to this depth: a container the user
+      // created must never become unreachable because its parent stopped being
+      // drawn.
+      for (const child of container.folders) {
+        this.pushContainer(out, child, depth);
+      }
+      return;
+    }
     out.push({ key: `c:${container.id}`, depth, container });
     if (this.isSealed(container) || !this.isContainerExpanded(container)) {
       return;
@@ -1365,5 +1445,15 @@ function readStoredSharedSet(): ReadonlySet<string> {
       : new Set();
   } catch {
     return new Set();
+  }
+}
+
+/** Read a persisted boolean, tolerating a blocked or empty store. */
+function readStoredBoolean(key: string, fallback: boolean): boolean {
+  try {
+    const raw = localStorage.getItem(key);
+    return raw === null ? fallback : JSON.parse(raw) === true;
+  } catch {
+    return fallback;
   }
 }


### PR DESCRIPTION
## The bug

`is_root` marks the one always-open note folder that backs the "Notes" section —
unfiled notes land there and it can never be sealed. The migration that
introduced it states the intent plainly:

> the FE hides it from the folder tree (it IS the section, not a nested child)

The 2026-08-22 hierarchy rebuild renders every container `list_containers`
returns, and `renderable_container` filters on `kind` and `path` but **not** on
`is_root`. Nobody re-applied the hide, so the root came back as an ordinary
folder row — one where rename, delete, lock and (as of #629) share are all
disabled, because each is gated on `!isRoot`.

The result reads as broken rather than reserved: a folder whose ⋯ menu is
missing every action, with no explanation. A user hit exactly that while looking
for "Share to Org…".

## The fix

Render its notes as an **Unfiled notes** inbox beside the existing unfiled
recordings row — the shape this tree already uses for container-less content,
whose own comment says it best:

> `container_id = NULL` is an honest inbox, not a synthetic Space: it has no
> lock/manage/create affordances and cannot accept drops.

Frontend only. The database row, `ensure_notes_root`, and every gated reader are
untouched — the root still exists, because `documents.folder_id` is `NOT NULL`
and giving unfiled notes a real container is what keeps `visibility_clause` and
the seal machinery free of a NULL-folder branch.

A folder the user created **under** the root is hoisted to the root's depth. A
container must never become unreachable because its parent stopped being drawn.

## Verification

Four oracles in `e2e/shell/unfiled-notes-inbox.spec.ts`, **RED-verified**: with
the skip disabled the folder row reappears and two of the four fail.

The first assertion was rewritten after it passed in that state — it checked only
for the hover-revealed ⋯ menu, so its absence witnessed neither state. It now
asserts the row itself is absent, case-sensitively, since the replacement row
reads "Unfiled notes".

Full chromium project green: 477 passed, 1 skipped.
