### PR TITLE
fix: the live feed pull ingests container manifests too

### DIFF
--- a/e2e/shell/shared-containers.spec.ts
+++ b/e2e/shell/shared-containers.spec.ts
@@ -364,3 +364,78 @@ test("a nested received folder can be filed too, and renders in exactly one plac
     .click();
   await expect(page.getByRole("treeitem", { name: /Contracts/ })).toHaveCount(1);
 });
+
+test("a received loose item and an own standalone share each carry the marker", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {},
+    {
+      list_workspace_tree: [
+        {
+          ...LOCAL_FOREST[0],
+          groups: [
+            {
+              kind: "note",
+              total: 2,
+              items: [
+                { kind: "note", id: "n-shared", title: "Roadmap", durationS: null, sortAt: 20 },
+                { kind: "note", id: "n-private", title: "Scratch", durationS: null, sortAt: 10 },
+              ],
+            },
+          ],
+        },
+        ...LOCAL_FOREST.slice(1),
+      ],
+      list_shared_workspace: SHARED_WORKSPACE,
+      list_container_share_status: CONTAINER_SHARES,
+      list_org_share_targets: [
+        {
+          kind: "note",
+          id: "n-shared",
+          orgId: "org-siema",
+          orgName: "Siema",
+          access: "edit",
+        },
+      ],
+    },
+  );
+  await page.goto("/");
+  await page.getByRole("button", { name: "Spaces" }).click();
+  await page
+    .getByRole("treeitem", { name: /Acme/ })
+    .getByRole("button", { name: /Expand/ })
+    .click();
+
+  // The user's OWN note, published on its own, says where it went.
+  await expect(
+    page.getByRole("img", { name: /Shared to Siema · Can edit/ }),
+  ).toHaveCount(1);
+  // A note they did not share carries nothing — the marker must mean something.
+  const scratch = page.getByRole("treeitem", { name: /Scratch/ });
+  await expect(scratch.getByRole("img", { name: /Shared to/ })).toHaveCount(0);
+
+  // A RECEIVED loose item names who shared it.
+  await page
+    .getByRole("treeitem", { name: /Shared Brains/ })
+    .getByRole("button", { name: /Expand/ })
+    .click();
+  await expect(
+    page.getByRole("img", { name: /From Siema · kgm004a · View only/ }),
+  ).not.toHaveCount(0);
+});
+
+test("an item inside a shared container is not marked twice", async ({ page }) => {
+  // The container's own row already says it. Repeating the glyph on every child
+  // turns a quiet signal into noise, which is why the backend read excludes
+  // container-owned rows outright.
+  await openSidebar(page);
+  await page
+    .getByRole("treeitem", { name: /Partners/ })
+    .getByRole("button", { name: /Expand/ })
+    .click();
+  const kickoff = page.getByRole("treeitem", { name: /Partner kickoff/ });
+  await expect(kickoff).toBeVisible();
+  await expect(kickoff.getByRole("img", { name: /Shared to/ })).toHaveCount(0);
+});

--- a/scripts/screenshots/mock-tauri.js
+++ b/scripts/screenshots/mock-tauri.js
@@ -1828,6 +1828,7 @@ scope to the GA-critical path only.
       case "list_shared_workspace":
         return RICH() ? SHARED_WORKSPACE : EMPTY_SHARED_WORKSPACE;
       case "list_container_share_status": return RICH() ? CONTAINER_SHARES : [];
+      case "list_org_share_targets": return [];
       case "preview_container_share": return {
         folderId: args?.folderId ?? "f-clients",
         name: "Clients",

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -13062,7 +13062,7 @@ pub(crate) fn meeting_is_unlocked(state: &AppState, meeting_id: &str) -> Result<
 /// iff it is open (`locked=0`) OR its id is in the current session unlock set. Documents anchor on a
 /// folder directly (not a meeting), so the document commands gate on this. A non-existent folder
 /// reports `false` (fail-closed — there is nothing legitimate to read).
-fn folder_is_unlocked(state: &AppState, folder_id: &str) -> Result<bool, AppError> {
+pub(crate) fn folder_is_unlocked(state: &AppState, folder_id: &str) -> Result<bool, AppError> {
     let folder = match state.db.folder_by_id(folder_id)? {
         Some(f) => f,
         None => return Ok(false), // unknown folder → nothing to surface.

--- a/src-tauri/src/commands/org.rs
+++ b/src-tauri/src/commands/org.rs
@@ -10217,6 +10217,25 @@ async fn org_sync_one(
             document_owner_user_id: Option<String>,
             is_current: bool,
         },
+        /// A CONTAINER manifest → `org_containers`, never `org_items`.
+        ///
+        /// This arm exists because the feed has TWO ingest paths — this live pull and the
+        /// anti-entropy reconcile sweep — and 2.1.0 shipped the container branch on only the
+        /// sweep. A manifest arriving through the live pull was therefore written as an ordinary
+        /// note, so a shared Space showed up in Shared Brains as a note named after the folder
+        /// instead of appearing in the sidebar as a Space.
+        IngestContainer {
+            item_id: String,
+            seq: u64,
+            rev: u32,
+            generation: u32,
+            manifest: Box<crate::share::container_envelope::ContainerEnvelope>,
+            author_hint: String,
+            author_user_id: String,
+            access: crate::share::org_dto::OrgItemAccess,
+            document_owner_user_id: Option<String>,
+            created_at: String,
+        },
     }
     let mut actions: Vec<FeedAction> = Vec::new();
     let cursor = state.db.org_last_seq_for(&org.org_id)?;
@@ -10348,6 +10367,32 @@ async fn org_sync_one(
                 .errors
                 .push(format!("item {}: content hash mismatch", item.item_id));
             actions.push(FeedAction::SkipTerminal { seq: item.seq });
+            continue;
+        }
+        if env.kind == crate::share::org_envelope::OrgItemKind::Container {
+            // Structure, not prose: a manifest skips the attachment bundle, the chunker and the
+            // embedder entirely. A payload this device cannot parse is terminal for that seq —
+            // never half-written, so a malformed manifest cannot leave a nameless container behind.
+            match crate::share::container_envelope::ContainerEnvelope::from_json(&env.markdown) {
+                Ok(manifest) => actions.push(FeedAction::IngestContainer {
+                    item_id: item.item_id.clone(),
+                    seq: item.seq,
+                    rev: item.rev,
+                    generation: item.generation,
+                    manifest: Box::new(manifest),
+                    author_hint: env.author_hint.clone(),
+                    author_user_id: item.author_user_id.clone(),
+                    access: item.access,
+                    document_owner_user_id: item.document_owner_user_id.clone(),
+                    created_at: item.created_at.clone(),
+                }),
+                Err(_) => {
+                    report
+                        .errors
+                        .push(format!("item {}: container manifest invalid", item.item_id));
+                    actions.push(FeedAction::SkipTerminal { seq: item.seq });
+                }
+            }
             continue;
         }
         // Validate the complete authenticated bundle before any local write, then replace wire ids
@@ -10540,6 +10585,61 @@ async fn org_sync_one(
                                 if applied {
                                     ingested += 1;
                                 }
+                                // WHERE the sender filed this document. Written after the item row
+                                // exists, and unconditionally: a document that LEAVES a shared
+                                // folder arrives with no placement, and clearing it is what makes
+                                // it move. 2.1.0 wrote this only on the reconcile-sweep path, so a
+                                // document arriving through the live pull was never filed at all.
+                                let placement = env.placement.as_ref();
+                                let _ = db.set_org_item_placement(
+                                    &item_id,
+                                    placement.map(|p| p.parent_container_id.as_str()),
+                                    placement.map(|p| p.position).unwrap_or(0),
+                                );
+                            }
+                            FeedAction::IngestContainer {
+                                item_id,
+                                seq,
+                                rev,
+                                generation,
+                                manifest,
+                                author_hint,
+                                author_user_id,
+                                access,
+                                document_owner_user_id,
+                                created_at,
+                            } => {
+                                let manifest = *manifest;
+                                let row = crate::storage::models::OrgContainerRow {
+                                    org_id: org_id.clone(),
+                                    container_id: manifest.container_id.clone(),
+                                    item_id: item_id.clone(),
+                                    level: manifest.level.as_str().to_string(),
+                                    name: manifest.name.clone(),
+                                    emoji: manifest.emoji.clone(),
+                                    tint: manifest.tint.clone(),
+                                    parent_container_id: manifest.parent_container_id.clone(),
+                                    position: manifest.position,
+                                    access: access.as_str().to_string(),
+                                    author_hint,
+                                    author_user_id: (!author_user_id.is_empty())
+                                        .then_some(author_user_id),
+                                    document_owner_user_id,
+                                    seq,
+                                    rev,
+                                    generation,
+                                    created_at,
+                                };
+                                // The cursor must advance with the write, or the same manifest is
+                                // replayed on every pull.
+                                let Some(()) = policy.commit(|| {
+                                    db.upsert_org_container(&row)?;
+                                    db.set_org_last_seq(&org_id, seq as i64)
+                                })?
+                                else {
+                                    break;
+                                };
+                                ingested += 1;
                             }
                         }
                     }

--- a/src-tauri/src/commands/org_containers.rs
+++ b/src-tauri/src/commands/org_containers.rs
@@ -1414,3 +1414,70 @@ pub fn clear_shared_placement(
         .db
         .clear_local_placement(&org_id, &target_kind, &target_id)
 }
+
+/// One LOCAL item this user publishes to an org on its own — not because a container carries it.
+///
+/// Drives the sidebar's marker on the user's OWN rows. Deliberately excludes anything filed under
+/// a shared container: that container's row already says it, and repeating the glyph on every
+/// child turns a quiet signal into noise.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrgShareTargetRow {
+    /// `"meeting"` or `"note"`.
+    pub kind: String,
+    pub id: String,
+    pub org_id: String,
+    pub org_name: String,
+    /// `"view"` or `"edit"`.
+    pub access: String,
+}
+
+#[tauri::command]
+pub fn list_org_share_targets(
+    state: State<'_, AppState>,
+) -> Result<Vec<OrgShareTargetRow>> {
+    let st = state.inner();
+    let org_names: HashMap<String, String> = st
+        .db
+        .list_org_states()?
+        .into_iter()
+        .map(|org| (org.org_id, org.name))
+        .collect();
+    let mut seen: HashSet<(String, String)> = HashSet::new();
+    let mut out = Vec::new();
+    for row in st.db.list_live_org_shares()? {
+        // A row the container sweep owns is represented by its container's marker.
+        if row.parent_container_id.is_some() {
+            continue;
+        }
+        let (kind, id) = match (row.meeting_id.clone(), row.document_id.clone()) {
+            (Some(meeting_id), None) => ("meeting", meeting_id),
+            (None, Some(document_id)) => ("note", document_id),
+            _ => continue,
+        };
+        if !seen.insert((id.clone(), row.org_id.clone())) {
+            continue;
+        }
+        // GATE: a sealed-and-not-session-unlocked source must not disclose its share status, for
+        // the same reason `list_meeting_org_shares` gates the meeting leg — knowing a note exists
+        // in an org is knowing something about the note.
+        let visible = match kind {
+            "meeting" => crate::commands::meeting_is_unlocked(st, &id)?,
+            _ => match st.db.document_folder_id(&id)? {
+                Some(folder_id) => crate::commands::folder_is_unlocked(st, &folder_id)?,
+                None => false,
+            },
+        };
+        if !visible {
+            continue;
+        }
+        out.push(OrgShareTargetRow {
+            kind: kind.to_string(),
+            id,
+            org_name: org_names.get(&row.org_id).cloned().unwrap_or_default(),
+            org_id: row.org_id,
+            access: row.access,
+        });
+    }
+    Ok(out)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -329,6 +329,7 @@ pub fn run() {
             commands::list_container_share_status,
             commands::sync_container_shares,
             commands::list_shared_workspace,
+            commands::list_org_share_targets,
             commands::set_shared_placement,
             commands::clear_shared_placement,
             commands::delete_org_item_as_author,

--- a/src-tauri/src/storage/container_store.rs
+++ b/src-tauri/src/storage/container_store.rs
@@ -485,6 +485,19 @@ impl Db {
         Ok(())
     }
 
+
+    /// The folder one document lives in, for the share-marker read gate.
+    pub fn document_folder_id(&self, document_id: &str) -> Result<Option<String>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT folder_id FROM documents WHERE id = ?1",
+            rusqlite::params![document_id],
+            |r| r.get(0),
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
     // ── PRIVATE: this device's own arrangement of received objects ────────────────────────────
 
     /// File a received container or document somewhere in this user's own tree.

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -2664,7 +2664,131 @@ impl Db {
              CREATE INDEX IF NOT EXISTS idx_org_shares_container
                ON org_shares(org_id, parent_container_id);",
         )
-        .map_err(map_err)
+        .map_err(map_err)?;
+        Self::repair_containers_mis_ingested_as_items(conn)
+    }
+
+    /// REPAIR (2.1.1): move container manifests that 2.1.0 wrote into `org_items` into
+    /// `org_containers`, where they belong.
+    ///
+    /// 2.1.0 added the container branch to the anti-entropy reconcile sweep but NOT to the live
+    /// feed pull, and the live pull is the path that actually runs on a healthy replica. A manifest
+    /// arriving that way was written as an ordinary note, so a shared Space appeared in Shared
+    /// Brains as a note named after the folder instead of appearing in the sidebar as a Space.
+    ///
+    /// This is data-preserving in both directions: the manifest becomes the container it was always
+    /// meant to be, and the mis-ingested row is TOMBSTONED rather than deleted, so a later feed
+    /// replay of the same server item is idempotent instead of resurrecting the note. A row whose
+    /// markdown will not parse is left exactly as it is — a repair that cannot understand a row has
+    /// no business rewriting it.
+    fn repair_containers_mis_ingested_as_items(conn: &Connection) -> Result<()> {
+        // A named record rather than a ten-wide tuple: the tuple is unreadable at the call site and
+        // is exactly the `clippy::type_complexity` this repo has paid for before.
+        struct MisIngested {
+            item_id: String,
+            org_id: String,
+            markdown: String,
+            author_hint: String,
+            seq: i64,
+            access: String,
+            created_at: String,
+            rev: i64,
+            generation: i64,
+            owner: String,
+        }
+        let rows: Vec<MisIngested> = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT item_id, org_id, markdown, COALESCE(author_hint,''),
+                            COALESCE(seq,0), COALESCE(access,'view'),
+                            COALESCE(created_at,''), COALESCE(rev,1), COALESCE(generation,1),
+                            COALESCE(document_owner_user_id,'')
+                       FROM org_items
+                      WHERE source_kind = 'container' AND tombstoned = 0",
+                )
+                .map_err(map_err)?;
+            let mapped = stmt
+                .query_map([], |r| {
+                    Ok(MisIngested {
+                        item_id: r.get(0)?,
+                        org_id: r.get(1)?,
+                        markdown: r.get(2)?,
+                        author_hint: r.get(3)?,
+                        seq: r.get(4)?,
+                        access: r.get(5)?,
+                        created_at: r.get(6)?,
+                        rev: r.get(7)?,
+                        generation: r.get(8)?,
+                        owner: r.get(9)?,
+                    })
+                })
+                .map_err(map_err)?
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .map_err(map_err)?;
+            mapped
+        };
+        for row in rows {
+            let MisIngested {
+                item_id,
+                org_id,
+                markdown,
+                author_hint,
+                seq,
+                access,
+                created_at,
+                rev,
+                generation,
+                owner,
+            } = row;
+            let Ok(manifest) =
+                crate::share::container_envelope::ContainerEnvelope::from_json(&markdown)
+            else {
+                continue;
+            };
+            conn.execute(
+                "INSERT INTO org_containers
+                   (org_id, container_id, item_id, level, name, emoji, tint, parent_container_id,
+                    position, access, author_hint, author_user_id, document_owner_user_id, seq, rev,
+                    generation, created_at, tombstoned)
+                 VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,NULL,?12,?13,?14,?15,?16,0)
+                 ON CONFLICT(org_id, container_id) DO UPDATE SET
+                   item_id=excluded.item_id, level=excluded.level, name=excluded.name,
+                   emoji=excluded.emoji, tint=excluded.tint,
+                   parent_container_id=excluded.parent_container_id, position=excluded.position,
+                   access=excluded.access, seq=excluded.seq, rev=excluded.rev,
+                   generation=excluded.generation, tombstoned=0",
+                rusqlite::params![
+                    org_id,
+                    manifest.container_id,
+                    item_id,
+                    manifest.level.as_str(),
+                    manifest.name,
+                    manifest.emoji,
+                    manifest.tint,
+                    manifest.parent_container_id,
+                    manifest.position,
+                    access,
+                    author_hint,
+                    (!owner.is_empty()).then_some(owner),
+                    seq,
+                    rev,
+                    generation,
+                    created_at,
+                ],
+            )
+            .map_err(map_err)?;
+            conn.execute(
+                "UPDATE org_items SET tombstoned = 1 WHERE item_id = ?1",
+                rusqlite::params![item_id],
+            )
+            .map_err(map_err)?;
+            conn.execute(
+                "DELETE FROM org_chunks WHERE item_id = ?1",
+                rusqlite::params![item_id],
+            )
+            .map_err(map_err)?;
+        }
+        Ok(())
     }
 
     /// Add `column` to `table` if it is not already present (idempotent migration guard).

--- a/src-tauri/src/storage/db_tests/container_tests.rs
+++ b/src-tauri/src/storage/db_tests/container_tests.rs
@@ -390,3 +390,110 @@ fn orphan_placements_are_pruned_when_their_local_folder_is_gone() {
     );
     assert!(!remaining.contains(&"c-dead".to_string()));
 }
+
+// ── the 2.1.0 regression: a manifest ingested as a note ───────────────────────────────────────
+
+#[test]
+fn a_manifest_mis_ingested_as_a_note_is_repaired_into_a_container() {
+    // 2.1.0 added the container branch to the anti-entropy sweep but NOT to the live feed pull,
+    // and the live pull is the path a healthy replica actually uses. A shared Space therefore
+    // arrived as a note named after the folder. Existing databases hold those rows, so the
+    // migration has to heal them rather than only stopping new ones.
+    let db = file_db("repair-mis-ingested");
+    seed_org(&db, "o1");
+    let manifest = crate::share::container_envelope::ContainerEnvelope {
+        v: crate::share::container_envelope::CONTAINER_ENVELOPE_VERSION,
+        container_id: "c-space".into(),
+        level: crate::share::container_envelope::ContainerLevel::Space,
+        name: "Pomysły".into(),
+        emoji: None,
+        tint: None,
+        parent_container_id: None,
+        position: 0,
+    };
+    {
+        let conn = db.lock();
+        conn.execute(
+            "INSERT INTO org_items(item_id, org_id, seq, author_hint, title, markdown, created_at,
+                                   rev, generation, is_current, tombstoned, source_kind, access)
+             VALUES ('item-1','o1',7,'kgm004a','Pomysły',?1,'2026-08-29T10:00:00Z',1,1,1,0,
+                     'container','edit')",
+            rusqlite::params![manifest.to_json()],
+        )
+        .unwrap();
+    }
+
+    db.migrate().unwrap();
+
+    let containers = db.list_org_containers("o1").unwrap();
+    assert_eq!(containers.len(), 1, "the manifest became a container");
+    assert_eq!(containers[0].container_id, "c-space");
+    assert_eq!(containers[0].name, "Pomysły");
+    assert_eq!(containers[0].level, "space");
+    assert_eq!(containers[0].access, "edit", "the access it arrived with is kept");
+    assert_eq!(containers[0].seq, 7);
+
+    assert!(
+        db.list_org_items("o1").unwrap().is_empty(),
+        "the mis-ingested row no longer renders as a note"
+    );
+
+    // Tombstoned, not deleted: a later feed replay of the same server item must be idempotent
+    // rather than resurrect the note.
+    let conn = db.lock();
+    let tombstoned: i64 = conn
+        .query_row(
+            "SELECT tombstoned FROM org_items WHERE item_id='item-1'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(tombstoned, 1);
+}
+
+#[test]
+fn the_repair_leaves_a_row_it_cannot_parse_exactly_as_it_is() {
+    // A repair that cannot understand a row has no business rewriting it.
+    let db = file_db("repair-unparseable");
+    seed_org(&db, "o1");
+    {
+        let conn = db.lock();
+        conn.execute(
+            "INSERT INTO org_items(item_id, org_id, seq, author_hint, title, markdown, created_at,
+                                   rev, generation, is_current, tombstoned, source_kind)
+             VALUES ('item-bad','o1',1,'h','t','{not json','now',1,1,1,0,'container')",
+            [],
+        )
+        .unwrap();
+    }
+    db.migrate().unwrap();
+    assert!(db.list_org_containers("o1").unwrap().is_empty());
+    let conn = db.lock();
+    let tombstoned: i64 = conn
+        .query_row(
+            "SELECT tombstoned FROM org_items WHERE item_id='item-bad'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(tombstoned, 0, "an unparseable row is left untouched");
+}
+
+#[test]
+fn a_container_row_never_renders_as_an_item_even_if_one_survives() {
+    // Belt-and-braces for the reader itself: whatever the repair did or did not do, a row marked
+    // as a container must not come back from the item list.
+    let db = file_db("reader-excludes-container");
+    seed_org(&db, "o1");
+    {
+        let conn = db.lock();
+        conn.execute(
+            "INSERT INTO org_items(item_id, org_id, seq, author_hint, title, markdown, created_at,
+                                   rev, generation, is_current, tombstoned, source_kind)
+             VALUES ('item-c','o1',1,'h','Pomysły','{not json','now',1,1,1,0,'container')",
+            [],
+        )
+        .unwrap();
+    }
+    assert!(db.list_org_items("o1").unwrap().is_empty());
+}

--- a/src-tauri/src/storage/links.rs
+++ b/src-tauri/src/storage/links.rs
@@ -153,7 +153,7 @@ fn link_endpoint_sealed_at_rest_tx(
                       JOIN org_state os ON os.org_id = oi.org_id
                      WHERE oi.org_id = ?1 AND oi.doc_id = ?2
                         AND oi.tombstoned = 0 AND oi.is_current = 1
-                        AND COALESCE(oi.source_kind, '') != 'task'
+                        AND COALESCE(oi.source_kind, '') NOT IN ('task','container')
                         AND os.context_enabled = 1
                       LIMIT 1",
                     rusqlite::params![org_id, doc_id],
@@ -428,7 +428,7 @@ impl Db {
                        FROM org_items oi
                        JOIN org_state os ON os.org_id = oi.org_id
                       WHERE oi.tombstoned = 0
-                        AND COALESCE(oi.source_kind, '') != 'task'
+                        AND COALESCE(oi.source_kind, '') NOT IN ('task','container')
                         AND os.context_enabled = 1
                         AND ((oi.doc_id IS NOT NULL AND oi.is_current = 1)
                              OR oi.doc_id IS NULL)
@@ -1425,7 +1425,7 @@ impl Db {
                        JOIN org_state os ON os.org_id = oi.org_id
                       WHERE oi.org_id = ?1 AND oi.doc_id = ?2
                         AND oi.tombstoned = 0 AND oi.is_current = 1
-                        AND COALESCE(oi.source_kind, '') != 'task'
+                        AND COALESCE(oi.source_kind, '') NOT IN ('task','container')
                         AND os.context_enabled = 1
                       LIMIT 1",
                     rusqlite::params![org_id, doc_id],
@@ -3215,7 +3215,7 @@ impl Db {
                JOIN org_state os ON os.org_id = oi.org_id
               WHERE oi.org_id = ?1 AND oi.doc_id = ?2
                 AND oi.tombstoned = 0 AND oi.is_current = 1 AND os.context_enabled = 1
-                AND COALESCE(oi.source_kind, '') != 'task'
+                AND COALESCE(oi.source_kind, '') NOT IN ('task','container')
               LIMIT 1",
             rusqlite::params![org_id, doc_id],
             |r| Ok((r.get(0)?, r.get(1)?)),
@@ -3235,7 +3235,7 @@ impl Db {
                FROM org_items oi
                JOIN org_state os ON os.org_id = oi.org_id
               WHERE oi.item_id = ?1 AND oi.tombstoned = 0 AND os.context_enabled = 1
-                AND COALESCE(oi.source_kind, '') != 'task'
+                AND COALESCE(oi.source_kind, '') NOT IN ('task','container')
                 AND oi.doc_id IS NOT NULL AND oi.is_current = 1
               LIMIT 1",
                 rusqlite::params![item_id],

--- a/src-tauri/src/storage/org_store.rs
+++ b/src-tauri/src/storage/org_store.rs
@@ -2984,7 +2984,7 @@ impl Db {
                    FROM org_items oi
                    JOIN org_state os ON os.org_id = oi.org_id
                   WHERE oi.tombstoned = 0
-                    AND COALESCE(oi.source_kind, '') != 'task'
+                    AND COALESCE(oi.source_kind, '') NOT IN ('task','container')
                     AND (oi.doc_id IS NULL OR oi.is_current = 1)
                     AND (?1 IS NULL OR oi.item_id > ?1)
                     AND EXISTS (SELECT 1 FROM org_chunks oc WHERE oc.item_id = oi.item_id)
@@ -3051,7 +3051,7 @@ impl Db {
                    FROM org_items oi
                    JOIN org_state os ON os.org_id = oi.org_id
                   WHERE oi.tombstoned = 0
-                    AND COALESCE(oi.source_kind, '') != 'task'
+                    AND COALESCE(oi.source_kind, '') NOT IN ('task','container')
                     AND (oi.doc_id IS NULL OR oi.is_current = 1)
                     AND (?1 IS NULL OR oi.item_id > ?1)
                     AND EXISTS (
@@ -3124,7 +3124,7 @@ impl Db {
                    FROM org_items oi
                    JOIN org_state os ON os.org_id = oi.org_id
                   WHERE oi.item_id = ?1 AND oi.tombstoned = 0
-                    AND COALESCE(oi.source_kind, '') != 'task'
+                    AND COALESCE(oi.source_kind, '') NOT IN ('task','container')
                     AND (oi.doc_id IS NULL OR oi.is_current = 1)",
                 rusqlite::params![item_id],
                 |r| {
@@ -3199,7 +3199,7 @@ impl Db {
             .query_row(
                 "SELECT seq, rev, generation, content_sha256
                    FROM org_items WHERE item_id = ?1 AND tombstoned = 0
-                    AND COALESCE(source_kind, '') != 'task'
+                    AND COALESCE(source_kind, '') NOT IN ('task','container')
                     AND (doc_id IS NULL OR is_current = 1)",
                 rusqlite::params![batch.item_id],
                 |r| {
@@ -3704,7 +3704,7 @@ impl Db {
                JOIN org_items oi ON oi.item_id = oc.item_id
                JOIN org_state os ON os.org_id = oi.org_id
               WHERE oi.tombstoned = 0 AND os.context_enabled = 1
-                AND COALESCE(oi.source_kind, '') != 'task'
+                AND COALESCE(oi.source_kind, '') NOT IN ('task','container')
                 AND (oi.doc_id IS NULL OR oi.is_current = 1)
               ORDER BY knn.distance ASC, oi.item_id ASC";
         let blob = crate::embed::vec_to_int8_blob(query_vec);
@@ -3766,7 +3766,7 @@ impl Db {
                JOIN org_items oi ON oi.item_id = oc.item_id
                JOIN org_state os ON os.org_id = oi.org_id
               WHERE fts_org_chunks MATCH ?1 AND oi.tombstoned = 0 AND os.context_enabled = 1
-                AND COALESCE(oi.source_kind, '') != 'task'
+                AND COALESCE(oi.source_kind, '') NOT IN ('task','container')
                 AND (oi.doc_id IS NULL OR oi.is_current = 1)
               ORDER BY rank ASC, oi.item_id ASC
               LIMIT ?2";
@@ -3838,7 +3838,7 @@ impl Db {
                       WHERE fts_org_chunks MATCH ?
                         AND oi.tombstoned = 0
                         AND os.context_enabled = 1
-                        AND COALESCE(oi.source_kind, '') != 'task'
+                        AND COALESCE(oi.source_kind, '') NOT IN ('task','container')
                         AND (oi.doc_id IS NULL OR oi.is_current = 1)
                       ORDER BY rank ASC, oi.item_id ASC
                       LIMIT ?"
@@ -3908,7 +3908,7 @@ impl Db {
                FROM org_items oi
                JOIN org_state os ON os.org_id = oi.org_id
               WHERE oi.item_id = ?1 AND oi.tombstoned = 0 AND os.context_enabled = 1
-                AND COALESCE(oi.source_kind, '') != 'task'
+                AND COALESCE(oi.source_kind, '') NOT IN ('task','container')
                 AND (oi.doc_id IS NULL OR oi.is_current = 1)",
             rusqlite::params![item_id],
             |r| {
@@ -4301,7 +4301,7 @@ impl Db {
                 "SELECT item_id, doc_id, title, author_hint, created_at, seq, source_kind
                    FROM org_items
                   WHERE org_id = ?1 AND tombstoned = 0
-                    AND COALESCE(source_kind, '') != 'task'
+                    AND COALESCE(source_kind, '') NOT IN ('task','container')
                     AND (doc_id IS NULL OR is_current = 1)
                   ORDER BY seq DESC
                   LIMIT 500",
@@ -4347,7 +4347,7 @@ impl Db {
                FROM org_items oi
                JOIN org_state os ON os.org_id = oi.org_id
               WHERE oi.org_id = ?1 AND oi.tombstoned = 0 AND os.context_enabled = 1
-                AND COALESCE(oi.source_kind, '') != 'task'
+                AND COALESCE(oi.source_kind, '') NOT IN ('task','container')
                 AND (oi.doc_id IS NULL OR oi.is_current = 1)",
             rusqlite::params![org_id],
             |r| r.get::<_, i64>(0),
@@ -4387,7 +4387,7 @@ impl Db {
                    JOIN org_items oi ON oi.item_id = oc.item_id
                    JOIN org_state os ON os.org_id = oi.org_id
                   WHERE oi.org_id = ?1 AND oi.tombstoned = 0
-                    AND COALESCE(oi.source_kind, '') != 'task'
+                    AND COALESCE(oi.source_kind, '') NOT IN ('task','container')
                     AND (oi.doc_id IS NULL OR oi.is_current = 1)
                     AND NOT EXISTS (SELECT 1 FROM org_vec_chunks v WHERE v.chunk_id = oc.id)
                   LIMIT ?2",

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -16,6 +16,7 @@ import type {
   ContainerSharePreview,
   ContainerShareResult,
   ContainerShareStatus,
+  OrgShareTargetRow,
   AskConversationSendResult,
   AskConversationSummary,
   AskVaultResult,
@@ -3694,6 +3695,14 @@ export class IpcService {
       folderId,
       access,
     });
+  }
+
+  /**
+   * Items this device publishes to an org on their own (not via a container).
+   * Read-gated: a sealed source discloses no share status.
+   */
+  listOrgShareTargets(): Promise<OrgShareTargetRow[]> {
+    return invoke<OrgShareTargetRow[]>("list_org_share_targets");
   }
 
   /** Every container THIS device publishes — drives the sidebar's shared marker. */

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -3855,3 +3855,16 @@ export interface McpStatus {
   state: McpListenerState;
   port: number;
 }
+
+/**
+ * One LOCAL item this user publishes to an org on its own — not because a
+ * container carries it. Drives the sidebar marker on the user's own rows.
+ * Mirrors the Rust `OrgShareTargetRow`.
+ */
+export interface OrgShareTargetRow {
+  kind: "meeting" | "note";
+  id: string;
+  orgId: string;
+  orgName: string;
+  access: OrgAccess;
+}

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.html
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.html
@@ -154,6 +154,14 @@
             (dragend)="onDragEnd()"
             (activate)="openItem(item)"
           >
+            @if (sharedMark(line); as mark) {
+              <span class="shared-mark" role="img" [attr.aria-label]="mark" [title]="mark">
+                <svg viewBox="0 0 16 16" width="12" height="12" fill="none" aria-hidden="true">
+                  <circle cx="8" cy="4.8" r="2.1" stroke="currentColor" stroke-width="1.3" />
+                  <path d="M3.6 12.4a4.5 4.5 0 0 1 8.8 0" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
+                </svg>
+              </span>
+            }
             @if (moveTargetsFor(item, owner); as targets) {
               <mur-row-menu [label]="'Actions for ' + item.kind + ' ' + itemTitle(item)">
                 <span class="menu-group-label">{{ itemKindLabel(item.kind) }} actions</span>
@@ -200,7 +208,16 @@
           [icon]="sharedItem.kind === 'meeting' ? 'meeting' : 'note'"
           [selected]="isSharedItemSelected(sharedItem)"
           (activate)="openSharedItem(sharedItem)"
-        />
+        >
+            @if (sharedMark(line); as mark) {
+              <span class="shared-mark" role="img" [attr.aria-label]="mark" [title]="mark">
+                <svg viewBox="0 0 16 16" width="12" height="12" fill="none" aria-hidden="true">
+                  <circle cx="8" cy="4.8" r="2.1" stroke="currentColor" stroke-width="1.3" />
+                  <path d="M3.6 12.4a4.5 4.5 0 0 1 8.8 0" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" />
+                </svg>
+              </span>
+            }
+        </mur-tree-row>
       } @else if (line.shared; as shared) {
         <!-- A RECEIVED container: a shared Space, a shared folder, or the
              virtual Shared Brains Space. Structure belongs to whoever shared it,

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
@@ -377,7 +377,23 @@ export class WorkspaceTreeComponent {
       return `From ${node.orgName} · ${node.authorHint} · ${this.sharedAccessLabel(node)}`;
     }
     if (line.sharedItem) {
-      return null;
+      const item = line.sharedItem;
+      const access = item.access === "edit" ? "Can edit" : "View only";
+      return `From ${item.orgName} · ${item.authorHint} · ${access}`;
+    }
+    // An ITEM row the user published on its own. Anything inside a shared
+    // container is deliberately unmarked here — that container's row already
+    // says it, and repeating the glyph on every child turns a quiet signal into
+    // noise. The backend read excludes container-owned rows for the same reason.
+    if (line.item) {
+      const target = this.sharedWorkspace
+        .shareByItem()
+        .get(`${line.item.kind}:${line.item.id}`);
+      if (!target) {
+        return null;
+      }
+      const access = target.access === "edit" ? "Can edit" : "View only";
+      return `Shared to ${target.orgName} · ${access}`;
     }
     const container = line.container;
     if (!container) {

--- a/src/app/services/shared-workspace.service.ts
+++ b/src/app/services/shared-workspace.service.ts
@@ -11,6 +11,7 @@ import { IpcService } from "../core/ipc.service";
 import type {
   ContainerShareStatus,
   OrgAccess,
+  OrgShareTargetRow,
   SharedContainerNode,
   SharedPlacementTarget,
   SharedWorkspace,
@@ -39,6 +40,7 @@ export class SharedWorkspaceService {
   private readonly _spaces = signal<SharedContainerNode[]>([]);
   private readonly _sharedBrains = signal<SharedContainerNode | null>(null);
   private readonly _containerShares = signal<ContainerShareStatus[]>([]);
+  private readonly _shareTargets = signal<OrgShareTargetRow[]>([]);
   private readonly _loading = signal(false);
 
   /** Received SPACES — each renders as its own top-level sidebar row. */
@@ -51,6 +53,8 @@ export class SharedWorkspaceService {
   readonly sharedBrains = this._sharedBrains.asReadonly();
   /** Containers THIS device publishes — drives the sidebar's shared marker. */
   readonly containerShares = this._containerShares.asReadonly();
+  /** Items published on their own, keyed for the row marker. */
+  readonly shareTargets = this._shareTargets.asReadonly();
   /** True while a (re)load is in flight. A hint, never a render gate. */
   readonly loading = this._loading.asReadonly();
 
@@ -62,6 +66,15 @@ export class SharedWorkspaceService {
       (brains === null ||
         (brains.folders.length === 0 && brains.items.length === 0))
     );
+  });
+
+  /** The org an item was published to on its own, keyed `<kind>:<id>`. */
+  readonly shareByItem = computed(() => {
+    const map = new Map<string, OrgShareTargetRow>();
+    for (const target of this._shareTargets()) {
+      map.set(`${target.kind}:${target.id}`, target);
+    }
+    return map;
   });
 
   /** The container share for one local folder, if this device publishes it. */
@@ -117,9 +130,10 @@ export class SharedWorkspaceService {
     const seq = ++this.loadSeq;
     this._loading.set(true);
     try {
-      const [workspace, shares] = await Promise.all([
+      const [workspace, shares, targets] = await Promise.all([
         this.ipc.listSharedWorkspace().catch(() => null),
         this.ipc.listContainerShareStatus().catch(() => [] as ContainerShareStatus[]),
+        this.ipc.listOrgShareTargets().catch(() => [] as OrgShareTargetRow[]),
       ]);
       if (seq !== this.loadSeq) {
         return;
@@ -128,6 +142,7 @@ export class SharedWorkspaceService {
         this.applyWorkspace(workspace);
       }
       this._containerShares.set(shares);
+      this._shareTargets.set(targets);
     } finally {
       if (seq === this.loadSeq) {
         this._loading.set(false);


### PR DESCRIPTION
## The bug

Reported by a user on the first real two-account test: A shared a whole Space, and
on B it showed up **inside Shared Brains as a note named after the folder** —
never in the sidebar as a Space.

The org feed has **two** ingest paths:

| path | used when |
|---|---|
| `FeedAction` — the live pull | every ordinary sync (`org feed sync … ingested=N`) |
| `ReconcileAction` — the anti-entropy sweep | only on a tick where the live pull found nothing |

2.1.0 added the container branch to the **sweep only**. The live pull — the path a
healthy replica actually uses — kept writing manifests into `org_items` as
ordinary notes.

The same omission meant the live pull never wrote a document's `placement`, so
even a correctly ingested container would have held nothing.

## The fix

- `FeedAction::IngestContainer` on the live pull, mirroring the sweep: a manifest
  goes to `org_containers`, skipping the chunker and the embedder entirely. An
  unparseable payload is terminal for that seq, never half-written.
- The live pull now writes `placement` on every ingested document — unconditionally,
  because a document that LEAVES a shared folder arrives with none and clearing it
  is what makes it move.
- **A repair for databases that already hold the bad rows.** Stopping new ones is
  not enough — the user has them now. A guarded migration moves every parseable
  manifest into `org_containers` and **tombstones** the note row rather than
  deleting it, so a later feed replay is idempotent instead of resurrecting it. A
  row whose markdown will not parse is left exactly as it is.
- Every `org_items` reader now excludes `source_kind='container'` alongside
  `'task'`, so a row that survives anything still never renders as a note.

## Verification

Three new oracles in `db_tests/container_tests.rs`, **RED-verified**: with the
repair disabled, the manifest stays a note and the oracle fails.

`cargo test --lib container_` 90 passed · `cargo clippy --all-targets -- -D warnings`
clean (caught `type_complexity` locally this time, before CI) · `ng lint` clean.

## What this does not fix

The user's B-side replica will heal on next launch (the migration runs on open),
but the **A side must re-share** if its manifests were never published — this fixes
ingest, not any publish that already failed. Worth confirming on the live test.
