### PR TITLE
fix: a shared Space arrives with its contents, and a self-share renders once

### DIFF
--- a/src-tauri/src/commands/org_containers.rs
+++ b/src-tauri/src/commands/org_containers.rs
@@ -1220,6 +1220,21 @@ pub(crate) fn build_shared_workspace(state: &AppState) -> Result<SharedWorkspace
             continue;
         }
         let containers = state.db.list_org_containers(&org.org_id)?;
+        // A container THIS device published comes back down the feed like anyone else's. Rendering
+        // it would put a second, empty copy of the user's own Space beside the real one — which is
+        // exactly what a user hit: two "Sharing things" rows, one with content and one without.
+        // The original is the one they can actually act on, and its row already carries the
+        // "Shared to …" marker, so the received twin has nothing to add.
+        let published_here: HashSet<String> = state
+            .db
+            .list_container_shares(Some(&org.org_id))?
+            .into_iter()
+            .map(|row| row.container_id)
+            .collect();
+        let containers: Vec<_> = containers
+            .into_iter()
+            .filter(|c| !published_here.contains(&c.container_id))
+            .collect();
         let known: HashSet<String> = containers
             .iter()
             .map(|c| c.container_id.clone())

--- a/src-tauri/src/commands/tests/container_share_tests.rs
+++ b/src-tauri/src/commands/tests/container_share_tests.rs
@@ -564,3 +564,42 @@ fn received_items_inherit_their_containers_access() {
         "permission is inherited by the whole container, which is the point of sharing one"
     );
 }
+
+#[test]
+fn a_container_this_device_published_does_not_come_back_as_a_second_copy() {
+    // A self-share returns down the feed like anyone else's. Rendering it puts an empty duplicate
+    // of the user's own Space beside the real one — two "Sharing things" rows, one with content
+    // and one without, which is what a user actually hit.
+    let db = fresh_db("self-share");
+    seed_org(&db, "o1", "Siema");
+    received_container(&db, "o1", "c-mine", "Sharing things", "space", None);
+    received_container(&db, "o1", "c-theirs", "Partners", "space", None);
+    db.upsert_container_share(&ContainerShareRow {
+        id: "cs1".into(),
+        org_id: "o1".into(),
+        folder_id: "local-folder".into(),
+        container_id: "c-mine".into(),
+        access: "edit".into(),
+        scrub: true,
+        is_root: true,
+        state: "published".into(),
+        item_id: Some("item-c-mine".into()),
+        rev: 1,
+        generation: 1,
+        content_sha256: None,
+        position: 0,
+        last_error: None,
+        created_at: "t".into(),
+        updated_at: "t".into(),
+    })
+    .unwrap();
+    let state = state_with(db);
+
+    let workspace = build_shared_workspace(&state).unwrap();
+    let names: Vec<String> = workspace.spaces.iter().map(|s| s.name.clone()).collect();
+    assert_eq!(
+        names,
+        vec!["Partners".to_string()],
+        "only a container someone ELSE published belongs in the received forest"
+    );
+}

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -2665,7 +2665,43 @@ impl Db {
                ON org_shares(org_id, parent_container_id);",
         )
         .map_err(map_err)?;
-        Self::repair_containers_mis_ingested_as_items(conn)
+        Self::repair_containers_mis_ingested_as_items(conn)?;
+        Self::backfill_placement_from_the_outbound_journal(conn)
+    }
+
+    /// REPAIR (2.1.2): restore the container placement of documents this device published.
+    ///
+    /// 2.1.1 taught the live pull to WRITE placement, but only for items it ingests from then on.
+    /// An item already in the replica is "converged" — its stored content hash matches the feed's —
+    /// so neither the live pull nor the anti-entropy sweep ever re-reads it, and the placement it
+    /// was ingested without is never filled in. The visible result is a shared Space that arrives
+    /// EMPTY while its documents sit loose in Shared Brains.
+    ///
+    /// For a document THIS device published, the outbound journal already knows the answer, so the
+    /// repair is a local join — no network, no re-ingest. A document published by another member
+    /// has no local journal; its placement arrives with that member's next publish.
+    fn backfill_placement_from_the_outbound_journal(conn: &Connection) -> Result<()> {
+        conn.execute(
+            "UPDATE org_items
+                SET parent_container_id = (
+                      SELECT s.parent_container_id FROM org_shares s
+                       WHERE s.item_id = org_items.item_id
+                         AND s.parent_container_id IS NOT NULL
+                       LIMIT 1),
+                    position = COALESCE((
+                      SELECT s.position FROM org_shares s
+                       WHERE s.item_id = org_items.item_id
+                         AND s.parent_container_id IS NOT NULL
+                       LIMIT 1), position)
+              WHERE parent_container_id IS NULL
+                AND EXISTS (
+                      SELECT 1 FROM org_shares s
+                       WHERE s.item_id = org_items.item_id
+                         AND s.parent_container_id IS NOT NULL)",
+            [],
+        )
+        .map_err(map_err)?;
+        Ok(())
     }
 
     /// REPAIR (2.1.1): move container manifests that 2.1.0 wrote into `org_items` into

--- a/src-tauri/src/storage/db_tests/container_tests.rs
+++ b/src-tauri/src/storage/db_tests/container_tests.rs
@@ -497,3 +497,62 @@ fn a_container_row_never_renders_as_an_item_even_if_one_survives() {
     }
     assert!(db.list_org_items("o1").unwrap().is_empty());
 }
+
+#[test]
+fn placement_is_backfilled_for_documents_this_device_published() {
+    // 2.1.1 taught the live pull to WRITE placement, but only for items it ingests from then on.
+    // An already-converged item is never re-read, so its missing placement is never filled in —
+    // and the visible result is a shared Space that arrives EMPTY while its documents sit loose.
+    let db = file_db("backfill-placement");
+    seed_org(&db, "o1");
+    {
+        let conn = db.lock();
+        conn.execute(
+            "INSERT INTO org_items(item_id, org_id, seq, author_hint, title, markdown, created_at,
+                                   rev, generation, is_current, tombstoned, source_kind)
+             VALUES ('item-doc','o1',3,'h','Note-share','body','t',1,1,1,0,'document')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO org_shares(id,org_id,document_id,kind,state,item_id,
+                                    parent_container_id,position,explicit,created_at,updated_at)
+             VALUES ('s1','o1','d1','note','uploaded','item-doc','c-space',4,0,'t','t')",
+            [],
+        )
+        .unwrap();
+    }
+
+    db.migrate().unwrap();
+
+    let placement = db.org_item_container_placement("item-doc").unwrap().unwrap();
+    assert_eq!(placement.0.as_deref(), Some("c-space"));
+    assert_eq!(placement.1, 4, "the position travels with the container");
+}
+
+#[test]
+fn the_backfill_never_invents_a_placement_for_a_standalone_share() {
+    // A document shared on its own has no container, and the repair must not give it one.
+    let db = file_db("backfill-standalone");
+    seed_org(&db, "o1");
+    {
+        let conn = db.lock();
+        conn.execute(
+            "INSERT INTO org_items(item_id, org_id, seq, author_hint, title, markdown, created_at,
+                                   rev, generation, is_current, tombstoned, source_kind)
+             VALUES ('item-solo','o1',1,'h','Solo','body','t',1,1,1,0,'document')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO org_shares(id,org_id,document_id,kind,state,item_id,explicit,
+                                    created_at,updated_at)
+             VALUES ('s2','o1','d2','note','uploaded','item-solo',1,'t','t')",
+            [],
+        )
+        .unwrap();
+    }
+    db.migrate().unwrap();
+    let placement = db.org_item_container_placement("item-solo").unwrap().unwrap();
+    assert!(placement.0.is_none(), "a standalone share stays uncontained");
+}


### PR DESCRIPTION
Two bugs from the same live two-account test. Diagnosed against the reporter's
actual database, not from reading code.

## A shared Space arrived empty

The outbound journal was **correct**:

```
org_container_shares:  folder=04a877cf → cid=40e003ae  access=edit  root=1  state=published
org_shares:            "Note-share"               uploaded  explicit=0  parent=40e003ae
org_shares:            "Test nowego Murmura 2.0"  uploaded  explicit=0  parent=40e003ae
```

But both documents sat in the local replica with `parent_container_id = NULL`, so
the Space arrived with nothing in it and its documents showed up loose in Shared
Brains.

2.1.1 taught the live pull to *write* placement — but only for items it ingests
from then on. An item already in the replica is **converged** (its stored content
hash matches the feed's), so neither the live pull nor the anti-entropy sweep ever
re-reads it, and the placement it was ingested without is never filled in.

For a document **this device published**, the outbound journal already knows the
answer, so the repair is a local join — no network, no re-ingest. A document
published by another member has no local journal; its placement arrives with that
member's next publish. Stated plainly rather than overclaimed.

## A self-share rendered twice

A container this device published comes back down the feed like anyone else's, so
the reporter saw **two "Sharing things" rows** — their own Space with content, and
an empty received twin. One had a caret, one did not, which is what made it look
like a duplication bug rather than a self-share.

The original is the one they can act on, and its row already carries the
"Shared to …" marker, so the received twin has nothing to add.

## Verification

Three oracles, **RED-verified**. The self-share one prints the duplicate directly:

```
left:  ["Partners", "Sharing things"]
right: ["Partners"]
```

`cargo test --lib container_` 93 passed · clippy `-D warnings` clean · `ng lint`
clean · the container and inbox e2e 14 passed.
