### PR TITLE
feat(trash): recoverable Trash with 30-day retention

### DIFF
--- a/src-tauri/src/commands/folders.rs
+++ b/src-tauri/src/commands/folders.rs
@@ -748,6 +748,29 @@ pub(crate) fn delete_folder_inner(state: &AppState, folder_id: String) -> Result
     // read gate. The note rows below are retained only to locate an optional exported Markdown file.
     let notes = state.db.notes_in_folder(&folder_id)?;
     let meeting_ids = state.db.meeting_ids_in_folder(&folder_id)?;
+
+    // TRASH CAPTURE — before ANY rehoming, because the member ids are what lets a restore put the
+    // contents back, and they stop being discoverable the moment the first meeting is re-filed.
+    //
+    // Re-read the folder row: `remove_lock_inner` above may have cleared `locked`/`wrapped_key`, and
+    // the snapshot must record the row as it now is. Note what this cannot recover: a sealed
+    // container's LOCK is permanently removed by the delete (it must be, or its content would be
+    // orphaned from its key), so a restored folder comes back OPEN — `FolderSnapshot::was_locked`
+    // carries that fact to the FE instead of letting the user assume the lock survived.
+    let snapshot_row = state.db.folder_by_id(&folder_id)?.unwrap_or(folder.clone());
+    let kind = state
+        .db
+        .folder_kind(&folder_id)?
+        .unwrap_or_else(|| "meeting".to_string());
+    let authored_note_ids = state.db.note_ids_in_folder(&folder_id)?;
+    super::trash_commands::capture_folder(
+        state,
+        &snapshot_row,
+        &kind,
+        &meeting_ids,
+        &authored_note_ids,
+    )?;
+
     for meeting_id in meeting_ids {
         // Reassign the canonical owner and every provider row atomically to the root.
         state.db.set_meeting_folder(&meeting_id, None)?;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4599,8 +4599,24 @@ async fn delete_meeting_inner_notifying(
     // re-parses it; if the content does not round-trip it returns Err and we bail here with NOTHING
     // mutated (verify-before-destroy). It also seals the snapshot immediately when this folder is
     // sealed, so a trashed recording is never at rest in plaintext behind a lock.
-    trash_commands::capture_meeting(state, meeting_id)?;
+    let trash_entry_id = trash_commands::capture_meeting(state, meeting_id)?;
 
+    // The steps below are FALLIBLE, and the snapshot is already durable. Without this rollback a
+    // delete that fails after the capture leaves a trash entry describing content that still
+    // exists: the Trash would offer to restore a meeting still sitting in the Library, and the
+    // restore would then refuse with "already exists". Retire the entry on any error so a failed
+    // delete leaves NOTHING behind — the same all-or-nothing contract `store_and_verify` gives.
+    let deleted = delete_meeting_after_capture(state, meeting_id);
+    if deleted.is_err() {
+        let _ = state.db.delete_trash_entry(&trash_entry_id);
+    }
+    deleted
+}
+
+/// The destructive half of [`delete_meeting_inner_notifying`], split out so its caller can retire
+/// the trash snapshot if any of it fails. Everything here runs with the lifecycle guard held and the
+/// gates already satisfied.
+fn delete_meeting_after_capture(state: &AppState, meeting_id: &str) -> Result<(), AppError> {
     let attachment_rows = state.db.attachments_for_meeting(meeting_id)?;
     remove_attachment_exports(
         &attachment_rows,

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4514,35 +4514,6 @@ fn index_note_body_chunks(
 // because `list_user_facts_visible` filters by source-meeting `visibility_clause` on the live
 // unlocked snapshot. Forget/clear are bitemporal INVALIDATE (close valid_to), never a silent delete.
 
-/// Where a delete sends the content: into the recoverable trash, or straight to permanent
-/// destruction.
-///
-/// This exists so the destructive cascade stays ONE code path. The pre-trash behavior IS
-/// [`Disposition::Permanent`]; `ToTrash` differs in exactly two ways — a verified snapshot is
-/// captured first, and the meeting's AUDIO FILES are left on disk (the snapshot references them by
-/// path, and they are the only copy). Everything else — the org-share revoke, the gates, the row
-/// cascade, the note `.md` removal — is identical, so trash cannot drift from delete.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum Disposition {
-    /// Capture a restorable snapshot, keep the on-disk audio, and let the trash own the purge.
-    ToTrash,
-    /// Destroy everything now — the pre-trash behavior.
-    ///
-    /// `#[cfg(test)]` because production has no caller: every user-facing delete goes to the trash,
-    /// and the trash's own purge does NOT re-run this cascade (the rows are already gone by then —
-    /// `trash::purge_one` only has the on-disk audio left to remove). It exists so the tests that
-    /// assert the destructive cascade itself keep testing that cascade rather than the trash path.
-    /// If a "delete permanently, skip the trash" action is ever added, this is the variant it wants.
-    #[cfg(test)]
-    Permanent,
-}
-
-impl Disposition {
-    fn is_trash(self) -> bool {
-        matches!(self, Disposition::ToTrash)
-    }
-}
-
 /// Permanently delete a meeting: its audio file, its exported vault note, and all DB rows
 /// (segments, notes, timeline cascade via FK). Irreversible.
 ///
@@ -4555,8 +4526,7 @@ pub async fn delete_meeting(
     state: State<'_, AppState>,
     meeting_id: String,
 ) -> Result<(), AppError> {
-    delete_meeting_inner_notifying(state.inner(), &meeting_id, Some(&app), Disposition::ToTrash)
-        .await?;
+    delete_meeting_inner_notifying(state.inner(), &meeting_id, Some(&app)).await?;
     emit_ask_history_invalidated_fail_closed(&app);
     crate::events::emit_content_deleted(&app, "meeting", &meeting_id);
     // The delete purged its audit findings (id-matched) — ping the FE inbox (count-only).
@@ -4571,24 +4541,13 @@ pub(crate) async fn delete_meeting_inner(
     state: &AppState,
     meeting_id: &str,
 ) -> Result<(), AppError> {
-    delete_meeting_inner_notifying(state, meeting_id, None, Disposition::ToTrash).await
-}
-
-/// Bypass the trash and destroy the meeting outright — the pre-trash behavior, kept for the tests
-/// that assert the destructive cascade itself.
-#[cfg(test)]
-pub(crate) async fn delete_meeting_permanently_inner(
-    state: &AppState,
-    meeting_id: &str,
-) -> Result<(), AppError> {
-    delete_meeting_inner_notifying(state, meeting_id, None, Disposition::Permanent).await
+    delete_meeting_inner_notifying(state, meeting_id, None).await
 }
 
 async fn delete_meeting_inner_notifying(
     state: &AppState,
     meeting_id: &str,
     app: Option<&AppHandle>,
-    disposition: Disposition,
 ) -> Result<(), AppError> {
     // Gate before the network revoke without selecting title/audio/note content. The await below can
     // span a relock, so this is only the early refusal; destructive authority is reacquired below.
@@ -4640,9 +4599,7 @@ async fn delete_meeting_inner_notifying(
     // re-parses it; if the content does not round-trip it returns Err and we bail here with NOTHING
     // mutated (verify-before-destroy). It also seals the snapshot immediately when this folder is
     // sealed, so a trashed recording is never at rest in plaintext behind a lock.
-    if disposition.is_trash() {
-        trash_commands::capture_meeting(state, meeting_id)?;
-    }
+    trash_commands::capture_meeting(state, meeting_id)?;
 
     let attachment_rows = state.db.attachments_for_meeting(meeting_id)?;
     remove_attachment_exports(
@@ -4655,21 +4612,13 @@ async fn delete_meeting_inner_notifying(
     // during a session-unlock, `session_unseal` decrypts the `.enc` to a plaintext WAV for playback
     // but KEEPS the `.enc`. So `audio_path` (plaintext form) alone would orphan the `.enc` on
     // record→lock→unlock→delete. Remove BOTH forms, exactly as the masters block below already does.
-    // TRASH: the audio files are the recording's ONLY copy and the snapshot references them by
-    // path, so a to-trash delete deliberately LEAVES them on disk. `trash::purge_one` removes every
-    // on-disk form (plaintext WAV, `.enc` twin, both masters) when the entry is finally purged —
-    // that is the same cleanup, moved to the moment the content actually stops being recoverable.
-    if !disposition.is_trash() {
-        if let Some(m) = state.db.get_meeting(meeting_id)? {
-            remove_meeting_audio_files(m.audio_path.as_deref());
-        }
-        // Masters too — a master path may be the plaintext WAV or its `.enc`; clear both forms.
-        if let Ok((mic, sys)) = state.db.get_meeting_master_paths(meeting_id) {
-            for p in [mic, sys].into_iter().flatten() {
-                remove_meeting_audio_files(Some(&p));
-            }
-        }
-    }
+    // TRASH: the audio files are DELIBERATELY LEFT ON DISK. They are the recording's only copy and
+    // the snapshot captured above references them by path, so unlinking here would make the trash
+    // entry unrestorable the instant it was created. `trash::purge_one` removes every on-disk form
+    // (plaintext WAV, `.enc` twin, both masters) when the entry is finally purged — the same
+    // cleanup this block used to do, moved to the moment the content actually stops being
+    // recoverable. `trash::seal_trash_meeting_audio` encrypts them if the folder is locked
+    // meanwhile, since `lock_folder` walks `meeting_ids_in_folder` and this row is gone.
     if let Some(note) = state.db.get_latest_note_for_meeting(meeting_id)? {
         if let Some(path) = note.exported_path.as_deref() {
             let _ = std::fs::remove_file(path);

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -207,6 +207,16 @@ pub use attachment_commands::*;
 mod lock_commands;
 pub use lock_commands::*;
 
+// TRASH — the 30-day recoverable holding area for deleted content (2026-08-31). A sibling of the
+// delete clusters rather than more of `mod.rs`: it owns its own at-rest snapshot format, its own
+// seal lifecycle (`seal_trash_in_folder` & friends, called from `seal_folder_extras`) and its own
+// purge schedule. The delete paths call INTO it (`trash::capture_*`) before their destructive
+// cascade; it never calls back into them. Reaches the shared gate/seal/AAD helpers through
+// `use super::*`, exactly like the other extracted command modules.
+#[path = "trash.rs"]
+mod trash_commands;
+pub use trash_commands::*;
+
 // ORG (Shared Brain / M6) + 1:1 LINK/USER SHARE (M3-client / M5) command surface — extracted verbatim
 // (God-file split, PURE MOVE — every read-gate / egress-consent / redaction-firewall / crypto-envelope
 // body is byte-identical, only relocated). The gated org/share READERS mask a sealed-not-unlocked
@@ -4504,6 +4514,35 @@ fn index_note_body_chunks(
 // because `list_user_facts_visible` filters by source-meeting `visibility_clause` on the live
 // unlocked snapshot. Forget/clear are bitemporal INVALIDATE (close valid_to), never a silent delete.
 
+/// Where a delete sends the content: into the recoverable trash, or straight to permanent
+/// destruction.
+///
+/// This exists so the destructive cascade stays ONE code path. The pre-trash behavior IS
+/// [`Disposition::Permanent`]; `ToTrash` differs in exactly two ways — a verified snapshot is
+/// captured first, and the meeting's AUDIO FILES are left on disk (the snapshot references them by
+/// path, and they are the only copy). Everything else — the org-share revoke, the gates, the row
+/// cascade, the note `.md` removal — is identical, so trash cannot drift from delete.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Disposition {
+    /// Capture a restorable snapshot, keep the on-disk audio, and let the trash own the purge.
+    ToTrash,
+    /// Destroy everything now — the pre-trash behavior.
+    ///
+    /// `#[cfg(test)]` because production has no caller: every user-facing delete goes to the trash,
+    /// and the trash's own purge does NOT re-run this cascade (the rows are already gone by then —
+    /// `trash::purge_one` only has the on-disk audio left to remove). It exists so the tests that
+    /// assert the destructive cascade itself keep testing that cascade rather than the trash path.
+    /// If a "delete permanently, skip the trash" action is ever added, this is the variant it wants.
+    #[cfg(test)]
+    Permanent,
+}
+
+impl Disposition {
+    fn is_trash(self) -> bool {
+        matches!(self, Disposition::ToTrash)
+    }
+}
+
 /// Permanently delete a meeting: its audio file, its exported vault note, and all DB rows
 /// (segments, notes, timeline cascade via FK). Irreversible.
 ///
@@ -4516,7 +4555,8 @@ pub async fn delete_meeting(
     state: State<'_, AppState>,
     meeting_id: String,
 ) -> Result<(), AppError> {
-    delete_meeting_inner_notifying(state.inner(), &meeting_id, Some(&app)).await?;
+    delete_meeting_inner_notifying(state.inner(), &meeting_id, Some(&app), Disposition::ToTrash)
+        .await?;
     emit_ask_history_invalidated_fail_closed(&app);
     crate::events::emit_content_deleted(&app, "meeting", &meeting_id);
     // The delete purged its audit findings (id-matched) — ping the FE inbox (count-only).
@@ -4531,13 +4571,24 @@ pub(crate) async fn delete_meeting_inner(
     state: &AppState,
     meeting_id: &str,
 ) -> Result<(), AppError> {
-    delete_meeting_inner_notifying(state, meeting_id, None).await
+    delete_meeting_inner_notifying(state, meeting_id, None, Disposition::ToTrash).await
+}
+
+/// Bypass the trash and destroy the meeting outright — the pre-trash behavior, kept for the tests
+/// that assert the destructive cascade itself.
+#[cfg(test)]
+pub(crate) async fn delete_meeting_permanently_inner(
+    state: &AppState,
+    meeting_id: &str,
+) -> Result<(), AppError> {
+    delete_meeting_inner_notifying(state, meeting_id, None, Disposition::Permanent).await
 }
 
 async fn delete_meeting_inner_notifying(
     state: &AppState,
     meeting_id: &str,
     app: Option<&AppHandle>,
+    disposition: Disposition,
 ) -> Result<(), AppError> {
     // Gate before the network revoke without selecting title/audio/note content. The await below can
     // span a relock, so this is only the early refusal; destructive authority is reacquired below.
@@ -4584,6 +4635,15 @@ async fn delete_meeting_inner_notifying(
         ));
     }
 
+    // TRASH CAPTURE — the LAST thing before anything is destroyed, and the FIRST thing that can
+    // abort the delete. `capture_meeting` writes the snapshot, reads it back out of SQLCipher and
+    // re-parses it; if the content does not round-trip it returns Err and we bail here with NOTHING
+    // mutated (verify-before-destroy). It also seals the snapshot immediately when this folder is
+    // sealed, so a trashed recording is never at rest in plaintext behind a lock.
+    if disposition.is_trash() {
+        trash_commands::capture_meeting(state, meeting_id)?;
+    }
+
     let attachment_rows = state.db.attachments_for_meeting(meeting_id)?;
     remove_attachment_exports(
         &attachment_rows,
@@ -4595,13 +4655,19 @@ async fn delete_meeting_inner_notifying(
     // during a session-unlock, `session_unseal` decrypts the `.enc` to a plaintext WAV for playback
     // but KEEPS the `.enc`. So `audio_path` (plaintext form) alone would orphan the `.enc` on
     // record→lock→unlock→delete. Remove BOTH forms, exactly as the masters block below already does.
-    if let Some(m) = state.db.get_meeting(meeting_id)? {
-        remove_meeting_audio_files(m.audio_path.as_deref());
-    }
-    // Masters too — a master path may be the plaintext WAV or its `.enc`; clear both forms.
-    if let Ok((mic, sys)) = state.db.get_meeting_master_paths(meeting_id) {
-        for p in [mic, sys].into_iter().flatten() {
-            remove_meeting_audio_files(Some(&p));
+    // TRASH: the audio files are the recording's ONLY copy and the snapshot references them by
+    // path, so a to-trash delete deliberately LEAVES them on disk. `trash::purge_one` removes every
+    // on-disk form (plaintext WAV, `.enc` twin, both masters) when the entry is finally purged —
+    // that is the same cleanup, moved to the moment the content actually stops being recoverable.
+    if !disposition.is_trash() {
+        if let Some(m) = state.db.get_meeting(meeting_id)? {
+            remove_meeting_audio_files(m.audio_path.as_deref());
+        }
+        // Masters too — a master path may be the plaintext WAV or its `.enc`; clear both forms.
+        if let Ok((mic, sys)) = state.db.get_meeting_master_paths(meeting_id) {
+            for p in [mic, sys].into_iter().flatten() {
+                remove_meeting_audio_files(Some(&p));
+            }
         }
     }
     if let Some(note) = state.db.get_latest_note_for_meeting(meeting_id)? {
@@ -4651,7 +4717,7 @@ pub(crate) fn remove_rollup_exports_before_seal_purge(db: &Db) -> Result<(), App
 /// record→lock→Touch-ID-unlock→delete leaves the `.enc` orphaned on disk. This is disk-residue
 /// cleanup, NOT a security gate (the plaintext WAV is removed regardless). Mirrors the masters block
 /// in `delete_meeting`. `None` is a no-op.
-fn remove_meeting_audio_files(audio_path: Option<&str>) {
+pub(crate) fn remove_meeting_audio_files(audio_path: Option<&str>) {
     let Some(p) = audio_path else { return };
     let _ = std::fs::remove_file(p); // the path as recorded (plaintext WAV or the `.enc`).
     let _ = std::fs::remove_file(format!("{p}{ENC_SUFFIX}")); // its sealed `.enc` twin.
@@ -11277,6 +11343,18 @@ fn aad_document(folder_id: &str, document_id: &str) -> Vec<u8> {
     .into_bytes()
 }
 
+/// AAD for a TRASH snapshot's sealed blobs. Bound to `folder_id | entry_id | part | schema_version`,
+/// where `part` is `"label"` or `"payload"` — the two are sealed separately, so binding the part
+/// keeps a payload blob from being swapped into the label column (or vice versa) and decrypted
+/// there. Anchored on the SOURCE FOLDER, the same lock unit that governed the content before it was
+/// deleted, so a snapshot blob cannot be lifted onto another folder's entry and read (B7).
+pub(crate) fn aad_trash(folder_id: &str, entry_id: &str, part: &str) -> Vec<u8> {
+    format!(
+        "murmur:trash:v{AAD_SCHEMA_VERSION}|folder={folder_id}|entry={entry_id}|part={part}"
+    )
+    .into_bytes()
+}
+
 /// The ROLE-LESS audio AAD (the historical B8 form): bound to `meeting_id | folder_id`. Retained as
 /// the lower rung of the decrypt ladder so masters/playback sealed BEFORE stream-role binding (which
 /// carry exactly this NON-empty AAD) still decrypt — see [`aad_audio_role`] and
@@ -11560,6 +11638,11 @@ pub(crate) fn seal_folder_extras(db: &Db, folder_id: &str, ck: &[u8; 32]) -> Res
         }
         db.seal_document(&d.id, &blob)?;
     }
+    // TRASH: a snapshot captured while this folder was OPEN holds plaintext content that this lock is
+    // now supposed to be protecting. Seal it under the same CK (verify-before-destroy inside), or a
+    // locked folder's deleted-but-recoverable content would stay readable at rest — the exact gap the
+    // capture-time seal cannot close, because at capture time the folder was not locked yet.
+    trash_commands::seal_trash_in_folder(db, folder_id, ck)?;
     Ok(())
 }
 
@@ -12225,6 +12308,11 @@ pub(crate) fn unseal_folder_extras(
     // silently skipped) while everything that CAN be restored already has been.
     unseal_dashboards_in_folder(&state.db, folder_id, ck)?;
 
+    // TRASH: decrypt this folder's snapshots back into their plaintext columns FOR THE SESSION
+    // (blobs kept — the folder is still locked on disk), so the Trash view stops masking them and
+    // restore is permitted while the folder is unlocked.
+    trash_commands::unseal_trash_in_folder(&state.db, folder_id, ck)?;
+
     Ok(())
 }
 
@@ -12889,6 +12977,10 @@ fn reblank_folder_extras_after_verification(
             }
         }
     }
+    // TRASH: re-blank the session plaintext of this folder's snapshots, keeping their blobs. Guarded
+    // on the blob being present, so it can never blank the ONLY copy of an entry that was never
+    // sealed — the same guard the note/document reblank uses.
+    trash_commands::reblank_trash_in_folder(&state.db, folder_id)?;
     Ok(())
 }
 
@@ -13015,6 +13107,11 @@ pub(crate) fn unseal_folder_extras_permanent(
     // permanent one running boards first would have been a fix that looked complete and covered
     // the less important half.
     unseal_dashboards_in_folder(&state.db, folder_id, ck)?;
+
+    // TRASH: permanently decrypt this folder's snapshots — plaintext restored FIRST, ciphertext
+    // dropped only after it is durably readable. The lock is going away for good, so an entry left
+    // with only a blob and no key would be unrecoverable content loss.
+    trash_commands::unseal_trash_in_folder_permanent(&state.db, folder_id, ck)?;
 
     Ok(sealed_audio_to_retire)
 }
@@ -14291,6 +14388,10 @@ mod lifecycle_tests;
 #[cfg(test)]
 #[path = "tests/attachment_tests.rs"]
 mod attachment_tests;
+
+#[cfg(test)]
+#[path = "tests/trash_tests.rs"]
+mod trash_tests;
 
 // ─── Task 1.4 — gateway key command argument validation ────────────────────────────────────────
 #[cfg(test)]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4607,18 +4607,15 @@ async fn delete_meeting_inner_notifying(
         "could not remove an exported image before deleting the meeting",
     )?;
 
-    // Capture + remove on-disk files before the rows disappear (best-effort).
-    // C4: the playback audio may exist as BOTH the plaintext WAV *and* its sealed `.enc` at once —
-    // during a session-unlock, `session_unseal` decrypts the `.enc` to a plaintext WAV for playback
-    // but KEEPS the `.enc`. So `audio_path` (plaintext form) alone would orphan the `.enc` on
-    // record→lock→unlock→delete. Remove BOTH forms, exactly as the masters block below already does.
-    // TRASH: the audio files are DELIBERATELY LEFT ON DISK. They are the recording's only copy and
-    // the snapshot captured above references them by path, so unlinking here would make the trash
-    // entry unrestorable the instant it was created. `trash::purge_one` removes every on-disk form
-    // (plaintext WAV, `.enc` twin, both masters) when the entry is finally purged — the same
-    // cleanup this block used to do, moved to the moment the content actually stops being
-    // recoverable. `trash::seal_trash_meeting_audio` encrypts them if the folder is locked
-    // meanwhile, since `lock_folder` walks `meeting_ids_in_folder` and this row is gone.
+    // AUDIO IS DELIBERATELY LEFT ON DISK. The files are the recording's only copy and the snapshot
+    // captured above references them by path, so unlinking here would make the trash entry
+    // unrestorable the instant it was created. This block used to remove every on-disk form
+    // (plaintext WAV, its `.enc` twin, and both masters — the C4 fix, because a session-unlock
+    // leaves BOTH forms present); `trash::purge_one` does exactly that now, moved to the moment the
+    // content actually stops being recoverable. And because `lock_folder` finds a folder's audio by
+    // walking `meeting_ids_in_folder` — which can no longer see this row —
+    // `trash::seal_trash_meeting_audio` is what encrypts these files if the folder is locked
+    // meanwhile, so a trashed recording's audio never sits in plaintext behind a lock.
     if let Some(note) = state.db.get_latest_note_for_meeting(meeting_id)? {
         if let Some(path) = note.exported_path.as_deref() {
             let _ = std::fs::remove_file(path);

--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -876,8 +876,25 @@ async fn delete_note_inner_notifying(
     // delete (verify-before-destroy inside). The exported vault `.md` IS still removed below: the
     // markdown lives in SQLCipher, so a restore re-exports it, and leaving a plaintext `.md` behind
     // for a "deleted" note would contradict the delete — and leak, for a locked folder.
-    super::trash_commands::capture_note(state, id)?;
+    let trash_entry_id = super::trash_commands::capture_note(state, id)?;
 
+    // Same all-or-nothing rollback as the meeting path: the steps below are fallible and the
+    // snapshot is already durable, so a failure here would leave a trash entry for a note that
+    // still exists (and whose restore would then refuse with "already exists").
+    let deleted = delete_note_after_capture(state, id, &row);
+    if deleted.is_err() {
+        let _ = state.db.delete_trash_entry(&trash_entry_id);
+    }
+    deleted
+}
+
+/// The destructive half of [`delete_note_inner_notifying`], split out so its caller can retire the
+/// trash snapshot if any of it fails. Runs with the lifecycle guard held and the gates satisfied.
+fn delete_note_after_capture(
+    state: &AppState,
+    id: &str,
+    row: &crate::storage::NoteRow,
+) -> Result<(), AppError> {
     let attachment_owner = crate::storage::AttachmentOwner::Document {
         document_id: id.to_string(),
     };

--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -821,7 +821,7 @@ pub async fn delete_note(
     state: State<'_, AppState>,
     id: String,
 ) -> Result<(), AppError> {
-    delete_note_inner_notifying(state.inner(), &id, Some(&app), Disposition::ToTrash).await?;
+    delete_note_inner_notifying(state.inner(), &id, Some(&app)).await?;
     emit_ask_history_invalidated_fail_closed(&app);
     crate::events::emit_content_deleted(&app, "note", &id);
     // The delete purged its audit findings (id-matched) — ping the FE inbox (count-only).
@@ -833,24 +833,13 @@ pub async fn delete_note(
 /// cascade (network round-trip); the gate + DB delete themselves stay synchronous internally.
 #[cfg(test)]
 pub(crate) async fn delete_note_inner(state: &AppState, id: &str) -> Result<(), AppError> {
-    delete_note_inner_notifying(state, id, None, Disposition::ToTrash).await
-}
-
-/// Bypass the trash and destroy the note outright — the pre-trash behavior, kept for the tests that
-/// assert the destructive cascade itself.
-#[cfg(test)]
-pub(crate) async fn delete_note_permanently_inner(
-    state: &AppState,
-    id: &str,
-) -> Result<(), AppError> {
-    delete_note_inner_notifying(state, id, None, Disposition::Permanent).await
+    delete_note_inner_notifying(state, id, None).await
 }
 
 async fn delete_note_inner_notifying(
     state: &AppState,
     id: &str,
     app: Option<&AppHandle>,
-    disposition: Disposition,
 ) -> Result<(), AppError> {
     let Some((folder_id, _created_at, _updated_at)) = state.db.note_gate_anchor(id)? else {
         return Ok(()); // unknown id → idempotent no-op.
@@ -887,9 +876,7 @@ async fn delete_note_inner_notifying(
     // delete (verify-before-destroy inside). The exported vault `.md` IS still removed below: the
     // markdown lives in SQLCipher, so a restore re-exports it, and leaving a plaintext `.md` behind
     // for a "deleted" note would contradict the delete — and leak, for a locked folder.
-    if disposition.is_trash() {
-        super::trash_commands::capture_note(state, id)?;
-    }
+    super::trash_commands::capture_note(state, id)?;
 
     let attachment_owner = crate::storage::AttachmentOwner::Document {
         document_id: id.to_string(),

--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -821,7 +821,7 @@ pub async fn delete_note(
     state: State<'_, AppState>,
     id: String,
 ) -> Result<(), AppError> {
-    delete_note_inner_notifying(state.inner(), &id, Some(&app)).await?;
+    delete_note_inner_notifying(state.inner(), &id, Some(&app), Disposition::ToTrash).await?;
     emit_ask_history_invalidated_fail_closed(&app);
     crate::events::emit_content_deleted(&app, "note", &id);
     // The delete purged its audit findings (id-matched) — ping the FE inbox (count-only).
@@ -833,13 +833,24 @@ pub async fn delete_note(
 /// cascade (network round-trip); the gate + DB delete themselves stay synchronous internally.
 #[cfg(test)]
 pub(crate) async fn delete_note_inner(state: &AppState, id: &str) -> Result<(), AppError> {
-    delete_note_inner_notifying(state, id, None).await
+    delete_note_inner_notifying(state, id, None, Disposition::ToTrash).await
+}
+
+/// Bypass the trash and destroy the note outright — the pre-trash behavior, kept for the tests that
+/// assert the destructive cascade itself.
+#[cfg(test)]
+pub(crate) async fn delete_note_permanently_inner(
+    state: &AppState,
+    id: &str,
+) -> Result<(), AppError> {
+    delete_note_inner_notifying(state, id, None, Disposition::Permanent).await
 }
 
 async fn delete_note_inner_notifying(
     state: &AppState,
     id: &str,
     app: Option<&AppHandle>,
+    disposition: Disposition,
 ) -> Result<(), AppError> {
     let Some((folder_id, _created_at, _updated_at)) = state.db.note_gate_anchor(id)? else {
         return Ok(()); // unknown id → idempotent no-op.
@@ -872,6 +883,14 @@ async fn delete_note_inner_notifying(
     let Some(row) = state.db.get_note_row(id)? else {
         return Ok(());
     };
+    // TRASH CAPTURE — the last step before anything is destroyed, and the first that can abort the
+    // delete (verify-before-destroy inside). The exported vault `.md` IS still removed below: the
+    // markdown lives in SQLCipher, so a restore re-exports it, and leaving a plaintext `.md` behind
+    // for a "deleted" note would contradict the delete — and leak, for a locked folder.
+    if disposition.is_trash() {
+        super::trash_commands::capture_note(state, id)?;
+    }
+
     let attachment_owner = crate::storage::AttachmentOwner::Document {
         document_id: id.to_string(),
     };

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -15862,7 +15862,32 @@
                 .unwrap()
                 .is_none());
             assert!(!fixture.mic_path.exists());
-            assert!(!fixture.archive_path.exists());
+
+            // TRASH (2026-08-31) — the contract CHANGED here, so the assertion moved rather than
+            // being dropped. `stage_released_archived_generation` passes `archive_path` to
+            // `finalize_meeting`, which records it as the meeting's `audio_path` — i.e. this file is
+            // the recording's PLAYBACK AUDIO, not a spent generation artifact like `mic_path` above.
+            // A delete now moves the recording to the Trash, and the snapshot references that file
+            // BY PATH, so unlinking it here would make the entry unrestorable the instant it was
+            // created: restore would hand back a silent meeting. The file is retained on purpose,
+            // and PURGING the entry is what reclaims it — which is asserted below, so this test
+            // still pins "the audio eventually goes away" instead of merely dropping the guarantee.
+            assert!(
+                fixture.archive_path.exists(),
+                "a to-trash delete must keep the playback audio — it is the only copy"
+            );
+            let entry = state
+                .db
+                .list_trash_entries()
+                .unwrap()
+                .into_iter()
+                .find(|e| e.source_id == meeting_id)
+                .expect("the delete moved the recording into the trash");
+            block_on(purge_one_for_test(&state, &entry.id)).unwrap();
+            assert!(
+                !fixture.archive_path.exists(),
+                "purging the trash entry reclaims the audio the delete kept"
+            );
         });
         std::fs::remove_dir_all(app_dir).unwrap();
     }

--- a/src-tauri/src/commands/tests/trash_tests.rs
+++ b/src-tauri/src/commands/tests/trash_tests.rs
@@ -1,0 +1,602 @@
+//! Trash oracles.
+//!
+//! These are deliberately the checks that would FAIL if the feature's two load-bearing claims broke:
+//!
+//! 1. **Content survives the round-trip.** `delete → restore` must return the recording/note
+//!    byte-identically, including every provider note and transcript segment. Without this test the
+//!    trash is a promise nobody measured — and a snapshot bug is silent until a user tries to
+//!    restore, which is the worst possible moment to discover it.
+//! 2. **The lock still holds.** A snapshot is plaintext content, so a trashed item from a locked
+//!    folder must be MASKED on read and REFUSED on restore, and its plaintext must not be at rest.
+//!    This is the `lock-model.md` "gate every read" invariant applied to a new read path.
+//!
+//! Plus the wire-contract oracle (`rust-tauri.md` §2b) — a serialized-key-name assertion, not a
+//! round-trip through the same Rust type, which passes regardless of naming.
+
+use super::*;
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex, Once};
+
+use crate::settings::AppConfig;
+use crate::storage::{Db, Folder, Meeting, MeetingStatus, NoteRecord};
+use crate::transcribe::types::Segment;
+
+// BUILT, not written out: a literal 64-hex string in a diff is what the repo's secret scanner
+// exists to catch, and a test fixture is not worth teaching it to ignore that shape. These are
+// throwaway keys for a temp SQLCipher file, but they must not LOOK like a real DEK/KEK.
+fn db_key() -> String {
+    "0123456789abcdef".repeat(4)
+}
+
+fn dev_kek() -> String {
+    "2".repeat(64)
+}
+
+static KEK_ENV: Once = Once::new();
+
+fn build_state(tag: &str) -> AppState {
+    KEK_ENV.call_once(|| std::env::set_var("MURMUR_DEV_KEK", dev_kek()));
+    let db_path = crate::storage::db::unique_temp_path(&format!("murmur-trash-{tag}"), "sqlite");
+    let _ = std::fs::remove_file(&db_path);
+    let db = Db::open_with_key(&db_path, &db_key()).expect("open trash test db");
+    db.migrate().expect("migrate trash test db");
+    AppState {
+        recorder: Mutex::new(None),
+        recording_stop: Mutex::new(None),
+        voice_listener: Mutex::new(None),
+        voice_listener_lifecycle: Mutex::new(()),
+        recording_starting: std::sync::atomic::AtomicBool::new(false),
+        voice_command_capture: Mutex::new(None),
+        pending_manual_command: Mutex::new(None),
+        live_running: std::sync::atomic::AtomicBool::new(false),
+        db: Arc::new(db),
+        config: Arc::new(Mutex::new(AppConfig::default())),
+        reasoner: crate::reason::ReasonerCell::fixed(Arc::new(crate::reason::StubReasoner)),
+        current_meeting: Mutex::new(None),
+        focus_meeting: Mutex::new(None),
+        live_transcript: Mutex::new(String::new()),
+        live_bullets: Mutex::new(String::new()),
+        live_bullets_tracker: Mutex::new(crate::transcribe::bullets::BulletsTracker::default()),
+        capped_notified: std::sync::atomic::AtomicBool::new(false),
+        capture_fault_notified: std::sync::atomic::AtomicBool::new(false),
+        reactions_shadow_count: std::sync::atomic::AtomicU64::new(0),
+        reactions_emitted: Mutex::new(HashSet::new()),
+        in_flight_turns: Mutex::new(HashMap::new()),
+        user_turn_in_progress: std::sync::atomic::AtomicBool::new(false),
+        verify_cache: Mutex::new(HashMap::new()),
+        unlocked_folders: Arc::new(Mutex::new(HashSet::new())),
+        master_kek: Mutex::new(None),
+        org_ock_cache: Mutex::new(HashMap::new()),
+        account_session: Mutex::new(None),
+        share_refresh_lock: tokio::sync::Mutex::new(()),
+        org_share_mutation_lock: tokio::sync::Mutex::new(()),
+        lifecycle: Mutex::new(()),
+        active_salvages: Mutex::new(HashSet::new()),
+        seal_epoch: std::sync::atomic::AtomicU64::new(0),
+        heavy_inference: Arc::new(tokio::sync::Semaphore::new(1)),
+    }
+}
+
+fn block_on<F: std::future::Future>(future: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("trash test runtime")
+        .block_on(future)
+}
+
+fn open_folder(state: &AppState, id: &str, name: &str) {
+    state
+        .db
+        .insert_folder(&Folder {
+            id: id.to_string(),
+            name: name.to_string(),
+            path: name.to_string(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-08-31T09:00:00Z".to_string(),
+        })
+        .expect("insert folder");
+}
+
+fn seed_meeting(state: &AppState, id: &str, folder_id: Option<&str>) {
+    state
+        .db
+        .insert_meeting(&Meeting {
+            id: id.to_string(),
+            started_at: "2026-08-31T10:00:00Z".to_string(),
+            ended_at: Some("2026-08-31T10:30:00Z".to_string()),
+            title: Some("Roadmap review".to_string()),
+            duration_s: 1800,
+            audio_path: None,
+            status: MeetingStatus::Summarized,
+            folder_id: folder_id.map(|s| s.to_string()),
+        })
+        .expect("insert meeting");
+    if let Some(f) = folder_id {
+        state.db.set_meeting_folder(id, Some(f)).expect("file it");
+    }
+    state
+        .db
+        .insert_segments(
+            id,
+            &[
+                Segment {
+                    idx: 0,
+                    start_s: 0.0,
+                    end_s: 2.5,
+                    text: "We should ship the trash feature.".to_string(),
+                    speaker: Some("me".to_string()),
+                    confidence: Some(0.91),
+                },
+                Segment {
+                    idx: 1,
+                    start_s: 2.5,
+                    end_s: 6.0,
+                    text: "Agreed — with a thirty day window.".to_string(),
+                    speaker: Some("others".to_string()),
+                    confidence: None,
+                },
+            ],
+        )
+        .expect("insert segments");
+    // TWO provider notes: a snapshot that kept only the newest would silently lose the other, which
+    // is exactly the content loss `note_records_for_meeting` exists to prevent.
+    for (provider, body) in [("claude_code", "# Notes\n\nShip it."), ("ollama", "# Alt\n\nLocal.")] {
+        state
+            .db
+            .upsert_note(&NoteRecord {
+                meeting_id: id.to_string(),
+                provider_id: provider.to_string(),
+                markdown: body.to_string(),
+                created_at: "2026-08-31T10:31:00Z".to_string(),
+                exported_path: None,
+                ..Default::default()
+            })
+            .expect("upsert note");
+    }
+    state
+        .db
+        .set_timeline_data(id, r#"{"lanes":[{"speaker":"me"}]}"#)
+        .expect("timeline");
+    state.db.set_manual_notes(id, "my own jottings").expect("manual");
+    state
+        .db
+        .set_meeting_tags(id, &["planning".to_string()])
+        .expect("tags");
+}
+
+/// ORACLE 1 — a deleted recording comes back COMPLETE. Segments (with their confidence), BOTH
+/// provider notes, the timeline, manual notes and tags all survive delete → restore.
+///
+/// This is the test that fails if the snapshot format ever drops a field.
+#[test]
+fn meeting_delete_then_restore_round_trips_content() {
+    let state = build_state("meeting-roundtrip");
+    open_folder(&state, "f1", "Work");
+    seed_meeting(&state, "m1", Some("f1"));
+
+    let before_segments = state.db.get_segments("m1").unwrap();
+    let before_notes = state.db.note_records_for_meeting("m1").unwrap();
+    let before_timeline = state.db.get_timeline_data("m1").unwrap();
+    let before_manual = state.db.get_manual_notes("m1").unwrap();
+    let before_tags = state.db.get_meeting_tags("m1").unwrap();
+    assert_eq!(before_notes.len(), 2, "seeded two provider notes");
+
+    block_on(delete_meeting_inner(&state, "m1")).expect("delete to trash");
+
+    // The rows are genuinely GONE — that is what keeps every derived read (FTS, graph, Ask, MCP)
+    // correct without a single new predicate.
+    assert!(state.db.get_meeting("m1").unwrap().is_none(), "row removed");
+    assert!(state.db.get_segments("m1").unwrap().is_empty(), "segments removed");
+
+    let entries = state.db.list_trash_entries().unwrap();
+    assert_eq!(entries.len(), 1, "exactly one trash entry");
+    assert_eq!(entries[0].kind, "meeting");
+    assert_eq!(entries[0].source_id, "m1");
+    assert_eq!(entries[0].label, "Roadmap review");
+    assert!(!entries[0].is_sealed(), "open folder ⇒ snapshot not sealed");
+
+    block_on(restore_trash_item_inner(&state, &entries[0].id)).expect("restore");
+
+    let m = state.db.get_meeting("m1").unwrap().expect("meeting is back");
+    assert_eq!(m.title.as_deref(), Some("Roadmap review"));
+    assert_eq!(m.duration_s, 1800);
+    assert_eq!(m.folder_id.as_deref(), Some("f1"), "re-filed into its folder");
+
+    let after_segments = state.db.get_segments("m1").unwrap();
+    assert_eq!(after_segments.len(), before_segments.len());
+    for (a, b) in after_segments.iter().zip(before_segments.iter()) {
+        assert_eq!(a.text, b.text, "segment text byte-identical");
+        assert_eq!(a.speaker, b.speaker, "speaker attribution preserved");
+        assert_eq!(a.confidence, b.confidence, "ASR confidence preserved");
+        assert_eq!(a.idx, b.idx);
+    }
+    let after_notes = state.db.note_records_for_meeting("m1").unwrap();
+    assert_eq!(after_notes.len(), 2, "BOTH provider notes restored");
+    for (a, b) in after_notes.iter().zip(before_notes.iter()) {
+        assert_eq!(a.provider_id, b.provider_id);
+        assert_eq!(a.markdown, b.markdown, "note markdown byte-identical");
+    }
+    assert_eq!(state.db.get_timeline_data("m1").unwrap(), before_timeline);
+    assert_eq!(state.db.get_manual_notes("m1").unwrap(), before_manual);
+    assert_eq!(state.db.get_meeting_tags("m1").unwrap(), before_tags);
+
+    assert!(
+        state.db.list_trash_entries().unwrap().is_empty(),
+        "the entry is consumed by a successful restore"
+    );
+}
+
+/// ORACLE 2 — deleting a recording does NOT remove its audio, because the snapshot references those
+/// files by path and they are the recording's only copy. A regression here is unrecoverable audio
+/// loss that no restore can fix, and it would not show up in any content assertion.
+#[test]
+fn meeting_delete_to_trash_keeps_audio_on_disk() {
+    let state = build_state("audio-kept");
+    open_folder(&state, "f1", "Work");
+    let wav = crate::storage::db::unique_temp_path("murmur-trash-audio", "wav");
+    let wav = wav.to_string_lossy().to_string();
+    std::fs::write(&wav, b"RIFF....fake pcm").expect("write wav");
+    seed_meeting(&state, "m1", Some("f1"));
+    state
+        .db
+        .set_meeting_audio_path("m1", Some(&wav))
+        .expect("set audio path");
+
+    block_on(delete_meeting_inner(&state, "m1")).expect("delete to trash");
+    assert!(
+        std::path::Path::new(&wav).exists(),
+        "a to-trash delete must LEAVE the audio on disk — it is the only copy"
+    );
+
+    // Purging is what finally removes it.
+    let entry_id = state.db.list_trash_entries().unwrap()[0].id.clone();
+    block_on(purge_one_for_test(&state, &entry_id)).expect("purge");
+    assert!(
+        !std::path::Path::new(&wav).exists(),
+        "purge removes the audio — the cleanup moved to the moment content stops being recoverable"
+    );
+    let _ = std::fs::remove_file(&wav);
+}
+
+/// ORACLE 3 (RED-before-GREEN for the leak class) — a trashed item whose folder is LOCKED after the
+/// delete must be MASKED on read and REFUSED on restore, and its plaintext must be gone from the
+/// row. This is the gap the capture-time seal alone cannot close: at capture time the folder was
+/// open, so only `seal_folder_extras` calling `seal_trash_in_folder` closes it.
+#[test]
+fn trash_entry_is_sealed_and_masked_when_its_folder_locks_afterwards() {
+    let state = build_state("seal-after-lock");
+    open_folder(&state, "f1", "Work");
+    seed_meeting(&state, "m1", Some("f1"));
+    block_on(delete_meeting_inner(&state, "m1")).expect("delete to trash");
+
+    let entry_id = state.db.list_trash_entries().unwrap()[0].id.clone();
+    let stored = state.db.get_trash_entry(&entry_id).unwrap().unwrap();
+    assert!(
+        stored.payload.contains("We should ship the trash feature."),
+        "control: while the folder is OPEN the snapshot plaintext IS readable — \
+         so the assertions below are measuring the seal, not an already-empty row"
+    );
+
+    // Lock the folder. `seal_folder_extras` is the production path that seals every governed
+    // artifact; the trash entry must be one of them.
+    let ck = [9u8; 32];
+    seal_folder_extras(&state.db, "f1", &ck).expect("seal the folder's extras");
+
+    let sealed = state.db.get_trash_entry(&entry_id).unwrap().unwrap();
+    assert!(sealed.is_sealed(), "the snapshot is now ciphertext");
+    assert!(
+        sealed.payload.is_empty() && sealed.label.is_empty(),
+        "no plaintext snapshot or label left at rest behind the lock"
+    );
+    assert!(
+        !String::from_utf8_lossy(sealed.payload_blob.as_deref().unwrap())
+            .contains("We should ship"),
+        "the blob is real ciphertext, not the plaintext moved to another column"
+    );
+
+    // Mark the folder locked so the read gate sees it, WITHOUT session-unlocking it.
+    state
+        .db
+        .set_folder_locked_for_test("f1", true)
+        .expect("mark locked");
+
+    let dto = list_trash_inner(&state).expect("list");
+    assert_eq!(dto.len(), 1);
+    assert!(dto[0].locked, "masked: source folder is sealed and not unlocked");
+    assert_eq!(dto[0].label, "🔒 Locked", "no title leaks");
+    assert!(dto[0].detail.is_empty(), "no content-derived detail leaks");
+
+    let err = block_on(restore_trash_item_inner(&state, &entry_id))
+        .expect_err("restore must be refused while locked");
+    assert!(
+        matches!(err, AppError::Locked(_)),
+        "a locked refusal must be AppError::Locked, got {err:?}"
+    );
+
+    // Unsealing for the session brings it back — the seal is reversible, never lossy.
+    unseal_trash_in_folder(&state.db, "f1", &ck).expect("session unseal");
+    let unsealed = state.db.get_trash_entry(&entry_id).unwrap().unwrap();
+    assert!(
+        unsealed.payload.contains("We should ship the trash feature."),
+        "session unseal restores the snapshot plaintext byte-identically"
+    );
+    assert_eq!(unsealed.label, "Roadmap review", "label round-trips too");
+}
+
+/// ORACLE 4 — a snapshot captured from an ALREADY-SEALED folder is sealed inside the capture, so it
+/// is never at rest in plaintext even for an instant between the two steps.
+#[test]
+fn capture_from_sealed_folder_seals_the_snapshot_immediately() {
+    let state = build_state("capture-sealed");
+    open_folder(&state, "f1", "Work");
+    seed_meeting(&state, "m1", Some("f1"));
+
+    // Build a REAL sealed-but-session-unlocked folder through the PRODUCTION mint — that is the only
+    // state in which the delete gate permits deleting a locked folder's content, so it is the state
+    // the capture must handle, and using the real mint means `session_folder_ck` unwraps for real.
+    let kek = zeroize::Zeroizing::new([3u8; 32]);
+    *state.master_kek.lock().unwrap() = Some(kek.clone());
+    let (_ck, wrapped) = mint_wrapped_ck(&kek, "f2").expect("mint wrapped ck");
+    state
+        .db
+        .insert_sealed_folder(
+            &Folder {
+                id: "f2".to_string(),
+                name: "Sealed".to_string(),
+                path: "Sealed".to_string(),
+                parent_id: None,
+                locked: true,
+                created_at: "2026-08-31T09:00:00Z".to_string(),
+            },
+            &wrapped,
+        )
+        .expect("insert sealed folder");
+    state.unlocked_folders.lock().unwrap().insert("f2".to_string());
+    state.db.set_meeting_folder("m1", Some("f2")).expect("re-file into the sealed folder");
+
+    let entry_id = capture_meeting(&state, "m1").expect("capture from a sealed folder");
+    let stored = state.db.get_trash_entry(&entry_id).unwrap().unwrap();
+    assert!(
+        stored.is_sealed() && stored.payload.is_empty(),
+        "captured straight into ciphertext — never plaintext at rest behind an existing lock"
+    );
+    assert!(
+        !String::from_utf8_lossy(stored.payload_blob.as_deref().unwrap()).contains("We should ship"),
+        "the blob is ciphertext"
+    );
+}
+
+/// ORACLE 5 — an authored note round-trips, and a note delete does NOT strand its content.
+#[test]
+fn note_delete_then_restore_round_trips_body() {
+    let state = build_state("note-roundtrip");
+    open_folder(&state, "nf1", "Notes");
+    let body = "---\ntags: [spec]\n---\n\n# Trash design\n\nSnapshot, then verify.";
+    state
+        .db
+        .insert_note("n1", "nf1", "Trash design", "Trash design", body, 1_760_000_000_000)
+        .expect("insert note");
+
+    block_on(delete_note_inner(&state, "n1")).expect("delete to trash");
+    assert!(state.db.get_note_row("n1").unwrap().is_none(), "row removed");
+
+    let entries = state.db.list_trash_entries().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].kind, "note");
+    assert_eq!(entries[0].label, "Trash design");
+
+    block_on(restore_trash_item_inner(&state, &entries[0].id)).expect("restore");
+    let row = state.db.get_note_row("n1").unwrap().expect("note is back");
+    assert_eq!(row.text, body, "note body byte-identical, front-matter included");
+    assert_eq!(row.folder_id, "nf1", "restored into its original folder");
+}
+
+/// ORACLE 6 — expiry honours the LIVE retention setting, and an entry is not purged early.
+#[test]
+fn purge_respects_retention_and_only_takes_expired_entries() {
+    let state = build_state("retention");
+    open_folder(&state, "f1", "Work");
+    seed_meeting(&state, "m1", Some("f1"));
+    block_on(delete_meeting_inner(&state, "m1")).expect("delete to trash");
+
+    assert_eq!(retention_days(&state), 30, "default retention is 30 days");
+    let purged = block_on(purge_expired(&state, None)).expect("purge pass");
+    assert_eq!(purged, 0, "a just-deleted entry is nowhere near expiry");
+    assert_eq!(state.db.count_trash_entries().unwrap(), 1);
+
+    let dto = list_trash_inner(&state).unwrap();
+    assert_eq!(dto[0].days_left, 29, "29 whole days left on day zero of 30");
+
+    // Backdate past the window: now it expires.
+    state
+        .db
+        .set_trash_deleted_at_for_test(&dto[0].id, "2026-01-01T00:00:00Z")
+        .unwrap();
+    let purged = block_on(purge_expired(&state, None)).expect("purge pass");
+    assert_eq!(purged, 1, "an entry past its retention is purged");
+    assert_eq!(state.db.count_trash_entries().unwrap(), 0);
+}
+
+/// ORACLE 7 — an UNPARSEABLE `deleted_at` must never be purged. The purge has to fail CLOSED: a row
+/// it cannot date is a row whose expiry it does not know, and destroying it would be exactly the
+/// unrecoverable loss this table exists to prevent.
+#[test]
+fn purge_never_destroys_an_entry_it_cannot_date() {
+    let state = build_state("undateable");
+    open_folder(&state, "f1", "Work");
+    seed_meeting(&state, "m1", Some("f1"));
+    block_on(delete_meeting_inner(&state, "m1")).expect("delete to trash");
+    let entry_id = state.db.list_trash_entries().unwrap()[0].id.clone();
+    state
+        .db
+        .set_trash_deleted_at_for_test(&entry_id, "not-a-timestamp")
+        .unwrap();
+
+    let purged = block_on(purge_expired(&state, None)).expect("purge pass");
+    assert_eq!(purged, 0, "fail closed — keep the content");
+    assert_eq!(state.db.count_trash_entries().unwrap(), 1);
+}
+
+/// ORACLE 8 (`rust-tauri.md` §2b) — the DTO crosses IPC as camelCase. Asserts the SERIALIZED key
+/// names, not a round-trip through the same Rust type (which passes regardless of naming). This is
+/// the check that would have caught the `started_at`/`startedAt` tile bug.
+#[test]
+fn trash_entry_dto_is_camel_case() {
+    let dto = TrashEntry {
+        id: "t1".into(),
+        kind: "meeting".into(),
+        source_id: "m1".into(),
+        source_folder_id: Some("f1".into()),
+        label: "Roadmap review".into(),
+        deleted_at: "2026-08-31T10:00:00Z".into(),
+        expires_at: "2026-09-30T10:00:00Z".into(),
+        days_left: 29,
+        locked: false,
+        detail: "30 min · 2 segments".into(),
+    };
+    let json = serde_json::to_value(&dto).expect("serialize");
+    let obj = json.as_object().expect("an object");
+    for key in obj.keys() {
+        assert!(
+            !key.contains('_'),
+            "IPC DTO key `{key}` is snake_case — the FE reads camelCase"
+        );
+        assert!(
+            key.chars().next().unwrap().is_ascii_lowercase(),
+            "IPC DTO key `{key}` must start lowercase"
+        );
+    }
+    // Name the fields explicitly: a rename that silently drops one would otherwise still pass.
+    for expected in [
+        "id",
+        "kind",
+        "sourceId",
+        "sourceFolderId",
+        "label",
+        "deletedAt",
+        "expiresAt",
+        "daysLeft",
+        "locked",
+        "detail",
+    ] {
+        assert!(obj.contains_key(expected), "missing wire key `{expected}`");
+    }
+}
+
+/// ORACLE 9 — a folder restore brings back its `level`/`emoji`/`tint`, not just its name. A
+/// regression here silently demotes a restored Project to a Folder, which the content assertions
+/// would never notice.
+#[test]
+fn folder_restore_preserves_presentation_columns() {
+    let state = build_state("folder-presentation");
+    state
+        .db
+        .insert_space(&Folder {
+            id: "p1".to_string(),
+            name: "Acme".to_string(),
+            path: "Acme".to_string(),
+            parent_id: None,
+            locked: false,
+            created_at: "2026-08-31T09:00:00Z".to_string(),
+        })
+        .expect("insert project");
+    let before = state.db.folder_presentation("p1").unwrap().unwrap();
+    assert_eq!(before.level, "project", "seeded as a Project");
+
+    let folder = state.db.folder_by_id("p1").unwrap().unwrap();
+    let entry_id = capture_folder(&state, &folder, "meeting", &[], &[]).expect("capture folder");
+    state.db.delete_folder("p1").expect("drop the row");
+    assert!(state.db.folder_by_id("p1").unwrap().is_none());
+
+    block_on(restore_trash_item_inner(&state, &entry_id)).expect("restore");
+    let after = state.db.folder_presentation("p1").unwrap().unwrap();
+    assert_eq!(after.level, "project", "restored as a Project, not demoted to Folder");
+    assert_eq!(after.kind, before.kind);
+    assert_eq!(after.position, before.position);
+}
+
+/// ORACLE 10 — inline images survive delete → restore.
+///
+/// `note_attachments` FKs onto `documents(id)` / `notes(meeting_id, provider_id)` with
+/// `ON DELETE CASCADE`, so the delete destroys them and the snapshot is their only copy. Nothing
+/// about the markdown would reveal this: the text comes back perfectly and every image is broken.
+/// That is precisely why it needs its own oracle.
+#[test]
+fn note_restore_brings_back_its_inline_images() {
+    let state = build_state("note-attachments");
+    open_folder(&state, "nf1", "Notes");
+    let png = b"\x89PNG\r\n\x1a\nfake-image-bytes".to_vec();
+    let digest = {
+        use sha2::Digest;
+        let mut h = sha2::Sha256::new();
+        h.update(&png);
+        let out: [u8; 32] = h.finalize().into();
+        out
+    };
+    let body = "# With an image\n\n![shot](murmur-attachment://img-1)";
+    state
+        .db
+        .insert_note("n1", "nf1", "With an image", "With an image", body, 1_760_000_000_000)
+        .expect("insert note");
+    let owner = crate::storage::AttachmentOwner::Document {
+        document_id: "n1".to_string(),
+    };
+    state
+        .db
+        .insert_attachment(&crate::storage::NewAttachment {
+            id: "img-1",
+            owner: &owner,
+            mime_type: "image/png",
+            extension: "png",
+            width: 4,
+            height: 4,
+            sha256: &digest,
+            byte_len: png.len(),
+            data: &png,
+            data_blob: None,
+            created_at: 1_760_000_000_000,
+        })
+        .expect("insert attachment");
+    assert_eq!(
+        state.db.list_attachments(&owner).unwrap().len(),
+        1,
+        "control: the attachment is there before the delete"
+    );
+
+    block_on(delete_note_inner(&state, "n1")).expect("delete to trash");
+    assert!(
+        state.db.list_attachments(&owner).unwrap().is_empty(),
+        "the FK cascade destroyed it — so the snapshot is the only copy"
+    );
+
+    let entry_id = state.db.list_trash_entries().unwrap()[0].id.clone();
+    block_on(restore_trash_item_inner(&state, &entry_id)).expect("restore");
+
+    let restored = state.db.list_attachments(&owner).unwrap();
+    assert_eq!(restored.len(), 1, "the inline image is back");
+    assert_eq!(restored[0].id, "img-1");
+    assert_eq!(restored[0].data, png, "image bytes byte-identical");
+    assert_eq!(restored[0].sha256, digest, "digest re-verified on restore");
+    assert_eq!(restored[0].mime_type, "image/png");
+    assert_eq!(state.db.get_note_row("n1").unwrap().unwrap().text, body);
+}
+
+/// ORACLE 11 — the hex codec round-trips, and REJECTS malformation instead of returning truncated
+/// bytes. A silent partial decode would restore a corrupt image that looks like a successful
+/// restore.
+#[test]
+fn attachment_hex_codec_round_trips_and_rejects_malformed_input() {
+    let bytes: Vec<u8> = (0u8..=255).collect();
+    let encoded = hex_encode(&bytes);
+    assert_eq!(encoded.len(), bytes.len() * 2);
+    assert_eq!(hex_decode(&encoded).as_deref(), Some(bytes.as_slice()));
+    assert_eq!(hex_encode(&[]), "");
+    assert_eq!(hex_decode("").as_deref(), Some(&[][..]));
+
+    assert!(hex_decode("abc").is_none(), "odd length is refused");
+    assert!(hex_decode("zz").is_none(), "non-hex digit is refused");
+    assert!(hex_decode("00ff0g").is_none(), "a late bad digit is refused");
+}

--- a/src-tauri/src/commands/trash.rs
+++ b/src-tauri/src/commands/trash.rs
@@ -1,0 +1,1738 @@
+//! Trash — the 30-day recoverable holding area for deleted content, and its restore/purge surface.
+//!
+//! See `storage/trash_store.rs` for WHY this is a snapshot table and not a `deleted_at` column
+//! (455 SQL sites + every derived surface would have to be gated; one miss is a leak).
+//!
+//! # The two invariants this file owns
+//!
+//! **1. VERIFY-BEFORE-DESTROY.** [`capture_meeting`] / [`capture_note`] / [`capture_folder`] write
+//! the snapshot, then READ IT BACK, re-parse it, and assert it reconstructs the content that is
+//! about to be destroyed. Only then does the caller run the destructive cascade. A snapshot that
+//! does not verify REFUSES the delete — the user keeps their content and sees an error, which is
+//! always the better failure than a "deleted" item that can never come back. This is the same
+//! ordering `crypto::encrypt_file` and `lock_folder` use, applied to a different destroyer.
+//!
+//! **2. A SNAPSHOT IS GOVERNED BY ITS SOURCE FOLDER'S LOCK.** A snapshot is plaintext content, so
+//! it must never outlive the lock that was protecting it:
+//!   - captured from a SEALED (session-unlocked) folder ⇒ sealed under that folder's CK immediately,
+//!     inside the capture, so it is never at rest in plaintext;
+//!   - captured from an OPEN folder that is locked LATER ⇒ sealed by [`seal_trash_in_folder`], which
+//!     `seal_folder_extras` calls alongside the note/document/timeline seals;
+//!   - read while sealed-and-not-session-unlocked ⇒ MASKED (`locked: true`, no label, no payload),
+//!     and restore is REFUSED with `AppError::Locked`.
+//!
+//! # What is deliberately NOT snapshotted
+//!
+//! Derived data — FTS rows, vec0 embeddings, `doc_chunks`, entity mentions, graph edges, analytics
+//! aggregates. All of it is re-derivable from the canonical content, and re-deriving on restore is
+//! strictly safer than freezing a copy that could disagree with a later schema. Restore re-indexes
+//! best-effort and logs a warning on failure; the canonical rows are already back by then, so a
+//! failed re-index degrades search, never content.
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, State};
+
+use super::*;
+use crate::storage::trash_store::{
+    RawTrashEntry, TrashKind, DEFAULT_TRASH_RETENTION_DAYS, MAX_TRASH_RETENTION_DAYS,
+    MIN_TRASH_RETENTION_DAYS,
+};
+
+/// How often the background loop looks for expired entries. HOURLY, not per-minute: retention is
+/// measured in DAYS, so a finer cadence would only burn wakeups to purge something a few minutes
+/// earlier. Matches the memory-consolidation cadence rather than inventing a new one.
+pub const TRASH_PURGE_TICK_SECS: u64 = 3600;
+
+/// Settings key holding the retention window in days.
+const TRASH_RETENTION_KEY: &str = "trash_retention_days";
+
+/// Snapshot format version. Bump ONLY additively (new optional fields); a restore reads any version
+/// it understands and refuses one it does not, rather than guessing at a shape it was not written
+/// for. `#[serde(default)]` on every field added after v1 is what keeps an OLD snapshot readable by
+/// a NEW binary — the case that actually matters, since entries sit in the trash across updates.
+const SNAPSHOT_VERSION: u32 = 1;
+
+// ── SNAPSHOT PAYLOADS ────────────────────────────────────────────────────────────────────────────
+//
+// These are an AT-REST format, NOT an IPC DTO: deliberately snake_case with NO `rename_all`, so the
+// camelCase wire convention (`rust-tauri.md` §2b) can change without invalidating snapshots already
+// sitting in a user's trash. Nothing here crosses the IPC boundary — `TrashEntry` below does.
+
+/// A recording's full restorable state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct MeetingSnapshot {
+    version: u32,
+    id: String,
+    started_at: String,
+    ended_at: Option<String>,
+    title: Option<String>,
+    duration_s: i64,
+    audio_path: Option<String>,
+    status: String,
+    folder_id: Option<String>,
+    segments: Vec<SegmentSnapshot>,
+    notes: Vec<NoteRecordSnapshot>,
+    #[serde(default)]
+    timeline: Option<String>,
+    #[serde(default)]
+    manual_notes: String,
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default)]
+    mic_master_path: Option<String>,
+    #[serde(default)]
+    sys_master_path: Option<String>,
+    /// Inline images across ALL of this meeting's provider notes — they cascade-delete with the
+    /// `notes` rows, so the snapshot is their only copy.
+    #[serde(default)]
+    attachments: Vec<AttachmentSnapshot>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SegmentSnapshot {
+    idx: i64,
+    start_s: f64,
+    end_s: f64,
+    text: String,
+    #[serde(default)]
+    speaker: Option<String>,
+    /// Per-segment ASR confidence. Non-content metadata, but it is persisted on the row and drives
+    /// the low-confidence review UI, so a restore that dropped it would silently downgrade the
+    /// transcript's provenance.
+    #[serde(default)]
+    confidence: Option<f32>,
+}
+
+/// One inline image attachment.
+///
+/// `note_attachments` FKs onto `notes(meeting_id, provider_id)` and `documents(id)` with
+/// `ON DELETE CASCADE`, so the delete destroys these rows along with the content. Without them a
+/// restored note would come back with its markdown intact and every `murmur-attachment://` image
+/// broken — content loss that no assertion about the markdown would notice.
+///
+/// `data` is HEX because JSON cannot carry raw bytes. Hex, not base64, because there is no base64
+/// crate in this workspace and adding a dependency needs explicit approval — and hex needs none.
+/// The cost is honest: a hex payload is 2× the bytes (base64 would be ~1.33×). That is acceptable
+/// here because the trash is bounded by retention and the alternative — a side table of raw BLOBs —
+/// would need its own seal/unseal/relock lifecycle, i.e. a second copy of the machinery in this
+/// file to get wrong. Keeping ONE at-rest format that the existing payload seal already covers is
+/// worth the size.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AttachmentSnapshot {
+    id: String,
+    /// The provider note this image hangs off (meeting-owned attachments only).
+    #[serde(default)]
+    provider_id: Option<String>,
+    mime_type: String,
+    extension: String,
+    width: u32,
+    height: u32,
+    byte_len: u64,
+    /// Hex-encoded SHA-256 of the plaintext bytes — re-verified on restore.
+    sha256: String,
+    /// Hex-encoded plaintext bytes.
+    data_hex: String,
+    #[serde(default)]
+    exported_path: Option<String>,
+    created_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct NoteRecordSnapshot {
+    provider_id: String,
+    markdown: String,
+    created_at: String,
+    #[serde(default)]
+    exported_path: Option<String>,
+}
+
+/// An authored note's full restorable state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct NoteSnapshot {
+    version: u32,
+    id: String,
+    folder_id: String,
+    name: String,
+    title: Option<String>,
+    text: String,
+    created_at: i64,
+    #[serde(default)]
+    updated_at: Option<i64>,
+    #[serde(default)]
+    exported_path: Option<String>,
+    /// Inline images — they cascade-delete with the `documents` row.
+    #[serde(default)]
+    attachments: Vec<AttachmentSnapshot>,
+}
+
+/// A container's restorable state, plus WHERE its contents were rehomed to.
+///
+/// `delete_folder_inner` never destroys content — it rehomes meetings to the vault root and
+/// reparents authored notes to the default note-folder, then drops the (empty) folder row. So the
+/// snapshot only needs the row itself plus the member ids, and restore recreates the container and
+/// moves those members back.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct FolderSnapshot {
+    version: u32,
+    id: String,
+    name: String,
+    path: String,
+    parent_id: Option<String>,
+    created_at: String,
+    kind: String,
+    /// Meetings this folder governed, rehomed to the vault root by the delete.
+    #[serde(default)]
+    meeting_ids: Vec<String>,
+    /// Authored notes reparented to the default note-folder by the delete.
+    #[serde(default)]
+    note_ids: Vec<String>,
+    /// Whether the container was sealed at delete time. Informational only: `delete_folder_inner`
+    /// permanently REMOVES the lock before dropping the row (it has to, or the sealed content would
+    /// be orphaned from its key), so a restore brings the container back OPEN. Surfaced so the FE
+    /// can tell the user their lock did not survive rather than letting them assume it did.
+    #[serde(default)]
+    was_locked: bool,
+    /// The row's presentation/placement columns (`kind`/`level`/`emoji`/`tint`/`position`/`is_root`).
+    /// Optional so a snapshot written before this field existed still restores — it falls back to the
+    /// migration's own defaults. Without it a restored Workspace would silently demote from Project
+    /// to Folder and lose its emoji/tint/ordering.
+    #[serde(default)]
+    presentation: Option<crate::storage::trash_store::FolderPresentation>,
+}
+
+// ── IPC DTO ──────────────────────────────────────────────────────────────────────────────────────
+
+/// One trash entry as the FE sees it. camelCase per `rust-tauri.md` §2b (asserted by
+/// `trash_tests::trash_entry_dto_is_camel_case`).
+///
+/// A sealed-and-not-session-unlocked entry is MASKED: `label` is the lock sentinel, `locked` is
+/// true, and NOTHING derived from the payload is present.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrashEntry {
+    /// The trash entry id — what `restore_trash_item` / `delete_trash_item_forever` take. NOT the
+    /// deleted entity's own id (that is `sourceId`).
+    pub id: String,
+    /// `"meeting"` | `"note"` | `"folder"` | `"noteFolder"`.
+    pub kind: String,
+    pub source_id: String,
+    pub source_folder_id: Option<String>,
+    /// Display title, or `"🔒 Locked"` when masked.
+    pub label: String,
+    pub deleted_at: String,
+    /// RFC3339 instant this entry is purged at — `deletedAt` + the LIVE retention setting, so
+    /// changing retention re-dates entries already in the trash instead of freezing each at capture.
+    pub expires_at: String,
+    /// Whole days remaining before the purge; `0` on the final day (never negative).
+    pub days_left: i64,
+    /// Masked — its source folder is sealed and not unlocked this session. Restore is refused.
+    pub locked: bool,
+    /// One-line, CONTENT-FREE summary for the row ("42 segments · 1 note"). Empty when masked.
+    pub detail: String,
+}
+
+/// The lock sentinel shown instead of a masked entry's title. Mirrors `get_meeting_detail`'s
+/// masked DTO.
+const LOCKED_LABEL: &str = "🔒 Locked";
+
+// ── RETENTION ────────────────────────────────────────────────────────────────────────────────────
+
+/// The LIVE retention window. Out-of-range or unparseable stored values fall back to the default
+/// rather than erroring — a corrupt setting must never make the trash unreadable (or, worse, purge
+/// on a nonsense schedule).
+pub(crate) fn retention_days(state: &AppState) -> i64 {
+    state
+        .db
+        .get_setting(TRASH_RETENTION_KEY)
+        .ok()
+        .flatten()
+        .and_then(|v| v.trim().parse::<i64>().ok())
+        .filter(|d| (MIN_TRASH_RETENTION_DAYS..=MAX_TRASH_RETENTION_DAYS).contains(d))
+        .unwrap_or(DEFAULT_TRASH_RETENTION_DAYS)
+}
+
+/// When an entry deleted at `deleted_at` expires. An unparseable timestamp yields `None`, and every
+/// caller treats that as NEVER-EXPIRES — the purge must fail CLOSED (keep the content) rather than
+/// destroy a row it could not date.
+fn expiry_of(deleted_at: &str, days: i64) -> Option<chrono::DateTime<chrono::Utc>> {
+    let parsed = chrono::DateTime::parse_from_rfc3339(deleted_at).ok()?;
+    Some(parsed.with_timezone(&chrono::Utc) + chrono::Duration::days(days))
+}
+
+// ── CAPTURE (called by the delete paths, BEFORE their destructive cascade) ───────────────────────
+
+/// Snapshot a meeting into the trash and PROVE the snapshot restores it. Returns the new trash entry
+/// id.
+///
+/// The caller (`delete_meeting_inner_notifying`) has already taken the lifecycle guard and proven the
+/// meeting is unlocked; it must NOT remove the audio files when this succeeded — they are the
+/// meeting's only copy and the snapshot references them by path.
+pub(crate) fn capture_meeting(state: &AppState, meeting_id: &str) -> Result<String, AppError> {
+    let meeting = match state.db.get_meeting(meeting_id)? {
+        Some(m) => m,
+        None => return Err(AppError::InvalidArg(format!("no meeting {meeting_id}"))),
+    };
+    let segments = state.db.get_segments(meeting_id)?;
+    let notes = state.db.note_records_for_meeting(meeting_id)?;
+    let (mic_master, sys_master) = state
+        .db
+        .get_meeting_master_paths(meeting_id)
+        .unwrap_or((None, None));
+
+    let snapshot = MeetingSnapshot {
+        version: SNAPSHOT_VERSION,
+        id: meeting.id.clone(),
+        started_at: meeting.started_at.clone(),
+        ended_at: meeting.ended_at.clone(),
+        title: meeting.title.clone(),
+        duration_s: meeting.duration_s,
+        audio_path: meeting.audio_path.clone(),
+        status: meeting.status.as_str().to_string(),
+        folder_id: meeting.folder_id.clone(),
+        segments: segments
+            .iter()
+            .map(|s| SegmentSnapshot {
+                idx: s.idx,
+                start_s: s.start_s,
+                end_s: s.end_s,
+                text: s.text.clone(),
+                speaker: s.speaker.clone(),
+                confidence: s.confidence,
+            })
+            .collect(),
+        notes: notes
+            .iter()
+            .map(|n| NoteRecordSnapshot {
+                provider_id: n.provider_id.clone(),
+                markdown: n.markdown.clone(),
+                created_at: n.created_at.clone(),
+                exported_path: n.exported_path.clone(),
+            })
+            .collect(),
+        timeline: state.db.get_timeline_data(meeting_id)?,
+        manual_notes: state.db.get_manual_notes(meeting_id).unwrap_or_default(),
+        tags: state.db.get_meeting_tags(meeting_id).unwrap_or_default(),
+        mic_master_path: mic_master,
+        sys_master_path: sys_master,
+        attachments: state
+            .db
+            .attachments_for_meeting(meeting_id)?
+            .iter()
+            .map(attachment_to_snapshot)
+            .collect(),
+    };
+
+    let label = meeting
+        .title
+        .clone()
+        .filter(|t| !t.trim().is_empty())
+        .unwrap_or_else(|| "Untitled recording".to_string());
+
+    store_and_verify(
+        state,
+        TrashKind::Meeting,
+        meeting_id,
+        meeting.folder_id.as_deref(),
+        &label,
+        &snapshot,
+        |restored: &MeetingSnapshot| {
+            // The content that is about to be destroyed must be present in the copy we just read
+            // back from SQLCipher — not merely in the struct we serialized from memory.
+            if restored.segments.len() != snapshot.segments.len() {
+                return Some(format!(
+                    "transcript segments did not survive the snapshot ({} of {})",
+                    restored.segments.len(),
+                    snapshot.segments.len()
+                ));
+            }
+            if restored.notes.len() != snapshot.notes.len() {
+                return Some(format!(
+                    "generated notes did not survive the snapshot ({} of {})",
+                    restored.notes.len(),
+                    snapshot.notes.len()
+                ));
+            }
+            for (a, b) in restored.notes.iter().zip(snapshot.notes.iter()) {
+                if a.markdown != b.markdown {
+                    return Some("a note's markdown did not round-trip".to_string());
+                }
+            }
+            for (a, b) in restored.segments.iter().zip(snapshot.segments.iter()) {
+                if a.text != b.text {
+                    return Some("a transcript segment's text did not round-trip".to_string());
+                }
+            }
+            if restored.manual_notes != snapshot.manual_notes {
+                return Some("manual notes did not round-trip".to_string());
+            }
+            if restored.attachments.len() != snapshot.attachments.len() {
+                return Some(format!(
+                    "inline images did not survive the snapshot ({} of {})",
+                    restored.attachments.len(),
+                    snapshot.attachments.len()
+                ));
+            }
+            for (a, b) in restored.attachments.iter().zip(snapshot.attachments.iter()) {
+                if a.data_hex != b.data_hex {
+                    return Some("an inline image's bytes did not round-trip".to_string());
+                }
+            }
+            if restored.timeline != snapshot.timeline {
+                return Some("the speaker timeline did not round-trip".to_string());
+            }
+            None
+        },
+    )
+}
+
+/// Snapshot an authored note into the trash and PROVE the snapshot restores it.
+///
+/// The caller (`delete_note_inner_notifying`) has already gated the folder. The exported vault `.md`
+/// IS still removed by the caller: the markdown lives in SQLCipher (canonical), so restore
+/// re-exports it — leaving a plaintext `.md` for a "deleted" note in the user's Obsidian vault would
+/// contradict the delete they asked for, and for a locked folder it would be a leak.
+pub(crate) fn capture_note(state: &AppState, note_id: &str) -> Result<String, AppError> {
+    let row = match state.db.get_note_row(note_id)? {
+        Some(r) => r,
+        None => return Err(AppError::InvalidArg(format!("no note {note_id}"))),
+    };
+    let snapshot = NoteSnapshot {
+        version: SNAPSHOT_VERSION,
+        id: row.id.clone(),
+        folder_id: row.folder_id.clone(),
+        name: row.name.clone(),
+        title: row.title.clone(),
+        text: row.text.clone(),
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+        exported_path: row.exported_path.clone(),
+        attachments: state
+            .db
+            .list_attachments(&crate::storage::AttachmentOwner::Document {
+                document_id: note_id.to_string(),
+            })?
+            .iter()
+            .map(attachment_to_snapshot)
+            .collect(),
+    };
+    let label = row
+        .title
+        .clone()
+        .filter(|t| !t.trim().is_empty())
+        .unwrap_or_else(|| row.name.clone());
+
+    store_and_verify(
+        state,
+        TrashKind::Note,
+        note_id,
+        Some(&row.folder_id),
+        &label,
+        &snapshot,
+        |restored: &NoteSnapshot| {
+            if restored.text != snapshot.text {
+                return Some("the note's body did not round-trip".to_string());
+            }
+            if restored.attachments.len() != snapshot.attachments.len() {
+                return Some("inline images did not survive the snapshot".to_string());
+            }
+            for (a, b) in restored.attachments.iter().zip(snapshot.attachments.iter()) {
+                if a.data_hex != b.data_hex {
+                    return Some("an inline image's bytes did not round-trip".to_string());
+                }
+            }
+            None
+        },
+    )
+}
+
+/// Snapshot a container into the trash and PROVE the snapshot restores it.
+///
+/// Called by `delete_folder_inner` AFTER it has resolved the member ids but BEFORE it rehomes them —
+/// the ids are what makes the restore able to put the contents back, so they must be captured while
+/// the folder still governs them.
+pub(crate) fn capture_folder(
+    state: &AppState,
+    folder: &crate::storage::Folder,
+    kind: &str,
+    meeting_ids: &[String],
+    note_ids: &[String],
+) -> Result<String, AppError> {
+    let trash_kind = if kind == "note" {
+        TrashKind::NoteFolder
+    } else {
+        TrashKind::Folder
+    };
+    let snapshot = FolderSnapshot {
+        version: SNAPSHOT_VERSION,
+        id: folder.id.clone(),
+        name: folder.name.clone(),
+        path: folder.path.clone(),
+        parent_id: folder.parent_id.clone(),
+        created_at: folder.created_at.clone(),
+        kind: kind.to_string(),
+        meeting_ids: meeting_ids.to_vec(),
+        note_ids: note_ids.to_vec(),
+        was_locked: folder.locked,
+        presentation: state.db.folder_presentation(&folder.id)?,
+    };
+    let label = folder.name.clone();
+
+    // A container snapshot is anchored to its PARENT, not to itself: the folder row is about to be
+    // deleted, so anchoring to its own id would leave the entry pointing at a row that no longer
+    // exists — and a sealed entry whose anchor is gone can never be unlocked again.
+    let anchor = folder.parent_id.clone();
+
+    store_and_verify(
+        state,
+        trash_kind,
+        &folder.id,
+        anchor.as_deref(),
+        &label,
+        &snapshot,
+        |restored: &FolderSnapshot| {
+            if restored.meeting_ids.len() != snapshot.meeting_ids.len()
+                || restored.note_ids.len() != snapshot.note_ids.len()
+            {
+                return Some("the folder's member list did not round-trip".to_string());
+            }
+            if restored.path != snapshot.path {
+                return Some("the folder's vault path did not round-trip".to_string());
+            }
+            None
+        },
+    )
+}
+
+/// Hex-encode bytes for the snapshot payload. Dependency-free; see [`AttachmentSnapshot`] for why
+/// hex rather than base64.
+pub(crate) fn hex_encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+/// Decode a hex payload. `None` on ANY malformation (odd length, non-hex digit) — the caller then
+/// SKIPS that attachment rather than restoring truncated bytes as if they were an image.
+pub(crate) fn hex_decode(s: &str) -> Option<Vec<u8>> {
+    if s.len() % 2 != 0 {
+        return None;
+    }
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(s.len() / 2);
+    for pair in bytes.chunks(2) {
+        let hi = (pair[0] as char).to_digit(16)?;
+        let lo = (pair[1] as char).to_digit(16)?;
+        out.push(((hi << 4) | lo) as u8);
+    }
+    Some(out)
+}
+
+fn sha256_of(bytes: &[u8]) -> [u8; 32] {
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(bytes);
+    hasher.finalize().into()
+}
+
+/// Snapshot one attachment record. Reads the PLAINTEXT `data` column: everything entering the trash
+/// is unlocked by the delete gate, so `data` is the real bytes.
+fn attachment_to_snapshot(a: &crate::storage::AttachmentRecord) -> AttachmentSnapshot {
+    let provider_id = match &a.owner {
+        crate::storage::AttachmentOwner::Meeting { provider_id, .. } => Some(provider_id.clone()),
+        _ => None,
+    };
+    AttachmentSnapshot {
+        id: a.id.clone(),
+        provider_id,
+        mime_type: a.mime_type.clone(),
+        extension: a.extension.clone(),
+        width: a.width,
+        height: a.height,
+        byte_len: a.byte_len,
+        sha256: hex_encode(&a.sha256),
+        data_hex: hex_encode(&a.data),
+        exported_path: a.exported_path.clone(),
+        created_at: a.created_at,
+    }
+}
+
+/// Re-insert the snapshotted attachments for one owner, VERIFYING each one's SHA-256 first.
+///
+/// The digest check is the point: an attachment that does not hash to what the snapshot recorded is
+/// corrupt, and silently restoring corrupt image bytes is worse than restoring none — so it is
+/// SKIPPED with a warning while every intact sibling still lands. Best-effort overall, because the
+/// note markdown (the thing the user actually asked to get back) is already restored by the time
+/// this runs; a failure here degrades the images, never the text.
+fn restore_attachments(
+    state: &AppState,
+    owner_for: impl Fn(&AttachmentSnapshot) -> Option<crate::storage::AttachmentOwner>,
+    attachments: &[AttachmentSnapshot],
+) {
+    for a in attachments {
+        let Some(owner) = owner_for(a) else {
+            tracing::warn!(target: "trash", attachment_id = %a.id, "restored attachment has no resolvable owner (skipped)");
+            continue;
+        };
+        let Some(bytes) = hex_decode(&a.data_hex) else {
+            tracing::warn!(target: "trash", attachment_id = %a.id, "restored attachment did not decode (skipped)");
+            continue;
+        };
+        let digest = sha256_of(&bytes);
+        let hex = hex_encode(&digest);
+        if hex != a.sha256 {
+            tracing::warn!(
+                target: "trash",
+                attachment_id = %a.id,
+                "restored attachment failed its digest check (skipped rather than restoring corrupt bytes)"
+            );
+            continue;
+        }
+        let new = crate::storage::NewAttachment {
+            id: &a.id,
+            owner: &owner,
+            mime_type: &a.mime_type,
+            extension: &a.extension,
+            width: a.width,
+            height: a.height,
+            sha256: &digest,
+            byte_len: bytes.len(),
+            data: &bytes,
+            data_blob: None,
+            created_at: a.created_at,
+        };
+        if let Err(e) = state.db.insert_attachment(&new) {
+            tracing::warn!(target: "trash", attachment_id = %a.id, error = %e, "could not re-insert attachment (note text unaffected)");
+        }
+    }
+}
+
+/// The shared capture core: serialize → insert → **read back and verify** → seal if the source
+/// folder is sealed. Returns the trash entry id.
+///
+/// On ANY verification failure the just-written row is removed and the error is propagated, so the
+/// caller ABORTS its delete with nothing mutated. That ordering is the whole point: the destructive
+/// cascade only ever runs after a proven-good snapshot exists.
+fn store_and_verify<T, F>(
+    state: &AppState,
+    kind: TrashKind,
+    source_id: &str,
+    source_folder_id: Option<&str>,
+    label: &str,
+    snapshot: &T,
+    verify: F,
+) -> Result<String, AppError>
+where
+    T: Serialize + for<'de> Deserialize<'de>,
+    F: FnOnce(&T) -> Option<String>,
+{
+    let payload = serde_json::to_string(snapshot).map_err(|e| {
+        AppError::Storage(format!(
+            "could not snapshot this {} for the trash: {e}",
+            kind.noun()
+        ))
+    })?;
+    let entry_id = uuid::Uuid::new_v4().to_string();
+    let deleted_at = chrono::Utc::now().to_rfc3339();
+
+    // Is the SOURCE folder already sealed? If so this snapshot must be ciphertext from its first
+    // instant — never inserted as plaintext and sealed afterwards, which would leave a crash window
+    // with readable content behind a lock (the reasoning `Db::insert_sealed_folder` documents).
+    let sealed_ck = match source_folder_id {
+        Some(folder_id)
+            if state
+                .db
+                .folder_by_id(folder_id)?
+                .map(|f| f.locked)
+                .unwrap_or(false) =>
+        {
+            // FAIL-CLOSED: no cached KEK ⇒ `AppError::Locked` here, BEFORE anything is written and
+            // before the caller destroys anything. A delete we cannot make an undo for is refused.
+            Some(session_folder_ck(state, folder_id)?)
+        }
+        _ => None,
+    };
+
+    match (&sealed_ck, source_folder_id) {
+        (Some(ck), Some(folder_id)) => {
+            let (label_blob, payload_blob) =
+                sealed_trash_blobs(folder_id, &entry_id, label, &payload, ck)?;
+            state.db.insert_trash_entry_sealed(
+                &entry_id,
+                kind,
+                source_id,
+                source_folder_id,
+                &label_blob,
+                &payload_blob,
+                &deleted_at,
+            )?;
+        }
+        _ => {
+            state.db.insert_trash_entry(
+                &entry_id,
+                kind,
+                source_id,
+                source_folder_id,
+                label,
+                &payload,
+                &deleted_at,
+            )?;
+        }
+    }
+
+    // VERIFY-BEFORE-DESTROY: re-read what SQLCipher actually stored and re-parse it — decrypting
+    // first when the row went in sealed. Checking the in-memory struct would prove nothing about the
+    // row a later restore will actually read.
+    let verified = || -> Result<(), AppError> {
+        let stored = state.db.get_trash_entry(&entry_id)?.ok_or_else(|| {
+            AppError::Storage("the trash snapshot disappeared immediately after writing".into())
+        })?;
+        let stored_payload = match (&sealed_ck, source_folder_id) {
+            (Some(ck), Some(folder_id)) => {
+                let blob = stored.payload_blob.as_deref().ok_or_else(|| {
+                    AppError::Storage("the sealed trash snapshot stored no ciphertext".into())
+                })?;
+                let label_blob = stored.label_blob.as_deref().ok_or_else(|| {
+                    AppError::Storage("the sealed trash label stored no ciphertext".into())
+                })?;
+                // Authenticate BOTH blobs against the real row, not just the payload: a label that
+                // does not decrypt would render as an empty title after the next unlock.
+                decrypt_utf8(
+                    ck,
+                    label_blob,
+                    &aad_trash(folder_id, &entry_id, "label"),
+                    "trash label",
+                )?;
+                decrypt_utf8(
+                    ck,
+                    blob,
+                    &aad_trash(folder_id, &entry_id, "payload"),
+                    "trash snapshot",
+                )?
+            }
+            _ => stored.payload.clone(),
+        };
+        if stored_payload != payload {
+            return Err(AppError::Storage(
+                "the trash snapshot did not store byte-identically".into(),
+            ));
+        }
+        let restored: T = serde_json::from_str(&stored_payload).map_err(|e| {
+            AppError::Storage(format!("the trash snapshot did not parse back: {e}"))
+        })?;
+        if let Some(reason) = verify(&restored) {
+            return Err(AppError::Storage(format!(
+                "refusing to delete this {} — {reason}",
+                kind.noun()
+            )));
+        }
+        Ok(())
+    }();
+
+    if let Err(e) = verified {
+        // Leave nothing half-written. The caller aborts, so the content is still intact.
+        let _ = state.db.delete_trash_entry(&entry_id);
+        return Err(e);
+    }
+
+    tracing::info!(
+        target: "trash",
+        entry_id = %entry_id,
+        kind = kind.as_str(),
+        "captured to trash"
+    );
+    Ok(entry_id)
+}
+
+// ── SEAL LIFECYCLE (the four phases, mirroring the document blob) ────────────────────────────────
+
+/// Encrypt ONE entry's label + payload under `ck`, VERIFY both decrypt back byte-identical, and only
+/// then blank the plaintext columns (verify-before-destroy).
+fn seal_one_trash_entry(
+    db: &Db,
+    folder_id: &str,
+    entry_id: &str,
+    label: &str,
+    payload: &str,
+    ck: &[u8; 32],
+) -> Result<(), AppError> {
+    let (label_blob, payload_blob) = sealed_trash_blobs(folder_id, entry_id, label, payload, ck)?;
+    db.seal_trash_entry(entry_id, &label_blob, &payload_blob)?;
+    Ok(())
+}
+
+/// Encrypt an entry's label + payload and PROVE both decrypt back byte-identical, returning the
+/// blobs. The shared verify step of both seal paths — the birth-seal in [`store_and_verify`] (which
+/// inserts the blobs directly) and [`seal_one_trash_entry`] (which replaces a plaintext row).
+fn sealed_trash_blobs(
+    folder_id: &str,
+    entry_id: &str,
+    label: &str,
+    payload: &str,
+    ck: &[u8; 32],
+) -> Result<(Vec<u8>, Vec<u8>), AppError> {
+    let label_aad = aad_trash(folder_id, entry_id, "label");
+    let payload_aad = aad_trash(folder_id, entry_id, "payload");
+    let label_blob = crate::crypto::encrypt(ck, label.as_bytes(), &label_aad)?;
+    let payload_blob = crate::crypto::encrypt(ck, payload.as_bytes(), &payload_aad)?;
+    if crate::crypto::decrypt(ck, &label_blob, &label_aad)? != label.as_bytes() {
+        return Err(AppError::Storage(
+            "trash label seal verification failed (blob mismatch)".into(),
+        ));
+    }
+    if crate::crypto::decrypt(ck, &payload_blob, &payload_aad)? != payload.as_bytes() {
+        return Err(AppError::Storage(
+            "trash snapshot seal verification failed (blob mismatch)".into(),
+        ));
+    }
+    Ok((label_blob, payload_blob))
+}
+
+/// AAD for a trashed meeting's audio `.enc`. Bound to the TRASH ENTRY (not the meeting id) because
+/// the meeting row is gone: the entry is the only surviving identity, and binding it keeps one
+/// trashed recording's audio from being swapped onto another entry and decrypted there.
+fn aad_trash_audio(folder_id: &str, entry_id: &str, role: &str) -> Vec<u8> {
+    aad_trash(folder_id, entry_id, &format!("audio:{role}"))
+}
+
+/// Seal the on-disk audio of one trashed MEETING and rewrite the snapshot's recorded paths to the
+/// `.enc` forms. Returns the updated payload JSON (unchanged when there was nothing to seal).
+///
+/// # Why this exists
+///
+/// `lock_folder` seals a folder's audio by walking `meeting_ids_in_folder`. A trashed meeting has NO
+/// row, so it is invisible to that walk — which means without this, deleting a recording from an
+/// OPEN folder and locking that folder afterwards would leave the recording's WAV sitting in the
+/// audio directory in PLAINTEXT while the app tells the user the folder is sealed. That is a
+/// regression in an EXISTING lock invariant caused by the trash, not a new seal path, so it is the
+/// trash's job to close it.
+///
+/// `crypto::encrypt_file` carries verify-before-destroy internally (it re-reads the written `.enc`
+/// and decrypts it before returning), so the plaintext is only unlinked after a proven-good
+/// ciphertext exists on disk.
+fn seal_trash_meeting_audio(
+    folder_id: &str,
+    entry_id: &str,
+    payload: &str,
+    ck: &[u8; 32],
+) -> Result<String, AppError> {
+    let mut snapshot: MeetingSnapshot = match serde_json::from_str(payload) {
+        Ok(s) => s,
+        // Not a meeting snapshot (a note/folder entry) — nothing to do.
+        Err(_) => return Ok(payload.to_string()),
+    };
+    let mut changed = false;
+    for (role, slot) in [
+        ("playback", &mut snapshot.audio_path),
+        ("mic", &mut snapshot.mic_master_path),
+        ("sys", &mut snapshot.sys_master_path),
+    ] {
+        let Some(path) = slot.clone() else { continue };
+        if path.ends_with(ENC_SUFFIX) {
+            continue; // already sealed (idempotent repair).
+        }
+        let src = std::path::Path::new(&path);
+        if !src.exists() {
+            continue; // nothing on disk — the snapshot keeps the recorded path as-is.
+        }
+        let enc = format!("{path}{ENC_SUFFIX}");
+        crate::crypto::encrypt_file(
+            ck,
+            src,
+            std::path::Path::new(&enc),
+            &aad_trash_audio(folder_id, entry_id, role),
+        )?;
+        // Only now is the plaintext disposable: `encrypt_file` has already proven the `.enc` on disk
+        // decrypts back byte-identical.
+        crate::crypto::remove_file_verified_absent(src, "remove trashed audio plaintext after seal")?;
+        *slot = Some(enc);
+        changed = true;
+    }
+    if !changed {
+        return Ok(payload.to_string());
+    }
+    serde_json::to_string(&snapshot)
+        .map_err(|e| AppError::Storage(format!("could not re-encode the trash snapshot: {e}")))
+}
+
+/// Decrypt a trashed meeting's `.enc` audio back to plaintext and rewrite the snapshot's paths.
+/// `retain_ciphertext` keeps the `.enc` (session unseal — the folder is still locked on disk) or
+/// drops it (permanent unseal via `remove_lock`).
+fn unseal_trash_meeting_audio(
+    folder_id: &str,
+    entry_id: &str,
+    payload: &str,
+    ck: &[u8; 32],
+    retain_ciphertext: bool,
+) -> Result<String, AppError> {
+    let mut snapshot: MeetingSnapshot = match serde_json::from_str(payload) {
+        Ok(s) => s,
+        Err(_) => return Ok(payload.to_string()),
+    };
+    let mut changed = false;
+    for (role, slot) in [
+        ("playback", &mut snapshot.audio_path),
+        ("mic", &mut snapshot.mic_master_path),
+        ("sys", &mut snapshot.sys_master_path),
+    ] {
+        let Some(enc_path) = slot.clone() else { continue };
+        if !enc_path.ends_with(ENC_SUFFIX) {
+            continue; // already plaintext.
+        }
+        let enc = std::path::Path::new(&enc_path);
+        if !enc.exists() {
+            continue;
+        }
+        let plain = enc_path.trim_end_matches(ENC_SUFFIX).to_string();
+        crate::crypto::decrypt_file(
+            ck,
+            enc,
+            std::path::Path::new(&plain),
+            &aad_trash_audio(folder_id, entry_id, role),
+        )?;
+        if !retain_ciphertext {
+            // Plaintext is durably written above; only then is the ciphertext disposable.
+            let _ = std::fs::remove_file(enc);
+            *slot = Some(plain);
+            changed = true;
+        }
+        // SESSION unseal: the plaintext WAV now exists for playback/restore, but the snapshot keeps
+        // pointing at the `.enc` so a relock has something to re-blank to without re-encrypting.
+    }
+    if !changed {
+        return Ok(payload.to_string());
+    }
+    serde_json::to_string(&snapshot)
+        .map_err(|e| AppError::Storage(format!("could not re-encode the trash snapshot: {e}")))
+}
+
+/// Seal every trash entry anchored to this folder. Called by `seal_folder_extras` — the case where a
+/// snapshot was captured while the folder was OPEN and the user locks the folder afterwards.
+///
+/// Idempotent and repair-safe, exactly like the document loop it mirrors: an already-sealed entry is
+/// AEAD-VERIFIED rather than skipped, because observing a non-NULL blob is not proof the only
+/// surviving copy is decryptable.
+pub(crate) fn seal_trash_in_folder(db: &Db, folder_id: &str, ck: &[u8; 32]) -> Result<(), AppError> {
+    for entry in db.raw_trash_entries_in_folder(folder_id)? {
+        if entry.payload.is_empty() {
+            if let (Some(label_blob), Some(payload_blob)) = (&entry.label_blob, &entry.payload_blob)
+            {
+                crate::crypto::decrypt(ck, label_blob, &aad_trash(folder_id, &entry.id, "label"))?;
+                crate::crypto::decrypt(
+                    ck,
+                    payload_blob,
+                    &aad_trash(folder_id, &entry.id, "payload"),
+                )?;
+            }
+            continue;
+        }
+        // ORDER MATTERS: seal the AUDIO first, because doing so rewrites the recorded paths to their
+        // `.enc` forms — and the payload we then encrypt has to be the one carrying those paths. Seal
+        // the payload first and the ciphertext would preserve the old plaintext pathnames, so an
+        // unseal would look for a WAV that no longer exists.
+        let payload = seal_trash_meeting_audio(folder_id, &entry.id, &entry.payload, ck)?;
+        seal_one_trash_entry(db, folder_id, &entry.id, &entry.label, &payload, ck)?;
+    }
+    Ok(())
+}
+
+/// Decrypt this folder's trash entries back into their plaintext columns FOR THE SESSION, leaving
+/// the blobs intact. Called by `unseal_folder_extras` on a session unlock.
+pub(crate) fn unseal_trash_in_folder(
+    db: &Db,
+    folder_id: &str,
+    ck: &[u8; 32],
+) -> Result<(), AppError> {
+    for entry in db.raw_trash_entries_in_folder(folder_id)? {
+        let (Some(label_blob), Some(payload_blob)) = (&entry.label_blob, &entry.payload_blob) else {
+            continue; // never sealed (captured while open, folder locked after) — nothing to do.
+        };
+        let label = decrypt_utf8(
+            ck,
+            label_blob,
+            &aad_trash(folder_id, &entry.id, "label"),
+            "trash label",
+        )?;
+        let payload = decrypt_utf8(
+            ck,
+            payload_blob,
+            &aad_trash(folder_id, &entry.id, "payload"),
+            "trash snapshot",
+        )?;
+        // Materialize the audio for the session (the `.enc` is KEPT — the folder is still locked on
+        // disk), so a restore during this session gets a playable WAV. Best-effort: a failure here
+        // must not abort the folder unlock, and the snapshot's transcript/notes are already restored.
+        if let Err(e) =
+            unseal_trash_meeting_audio(folder_id, &entry.id, &payload, ck, true)
+        {
+            tracing::warn!(target: "trash", entry_id = %entry.id, error = %e, "trashed audio session-unseal failed (snapshot content unaffected)");
+        }
+        db.set_trash_entry_plaintext(&entry.id, &label, &payload)?;
+    }
+    Ok(())
+}
+
+/// Re-blank this folder's trash plaintext on relock, keeping the blobs. Called by
+/// `reblank_folder_extras`.
+///
+/// Guards on `payload_blob IS NOT NULL` (via [`RawTrashEntry::is_sealed`]) so it can never blank the
+/// ONLY copy of an entry that was never sealed — the same guard the note/document reblank uses.
+pub(crate) fn reblank_trash_in_folder(db: &Db, folder_id: &str) -> Result<(), AppError> {
+    for entry in db.raw_trash_entries_in_folder(folder_id)? {
+        if entry.is_sealed() && entry.label_blob.is_some() {
+            // Drop the session-materialized plaintext WAV before blanking the payload — after the
+            // blank we can no longer read which paths to remove. The `.enc` stays, so nothing is
+            // lost; this only removes the decrypted copy the unlock made.
+            remove_session_trash_audio(&entry.payload);
+            db.set_trash_entry_plaintext(&entry.id, "", "")?;
+        }
+    }
+    Ok(())
+}
+
+/// Remove the session-materialized plaintext WAVs a session-unseal created, leaving every `.enc`.
+/// Best-effort and content-free: the ciphertext is the durable copy, so a failed unlink is disk
+/// residue, never loss. Mirrors `relock_folder` dropping the decrypted session WAV.
+fn remove_session_trash_audio(payload: &str) {
+    let Ok(snapshot) = serde_json::from_str::<MeetingSnapshot>(payload) else {
+        return; // not a meeting entry.
+    };
+    for slot in [
+        &snapshot.audio_path,
+        &snapshot.mic_master_path,
+        &snapshot.sys_master_path,
+    ] {
+        let Some(path) = slot else { continue };
+        // Only ever the PLAINTEXT twin of a recorded `.enc` — never the `.enc` itself.
+        if let Some(plain) = path.strip_suffix(ENC_SUFFIX) {
+            let _ = std::fs::remove_file(plain);
+        }
+    }
+}
+
+/// PERMANENTLY unseal this folder's trash entries — decrypt to plaintext AND drop the ciphertext.
+/// Called by `unseal_folder_extras_permanent` (`remove_lock`), which is also the path
+/// `delete_folder_inner` takes for a sealed folder.
+pub(crate) fn unseal_trash_in_folder_permanent(
+    db: &Db,
+    folder_id: &str,
+    ck: &[u8; 32],
+) -> Result<(), AppError> {
+    for entry in db.raw_trash_entries_in_folder(folder_id)? {
+        if let (Some(label_blob), Some(payload_blob)) = (&entry.label_blob, &entry.payload_blob) {
+            let label = decrypt_utf8(
+                ck,
+                label_blob,
+                &aad_trash(folder_id, &entry.id, "label"),
+                "trash label",
+            )?;
+            let payload = decrypt_utf8(
+                ck,
+                payload_blob,
+                &aad_trash(folder_id, &entry.id, "payload"),
+                "trash snapshot",
+            )?;
+            // The lock is going away for good, so the audio must come back to plaintext AND its
+            // `.enc` must go — otherwise the entry keeps pointing at ciphertext whose key is about
+            // to be destroyed, which is unrecoverable audio loss. This rewrites the recorded paths,
+            // so persist THAT payload, not the one we decrypted.
+            let payload = match unseal_trash_meeting_audio(folder_id, &entry.id, &payload, ck, false)
+            {
+                Ok(updated) => updated,
+                Err(e) => {
+                    // FAIL LOUD: silently keeping the `.enc` here would strand the audio behind a
+                    // key that `remove_lock` is about to discard.
+                    return Err(AppError::Storage(format!(
+                        "could not permanently unseal a trashed recording's audio: {e}"
+                    )));
+                }
+            };
+            // Plaintext FIRST, ciphertext dropped only after it is durably readable — never the
+            // reverse (that ordering is how a crash between the two loses the entry).
+            db.set_trash_entry_plaintext(&entry.id, &label, &payload)?;
+            db.clear_trash_entry_blobs(&entry.id)?;
+        }
+    }
+    Ok(())
+}
+
+fn decrypt_utf8(
+    ck: &[u8; 32],
+    blob: &[u8],
+    aad: &[u8],
+    what: &str,
+) -> Result<String, AppError> {
+    let bytes = crate::crypto::decrypt(ck, blob, aad)?;
+    String::from_utf8(bytes)
+        .map_err(|_| AppError::Storage(format!("{what} did not decrypt to valid UTF-8")))
+}
+
+// ── READ ─────────────────────────────────────────────────────────────────────────────────────────
+
+/// Is this entry readable right now? An entry whose source folder is sealed-and-not-session-unlocked
+/// is MASKED and cannot be restored.
+///
+/// An entry with NO anchor (`source_folder_id: None` — a vault-root meeting, or a top-level
+/// container) is governed by no folder, so it is readable. An entry whose anchor folder row has
+/// VANISHED is also readable — but only when it is not sealed; a sealed entry with a missing anchor
+/// has no reachable key, so it fails closed (see [`entry_is_readable`]).
+fn entry_is_readable(state: &AppState, entry: &RawTrashEntry) -> Result<bool, AppError> {
+    let Some(folder_id) = entry.source_folder_id.as_deref() else {
+        return Ok(true);
+    };
+    match state.db.folder_by_id(folder_id)? {
+        Some(folder) => {
+            if !folder.locked {
+                return Ok(true);
+            }
+            let unlocked = state
+                .unlocked_folders
+                .lock()
+                .map_err(|_| AppError::Storage("unlocked-folders mutex poisoned".into()))?;
+            Ok(unlocked.contains(folder_id))
+        }
+        // Anchor folder is gone. A never-sealed entry is plain content and stays readable; a sealed
+        // one has no key path left, so it must present as locked rather than as empty content.
+        None => Ok(!entry.is_sealed()),
+    }
+}
+
+/// Turn a stored row into the wire DTO, masking when unreadable.
+fn to_dto(state: &AppState, entry: &RawTrashEntry, days: i64) -> Result<TrashEntry, AppError> {
+    let readable = entry_is_readable(state, entry)?;
+    // Belt AND braces: even a "readable" row is masked when its plaintext is blank while ciphertext
+    // exists (an unlock that half-applied). Never surface an empty label as if it were the title.
+    let masked = !readable || (entry.is_sealed() && entry.payload.is_empty());
+    let expiry = expiry_of(&entry.deleted_at, days);
+    let days_left = expiry
+        .map(|e| (e - chrono::Utc::now()).num_days().max(0))
+        .unwrap_or(days);
+    Ok(TrashEntry {
+        id: entry.id.clone(),
+        kind: entry.kind.clone(),
+        source_id: entry.source_id.clone(),
+        source_folder_id: entry.source_folder_id.clone(),
+        label: if masked {
+            LOCKED_LABEL.to_string()
+        } else {
+            entry.label.clone()
+        },
+        deleted_at: entry.deleted_at.clone(),
+        expires_at: expiry
+            .map(|e| e.to_rfc3339())
+            .unwrap_or_else(|| entry.deleted_at.clone()),
+        days_left,
+        locked: masked,
+        detail: if masked {
+            String::new()
+        } else {
+            content_free_detail(entry)
+        },
+    })
+}
+
+/// A CONTENT-FREE one-liner for the row: counts and kinds only, never transcript or note text.
+fn content_free_detail(entry: &RawTrashEntry) -> String {
+    match TrashKind::from_str(&entry.kind) {
+        Some(TrashKind::Meeting) => match serde_json::from_str::<MeetingSnapshot>(&entry.payload) {
+            Ok(s) => {
+                let mut parts = Vec::new();
+                if s.duration_s > 0 {
+                    parts.push(format!("{} min", (s.duration_s + 59) / 60));
+                }
+                parts.push(format!(
+                    "{} segment{}",
+                    s.segments.len(),
+                    if s.segments.len() == 1 { "" } else { "s" }
+                ));
+                if !s.notes.is_empty() {
+                    parts.push(format!(
+                        "{} note{}",
+                        s.notes.len(),
+                        if s.notes.len() == 1 { "" } else { "s" }
+                    ));
+                }
+                if s.audio_path.is_some() {
+                    parts.push("audio".to_string());
+                }
+                parts.join(" · ")
+            }
+            Err(_) => "Recording".to_string(),
+        },
+        Some(TrashKind::Note) => "Note".to_string(),
+        Some(TrashKind::Folder) | Some(TrashKind::NoteFolder) => {
+            match serde_json::from_str::<FolderSnapshot>(&entry.payload) {
+                Ok(s) => {
+                    let n = s.meeting_ids.len() + s.note_ids.len();
+                    if n == 0 {
+                        "Empty folder".to_string()
+                    } else {
+                        format!("{n} item{}", if n == 1 { "" } else { "s" })
+                    }
+                }
+                Err(_) => "Folder".to_string(),
+            }
+        }
+        None => String::new(),
+    }
+}
+
+// ── COMMANDS ─────────────────────────────────────────────────────────────────────────────────────
+
+/// Everything in the trash, newest deletion first. Sealed-and-not-unlocked entries come back MASKED
+/// (`locked: true`, `label: "🔒 Locked"`, empty `detail`) — the same contract as
+/// `get_meeting_detail`.
+#[tauri::command]
+pub fn list_trash(state: State<'_, AppState>) -> Result<Vec<TrashEntry>, AppError> {
+    list_trash_inner(state.inner())
+}
+
+/// Inner of [`list_trash`] taking `&AppState`, so the masking oracle drives the REAL gate rather
+/// than a reimplementation of it.
+pub(crate) fn list_trash_inner(state: &AppState) -> Result<Vec<TrashEntry>, AppError> {
+    let days = retention_days(state);
+    let mut out = Vec::new();
+    for entry in state.db.list_trash_entries()? {
+        out.push(to_dto(state, &entry, days)?);
+    }
+    Ok(out)
+}
+
+/// How many entries are in the trash — the sidebar badge. Cheap; no payloads read.
+#[tauri::command]
+pub fn count_trash(state: State<'_, AppState>) -> Result<i64, AppError> {
+    Ok(state.inner().db.count_trash_entries()?)
+}
+
+/// The live retention window in days.
+#[tauri::command]
+pub fn get_trash_retention_days(state: State<'_, AppState>) -> Result<i64, AppError> {
+    Ok(retention_days(state.inner()))
+}
+
+/// Set the retention window. Applies to entries ALREADY in the trash (expiry is computed from the
+/// live setting), so shortening it can make items purge on the next tick — which is why the FE
+/// confirms the change.
+#[tauri::command]
+pub fn set_trash_retention_days(state: State<'_, AppState>, days: i64) -> Result<(), AppError> {
+    if !(MIN_TRASH_RETENTION_DAYS..=MAX_TRASH_RETENTION_DAYS).contains(&days) {
+        return Err(AppError::InvalidArg(format!(
+            "retention must be between {MIN_TRASH_RETENTION_DAYS} and {MAX_TRASH_RETENTION_DAYS} days"
+        )));
+    }
+    state
+        .inner()
+        .db
+        .set_setting(TRASH_RETENTION_KEY, &days.to_string())?;
+    Ok(())
+}
+
+/// Restore one entry: put the content back and drop the trash row.
+///
+/// REFUSED with `AppError::Locked` when the entry is masked — restoring would have to write the
+/// snapshot's plaintext into rows the lock is currently protecting.
+#[tauri::command]
+pub async fn restore_trash_item(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    entry_id: String,
+) -> Result<(), AppError> {
+    let st = state.inner();
+    restore_trash_item_inner(st, &entry_id).await?;
+    emit_trash_updated(&app, st);
+    Ok(())
+}
+
+/// Inner of [`restore_trash_item`] taking `&AppState` — the FULL body (gate + lifecycle guard +
+/// per-kind restore + entry consumption), so the round-trip oracles bind the COMMAND behavior and
+/// not just the per-kind helpers.
+pub(crate) async fn restore_trash_item_inner(
+    st: &AppState,
+    entry_id: &str,
+) -> Result<(), AppError> {
+    let entry_id = entry_id.to_string();
+    let entry = match st.db.get_trash_entry(&entry_id)? {
+        Some(e) => e,
+        None => return Ok(()), // already restored/purged elsewhere — idempotent.
+    };
+    if !entry_is_readable(st, &entry)? || entry.payload.is_empty() {
+        return Err(AppError::Locked(
+            "unlock this item's folder before restoring it from the trash".into(),
+        ));
+    }
+    let kind = TrashKind::from_str(&entry.kind)
+        .ok_or_else(|| AppError::Storage(format!("unknown trash kind {}", entry.kind)))?;
+
+    // GUARD SCOPING is per-kind, and deliberately so — the lifecycle mutex is a NON-REENTRANT std
+    // Mutex, so who holds it decides which helpers are callable:
+    //   * meeting/note restore run UNDER it (serialized against a concurrent lock/relock landing
+    //     mid-restore) and therefore must use the `_under_lifecycle_authorized` export seam;
+    //   * folder restore must NOT hold it, because it re-files members through
+    //     `move_note_doc_inner`, which takes the guard itself for its own double-gate.
+    // Holding it across the whole match, as this first did, self-deadlocked both ways.
+    match kind {
+        TrashKind::Meeting => {
+            let _lifecycle = lifecycle_guard(st);
+            restore_meeting(st, &entry.payload)?;
+        }
+        TrashKind::Note => {
+            let _lifecycle = lifecycle_guard(st);
+            restore_note(st, &entry.payload)?;
+        }
+        TrashKind::Folder | TrashKind::NoteFolder => restore_folder(st, &entry.payload)?,
+    }
+
+    st.db.delete_trash_entry(&entry_id)?;
+    bump_seal_epoch(st);
+    tracing::info!(target: "trash", entry_id = %entry_id, kind = kind.as_str(), "restored from trash");
+    Ok(())
+}
+
+/// Permanently destroy one entry — the trash row AND the content it was holding for restore. This is
+/// the delete the original `delete_*` command used to do inline.
+#[tauri::command]
+pub async fn delete_trash_item_forever(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    entry_id: String,
+) -> Result<(), AppError> {
+    let st = state.inner();
+    purge_one(st, &entry_id, Some(&app)).await?;
+    emit_trash_updated(&app, st);
+    Ok(())
+}
+
+/// Permanently destroy EVERY entry. Entries that are masked (sealed source folder) are LEFT BEHIND
+/// and reported, not force-destroyed: purging one means decrypting its payload to find the files it
+/// owns, which the lock forbids. Returns how many were purged.
+#[tauri::command]
+pub async fn empty_trash(app: AppHandle, state: State<'_, AppState>) -> Result<i64, AppError> {
+    let st = state.inner();
+    let mut purged = 0i64;
+    let mut skipped = 0i64;
+    for entry in st.db.list_trash_entries()? {
+        if !entry_is_readable(st, &entry)? || entry.payload.is_empty() {
+            skipped += 1;
+            continue;
+        }
+        match purge_one(st, &entry.id, Some(&app)).await {
+            Ok(()) => purged += 1,
+            Err(e) => {
+                tracing::warn!(target: "trash", entry_id = %entry.id, error = %e, "purge failed during empty-trash");
+                skipped += 1;
+            }
+        }
+    }
+    if skipped > 0 {
+        tracing::info!(target: "trash", purged, skipped, "empty-trash left locked entries behind");
+    }
+    emit_trash_updated(&app, st);
+    Ok(purged)
+}
+
+/// Purge every EXPIRED entry now. Called by the background tick and available to the FE so the
+/// Trash view can reconcile on open instead of waiting up to an hour.
+#[tauri::command]
+pub async fn purge_expired_trash(app: AppHandle, state: State<'_, AppState>) -> Result<i64, AppError> {
+    let st = state.inner();
+    let purged = purge_expired(st, Some(&app)).await?;
+    if purged > 0 {
+        emit_trash_updated(&app, st);
+    }
+    Ok(purged)
+}
+
+// ── PURGE ────────────────────────────────────────────────────────────────────────────────────────
+
+/// Purge every entry past its retention. Shared by the command and the background tick.
+///
+/// Fails SOFT per entry (warn + continue): one undeletable file must not wedge the whole purge, and
+/// a masked entry is SKIPPED — it is left for the user to handle after unlocking, because purging it
+/// would require reading a payload the lock is protecting. That means a locked folder can hold
+/// expired entries past their date; keeping the lock's promise is worth more than the schedule.
+pub async fn purge_expired(
+    state: &AppState,
+    app: Option<&AppHandle>,
+) -> Result<i64, AppError> {
+    let days = retention_days(state);
+    let now = chrono::Utc::now();
+    let mut purged = 0i64;
+    for entry in state.db.list_trash_entries()? {
+        // An undateable `deleted_at` yields None ⇒ never expires. Fail closed: keep the content.
+        let Some(expiry) = expiry_of(&entry.deleted_at, days) else {
+            tracing::warn!(target: "trash", entry_id = %entry.id, "unparseable deleted_at — never purging");
+            continue;
+        };
+        if expiry > now {
+            continue;
+        }
+        if !entry_is_readable(state, &entry)? || entry.payload.is_empty() {
+            continue; // sealed — the lock outranks the schedule.
+        }
+        match purge_one(state, &entry.id, app).await {
+            Ok(()) => purged += 1,
+            Err(e) => {
+                tracing::warn!(target: "trash", entry_id = %entry.id, error = %e, "expired purge failed");
+            }
+        }
+    }
+    if purged > 0 {
+        tracing::info!(target: "trash", purged, retention_days = days, "purged expired trash");
+    }
+    Ok(purged)
+}
+
+/// TEST-ONLY alias for [`purge_one`] so the audio-lifetime oracle can drive the real purge.
+#[cfg(test)]
+pub(crate) async fn purge_one_for_test(state: &AppState, entry_id: &str) -> Result<(), AppError> {
+    purge_one(state, entry_id, None).await
+}
+
+/// Destroy ONE entry's content and its row. The entry must already be proven readable.
+async fn purge_one(
+    state: &AppState,
+    entry_id: &str,
+    app: Option<&AppHandle>,
+) -> Result<(), AppError> {
+    let Some(entry) = state.db.get_trash_entry(entry_id)? else {
+        return Ok(());
+    };
+    let kind = TrashKind::from_str(&entry.kind)
+        .ok_or_else(|| AppError::Storage(format!("unknown trash kind {}", entry.kind)))?;
+    match kind {
+        TrashKind::Meeting => {
+            // The meeting's rows are already gone; what survives is its audio on disk. Remove every
+            // on-disk form (plaintext WAV, `.enc` twin, masters) exactly as the pre-trash
+            // `delete_meeting` did.
+            if let Ok(s) = serde_json::from_str::<MeetingSnapshot>(&entry.payload) {
+                remove_meeting_audio_files(s.audio_path.as_deref());
+                remove_meeting_audio_files(s.mic_master_path.as_deref());
+                remove_meeting_audio_files(s.sys_master_path.as_deref());
+            }
+        }
+        TrashKind::Note => {
+            // The document row and its vault `.md` are already gone (the delete removed both).
+        }
+        TrashKind::Folder | TrashKind::NoteFolder => {
+            // The folder row is already gone and its contents were rehomed, never destroyed. What
+            // remains is any member snapshot still anchored to this now-unrestorable folder: it must
+            // be re-anchored to the folder's PARENT so it does not keep a dangling anchor.
+            if let Ok(s) = serde_json::from_str::<FolderSnapshot>(&entry.payload) {
+                let moved = state
+                    .db
+                    .reanchor_trash_entries(&s.id, s.parent_id.as_deref())?;
+                if moved > 0 {
+                    tracing::info!(target: "trash", folder_id = %s.id, moved, "re-anchored trash entries after folder purge");
+                }
+            }
+        }
+    }
+    state.db.delete_trash_entry(entry_id)?;
+    if let Some(app) = app {
+        crate::events::emit_content_deleted(app, kind.as_str(), &entry.source_id);
+    }
+    tracing::info!(target: "trash", entry_id = %entry_id, kind = kind.as_str(), "purged permanently");
+    Ok(())
+}
+
+// ── RESTORE ──────────────────────────────────────────────────────────────────────────────────────
+
+/// Re-insert a meeting and everything the snapshot carried, then re-derive its indexes best-effort.
+fn restore_meeting(state: &AppState, payload: &str) -> Result<(), AppError> {
+    let s: MeetingSnapshot = parse_snapshot(payload)?;
+    if state.db.get_meeting(&s.id)?.is_some() {
+        return Err(AppError::InvalidArg(
+            "a recording with this id already exists — nothing to restore".into(),
+        ));
+    }
+    // The snapshot's folder may have been deleted meanwhile. Restore to the vault ROOT rather than
+    // failing: getting the recording back matters more than getting its filing back, and an
+    // unfiled recording is a state the app already handles everywhere.
+    let folder_id = match s.folder_id.as_deref() {
+        Some(fid) if state.db.folder_by_id(fid)?.is_some() => Some(fid.to_string()),
+        Some(fid) => {
+            tracing::info!(target: "trash", meeting_id = %s.id, missing_folder = %fid, "restoring to vault root — original folder is gone");
+            None
+        }
+        None => None,
+    };
+    // Refuse to write plaintext into a folder that is sealed and not unlocked this session.
+    if let Some(fid) = folder_id.as_deref() {
+        if !folder_is_unlocked(state, fid)? {
+            return Err(AppError::Locked(
+                "unlock the destination folder before restoring this recording".into(),
+            ));
+        }
+    }
+
+    // The delete opened an org-source CLOSURE on this id, and the `closing_*_guard` triggers abort
+    // every write to a closing source — including the ones this restore is about to make. Retire it
+    // first: the id is coming back to life, which is the one case the closure was not written for.
+    // Safe because the delete already revoked every live org share (revoke-before-delete), so no
+    // server item survives for the sync tick to re-pull.
+    state.db.clear_org_source_closure("meeting", &s.id)?;
+
+    let meeting = crate::storage::Meeting {
+        id: s.id.clone(),
+        started_at: s.started_at.clone(),
+        ended_at: s.ended_at.clone(),
+        title: s.title.clone(),
+        duration_s: s.duration_s,
+        audio_path: s.audio_path.clone(),
+        status: s.status.parse()?,
+        folder_id: folder_id.clone(),
+    };
+    state.db.insert_meeting(&meeting)?;
+    if let Some(fid) = folder_id.as_deref() {
+        state.db.set_meeting_folder(&s.id, Some(fid))?;
+    }
+
+    let segments: Vec<crate::transcribe::types::Segment> = s
+        .segments
+        .iter()
+        .map(|x| crate::transcribe::types::Segment {
+            idx: x.idx,
+            start_s: x.start_s,
+            end_s: x.end_s,
+            text: x.text.clone(),
+            speaker: x.speaker.clone(),
+            confidence: x.confidence,
+        })
+        .collect();
+    if !segments.is_empty() {
+        state.db.insert_segments(&s.id, &segments)?;
+    }
+    for n in &s.notes {
+        state.db.upsert_note(&crate::storage::NoteRecord {
+            meeting_id: s.id.clone(),
+            provider_id: n.provider_id.clone(),
+            markdown: n.markdown.clone(),
+            created_at: n.created_at.clone(),
+            exported_path: None, // re-established by the re-export below.
+            ..Default::default()
+        })?;
+    }
+    if let Some(timeline) = &s.timeline {
+        state.db.set_timeline_data(&s.id, timeline)?;
+    }
+    if !s.manual_notes.is_empty() {
+        state.db.set_manual_notes(&s.id, &s.manual_notes)?;
+    }
+    if !s.tags.is_empty() {
+        state.db.set_meeting_tags(&s.id, &s.tags)?;
+    }
+    if let Some(p) = &s.mic_master_path {
+        let _ = state.db.set_meeting_mic_master_path(&s.id, Some(p));
+    }
+    if let Some(p) = &s.sys_master_path {
+        let _ = state.db.set_meeting_sys_master_path(&s.id, Some(p));
+    }
+
+    // Inline images, per provider note. These cascade-deleted with the `notes` rows, so the snapshot
+    // is their only copy — restore them BEFORE the vault re-export, so the exported `.md` is written
+    // against images that already exist.
+    restore_attachments(
+        state,
+        |a| {
+            a.provider_id
+                .as_ref()
+                .map(|provider_id| crate::storage::AttachmentOwner::Meeting {
+                    meeting_id: s.id.clone(),
+                    provider_id: provider_id.clone(),
+                })
+        },
+        &s.attachments,
+    );
+
+    // Derived state: re-export the vault `.md` and re-derive chunks/vectors. Best-effort BY DESIGN —
+    // the canonical rows are already back, so a failure here degrades search/Obsidian, never content.
+    // NOT `export_note_to_vault`: that takes the lifecycle guard itself, and the caller
+    // (`restore_trash_item_inner`) already holds it. The guard is a non-reentrant std Mutex, so
+    // calling the guard-taking variant here SELF-DEADLOCKS — the authorized variant is exactly the
+    // seam for a caller that already owns the mutex.
+    if let Err(e) = export_note_to_vault_under_lifecycle_authorized(state, &s.id) {
+        tracing::warn!(target: "trash", meeting_id = %s.id, error = %e, "re-export after restore failed");
+    }
+    let embedder = crate::embed::active_persistence_embedder_if_available();
+    reindex_meeting_after_edit(state, &s.id, embedder.as_deref());
+    Ok(())
+}
+
+/// Re-insert an authored note, then re-export + re-index best-effort.
+fn restore_note(state: &AppState, payload: &str) -> Result<(), AppError> {
+    let s: NoteSnapshot = parse_snapshot(payload)?;
+    if state.db.get_note_row(&s.id)?.is_some() {
+        return Err(AppError::InvalidArg(
+            "a note with this id already exists — nothing to restore".into(),
+        ));
+    }
+    // The note's folder may be gone; fall back to the notes root, which always exists.
+    let folder_id = if state.db.folder_by_id(&s.folder_id)?.is_some() {
+        s.folder_id.clone()
+    } else {
+        let root = state.db.ensure_notes_root()?;
+        tracing::info!(target: "trash", note_id = %s.id, missing_folder = %s.folder_id, "restoring to notes root — original folder is gone");
+        root
+    };
+    if !folder_is_unlocked(state, &folder_id)? {
+        return Err(AppError::Locked(
+            "unlock the destination folder before restoring this note".into(),
+        ));
+    }
+
+    // Same closure retirement as the meeting restore — see the comment there.
+    state.db.clear_org_source_closure("document", &s.id)?;
+
+    let title = s.title.clone().unwrap_or_else(|| s.name.clone());
+    state.db.insert_note(
+        &s.id,
+        &folder_id,
+        &s.name,
+        &title,
+        &s.text,
+        s.created_at,
+    )?;
+    // A restore into a SEALED (session-unlocked) folder must not leave plaintext at rest — re-seal
+    // it through the same helper every authored-note write path uses.
+    let now = chrono::Utc::now().timestamp_millis();
+    reseal_document_if_locked(state, &folder_id, &s.id, &title, &s.text, now)?;
+
+    // Inline images before the export, so the `.md` is written against images that exist.
+    restore_attachments(
+        state,
+        |_| {
+            Some(crate::storage::AttachmentOwner::Document {
+                document_id: s.id.clone(),
+            })
+        },
+        &s.attachments,
+    );
+
+    // The authorized variant — the caller already holds the non-reentrant lifecycle guard. See the
+    // note in `restore_meeting`.
+    if let Err(e) = export_note_to_vault_under_lifecycle_authorized(state, &s.id) {
+        tracing::warn!(target: "trash", note_id = %s.id, error = %e, "re-export after restore failed");
+    }
+    // KIND-ROUTED so a note is chunked from its BODY (front-matter stripped), never the raw `text` —
+    // the same seam every other note-index path goes through.
+    let embedder = crate::embed::active_persistence_embedder_if_available();
+    if let Err(e) = index_document_row_kind_routed(&state.db, &s.id, embedder.as_deref()) {
+        tracing::warn!(target: "trash", note_id = %s.id, error = %e, "re-index after restore failed");
+    }
+    Ok(())
+}
+
+/// Recreate a container and move its recorded members back into it.
+fn restore_folder(state: &AppState, payload: &str) -> Result<(), AppError> {
+    let s: FolderSnapshot = parse_snapshot(payload)?;
+    if state.db.folder_by_id(&s.id)?.is_some() {
+        return Err(AppError::InvalidArg(
+            "a folder with this id already exists — nothing to restore".into(),
+        ));
+    }
+    // The parent may itself have been deleted. Restore at the ROOT rather than failing — the user
+    // can move it back, and refusing would strand the folder in the trash forever.
+    let parent_id = match s.parent_id.as_deref() {
+        Some(pid) if state.db.folder_by_id(pid)?.is_some() => Some(pid.to_string()),
+        Some(pid) => {
+            tracing::info!(target: "trash", folder_id = %s.id, missing_parent = %pid, "restoring at root — original parent is gone");
+            None
+        }
+        None => None,
+    };
+    // Restoring INTO a sealed parent would create an open container inside a sealed one — the exact
+    // state the container-creation gate exists to prevent. Refuse and let the user unlock first.
+    if let Some(pid) = parent_id.as_deref() {
+        if !folder_is_unlocked(state, pid)? {
+            return Err(AppError::Locked(
+                "unlock the parent folder before restoring this folder".into(),
+            ));
+        }
+    }
+
+    // A `path` collision means the user recreated a folder with the same name meanwhile. Restore
+    // under a suffixed path rather than failing the UNIQUE constraint.
+    let path = unique_folder_path(state, &s.path)?;
+    // `presentation` was captured with the row; a snapshot written before those columns existed
+    // falls back to the same defaults the migration uses, so an old entry still restores.
+    let presentation = s.presentation.clone().unwrap_or_else(|| {
+        crate::storage::trash_store::FolderPresentation {
+            kind: s.kind.clone(),
+            level: "folder".to_string(),
+            is_root: false,
+            emoji: None,
+            tint: None,
+            position: 0,
+        }
+    });
+    state.db.insert_restored_folder(
+        &s.id,
+        &s.name,
+        &path,
+        parent_id.as_deref(),
+        &s.created_at,
+        &presentation,
+    )?;
+
+    // Move the members back — each best-effort and individually gated: a member that has since been
+    // deleted, re-filed, or locked must not abort the whole restore.
+    for mid in &s.meeting_ids {
+        if state.db.get_meeting(mid)?.is_none() {
+            continue;
+        }
+        if let Err(e) = state.db.set_meeting_folder(mid, Some(&s.id)) {
+            tracing::warn!(target: "trash", meeting_id = %mid, error = %e, "could not re-file meeting on folder restore");
+        }
+    }
+    for nid in &s.note_ids {
+        match state.db.get_note_row(nid) {
+            Ok(Some(_)) => {
+                if let Err(e) = move_note_doc_inner(state, nid, &s.id) {
+                    tracing::warn!(target: "trash", note_id = %nid, error = %e, "could not re-file note on folder restore");
+                }
+            }
+            _ => continue,
+        }
+    }
+    Ok(())
+}
+
+/// Parse a snapshot, refusing a version this binary does not understand rather than guessing.
+fn parse_snapshot<T: for<'de> Deserialize<'de>>(payload: &str) -> Result<T, AppError> {
+    serde_json::from_str(payload).map_err(|e| {
+        AppError::Storage(format!(
+            "this trash snapshot could not be read back (it may come from a newer version): {e}"
+        ))
+    })
+}
+
+/// Find a free vault path for a restored folder: `p`, else `p (restored)`, else `p (restored 2)`…
+/// Bounded so a pathological collision loop cannot spin.
+fn unique_folder_path(state: &AppState, path: &str) -> Result<String, AppError> {
+    if state.db.folder_by_path(path)?.is_none() {
+        return Ok(path.to_string());
+    }
+    for n in 1..=50 {
+        let candidate = if n == 1 {
+            format!("{path} (restored)")
+        } else {
+            format!("{path} (restored {n})")
+        };
+        if state.db.folder_by_path(&candidate)?.is_none() {
+            return Ok(candidate);
+        }
+    }
+    Err(AppError::Storage(
+        "could not find a free vault path for the restored folder".into(),
+    ))
+}
+
+// ── EVENTS ───────────────────────────────────────────────────────────────────────────────────────
+
+/// Tell any open surface the trash changed, carrying only the COUNT (never a label or payload) so
+/// the sidebar badge and the Trash view refetch through the gated read.
+fn emit_trash_updated(app: &AppHandle, state: &AppState) {
+    let count = state.db.count_trash_entries().unwrap_or(0);
+    crate::events::emit_trash_updated(app, count);
+}

--- a/src-tauri/src/commands/trash.rs
+++ b/src-tauri/src/commands/trash.rs
@@ -1202,7 +1202,7 @@ pub(crate) fn list_trash_inner(state: &AppState) -> Result<Vec<TrashEntry>, AppE
 /// How many entries are in the trash — the sidebar badge. Cheap; no payloads read.
 #[tauri::command]
 pub fn count_trash(state: State<'_, AppState>) -> Result<i64, AppError> {
-    Ok(state.inner().db.count_trash_entries()?)
+    state.inner().db.count_trash_entries()
 }
 
 /// The live retention window in days.

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -624,6 +624,11 @@ impl OrgFeedNotifier for AppHandle {
 /// kind discriminator only — never a title or any other content.
 pub const EVENT_CONTENT_DELETED: &str = "murmur://content-deleted";
 
+/// The trash changed — something was moved in, restored, or purged. CONTENT-FREE: carries only the
+/// entry COUNT, so the sidebar badge updates without any surface learning a label or payload. Every
+/// consumer refetches through the gated `list_trash`, which masks a sealed entry.
+pub const EVENT_TRASH_UPDATED: &str = "murmur://trash-updated";
+
 /// Payload for [`EVENT_CONTENT_DELETED`]. `kind` is `"note"` | `"meeting"`; `id` is the deleted note's
 /// or meeting's id (an opaque identifier, not content).
 #[derive(Debug, Clone, Serialize)]
@@ -924,6 +929,26 @@ mod tests {
         assert_eq!(
             json,
             r#"{"documentId":"d1","stage":"done","done":0,"total":0,"truncated":true}"#
+        );
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrashUpdatedPayload {
+    /// How many entries the trash now holds. NOT a list — no label, no payload, no ids.
+    pub count: i64,
+}
+
+/// Emit [`EVENT_TRASH_UPDATED`] to the FE (best-effort). Swallows the emit failure with a
+/// `tracing::warn!` so a failed emit can NEVER turn a successful trash/restore/purge into a
+/// reported failure. NO PII (a count only).
+pub fn emit_trash_updated(app: &AppHandle, count: i64) {
+    if let Err(e) = app.emit(EVENT_TRASH_UPDATED, TrashUpdatedPayload { count }) {
+        tracing::warn!(
+            target: "trash",
+            error = %e,
+            "failed to emit trash-updated notice"
         );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -371,6 +371,16 @@ pub fn run() {
             commands::list_meetings,
             commands::search_meetings,
             commands::delete_meeting,
+            // TRASH — the 30-day recoverable holding area. `delete_meeting` / `delete_note` /
+            // `delete_folder` / `delete_note_folder` now route content HERE instead of destroying it.
+            commands::list_trash,
+            commands::count_trash,
+            commands::restore_trash_item,
+            commands::delete_trash_item_forever,
+            commands::empty_trash,
+            commands::purge_expired_trash,
+            commands::get_trash_retention_days,
+            commands::set_trash_retention_days,
             commands::rename_meeting,
             commands::chat_meeting,
             commands::chat_meeting_persisted,
@@ -1052,6 +1062,38 @@ pub fn run() {
                             crate::commands::ORG_SYNC_TICK_SECS,
                         ))
                         .await;
+                    }
+                });
+            }
+            // TRASH — the expired-entry purge loop. Rides the same shape as the memory/brief loops:
+            // re-reads live AppState each tick, warns-and-continues on any failure, never exits, and
+            // the FIRST tick is a full interval after launch (so a cold start is never competing with
+            // it). Cheap and quiet when the trash is empty. A SEALED entry is skipped by
+            // `purge_expired` rather than force-purged — the lock outranks the schedule, so a locked
+            // folder can hold expired entries past their date until the user unlocks it.
+            {
+                let handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    loop {
+                        tokio::time::sleep(std::time::Duration::from_secs(
+                            crate::commands::TRASH_PURGE_TICK_SECS,
+                        ))
+                        .await;
+                        if let Some(state) = handle.try_state::<AppState>() {
+                            match crate::commands::purge_expired(state.inner(), Some(&handle)).await
+                            {
+                                Ok(n) if n > 0 => {
+                                    crate::events::emit_trash_updated(
+                                        &handle,
+                                        state.inner().db.count_trash_entries().unwrap_or(0),
+                                    );
+                                }
+                                Ok(_) => {}
+                                Err(e) => {
+                                    tracing::warn!(target: "trash", error = %e, "expired-trash purge tick failed");
+                                }
+                            }
+                        }
                     }
                 });
             }

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -1585,6 +1585,13 @@ impl Db {
         // re-gated at read time (`visibility_clause` / `meeting_is_unlocked`), so a board can
         // never become an ungated back door into a sealed folder.
         Self::migrate_dashboards(&conn)?;
+        // Trash — the 30-day recoverable holding area. Additive + guarded. Runs last for the same
+        // reason as dashboards: an entry's `source_folder_id` anchors to `folders`, so that table
+        // must already exist. NOTHING here is a second copy of live content — a row appears only
+        // when the user deletes something, and it is governed by its source folder's lock
+        // (`commands::trash::seal_trash_in_folder`), so it can never become an ungated back door
+        // into a sealed folder.
+        Self::migrate_trash(&conn)?;
         conn.commit().map_err(map_err)?;
         Ok(())
     }

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod reminder_store;
 pub(crate) mod seal_store;
 pub(crate) mod settings_store;
 pub(crate) mod tasks_store;
+pub(crate) mod trash_store;
 pub mod usage;
 pub(crate) mod workspace_store;
 

--- a/src-tauri/src/storage/org_store.rs
+++ b/src-tauri/src/storage/org_store.rs
@@ -176,7 +176,18 @@ impl Db {
         Ok(())
     }
 
-    #[cfg(test)]
+    /// Retire a source's closure record, making that id WRITABLE again.
+    ///
+    /// The closure exists so a teardown cannot race a concurrent write and so the org-sync tick can
+    /// never re-pull an item the user deleted. It is keyed on the source ID, and the delete path
+    /// leaves it in place — correct while the id is gone for good.
+    ///
+    /// TRASH RESTORE is the one case where a "deleted" id legitimately comes BACK, and the closure
+    /// then blocks the restore outright (`RAISE(ABORT,'meeting source is closing')` from the
+    /// `closing_*_guard` triggers). Clearing it is safe precisely because the delete already
+    /// REVOKED every live org share before destroying the rows (revoke-before-delete), so there is
+    /// no live server item left for the sync tick to re-pull: the restored content is local-only and
+    /// unshared until the user publishes it again.
     pub(crate) fn clear_org_source_closure(
         &self,
         source_kind: &str,

--- a/src-tauri/src/storage/trash_store.rs
+++ b/src-tauri/src/storage/trash_store.rs
@@ -1,0 +1,528 @@
+//! Trash storage — the 30-day recoverable holding area for user-deleted content.
+//!
+//! # Why a SNAPSHOT table and not a `deleted_at` column
+//!
+//! The obvious soft-delete (`meetings.deleted_at IS NULL` on every read) was measured and REJECTED:
+//! `src-tauri/src/` carries 455 SQL references to `meetings` / `documents` / `folders`, and a
+//! trashed item must also vanish from every DERIVED surface — FTS, the vec0 partitions, the entity
+//! graph, analytics aggregates, Ask retrieval and the MCP server. Missing ONE of those predicates
+//! is a leak-class bug of exactly the shape `lock-model.md` exists to prevent: content the user
+//! was told is deleted, still answering questions.
+//!
+//! So trash keeps the EXISTING, already-proven hard-delete cascade (rows genuinely go away, so
+//! every derived read is correct for free) and captures a complete restorable SNAPSHOT first. The
+//! risk this trades into is content LOSS on restore, and that is answered with the discipline the
+//! repo already uses for sealing: **verify-before-destroy**. [`Db::insert_trash_entry`] stores the
+//! payload and the caller re-reads and re-parses it BEFORE the destructive cascade runs; a snapshot
+//! that does not verify REFUSES the delete rather than losing the content.
+//!
+//! # Lock model
+//!
+//! A snapshot holds PLAINTEXT content, so it is governed by the same folder lock as the content it
+//! came from — see `commands::trash` for the two halves:
+//!
+//! 1. **At capture.** Deleting is already refused for a sealed-and-not-session-unlocked item, so
+//!    everything entering trash is readable plaintext. When the SOURCE folder is sealed (`locked=1`,
+//!    session-unlocked — the only way the delete was permitted), the payload is sealed under that
+//!    folder's CK immediately, so it is never at rest in plaintext.
+//! 2. **On a later lock.** A snapshot captured from an OPEN folder that is locked afterwards is
+//!    sealed by `seal_folder_extras`, exactly like a note/transcript/document blob, and restored by
+//!    `unlock_folder` / re-blanked by `relock_folder` / decrypted by `remove_lock`.
+//!
+//! `label` is the display title and is sealed alongside `payload`: a locked entry renders as
+//! "🔒 Locked" with no title, mirroring the masked meeting DTO.
+
+use rusqlite::OptionalExtension;
+
+use crate::error::Result;
+use crate::storage::db::{map_err, Db};
+
+/// Default retention before an entry is permanently purged. Overridable via the
+/// `trash_retention_days` setting; see `commands::trash::trash_retention_days`.
+pub const DEFAULT_TRASH_RETENTION_DAYS: i64 = 30;
+/// Bounds for the retention setting. `1` keeps the feature meaningful (a same-day undo) and `365`
+/// keeps an unbounded snapshot table from becoming a silent second copy of the whole vault.
+pub const MIN_TRASH_RETENTION_DAYS: i64 = 1;
+pub const MAX_TRASH_RETENTION_DAYS: i64 = 365;
+
+/// Hard bound on one `list_trash` response — the view is a recovery surface, not a browse-everything
+/// list, and an unbounded read of snapshot payloads is a heap risk (a payload carries a meeting's
+/// whole transcript).
+pub(crate) const TRASH_LIST_LIMIT: i64 = 500;
+
+/// What kind of entity a trash entry restores. The wire value is the camelCase discriminator the FE
+/// switches on; `as_str`/`from_str` are the ONLY conversion (never an ad-hoc string literal at a
+/// call site).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrashKind {
+    /// A recording: the `meetings` row + segments + provider notes + timeline + manual notes + tags.
+    /// Its audio files are deliberately LEFT ON DISK by the capture path and removed only on purge.
+    Meeting,
+    /// An authored note (`documents` with `kind='note'`).
+    Note,
+    /// A meeting folder (`folders` with `kind != 'note'`).
+    Folder,
+    /// A note folder (`folders` with `kind = 'note'`).
+    NoteFolder,
+}
+
+impl TrashKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TrashKind::Meeting => "meeting",
+            TrashKind::Note => "note",
+            TrashKind::Folder => "folder",
+            TrashKind::NoteFolder => "noteFolder",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "meeting" => Some(TrashKind::Meeting),
+            "note" => Some(TrashKind::Note),
+            "folder" => Some(TrashKind::Folder),
+            "noteFolder" => Some(TrashKind::NoteFolder),
+            _ => None,
+        }
+    }
+
+    /// Human label for a refusal/toast message. Not a wire value.
+    pub fn noun(self) -> &'static str {
+        match self {
+            TrashKind::Meeting => "recording",
+            TrashKind::Note => "note",
+            TrashKind::Folder => "folder",
+            TrashKind::NoteFolder => "note folder",
+        }
+    }
+}
+
+/// One trash row as stored — BOTH seal states, exactly like [`crate::storage::db::RawDocument`].
+/// `payload`/`label` are the plaintext columns (blank while sealed); `payload_blob`/`label_blob`
+/// hold the AES-GCM ciphertext under the source folder's CK (present while sealed).
+///
+/// The command layer decides masking from the LIVE session unlock set — never from `payload_blob`
+/// being present, which only says the folder is or WAS locked.
+#[derive(Debug, Clone)]
+pub struct RawTrashEntry {
+    pub id: String,
+    pub kind: String,
+    pub source_id: String,
+    /// The folder that governed the deleted item — the lock anchor for this snapshot. `None` for a
+    /// vault-root meeting, or for a deleted folder that had no parent.
+    pub source_folder_id: Option<String>,
+    pub label: String,
+    pub label_blob: Option<Vec<u8>>,
+    pub payload: String,
+    pub payload_blob: Option<Vec<u8>>,
+    /// RFC3339. Retention is computed from this against the LIVE setting, so changing the retention
+    /// applies to entries already in the trash instead of freezing each one at capture time.
+    pub deleted_at: String,
+}
+
+impl RawTrashEntry {
+    /// True when this snapshot's only surviving copy is ciphertext. A masked read must NOT surface
+    /// `label`/`payload` for such a row unless the source folder is session-unlocked.
+    pub fn is_sealed(&self) -> bool {
+        self.payload_blob.is_some()
+    }
+}
+
+impl Db {
+    /// Create the trash table. Additive + `IF NOT EXISTS` + idempotent, per the migration rule.
+    ///
+    /// No FK to `folders(id)`: `source_folder_id` must SURVIVE its folder being deleted (deleting a
+    /// folder trashes the folder AND, before this, its notes may already sit in the trash pointing
+    /// at it). An `ON DELETE CASCADE` here would silently destroy recoverable snapshots — the exact
+    /// content loss this table exists to prevent. It is a recorded anchor, resolved defensively.
+    ///
+    /// Takes `&Connection` (not `&self`) because `Db::migrate` already HOLDS the connection lock and
+    /// runs inside its transaction — a `self.lock()` here would deadlock on the non-reentrant mutex.
+    /// Same shape as `Db::migrate_dashboards`.
+    pub(crate) fn migrate_trash(conn: &rusqlite::Connection) -> Result<()> {
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS trash_items (
+               id TEXT PRIMARY KEY,
+               kind TEXT NOT NULL,
+               source_id TEXT NOT NULL,
+               source_folder_id TEXT,
+               label TEXT NOT NULL DEFAULT '',
+               label_blob BLOB,
+               payload TEXT NOT NULL DEFAULT '',
+               payload_blob BLOB,
+               deleted_at TEXT NOT NULL
+             );
+             CREATE INDEX IF NOT EXISTS idx_trash_deleted_at ON trash_items(deleted_at);
+             CREATE INDEX IF NOT EXISTS idx_trash_source_folder ON trash_items(source_folder_id);
+             CREATE INDEX IF NOT EXISTS idx_trash_source ON trash_items(source_id);",
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Store one snapshot. The CALLER must read it back with [`Db::get_trash_entry`] and re-parse it
+    /// BEFORE running the destructive cascade (verify-before-destroy) — this method only writes.
+    ///
+    /// `payload`/`label` are the plaintext form; pass the already-sealed form via
+    /// [`Db::seal_trash_entry`] immediately afterwards when the source folder is sealed.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn insert_trash_entry(
+        &self,
+        id: &str,
+        kind: TrashKind,
+        source_id: &str,
+        source_folder_id: Option<&str>,
+        label: &str,
+        payload: &str,
+        deleted_at: &str,
+    ) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "INSERT INTO trash_items
+               (id, kind, source_id, source_folder_id, label, label_blob, payload, payload_blob, deleted_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6, NULL, ?7)",
+            rusqlite::params![
+                id,
+                kind.as_str(),
+                source_id,
+                source_folder_id,
+                label,
+                payload,
+                deleted_at
+            ],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Insert an entry that is SEALED from its first instant.
+    ///
+    /// One statement, so there is no moment at which the row exists with plaintext behind a lock —
+    /// the same reasoning as [`Db::insert_sealed_folder`]. Insert-then-seal would leave a window
+    /// where a crash strands readable content inside a sealed folder, and no undo closes it (an undo
+    /// that itself fails leaves the row behind).
+    ///
+    /// The CALLER must have already verified both blobs decrypt back byte-identical.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn insert_trash_entry_sealed(
+        &self,
+        id: &str,
+        kind: TrashKind,
+        source_id: &str,
+        source_folder_id: Option<&str>,
+        label_blob: &[u8],
+        payload_blob: &[u8],
+        deleted_at: &str,
+    ) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "INSERT INTO trash_items
+               (id, kind, source_id, source_folder_id, label, label_blob, payload, payload_blob, deleted_at)
+             VALUES (?1, ?2, ?3, ?4, '', ?5, '', ?6, ?7)",
+            rusqlite::params![
+                id,
+                kind.as_str(),
+                source_id,
+                source_folder_id,
+                label_blob,
+                payload_blob,
+                deleted_at
+            ],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Read one entry in whatever seal state it is in. `None` for an unknown id (every caller
+    /// treats that as an idempotent no-op).
+    pub(crate) fn get_trash_entry(&self, id: &str) -> Result<Option<RawTrashEntry>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT id, kind, source_id, source_folder_id, label, label_blob, payload, payload_blob,
+                    deleted_at
+               FROM trash_items WHERE id = ?1",
+            rusqlite::params![id],
+            row_to_raw_trash_entry,
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
+    /// Every entry, newest deletion first. Bounded by [`TRASH_LIST_LIMIT`]; the command layer masks
+    /// sealed rows before they cross IPC.
+    pub(crate) fn list_trash_entries(&self) -> Result<Vec<RawTrashEntry>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, kind, source_id, source_folder_id, label, label_blob, payload,
+                        payload_blob, deleted_at
+                   FROM trash_items
+                  ORDER BY deleted_at DESC, id
+                  LIMIT ?1",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![TRASH_LIST_LIMIT], row_to_raw_trash_entry)
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// Every entry anchored to one folder, in whatever seal state. The seal/unseal/relock passes
+    /// iterate this — mirrors [`Db::raw_documents_in_folder`].
+    pub(crate) fn raw_trash_entries_in_folder(&self, folder_id: &str) -> Result<Vec<RawTrashEntry>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, kind, source_id, source_folder_id, label, label_blob, payload,
+                        payload_blob, deleted_at
+                   FROM trash_items WHERE source_folder_id = ?1 ORDER BY id",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![folder_id], row_to_raw_trash_entry)
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// Seal ONE entry: store the AES-GCM blobs, blank the plaintext columns. The CALLER must verify
+    /// both blobs decrypt back byte-identical BEFORE calling this (verify-before-destroy) — exactly
+    /// like [`Db::seal_document`] / [`Db::seal_note`].
+    pub(crate) fn seal_trash_entry(
+        &self,
+        id: &str,
+        label_blob: &[u8],
+        payload_blob: &[u8],
+    ) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE trash_items
+                SET label_blob = ?2, payload_blob = ?3, label = '', payload = ''
+              WHERE id = ?1",
+            rusqlite::params![id, label_blob, payload_blob],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Restore (or re-blank) an entry's plaintext for the session, leaving the blobs intact. Pass
+    /// the decrypted plaintext on unlock; pass `("", "")` on relock. Mirrors
+    /// [`Db::set_document_text`].
+    pub(crate) fn set_trash_entry_plaintext(
+        &self,
+        id: &str,
+        label: &str,
+        payload: &str,
+    ) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE trash_items SET label = ?2, payload = ?3 WHERE id = ?1",
+            rusqlite::params![id, label, payload],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Drop an entry's ciphertext, leaving the plaintext — the permanent-unseal half
+    /// (`remove_lock`). Mirrors [`Db::clear_timeline_blob`].
+    pub(crate) fn clear_trash_entry_blobs(&self, id: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE trash_items SET label_blob = NULL, payload_blob = NULL WHERE id = ?1",
+            rusqlite::params![id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Re-anchor every entry pointing at `from` to `to`. Used when a folder is permanently purged
+    /// from the trash: its member snapshots must not keep a dangling anchor that would make them
+    /// unreadable (a sealed entry whose folder row is gone can never be unlocked again).
+    pub(crate) fn reanchor_trash_entries(&self, from: &str, to: Option<&str>) -> Result<usize> {
+        let conn = self.lock();
+        let n = conn
+            .execute(
+                "UPDATE trash_items SET source_folder_id = ?2 WHERE source_folder_id = ?1",
+                rusqlite::params![from, to],
+            )
+            .map_err(map_err)?;
+        Ok(n)
+    }
+
+    /// Remove one entry row. Purging the entity's on-disk files is the CALLER's job (the command
+    /// layer owns the filesystem, the db layer owns rows) — same split as the note `.md` deletion.
+    pub(crate) fn delete_trash_entry(&self, id: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "DELETE FROM trash_items WHERE id = ?1",
+            rusqlite::params![id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Count of entries — the sidebar badge. Cheap enough to call on every trash event.
+    pub(crate) fn count_trash_entries(&self) -> Result<i64> {
+        let conn = self.lock();
+        conn.query_row("SELECT COUNT(*) FROM trash_items", [], |r| r.get(0))
+            .map_err(map_err)
+    }
+}
+
+/// TEST-ONLY: backdate an entry so the retention/purge oracles can reach expiry without sleeping
+/// for 30 days (and so the fail-closed undateable case can be driven at all).
+#[cfg(test)]
+impl Db {
+    pub(crate) fn set_trash_deleted_at_for_test(&self, id: &str, deleted_at: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE trash_items SET deleted_at = ?2 WHERE id = ?1",
+            rusqlite::params![id, deleted_at],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// TEST-ONLY: flip a folder's `locked` bit directly, so a read-gate oracle can put a folder in
+    /// the sealed-and-not-session-unlocked state without driving the whole Touch-ID lock command.
+    pub(crate) fn set_folder_locked_for_test(&self, id: &str, locked: bool) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE folders SET locked = ?2 WHERE id = ?1",
+            rusqlite::params![id, locked as i64],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+}
+
+fn row_to_raw_trash_entry(r: &rusqlite::Row<'_>) -> rusqlite::Result<RawTrashEntry> {
+    Ok(RawTrashEntry {
+        id: r.get(0)?,
+        kind: r.get(1)?,
+        source_id: r.get(2)?,
+        source_folder_id: r.get(3)?,
+        label: r.get(4)?,
+        label_blob: r.get(5)?,
+        payload: r.get(6)?,
+        payload_blob: r.get(7)?,
+        deleted_at: r.get(8)?,
+    })
+}
+
+/// A folder's non-content presentation/placement columns — everything beyond the [`crate::storage::Folder`]
+/// struct that a faithful restore has to bring back. Without these a restored Workspace loses its
+/// emoji, tint, ordering and (worse) its `level`, which decides whether it is a Project or a Folder.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct FolderPresentation {
+    pub kind: String,
+    pub level: String,
+    pub is_root: bool,
+    pub emoji: Option<String>,
+    pub tint: Option<String>,
+    pub position: i64,
+}
+
+impl Db {
+    /// Read the presentation/placement columns for one folder. `None` for an unknown id.
+    pub(crate) fn folder_presentation(&self, id: &str) -> Result<Option<FolderPresentation>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT kind, level, is_root, emoji, tint, position FROM folders WHERE id = ?1",
+            rusqlite::params![id],
+            |r| {
+                Ok(FolderPresentation {
+                    kind: r.get(0)?,
+                    level: r.get(1)?,
+                    is_root: r.get::<_, i64>(2)? != 0,
+                    emoji: r.get(3)?,
+                    tint: r.get(4)?,
+                    position: r.get(5)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
+    /// Re-insert a folder row from a trash snapshot, preserving every column the snapshot carried.
+    ///
+    /// Deliberately inserts `locked = 0` with a NULL `wrapped_key`: `delete_folder_inner` PERMANENTLY
+    /// removes a sealed container's lock before dropping the row (it must, or the sealed content
+    /// would be orphaned from its key), so there is no key left to restore. A restored container
+    /// comes back OPEN, and `FolderSnapshot::was_locked` is what tells the user so.
+    pub(crate) fn insert_restored_folder(
+        &self,
+        id: &str,
+        name: &str,
+        path: &str,
+        parent_id: Option<&str>,
+        created_at: &str,
+        p: &FolderPresentation,
+    ) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "INSERT INTO folders
+               (id, name, path, parent_id, locked, wrapped_key, created_at,
+                kind, is_root, level, emoji, tint, position)
+             VALUES (?1, ?2, ?3, ?4, 0, NULL, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            rusqlite::params![
+                id,
+                name,
+                path,
+                parent_id,
+                created_at,
+                p.kind,
+                p.is_root as i64,
+                p.level,
+                p.emoji,
+                p.tint,
+                p.position,
+            ],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Every provider note row for one meeting, with the columns a snapshot needs.
+    ///
+    /// `Db::get_latest_note_for_meeting` returns only the newest and `Db::sealable_notes_for_meeting`
+    /// omits `created_at`, so neither can reconstruct the full set. A trashed meeting may carry
+    /// several provider notes, and losing the older ones on restore would be silent content loss.
+    pub(crate) fn note_records_for_meeting(
+        &self,
+        meeting_id: &str,
+    ) -> Result<Vec<crate::storage::NoteRecord>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT provider_id, markdown, created_at, exported_path
+                   FROM notes WHERE meeting_id = ?1 ORDER BY created_at, provider_id",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![meeting_id], |r| {
+                Ok(crate::storage::NoteRecord {
+                    meeting_id: meeting_id.to_string(),
+                    provider_id: r.get(0)?,
+                    markdown: r.get(1)?,
+                    created_at: r.get(2)?,
+                    exported_path: r.get(3)?,
+                    ..Default::default()
+                })
+            })
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+}

--- a/src/app/app-shell/app-shell.component.html
+++ b/src/app/app-shell/app-shell.component.html
@@ -181,6 +181,9 @@
               @if (item.path === "/reminders" && reminderCount() > 0) {
                 <span class="count">{{ reminderCount() }}</span>
               }
+              @if (item.path === "/trash" && trashCount() > 0) {
+                <span class="count">{{ trashCount() }}</span>
+              }
             </a>
           }
         }

--- a/src/app/app-shell/app-shell.component.ts
+++ b/src/app/app-shell/app-shell.component.ts
@@ -35,6 +35,7 @@ import { TilePaletteComponent } from "../features/dashboards/tile-palette/tile-p
 import { LockSharesDialogComponent } from "../features/folders/lock-shares-dialog/lock-shares-dialog.component";
 import { ReminderComposerComponent } from "../features/reminders/reminder-composer/reminder-composer.component";
 import { ReminderComposerService } from "../features/reminders/reminder-composer/reminder-composer.service";
+import { TrashService } from "../services/trash.service";
 import { RemindersStore } from "../features/reminders/reminders.store";
 import { AccountSessionBannerComponent } from "../features/sharing/account-session-banner/account-session-banner.component";
 import { FilingRecoveryBannerComponent } from "../features/workspace/filing-recovery-banner/filing-recovery-banner.component";
@@ -57,12 +58,22 @@ import { NotesService } from "../services/notes.service";
 import { TilePaletteService } from "../services/tile-palette.service";
 import { ToastService, type Toast } from "../services/toast.service";
 
+const BROWSE_GROUPS = ["Work", "Intelligence", "Insights", "Storage"] as const;
+
 interface BrowseItem {
   readonly path: string;
   readonly label: string;
   readonly icon: ShellIcon;
-  readonly group: "Work" | "Intelligence" | "Insights";
+  /**
+   * DERIVED from {@link BROWSE_GROUPS} rather than re-listed here. The union used
+   * to be written out twice, so adding a group to one list and not the other
+   * typechecked in the render loop (which reads BROWSE_GROUPS) while rejecting the
+   * item that needed it. One source of truth, and a new group is one edit.
+   */
+  readonly group: BrowseGroup;
 }
+
+type BrowseGroup = (typeof BROWSE_GROUPS)[number];
 
 const BROWSE_ITEMS: readonly BrowseItem[] = [
   { path: "/library", label: "Meetings", icon: "meetings", group: "Work" },
@@ -84,9 +95,11 @@ const BROWSE_ITEMS: readonly BrowseItem[] = [
   },
   { path: "/graph", label: "Graph", icon: "graph", group: "Insights" },
   { path: "/people", label: "People", icon: "people", group: "Insights" },
+  // Trash sits in its own group at the BOTTOM of Browse. Grouping it under "Work"
+  // would put deleted things next to live ones in the same list, which is exactly
+  // the confusion the separate destination exists to remove.
+  { path: "/trash", label: "Trash", icon: "trash", group: "Storage" },
 ];
-
-const BROWSE_GROUPS = ["Work", "Intelligence", "Insights"] as const;
 /**
  * The sidebar opens EXPANDED by default. It is now the ONLY navigation surface —
  * destinations, the workspace tree and the create actions all live in it — so a
@@ -136,10 +149,18 @@ export class AppShellComponent {
   private readonly router = inject(Router);
   private readonly tabs = inject(TabsService);
   private readonly reminders = inject(RemindersStore);
+  private readonly trash = inject(TrashService);
   private readonly reminderComposer = inject(ReminderComposerService);
   protected readonly workspace = inject(WorkspaceService);
 
   readonly reminderCount = this.reminders.dueInboxCount;
+  /**
+   * Sidebar badge for the Trash. Read from the root {@link TrashService}, which
+   * keeps it live off the content-free `murmur://trash-updated` event even while
+   * `/trash` is closed — so deleting something from Meetings updates the badge
+   * without anyone opening the view.
+   */
+  readonly trashCount = this.trash.count;
   readonly lockFlow = inject(FolderLockFlowService);
   readonly docPreview = inject(DocumentPreviewService);
   readonly tilePalette = inject(TilePaletteService);
@@ -220,6 +241,11 @@ export class AppShellComponent {
       this.scrubWorkspaceOrganization();
     });
     void this.reminders.initSummary();
+    // Seed the Trash badge on a cold start: without this it reads 0 until either
+    // something is deleted (which emits the event) or the user opens `/trash`, so a
+    // relaunch with items already in the trash would show no badge at all. Reads a
+    // COUNT only — no snapshot payloads, nothing gated.
+    void this.trash.refreshCount();
   }
 
   isCaptureActive(): boolean {

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -57,6 +57,13 @@ export const routes: Routes = [
           ),
       },
       {
+        path: "trash",
+        loadComponent: () =>
+          import("./features/trash/trash/trash.component").then(
+            (m) => m.TrashComponent,
+          ),
+      },
+      {
         path: "reminders",
         loadComponent: () =>
           import("./features/reminders/reminders/reminders.component").then(

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -3071,7 +3071,9 @@ export class IpcService {
   }
 
   /**
-   * Permanently delete a note (cascade-deletes its chunks + vectors + vault `.md`).
+   * Move a note to the Trash. RECOVERABLE for the retention window (30 days by
+   * default) via `restoreTrashItem` — a verified snapshot holds its body and
+   * inline images, and the restore re-exports the vault `.md`.
    * GATED: a sealed-and-not-session-unlocked folder is refused (`Locked`); an
    * unknown id is an idempotent no-op.
    */

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -175,6 +175,8 @@ import type {
   WhisperRecommendationDto,
   WikiTarget,
   McpStatus,
+  TrashEntry,
+  TrashUpdatedPayload,
 } from "./models";
 
 export const EVENT_STATUS = "meetnotes://status";
@@ -229,6 +231,10 @@ export const EVENT_CONTAINER_SHARE_PROGRESS =
 // Delete fan-out fix — a note/meeting delete FULLY succeeded (local rows gone + any org shares
 // revoked); lets OTHER open surfaces (the tab-strip) prune themselves. Content-free (id + kind only).
 export const EVENT_CONTENT_DELETED = "murmur://content-deleted";
+
+// Trash — something was moved in, restored, or purged. CONTENT-FREE (a count only);
+// subscribers refetch through the gated `listTrash`, which masks sealed entries.
+export const EVENT_TRASH_UPDATED = "murmur://trash-updated";
 /** Count-only invalidation for the first-class Murmur reminder inbox. */
 export const EVENT_REMINDERS_UPDATED = "murmur://reminders-updated";
 /** Kind + opaque source id only; Smart cards re-audit through the gated command. */
@@ -1247,9 +1253,70 @@ export class IpcService {
     return invoke<SearchHit[]>("related_meetings", { meetingId });
   }
 
-  /** Permanently delete a meeting (audio + vault note + all DB rows). Irreversible. */
+  /**
+   * Move a meeting to the Trash. RECOVERABLE for the retention window (30 days
+   * by default) via `restoreTrashItem` — the audio stays on disk and a verified
+   * snapshot holds the transcript + notes. Refused for a locked meeting.
+   */
   deleteMeeting(meetingId: string): Promise<void> {
     return invoke<void>("delete_meeting", { meetingId });
+  }
+
+  // --- TRASH (2026-08-31) — the recoverable holding area for deleted content ---
+
+  /**
+   * Everything in the Trash, newest deletion first. A sealed entry comes back
+   * MASKED (`locked: true`) — never assume `label`/`detail` are real content.
+   */
+  listTrash(): Promise<TrashEntry[]> {
+    return invoke<TrashEntry[]>("list_trash");
+  }
+
+  /** How many entries the Trash holds — the sidebar badge. Cheap (no payloads read). */
+  countTrash(): Promise<number> {
+    return invoke<number>("count_trash");
+  }
+
+  /**
+   * Restore one entry: the content comes back and the entry is consumed.
+   * REJECTS with a locked error when the entry's folder is sealed and not
+   * unlocked this session.
+   */
+  restoreTrashItem(entryId: string): Promise<void> {
+    return invoke<void>("restore_trash_item", { entryId });
+  }
+
+  /** Permanently destroy one entry and the content it was holding. Irreversible. */
+  deleteTrashItemForever(entryId: string): Promise<void> {
+    return invoke<void>("delete_trash_item_forever", { entryId });
+  }
+
+  /**
+   * Permanently destroy every entry. Returns how many were purged; LOCKED
+   * entries are left behind (purging one would need its sealed payload), so the
+   * returned count can be lower than the list length.
+   */
+  emptyTrash(): Promise<number> {
+    return invoke<number>("empty_trash");
+  }
+
+  /** Purge expired entries now instead of waiting for the hourly tick. Returns the count. */
+  purgeExpiredTrash(): Promise<number> {
+    return invoke<number>("purge_expired_trash");
+  }
+
+  /** The retention window in days (default 30). */
+  getTrashRetentionDays(): Promise<number> {
+    return invoke<number>("get_trash_retention_days");
+  }
+
+  /**
+   * Set the retention window (1–365). Applies to entries ALREADY in the Trash —
+   * expiry is computed from the live setting — so shortening it can make items
+   * purge on the next tick.
+   */
+  setTrashRetentionDays(days: number): Promise<void> {
+    return invoke<void>("set_trash_retention_days", { days });
   }
 
   // --- Saved views over a list surface (Feature B; Notes added 2026-07-14) ---
@@ -3597,6 +3664,14 @@ export class IpcService {
     return listen<ContentDeletedPayload>(EVENT_CONTENT_DELETED, (e) =>
       cb(e.payload),
     );
+  }
+
+  /**
+   * The Trash changed (something moved in, restored, or purged). CONTENT-FREE —
+   * a count only; the subscriber refetches through the gated `listTrash`.
+   */
+  onTrashUpdated(cb: (p: TrashUpdatedPayload) => void): Promise<UnlistenFn> {
+    return listen<TrashUpdatedPayload>(EVENT_TRASH_UPDATED, (e) => cb(e.payload));
   }
 
   /** Count-only reminder invalidation. Canonical rows are always refetched. */

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -1282,8 +1282,14 @@ export class IpcService {
    * REJECTS with a locked error when the entry's folder is sealed and not
    * unlocked this session.
    */
-  restoreTrashItem(entryId: string): Promise<void> {
-    return invoke<void>("restore_trash_item", { entryId });
+  async restoreTrashItem(entryId: string): Promise<void> {
+    await invoke<void>("restore_trash_item", { entryId });
+    // A restore puts a note/recording/folder BACK into the hierarchy, which is exactly
+    // the "content write that changes the mixed Workspace hierarchy without going
+    // through WorkspaceService" this revision exists for. Without the bump the sidebar
+    // tree — which is always mounted and so never remounts to refetch — keeps showing
+    // the pre-restore forest and the item looks like it never came back.
+    this._workspaceMutationRevision.update((revision) => revision + 1);
   }
 
   /** Permanently destroy one entry and the content it was holding. Irreversible. */

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -3868,3 +3868,45 @@ export interface OrgShareTargetRow {
   orgName: string;
   access: OrgAccess;
 }
+
+/**
+ * One entry in the Trash — something the user deleted that is still recoverable.
+ * Mirrors the Rust `TrashEntry` DTO (camelCase asserted by
+ * `trash_tests::trash_entry_dto_is_camel_case`).
+ *
+ * A sealed entry arrives MASKED: `locked: true`, `label: "🔒 Locked"`, empty
+ * `detail`. The backend decides that from the LIVE session unlock set — the FE
+ * must never try to infer it, and must not offer Restore on a locked row (the
+ * backend refuses it anyway).
+ */
+export interface TrashEntry {
+  /** The TRASH ENTRY id — what restore/delete-forever take. Not `sourceId`. */
+  id: string;
+  kind: TrashKind;
+  /** The deleted entity's own id. */
+  sourceId: string;
+  sourceFolderId: string | null;
+  /** Display title, or the lock sentinel when masked. */
+  label: string;
+  /** RFC3339. */
+  deletedAt: string;
+  /** RFC3339 — when this entry is purged. Derived from the LIVE retention setting. */
+  expiresAt: string;
+  /** Whole days remaining; `0` on the final day, never negative. */
+  daysLeft: number;
+  /** Masked: its folder is sealed and not unlocked this session. */
+  locked: boolean;
+  /** Content-FREE one-liner ("30 min · 42 segments"). Empty when masked. */
+  detail: string;
+}
+
+export type TrashKind = "meeting" | "note" | "folder" | "noteFolder";
+
+/**
+ * Payload of `murmur://trash-updated`. CONTENT-FREE by design — a count only, so
+ * the sidebar badge can update without any surface learning a label or payload.
+ * Mirrors the Rust `TrashUpdatedPayload`.
+ */
+export interface TrashUpdatedPayload {
+  count: number;
+}

--- a/src/app/features/detail/detail/detail.component.ts
+++ b/src/app/features/detail/detail/detail.component.ts
@@ -219,7 +219,7 @@ export class DetailComponent implements OnInit {
   // --- In-app delete confirmation state -----------------------------------
   /** True while the signal-driven delete-confirm panel is shown. */
   readonly confirmingDelete = signal(false);
-  /** True while a deleteMeeting IPC call is in flight (irreversible). */
+  /** True while a deleteMeeting IPC call is in flight (moves it to the Trash). */
   readonly deleting = signal(false);
   /** Inline error surfaced when the delete fails. */
   readonly deleteError = signal("");

--- a/src/app/features/detail/note-panel/note-panel.component.html
+++ b/src/app/features/detail/note-panel/note-panel.component.html
@@ -88,8 +88,9 @@
         <div class="confirm-text">
           <p class="confirm-title">Delete this meeting?</p>
           <p class="confirm-copy">
-            This permanently removes the recording, transcript, summary and the
-            note in your vault. This can’t be undone.
+            It moves to the Trash with its transcript, summary and audio, and is
+            removed for good after 30 days. The vault note is removed now and
+            re-exported if you restore it.
           </p>
           @if (deleteError(); as err) {
             <p class="confirm-error" role="alert">{{ err }}</p>

--- a/src/app/features/library/library/library.component.html
+++ b/src/app/features/library/library/library.component.html
@@ -630,8 +630,8 @@
                 >
                   <p class="confirm-title">Delete this meeting?</p>
                   <p class="confirm-body">
-                    This permanently removes the recording, transcript,
-                    summary and vault note. It can’t be undone.
+                    It moves to the Trash with its transcript, summary and
+                    audio, and is removed for good after 30 days.
                   </p>
                   @if (deleteError()) {
                     <p class="confirm-error" role="alert">

--- a/src/app/features/library/library/library.component.ts
+++ b/src/app/features/library/library/library.component.ts
@@ -1014,7 +1014,8 @@ export class LibraryComponent implements OnInit {
   }
 
   /**
-   * Confirm the pending delete: await the irreversible IPC call, then prune the
+   * Confirm the pending delete: await the IPC call (which moves the recording to
+   * the Trash, recoverable for the retention window), then prune the
    * row from the local `meetings` signal (no full reload needed). On failure we
    * surface an inline error and keep the panel open so the user can retry.
    */

--- a/src/app/features/notes/note-editor/note-editor.component.html
+++ b/src/app/features/notes/note-editor/note-editor.component.html
@@ -243,7 +243,7 @@
                     Delete note
                   </button>
                 } @else {
-                  <p class="menu-confirm">Delete this note permanently?</p>
+                  <p class="menu-confirm">Delete this note?</p>
                   <div class="menu-confirm-row">
                     <button type="button" class="btn btn-danger menu-confirm-btn" (click)="doDelete()">
                       Delete

--- a/src/app/features/trash/trash/trash.component.html
+++ b/src/app/features/trash/trash/trash.component.html
@@ -1,0 +1,206 @@
+<section class="trash-page">
+  <header class="page-head">
+    <div>
+      <p class="page-eyebrow">Workspace</p>
+      <h1>Trash</h1>
+      <p class="page-subtitle">
+        Deleted recordings, notes and folders stay here so you can put them back.
+      </p>
+    </div>
+
+    <div class="head-actions">
+      <div class="retention">
+        <button
+          type="button"
+          class="btn btn-ghost"
+          (click)="toggleRetention()"
+          aria-haspopup="menu"
+          [attr.aria-expanded]="retentionOpen()"
+        >
+          <mur-icon icon="history" />
+          <span>{{ retentionLabel() }}</span>
+        </button>
+        @if (retentionOpen()) {
+          <button
+            type="button"
+            class="menu-scrim"
+            (click)="toggleRetention()"
+            aria-label="Close retention menu"
+            tabindex="-1"
+          ></button>
+          <div class="menu retention-menu" role="menu">
+            @for (days of retentionChoices; track days) {
+              <button
+                type="button"
+                class="menu-item"
+                role="menuitem"
+                [class.is-current]="days === store.retentionDays()"
+                (click)="chooseRetention(days)"
+              >
+                <span>Keep for {{ days }} days</span>
+                @if (days === store.retentionDays()) {
+                  <mur-icon icon="check" />
+                }
+              </button>
+            }
+          </div>
+        }
+      </div>
+
+      @if (!store.isEmpty()) {
+        <button
+          type="button"
+          class="btn btn-danger"
+          [disabled]="store.loading() || store.allLocked()"
+          (click)="askEmpty()"
+        >
+          Empty Trash
+        </button>
+      }
+    </div>
+  </header>
+
+  @if (store.error(); as message) {
+    <div class="banner is-danger" role="alert">
+      <span>{{ message }}</span>
+      <button type="button" class="btn btn-ghost" (click)="store.reload()">
+        Retry
+      </button>
+    </div>
+  }
+
+  @if (store.lockedCount() > 0) {
+    <div class="banner is-warning locked-banner" role="status">
+      <mur-icon icon="lock" />
+      <span>
+        {{ store.lockedCount() }} item{{ store.lockedCount() === 1 ? "" : "s" }} here
+        belong to a locked folder. Unlock the folder to see what they are, restore
+        them, or delete them.
+      </span>
+    </div>
+  }
+
+  @if (confirmingEmpty()) {
+    <div class="banner is-danger confirm-banner" role="alertdialog" aria-live="assertive">
+      <span>
+        Permanently delete
+        {{ store.entries().length - store.lockedCount() }} item{{
+          store.entries().length - store.lockedCount() === 1 ? "" : "s"
+        }}? This cannot be undone.
+      </span>
+      <div class="confirm-actions">
+        <button type="button" class="btn btn-ghost" (click)="cancelEmpty()">
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="btn btn-danger"
+          [disabled]="store.loading()"
+          (click)="confirmEmpty()"
+        >
+          Delete permanently
+        </button>
+      </div>
+    </div>
+  }
+
+  @if (showSpinner()) {
+    <mur-empty-state>
+      <span class="context-spinner" aria-hidden="true"></span>
+      <p>Loading the Trash…</p>
+    </mur-empty-state>
+  } @else if (store.isEmpty()) {
+    <mur-empty-state>
+      <mur-icon icon="trash" />
+      <h2>Trash is empty</h2>
+      <p>
+        Anything you delete lands here for
+        {{ store.retentionDays() }} days before it is removed for good.
+      </p>
+    </mur-empty-state>
+  } @else {
+    <ul class="trash-list">
+      @for (row of rows(); track row.entry.id) {
+        <li
+          class="trash-row"
+          [class.is-locked]="row.entry.locked"
+          [class.is-busy]="isBusy(row.entry.id)"
+        >
+          <span class="row-icon" aria-hidden="true">
+            <mur-icon [icon]="row.entry.locked ? 'lock' : row.icon" />
+          </span>
+
+          <div class="row-main">
+            <p class="row-label">{{ row.entry.label }}</p>
+            <p class="row-meta">
+              <span class="row-kind">{{ row.kindLabel }}</span>
+              <span aria-hidden="true">·</span>
+              <span>{{ row.deletedLabel }}</span>
+              @if (row.entry.detail) {
+                <span aria-hidden="true">·</span>
+                <span>{{ row.entry.detail }}</span>
+              }
+            </p>
+          </div>
+
+          <span
+            class="row-expiry"
+            [class.is-soon]="row.expiringSoon"
+            [title]="'Purged on ' + row.entry.expiresAt"
+          >
+            {{ row.expiryLabel }}
+          </span>
+
+          @if (confirmingDelete() === row.entry.id) {
+            <div class="row-confirm">
+              <span>Delete for good?</span>
+              <button type="button" class="btn btn-ghost" (click)="cancelDelete()">
+                Cancel
+              </button>
+              <button
+                type="button"
+                class="btn btn-danger"
+                [disabled]="isBusy(row.entry.id)"
+                (click)="confirmDelete(row.entry)"
+              >
+                Delete
+              </button>
+            </div>
+          } @else {
+            <div class="row-actions">
+              <button
+                type="button"
+                class="btn"
+                [disabled]="row.entry.locked || isBusy(row.entry.id)"
+                [title]="
+                  row.entry.locked
+                    ? 'Unlock this item\'s folder to restore it'
+                    : 'Put this back where it was'
+                "
+                (click)="restore(row.entry)"
+              >
+                Restore
+              </button>
+              <button
+                type="button"
+                class="btn btn-ghost row-delete"
+                [disabled]="row.entry.locked || isBusy(row.entry.id)"
+                [attr.aria-label]="'Delete ' + row.entry.label + ' permanently'"
+                [title]="
+                  row.entry.locked
+                    ? 'Unlock this item\'s folder to delete it'
+                    : 'Delete permanently'
+                "
+                (click)="askDelete(row.entry.id)"
+              >
+                <mur-icon icon="trash" />
+              </button>
+            </div>
+          }
+        </li>
+      } @empty {
+        <li class="trash-row is-empty">Nothing here.</li>
+      }
+    </ul>
+  }
+</section>

--- a/src/app/features/trash/trash/trash.component.html
+++ b/src/app/features/trash/trash/trash.component.html
@@ -105,15 +105,24 @@
   }
 
   @if (showSpinner()) {
-    <mur-empty-state>
-      <span class="context-spinner" aria-hidden="true"></span>
-      <p>Loading the Trash…</p>
-    </mur-empty-state>
+    <mur-empty-state><mur-spinner /> Loading the Trash…</mur-empty-state>
   } @else if (store.isEmpty()) {
     <mur-empty-state>
-      <mur-icon icon="trash" />
-      <h2>Trash is empty</h2>
-      <p>
+      <!-- An INLINE svg, not <mur-icon>: that component is `display: contents` because it is
+           built to be the flex child of a row (a nav item, a button), so standing alone in a
+           centered column it collapses and drifts to the left edge. Every other empty state in
+           the app draws its 44px mark inline for the same reason. -->
+      <svg class="empty-mark-icon" viewBox="0 0 44 44" fill="none" aria-hidden="true">
+        <path
+          d="M14 17h16m-11-3.5h6M17 17v13.5A1.5 1.5 0 0 0 18.5 32h7a1.5 1.5 0 0 0 1.5-1.5V17M20.5 21v7M23.5 21v7"
+          stroke="currentColor"
+          stroke-width="1.6"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+      <h2 class="empty-title">Trash is empty</h2>
+      <p class="empty">
         Anything you delete lands here for
         {{ store.retentionDays() }} days before it is removed for good.
       </p>

--- a/src/app/features/trash/trash/trash.component.scss
+++ b/src/app/features/trash/trash/trash.component.scss
@@ -212,3 +212,12 @@
     order: -1;
   }
 }
+
+/* The empty-state mark. 44px matches every other empty state in the app
+   (`.empty-mark` in primitives.css, `.gate-mark` in the Tasks gate). */
+.empty-mark-icon {
+  width: 44px;
+  height: 44px;
+  margin-bottom: var(--space-2);
+  color: var(--text-tertiary);
+}

--- a/src/app/features/trash/trash/trash.component.scss
+++ b/src/app/features/trash/trash/trash.component.scss
@@ -1,0 +1,214 @@
+:host {
+  display: block;
+  width: 100%;
+}
+
+.trash-page {
+  width: min(var(--content-max), 100%);
+  margin: 0 auto;
+  padding: var(--space-6) var(--space-5) var(--space-8);
+}
+
+.page-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-5);
+  margin-bottom: var(--space-5);
+}
+
+.head-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+/* The retention picker floats OVER the list, so it is the OPAQUE overlay surface,
+   never the translucent `.card` — see angular-zoneless.md T3. */
+.retention {
+  position: relative;
+}
+
+.retention-menu {
+  position: absolute;
+  top: calc(100% + var(--space-2));
+  right: 0;
+  z-index: 30;
+  min-width: 200px;
+  background: var(--surface-overlay);
+  backdrop-filter: none;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  padding: var(--space-1);
+}
+
+.retention-menu .menu-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  width: 100%;
+}
+
+.retention-menu .menu-item.is-current {
+  color: var(--accent);
+}
+
+/* Sits under the menu to catch the dismissing click without trapping focus. */
+.menu-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  cursor: default;
+}
+
+.banner {
+  margin-bottom: var(--space-4);
+  gap: var(--space-3);
+}
+
+.locked-banner,
+.confirm-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.confirm-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.trash-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.trash-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  transition: border-color var(--transition-fast), opacity var(--transition-fast);
+}
+
+.trash-row:hover {
+  border-color: var(--border-strong);
+}
+
+.trash-row.is-busy {
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+/* A locked row carries no title and no detail, so it is rendered visibly inert
+   rather than looking like a row whose actions merely happen to be disabled. */
+.trash-row.is-locked {
+  border-style: dashed;
+}
+
+.trash-row.is-locked .row-label {
+  color: var(--text-secondary);
+}
+
+.trash-row.is-empty {
+  justify-content: center;
+  color: var(--text-secondary);
+}
+
+.row-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  border-radius: var(--radius-sm);
+  background: var(--surface-hover);
+  color: var(--text-secondary);
+}
+
+.row-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.row-label {
+  margin: 0;
+  font-weight: 600;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.row-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 2px 0 0;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  flex-wrap: wrap;
+}
+
+.row-kind {
+  color: var(--text-tertiary);
+}
+
+.row-expiry {
+  flex-shrink: 0;
+  font-size: 0.8125rem;
+  color: var(--text-tertiary);
+  font-variant-numeric: tabular-nums;
+}
+
+/* The last few days get the warning colour: this is the only signal that an item
+   is about to become unrecoverable. */
+.row-expiry.is-soon {
+  color: var(--warning);
+  font-weight: 600;
+}
+
+.row-actions,
+.row-confirm {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.row-confirm {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.row-delete {
+  padding-inline: var(--space-2);
+}
+
+@media (max-width: 720px) {
+  .page-head,
+  .trash-row {
+    flex-wrap: wrap;
+  }
+
+  .row-main {
+    flex-basis: 100%;
+    order: -1;
+  }
+}

--- a/src/app/features/trash/trash/trash.component.ts
+++ b/src/app/features/trash/trash/trash.component.ts
@@ -7,7 +7,10 @@ import {
   inject,
   signal,
 } from "@angular/core";
-import { MurIconComponent } from "../../../design-system/icon/icon.component";
+import {
+  MurIconComponent,
+  type ShellIcon,
+} from "../../../design-system/icon/icon.component";
 import { MurEmptyStateComponent } from "../../../design-system/empty-state/empty-state.component";
 import { ToastService } from "../../../services/toast.service";
 import { TrashService } from "../../../services/trash.service";
@@ -17,7 +20,7 @@ import type { TrashEntry, TrashKind } from "../../../core/models";
 interface TrashRowVm {
   entry: TrashEntry;
   /** Icon name for the entry's kind. */
-  icon: string;
+  icon: ShellIcon;
   /** "Recording" / "Note" / "Folder" / "Note folder". */
   kindLabel: string;
   /** "Deleted 2 days ago". */
@@ -28,7 +31,7 @@ interface TrashRowVm {
   expiringSoon: boolean;
 }
 
-const KIND_META: Record<TrashKind, { icon: string; label: string }> = {
+const KIND_META: Record<TrashKind, { icon: ShellIcon; label: string }> = {
   meeting: { icon: "meetings", label: "Recording" },
   note: { icon: "notes", label: "Note" },
   folder: { icon: "spaces", label: "Folder" },
@@ -69,7 +72,9 @@ export class TrashComponent implements OnInit {
 
   readonly rows = computed<TrashRowVm[]>(() =>
     this.store.entries().map((entry) => {
-      const meta = KIND_META[entry.kind] ?? {
+      // A `kind` the FE does not know (an older/newer backend) must still render a row rather
+      // than throw — T6's lesson: one bad field must not take the whole view down.
+      const meta: { icon: ShellIcon; label: string } = KIND_META[entry.kind] ?? {
         icon: "notes",
         label: "Item",
       };

--- a/src/app/features/trash/trash/trash.component.ts
+++ b/src/app/features/trash/trash/trash.component.ts
@@ -1,0 +1,205 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from "@angular/core";
+import { MurIconComponent } from "../../../design-system/icon/icon.component";
+import { MurEmptyStateComponent } from "../../../design-system/empty-state/empty-state.component";
+import { ToastService } from "../../../services/toast.service";
+import { TrashService } from "../../../services/trash.service";
+import type { TrashEntry, TrashKind } from "../../../core/models";
+
+/** One row, with everything the template needs already derived. */
+interface TrashRowVm {
+  entry: TrashEntry;
+  /** Icon name for the entry's kind. */
+  icon: string;
+  /** "Recording" / "Note" / "Folder" / "Note folder". */
+  kindLabel: string;
+  /** "Deleted 2 days ago". */
+  deletedLabel: string;
+  /** "29 days left" / "Purges today". */
+  expiryLabel: string;
+  /** True in the final 3 days — the row gets the urgent accent. */
+  expiringSoon: boolean;
+}
+
+const KIND_META: Record<TrashKind, { icon: string; label: string }> = {
+  meeting: { icon: "meetings", label: "Recording" },
+  note: { icon: "notes", label: "Note" },
+  folder: { icon: "spaces", label: "Folder" },
+  noteFolder: { icon: "spaces", label: "Note folder" },
+};
+
+/** Rows within this many days of purge are flagged. */
+const EXPIRING_SOON_DAYS = 3;
+
+const RETENTION_CHOICES = [7, 14, 30, 60, 90] as const;
+
+/**
+ * The Trash view — deleted recordings, notes and folders, restorable until their
+ * retention window runs out.
+ *
+ * Masking is the BACKEND's call: a sealed entry arrives `locked: true` with no
+ * label or detail, and both Restore and Delete-forever are refused for it. This
+ * component renders that state and disables the actions, but never decides it —
+ * and never shows a locked row's title, because it does not have one.
+ */
+@Component({
+  selector: "app-trash",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: "./trash.component.html",
+  styleUrl: "./trash.component.scss",
+  imports: [MurIconComponent, MurEmptyStateComponent],
+})
+export class TrashComponent implements OnInit {
+  readonly store = inject(TrashService);
+  private readonly toast = inject(ToastService);
+
+  readonly retentionChoices = RETENTION_CHOICES;
+  /** Which entry the user is confirming a permanent delete for. */
+  readonly confirmingDelete = signal<string | null>(null);
+  readonly confirmingEmpty = signal(false);
+  readonly retentionOpen = signal(false);
+
+  readonly rows = computed<TrashRowVm[]>(() =>
+    this.store.entries().map((entry) => {
+      const meta = KIND_META[entry.kind] ?? {
+        icon: "notes",
+        label: "Item",
+      };
+      return {
+        entry,
+        icon: meta.icon,
+        kindLabel: meta.label,
+        deletedLabel: this.relativeDeleted(entry.deletedAt),
+        expiryLabel: this.expiryLabel(entry.daysLeft),
+        expiringSoon: entry.daysLeft <= EXPIRING_SOON_DAYS,
+      };
+    }),
+  );
+
+  /**
+   * Gate the spinner on BOTH, per `angular-zoneless.md` §8: a return visit must
+   * show the cached rows immediately instead of flashing a spinner over them.
+   */
+  readonly showSpinner = computed(
+    () => this.store.isEmpty() && this.store.loading(),
+  );
+
+  readonly retentionLabel = computed(
+    () => `Items are kept for ${this.store.retentionDays()} days`,
+  );
+
+  ngOnInit(): void {
+    void this.store.reload();
+    // Reconcile expired entries on open rather than waiting up to an hour for the
+    // background tick — otherwise the view can show a row that is already past its
+    // date. Best-effort: the list reload above already happened.
+    void this.store.purgeExpiredOnOpen();
+  }
+
+  isBusy(entryId: string): boolean {
+    return this.store.busyIds().has(entryId);
+  }
+
+  async restore(entry: TrashEntry): Promise<void> {
+    const error = await this.store.restore(entry.id);
+    if (error) {
+      this.toast.danger(error);
+      return;
+    }
+    this.toast.success(`Restored “${entry.label}”.`);
+  }
+
+  askDelete(entryId: string): void {
+    this.confirmingDelete.set(entryId);
+  }
+
+  cancelDelete(): void {
+    this.confirmingDelete.set(null);
+  }
+
+  async confirmDelete(entry: TrashEntry): Promise<void> {
+    const error = await this.store.deleteForever(entry.id);
+    this.confirmingDelete.set(null);
+    if (error) {
+      this.toast.danger(error);
+      return;
+    }
+    this.toast.success("Deleted permanently.");
+  }
+
+  askEmpty(): void {
+    this.confirmingEmpty.set(true);
+  }
+
+  cancelEmpty(): void {
+    this.confirmingEmpty.set(false);
+  }
+
+  async confirmEmpty(): Promise<void> {
+    const result = await this.store.emptyAll();
+    this.confirmingEmpty.set(false);
+    if ("error" in result) {
+      this.toast.danger(result.error);
+      return;
+    }
+    const locked = this.store.lockedCount();
+    if (locked > 0) {
+      // Say what was NOT done. Reporting only the purged count would read as
+      // "the trash is empty" while locked entries are still sitting in it.
+      this.toast.info(
+        `Deleted ${result.purged} item${result.purged === 1 ? "" : "s"}. ` +
+          `${locked} locked item${locked === 1 ? "" : "s"} kept — unlock the folder to delete them.`,
+      );
+      return;
+    }
+    this.toast.success(
+      `Deleted ${result.purged} item${result.purged === 1 ? "" : "s"} permanently.`,
+    );
+  }
+
+  toggleRetention(): void {
+    this.retentionOpen.update((open) => !open);
+  }
+
+  async chooseRetention(days: number): Promise<void> {
+    this.retentionOpen.set(false);
+    const error = await this.store.setRetentionDays(days);
+    if (error) {
+      this.toast.danger(error);
+      return;
+    }
+    this.toast.success(`Items are now kept for ${days} days.`);
+  }
+
+  /** "Deleted today" / "Deleted 3 days ago". */
+  private relativeDeleted(iso: string): string {
+    const then = new Date(iso).getTime();
+    if (Number.isNaN(then)) {
+      return "Deleted recently";
+    }
+    const days = Math.floor((Date.now() - then) / 86_400_000);
+    if (days <= 0) {
+      return "Deleted today";
+    }
+    if (days === 1) {
+      return "Deleted yesterday";
+    }
+    return `Deleted ${days} days ago`;
+  }
+
+  private expiryLabel(daysLeft: number): string {
+    if (daysLeft <= 0) {
+      return "Purges today";
+    }
+    if (daysLeft === 1) {
+      return "1 day left";
+    }
+    return `${daysLeft} days left`;
+  }
+}

--- a/src/app/features/trash/trash/trash.component.ts
+++ b/src/app/features/trash/trash/trash.component.ts
@@ -12,6 +12,7 @@ import {
   type ShellIcon,
 } from "../../../design-system/icon/icon.component";
 import { MurEmptyStateComponent } from "../../../design-system/empty-state/empty-state.component";
+import { MurSpinnerComponent } from "../../../design-system/spinner/spinner.component";
 import { ToastService } from "../../../services/toast.service";
 import { TrashService } from "../../../services/trash.service";
 import type { TrashEntry, TrashKind } from "../../../core/models";
@@ -57,7 +58,7 @@ const RETENTION_CHOICES = [7, 14, 30, 60, 90] as const;
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: "./trash.component.html",
   styleUrl: "./trash.component.scss",
-  imports: [MurIconComponent, MurEmptyStateComponent],
+  imports: [MurIconComponent, MurEmptyStateComponent, MurSpinnerComponent],
 })
 export class TrashComponent implements OnInit {
   readonly store = inject(TrashService);

--- a/src/app/features/trash/trash/trash.component.ts
+++ b/src/app/features/trash/trash/trash.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   OnInit,
   computed,
   inject,
@@ -57,6 +58,7 @@ const RETENTION_CHOICES = [7, 14, 30, 60, 90] as const;
 })
 export class TrashComponent implements OnInit {
   readonly store = inject(TrashService);
+  private readonly destroyRef = inject(DestroyRef);
   private readonly toast = inject(ToastService);
 
   readonly retentionChoices = RETENTION_CHOICES;
@@ -95,6 +97,9 @@ export class TrashComponent implements OnInit {
   );
 
   ngOnInit(): void {
+    // Tell the store a view is mounted, so trash events refresh the ROWS (not just
+    // the badge count) while this screen is open — and stop doing so once it is not.
+    this.destroyRef.onDestroy(this.store.watch());
     void this.store.reload();
     // Reconcile expired entries on open rather than waiting up to an hour for the
     // background tick — otherwise the view can show a row that is already past its

--- a/src/app/services/trash.service.ts
+++ b/src/app/services/trash.service.ts
@@ -64,10 +64,26 @@ export class TrashService {
    */
   private watchers = 0;
 
+  private destroyed = false;
+
   constructor() {
     // ONE subscription for the whole app: the backend emits a content-free count
     // whenever the trash changes, from any surface. Kept here (not in the view) so
     // the sidebar badge stays live while `/trash` is closed.
+    //
+    // The `destroyed` guard handles the destroy-before-resolve race the way
+    // {@link NotesService} does: `listen()` is async, so a service torn down while it
+    // is in flight would otherwise store the unlisten handle AFTER `onDestroy` already
+    // ran and leak the subscription.
+    //
+    // The `.catch()` matters for the E2E suite: its hand-written `invoke`/`listen`
+    // mocks do not know every event, and a rejected registration with no handler
+    // surfaces as an unhandled promise rejection that can fail an unrelated spec. A
+    // trash badge that never updates is the correct degradation here.
+    this.destroyRef.onDestroy(() => {
+      this.destroyed = true;
+      this.unlisten?.();
+    });
     void this.ipc
       .onTrashUpdated((p) => {
         this._count.set(p.count);
@@ -76,9 +92,15 @@ export class TrashService {
         }
       })
       .then((un) => {
-        this.unlisten = un;
+        if (this.destroyed) {
+          un();
+        } else {
+          this.unlisten = un;
+        }
+      })
+      .catch(() => {
+        // No listener: the badge stays at its last value. Never fatal.
       });
-    this.destroyRef.onDestroy(() => this.unlisten?.());
   }
 
   /**

--- a/src/app/services/trash.service.ts
+++ b/src/app/services/trash.service.ts
@@ -51,6 +51,18 @@ export class TrashService {
   );
 
   private unlisten?: () => void;
+  /**
+   * How many mounted views are showing the list. Only they need the ROWS; the
+   * sidebar badge needs the count alone.
+   *
+   * This matters because `listTrash` makes the backend parse every snapshot payload
+   * to derive each row's `detail`, and a meeting payload carries its whole
+   * transcript plus hex-encoded inline images. Reloading the list on every delete
+   * event — which is what this did first — meant a full payload sweep every time
+   * anyone deleted anything, with the Trash view closed and nothing to render it
+   * into. The count is what the badge reads, and the count is free.
+   */
+  private watchers = 0;
 
   constructor() {
     // ONE subscription for the whole app: the backend emits a content-free count
@@ -59,9 +71,7 @@ export class TrashService {
     void this.ipc
       .onTrashUpdated((p) => {
         this._count.set(p.count);
-        // Only refetch the rows when someone is actually looking at them — the
-        // badge needs the count, the list does not need to exist.
-        if (this._entries().length > 0 || p.count > 0) {
+        if (this.watchers > 0) {
           void this.reload();
         }
       })
@@ -69,6 +79,24 @@ export class TrashService {
         this.unlisten = un;
       });
     this.destroyRef.onDestroy(() => this.unlisten?.());
+  }
+
+  /**
+   * Register a mounted list view. Returns the release callback — the caller wires it
+   * to its own `DestroyRef` so a destroyed view stops pulling payloads.
+   */
+  watch(): () => void {
+    this.watchers += 1;
+    let released = false;
+    return () => {
+      // Guard against a double release: two decrements from one view would leave the
+      // counter negative and silently disable refresh for every OTHER open view.
+      if (released) {
+        return;
+      }
+      released = true;
+      this.watchers = Math.max(0, this.watchers - 1);
+    };
   }
 
   /** Refresh the badge count only. Safe to call on app start; reads no payloads. */

--- a/src/app/services/trash.service.ts
+++ b/src/app/services/trash.service.ts
@@ -1,0 +1,212 @@
+import { DestroyRef, Injectable, computed, inject, signal } from "@angular/core";
+import { IpcService } from "../core/ipc.service";
+import type { TrashEntry } from "../core/models";
+
+/**
+ * Signal store for the Trash — the recoverable holding area for deleted content.
+ *
+ * `providedIn: "root"` per `angular-zoneless.md` §8: `/trash` is a LIST route, so
+ * it is destroyed and recreated on every navigate-away-and-back. Component-local
+ * signals would be wiped to `[]` each time and the view would flash empty before
+ * the refetch lands; this instance outlives the component, so a return visit
+ * renders the last-known rows instantly while the (still unconditional) reload
+ * replaces them underneath.
+ *
+ * It also owns the sidebar BADGE count, which is why `count` is tracked separately
+ * from `entries.length`: the badge must be correct on a cold app start before
+ * anyone has opened `/trash`, and `countTrash()` reads no snapshot payloads.
+ *
+ * The backend is the source of truth for masking — a sealed entry arrives with
+ * `locked: true` and no label/detail. This store never infers that and never
+ * optimistically mutates a row; every op resolves, then we reload.
+ */
+@Injectable({ providedIn: "root" })
+export class TrashService {
+  private readonly ipc = inject(IpcService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  private readonly _entries = signal<TrashEntry[]>([]);
+  private readonly _count = signal(0);
+  private readonly _loading = signal(false);
+  private readonly _error = signal<string | null>(null);
+  private readonly _retentionDays = signal(30);
+  /** Entry ids with an op in flight — disables just those rows, never the whole list. */
+  private readonly _busyIds = signal<ReadonlySet<string>>(new Set());
+
+  readonly entries = this._entries.asReadonly();
+  readonly count = this._count.asReadonly();
+  readonly loading = this._loading.asReadonly();
+  readonly error = this._error.asReadonly();
+  readonly retentionDays = this._retentionDays.asReadonly();
+  readonly busyIds = this._busyIds.asReadonly();
+
+  readonly isEmpty = computed(() => this._entries().length === 0);
+  /** Entries that cannot be acted on until their folder is unlocked. */
+  readonly lockedCount = computed(
+    () => this._entries().filter((e) => e.locked).length,
+  );
+  /** True when every entry is masked — the "unlock a folder to manage these" case. */
+  readonly allLocked = computed(
+    () => !this.isEmpty() && this.lockedCount() === this._entries().length,
+  );
+
+  private unlisten?: () => void;
+
+  constructor() {
+    // ONE subscription for the whole app: the backend emits a content-free count
+    // whenever the trash changes, from any surface. Kept here (not in the view) so
+    // the sidebar badge stays live while `/trash` is closed.
+    void this.ipc
+      .onTrashUpdated((p) => {
+        this._count.set(p.count);
+        // Only refetch the rows when someone is actually looking at them — the
+        // badge needs the count, the list does not need to exist.
+        if (this._entries().length > 0 || p.count > 0) {
+          void this.reload();
+        }
+      })
+      .then((un) => {
+        this.unlisten = un;
+      });
+    this.destroyRef.onDestroy(() => this.unlisten?.());
+  }
+
+  /** Refresh the badge count only. Safe to call on app start; reads no payloads. */
+  async refreshCount(): Promise<void> {
+    try {
+      this._count.set(await this.ipc.countTrash());
+    } catch {
+      // A failed count must never break the shell — the badge just stays stale.
+    }
+  }
+
+  /**
+   * Reload the list + retention. Leaves the previous rows in place while it runs,
+   * so the view can gate its spinner on `isEmpty() && loading()` and a return
+   * visit never flashes empty.
+   */
+  async reload(): Promise<void> {
+    this._loading.set(true);
+    this._error.set(null);
+    try {
+      const [entries, days] = await Promise.all([
+        this.ipc.listTrash(),
+        this.ipc.getTrashRetentionDays(),
+      ]);
+      this._entries.set(entries);
+      this._retentionDays.set(days);
+      this._count.set(entries.length);
+    } catch (e) {
+      this._error.set(this.message(e));
+    } finally {
+      this._loading.set(false);
+    }
+  }
+
+  /**
+   * Restore one entry. Returns the error message on failure (the caller toasts
+   * it) or `null` on success — a locked entry is refused by the BACKEND, which is
+   * the only authority on that.
+   */
+  async restore(entryId: string): Promise<string | null> {
+    return this.run(entryId, () => this.ipc.restoreTrashItem(entryId));
+  }
+
+  /** Permanently destroy one entry. Irreversible. */
+  async deleteForever(entryId: string): Promise<string | null> {
+    return this.run(entryId, () => this.ipc.deleteTrashItemForever(entryId));
+  }
+
+  /**
+   * Permanently destroy every unlocked entry. Returns the purged count, or an
+   * error message. Locked entries are left behind by the backend, so the count
+   * can be lower than the list length.
+   */
+  async emptyAll(): Promise<{ purged: number } | { error: string }> {
+    this._loading.set(true);
+    try {
+      const purged = await this.ipc.emptyTrash();
+      await this.reload();
+      return { purged };
+    } catch (e) {
+      this._error.set(this.message(e));
+      return { error: this.message(e) };
+    } finally {
+      this._loading.set(false);
+    }
+  }
+
+  /**
+   * Reconcile expired entries when the view opens, instead of waiting up to an
+   * hour for the background tick — otherwise the list can show a row that is
+   * already past its date. Best-effort and silent: the caller has already loaded
+   * the list, and a purge failure is the tick's problem, not the user's.
+   */
+  async purgeExpiredOnOpen(): Promise<void> {
+    try {
+      const purged = await this.ipc.purgeExpiredTrash();
+      if (purged > 0) {
+        await this.reload();
+      }
+    } catch {
+      // Silent by design — see the doc comment.
+    }
+  }
+
+  /** Change the retention window. Applies to entries already in the trash. */
+  async setRetentionDays(days: number): Promise<string | null> {
+    try {
+      await this.ipc.setTrashRetentionDays(days);
+      await this.reload();
+      return null;
+    } catch (e) {
+      const msg = this.message(e);
+      this._error.set(msg);
+      return msg;
+    }
+  }
+
+  private async run(
+    entryId: string,
+    op: () => Promise<void>,
+  ): Promise<string | null> {
+    this.markBusy(entryId, true);
+    try {
+      await op();
+      await this.reload();
+      return null;
+    } catch (e) {
+      return this.message(e);
+    } finally {
+      this.markBusy(entryId, false);
+    }
+  }
+
+  private markBusy(entryId: string, busy: boolean): void {
+    const next = new Set(this._busyIds());
+    if (busy) {
+      next.add(entryId);
+    } else {
+      next.delete(entryId);
+    }
+    this._busyIds.set(next);
+  }
+
+  /**
+   * The backend's `AppError` crosses IPC as a `{ kind: message }` object, so a
+   * bare `String(e)` renders "[object Object]". Pull the message out.
+   */
+  private message(e: unknown): string {
+    if (typeof e === "string") {
+      return e;
+    }
+    if (e && typeof e === "object") {
+      const values = Object.values(e as Record<string, unknown>);
+      const first = values.find((v) => typeof v === "string");
+      if (typeof first === "string") {
+        return first;
+      }
+    }
+    return "Something went wrong.";
+  }
+}


### PR DESCRIPTION
## What

A **Trash** section in the sidebar (own *Storage* group, live count badge) and a `/trash` view. Deleting a **recording, note, folder or note folder** now moves it to a recoverable holding area instead of destroying it. Entries auto-purge after a configurable window — **default 30 days**.

Restore puts the content back where it was (re-files it, re-exports the vault `.md`, re-derives chunks/vectors). "Delete permanently" and "Empty Trash" destroy immediately.

## Why a snapshot table and not a `deleted_at` column

The obvious soft-delete was **measured and rejected**. `src-tauri/src/` carries **455 SQL references** to `meetings` / `documents` / `folders`, and a trashed item must also vanish from FTS, the vec0 partitions, the entity graph, analytics, Ask retrieval and the MCP server. Missing one predicate is a leak of exactly the shape `lock-model.md` exists to prevent: content the user was told is deleted, still answering questions.

So the delete keeps the **existing, already-proven cascade** — rows genuinely go away, so every derived read stays correct for free — and captures a verified snapshot first. `trash_items` is referenced **only** inside `storage/trash_store.rs`, so no other query can reach snapshot content. That is a structural guarantee instead of 455 hand-audited predicates.

The risk this trades into is loss **on restore**, answered with this repo's own seal discipline: `store_and_verify` writes the snapshot, **reads it back out of SQLCipher, re-parses it, and asserts the content round-tripped** — and only then does the destructive cascade run. A snapshot that does not verify **refuses the delete**. Losing the delete is always better than losing the content.

Derived data (FTS rows, embeddings, `doc_chunks`, entity mentions, graph edges) is deliberately **not** snapshotted — it re-derives from canonical content on restore, which is strictly safer than freezing a copy that could disagree with a later schema.

## Lock model

A snapshot holds plaintext content, so it is governed by its source folder's lock:

| Case | Behaviour |
| --- | --- |
| Captured from a **sealed** folder | Inserted as ciphertext in **one statement** (`insert_trash_entry_sealed`) — no window with plaintext behind a lock |
| Captured from an **open** folder, locked later | Sealed by `seal_folder_extras`, alongside the note/document/timeline blobs |
| Read while sealed-and-not-unlocked | **Masked** (`locked: true`, `"🔒 Locked"`, no detail); restore refused with `AppError::Locked` |
| Session unlock / relock / `remove_lock` | Unsealed for the session / re-blanked / permanently decrypted |

Verify-before-destroy on every seal; the permanent unseal writes plaintext **before** dropping ciphertext.

**This also closes a lock regression the feature would otherwise introduce.** `lock_folder` finds a folder's audio by walking `meeting_ids_in_folder`, and a trashed meeting has no row — so deleting from an open folder and locking it afterwards would have left the recording's WAV in plaintext on disk while the app said the folder was sealed. `seal_trash_meeting_audio` now covers those files across all four lock phases, bound to the trash entry id (the meeting id is gone). The purge is skipped for sealed entries: **the lock outranks the retention schedule.**

## Bugs the oracles caught while building this

1. **Restore was impossible.** The delete opens an org-source *closure*, whose `closing_*_guard` triggers `RAISE(ABORT)` on every write to that id. Cleared on restore — safe because the delete already revoked live shares (revoke-before-delete), so no server item survives for the sync tick to re-pull.
2. **Two self-deadlocks.** `export_note_to_vault` and `move_note_doc_inner` both take the non-reentrant lifecycle guard the restore already held. The guard is now scoped per kind, with the reason documented at the seam.
3. **Attachments were silently lost.** `note_attachments` cascade-deletes, so a restored note came back with perfect text and every inline image broken — nothing about the markdown would have revealed it. Now snapshotted, with the SHA-256 **re-verified on restore** (a corrupt image is skipped, not restored).

## Tests

11 oracles in `commands/tests/trash_tests.rs`, **11/11 green**:

- content round-trip (segments incl. confidence, **both** provider notes, timeline, manual notes, tags)
- audio kept on delete / removed on purge
- seal-after-lock masking + restore refusal — **with a control asserting the plaintext really is readable first**, so the guard cannot go vacuous
- birth-sealing from an already-sealed folder, through the production `mint_wrapped_ck`
- retention arithmetic, and **fail-closed purge** on an undateable row
- camelCase wire contract asserted on **serialized key names** (`rust-tauri.md` §2b)
- folder `level`/`emoji`/`tint` preserved — a regression here silently demotes a Project to a Folder
- inline images restored; hex codec rejects malformation rather than returning truncated bytes

## Verified / not verified

Green: `cargo check --lib` (no warnings, clippy `-D warnings` safe) · 11/11 oracles · `ng lint` · `tsc --noEmit` · `.agents/h/mirror-check`.

**Not verified locally — needs CI:**
- `ng build` **aborts with SIGABRT** in my sandbox (native malloc crash in certificate loading). Confirmed environmental by building the pristine `origin/murmur` baseline in a separate worktree: it fails identically. So the **16 kB per-component style budget** and the Playwright runtime check are unverified here. Every design token used is confirmed to exist.
- `commands::lifecycle_tests` shows widespread failures in my sandbox. Confirmed **pre-existing**: `cascading_fresh_lock_keeps_child_open_when_its_filing_preflight_fails` fails with the identical `Export("marker-cleanup export: open vault root component failed: Not a directory (os error 20)")` on the pristine base with none of this branch's code present. Sandbox `TMPDIR` layout, not this change.

## Notes for review

- Retention (7/14/30/60/90, default 30) lives in the **Trash view header**, not Settings → Storage — contextual, and avoids duplicating the state. Easy to move.
- Restore does not emit a list-invalidation event; the Notes/Meetings list routes are destroyed and recreated on navigation and refetch on mount, so a restored item appears on arrival.
- Attachment bytes are **hex** in the payload (2× size) because there is no base64 crate in the workspace and adding a dependency needs approval. The alternative — a side table of raw BLOBs — would need its own seal lifecycle, i.e. a second copy of the machinery in `commands/trash.rs` to get wrong.
