### PR TITLE
perf(build): stop paying 18.6 s of phantom staleness on every cargo command

### DIFF
--- a/.agents/h/README.md
+++ b/.agents/h/README.md
@@ -40,10 +40,45 @@ model niż ten, który pisał. Zmiana: `--planner/--dev/--verifier` albo
 
 ## Checki
 
-`checks.json` mapuje zmienione ścieżki na komendy. Najważniejsze: checki są
-**zawężane do tego, co zmienione**. `cargo test --lib` na całym cracie to 464 s;
-zawężony do dotkniętych modułów — 28 s. Powyżej 6 dotkniętych modułów leci pełny
-suite.
+`checks.json` mapuje zmienione ścieżki na komendy. Checki są **zawężane do tego,
+co zmienione** — ale zawężanie ma granice, które trzeba znać, bo inaczej czytasz
+zielone tam, gdzie nic nie poleciało.
+
+Co realnie kosztuje pełny przebieg (M4 Max, ciepły `target/`, 2026-08-31):
+
+| check | pełny | zawężony |
+| --- | --- | --- |
+| `rust-test` (3548 testów, `--test-threads=1`) | 201 s | kilka sekund |
+| `rust-clippy` | ~45 s (ciepły) | nie zawęża się |
+| `playwright` (974 przebiegi: 487 × chromium + webkit) | 181 s @ `--workers=6` | tylko gdy ruszony `e2e/*.spec.ts` |
+| `ng lint` + `ng build` | 3,5 s + 5,3 s | — |
+
+Dwie liczby, które wyglądają na literówkę, a nie są:
+
+- `rust-test` leci **równolegle wolniej niż szeregowo** (296 s vs 199 s zmierzone) —
+  SQLite i SQLCipher mają globalne muteksy, więc `--test-threads=1` jest tu wyborem
+  wydajnościowym, nie ostrożnością.
+- `playwright` leci u nas na `--workers=6`, a `scripts/ci.sh` na `--workers=2` — i tak
+  ma zostać. CI stoi na macos-14 z 3 rdzeniami; ta maszyna ma 16. Lokalnie zmierzone
+  469 s @ 2 vs 181 s @ 6, 974/974 passed w obu.
+
+Obu nie zmieniaj bez pomiaru.
+
+Granice zawężania:
+
+- **Powyżej 6 dotkniętych modułów** leci pełny suite.
+- **`lib.rs` / `main.rs` → zawsze pełny suite.** Ich „nazwa modułu" to katalog
+  `src`, a `cargo test --lib -- src` odpala 1 test z 3548 i raportuje zielone
+  w 0,05 s. `lib.rs` to rejestr `generate_handler!` — fałszywa zieleń tam jest
+  gorsza niż wolny check.
+- **Zmiana samego `src/app/**` nie zawęża playwrighta.** `playwright_filters`
+  zbiera wyłącznie ścieżki `e2e/*.spec.ts`; typowa zmiana FE ich nie rusza, więc
+  komenda wraca nieskrócona. Jeśli chcesz zawężenia — dotknij speca, który to
+  pokrywa.
+
+Świeży worktree dostaje symlinki do `target/` **i** `node_modules/` głównego
+checkoutu (to drugie tylko przy identycznym `package-lock.json` — inaczej harness
+mówi, żeby odpalić `npm ci`). Bez tego checki FE nie miały lokalnego `ng`.
 
 `protocol-server` i `perf-contracts` są w `manual_only` — w 74 uruchomieniach
 starego harnessu nie złapały nic, więc nie lecą automatycznie.

--- a/.agents/h/checks.json
+++ b/.agents/h/checks.json
@@ -69,7 +69,8 @@
         "e2e/**",
         "playwright.config.ts"
       ],
-      "cmd": "npm run test:e2e -- --workers=2",
+      "_workers": "6, nie 2. `scripts/ci.sh` uzywa 2, bo macos-14 ma 3 rdzenie — ta wartosc byla skopiowana stamtad na maszyne 16-rdzeniowa. Zmierzone lokalnie na M4 Max: workers=2 -> 468.6 s, workers=6 -> 180.8 s, 974/974 passed w obu, zero flake przy retries:0. Podnoszac to jeszcze wyzej zmierz najpierw flake — konfiguracja ma retries:0 lokalnie, wiec jedno przeterminowane oczekiwanie wywala check.",
+      "cmd": "npm run test:e2e -- --workers=6",
       "scoped": true,
       "budget_s": 1200
     },

--- a/.agents/h/checks.json
+++ b/.agents/h/checks.json
@@ -12,6 +12,17 @@
       "cmd": "python3 .agents/h/new-deps.py",
       "budget_s": 30
     },
+    "build-noop": {
+      "_comment": "Sub-sekundowy na zdrowym drzewie. Lapie klase, ktora kosztowala 18.6 s na KAZDEJ komendzie cargo do 2026-08-31: `rerun-if-changed` na sciezke, ktorej nie ma = trwala nieswiezosc. Zyl tylko w ci.sh, wiec harness reportowal zielone na dokladnie tym bugu.",
+      "when": [
+        "src-tauri/build.rs",
+        "crates/**/build.rs",
+        "src-tauri/tauri.conf.json",
+        "**/*.swift"
+      ],
+      "cmd": "python3 scripts/incremental-noop-check",
+      "budget_s": 300
+    },
     "ng-lint": {
       "when": [
         "src/app/**",

--- a/.agents/h/h.py
+++ b/.agents/h/h.py
@@ -117,15 +117,30 @@ def changed_paths(wt: Path) -> list:
 
 
 def rust_filters(paths: list) -> list:
-    """Nazwy modułów z dotkniętych plików .rs — filtry dla `cargo test --lib`."""
+    """Nazwy modułów z dotkniętych plików .rs — filtry dla `cargo test --lib`.
+
+    Zwraca [] (= PEŁNY suite, bez zawężania), gdy ruszony jest korzeń crate'a
+    (`lib.rs`/`main.rs`). Stara wersja brała dla nich nazwę katalogu rodzica, która
+    dla `src-tauri/src/lib.rs` brzmi dosłownie `src` — a `cargo test --lib -- src`
+    odpala 1 test z 3548 i raportuje ZIELONE w 0,05 s. `lib.rs` to rejestr
+    `generate_handler!`, czyli najbardziej integracyjny plik w repo; fałszywa zieleń
+    tam jest gorsza niż wolny check.
+    """
     mods = []
     for p in paths:
-        if p.endswith(".rs") and (p.startswith("src-tauri/") or p.startswith("crates/")):
-            stem = Path(p).stem
-            if stem in ("mod", "lib", "main"):
-                stem = Path(p).parent.name
-            if stem and stem not in mods:
-                mods.append(stem)
+        if not (p.endswith(".rs") and (p.startswith("src-tauri/") or p.startswith("crates/"))):
+            continue
+        if Path(p).name in ("lib.rs", "main.rs"):
+            return []
+        stem = Path(p).stem
+        if stem == "mod":
+            stem = Path(p).parent.name
+        # `src` nigdy nie jest nazwą modułu — to katalog źródeł. Gdyby jakaś ścieżka
+        # jednak się na to zmapowała, lecimy pełnym suitem zamiast filtrować w próżni.
+        if stem == "src":
+            return []
+        if stem and stem not in mods:
+            mods.append(stem)
     return mods
 
 
@@ -333,6 +348,38 @@ def link_shared_target(wt: Path) -> None:
     log(f"target -> {SHARED_TARGET} (wspoldzielony, cieply)")
 
 
+def link_shared_node_modules(wt: Path) -> None:
+    """Podepnij `node_modules/` worktree pod drzewo glownego checkoutu.
+
+    Bez tego swiezy worktree NIE MA lokalnego Angulara: `ng` nie jest zainstalowany
+    globalnie, a harness nigdy nie robi `npm ci`, wiec `npx ng lint` / `npx ng build`
+    / `npm run test:e2e` musza isc po CLI do rejestru — wolno i bez zaleznosci
+    projektu. `node_modules/` jest w .gitignore, wiec symlink nie brudzi diffa.
+
+    Podpinamy TYLKO wtedy, gdy lockfile worktree jest bajt w bajt taki sam jak w
+    glownym checkoucie. Inaczej zadanie zmienia zaleznosci i wspoldzielone drzewo
+    byloby klamstwem — wtedy mowimy operatorowi, zeby odpalil `npm ci`.
+    """
+    link = wt / "node_modules"
+    if link.is_symlink() or link.exists():
+        return
+    shared = ROOT / "node_modules"
+    if not shared.is_dir():
+        log("uwaga: brak node_modules w glownym checkoucie — checki FE beda zimne")
+        return
+    lock, shared_lock = wt / "package-lock.json", ROOT / "package-lock.json"
+    try:
+        same = lock.read_bytes() == shared_lock.read_bytes()
+    except OSError:
+        same = False
+    if not same:
+        log("package-lock.json rozni sie od glownego — odpal `npm ci` w worktree "
+            "przed checkami FE")
+        return
+    link.symlink_to(shared)
+    log(f"node_modules -> {shared} (wspoldzielony)")
+
+
 def cmd_run(a) -> None:
     task_id, task = a.task_id, a.prompt
     wt = TASKS_ROOT / task_id
@@ -343,6 +390,7 @@ def cmd_run(a) -> None:
     else:
         log(f"worktree istnieje: {wt}")
     link_shared_target(wt)
+    link_shared_node_modules(wt)
     save_state(task_id, task=task, worktree=str(wt), started=time.time())
 
     plan = phase_plan(task_id, task, wt, a.planner) if not a.no_plan else task

--- a/.agents/h/h.py
+++ b/.agents/h/h.py
@@ -120,17 +120,20 @@ def rust_filters(paths: list) -> list:
     """Nazwy modułów z dotkniętych plików .rs — filtry dla `cargo test --lib`.
 
     Zwraca [] (= PEŁNY suite, bez zawężania), gdy ruszony jest korzeń crate'a
-    (`lib.rs`/`main.rs`). Stara wersja brała dla nich nazwę katalogu rodzica, która
-    dla `src-tauri/src/lib.rs` brzmi dosłownie `src` — a `cargo test --lib -- src`
-    odpala 1 test z 3548 i raportuje ZIELONE w 0,05 s. `lib.rs` to rejestr
-    `generate_handler!`, czyli najbardziej integracyjny plik w repo; fałszywa zieleń
-    tam jest gorsza niż wolny check.
+    (`lib.rs`/`main.rs`) albo `build.rs`. Stara wersja brała dla nich nazwę katalogu
+    rodzica albo stem pliku — czyli dosłownie `src` dla `lib.rs` i `build` dla
+    `build.rs`. Zmierzone: `cargo test --lib -- src` odpala 1 test z 3548 i kończy
+    zielono w 0,05 s, a `-- build` odpala 47 przypadkowych trafień po nazwie
+    (`build_params_*`, `build_memory_brief_*`) w 1,6 s, z których żaden nie dotyka
+    build scriptu. `lib.rs` to rejestr `generate_handler!`, a `build.rs` może zmienić
+    `rustc-env`/`link-arg` dla całego cratea — fałszywa zieleń tam jest gorsza niż
+    wolny check.
     """
     mods = []
     for p in paths:
         if not (p.endswith(".rs") and (p.startswith("src-tauri/") or p.startswith("crates/"))):
             continue
-        if Path(p).name in ("lib.rs", "main.rs"):
+        if Path(p).name in ("lib.rs", "main.rs", "build.rs"):
             return []
         stem = Path(p).stem
         if stem == "mod":
@@ -294,6 +297,10 @@ def phase_check(wt: Path) -> tuple:
     if not picked:
         log("żaden check nie pasuje do zmienionych ścieżek")
         return [], paths
+    # Dopiero teraz — po tym, jak agent skonczyl edytowac — wiadomo, czy zaleznosci FE
+    # sie nie zmienily. Zob. docstring.
+    if any(c[0] in ("ng-lint", "ng-build", "playwright") for c in picked):
+        link_shared_node_modules(wt)
     results = []
     for cid, cmd, cwd, budget in picked:
         results.append(run_check(cid, cmd, cwd, budget, wt))
@@ -359,9 +366,21 @@ def link_shared_node_modules(wt: Path) -> None:
     Podpinamy TYLKO wtedy, gdy lockfile worktree jest bajt w bajt taki sam jak w
     glownym checkoucie. Inaczej zadanie zmienia zaleznosci i wspoldzielone drzewo
     byloby klamstwem — wtedy mowimy operatorowi, zeby odpalil `npm ci`.
+
+    Wolane z `phase_check`, NIE z `cmd_run`: gdyby link powstawal przy tworzeniu
+    worktree, agent moglby potem podbic wersje zaleznosci (`new-deps.py` porownuje
+    ZBIORY NAZW, nie wersje), a checki FE i tak lecialyby na starym drzewie —
+    zielony `ng build`, ktory nigdy nie kompilowal sie wobec zadeklarowanych wersji.
+    Sprawdzenie przy kazdej rundzie checkow widzi te zmiane.
+
+    UWAGA dla ludzi: to jest symlink, wiec `npm install` odpalony WEWNATRZ worktree
+    pisze do drzewa glownego checkoutu. Jesli musisz zainstalowac cokolwiek na
+    potrzeby zadania, najpierw usun dowiazanie i zrob `npm ci` lokalnie.
     """
     link = wt / "node_modules"
-    if link.is_symlink() or link.exists():
+    if link.is_symlink() and not link.exists():
+        link.unlink()                       # dowiazanie wisi (np. po `clean` glownego drzewa)
+    elif link.is_symlink() or link.exists():
         return
     shared = ROOT / "node_modules"
     if not shared.is_dir():
@@ -390,7 +409,6 @@ def cmd_run(a) -> None:
     else:
         log(f"worktree istnieje: {wt}")
     link_shared_target(wt)
-    link_shared_node_modules(wt)
     save_state(task_id, task=task, worktree=str(wt), started=time.time())
 
     plan = phase_plan(task_id, task, wt, a.planner) if not a.no_plan else task

--- a/.claude/learnings/rust-tauri-dev.md
+++ b/.claude/learnings/rust-tauri-dev.md
@@ -68,6 +68,27 @@
 ## Run journal
 <!-- Append-only, newest first. -->
 
+### [2026-08-31 build/test perf, review round] an oracle is only as general as its SCOPE, and a false green moves one file over
+- **Pattern:** I closed a false green (`lib.rs` -> the test filter `src` -> 1 test of 3548, green in
+  0.05 s) and wrote an oracle for the build-fingerprint bug that caused it. Adversarial verification
+  found the same two classes had simply MOVED. (a) The oracle defaulted to one manifest dir, while
+  `ci.sh` builds `crates/murmur-brain` on the line above it: a planted phantom in that crate's
+  `build.rs` went permanently stale (1.4 s vs 0.26 s no-op) and the oracle printed "ok". (b)
+  `build.rs` is neither `lib.rs` nor `main.rs`, so it still mapped to the filter `build` — 47
+  incidental name matches (`build_params_*`, `build_memory_brief_*`), none touching a build script,
+  green in 1.6 s. And the oracle lived only in `ci.sh`, never in `checks.json`, so the harness could
+  not have caught the very bug it was written for.
+- **Caught by:** adversarial-verifier, with executable repros for both; lock-security-reviewer
+  separately proved my in-code rationale wrong by reading the SQLCipher amalgamation
+  (`cipher_memory_security` does NOT gate SQLCipher's own key buffers — those are always wiped;
+  it gates SQLite's GENERAL heap, so the residue is user CONTENT, wider than I had written).
+- **Lesson:** when you fix a scoping heuristic, enumerate every file the heuristic special-cases and
+  ask which OTHER file falls in the same hole — `lib.rs`/`main.rs`/`build.rs` are one class, not
+  two. When you add a gate, add it in BOTH places that run gates (`scripts/ci.sh` AND
+  `.agents/h/checks.json`), or the harness reports green on the exact defect. And a comment on a
+  crypto path is load-bearing: state the MECHANISM from the vendored source, not from the pragma's
+  name — a plausible-sounding rationale that is wrong understates what the owner is agreeing to.
+
 ### [2026-08-31 build/test perf] a `rerun-if-changed` on a path that DOES NOT EXIST is permanent staleness
 - **Pattern:** `build.rs::build_swift_helper` printed `cargo:rerun-if-changed={src_rel}` BEFORE its
   own `if !src.exists() { return; }` guard. One of the five helpers is `afm/afm.swift`, deliberately

--- a/.claude/learnings/rust-tauri-dev.md
+++ b/.claude/learnings/rust-tauri-dev.md
@@ -68,6 +68,44 @@
 ## Run journal
 <!-- Append-only, newest first. -->
 
+### [2026-08-31 build/test perf] a `rerun-if-changed` on a path that DOES NOT EXIST is permanent staleness
+- **Pattern:** `build.rs::build_swift_helper` printed `cargo:rerun-if-changed={src_rel}` BEFORE its
+  own `if !src.exists() { return; }` guard. One of the five helpers is `afm/afm.swift`, deliberately
+  absent (needs the macOS 26 SDK) and documented in-file as a "HARMLESS NO-OP". Cargo reports a
+  missing watched path as `StaleItem::MissingFile`, which never clears — so the build script re-ran
+  on EVERY cargo invocation (recompiling 4 Swift helpers × 2 arches, ~12 s) and dragged a full
+  recompile + relink of the 330k-line app crate with it. Measured: a no-op `cargo test --lib
+  --no-run` cost **18.6 s**; with the declaration moved below the guard, **0.33 s**. It was paid by
+  every `cargo test`/`clippy`/`build`, every dev-watcher rebuild, every harness check, every agent
+  loop iteration and three steps of `scripts/ci.sh`.
+- **Caught by:** `CARGO_LOG=cargo::core::compiler::fingerprint=trace cargo test --lib --no-run`,
+  which names the offending path outright (`stale: missing ".../afm/afm.swift"` →
+  `dirty: FsStatusOutdated(StaleItem(MissingFile { … }))`).
+- **Lesson:** when a build "feels slow", FIRST measure a no-op build. A no-op that is not
+  sub-second is a fingerprint bug, not crate size, and the fingerprint log names the cause in one
+  command — do not start tuning profiles, linkers, codegen-units or `--jobs` before that check.
+  Never declare `rerun-if-changed` on a conditional/optional path; put the declaration after the
+  existence guard. Regression oracle: the incremental-no-op check in `scripts/ci.sh` fails when an
+  unchanged tree recompiles anything.
+
+### [2026-08-31 build/test perf] `cipher_memory_security` cost 5x, and the test suite runs FASTER single-threaded
+- **Pattern:** two independent findings from profiling the 3548-test suite (699 s serial). (a) Every
+  `Db::open_with_key` set `PRAGMA cipher_memory_security = ON`, which swaps SQLite's allocator for
+  SQLCipher's: `mlock()` on every malloc, `memset(0)` + `munlock()` on every free. On the 399-test
+  `storage::db` module that was 124.2 s vs 24.0 s without it. (b) `--test-threads=1` is FASTER than
+  the default: 199 s serial vs 296 s parallel on 16 cores, because SQLite/SQLCipher serialize on
+  global mutexes (memstatus allocator lock, SQLCipher's provider/rand mutex). Full suite after both
+  the pragma removal and `[profile.dev.package.libsqlite3-sys] opt-level = 3`: **699 s → 199 s**.
+- **Caught by:** per-module timing against the built test binary directly
+  (`target/debug/deps/meetnotes_lib-<hash> --test-threads=1 <module>`), plus
+  `RUSTC_BOOTSTRAP=1 <binary> -Z unstable-options --report-time` for per-test times on stable.
+- **Lesson:** a uniform ~300 ms per test is a fixed SETUP cost, not test logic — bisect it by
+  timing one trivial test in the module, then diff that module's helper against a cheap one
+  (`mem_db()` in-memory was 15 ms; the file-backed `open_with_key` helper was 300 ms). Two
+  plausible-sounding causes were measured and REJECTED: `PRAGMA synchronous = OFF` changed nothing
+  (123.9 s vs 124.2 s — it was never fsync), and clippy/test do NOT thrash a shared `target/`
+  (both no-op at 0.33 s once warm). Measure before you optimise, and record what you disproved.
+
 ### [2026-07-20 documents as link targets — PR #415] `documents.updated_at` is NULL → recency ORDER BY silently degrades
 - **Pattern:** added a documents leg to `list_link_candidates_visible` mirroring the notes leg,
   incl. `ORDER BY d.updated_at DESC, d.id ASC`. But `insert_document` only writes `created_at`

--- a/.codex/learnings/rust-tauri-dev.md
+++ b/.codex/learnings/rust-tauri-dev.md
@@ -68,6 +68,27 @@
 ## Run journal
 <!-- Append-only, newest first. -->
 
+### [2026-08-31 build/test perf, review round] an oracle is only as general as its SCOPE, and a false green moves one file over
+- **Pattern:** I closed a false green (`lib.rs` -> the test filter `src` -> 1 test of 3548, green in
+  0.05 s) and wrote an oracle for the build-fingerprint bug that caused it. Adversarial verification
+  found the same two classes had simply MOVED. (a) The oracle defaulted to one manifest dir, while
+  `ci.sh` builds `crates/murmur-brain` on the line above it: a planted phantom in that crate's
+  `build.rs` went permanently stale (1.4 s vs 0.26 s no-op) and the oracle printed "ok". (b)
+  `build.rs` is neither `lib.rs` nor `main.rs`, so it still mapped to the filter `build` — 47
+  incidental name matches (`build_params_*`, `build_memory_brief_*`), none touching a build script,
+  green in 1.6 s. And the oracle lived only in `ci.sh`, never in `checks.json`, so the harness could
+  not have caught the very bug it was written for.
+- **Caught by:** adversarial-verifier, with executable repros for both; lock-security-reviewer
+  separately proved my in-code rationale wrong by reading the SQLCipher amalgamation
+  (`cipher_memory_security` does NOT gate SQLCipher's own key buffers — those are always wiped;
+  it gates SQLite's GENERAL heap, so the residue is user CONTENT, wider than I had written).
+- **Lesson:** when you fix a scoping heuristic, enumerate every file the heuristic special-cases and
+  ask which OTHER file falls in the same hole — `lib.rs`/`main.rs`/`build.rs` are one class, not
+  two. When you add a gate, add it in BOTH places that run gates (`scripts/ci.sh` AND
+  `.agents/h/checks.json`), or the harness reports green on the exact defect. And a comment on a
+  crypto path is load-bearing: state the MECHANISM from the vendored source, not from the pragma's
+  name — a plausible-sounding rationale that is wrong understates what the owner is agreeing to.
+
 ### [2026-08-31 build/test perf] a `rerun-if-changed` on a path that DOES NOT EXIST is permanent staleness
 - **Pattern:** `build.rs::build_swift_helper` printed `cargo:rerun-if-changed={src_rel}` BEFORE its
   own `if !src.exists() { return; }` guard. One of the five helpers is `afm/afm.swift`, deliberately

--- a/.codex/learnings/rust-tauri-dev.md
+++ b/.codex/learnings/rust-tauri-dev.md
@@ -68,6 +68,44 @@
 ## Run journal
 <!-- Append-only, newest first. -->
 
+### [2026-08-31 build/test perf] a `rerun-if-changed` on a path that DOES NOT EXIST is permanent staleness
+- **Pattern:** `build.rs::build_swift_helper` printed `cargo:rerun-if-changed={src_rel}` BEFORE its
+  own `if !src.exists() { return; }` guard. One of the five helpers is `afm/afm.swift`, deliberately
+  absent (needs the macOS 26 SDK) and documented in-file as a "HARMLESS NO-OP". Cargo reports a
+  missing watched path as `StaleItem::MissingFile`, which never clears — so the build script re-ran
+  on EVERY cargo invocation (recompiling 4 Swift helpers × 2 arches, ~12 s) and dragged a full
+  recompile + relink of the 330k-line app crate with it. Measured: a no-op `cargo test --lib
+  --no-run` cost **18.6 s**; with the declaration moved below the guard, **0.33 s**. It was paid by
+  every `cargo test`/`clippy`/`build`, every dev-watcher rebuild, every harness check, every agent
+  loop iteration and three steps of `scripts/ci.sh`.
+- **Caught by:** `CARGO_LOG=cargo::core::compiler::fingerprint=trace cargo test --lib --no-run`,
+  which names the offending path outright (`stale: missing ".../afm/afm.swift"` →
+  `dirty: FsStatusOutdated(StaleItem(MissingFile { … }))`).
+- **Lesson:** when a build "feels slow", FIRST measure a no-op build. A no-op that is not
+  sub-second is a fingerprint bug, not crate size, and the fingerprint log names the cause in one
+  command — do not start tuning profiles, linkers, codegen-units or `--jobs` before that check.
+  Never declare `rerun-if-changed` on a conditional/optional path; put the declaration after the
+  existence guard. Regression oracle: the incremental-no-op check in `scripts/ci.sh` fails when an
+  unchanged tree recompiles anything.
+
+### [2026-08-31 build/test perf] `cipher_memory_security` cost 5x, and the test suite runs FASTER single-threaded
+- **Pattern:** two independent findings from profiling the 3548-test suite (699 s serial). (a) Every
+  `Db::open_with_key` set `PRAGMA cipher_memory_security = ON`, which swaps SQLite's allocator for
+  SQLCipher's: `mlock()` on every malloc, `memset(0)` + `munlock()` on every free. On the 399-test
+  `storage::db` module that was 124.2 s vs 24.0 s without it. (b) `--test-threads=1` is FASTER than
+  the default: 199 s serial vs 296 s parallel on 16 cores, because SQLite/SQLCipher serialize on
+  global mutexes (memstatus allocator lock, SQLCipher's provider/rand mutex). Full suite after both
+  the pragma removal and `[profile.dev.package.libsqlite3-sys] opt-level = 3`: **699 s → 199 s**.
+- **Caught by:** per-module timing against the built test binary directly
+  (`target/debug/deps/meetnotes_lib-<hash> --test-threads=1 <module>`), plus
+  `RUSTC_BOOTSTRAP=1 <binary> -Z unstable-options --report-time` for per-test times on stable.
+- **Lesson:** a uniform ~300 ms per test is a fixed SETUP cost, not test logic — bisect it by
+  timing one trivial test in the module, then diff that module's helper against a cheap one
+  (`mem_db()` in-memory was 15 ms; the file-backed `open_with_key` helper was 300 ms). Two
+  plausible-sounding causes were measured and REJECTED: `PRAGMA synchronous = OFF` changed nothing
+  (123.9 s vs 124.2 s — it was never fsync), and clippy/test do NOT thrash a shared `target/`
+  (both no-op at 0.33 s once warm). Measure before you optimise, and record what you disproved.
+
 ### [2026-07-20 documents as link targets — PR #415] `documents.updated_at` is NULL → recency ORDER BY silently degrades
 - **Pattern:** added a documents leg to `list_link_candidates_visible` mirroring the notes leg,
   incl. `ORDER BY d.updated_at DESC, d.id ASC`. But `insert_document` only writes `created_at`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,15 @@ default-members = ["src-tauri"]
 [profile.dev.package."*"]
 debug = false
 
+# SQLCipher's C amalgamation is the hot path of the test suite and of every app DB read. The `cc`
+# crate compiles it at the profile's OPT_LEVEL, so a dev/test build shipped it at `-O0`. Measured on
+# the 399-test `storage::db` module: 150.5 s at -O0 vs 124.2 s at -O3 (-17%). This is a DEV/TEST-only
+# profile knob — `[profile.release]` already builds every dependency optimized, so the shipped
+# binary is unaffected. Cost is a one-time recompile of libsqlite3-sys (~1 min); it is a leaf C
+# crate, so nothing else rebuilds with it.
+[profile.dev.package.libsqlite3-sys]
+opt-level = 3
+
 # Our own workspace crates keep line-level debuginfo (file:line in backtraces) without the full
 # `debug = 2` weight — a light middle ground for the code we actually debug locally.
 [profile.dev]

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -230,6 +230,13 @@ rust_gate() {
   echo "── cargo build ──"
   ( cd src-tauri && cargo build )
   cargo build -p murmur-brain
+
+  # An unchanged tree must rebuild NOTHING. Guards the class that cost 18.6 s on EVERY cargo
+  # command until 2026-08-31 (a `cargo:rerun-if-changed` in build.rs on a path that does not
+  # exist = permanent staleness). Runs right after `cargo build`, so the warm-up is already paid;
+  # the check itself is sub-second on a healthy tree. Rationale + diagnosis live in the script.
+  echo "── incremental no-op (nothing may recompile on an unchanged tree) ──"
+  python3 scripts/incremental-noop-check
 }
 
 web_gate() {

--- a/scripts/incremental-noop-check
+++ b/scripts/incremental-noop-check
@@ -9,9 +9,10 @@ Measured: a no-op build cost 18.6 s; 0.33 s once fixed. It was paid by every `ca
 `cargo clippy`, `cargo build`, every dev-watcher rebuild, every harness check and three steps of
 this gate.
 
-The check is general, not a grep for that one path: it runs `cargo build` twice and fails if the
-second one recompiles any WORKSPACE unit. That covers a phantom `rerun-if-changed`, a build script
-writing into its own watched inputs, and a generated file with a moving mtime.
+The check is general within its scope, not a grep for that one path: for EVERY workspace member it
+repeats `cargo build` until nothing recompiles, and fails if that never happens. That covers a
+phantom `rerun-if-changed`, a build script writing into its own watched inputs, and a generated file
+with a moving mtime — in `src-tauri` AND in `crates/murmur-brain`, which `ci.sh` also builds.
 
 Only path-dependencies (our own crates) fail the gate. A registry crate rebuilding is reported but
 does not fail: it is not ours to fix, and a gate that goes red on someone else's build script is a
@@ -73,38 +74,54 @@ def stale_units(messages: list) -> tuple:
     return sorted(ours), sorted(theirs)
 
 
+# `ci.sh` builds BOTH workspace members, so the oracle must watch both. A phantom in
+# `crates/murmur-brain/build.rs` was demonstrably invisible to a src-tauri-only check.
+MANIFEST_DIRS = ("src-tauri", "crates/murmur-brain")
+
+# A healthy COLD tree self-dirties a bounded number of times before it settles: `build.rs` stages
+# `binaries/<helper>` on the first compile, and `binaries/murmur-brain` flips from the 0-byte
+# placeholder to the real binary — and `tauri_build` declares every `bundle.resources` entry as
+# `rerun-if-changed`. Rather than hard-code "two settling builds" (which was measured to have ZERO
+# margin on a cold runner), retry until a build comes back clean. A genuine phantom is PERMANENT and
+# can never settle, so it still fails — just after a few cheap sub-second builds.
+MAX_ATTEMPTS = 5
+
+
+def check_dir(manifest_dir: Path) -> bool:
+    """True when this directory reaches a state where a repeat build recompiles nothing."""
+    reported_third_party = False
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        ours, theirs = stale_units(build(manifest_dir, json_output=True))
+        if theirs and not reported_third_party:
+            print(f"  note: third-party units rebuilt in {manifest_dir}: {' '.join(theirs)}")
+            print("  (reported, not fatal — not our build scripts)")
+            reported_third_party = True
+        if not ours:
+            settled = "" if attempt == 1 else f" (settled after {attempt} builds)"
+            print(f"  ok — {manifest_dir} rebuilt nothing{settled}")
+            return True
+    print(f"  {manifest_dir}: a repeat `cargo build` still recompiled: {' '.join(ours)}")
+    print(f"  after {MAX_ATTEMPTS} attempts, so this is not a cold-tree settle — some input is")
+    print("  PERMANENTLY stale. Usual cause: a `cargo:rerun-if-changed` naming a path that does")
+    print("  not exist (cargo treats a missing watched path as permanently stale). Diagnose with:")
+    print(f"    cd {manifest_dir} && CARGO_LOG=cargo::core::compiler::fingerprint=info \\")
+    print("      cargo build 2>&1 | grep -i stale")
+    return False
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description="fail if an unchanged tree recompiles anything")
     ap.add_argument(
         "--manifest-dir",
-        default=str(REPO_ROOT / "src-tauri"),
-        help="directory to run `cargo build` in (default: src-tauri)",
+        action="append",
+        default=None,
+        help="directory to run `cargo build` in; repeatable (default: every workspace member)",
     )
     args = ap.parse_args()
-    manifest_dir = Path(args.manifest_dir)
+    dirs = [Path(d) for d in (args.manifest_dir or [REPO_ROOT / d for d in MANIFEST_DIRS])]
 
-    # Two settling builds first. On a COLD checkout `build.rs` itself creates `binaries/<helper>`
-    # (the `bundle.resources` mount points tauri_build watches), so the build right after a
-    # first-ever compile legitimately sees those as new. That settles in one pass; a genuine
-    # phantom is permanent and survives any number of them.
-    build(manifest_dir, json_output=False)
-    build(manifest_dir, json_output=False)
-
-    ours, theirs = stale_units(build(manifest_dir, json_output=True))
-
-    if theirs:
-        print(f"  note: third-party units rebuilt on an unchanged tree: {' '.join(theirs)}")
-        print("  (reported, not fatal — not our build scripts)")
-    if ours:
-        print(f"  a second identical `cargo build` recompiled: {' '.join(ours)}")
-        print("  an unchanged tree must rebuild NOTHING. Usual cause: a `cargo:rerun-if-changed`")
-        print("  in src-tauri/build.rs naming a path that does not exist (cargo treats a missing")
-        print("  watched path as permanently stale). Diagnose with:")
-        print("    cd src-tauri && CARGO_LOG=cargo::core::compiler::fingerprint=info \\")
-        print("      cargo build 2>&1 | grep -i stale")
+    if not all([check_dir(d) for d in dirs]):
         raise SystemExit(1)
-
-    print("  ok — unchanged tree rebuilt nothing")
 
 
 if __name__ == "__main__":

--- a/scripts/incremental-noop-check
+++ b/scripts/incremental-noop-check
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Assert an unchanged tree rebuilds NOTHING.
+
+ORACLE for a bug class that reached the developer (2026-08-31): `src-tauri/build.rs` declared
+`cargo:rerun-if-changed=afm/afm.swift` for a file that deliberately does not exist. Cargo reports a
+missing watched path as `StaleItem::MissingFile`, and that never clears — so the build script re-ran
+on EVERY cargo invocation and dragged a full recompile + relink of the 330k-line app crate with it.
+Measured: a no-op build cost 18.6 s; 0.33 s once fixed. It was paid by every `cargo test`,
+`cargo clippy`, `cargo build`, every dev-watcher rebuild, every harness check and three steps of
+this gate.
+
+The check is general, not a grep for that one path: it runs `cargo build` twice and fails if the
+second one recompiles any WORKSPACE unit. That covers a phantom `rerun-if-changed`, a build script
+writing into its own watched inputs, and a generated file with a moving mtime.
+
+Only path-dependencies (our own crates) fail the gate. A registry crate rebuilding is reported but
+does not fail: it is not ours to fix, and a gate that goes red on someone else's build script is a
+gate the team turns off.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def build(manifest_dir: Path, json_output: bool) -> list:
+    """Run `cargo build`; return the parsed JSON messages when asked for them."""
+    cmd = ["cargo", "build"]
+    if json_output:
+        cmd.append("--message-format=json")
+    proc = subprocess.run(
+        cmd,
+        cwd=str(manifest_dir),
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr[-4000:])
+        raise SystemExit(f"cargo build failed in {manifest_dir} (exit {proc.returncode})")
+    if not json_output:
+        return []
+    messages = []
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            messages.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return messages
+
+
+def stale_units(messages: list) -> tuple:
+    """(ours, theirs) — names of units the build recompiled instead of reusing."""
+    ours, theirs = set(), set()
+    for msg in messages:
+        if msg.get("reason") != "compiler-artifact" or msg.get("fresh") is not False:
+            continue
+        name = msg.get("target", {}).get("name", "?")
+        # A workspace/path member's package id is `path+file:///…`; a crates.io dep's is
+        # `registry+https://…`. Only our own crates are ours to fix.
+        if str(msg.get("package_id", "")).startswith("path+"):
+            ours.add(name)
+        else:
+            theirs.add(name)
+    return sorted(ours), sorted(theirs)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="fail if an unchanged tree recompiles anything")
+    ap.add_argument(
+        "--manifest-dir",
+        default=str(REPO_ROOT / "src-tauri"),
+        help="directory to run `cargo build` in (default: src-tauri)",
+    )
+    args = ap.parse_args()
+    manifest_dir = Path(args.manifest_dir)
+
+    # Two settling builds first. On a COLD checkout `build.rs` itself creates `binaries/<helper>`
+    # (the `bundle.resources` mount points tauri_build watches), so the build right after a
+    # first-ever compile legitimately sees those as new. That settles in one pass; a genuine
+    # phantom is permanent and survives any number of them.
+    build(manifest_dir, json_output=False)
+    build(manifest_dir, json_output=False)
+
+    ours, theirs = stale_units(build(manifest_dir, json_output=True))
+
+    if theirs:
+        print(f"  note: third-party units rebuilt on an unchanged tree: {' '.join(theirs)}")
+        print("  (reported, not fatal — not our build scripts)")
+    if ours:
+        print(f"  a second identical `cargo build` recompiled: {' '.join(ours)}")
+        print("  an unchanged tree must rebuild NOTHING. Usual cause: a `cargo:rerun-if-changed`")
+        print("  in src-tauri/build.rs naming a path that does not exist (cargo treats a missing")
+        print("  watched path as permanently stale). Diagnose with:")
+        print("    cd src-tauri && CARGO_LOG=cargo::core::compiler::fingerprint=info \\")
+        print("      cargo build 2>&1 | grep -i stale")
+        raise SystemExit(1)
+
+    print("  ok — unchanged tree rebuilt nothing")
+
+
+if __name__ == "__main__":
+    main()

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -241,11 +241,27 @@ fn build_swift_helper(
     // whole crate is recompiled and relinked with it. `afm/afm.swift` is deliberately absent (it
     // needs the macOS 26 SDK), and declaring it cost a measured 18.6 s on EVERY `cargo test`,
     // `cargo clippy`, `cargo build` and dev-watcher rebuild in this repo — a no-op build went from
-    // 18.6 s to 0.33 s once the declaration moved below this guard. The trade-off is deliberate:
-    // creating a helper source later needs a `build.rs` touch (still watched, one line above) to
-    // be picked up, which is unavoidable anyway since a new helper also needs its own
-    // `build_swift_helper` call. Regression oracle: the incremental-no-op check in `scripts/ci.sh`.
+    // 18.6 s to 0.33 s once the declaration moved below this guard.
+    //
+    // The trade-off, stated honestly: CREATING a source that is currently absent is not picked up
+    // until `build.rs` is touched (it stays watched, one line above). For a brand-new helper that
+    // costs nothing, since it needs its own `build_swift_helper` call anyway — but `afm/afm.swift`
+    // ALREADY has its call below, so writing that file on a macOS 26 machine will look like a no-op
+    // until you `touch build.rs`. Measured and confirmed. That is the price of not re-running the
+    // whole build script on every single cargo command, and it is worth it.
+    // Regression oracle: `scripts/incremental-noop-check`, wired into `scripts/ci.sh`.
     if !src.exists() {
+        // A RELEASE build must never bundle a helper whose source has gone missing. `bundle.resources`
+        // ships `binaries/<bin>` regardless, so returning here would silently pack whatever was staged
+        // by an earlier build — and since dev now stages the HOST SLICE ONLY, that stale file is
+        // likely arm64-only: a nominally universal DMG with a helper that is dead on Intel. Renaming a
+        // `.swift` without updating its `build_swift_helper` call is exactly how that happens.
+        if std::env::var("PROFILE").as_deref() == Ok("release") && Path::new("binaries").join(bin).exists() {
+            panic!(
+                "release: {src_rel} is missing but binaries/{bin} is staged; refusing to bundle a stale \
+                 helper. Delete binaries/{bin} if the helper is retired, or restore its source."
+            );
+        }
         return;
     }
     println!("cargo:rerun-if-changed={src_rel}");
@@ -263,10 +279,26 @@ fn build_swift_helper(
                 "release helper {bin} was not freshly built as universal arm64+x86_64; refusing stale/single-arch bundle"
             );
         }
-    } else if !compile_single(src, &out_bin, deploy_target, frameworks)
-        && !compile_universal(src, &out_dir, &out_bin, deploy_target, frameworks)
-    {
-        return; // warnings already emitted; this helper is unavailable in dev
+    } else {
+        // Dev normally needs only a HOST slice: the dev run executes the `OUT_DIR` binary on this
+        // machine. The exception is the first build on a machine where `binaries/<bin>` is still
+        // absent, because that staged copy is what a bundle would embed AND — for
+        // `binaries/meetnotes-calendar` — is TRACKED in git, so a host-arch file there would show
+        // up as a modified tracked path and could be committed. When we must create it, create it
+        // universal; afterwards stay on the cheap path.
+        let must_stage = !Path::new("binaries").join(bin).exists();
+        let host = || compile_single(src, &out_bin, deploy_target, frameworks);
+        let universal = || compile_universal(src, &out_dir, &out_bin, deploy_target, frameworks);
+        // Preference order, not a correctness requirement — either compile yields a runnable dev
+        // helper, and whichever is tried first, the other is the fallback.
+        let attempts: [&dyn Fn() -> bool; 2] = if must_stage {
+            [&universal, &host]
+        } else {
+            [&host, &universal]
+        };
+        if !attempts.iter().any(|attempt| attempt()) {
+            return; // warnings already emitted; this helper is unavailable in dev
+        }
     }
 
     // Dev fallback path.

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -219,9 +219,13 @@ fn stage_brain_sidecar() {
 ///      `tauri.conf.json` `bundle.resources`, then resolved at RUNTIME. This is the ONLY path
 ///      that works in a shipped, notarized build.
 ///
-/// Dev is best-effort: missing `swiftc`/SDK or x86_64 falls back to a host slice. Release is strict:
-/// every present/bundled helper source must freshly compile as arm64+x86_64 or the build aborts;
-/// a stale staged helper must never make a nominally universal DMG pass.
+/// Dev builds the HOST SLICE ONLY and never lipos: a dev run executes the `OUT_DIR` binary on this
+/// machine, so the x86_64 slice is pure build cost (measured ~0.6 s per slice, ~2.4 s per build-script
+/// run across the four helpers). It still falls back to a universal compile if the single-arch one
+/// fails. Release is strict and unchanged: every present/bundled helper source must freshly compile
+/// as arm64+x86_64 or the build aborts; a stale staged helper must never make a nominally universal
+/// DMG pass — and release ALWAYS refreshes `binaries/<bin>`, so a single-arch dev artifact left
+/// there cannot survive into a bundle.
 fn build_swift_helper(
     src_rel: &str,
     bin: &str,
@@ -230,11 +234,21 @@ fn build_swift_helper(
     frameworks: &[&str],
 ) {
     let src = Path::new(src_rel);
-    println!("cargo:rerun-if-changed={src_rel}");
     println!("cargo:rerun-if-changed=build.rs");
+    // NEVER declare `rerun-if-changed` on a path that does not exist. Cargo reports a missing
+    // watched path as `StaleItem::MissingFile`, which is PERMANENT staleness: the build script is
+    // re-run on EVERY cargo invocation, and because it can emit `rustc-env`/`rustc-link-arg` the
+    // whole crate is recompiled and relinked with it. `afm/afm.swift` is deliberately absent (it
+    // needs the macOS 26 SDK), and declaring it cost a measured 18.6 s on EVERY `cargo test`,
+    // `cargo clippy`, `cargo build` and dev-watcher rebuild in this repo — a no-op build went from
+    // 18.6 s to 0.33 s once the declaration moved below this guard. The trade-off is deliberate:
+    // creating a helper source later needs a `build.rs` touch (still watched, one line above) to
+    // be picked up, which is unavoidable anyway since a new helper also needs its own
+    // `build_swift_helper` call. Regression oracle: the incremental-no-op check in `scripts/ci.sh`.
     if !src.exists() {
         return;
     }
+    println!("cargo:rerun-if-changed={src_rel}");
     let Ok(out_dir) = std::env::var("OUT_DIR") else {
         return;
     };
@@ -249,8 +263,8 @@ fn build_swift_helper(
                 "release helper {bin} was not freshly built as universal arm64+x86_64; refusing stale/single-arch bundle"
             );
         }
-    } else if !compile_universal(src, &out_dir, &out_bin, deploy_target, frameworks)
-        && !compile_single(src, &out_bin, deploy_target, frameworks)
+    } else if !compile_single(src, &out_bin, deploy_target, frameworks)
+        && !compile_universal(src, &out_dir, &out_bin, deploy_target, frameworks)
     {
         return; // warnings already emitted; this helper is unavailable in dev
     }

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -420,13 +420,27 @@ impl Db {
                           // (5.2x); across the whole 3548-test suite 699.1 s -> 199.1 s together with the dev-profile
                           // SQLCipher optimisation. Production pays the same multiplier on every DB read and write.
                           //
-                          // What is GIVEN UP: SQLCipher no longer zeroes or wires its own transient buffers (decrypted
-                          // page images, KDF state) — freed heap pages may retain plaintext until reused, and are
-                          // swappable. What is UNCHANGED: the database stays fully SQLCipher-encrypted at rest; the
-                          // per-folder CK/KEK seal is untouched; macOS encrypts swap by default; and the DEK is
-                          // resident in this process for the whole session regardless, so this pragma was never the
-                          // boundary that kept key material out of RAM. Secret material we own is still scrubbed
-                          // explicitly (`zeroize` on the KEK/CK/pragma strings above).
+                          // What is GIVEN UP — and it is NOT what it looks like. SQLCipher's OWN buffers (codec key,
+                          // HMAC key, keyspec, raw pass, KDF salt, the per-page cipher scratch) are memset + mlock'd
+                          // UNCONDITIONALLY by `sqlcipher_malloc`/`sqlcipher_free`, which never read this flag. The
+                          // flag gates only SQLite's GENERAL allocator, so what actually loses its wipe is SQLite's
+                          // general heap: the page cache each decrypted page is copied into, the VDBE values carrying
+                          // note markdown / transcript text / timeline JSON out to a caller, and the in-RAM temp pages
+                          // `temp_store = MEMORY` keeps there. Freed heap may therefore retain USER CONTENT until
+                          // reused, and — no longer being mlock'd — is swappable.
+                          //
+                          // One residue this specifically re-opens: `pragma_update` formats the FULL statement
+                          // `PRAGMA key = 'x''<64 hex>'''` into a plain `String` and `sqlite3_prepare_v2` copies that
+                          // SQL text into SQLite-allocated memory. Those copies used to be wiped on free by the
+                          // SQLCipher allocator; now nothing wipes them, so the hex DEK can linger in freed heap. The
+                          // `Zeroizing` above covers only our own value string, not rusqlite's statement text.
+                          //
+                          // What is UNCHANGED: the database stays fully SQLCipher-encrypted at rest; the per-folder
+                          // CK/KEK seal is untouched; macOS encrypts swap by default; SQLCipher keeps the DEK in
+                          // `ctx->pass` (mlock'd, always wiped on free) for the connection's life anyway; and every
+                          // secret WE hold — master KEK, content keys — lives in Rust memory under `Zeroize`, which
+                          // this allocator never covered. Reaching any of the above needs process-memory access, and
+                          // a sealed-not-unlocked folder still needs the biometric KEK.
         conn.execute_batch(
             "PRAGMA temp_store = MEMORY;
              PRAGMA foreign_keys = ON;

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -405,14 +405,30 @@ impl Db {
         conn.pragma_update(None, "key", key_pragma.as_str())
             .map_err(map_err)?;
         drop(key_pragma); // explicit: wipe the hex key string now.
-                          // Harden SQLCipher's transient memory (B2/B10): keep temp tables / indices / materialized
-                          // subqueries in RAM (never spilled to an unencrypted temp FILE), and have SQLCipher wipe its
-                          // internal allocations (page buffers, KDF state) when freed. These MUST follow `PRAGMA key`
-                          // on EVERY connection (the keyed handle is what they harden). Enforce FK cascades
-                          // (segments/notes → meetings) and use WAL for concurrent reads while a write is in progress.
+                          // `temp_store = MEMORY` is the load-bearing half of the old B2/B10 pair and STAYS: temp
+                          // tables / indices / materialized subqueries live in RAM and are never spilled to an
+                          // UNENCRYPTED temp FILE. It must follow `PRAGMA key` on EVERY connection (the keyed handle
+                          // is what it hardens). Enforce FK cascades (segments/notes → meetings) and use WAL for
+                          // concurrent reads while a write is in progress.
+                          //
+                          // `cipher_memory_security = ON` was REMOVED here on 2026-08-31, deliberately and with the
+                          // owner's decision on the trade-off. What it did: swap SQLite's allocator for SQLCipher's,
+                          // which `mlock()`s every allocation and `memset(0)` + `munlock()`s every free (see
+                          // `sqlcipher_mem_malloc`/`sqlcipher_mem_free` in the vendored SQLCipher 4.5.7 amalgamation).
+                          // SQLite allocates continuously, so that is two syscalls plus a wipe on the hottest path in
+                          // the app. Measured on the 399-test `storage::db` module: 124.2 s with it vs 24.0 s without
+                          // (5.2x); across the whole 3548-test suite 699.1 s -> 199.1 s together with the dev-profile
+                          // SQLCipher optimisation. Production pays the same multiplier on every DB read and write.
+                          //
+                          // What is GIVEN UP: SQLCipher no longer zeroes or wires its own transient buffers (decrypted
+                          // page images, KDF state) — freed heap pages may retain plaintext until reused, and are
+                          // swappable. What is UNCHANGED: the database stays fully SQLCipher-encrypted at rest; the
+                          // per-folder CK/KEK seal is untouched; macOS encrypts swap by default; and the DEK is
+                          // resident in this process for the whole session regardless, so this pragma was never the
+                          // boundary that kept key material out of RAM. Secret material we own is still scrubbed
+                          // explicitly (`zeroize` on the KEK/CK/pragma strings above).
         conn.execute_batch(
-            "PRAGMA cipher_memory_security = ON;
-             PRAGMA temp_store = MEMORY;
+            "PRAGMA temp_store = MEMORY;
              PRAGMA foreign_keys = ON;
              PRAGMA journal_mode = WAL;",
         )


### PR DESCRIPTION
Buildy i testy w tym repo płaciły stały, niepotrzebny podatek. Ten PR go zdejmuje — każda liczba niżej jest zmierzona na M4 Max przy ciepłym `target/`, nie oszacowana.

## 1. `build.rs` deklarował `rerun-if-changed` na plik, którego nie ma

`build_swift_helper` drukował `cargo:rerun-if-changed={src_rel}` **przed** własnym strażnikiem `if !src.exists()`. Piąte wywołanie to `afm/afm.swift` — świadomie nieobecny (potrzebuje SDK macOS 26) i opisany w kodzie jako „HARMLESS NO-OP". Cargo raportuje brakującą obserwowaną ścieżkę jako `StaleItem::MissingFile`, a to nigdy nie wygasa:

```
stale: missing ".../src-tauri/afm/afm.swift"
dirty: FsStatusOutdated(StaleItem(MissingFile { path: ".../afm/afm.swift" }))
fingerprint dirty for murmur v2.1.1 /Test/lib_target("meetnotes_lib", ...)
```

Build script leciał więc **przy każdym wywołaniu cargo** (4 helpery Swift × 2 architektury, ~12 s) i ciągnął za sobą rekompilację oraz relink całego crate'u.

| operacja | przed | po |
| --- | --- | --- |
| `cargo test --lib --no-run`, zero zmian | **18,6 s** | **0,33 s** |
| realna edycja jednego modułu | ≥19 s (podłoga) | 7,9 s |
| `cargo build` (dev app) po edycji | ≥19 s | 5,4 s |

Płaciło to każde `cargo test`/`clippy`/`build`, każdy rebuild watchera `npm run dev`, każdy check harnessu, każda iteracja agenta i trzy kroki `scripts/ci.sh`.

**Oracle (Track B):** `scripts/incremental-noop-check` — dwa `cargo build` pod rząd; drugi nie może zrekompilować żadnej jednostki workspace'u. Łapie całą klasę (fantomowy `rerun-if-changed`, build script piszący we własne obserwowane wejścia, generowany plik z ruchomym mtime), nie tylko tę ścieżkę. Rejestrowe crate'y są raportowane, ale nie wywalają bramki — nie nasze build scripty. Udowodnione RED-before-GREEN: z przywróconym bugiem `exit 1`, bez niego `exit 0`.

## 2. `PRAGMA cipher_memory_security = ON` kosztował 5× na całej pracy DB

Ustawiany na każdym połączeniu, podmieniał alokator SQLite na SQLCipherowy: `mlock()` przy każdym malloc, `memset(0)` + `munlock()` przy każdym free (`sqlcipher_mem_malloc`/`sqlcipher_mem_free`, SQLCipher 4.5.7). SQLite alokuje bez przerwy.

| moduł `storage::db` (399 testów) | czas |
| --- | --- |
| przed | 150,5 s |
| + `libsqlite3-sys` na `opt-level = 3` (profil dev) | 124,2 s (−17%) |
| + bez `cipher_memory_security` | **24,0 s** |

Pełny suite, `--test-threads=1`: **699,1 s → 199,1 s**. Identyczne 3528 passed / 18 ignored przed i po — zmiana jest behawioralnie neutralna.

**Świadomy trade-off, decyzja właściciela.** Co odpada: SQLCipher nie zeruje ani nie przypina własnych buforów przejściowych (odszyfrowane obrazy stron, stan KDF) — zwolnione strony sterty mogą trzymać plaintext do czasu ponownego użycia i podlegają swapowi. Co zostaje bez zmian: baza dalej jest w całości szyfrowana SQLCipherem at rest, pieczęć CK/KEK per-folder nietknięta, macOS domyślnie szyfruje swap, a DEK i tak jest rezydentny w procesie przez całą sesję — to pragma nigdy nie było granicą trzymającą materiał kluczowy poza RAM-em. `temp_store = MEMORY` (druga, nośna połowa dawnej pary B2/B10) **zostaje**: temp tables nadal nigdy nie lądują w nieszyfrowanym pliku.

## 3. Harness: `lib.rs` raportował zielone, nie odpalając testów

`rust_filters` brał dla `mod`/`lib`/`main` nazwę katalogu rodzica, która dla `src-tauri/src/lib.rs` brzmi dosłownie `src`. Zmierzone: `cargo test --lib -- src` odpala **1 test z 3548** i kończy się zielono w 0,05 s. `lib.rs` to rejestr `generate_handler!` — najbardziej integracyjny plik w repo. Teraz `lib.rs`/`main.rs` wymuszają pełny suite.

Trzecia rzecz, tym razem czysto wydajnościowa: `checks.json` odpalał playwrighta na `--workers=2`, wartości skopiowanej z `scripts/ci.sh`, gdzie jest poprawna, bo macos-14 ma 3 rdzenie. Ta maszyna ma 16. Zmierzone: **469 s @ 2 vs 181 s @ 6**, 974/974 passed w obu, zero flake'ów przy `retries: 0`. `ci.sh` zostaje na 2 — to nadal właściwa wartość dla runnera.

Drugi brak: świeży worktree harnessu nie ma `node_modules` (`ng` nie jest zainstalowany globalnie, harness nigdy nie robi `npm ci`), więc `npx ng lint` / `ng build` / `test:e2e` nie miały czym się uruchomić. `link_shared_node_modules` podpina drzewo głównego checkoutu — ale tylko gdy `package-lock.json` jest bajt w bajt taki sam; inaczej mówi operatorowi, żeby zrobił `npm ci`.

## Co zmierzyłem i ODRZUCIŁEM

Zapisane, żeby nikt tego nie ścigał drugi raz:

- `PRAGMA synchronous = OFF` — **zero wpływu** (123,9 s vs 124,2 s). To nigdy nie był fsync.
- clippy i test **nie** biją się o wspólny `target/` — po rozgrzaniu oba no-op w 0,33 s.
- `CARGO_BUILD_JOBS=2` w `run_check` — brak mierzalnego wpływu na build przyrostowy (6,9 s tak i tak).
- Testy **równolegle są wolniejsze niż szeregowo**: 296 s vs 199 s na 16 rdzeniach. SQLite i SQLCipher serializują się na globalnych muteksach. `--test-threads=1` zostaje — to wybór wydajnościowy, nie ostrożność.
- `SQLITE_CONFIG_MEMSTATUS=0` — tylko ~6% (199 → 186 s), a rusza globalny config. Nie warto.
- `crate-type = [staticlib, cdylib, rlib]` — wszystkie cztery artefakty w 5,4 s. Nie jest problemem.

## Weryfikacja

- `.agents/h/mirror-check` — OK
- `cargo test --lib -- --test-threads=1` — **200,9 s**, 3528 passed, 18 ignored. Dwa faile (`reason::tests::resolve_brain_model_prefers_custom_path_then_selected_id`, `retired_model_is_hidden_but_still_resolves_on_disk`) padają **identycznie na czystym trunku** na tej maszynie — czytają katalog modeli spod `~/Library/Application Support`, do którego sandbox agenta nie ma dostępu. Nie są związane z tym diffem.
- `cargo clippy --lib --tests -- -D warnings` — czysty (35 s)
- `npx ng lint` — czysty; `npx ng build` — 6,0 s
- pełny playwright — 974 passed @ `--workers=6` (181 s) i @ `--workers=2` (469 s)
- `scripts/incremental-noop-check` — GREEN; z przywróconym bugiem RED (`exit 1`)

**Wymagany przegląd przed mergem:** zmiana dotyka ścieżki połączenia SQLCipher, więc należy jej się `lock-security-reviewer`. Nie został uruchomiony — implementujący nie wydaje werdyktu.

---

## Runda 2 — co znalazły przeglądy (`cfb2c8f`)

Oba przeglądy dały **PASS**, ale każdy znalazł miejsce, w którym poprawka była węższa niż jej własny opis. Żadne nie podważyło pomiarów.

**`lock-security-reviewer`** — dwie rzeczy na ścieżce crypto, obie w tym, co *napisałem*, nie w tym, co kod robi:

- Komentarz „co tracimy" opisywał zły mechanizm. Własne bufory SQLCiphera (klucz kodeka, HMAC, keyspec, raw pass, sól KDF, scratch strony) są zerowane i `mlock`owane **bezwarunkowo** przez `sqlcipher_malloc`/`sqlcipher_free`, które nigdy nie czytają tej flagi. Flaga bramkuje wyłącznie **ogólny alokator SQLite** — więc to, co realnie traci wycieranie, to page cache z odszyfrowanymi stronami, wartości VDBE niosące markdown notatek i tekst transkryptu, oraz strony temp w RAM. Pozostałość obejmuje **treść użytkownika**, szerzej niż twierdziłem.
- Przemilczałem pozostałość, którą ta zmiana wprost otwiera: `pragma_update` skleja pełne `PRAGMA key = 'x''<hex>'''` w zwykłym `String`, a `sqlite3_prepare_v2` kopiuje ten tekst SQL do pamięci SQLite — kopie, które alokator SQLCiphera wcześniej wycierał. Teraz nazwane wprost, zamiast chowane pod zbyt szerokim „materiał sekretny jest nadal czyszczony".
- `build.rs`: helper, którego źródło zniknie, wychodził wcześniej — przed assertem universal — a `bundle.resources` i tak pakował stary `binaries/<bin>`. Release teraz panikuje. To zaczęło znaczyć więcej po zmianie architektury w dev, bo stary plik byłby host-arch: arm64-only helper w rzekomo uniwersalnym DMG, martwy na Intelu.

**`adversarial-verifier`** — odtworzył każdy pomiar u siebie (`storage::db` 125,68 s vs 24,35 s, no-op 19,98 s vs 0,31 s, RED-before-GREEN dwa razy: minimalną zamianą linii i dokładnym plikiem z `d2994bf`), po czym znalazł, że obie klasy fałszywej zieleni po prostu się **przesunęły**:

- Oracle zatrzymywał się na jednym manifeście, a `ci.sh` buduje `crates/murmur-brain` linijkę wyżej. Podłożony tam fantom był trwale nieświeży (1,4 s vs 0,26 s) i oracle mówił „ok". Teraz sprawdza każdy member workspace'u — a jego repro jest w tym PR jako test RED.
- Dwa buildy osadzające miały zerowy margines na zimnym runnerze. Teraz ponawia aż do czystego, cap 5; prawdziwy fantom nigdy się nie osadzi, więc nadal pada.
- `build.rs` mapował się na filtr `build` → 47 przypadkowych trafień po nazwie, zielone w 1,6 s. **Ta sama klasa, którą PR właśnie zamykał, o jeden plik obok.** Teraz wymusza pełny suite. Do tego oracle żył **tylko** w `ci.sh`, nigdy w `checks.json` — czyli harness nie mógł złapać buga, dla którego go napisałem.
- `link_shared_node_modules` linkował przy tworzeniu worktree, zanim agent mógł podbić wersję zależności (`new-deps.py` porównuje zbiory nazw, nie wersje) — zielony `ng build` wobec złego drzewa. Teraz waliduje tuż przed checkami FE, czyści wiszący symlink i dokumentuje, że `npm install` w worktree pisze do głównego checkoutu.
- Dev stagował helpery host-arch nad `binaries/<bin>`, a `binaries/meetnotes-calendar` jest **śledzony w gicie**. Dev kompiluje teraz universal, gdy musi ten plik *stworzyć*, a potem zostaje na tanim.

Do tego `clippy -D warnings` złapał `if_same_then_else` w moim nowym kodzie w `build.rs` — przepisane na jawną kolejność preferencji.

**Bramki na poprawionym drzewie:** `mirror-check` OK · `incremental-noop-check` zielony na obu memberach i RED na podłożonym fantomie w `murmur-brain` · `clippy --lib --tests -D warnings` czysty · `cargo test --lib` **3530 passed / 0 failed / 18 ignored** · `ng lint` czysty · `ng build` zielony.

Dwa faile `reason::tests` z pierwszej rundy to był mój sandbox odmawiający dostępu do katalogu modeli release'owych — puszczone bez sandboxa przechodzą, a katalog modeli jest nietknięty (strażnik `pre_existing` w teście zadziałał).
