### PR TITLE
perf(ci): shard the web lane, and stop recording every passing test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,20 @@ jobs:
 
   # ── Web lane: ng lint + ng build + Playwright UI E2E. Node only — no Rust. ──
   web:
-    name: web lane (ci.sh web)
+    name: web lane ${{ matrix.shard }}/4 (ci.sh web)
+    # Playwright bylo 98.6% tej lane (zmierzone: ng lint 6.3 s + ng build 14.9 s + e2e 27 min 28 s),
+    # a runner ma 3 rdzenie, wiec pojedynczy job byl ograniczony CPU, nie iloscia pracy. Cztery
+    # shardy tna sciane do ~6-7 min i bramka przestaje byc ograniczona frontem — wiazacy staje sie
+    # rust lane (~9.6 min), dlatego CZTERY, nie osiem: wiecej nie skroci juz `gate`.
+    #
+    # Nazwa tego joba zmienia sie przez matryce, a to JEST bezpieczne: jedynym wymaganym kontekstem
+    # branch ruleset jest agregat "gate (full ci.sh — release parity)", ktory czyta `needs.web.result`
+    # — a dla matrycy jest ono `success` tylko wtedy, gdy KAZDY shard przeszedl. Sprawdzone w ruleset
+    # 18402368 przed ta zmiana. `fail-fast: false`, zeby jeden czerwony shard nie ukryl pozostalych.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     # macos-14 to mirror the release/dev WebKit + Chromium behavior of the shipped app.
     runs-on: macos-14
     timeout-minutes: 45
@@ -214,6 +227,8 @@ jobs:
         run: npx playwright install chromium webkit
 
       - name: Run the Web lane (scripts/ci.sh web)
+        env:
+          MURMUR_E2E_SHARD: ${{ matrix.shard }}/4
         run: bash scripts/ci.sh web
 
   # ── Aggregation: the SINGLE required status check. Its name is the branch-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,11 +187,17 @@ jobs:
 
   # ── Web lane: ng lint + ng build + Playwright UI E2E. Node only — no Rust. ──
   web:
-    name: web lane ${{ matrix.shard }}/4 (ci.sh web)
+    name: web lane ${{ matrix.shard }}/6 (ci.sh web)
     # Playwright bylo 98.6% tej lane (zmierzone: ng lint 6.3 s + ng build 14.9 s + e2e 27 min 28 s),
-    # a runner ma 3 rdzenie, wiec pojedynczy job byl ograniczony CPU, nie iloscia pracy. Cztery
-    # shardy tna sciane do ~6-7 min i bramka przestaje byc ograniczona frontem — wiazacy staje sie
-    # rust lane (~9.6 min), dlatego CZTERY, nie osiem: wiecej nie skroci juz `gate`.
+    # a runner ma 3 rdzenie, wiec pojedynczy job byl ograniczony CPU, nie iloscia pracy.
+    #
+    # SZESC, nie cztery — i to jest wynik pomiaru, nie wyboru. Playwright dzieli po LICZBIE testow,
+    # a suite to dokladnie 488 chromium + 488 webkit, wiec przy czterech shardach granica podzialu
+    # trafia w granice projektow: 1-2 to czyste chromium, 3-4 czysty webkit. Zmierzone na realnym
+    # przebiegu: 3.5 / 3.9 / 10.7 / 9.0 min — nierownowaga 3x, bo webkit na trzech rdzeniach kosztuje
+    # ~2.2 s na test wobec ~0.8 s w chromium. Bramka zostawala wiec ograniczona frontem (10.7 min
+    # przy rust lane 9.0 min). Przy szesciu najciezszy shard schodzi do ~7 min i wiazacy staje sie
+    # rust lane. Osiem nie da juz nic: `gate` jest wtedy ograniczony rustem, nie frontem.
     #
     # Nazwa tego joba zmienia sie przez matryce, a to JEST bezpieczne: jedynym wymaganym kontekstem
     # branch ruleset jest agregat "gate (full ci.sh — release parity)", ktory czyta `needs.web.result`
@@ -200,7 +206,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6]
     # macos-14 to mirror the release/dev WebKit + Chromium behavior of the shipped app.
     runs-on: macos-14
     timeout-minutes: 45
@@ -228,7 +234,7 @@ jobs:
 
       - name: Run the Web lane (scripts/ci.sh web)
         env:
-          MURMUR_E2E_SHARD: ${{ matrix.shard }}/4
+          MURMUR_E2E_SHARD: ${{ matrix.shard }}/6
         run: bash scripts/ci.sh web
 
   # ── Aggregation: the SINGLE required status check. Its name is the branch-

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,9 +40,25 @@ export default defineConfig({
   use: {
     baseURL: `http://127.0.0.1:${PORT}`,
     colorScheme: "dark",
-    trace: "retain-on-failure",
+    // `retain-on-failure` RECORDS every test and throws the recording away when it passes, which
+    // is pure cost on a suite that is ~99% passing. Measured on the FULL suite, same machine,
+    // `--workers=2`: 7.5 min -> 7.1 / 7.2 min across two runs, i.e. about 5%.
+    //
+    // Do not trust the bigger number a small sample gives you here: a 14-test subset showed
+    // webkit 14.0 s -> 11.2 s and chromium 11.0 s -> 8.7 s, which reads as 20% — but per-test
+    // recording overhead is a larger share of a short run than of the whole suite, and
+    // extrapolating it overstated the win four-fold. 5% is the honest figure.
+    //
+    // CI therefore records on the RETRY instead: it runs `retries: 2`, so anything that actually
+    // fails is re-run and the second attempt carries a full trace and video. Nothing that fails
+    // arrives without artifacts; they just come from attempt #2.
+    //
+    // LOCAL keeps `retain-on-failure`, deliberately: `retries: 0` there, so `on-first-retry` would
+    // capture NOTHING — and the harness's verifier reads exactly these artifacts. Screenshots stay
+    // `only-on-failure` everywhere; they are captured after the fact and cost nothing on a pass.
+    trace: process.env["CI"] ? "on-first-retry" : "retain-on-failure",
     screenshot: "only-on-failure",
-    video: "retain-on-failure",
+    video: process.env["CI"] ? "on-first-retry" : "retain-on-failure",
   },
   projects: [
     { name: "chromium", use: { ...devices["Desktop Chrome"] } },

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -252,7 +252,16 @@ playwright_e2e() {
   # workers=2 (not 1): specs are page-side mocked and hermetic (private port, no server reuse, no
   # shared state), so spec-file-level parallelism is safe. macos-14 has 3 cores; 2 keeps contention
   # mild against the 30s per-test timeout with retries:0. Do NOT go to 3 without config retries:1.
-  npm run test:e2e -- --workers=2
+  #
+  # MURMUR_E2E_SHARD ("i/N") rozbija suite na rownolegle joby CI. Bez niego lecimy calosc, wiec
+  # `bash scripts/ci.sh web` odpalone recznie nadal jest PELNA bramka web — shardowanie jest
+  # wylacznie sposobem, w jaki workflow rozklada ta sama prace na wiecej runnerow.
+  if [ -n "${MURMUR_E2E_SHARD:-}" ]; then
+    echo "  shard ${MURMUR_E2E_SHARD}"
+    npm run test:e2e -- --workers=2 --shard="${MURMUR_E2E_SHARD}"
+  else
+    npm run test:e2e -- --workers=2
+  fi
 }
 
 audio_e2e() {


### PR DESCRIPTION
Bramka PR była ograniczona wyłącznie przez front. Ten PR to naprawia. Wszystkie liczby niżej są zmierzone na realnych przebiegach CI.

## Gdzie siedział czas

Rozbicie web lane co do sekundy, z logu przebiegu:

| krok | czas | udział |
| --- | --- | --- |
| `ng lint` | 6,3 s | 0,4% |
| `ng build` | 14,9 s | 0,9% |
| **Playwright** | **27 min 28 s** | **98,6%** |

Narzędzia buildowe frontu nie były problemem. 976 testów × 2 przeglądarki, 2 workery, 3 rdzenie.

## Wynik

| | przed | po |
| --- | --- | --- |
| web lane (najcięższy job) | **27 min 49 s** | **7,4 min** |
| pełny suite lokalnie, `workers=2` | 7,5 min | 7,1 / 7,2 min |

Bramka przestała być ograniczona frontem. Jej pozostałym wiążącym elementem jest rust lane, który na dwóch przebiegach zmierzył 9,0 i 11,5 min — to jego własna zmienność na współdzielonym runnerze, nie skutek tej zmiany.

## 1. Shardowanie web lane

Suite jest ograniczony CPU, nie ilością pracy. Te same 14 testów lokalnie: WebKit 14,0 s, Chromium 11,0 s — **1,27×**. Na runnerze ta sama para różni się **2,8×** (mediana 4500 vs 1500 ms). Wieloprocesowy WebKit nie ma dokąd się rozejść na trzech rdzeniach, więc lekarstwem są runnery, nie szybszy silnik.

**Sześć shardów, i to jest wynik pomiaru, nie wyboru.** Pierwsza wersja miała cztery i zmierzyła się jako rozjechana 3×: **3,5 / 3,9 / 10,7 / 9,0 min**. Playwright dzieli po LICZBIE testów, a suite to dokładnie 488 chromium + 488 webkit — więc granica podziału na cztery trafia idealnie w granicę projektów: shardy 1-2 czyste chromium, 3-4 czysty webkit. Przy sześciu wychodzi po ~163 testy (3× chromium, 3× webkit) i zmierzone **2,3 / 3,8 / 2,7 / 6,9 / 6,5 / 7,4 min**. Osiem nie dałoby już nic — bramkę ogranicza wtedy rust.

**Podział sprawdzony na zbiorach, zanim cokolwiek na nim oparłem:** unia sześciu shardów to wszystkie 976 testów, zero nakładania, zero zgubionych. Shardowanie, które gubi testy, robi z bramki dekorację.

`ci.sh web` bez `MURMUR_E2E_SHARD` nadal robi całość, więc ręczne wywołanie pozostaje pełną bramką web.

Nazwy jobów zmienia matryca, i to jest bezpieczne: jedynym wymaganym kontekstem branch rulesetu (18402368) jest agregat `gate (full ci.sh — release parity)`, który czyta `needs.web.result` — dla matrycy `success` tylko gdy przeszły **wszystkie** shardy. Sprawdzone przed zaprojektowaniem zmiany. `fail-fast: false`, żeby jeden czerwony shard nie ukrył reszty.

## 2. Nagrywanie na retry, nie na każdym teście

`retain-on-failure` nagrywa **każdy** test i kasuje nagranie, gdy przejdzie — czysty koszt na suicie przechodzącym w ~99%. Pełny suite lokalnie: 7,5 min → 7,1 / 7,2 min, czyli **~5%**.

CI ma `retries: 2`, więc cokolwiek naprawdę padnie, leci ponownie i drugie podejście niesie pełny trace i video. Udowodnione celowo padającym specem: pod `CI` powstały `trace.zip`, `video.webm` i trzy screenshoty, lokalnie te same artefakty. Lokalnie zostaje `retain-on-failure` świadomie — tam `retries: 0`, więc `on-first-retry` nie złapałoby nic, a weryfikator harnessu czyta dokładnie te pliki.

**Uczciwie o własnej pomyłce:** próbka 14 testów pokazywała tę zmianę jako 20% i taką liczbę podałem, zanim zmierzyłem całość. Narzut nagrywania jest większym udziałem krótkiego przebiegu niż całego suite'u, więc ekstrapolacja zawyżyła wynik czterokrotnie. Komentarz w konfiguracji niesie zmierzone 5% i powód, dla którego mała próbka kłamie.

## Zmierzone i ODRZUCONE

- **`backdrop-filter` nie jest kosztem WebKitu.** Boot z `backdrop-filter: none !important` vs bez: **177 ms vs 187 ms**. To zamyka stojące od PR #423 podejrzenie, że tłumaczy lag wejścia w WebKicie.
- **Praca samego testu jest neutralna silnikowo.** Rozbity na fazy typowy test: `mockTauri` 9 ms, `goto` 179 ms, hydratacja 108 ms, klik 49 ms — **451 ms w WebKicie wobec 437 ms w Chromium**. Różnica 2,8× na CI to kontencja trzech rdzeni, nie aplikacja.
- **Twarde czekania.** Wszystkie `waitForTimeout` w 115 plikach sumują się do 12,8 s na przebieg.

## Weryfikacja

- podział shardów dokładny przy 4 i przy 6: unia == 976, zero nakładania, zero zgubionych
- `MURMUR_E2E_SHARD=3/4 bash scripts/ci.sh web` — zielone end-to-end w 135,8 s lokalnie
- pełny suite pod `CI=1` — 974 passed / 2 skipped / **0 failed**
- padający spec zostawia trace + video + screenshoty w obu konfiguracjach
- oba przebiegi CI tego PR — wszystkie lane zielone