### PR TITLE
chore(release): 2.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4637,7 +4637,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murmur",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murmur",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "dependencies": {
         "@angular/common": "^22.0.8",
         "@angular/compiler": "^22.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "scripts": {
     "start": "cargo build -p murmur-brain && ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "2.1.1"
+version = "2.2.0"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump for the 2.2.0 release.

Since v2.1.1: recoverable Trash with 30-day retention, the Workspaces sidebar rewrite (Spaces renamed, one collapsible rail), Quick note in the sidebar footer, New note choosing its destination, a larger default window, and the shared-Space arrival fix.

Preflight: `.murmur-server-revision` matches a clean `main` in the sibling checkout; the relay's /healthz advertises `share-owner-claim-v1`.