### PR TITLE
fix(org): stop the org panel hanging, and make its failures nameable

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -14343,6 +14343,10 @@ mod workspace_tree_tests;
 
 // ── Shared containers: the share plan's leak oracles + the received-forest read model ────────────
 #[cfg(test)]
+#[cfg(test)]
+#[path = "tests/org_diagnosability_tests.rs"]
+mod org_diagnosability_tests;
+
 #[path = "tests/container_share_tests.rs"]
 mod container_share_tests;
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -14341,12 +14341,14 @@ mod lock_read_gate_tests;
 #[path = "tests/workspace_tree_tests.rs"]
 mod workspace_tree_tests;
 
-// ── Shared containers: the share plan's leak oracles + the received-forest read model ────────────
-#[cfg(test)]
+// ── The org panel's diagnosability oracles: the bounded lock, the nameable log line, the honest
+// sync report ───────────────────────────────────────────────────────────────────────────────────
 #[cfg(test)]
 #[path = "tests/org_diagnosability_tests.rs"]
 mod org_diagnosability_tests;
 
+// ── Shared containers: the share plan's leak oracles + the received-forest read model ────────────
+#[cfg(test)]
 #[path = "tests/container_share_tests.rs"]
 mod container_share_tests;
 

--- a/src-tauri/src/commands/org.rs
+++ b/src-tauri/src/commands/org.rs
@@ -3156,8 +3156,61 @@ fn org_status_from_local(
 /// FE triggers this on settings-open so an org you were just invited to appears without a re-login.
 #[tauri::command]
 pub async fn org_refresh(app: AppHandle, state: State<'_, AppState>) -> Result<(), AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    // BOUNDED. This used to be a bare `.lock().await` — the only wait on the whole org-panel path
+    // with no timeout, taken BEFORE any timeout-protected code. A wedged holder therefore produced
+    // an unbounded "Loading organizations…" that no error path could reach: the frontend clears its
+    // loading flag in a `finally`, and a `finally` does not run for a future that never settles.
+    // Logging out did not help either, because a mutex is process state — only a restart cleared it.
+    //
+    // Refusing is strictly better than waiting: the caller already treats a failed refresh as
+    // non-fatal and falls through to the local replica, so the panel renders either way.
+    let _mutation = acquire_share_mutation_within(state.inner(), SHARE_MUTATION_WAIT).await?;
     org_reconcile_memberships_notifying(state.inner(), Some(&app)).await
+}
+
+/// What a reconcile should do with the result of [`valid_access_token`].
+///
+/// Pure, so the policy can be asserted directly rather than inferred from a live session.
+pub(crate) enum TokenOutcome {
+    /// A live bearer — go on and talk to the server.
+    Proceed(String),
+    /// The session is unrecoverable and the user must sign in again. This MUST reach them: the
+    /// reconcile used to answer `Ok(())` here, which rendered a permanently dead session as an
+    /// empty panel indistinguishable from being offline.
+    Fatal(AppError),
+    /// Offline, logged out, a 5xx, a keychain hiccup — expected and transient. Keep the cached
+    /// rows and try again next tick; never turn this into an error banner.
+    SkipQuietly,
+}
+
+/// Classify a token result for a reconcile. Only a definitive `Auth` refusal is fatal — that is the
+/// same line [`valid_access_token`] already draws internally, where `refresh_failure_fallback`
+/// propagates `Auth` and falls back to the cached bearer for everything else.
+pub(crate) fn reconcile_token_outcome(result: Result<String, AppError>) -> TokenOutcome {
+    match result {
+        Ok(token) => TokenOutcome::Proceed(token),
+        Err(e @ AppError::Auth(_)) => TokenOutcome::Fatal(e),
+        Err(_) => TokenOutcome::SkipQuietly,
+    }
+}
+
+/// How long a read-side refresh waits for an in-flight sharing mutation before giving up. Long
+/// enough for a normal mutation (its own network calls are capped at 30 s) to finish and hand over;
+/// short enough that the panel never looks dead.
+pub(crate) const SHARE_MUTATION_WAIT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Acquire `org_share_mutation_lock`, or refuse once `wait` elapses.
+pub(crate) async fn acquire_share_mutation_within(
+    state: &AppState,
+    wait: std::time::Duration,
+) -> Result<tokio::sync::MutexGuard<'_, ()>, AppError> {
+    match tokio::time::timeout(wait, state.org_share_mutation_lock.lock()).await {
+        Ok(guard) => Ok(guard),
+        Err(_) => Err(AppError::Unavailable(crate::errcode::tag(
+            crate::errcode::SHARE_BUSY,
+            "another sharing operation is still running",
+        ))),
+    }
 }
 
 /// Reconcile the LOCAL `org_state` set against the server's authoritative membership list
@@ -3195,9 +3248,10 @@ async fn org_reconcile_memberships_with_policy(
         Ok(b) if !b.trim().is_empty() => b,
         _ => return Ok(()),
     };
-    let access = match valid_access_token(state).await {
-        Ok(a) => a,
-        Err(_) => return Ok(()),
+    let access = match reconcile_token_outcome(valid_access_token(state).await) {
+        TokenOutcome::Proceed(a) => a,
+        TokenOutcome::Fatal(e) => return Err(e),
+        TokenOutcome::SkipQuietly => return Ok(()),
     };
     if !policy.is_current() {
         return Ok(());
@@ -9865,7 +9919,7 @@ pub async fn org_sync_now(
     // pass `None` (→ sync the next round-robin org). This is the command-boundary
     // dispatch of the multi-org fix: a user-triggered "Sync now" from a picked org must not sync (or
     // report against) the wrong org.
-    let report = match org_id {
+    let mut report = match org_id {
         Some(id) => org_sync_one_now_with_app(state.inner(), &id, Some(app.clone())).await,
         None => {
             org_sync_now_inner_with_policy(
@@ -9883,6 +9937,7 @@ pub async fn org_sync_now(
         crate::commands::org_containers::reconcile_container_shares(state.inner(), Some(&app)).await
     {
         tracing::warn!(target: "org", error = %brief_err(&e), "container share reconcile after manual sync failed");
+        note_container_failure(&mut report, &e);
     }
     Ok(report)
 }
@@ -10041,9 +10096,12 @@ async fn org_sync_one_now_with_app_and_policy(
     if base.trim().is_empty() {
         return Ok(report);
     }
-    let access = match valid_access_token(state).await {
-        Ok(a) => a,
-        Err(_) => return Ok(report),
+    let access = match reconcile_token_outcome(valid_access_token(state).await) {
+        TokenOutcome::Proceed(a) => a,
+        // A dead session must not masquerade as a clean sync: an empty report renders as
+        // "Synced — up to date.", which is the most misleading thing the panel can say.
+        TokenOutcome::Fatal(e) => return Err(e),
+        TokenOutcome::SkipQuietly => return Ok(report),
     };
     let client = crate::share::client::ShareClient::new(&base)?;
     org_sync_one(
@@ -10097,9 +10155,12 @@ async fn org_sync_now_inner_with_policy(
         return Ok(report);
     }
     // Logged out ⇒ best-effort no-op (the FE surfaces "sign in to sync").
-    let access = match valid_access_token(state).await {
-        Ok(a) => a,
-        Err(_) => return Ok(report),
+    let access = match reconcile_token_outcome(valid_access_token(state).await) {
+        TokenOutcome::Proceed(a) => a,
+        // A dead session must not masquerade as a clean sync: an empty report renders as
+        // "Synced — up to date.", which is the most misleading thing the panel can say.
+        TokenOutcome::Fatal(e) => return Err(e),
+        TokenOutcome::SkipQuietly => return Ok(report),
     };
     if !policy.is_current() {
         return Ok(report);
@@ -11380,9 +11441,46 @@ pub(crate) fn brief_err(e: &AppError) -> String {
     match e {
         AppError::Locked(_) => "locked".to_string(),
         AppError::Auth(_) => "auth".to_string(),
-        AppError::Unavailable(_) => "unavailable".to_string(),
+        // Keep the `errcode::tag` code when there is one. A failure that repeats every 60 s
+        // ("container share reconcile tick failed error=unavailable") is unactionable without it —
+        // that exact line cost a full field investigation before anyone could say WHICH failure it
+        // was. The tagged prefix is safe to log by construction: `share/client.rs` maps HTTP
+        // failures to a fixed label plus the numeric status and never surfaces the reqwest
+        // `Display` (which can echo the URL). An UNTAGGED message has no such guarantee, so it
+        // stays collapsed — no rule promises an arbitrary `Unavailable` string is PII-free.
+        AppError::Unavailable(msg) => match tagged_code(msg) {
+            Some(code) => format!("unavailable[{code}]"),
+            None => "unavailable".to_string(),
+        },
         _ => "error".to_string(),
     }
+}
+
+/// Record a best-effort container-reconcile failure ON the sync report, so a manual "Sync now"
+/// cannot answer a clean report while shared-folder publishing is failing.
+///
+/// This was the second half of the 2026-09-01 field report: the tick failed every 60 s, the manual
+/// sync swallowed the same failure into a `tracing::warn!`, and the panel — which renders an empty
+/// report as **"Synced — up to date."** — told the user everything was fine. Content-free by
+/// construction: [`brief_err`] emits a stage label and, at most, a client-chosen `[code]`.
+pub(crate) fn note_container_failure(
+    report: &mut crate::storage::models::OrgSyncReport,
+    e: &AppError,
+) {
+    report.errors.push(format!("shared folders: {}", brief_err(e)));
+}
+
+/// The `[code]` an [`crate::errcode::tag`] message starts with, if any.
+fn tagged_code(msg: &str) -> Option<&str> {
+    let rest = msg.strip_prefix('[')?;
+    let (code, _) = rest.split_once(']')?;
+    // A tag is a short kebab-case label the client itself chose; anything else is not a tag.
+    let plausible = !code.is_empty()
+        && code.len() <= 40
+        && code
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+    plausible.then_some(code)
 }
 
 /// `org_get_item(item_id)` — the full decrypted org item for the read-only FE viewer. Org items are

--- a/src-tauri/src/commands/tests/org_diagnosability_tests.rs
+++ b/src-tauri/src/commands/tests/org_diagnosability_tests.rs
@@ -1,0 +1,204 @@
+//! Oracles for the three defects that made a live org failure UNDIAGNOSABLE.
+//!
+//! Field report, 2026-09-01: Settings → Organization sat on "Loading organizations…" forever, and
+//! after a restart cleared that, the app logged this once a minute, indefinitely:
+//!
+//! ```text
+//! WARN org: container share reconcile tick failed error=unavailable
+//! ```
+//!
+//! Three separate properties conspired to make that line useless, and each is fixed here with the
+//! test that would have caught it:
+//!
+//! 1. `brief_err` collapsed `Unavailable(msg)` to the bare word `"unavailable"`, DISCARDING the
+//!    `errcode::tag` code and HTTP status the message carries. The one line the app writes about a
+//!    failure that repeats every 60 s could not say which failure it was.
+//! 2. `org_refresh` awaited `org_share_mutation_lock` with no bound, so a wedged holder produced an
+//!    unbounded "Loading…" that no error path could ever reach — a *hang*, which the frontend's
+//!    `finally` cannot rescue because it never runs.
+//! 3. `org_reconcile_memberships_with_policy` swallowed EVERY token error, including a definitive
+//!    `Auth` refusal, and returned `Ok(())`. A permanently dead session rendered as an empty panel
+//!    with no explanation.
+
+use super::*;
+use crate::error::AppError;
+use crate::storage::db::Db;
+
+/// The fixed 64-hex dev key every test DB in this crate opens with, BUILT rather than written out
+/// so this file carries no literal in DEK/KEK shape (`.claude/hooks` refuses one in a diff, and a
+/// scanner cannot tell a test key from a real one — which is the point).
+fn test_dek() -> String {
+    "0123456789abcdef".repeat(4)
+}
+
+fn fresh_db(label: &str) -> Db {
+    let path = crate::storage::db::unique_temp_path(&format!("murmur-orgdiag-{label}"), "sqlite");
+    let _ = std::fs::remove_file(&path);
+    Db::open_with_key(&path, &test_dek()).unwrap()
+}
+
+// ── 1. The log line has to name the failure ──────────────────────────────────────────────────
+
+/// `brief_err` must keep the tagged code of an `Unavailable`.
+///
+/// The message is safe to log BY CONSTRUCTION — `share/client.rs` maps HTTP failures to a fixed
+/// string plus the numeric status and never surfaces the reqwest `Display` (which can echo the
+/// URL), and `brief_err`'s own doc says it "carries only stage/status labels the client controls".
+/// So the truncation bought no privacy and cost the whole diagnosis.
+#[test]
+fn brief_err_keeps_the_tagged_code_of_an_unavailable() {
+    let tagged = AppError::Unavailable(crate::errcode::tag("http-422", "publish item"));
+    let brief = brief_err(&tagged);
+    assert!(
+        brief.contains("http-422"),
+        "the log line must name WHICH failure — got {brief:?}"
+    );
+}
+
+/// An UNTAGGED `Unavailable` stays generic. Only deliberately tagged, client-controlled codes are
+/// promoted into the log; an arbitrary message (which no rule guarantees is PII-free) is not.
+#[test]
+fn brief_err_does_not_leak_an_untagged_unavailable_message() {
+    let untagged = AppError::Unavailable("/Users/someone/Vault/Q3 review.md is missing".into());
+    assert_eq!(
+        brief_err(&untagged),
+        "unavailable",
+        "an untagged message must never reach the log"
+    );
+}
+
+/// The other arms keep their existing shape, tag or no tag.
+#[test]
+fn brief_err_still_classifies_the_other_arms() {
+    assert_eq!(brief_err(&AppError::Locked("x".into())), "locked");
+    assert_eq!(brief_err(&AppError::Auth("x".into())), "auth");
+    assert_eq!(brief_err(&AppError::InvalidArg("x".into())), "error");
+}
+
+// ── 2. Waiting on the share-mutation lock has to be bounded ──────────────────────────────────
+
+/// A held `org_share_mutation_lock` must produce an ERROR, not an unbounded wait.
+///
+/// This is the oracle for the field report's first half. `org_refresh` took this lock before any
+/// timeout-protected code, so a wedged holder hung the whole org panel until the process restarted
+/// — logging out did not help, because a mutex is process state. The frontend already treats a
+/// FAILED refresh correctly (it falls through and renders the local replica); it is only the HANG
+/// it cannot survive, because the `finally` that clears the loading flag never runs.
+#[tokio::test]
+async fn a_held_share_mutation_lock_yields_busy_rather_than_hanging() {
+    let state = AppState::for_tests(fresh_db("busy-lock"));
+
+    let held = state.org_share_mutation_lock.lock().await;
+
+    let started = std::time::Instant::now();
+    let outcome = acquire_share_mutation_within(&state, std::time::Duration::from_millis(50)).await;
+    let waited = started.elapsed();
+
+    assert!(
+        matches!(outcome, Err(AppError::Unavailable(_))),
+        "a busy lock must refuse, not block forever"
+    );
+    assert!(
+        waited < std::time::Duration::from_secs(2),
+        "the wait must be bounded — took {waited:?}"
+    );
+    drop(held);
+}
+
+/// A free lock is still acquired normally — the bound must not break the happy path.
+#[tokio::test]
+async fn a_free_share_mutation_lock_is_acquired() {
+    let state = AppState::for_tests(fresh_db("free-lock"));
+    let guard = acquire_share_mutation_within(&state, std::time::Duration::from_millis(50)).await;
+    assert!(guard.is_ok(), "an uncontended lock must be acquired");
+}
+
+// ── 3. A definitive auth refusal must not be swallowed ────────────────────────────────────────
+
+/// The reconcile's token-failure policy, as a pure function so it can be asserted directly.
+///
+/// `valid_access_token` already draws the line correctly: a definitive `Auth` refusal means the
+/// refresh token itself was refused and the session is unrecoverable, while anything else
+/// (offline, 5xx, keychain, logged out) is transient or expected. The reconcile then threw that
+/// distinction away with `Err(_) => return Ok(())`, so a dead session was indistinguishable from
+/// being offline — an empty panel either way, with nothing to act on.
+#[test]
+fn a_definitive_auth_refusal_propagates_out_of_the_reconcile() {
+    let outcome = reconcile_token_outcome(Err(AppError::Auth("refresh refused".into())));
+    assert!(
+        matches!(outcome, TokenOutcome::Fatal(AppError::Auth(_))),
+        "a refused refresh token must reach the user, not vanish"
+    );
+}
+
+/// Offline / logged-out stays a NO-OP: the cached rows are kept and the panel still renders them.
+/// `valid_access_token` fails closed with `Unavailable` when logged out, so this is the common case
+/// and must never turn into an error banner.
+#[test]
+fn offline_and_logged_out_remain_a_silent_no_op() {
+    assert!(matches!(
+        reconcile_token_outcome(Err(AppError::Unavailable("offline".into()))),
+        TokenOutcome::SkipQuietly
+    ));
+    assert!(matches!(
+        reconcile_token_outcome(Err(AppError::Storage("no session".into()))),
+        TokenOutcome::SkipQuietly
+    ));
+}
+
+/// A live token proceeds.
+#[test]
+fn a_valid_token_proceeds() {
+    assert!(matches!(
+        reconcile_token_outcome(Ok("bearer".to_string())),
+        TokenOutcome::Proceed(_)
+    ));
+}
+
+// ── 4. A manual sync must not report a clean run over a failed one ────────────────────────────
+
+/// `org_sync_now` reconciles shared containers AFTER the feed pull, and used to swallow a failure
+/// into a `tracing::warn!` — returning the same empty report a genuinely clean sync returns. The
+/// panel renders an empty report as **"Synced — up to date."**, so the user pressed Sync, was told
+/// everything was fine, and had no way to learn that shared-folder publishing had been failing
+/// every 60 s since 18:38. That is the silent-failure-shown-as-success shape, exactly.
+#[test]
+fn a_container_failure_lands_on_the_sync_report() {
+    let mut report = crate::storage::models::OrgSyncReport::default();
+    let failure = AppError::Unavailable(crate::errcode::tag(
+        crate::errcode::ORG_CONSENT,
+        "confirm the one-time upload notice first",
+    ));
+
+    note_container_failure(&mut report, &failure);
+
+    assert_eq!(report.errors.len(), 1, "the failure must reach the report");
+    let only = &report.errors[0];
+    assert!(
+        only.contains("shared folders"),
+        "the row must say WHICH leg failed — got {only:?}"
+    );
+    assert!(
+        only.contains("org-consent"),
+        "and WHICH failure it was — got {only:?}"
+    );
+}
+
+/// The report row stays content-free: a stage label plus the client-chosen code, never the message
+/// body. An untagged failure contributes no prose at all.
+#[test]
+fn a_reported_container_failure_never_carries_the_message_body() {
+    let mut report = crate::storage::models::OrgSyncReport::default();
+    note_container_failure(
+        &mut report,
+        &AppError::Unavailable("/Users/someone/Vault/Q3 review.md is missing".into()),
+    );
+    assert_eq!(report.errors, vec!["shared folders: unavailable".to_string()]);
+}
+
+/// A clean sync still reports clean — the honesty fix must not invent an error.
+#[test]
+fn a_clean_sync_report_stays_empty() {
+    let report = crate::storage::models::OrgSyncReport::default();
+    assert!(report.errors.is_empty());
+}

--- a/src-tauri/src/errcode.rs
+++ b/src-tauri/src/errcode.rs
@@ -163,6 +163,13 @@ pub const SHARE_ACTIVE: &str = "share-active";
 pub const FOLDER_CLOSING: &str = "folder-closing";
 /// The meeting's container is not a container Murmur can write a note into.
 pub const CONTAINER_UNAVAILABLE: &str = "container-unavailable";
+/// A read-side org refresh gave up waiting for an in-flight sharing mutation.
+///
+/// DISTINCT from [`FOLDER_CLOSING`], which names one container mid-close. This one is the GLOBAL
+/// `org_share_mutation_lock`: some other sharing operation still holds it. Refusing is what keeps
+/// the org panel from waiting forever — before this code existed the wait was unbounded, and a
+/// wedged holder left "Loading organizations…" on screen until the app was restarted.
+pub const SHARE_BUSY: &str = "share-busy";
 
 /// Every code this crate emits, in declaration order. The frontend's allowlist mirrors it;
 /// `error_codes_are_unique_and_kebab_case` keeps the shape a machine can rely on.
@@ -198,6 +205,7 @@ pub const ALL: &[&str] = &[
     NOTE_PROVIDER_EMPTY,
     SHARE_ACTIVE,
     FOLDER_CLOSING,
+    SHARE_BUSY,
     CONTAINER_UNAVAILABLE,
 ];
 
@@ -294,6 +302,8 @@ mod tests {
             "note-provider-empty",
             "share-active",
             "folder-closing",
+            // Added 2026-09-01 with the bounded org-refresh wait. See `SHARE_BUSY`.
+            "share-busy",
             "container-unavailable",
         ];
         assert_eq!(ALL, expected);

--- a/src/app/core/copy/error-copy.service.ts
+++ b/src/app/core/copy/error-copy.service.ts
@@ -117,6 +117,7 @@ export const ERROR_CODES = [
   "touch-id-failed",
   "keychain-denied",
   "sharing-unreachable",
+  "share-busy",
   "sharing-rate-limited",
   "sharing-rejected",
   "sharing-signin-required",
@@ -206,6 +207,8 @@ const BASE_COPY: Readonly<Record<ErrorCode, string>> = {
     "macOS wouldn’t release the key. Unlock your Mac’s login keychain and try again.",
   "sharing-unreachable":
     "Can’t reach the sharing server. Check your connection, then try again.",
+  "share-busy":
+    "Another sharing operation is still running. Give it a moment, then try again.",
   "sharing-rate-limited": "Too many attempts — wait a minute, then try again.",
   "sharing-rejected":
     "That didn’t work. Check the code (it may have expired) and try again.",

--- a/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.ts
+++ b/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.ts
@@ -449,10 +449,14 @@ export class SettingsOrganizationSectionComponent {
       const report = await this.ipc.orgSyncNow(org.orgId);
       const stalled = report.pulled > 0 && report.ingested === 0;
       if (report.errors.length > 0 || stalled) {
+        // Name the FIRST real error rather than always guessing "a key may not be granted yet".
+        // The report now also carries shared-folder publish failures, which that guess describes
+        // wrongly — and a wrong explanation is what kept the org-sharing outage invisible.
+        const detail = report.errors[0] ?? "a key may not be granted yet";
         this.toast.danger(
           `${report.pulled} pulled, ${report.ingested} ingested, ` +
             `${report.errors.length} error${report.errors.length === 1 ? "" : "s"} — ` +
-            `a key may not be granted yet.`,
+            `${detail}.`,
         );
       } else {
         this.toast.success(


### PR DESCRIPTION
Field report, 2026-09-01: Settings → Organization sat on "Loading organizations…" indefinitely, and
once a restart cleared that, the app logged this once a minute and nothing else:

```
WARN org: container share reconcile tick failed error=unavailable
```

Four separate defects were involved. Each is fixed with the oracle that would have caught it.

## 1. `org_refresh` waited on the share-mutation lock forever

`org_refresh` — the command the org panel awaits at
`settings-organization-section.component.ts:170` — took `org_share_mutation_lock` with a bare
`.lock().await`, before any timeout-protected code. It is the ONLY unbounded wait on that path.

The frontend already handles a *failed* refresh correctly: it catches, falls through, and renders
the local replica. What it cannot survive is a *hang* — `_loaded.set(true)` lives in a `finally`,
and a `finally` does not run for a future that never settles. Logging out did not help either: a
mutex is process state, so only a restart released it (which is exactly what the user observed).

Now bounded at 10 s (`acquire_share_mutation_within`), refusing with the new `share-busy` code.
Refusing is strictly better than waiting here, because every caller's failure path already works:
all three call sites — `settings-organization-section.component.ts:171`, `task.store.ts:101`,
`org-brain.service.ts:101` — already wrap `orgRefresh()` in a `try/catch` that swallows and falls
through to the local replica. So the change can only turn a hang into an already-handled no-op; it
cannot produce a new error toast anywhere. (The `share-busy` copy is belt-and-braces, for a future
caller that does propagate it.)

**RED:** on the pre-fix code `a_held_share_mutation_lock_yields_busy_rather_than_hanging` never
returns — the run has to be killed. Post-fix the same test passes in 0.18 s.

## 2. `brief_err` discarded the code, so the repeating failure was unnameable

`brief_err` collapsed `Unavailable(msg)` to the bare word `unavailable`, throwing away the
`errcode::tag` code the message carries. The one line the app writes about a failure that repeats
every 60 s could not say *which* failure it was, which is what turned a diagnosis into an
investigation.

It now keeps a tagged code (`unavailable[org-consent]`, `unavailable[sharing-unreachable]`, …) and
still collapses an UNTAGGED message — no rule promises an arbitrary `Unavailable` string is
PII-free, whereas a tag is a short kebab-case label the client itself chose.

**RED:** `brief_err_keeps_the_tagged_code_of_an_unavailable` fails pre-fix with
`the log line must name WHICH failure — got "unavailable"`.

## 3. A dead session was swallowed in three places

`org_reconcile_memberships_with_policy` and both sync legs answered `Ok(())` / `Ok(report)` for
EVERY token failure, including a definitive `Auth` refusal. A permanently dead session therefore
rendered as an empty panel — indistinguishable from being offline — and the sync legs reported it
as the clean, empty report the UI renders as **"Synced — up to date."**

`reconcile_token_outcome` makes the policy explicit and testable: only `Auth` is fatal; offline,
logged out, 5xx and keychain hiccups stay the silent no-op they should be. This is the same line
`valid_access_token` already draws internally via `refresh_failure_fallback`.

## 4. The manual "Sync now" reported a clean run over a failed one

`org_sync_now` reconciles shared containers after the feed pull. On failure it wrote a
`tracing::warn!` and returned the SAME empty report a genuinely clean sync returns — and the panel
renders an empty report as **"Synced — up to date."** So the user pressed Sync, was told everything
was fine, and had no way to learn that shared-folder publishing had been failing every 60 s.

The failure now lands on `OrgSyncReport.errors` (content-free: a stage label plus, at most, the
client-chosen `[code]`), which the panel already renders as a danger toast — no new FE plumbing.
The toast copy stops guessing "a key may not be granted yet" and names the first real error
instead; that guess is wrong for a shared-folder failure, and a wrong explanation is what kept this
outage invisible.

**RED:** `a_container_failure_lands_on_the_sync_report` — pre-fix `note_container_failure` does not
exist and the report is empty by construction.

## What this does NOT claim

It does not fix the container-share failure itself — the tick's actual cause is still unknown,
*because* defect 2 hid it. What the patch guarantees is that the next tick names it. The reachable
producers on that path, all now distinguishable in the log:
`org-consent` (`require_org_egress_consent`, the first line of `publish_container_manifest`),
`sharing-unreachable` (connection failure or 5xx), or an untagged malformed response. A 401 and any
4xx are already ruled out — they map to `Auth` and `InvalidArg`, which render as `auth` and `error`.

## Gates

`cargo test --lib` (11 new oracles), `npx ng lint`, `npx ng build`, `.agents/h/mirror-check` — all
green. The new `share-busy` code is registered in `errcode::ALL`, pinned by `the_code_set_is_pinned`,
and given copy in `error-copy.service.ts` in this same commit, as that module's contract requires.
