### PR TITLE
chore: unify the commit identity on JakubGawr

### DIFF
--- a/.agents/skills/add-ci-gate/SKILL.md
+++ b/.agents/skills/add-ci-gate/SKILL.md
@@ -77,4 +77,4 @@ command -v actionlint >/dev/null && actionlint .github/workflows/ci.yml || echo 
 - [ ] Guardrail hook? BLOCK + ALLOW assertion added to `selftest.sh`, host-independent.
 - [ ] Runner prerequisite (if any) added to `ci.yml` per `/github-actions`; workflow still just `bash scripts/ci.sh`.
 - [ ] RED-before-GREEN proven; full/subset `ci.sh` green; no new dep added without user approval.
-- [ ] Landed via a PR into `murmur` (never direct-push), QueaT author, no Codex trailers.
+- [ ] Landed via a PR into `murmur` (never direct-push), JakubGawr author, no Codex trailers.

--- a/.agents/skills/release-murmur/SKILL.md
+++ b/.agents/skills/release-murmur/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-murmur
-description: Cut a signed, notarized macOS release of Murmur (Tauri 2 + Angular 22). The exact, proven step-by-step runbook — preflight gates → version bump (+ Cargo.lock sync) → QueaT commit → PR-merge to the `murmur` trunk (never direct-push) → rustup targets → stop dev → universal build → Developer-ID sign BY IDENTITY HASH (the Polish-ń cert gotcha) → DMG → notarize → staple/spctl → gh release create + upload. Use whenever the user wants to ship, release, cut a version, build a distributable .app/.dmg, sign/notarize, or publish a GitHub release of Murmur. Supersedes the stale docs/RELEASE-CHECKLIST.md.
+description: Cut a signed, notarized macOS release of Murmur (Tauri 2 + Angular 22). The exact, proven step-by-step runbook — preflight gates → version bump (+ Cargo.lock sync) → JakubGawr commit → PR-merge to the `murmur` trunk (never direct-push) → rustup targets → stop dev → universal build → Developer-ID sign BY IDENTITY HASH (the Polish-ń cert gotcha) → DMG → notarize → staple/spctl → gh release create + upload. Use whenever the user wants to ship, release, cut a version, build a distributable .app/.dmg, sign/notarize, or publish a GitHub release of Murmur. Supersedes the stale docs/RELEASE-CHECKLIST.md.
 ---
 
 # /release-murmur — the Murmur macOS release runbook
@@ -25,9 +25,9 @@ stop at that boundary and hand back the exact command the user must run.
 
 1. **`gh` active account MUST be `JakubGawr`.** `gh auth status` → "Active account: true"
    on `JakubGawr` (a second account `jakub-united` is also logged in — do not use it).
-2. **Commit author MUST be `QueaT <kgm004a@gmail.com>`.** NO `Co-Authored-By: Codex`,
+2. **Commit author MUST be `JakubGawr <63911380+JakubGawr@users.noreply.github.com>`.** NO `Co-Authored-By: Codex`,
    NO Codex trailers anywhere in release commits/PR bodies. (Repo git config is already
-   `QueaT` / `kgm004a@gmail.com`; the v0.3.0 bump commit `2038177` proves the shape.)
+   `JakubGawr` / `63911380+JakubGawr@users.noreply.github.com`; the v0.3.0 bump commit `be4ef0f3` proves the shape.)
 3. **NEVER `git push origin murmur` / `…main` directly.** The trunk branch is `murmur`;
    integrate via a PR (`gh pr create … --base murmur` → `gh pr merge`). An environment-level
    `block-bash.sh` guard rejects direct pushes to main/master — a PR is the only path.
@@ -51,7 +51,7 @@ source "$HOME/.cargo/env"
 cd /Users/jakubgawronski/Projects/meetnotes
 git rev-parse --abbrev-ref HEAD            # confirm a feature branch, NOT murmur/main
 gh auth status                            # confirm Active account: JakubGawr
-git log -1 --format='%an <%ae>'           # confirm QueaT <kgm004a@gmail.com>
+git log -1 --format='%an <%ae>'           # confirm JakubGawr <63911380+JakubGawr@users.noreply.github.com>
 scripts/agent-resource-run -- bash scripts/ci.sh  # must end "✅ CI: all gates green"
 ```
 
@@ -93,17 +93,17 @@ scripts/agent-resource-run --chdir src-tauri -- cargo update -p murmur --precise
 grep -A1 '^name = "murmur"' Cargo.lock   # workspace-root lock; confirm version = "<NEW>"
 ```
 
-## Stage 3 — Commit as QueaT (no Codex trailers)
+## Stage 3 — Commit as JakubGawr (no Codex trailers)
 
 ```bash
 git add package.json src-tauri/tauri.conf.json src-tauri/Cargo.toml Cargo.lock
 git commit -m "chore(release): bump version to $NEW"
-git log -1 --format='%an <%ae>%n%b'   # author QueaT, body has NO Co-Authored-By / Codex
+git log -1 --format='%an <%ae>%n%b'   # author JakubGawr, body has NO Co-Authored-By / Codex
 ```
 
 > **CALLOUT — no Codex trailers.** If your environment auto-appends a
 > `Co-Authored-By: Codex` trailer, strip it (`git commit --amend`) before pushing.
-> Release history is QueaT-only.
+> Release history is JakubGawr-only.
 
 ## Stage 4 — Merge to the `murmur` trunk via PR (NEVER direct push)
 
@@ -286,7 +286,7 @@ build→sign→notarize leg is long-running and Mac-bound. Two shapes:
   commit-author identity — collect verdicts, and only enter the bump stage when all PASS.
 
 Keep the **identity interlocks as preconditions** on every writing node: `gh`=JakubGawr,
-author=QueaT, base=`murmur`, identifier unchanged, sign-by-hash. The Mac-only stages stay a
+author=JakubGawr, base=`murmur`, identifier unchanged, sign-by-hash. The Mac-only stages stay a
 hard boundary — a headless orchestrator hands them to the user rather than faking them.
 
 ## Rules
@@ -295,7 +295,7 @@ hard boundary — a headless orchestrator hands them to the user rather than fak
 - **Never invent a green.** `lipo` must show both arches; `codesign --verify` must show
   `flags=0x10000(runtime)` + `Developer ID Application`; `spctl` must say accepted. If a
   check doesn't pass, STOP and report — do not "assume it worked."
-- **Identity is non-negotiable:** gh=JakubGawr, commit-author=QueaT (no Codex trailers),
+- **Identity is non-negotiable:** gh=JakubGawr, commit-author=JakubGawr (no Codex trailers),
   base=`murmur` via PR, identifier=`com.meetnotes.app` unchanged, sign **by hash**.
 - **Headless honesty.** If there is no Mac / no cert / no notary creds, say so and hand the
   user the exact remaining commands — never claim a notarized DMG you didn't produce.

--- a/.agents/skills/ship-feature/SKILL.md
+++ b/.agents/skills/ship-feature/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship-feature
-description: Ship a Murmur feature through scope, isolated implementation, fresh adversarial and required security review, project gates, a QueaT commit, and a PR to `murmur`. Use the verifier-only Harness for risky, multi-step, or explicitly requested work; ordinary low-risk fixes keep the normal isolated-worktree route.
+description: Ship a Murmur feature through scope, isolated implementation, fresh adversarial and required security review, project gates, a JakubGawr commit, and a PR to `murmur`. Use the verifier-only Harness for risky, multi-step, or explicitly requested work; ordinary low-risk fixes keep the normal isolated-worktree route.
 ---
 
 # /ship-feature — ship a Murmur feature end-to-end
@@ -33,7 +33,7 @@ builder and whether the lock-security review is mandatory:
 
 The harness is opt-in. A small docs/chore/mechanical/low-risk fix uses a normal
 isolated feature worktree, fresh independent review, the relevant project gates,
-and a normal QueaT commit. Do not add a Harness receipt merely because this
+and a normal JakubGawr commit. Do not add a Harness receipt merely because this
 skill was invoked.
 
 Use the Harness for lock/crypto/egress/protocol work, multi-step changes, or
@@ -175,18 +175,18 @@ append ONE `## Run journal` entry to the relevant `.claude/learnings/<agent>.md`
 promotes repeat offenders into `## Recurring patterns`. This is what makes "every bug a permanent
 lesson" instead of a re-paid one.
 
-### 6. Commit as QueaT
+### 6. Commit as JakubGawr
 ```bash
 # V2 route: commit through the runner; its durable intent survives a crash.
 git -C <worktree> commit -m \"<type>(<scope>): <subject>\"
 git -C ../.murmur-agent-tasks/v2/<task-id>/meetnotes log -1 --format='%an <%ae>'
-# MUST be QueaT <kgm004a@gmail.com>
+# MUST be JakubGawr <63911380+JakubGawr@users.noreply.github.com>
 ```
 Never use `git add -A` in a shared repository. **No AI co-author trailers.** Conventional-commit style
 (`feat`/`fix`/`chore(scope)`), matching the existing log.
 
 For the normal low-risk route, stage only the explicit owned files and create a
-normal QueaT commit without Harness trailers. Use a conventional `fix/<slug>`,
+normal JakubGawr commit without Harness trailers. Use a conventional `fix/<slug>`,
 `feat/<slug>`, or `chore/<slug>` branch so the remote `agent/*` receipt gate does
 not mistake it for a harness task. If an operator deliberately keeps a
 non-harness commit on an `agent/*` branch, the PR description must declare the
@@ -222,7 +222,7 @@ hand off to **`/release-murmur`**.
 - **Conventions are binding** — the Rust (AppError/Result, additive migrations,
   verify-before-destroy, gated reads, crash-safe FFI) and Angular-zoneless (signals/`@if`/
   `toSignal`/no-`setTimeout`/no-new-deps) rules above are non-negotiable.
-- **Identity interlocks:** commit author=QueaT (no AI trailers), gh=JakubGawr, PR base
+- **Identity interlocks:** commit author=JakubGawr (no AI trailers), gh=JakubGawr, PR base
   =`murmur`, `com.meetnotes.app` immutable.
 - **Honest about the signed-build boundary.** A dev run cannot prove Touch ID / lock-at-rest /
   screen-share — say so; only a Developer-ID build verifies them (`/release-murmur`).

--- a/.agents/skills/sync-release-copy/SKILL.md
+++ b/.agents/skills/sync-release-copy/SKILL.md
@@ -32,8 +32,8 @@ not silently rewrite marketing.
 
 1. **`gh` active account MUST be `JakubGawr`** (`gh auth status`). A second account
    `jakub-united` may also be logged in — do not use it.
-2. **Commit/PR author MUST be `QueaT <kgm004a@gmail.com>`. NO Codex trailers**, no
-   `Co-Authored-By: Codex`, anywhere. (Repo git config is already QueaT.)
+2. **Commit/PR author MUST be `JakubGawr <63911380+JakubGawr@users.noreply.github.com>`. NO Codex trailers**, no
+   `Co-Authored-By: Codex`, anywhere. (Repo git config is already JakubGawr.)
 3. **NEVER `git push origin murmur` directly** — the trunk is `murmur`; land landing
    edits via a PR (`gh pr create --base murmur` → `gh pr merge`). `block-bash.sh`
    rejects a direct trunk push anyway.

--- a/.claude/agents/ci-cd-engineer.md
+++ b/.claude/agents/ci-cd-engineer.md
@@ -26,7 +26,7 @@ Your final message **is** the deliverable: exactly what you changed, what you ra
 - **The heavy ML tree is ALWAYS compiled** (mistralrs/candle/tokenizers — the feature gates were removed). A cold CI build is slow (hundreds of MB); that is expected. `export MISTRALRS_METAL_PRECOMPILE=0` (baked into `ci.sh` and set in the workflow env) defers Metal-shader compile to first runtime use so headless build/test link cleanly.
 - **No new dependencies without explicit user approval** — not npm packages, not crates, and not new GitHub Actions. When you add an action, **pin it to a full commit SHA** (resolve it live, see Gotcha 3), with a `# vX.Y.Z` comment — never a floating tag.
 - **CI-focused; CD/release is the release-engineer's.** You may DESIGN a release-workflow blueprint, but you do NOT sign, notarize, staple, or publish, and you do NOT put Apple Developer-ID certs / notarytool creds into cloud CI without the user explicitly deciding to (it collides with the "keychain ops are user-interactive only" rule). Hand a real release off to `release-engineer` / the `/release-murmur` skill.
-- **`com.meetnotes.app` is immutable**; commits/PRs authored **only** by `QueaT <kgm004a@gmail.com>` with **no Claude trailers**; `gh` active account = `JakubGawr`.
+- **`com.meetnotes.app` is immutable**; commits/PRs authored **only** by `JakubGawr <63911380+JakubGawr@users.noreply.github.com>` with **no Claude trailers**; `gh` active account = `JakubGawr`.
 
 ## What you do
 

--- a/.claude/learnings/release-engineer.md
+++ b/.claude/learnings/release-engineer.md
@@ -22,7 +22,7 @@
   `git`/`gh` push ("could not read Username") — the user unlocks, you retry.
 - **PR-merge, never direct-push the trunk.** `git push origin murmur` is refused by
   `block-bash.sh`; land via `gh pr create --base murmur` → `gh pr merge`. `gh` active account =
-  `JakubGawr`; commits authored ONLY by `QueaT <kgm004a@gmail.com>`, NO AI co-author trailers.
+  `JakubGawr`; commits authored ONLY by `JakubGawr <63911380+JakubGawr@users.noreply.github.com>`, NO AI co-author trailers.
 - **Version bump touches four files in sync** — `package.json`, `src-tauri/tauri.conf.json`,
   `src-tauri/Cargo.toml`, then `cargo update -p murmur --precise <ver>` (Cargo.lock).
 - **`MURMUR_DEV_DEK` vs release-keychain DEK collide on a shared DB** → the release build can't open

--- a/.claude/skills/add-ci-gate/SKILL.md
+++ b/.claude/skills/add-ci-gate/SKILL.md
@@ -77,4 +77,4 @@ command -v actionlint >/dev/null && actionlint .github/workflows/ci.yml || echo 
 - [ ] Guardrail hook? BLOCK + ALLOW assertion added to `selftest.sh`, host-independent.
 - [ ] Runner prerequisite (if any) added to `ci.yml` per `/github-actions`; workflow still just `bash scripts/ci.sh`.
 - [ ] RED-before-GREEN proven; full/subset `ci.sh` green; no new dep added without user approval.
-- [ ] Landed via a PR into `murmur` (never direct-push), QueaT author, no Claude trailers.
+- [ ] Landed via a PR into `murmur` (never direct-push), JakubGawr author, no Claude trailers.

--- a/.claude/skills/release-murmur/SKILL.md
+++ b/.claude/skills/release-murmur/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-murmur
-description: Cut a signed, notarized macOS release of Murmur (Tauri 2 + Angular 22). The exact, proven step-by-step runbook — preflight gates → version bump (+ Cargo.lock sync) → QueaT commit → PR-merge to the `murmur` trunk (never direct-push) → rustup targets → stop dev → universal build → Developer-ID sign BY IDENTITY HASH (the Polish-ń cert gotcha) → DMG → notarize → staple/spctl → gh release create + upload. Use whenever the user wants to ship, release, cut a version, build a distributable .app/.dmg, sign/notarize, or publish a GitHub release of Murmur. Supersedes the stale docs/RELEASE-CHECKLIST.md.
+description: Cut a signed, notarized macOS release of Murmur (Tauri 2 + Angular 22). The exact, proven step-by-step runbook — preflight gates → version bump (+ Cargo.lock sync) → JakubGawr commit → PR-merge to the `murmur` trunk (never direct-push) → rustup targets → stop dev → universal build → Developer-ID sign BY IDENTITY HASH (the Polish-ń cert gotcha) → DMG → notarize → staple/spctl → gh release create + upload. Use whenever the user wants to ship, release, cut a version, build a distributable .app/.dmg, sign/notarize, or publish a GitHub release of Murmur. Supersedes the stale docs/RELEASE-CHECKLIST.md.
 ---
 
 # /release-murmur — the Murmur macOS release runbook
@@ -25,9 +25,9 @@ stop at that boundary and hand back the exact command the user must run.
 
 1. **`gh` active account MUST be `JakubGawr`.** `gh auth status` → "Active account: true"
    on `JakubGawr` (a second account `jakub-united` is also logged in — do not use it).
-2. **Commit author MUST be `QueaT <kgm004a@gmail.com>`.** NO `Co-Authored-By: Claude`,
+2. **Commit author MUST be `JakubGawr <63911380+JakubGawr@users.noreply.github.com>`.** NO `Co-Authored-By: Claude`,
    NO Claude trailers anywhere in release commits/PR bodies. (Repo git config is already
-   `QueaT` / `kgm004a@gmail.com`; the v0.3.0 bump commit `2038177` proves the shape.)
+   `JakubGawr` / `63911380+JakubGawr@users.noreply.github.com`; the v0.3.0 bump commit `be4ef0f3` proves the shape.)
 3. **NEVER `git push origin murmur` / `…main` directly.** The trunk branch is `murmur`;
    integrate via a PR (`gh pr create … --base murmur` → `gh pr merge`). An environment-level
    `block-bash.sh` guard rejects direct pushes to main/master — a PR is the only path.
@@ -51,7 +51,7 @@ source "$HOME/.cargo/env"
 cd /Users/jakubgawronski/Projects/meetnotes
 git rev-parse --abbrev-ref HEAD            # confirm a feature branch, NOT murmur/main
 gh auth status                            # confirm Active account: JakubGawr
-git log -1 --format='%an <%ae>'           # confirm QueaT <kgm004a@gmail.com>
+git log -1 --format='%an <%ae>'           # confirm JakubGawr <63911380+JakubGawr@users.noreply.github.com>
 scripts/agent-resource-run -- bash scripts/ci.sh  # must end "✅ CI: all gates green"
 ```
 
@@ -138,17 +138,17 @@ scripts/agent-resource-run --chdir src-tauri -- cargo update -p murmur --precise
 grep -A1 '^name = "murmur"' Cargo.lock   # workspace-root lock; confirm version = "<NEW>"
 ```
 
-## Stage 3 — Commit as QueaT (no Claude trailers)
+## Stage 3 — Commit as JakubGawr (no Claude trailers)
 
 ```bash
 git add package.json package-lock.json src-tauri/tauri.conf.json src-tauri/Cargo.toml Cargo.lock
 git commit -m "chore(release): bump version to $NEW"
-git log -1 --format='%an <%ae>%n%b'   # author QueaT, body has NO Co-Authored-By / Claude
+git log -1 --format='%an <%ae>%n%b'   # author JakubGawr, body has NO Co-Authored-By / Claude
 ```
 
 > **CALLOUT — no Claude trailers.** If your environment auto-appends a
 > `Co-Authored-By: Claude` trailer, strip it (`git commit --amend`) before pushing.
-> Release history is QueaT-only.
+> Release history is JakubGawr-only.
 
 ## Stage 4 — Merge to the `murmur` trunk via PR (NEVER direct push)
 
@@ -331,7 +331,7 @@ build→sign→notarize leg is long-running and Mac-bound. Two shapes:
   commit-author identity — collect verdicts, and only enter the bump stage when all PASS.
 
 Keep the **identity interlocks as preconditions** on every writing node: `gh`=JakubGawr,
-author=QueaT, base=`murmur`, identifier unchanged, sign-by-hash. The Mac-only stages stay a
+author=JakubGawr, base=`murmur`, identifier unchanged, sign-by-hash. The Mac-only stages stay a
 hard boundary — a headless orchestrator hands them to the user rather than faking them.
 
 ## Rules
@@ -340,7 +340,7 @@ hard boundary — a headless orchestrator hands them to the user rather than fak
 - **Never invent a green.** `lipo` must show both arches; `codesign --verify` must show
   `flags=0x10000(runtime)` + `Developer ID Application`; `spctl` must say accepted. If a
   check doesn't pass, STOP and report — do not "assume it worked."
-- **Identity is non-negotiable:** gh=JakubGawr, commit-author=QueaT (no Claude trailers),
+- **Identity is non-negotiable:** gh=JakubGawr, commit-author=JakubGawr (no Claude trailers),
   base=`murmur` via PR, identifier=`com.meetnotes.app` unchanged, sign **by hash**.
 - **Headless honesty.** If there is no Mac / no cert / no notary creds, say so and hand the
   user the exact remaining commands — never claim a notarized DMG you didn't produce.

--- a/.claude/skills/ship-feature/SKILL.md
+++ b/.claude/skills/ship-feature/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship-feature
-description: Ship a Murmur feature through scope, isolated implementation, fresh adversarial and required security review, project gates, a QueaT commit, and a PR to `murmur`. Use the verifier-only Harness for risky, multi-step, or explicitly requested work; ordinary low-risk fixes keep the normal isolated-worktree route.
+description: Ship a Murmur feature through scope, isolated implementation, fresh adversarial and required security review, project gates, a JakubGawr commit, and a PR to `murmur`. Use the verifier-only Harness for risky, multi-step, or explicitly requested work; ordinary low-risk fixes keep the normal isolated-worktree route.
 ---
 
 # /ship-feature — ship a Murmur feature end-to-end
@@ -33,7 +33,7 @@ builder and whether the lock-security review is mandatory:
 
 The harness is opt-in. A small docs/chore/mechanical/low-risk fix uses a normal
 isolated feature worktree, fresh independent review, the relevant project gates,
-and a normal QueaT commit. Do not add a Harness receipt merely because this
+and a normal JakubGawr commit. Do not add a Harness receipt merely because this
 skill was invoked.
 
 Use the Harness for lock/crypto/egress/protocol work, multi-step changes, or
@@ -175,18 +175,18 @@ append ONE `## Run journal` entry to the relevant `.claude/learnings/<agent>.md`
 promotes repeat offenders into `## Recurring patterns`. This is what makes "every bug a permanent
 lesson" instead of a re-paid one.
 
-### 6. Commit as QueaT
+### 6. Commit as JakubGawr
 ```bash
 # V2 route: commit through the runner; its durable intent survives a crash.
 git -C <worktree> commit -m \"<type>(<scope>): <subject>\"
 git -C ../.murmur-agent-tasks/v2/<task-id>/meetnotes log -1 --format='%an <%ae>'
-# MUST be QueaT <kgm004a@gmail.com>
+# MUST be JakubGawr <63911380+JakubGawr@users.noreply.github.com>
 ```
 Never use `git add -A` in a shared repository. **No AI co-author trailers.** Conventional-commit style
 (`feat`/`fix`/`chore(scope)`), matching the existing log.
 
 For the normal low-risk route, stage only the explicit owned files and create a
-normal QueaT commit without Harness trailers. Use a conventional `fix/<slug>`,
+normal JakubGawr commit without Harness trailers. Use a conventional `fix/<slug>`,
 `feat/<slug>`, or `chore/<slug>` branch so the remote `agent/*` receipt gate does
 not mistake it for a harness task. If an operator deliberately keeps a
 non-harness commit on an `agent/*` branch, the PR description must declare the
@@ -222,7 +222,7 @@ hand off to **`/release-murmur`**.
 - **Conventions are binding** — the Rust (AppError/Result, additive migrations,
   verify-before-destroy, gated reads, crash-safe FFI) and Angular-zoneless (signals/`@if`/
   `toSignal`/no-`setTimeout`/no-new-deps) rules above are non-negotiable.
-- **Identity interlocks:** commit author=QueaT (no AI trailers), gh=JakubGawr, PR base
+- **Identity interlocks:** commit author=JakubGawr (no AI trailers), gh=JakubGawr, PR base
   =`murmur`, `com.meetnotes.app` immutable.
 - **Honest about the signed-build boundary.** A dev run cannot prove Touch ID / lock-at-rest /
   screen-share — say so; only a Developer-ID build verifies them (`/release-murmur`).

--- a/.claude/skills/sync-release-copy/SKILL.md
+++ b/.claude/skills/sync-release-copy/SKILL.md
@@ -32,8 +32,8 @@ not silently rewrite marketing.
 
 1. **`gh` active account MUST be `JakubGawr`** (`gh auth status`). A second account
    `jakub-united` may also be logged in — do not use it.
-2. **Commit/PR author MUST be `QueaT <kgm004a@gmail.com>`. NO Claude trailers**, no
-   `Co-Authored-By: Claude`, anywhere. (Repo git config is already QueaT.)
+2. **Commit/PR author MUST be `JakubGawr <63911380+JakubGawr@users.noreply.github.com>`. NO Claude trailers**, no
+   `Co-Authored-By: Claude`, anywhere. (Repo git config is already JakubGawr.)
 3. **NEVER `git push origin murmur` directly** — the trunk is `murmur`; land landing
    edits via a PR (`gh pr create --base murmur` → `gh pr merge`). `block-bash.sh`
    rejects a direct trunk push anyway.

--- a/.codex/agents/ci-cd-engineer.toml
+++ b/.codex/agents/ci-cd-engineer.toml
@@ -24,7 +24,7 @@ Your final message **is** the deliverable: exactly what you changed, what you ra
 - **The heavy ML tree is ALWAYS compiled** (mistralrs/candle/tokenizers — the feature gates were removed). A cold CI build is slow (hundreds of MB); that is expected. `export MISTRALRS_METAL_PRECOMPILE=0` (baked into `ci.sh` and set in the workflow env) defers Metal-shader compile to first runtime use so headless build/test link cleanly.
 - **No new dependencies without explicit user approval** — not npm packages, not crates, and not new GitHub Actions. When you add an action, **pin it to a full commit SHA** (resolve it live, see Gotcha 3), with a `# vX.Y.Z` comment — never a floating tag.
 - **CI-focused; CD/release is the release-engineer's.** You may DESIGN a release-workflow blueprint, but you do NOT sign, notarize, staple, or publish, and you do NOT put Apple Developer-ID certs / notarytool creds into cloud CI without the user explicitly deciding to (it collides with the "keychain ops are user-interactive only" rule). Hand a real release off to `release-engineer` / the `/release-murmur` skill.
-- **`com.meetnotes.app` is immutable**; commits/PRs authored **only** by `QueaT <kgm004a@gmail.com>` with **no AI co-author trailers**; `gh` active account = `JakubGawr`.
+- **`com.meetnotes.app` is immutable**; commits/PRs authored **only** by `JakubGawr <63911380+JakubGawr@users.noreply.github.com>` with **no AI co-author trailers**; `gh` active account = `JakubGawr`.
 
 ## What you do
 

--- a/.codex/learnings/release-engineer.md
+++ b/.codex/learnings/release-engineer.md
@@ -22,7 +22,7 @@
   `git`/`gh` push ("could not read Username") — the user unlocks, you retry.
 - **PR-merge, never direct-push the trunk.** `git push origin murmur` is refused by
   `block-bash.sh`; land via `gh pr create --base murmur` → `gh pr merge`. `gh` active account =
-  `JakubGawr`; commits authored ONLY by `QueaT <kgm004a@gmail.com>`, NO AI co-author trailers.
+  `JakubGawr`; commits authored ONLY by `JakubGawr <63911380+JakubGawr@users.noreply.github.com>`, NO AI co-author trailers.
 - **Version bump touches four files in sync** — `package.json`, `src-tauri/tauri.conf.json`,
   `src-tauri/Cargo.toml`, then `cargo update -p murmur --precise <ver>` (Cargo.lock).
 - **`MURMUR_DEV_DEK` vs release-keychain DEK collide on a shared DB** → the release build can't open

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ A change is DONE only when verified — not when "code is written". Self-eval is
 
 ## Release / deployment
 
-Full runbook: **[`.agents/skills/release-murmur`](.agents/skills/release-murmur/SKILL.md)** (supersedes `docs/RELEASE-CHECKLIST.md`). Pipeline: gates green → version bump (package.json + src-tauri/tauri.conf.json + src-tauri/Cargo.toml, then `(cd src-tauri && cargo update -p murmur --precise <ver>)`) → QueaT commit → PR-merge to `murmur` → `rustup target add aarch64-apple-darwin x86_64-apple-darwin` → stop dev → `npx tauri build --target universal-apple-darwin --bundles app` → Developer-ID sign → DMG → **notarize** → staple → `gh release create`/upload.
+Full runbook: **[`.agents/skills/release-murmur`](.agents/skills/release-murmur/SKILL.md)** (supersedes `docs/RELEASE-CHECKLIST.md`). Pipeline: gates green → version bump (package.json + src-tauri/tauri.conf.json + src-tauri/Cargo.toml, then `(cd src-tauri && cargo update -p murmur --precise <ver>)`) → JakubGawr commit → PR-merge to `murmur` → `rustup target add aarch64-apple-darwin x86_64-apple-darwin` → stop dev → `npx tauri build --target universal-apple-darwin --bundles app` → Developer-ID sign → DMG → **notarize** → staple → `gh release create`/upload.
 
 ### Hard-won release rules — DO NOT repeat the 2026-06-27 mess
 
@@ -101,7 +101,7 @@ Full runbook: **[`.agents/skills/release-murmur`](.agents/skills/release-murmur/
 3. **NEVER run `security` / keychain CLI ops from the agent shell.** It can't surface the macOS auth dialog → the command HANGS → retries queue → many hung processes spamming the user (the 2026-06-27 loop was 11 `security` procs). Any keychain op needing auth (add / unlock / `notarytool store-credentials`) MUST be run by the **user** interactively (`!` in their terminal) or avoided. Even ACL/locked reads hang — never loop them. (Process kills like `pkill security` are fine; they don't touch the keychain.)
 4. **Dev and release data are intentionally isolated.** Debug/dev resolves through `state::app_dir_name()` to `MeetNotes-dev`; release uses `MeetNotes`. Never copy, restore, delete, or re-key the release database as part of a dev test.
 5. **A locked login keychain also breaks `git`/`gh` push** (the credential helper reads the GitHub token from it). `git push` → "could not read Username for https://github.com" means the keychain is locked, not that auth broke — the user unlocks it (`security unlock-keychain`, run BY THE USER) and you retry.
-6. Merge to `murmur` **via a PR, never a direct push** (guard script: `.codex/hooks/block-bash.sh`); commits/PRs authored **only** by `QueaT <kgm004a@gmail.com>`, **no AI co-author trailers**; `gh` account = `JakubGawr`; `com.meetnotes.app` immutable.
+6. Merge to `murmur` **via a PR, never a direct push** (guard script: `.codex/hooks/block-bash.sh`); commits/PRs authored **only** by `JakubGawr <63911380+JakubGawr@users.noreply.github.com>`, **no AI co-author trailers**; `gh` account = `JakubGawr`; `com.meetnotes.app` immutable.
 7. **Startup must never hard-crash on a keychain/DB failure** (v0.3.1 made it a graceful dialog + clean exit, DB untouched) — keep it; never reintroduce an `init().expect()` / `.unwrap()` on the keychain-or-DB-open path.
 
 ## Agents, skills, rules & hooks (this repo's `.codex/`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ A change is DONE only when verified — not when "code is written". Self-eval is
 
 ## Release / deployment
 
-Full runbook: **[`.claude/skills/release-murmur`](.claude/skills/release-murmur/SKILL.md)** (supersedes `docs/RELEASE-CHECKLIST.md`). Pipeline: gates green → version bump (package.json + src-tauri/tauri.conf.json + src-tauri/Cargo.toml, then `(cd src-tauri && cargo update -p murmur --precise <ver>)`) → QueaT commit → PR-merge to `murmur` → `rustup target add aarch64-apple-darwin x86_64-apple-darwin` → stop dev → `npx tauri build --target universal-apple-darwin --bundles app` → Developer-ID sign → DMG → **notarize** → staple → `gh release create`/upload.
+Full runbook: **[`.claude/skills/release-murmur`](.claude/skills/release-murmur/SKILL.md)** (supersedes `docs/RELEASE-CHECKLIST.md`). Pipeline: gates green → version bump (package.json + src-tauri/tauri.conf.json + src-tauri/Cargo.toml, then `(cd src-tauri && cargo update -p murmur --precise <ver>)`) → JakubGawr commit → PR-merge to `murmur` → `rustup target add aarch64-apple-darwin x86_64-apple-darwin` → stop dev → `npx tauri build --target universal-apple-darwin --bundles app` → Developer-ID sign → DMG → **notarize** → staple → `gh release create`/upload.
 
 ### Hard-won release rules — DO NOT repeat the 2026-06-27 mess
 
@@ -99,7 +99,7 @@ Full runbook: **[`.claude/skills/release-murmur`](.claude/skills/release-murmur/
 3. **NEVER run `security` / keychain CLI ops from the agent shell.** It can't surface the macOS auth dialog → the command HANGS → retries queue → many hung processes spamming the user (the 2026-06-27 loop was 11 `security` procs). Any keychain op needing auth (add / unlock / `notarytool store-credentials`) MUST be run by the **user** interactively (`!` in their terminal) or avoided. Even ACL/locked reads hang — never loop them. (Process kills like `pkill security` are fine; they don't touch the keychain.)
 4. **Dev and release data are intentionally isolated.** Debug/dev resolves through `state::app_dir_name()` to `MeetNotes-dev`; release uses `MeetNotes`. Never copy, restore, delete, or re-key the release database as part of a dev test.
 5. **A locked login keychain also breaks `git`/`gh` push** (the credential helper reads the GitHub token from it). `git push` → "could not read Username for https://github.com" means the keychain is locked, not that auth broke — the user unlocks it (`security unlock-keychain`, run BY THE USER) and you retry.
-6. Merge to `murmur` **via a PR, never a direct push** (enforced by `.claude/hooks/block-bash.sh`); commits/PRs authored **only** by `QueaT <kgm004a@gmail.com>`, **no Claude trailers**; `gh` account = `JakubGawr`; `com.meetnotes.app` immutable.
+6. Merge to `murmur` **via a PR, never a direct push** (enforced by `.claude/hooks/block-bash.sh`); commits/PRs authored **only** by `JakubGawr <63911380+JakubGawr@users.noreply.github.com>`, **no Claude trailers**; `gh` account = `JakubGawr`; `com.meetnotes.app` immutable.
 7. **Startup must never hard-crash on a keychain/DB failure** (v0.3.1 made it a graceful dialog + clean exit, DB untouched) — keep it; never reintroduce an `init().expect()` / `.unwrap()` on the keychain-or-DB-open path.
 
 ## Agents, skills, rules & hooks (this repo's `.claude/`)


### PR DESCRIPTION
## What

The repo committed under two identities that were the same person:

| Identity | Commits |
|---|---|
| `QueaT <kgm004a@gmail.com>` | 1013 |
| `JakubGawr <63911380+JakubGawr@users.noreply.github.com>` | 590 |

History has been rewritten so all 1603 carry the single GitHub-linked identity.
This PR updates the rules that would otherwise re-create the split on the very
next commit — the binding identity rule still said the author "MUST be QueaT".

## Files

- `CLAUDE.md` / `AGENTS.md` — the binding identity rule
- `release-murmur`, `ship-feature`, `sync-release-copy`, `add-ci-gate` skills, in
  both the `.claude/` and `.agents/` trees
- `.claude/agents/ci-cd-engineer.md` + `.codex/agents/ci-cd-engineer.toml`
- `.claude/learnings/release-engineer.md`, with `.codex/` re-mirrored via
  `.agents/h/mirror-check --fix`

Also repoints the release-shape example from `2038177` to `be4ef0f3`: the cited
SHA no longer exists after the rewrite. Same commit, new hash.

## Deliberately NOT changed

`kgm004a` stays in the test fixtures and — importantly — in the privacy scrubbers
at `scripts/screenshots/capture.mjs` and `scripts/promo/record.mjs`. Those regexes
exist to REFUSE a screenshot that leaks operator identity; removing the string
would weaken a guard, not clean it up.

## Verification

Markdown and TOML only — no Rust or Angular source touched.

```
.agents/h/mirror-check              → mirror OK (.claude/ == .codex/)
scripts/agent-remote-audit --selftest → PASS
python3 .agents/h/guard.py --selftest → PASS (8 przypadkow + skan sekretow)
python3 eval/agents/runner.py --selftest → 8 task(s), 0 failure(s)
```
