### PR TITLE
fix(org): finish the key rotation that follows removing a member

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -14347,6 +14347,12 @@ mod workspace_tree_tests;
 #[path = "tests/org_diagnosability_tests.rs"]
 mod org_diagnosability_tests;
 
+// ── The member-removal key rotation: the JSON body, full member coverage, and the re-drivable debt
+// ───────────────────────────────────────────────────────────────────────────────────────────────
+#[cfg(test)]
+#[path = "tests/org_rotation_tests.rs"]
+mod org_rotation_tests;
+
 // ── Shared containers: the share plan's leak oracles + the received-forest read model ────────────
 #[cfg(test)]
 #[path = "tests/container_share_tests.rs"]

--- a/src-tauri/src/commands/org.rs
+++ b/src-tauri/src/commands/org.rs
@@ -3578,6 +3578,20 @@ pub(crate) async fn org_invite_member_inner(
     // recipient_acct_id = the member's FINGERPRINT (the crypto binding THEY open with via `self_fp` in
     // `acquire_org_ock`); the DB grant key stays their server user id (`added.user_id`).
     let member_fp = crate::e2ee::key_fingerprint(&key.pk_enc, &key.pk_sig);
+    // Remember the key this invite just resolved. A later rotation has to wrap the new OCK for
+    // EVERY remaining member in one pass, and the only directory the relay offers is this same
+    // email-keyed lookup, capped at 20 calls a day against orgs of up to 50 members — so a rotation
+    // that re-looked-up everybody would fail on quota long before it failed on anything interesting.
+    // Remembering it here also means rotation prefers the key this device already saw over whatever
+    // the relay answers later, which is the strictly safer of the two.
+    state.db.upsert_org_member_key(
+        &org.org_id,
+        &added.user_id,
+        Some(&email),
+        &key.pk_enc,
+        &key.pk_sig,
+        &member_fp,
+    )?;
     let grant = crate::e2ee::org::wrap_ock_for_member(
         &ock,
         &org.org_id,
@@ -3678,6 +3692,170 @@ async fn task_org_members_read_with_permit(
     client.org_list_members(access_token, org_id).await
 }
 
+/// Mint a new org content key, wrap it for EVERY remaining active member, and commit the new
+/// generation.
+///
+/// # Why this is a whole function and not three lines inside the removal
+///
+/// The relay enforces the only rule that matters here: `POST /v1/orgs/{id}/generation` succeeds
+/// only when a key grant for the new generation already exists for every member whose `removed_at`
+/// is null, checked inside the same transaction that flips the generation. So a rotation is
+/// all-or-nothing by construction, and a rotation that reaches only the owner is not a partial
+/// success — it is a 409 and no rotation at all.
+///
+/// # Order
+///
+/// The removal MUST already have happened. While the departing member is still active the relay
+/// counts them in the coverage check, so a "rotate first, then remove" ordering could only succeed
+/// by granting the new key to the very person being removed. That is why the caller journals the
+/// debt first and rotates second, rather than the other way round.
+///
+/// # Resolving keys
+///
+/// Each member's public key comes from this device's own `org_member_keys` cache when it has one,
+/// and only otherwise from `POST /v1/keys/lookup` (which is then remembered). Preferring the cached
+/// copy is deliberate: it means a relay cannot substitute a key for a member this device has
+/// already met, and it keeps a 50-member org inside the 20-lookups-a-day quota.
+///
+/// Returns the generation the relay committed.
+pub(crate) async fn rotate_org_generation(state: &AppState, org_id: &str) -> Result<u32, AppError> {
+    let org = resolve_org(state, org_id)?;
+    let base = share_base_url(state)?;
+    let (account_id, gen_id, mk, access_token) = require_session_mk(state).await?;
+    let server_user_id = session_server_user_id(state)?;
+    let client = crate::share::client::ShareClient::new(&base)?;
+
+    // The generation to target is the RELAY's current one, never the local cache: a device that
+    // missed a rotation would otherwise aim at an already-used generation and take a 409 forever.
+    let status = client.org_status(&access_token, &org.org_id).await?;
+    let new_gen = status.current_generation.saturating_add(1);
+
+    let members = client
+        .org_list_members(&access_token, &org.org_id)
+        .await?
+        .members;
+    if members.is_empty() {
+        // The relay refuses a bump for a memberless org anyway; saying so here keeps the failure
+        // legible instead of arriving as an opaque 409.
+        return Err(AppError::Unavailable(crate::errcode::tag(
+            crate::errcode::ORG_ROTATION_PENDING,
+            "org has no active members to rotate to",
+        )));
+    }
+
+    let new_ock = crate::e2ee::org::generate_ock()?;
+    let owner = crate::e2ee::keys::derive_identity(&mk, &account_id, gen_id)?;
+    let owner_fp = crate::e2ee::key_fingerprint(&owner.pk_enc, &owner.pk_sig);
+
+    let mut grants: Vec<crate::share::org_dto::KeyGrantInput> = Vec::with_capacity(members.len());
+    for member in &members {
+        // (pk_enc, recipient fingerprint) for this member. Ours is derived locally; everyone
+        // else's is remembered or, failing that, looked up once and then remembered.
+        let (pk_enc, recipient_fp) = if member.user_id == server_user_id {
+            (owner.pk_enc.to_vec(), owner_fp.clone())
+        } else if let Some(known) = state.db.get_org_member_key(&org.org_id, &member.user_id)? {
+            (known.pk_enc, known.fingerprint)
+        } else {
+            let Some(email) = member.email.as_deref().filter(|e| !e.trim().is_empty()) else {
+                // Without an address there is no directory to ask. Refusing keeps the debt on the
+                // journal instead of committing a generation somebody cannot open.
+                return Err(AppError::Unavailable(crate::errcode::tag(
+                    crate::errcode::ORG_ROTATION_PENDING,
+                    "a remaining member's identity key is unknown and cannot be resolved",
+                )));
+            };
+            let lookup = client.lookup_key(&access_token, email).await?;
+            let Some(key) = lookup.key.filter(|_| lookup.registered) else {
+                return Err(AppError::Unavailable(crate::errcode::tag(
+                    crate::errcode::ORG_ROTATION_PENDING,
+                    "a remaining member is not a registered account",
+                )));
+            };
+            let fp = crate::e2ee::key_fingerprint(&key.pk_enc, &key.pk_sig);
+            state.db.upsert_org_member_key(
+                &org.org_id,
+                &member.user_id,
+                Some(email),
+                &key.pk_enc,
+                &key.pk_sig,
+                &fp,
+            )?;
+            (key.pk_enc, fp)
+        };
+
+        let grant = crate::e2ee::org::wrap_ock_for_member(
+            &new_ock,
+            &org.org_id,
+            new_gen,
+            &pk_enc,
+            // recipient_acct_id = the member's FINGERPRINT, matching what `acquire_org_ock` opens
+            // with as `self_fp`. Keying it on anything else produces a grant nobody can open.
+            &recipient_fp,
+            &owner,
+            &owner_fp,
+            gen_id,
+        )?;
+        grants.push(crate::share::org_dto::KeyGrantInput {
+            user_id: member.user_id.clone(),
+            generation: new_gen,
+            wrapped_key: grant.wrapped_key,
+            grant_sig: grant.grant_sig,
+        });
+    }
+
+    client
+        .org_put_key_grants(&access_token, &org.org_id, grants)
+        .await?;
+    let committed = client
+        .org_bump_generation(&access_token, &org.org_id, new_gen)
+        .await?;
+    if committed != new_gen {
+        // The grants were wrapped for `new_gen`. A relay that committed something else has left a
+        // live generation nobody holds a key for, so record nothing locally and keep the debt.
+        return Err(AppError::Unavailable(crate::errcode::tag(
+            crate::errcode::ORG_ROTATION_PENDING,
+            "the server committed a different generation than the one the grants cover",
+        )));
+    }
+
+    state.db.set_org_generation(&org.org_id, committed)?;
+    {
+        let mut cache = state
+            .org_ock_cache
+            .lock()
+            .map_err(|_| AppError::Storage("org-ock cache mutex poisoned".into()))?;
+        cache.insert(
+            (org.org_id.clone(), committed),
+            zeroize::Zeroizing::new(*new_ock),
+        );
+    }
+    state.db.clear_org_rotation_pending(&org.org_id)?;
+    crate::share::ledger_row(&state.db, &client.host(), "org_rotate_generation", 0);
+    Ok(committed)
+}
+
+/// Re-drive every org that still owes a key rotation. Returns how many settled.
+///
+/// A debt survives a restart on purpose: the window between "member removed" and "new generation
+/// committed" is exactly the window in which anything newly published stays readable with the
+/// removed member's old key, so it must be closed by a retry rather than by the user noticing.
+pub(crate) async fn drive_pending_org_rotations(state: &AppState) -> Result<u32, AppError> {
+    let mut settled = 0u32;
+    for org_id in state.db.list_org_rotations_pending()? {
+        match rotate_org_generation(state, &org_id).await {
+            Ok(_) => settled = settled.saturating_add(1),
+            Err(e) => {
+                // Keep the debt and record WHICH failure, in the same content-free vocabulary the
+                // org log uses. A rotation that keeps failing for one reason is a different problem
+                // from one that fails for a new reason every time, and the row is the only place
+                // that distinction survives a restart.
+                let _ = state.db.record_org_rotation_failure(&org_id, &brief_err(&e));
+            }
+        }
+    }
+    Ok(settled)
+}
+
 /// `org_remove_member(org_id, user_id)` — owner soft-removes a member from the TARGETED org, then
 /// ROTATES that org's OCK: generate gen N+1, wrap it to every REMAINING member, PUT the grants, and
 /// bump the server generation. The removed member keeps only the old-gen OCK (can't read anything
@@ -3700,72 +3878,45 @@ pub(crate) async fn org_remove_member_inner(
     let user_id = user_id.trim().to_string();
     let org = resolve_org(state, &org_id)?;
     let base = share_base_url(state)?;
-    let (account_id, gen_id, mk, access_token) = require_session_mk(state).await?;
-    // DB grant key = the owner's server user id (UUID), not the email `account_id`.
-    let server_user_id = session_server_user_id(state)?;
+    let access_token = valid_access_token(state).await?;
     let client = crate::share::client::ShareClient::new(&base)?;
+
+    // Journal the rotation debt BEFORE asking the relay to remove anybody. Everything after this
+    // point can be interrupted — a dropped connection, a quit, a crash — and the one outcome that
+    // must never happen is a member removed from an org that then stays on the generation their key
+    // still opens. The row is what makes that window closable by a retry instead of by luck. It is
+    // deliberately NOT cleared when the removal itself fails: a failure whose response was lost is
+    // indistinguishable from a success, and a redundant rotation costs one generation while a
+    // skipped one costs the whole point of removing the member.
+    state.db.mark_org_rotation_pending(&org.org_id)?;
 
     client
         .org_remove_member(&access_token, &org.org_id, &user_id)
         .await?;
 
-    // Rotate: new generation = current + 1. The owner generates the new OCK and MUST wrap it to every
-    // REMAINING active member (keyed by their published identity key) before bumping the generation.
-    //
-    // HONEST V1 BOUNDARY: the members endpoint is content-min (user_id/role/created_at only) and there
-    // is no "fetch a member's identity key by user_id" endpoint yet — only the email-keyed
-    // `keys/lookup`. So this v1 rotation re-grants the new OCK to the OWNER (whose key we derive
-    // locally) and bumps the generation; the removed member immediately loses access to anything sealed
-    // under gen N+1. Re-granting to OTHER remaining members needs a by-user_id key-directory read that
-    // the feed-sync slice adds — until then a rotation should be followed by re-inviting the remaining
-    // members (which re-wraps the current-gen OCK to each). This is a documented scope cut, not a leak:
-    // no content is exposed and the removed member is correctly locked out of future items.
-    let new_gen = org.generation.saturating_add(1);
-    let new_ock = crate::e2ee::org::generate_ock()?;
-    let owner = crate::e2ee::keys::derive_identity(&mk, &account_id, gen_id)?;
-    let owner_fp = crate::e2ee::key_fingerprint(&owner.pk_enc, &owner.pk_sig);
+    // Forget the departing member's key so a later re-invite has to learn it afresh rather than
+    // reusing one this device kept while they were outside the org.
+    state.db.forget_org_member_key(&org.org_id, &user_id)?;
 
-    let owner_grant = crate::e2ee::org::wrap_ock_for_member(
-        &new_ock,
-        &org.org_id,
-        new_gen,
-        &owner.pk_enc,
-        &owner_fp, // recipient_acct_id = our FINGERPRINT (matches `acquire_org_ock`'s open)
-        &owner,
-        &owner_fp,
-        gen_id,
-    )?;
-    client
-        .org_put_key_grants(
-            &access_token,
-            &org.org_id,
-            vec![crate::share::org_dto::KeyGrantInput {
-                user_id: server_user_id.clone(),
-                generation: new_gen,
-                wrapped_key: owner_grant.wrapped_key,
-                grant_sig: owner_grant.grant_sig,
-            }],
-        )
-        .await?;
-    // Bump the server generation (monotonic +1) — the server checks grant counts only.
-    client
-        .org_bump_generation(&access_token, &org.org_id)
-        .await?;
-
-    // Update the cached generation + OCK.
-    state.db.set_org_generation(&org.org_id, new_gen)?;
-    {
-        let mut cache = state
-            .org_ock_cache
-            .lock()
-            .map_err(|_| AppError::Storage("org-ock cache mutex poisoned".into()))?;
-        cache.insert(
-            (org.org_id.clone(), new_gen),
-            zeroize::Zeroizing::new(*new_ock),
-        );
-    }
+    // The removal is done and durable at the relay; the ledger records it whether or not the
+    // rotation that follows lands, because it happened.
     crate::share::ledger_row(&state.db, &client.host(), "org_remove_member", 0);
-    Ok(())
+
+    match rotate_org_generation(state, &org.org_id).await {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            let _ = state
+                .db
+                .record_org_rotation_failure(&org.org_id, &brief_err(&e));
+            // NOT a removal failure — saying so would invite the user to remove somebody who is
+            // already gone. This names the half that is outstanding, and the copy for the code says
+            // what it means for them: new posts stay readable with the old key until it lands.
+            Err(AppError::Unavailable(crate::errcode::tag(
+                crate::errcode::ORG_ROTATION_PENDING,
+                "member removed; the key rotation did not complete and will be retried",
+            )))
+        }
+    }
 }
 
 /// `org_leave(org_id)` — the caller leaves the TARGETED org (member self-removal). Drops that org's
@@ -9506,6 +9657,19 @@ async fn org_sweep_pending_with_policy(
     }
     let client = crate::share::client::ShareClient::new(&base)?;
     let direct_actor_user_id = Some(authenticated_actor_user_id);
+
+    // 0b-rot) OWED KEY ROTATIONS, first of the network passes. A member was removed and the new
+    // generation never committed, so until this settles anything published into that org is still
+    // readable with the key the removed member holds. That makes it the most time-critical debt in
+    // the sweep, ahead of any publish or access reconcile — a late publish is an inconvenience, a
+    // late rotation is the removal not having happened in the way the user was told it had.
+    // Failures leave the row in place (with its reason recorded) for the next sweep.
+    if !state.db.list_org_rotations_pending()?.is_empty() {
+        advanced = advanced.saturating_add(drive_pending_org_rotations(state).await?);
+        if !policy.is_current() {
+            return Ok(advanced);
+        }
+    }
 
     // 0c) Initial stable POST ambiguity is resolved from its pre-dispatch witness before any source
     // reread. Never overwrite the committed hash with a newer local edit and never redispatch while

--- a/src-tauri/src/commands/org.rs
+++ b/src-tauri/src/commands/org.rs
@@ -3718,7 +3718,24 @@ async fn task_org_members_read_with_permit(
 /// already met, and it keeps a 50-member org inside the 20-lookups-a-day quota.
 ///
 /// Returns the generation the relay committed.
-pub(crate) async fn rotate_org_generation(state: &AppState, org_id: &str) -> Result<u32, AppError> {
+/// How many identity lookups one rotation attempt may spend. The relay allows 20 a day per
+/// account against orgs of up to 50 members, so an org invited before member keys were remembered
+/// cannot resolve everyone in one pass. Bounding it per attempt means a first rotation converges
+/// over a few attempts instead of spending the whole day's quota — and leaving none for the
+/// invites and shares the same quota pays for.
+const ROTATION_LOOKUP_BUDGET: usize = 8;
+
+/// What one rotation attempt achieved when it did not finish: whether it LEARNED a key it did not
+/// have. A slow-but-progressing rotation must not be backed off; a doomed one must.
+pub(crate) struct RotationProgress {
+    pub learned_keys: usize,
+}
+
+pub(crate) async fn rotate_org_generation(
+    state: &AppState,
+    org_id: &str,
+    progress: &mut RotationProgress,
+) -> Result<u32, AppError> {
     let org = resolve_org(state, org_id)?;
     let base = share_base_url(state)?;
     let (account_id, gen_id, mk, access_token) = require_session_mk(state).await?;
@@ -3764,6 +3781,13 @@ pub(crate) async fn rotate_org_generation(state: &AppState, org_id: &str) -> Res
                     "a remaining member's identity key is unknown and cannot be resolved",
                 )));
             };
+            if progress.learned_keys >= ROTATION_LOOKUP_BUDGET {
+                return Err(AppError::Unavailable(crate::errcode::tag(
+                    crate::errcode::ORG_ROTATION_PENDING,
+                    "resolved this attempt's share of the remaining members' keys; \
+                     the rotation continues on the next pass",
+                )));
+            }
             let lookup = client.lookup_key(&access_token, email).await?;
             let Some(key) = lookup.key.filter(|_| lookup.registered) else {
                 return Err(AppError::Unavailable(crate::errcode::tag(
@@ -3780,6 +3804,7 @@ pub(crate) async fn rotate_org_generation(state: &AppState, org_id: &str) -> Res
                 &key.pk_sig,
                 &fp,
             )?;
+            progress.learned_keys += 1;
             (key.pk_enc, fp)
         };
 
@@ -3819,16 +3844,12 @@ pub(crate) async fn rotate_org_generation(state: &AppState, org_id: &str) -> Res
     }
 
     state.db.set_org_generation(&org.org_id, committed)?;
-    {
-        let mut cache = state
-            .org_ock_cache
-            .lock()
-            .map_err(|_| AppError::Storage("org-ock cache mutex poisoned".into()))?;
-        cache.insert(
-            (org.org_id.clone(), committed),
-            zeroize::Zeroizing::new(*new_ock),
-        );
-    }
+    // The freshly minted OCK is deliberately NOT cached here. The relay upserts grants, so a second
+    // owner device that PUT its own grants for the same generation between our PUT and our POST
+    // would have its key committed while ours is the one we hold — and everything we then sealed
+    // under this generation would be unreadable to everybody, ourselves included after a restart.
+    // Leaving the cache cold costs one round-trip on next use and makes `acquire_org_ock` fetch and
+    // OPEN the grant the relay actually stored, which is the only copy that can be authoritative.
     state.db.clear_org_rotation_pending(&org.org_id)?;
     crate::share::ledger_row(&state.db, &client.host(), "org_rotate_generation", 0);
     Ok(committed)
@@ -3841,15 +3862,21 @@ pub(crate) async fn rotate_org_generation(state: &AppState, org_id: &str) -> Res
 /// removed member's old key, so it must be closed by a retry rather than by the user noticing.
 pub(crate) async fn drive_pending_org_rotations(state: &AppState) -> Result<u32, AppError> {
     let mut settled = 0u32;
-    for org_id in state.db.list_org_rotations_pending()? {
-        match rotate_org_generation(state, &org_id).await {
+    for org_id in state.db.list_org_rotations_due()? {
+        let mut progress = RotationProgress { learned_keys: 0 };
+        match rotate_org_generation(state, &org_id, &mut progress).await {
             Ok(_) => settled = settled.saturating_add(1),
             Err(e) => {
                 // Keep the debt and record WHICH failure, in the same content-free vocabulary the
                 // org log uses. A rotation that keeps failing for one reason is a different problem
                 // from one that fails for a new reason every time, and the row is the only place
-                // that distinction survives a restart.
-                let _ = state.db.record_org_rotation_failure(&org_id, &brief_err(&e));
+                // that distinction survives a restart. An attempt that learned a key it did not
+                // have is converging, not stuck, so it keeps its place at the front of the queue.
+                let _ = state.db.record_org_rotation_failure(
+                    &org_id,
+                    &brief_err(&e),
+                    progress.learned_keys > 0,
+                );
             }
         }
     }
@@ -3881,6 +3908,16 @@ pub(crate) async fn org_remove_member_inner(
     let access_token = valid_access_token(state).await?;
     let client = crate::share::client::ShareClient::new(&base)?;
 
+    // Only an owner can rotate, and the relay answers a non-owner's removal with a uniform 404 that
+    // the client maps to Ok. Journaling first in that case would write a debt no later sweep could
+    // ever settle, and every retry would spend key lookups on it. Refusing here is visible and
+    // self-correcting (a membership refresh fixes a stale role); a permanent silent debt is not.
+    if !org.role.eq_ignore_ascii_case("owner") {
+        return Err(AppError::InvalidArg(
+            "only the organization owner can remove a member".into(),
+        ));
+    }
+
     // Journal the rotation debt BEFORE asking the relay to remove anybody. Everything after this
     // point can be interrupted — a dropped connection, a quit, a crash — and the one outcome that
     // must never happen is a member removed from an org that then stays on the generation their key
@@ -3902,12 +3939,15 @@ pub(crate) async fn org_remove_member_inner(
     // rotation that follows lands, because it happened.
     crate::share::ledger_row(&state.db, &client.host(), "org_remove_member", 0);
 
-    match rotate_org_generation(state, &org.org_id).await {
+    let mut progress = RotationProgress { learned_keys: 0 };
+    match rotate_org_generation(state, &org.org_id, &mut progress).await {
         Ok(_) => Ok(()),
         Err(e) => {
-            let _ = state
-                .db
-                .record_org_rotation_failure(&org.org_id, &brief_err(&e));
+            let _ = state.db.record_org_rotation_failure(
+                &org.org_id,
+                &brief_err(&e),
+                progress.learned_keys > 0,
+            );
             // NOT a removal failure — saying so would invite the user to remove somebody who is
             // already gone. This names the half that is outstanding, and the copy for the code says
             // what it means for them: new posts stay readable with the old key until it lands.
@@ -9664,7 +9704,7 @@ async fn org_sweep_pending_with_policy(
     // the sweep, ahead of any publish or access reconcile — a late publish is an inconvenience, a
     // late rotation is the removal not having happened in the way the user was told it had.
     // Failures leave the row in place (with its reason recorded) for the next sweep.
-    if !state.db.list_org_rotations_pending()?.is_empty() {
+    if !state.db.list_org_rotations_due()?.is_empty() {
         advanced = advanced.saturating_add(drive_pending_org_rotations(state).await?);
         if !policy.is_current() {
             return Ok(advanced);

--- a/src-tauri/src/commands/tests/org_rotation_tests.rs
+++ b/src-tauri/src/commands/tests/org_rotation_tests.rs
@@ -102,6 +102,10 @@ struct RelayLog {
     bump_body: Option<String>,
     /// Every `(user_id, generation)` a key-grant PUT covered, across all calls.
     granted: Vec<(String, u32)>,
+    /// The opaque bytes each grant carried, so a test can OPEN one with the member's own identity
+    /// instead of merely observing that a row exists — the relay's coverage rule counts rows, so a
+    /// test that also counts rows shares the relay's blind spot rather than covering it.
+    granted_material: Vec<(String, u32, Vec<u8>, Vec<u8>)>,
     removed: Vec<String>,
     lookups: Vec<String>,
     /// The bump the relay actually committed, if it committed one.
@@ -120,6 +124,16 @@ struct RotationRelay {
 impl RotationRelay {
     /// `members` is the live roster; `keys` maps an email to the identity the lookup publishes.
     fn start(members: Vec<MockMember>, keys: HashMap<String, (Vec<u8>, Vec<u8>)>) -> Self {
+        Self::start_at_generation(members, keys, 1)
+    }
+
+    /// The same relay, already living at `generation` — the state of an org this device has fallen
+    /// behind on.
+    fn start_at_generation(
+        members: Vec<MockMember>,
+        keys: HashMap<String, (Vec<u8>, Vec<u8>)>,
+        live_generation: u32,
+    ) -> Self {
         let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
         let base = format!("http://{}/", server.server_addr().to_ip().unwrap());
         let log = Arc::new(Mutex::new(RelayLog::default()));
@@ -130,7 +144,7 @@ impl RotationRelay {
         let handle = std::thread::spawn(move || {
             // The relay's own state: the roster and the live generation it would keep in Postgres.
             let mut roster = members;
-            let mut generation: u32 = 1;
+            let mut generation: u32 = live_generation;
             loop {
                 if shutdown_t.load(Ordering::SeqCst) {
                     break;
@@ -251,7 +265,18 @@ impl RotationRelay {
                                     .get("generation")
                                     .and_then(serde_json::Value::as_u64)
                                     .unwrap_or(0) as u32;
-                                guard.granted.push((uid, gen));
+                                let wrapped = g
+                                    .get("wrappedKey")
+                                    .and_then(serde_json::Value::as_str)
+                                    .and_then(|s| murmur_protocol::b64::decode(s).ok())
+                                    .unwrap_or_default();
+                                let sig = g
+                                    .get("grantSig")
+                                    .and_then(serde_json::Value::as_str)
+                                    .and_then(|s| murmur_protocol::b64::decode(s).ok())
+                                    .unwrap_or_default();
+                                guard.granted.push((uid.clone(), gen));
+                                guard.granted_material.push((uid, gen, wrapped, sig));
                             }
                         }
                     }
@@ -327,6 +352,15 @@ impl RotationRelay {
 
     fn set_refuse_bump(&self, refuse: bool) {
         self.log.lock().unwrap().refuse_bump = refuse;
+    }
+
+    /// The opaque grant one member received at `generation`, if any.
+    fn grant_material_for(&self, user_id: &str, generation: u32) -> Option<(Vec<u8>, Vec<u8>)> {
+        self.log()
+            .granted_material
+            .iter()
+            .find(|(u, g, _, _)| u == user_id && *g == generation)
+            .map(|(_, _, w, s)| (w.clone(), s.clone()))
     }
 
     /// Every user id granted at `generation`, deduplicated and sorted — the set the coverage rule
@@ -640,4 +674,184 @@ fn remembered_member_keys_are_scoped_to_their_org() {
         .get_org_member_key(ORG, STAYS_CACHED_UID)
         .unwrap()
         .is_none());
+}
+
+/// THE ORACLE THE FIRST ROUND OF THIS CHANGE WAS MISSING.
+///
+/// A lock-security review pointed out that every assertion above checks the same predicate the
+/// relay checks — that a grant ROW exists for each member — and never that the bytes in it are a
+/// key that member can actually open. A grant wrapped to the wrong `recipient_acct_id`, or to a
+/// stale `pk_enc`, satisfies the coverage rule perfectly, commits the generation, and locks the
+/// member out of everything published afterwards. That failure looks exactly like success from
+/// every other angle in this file.
+///
+/// So: rotate, take the bytes the relay received for a member, and open them with that member's
+/// own identity through the same `open_own_grant` the app uses. Both members are checked — the one
+/// whose key was remembered and the one whose key was looked up, since those are two different code
+/// paths for producing `(pk_enc, fingerprint)` and only one of them was exercised at invite time.
+#[tokio::test]
+async fn every_rotated_grant_opens_with_its_member_s_own_identity() {
+    let relay = RotationRelay::start(roster(), published_keys());
+    let state = AppState::for_tests(fresh_db("rotate-grants-open"));
+    wire_state(&state, &relay);
+    seed_cached_member_key(&state);
+
+    org_remove_member_inner(&state, ORG.into(), REMOVED_UID.into())
+        .await
+        .expect("removal + rotation must succeed");
+
+    let owner = crate::e2ee::keys::derive_identity(&Zeroizing::new([7u8; 32]), "owner@example.com", 1)
+        .unwrap();
+    let owner_fp = crate::e2ee::key_fingerprint(&owner.pk_enc, &owner.pk_sig);
+
+    let mut opened: Vec<[u8; 32]> = Vec::new();
+    for (uid, seed, email) in [
+        (STAYS_CACHED_UID, 3u8, "cached@example.com"),
+        (STAYS_LOOKED_UP_UID, 4u8, "lookedup@example.com"),
+    ] {
+        let member = member_identity(seed, email);
+        let member_fp = crate::e2ee::key_fingerprint(&member.pk_enc, &member.pk_sig);
+        let (wrapped, sig) = relay
+            .grant_material_for(uid, 2)
+            .unwrap_or_else(|| panic!("no gen-2 grant recorded for {uid}"));
+
+        // The granter identity travels inside the wrapped frame, exactly as `acquire_org_ock`
+        // reads it — nothing here is taken from the test's own knowledge of who granted.
+        let unpacked = crate::e2ee::wrap::unpack_wrapped_key(&wrapped, &sig).unwrap();
+        let granter_fp =
+            crate::e2ee::key_fingerprint(&unpacked.sender_pk_enc, &unpacked.sender_pk_sig);
+        assert_eq!(
+            granter_fp, owner_fp,
+            "the grant must be signed by the owner's identity"
+        );
+
+        let ock = crate::e2ee::org::open_own_grant(
+            &wrapped,
+            &sig,
+            &member,
+            &member_fp,
+            &member_fp,
+            &granter_fp,
+            1,
+            &granter_fp,
+            &unpacked.sender_pk_sig,
+            ORG,
+            2,
+        )
+        .unwrap_or_else(|e| {
+            panic!("{uid} cannot open the key they were granted — a rotation that locks a remaining member out is indistinguishable from success by every other assertion here: {e}")
+        });
+        opened.push(*ock);
+    }
+
+    assert_eq!(
+        opened[0], opened[1],
+        "every member must open the SAME org content key — different keys per member would mean \
+         each of them can read only what they sealed themselves"
+    );
+
+    // And the member who was removed got no grant at all to open.
+    assert!(
+        relay.grant_material_for(REMOVED_UID, 2).is_none(),
+        "the removed member must receive no gen-2 grant"
+    );
+}
+
+/// A rotation that learns NOTHING must back off, or one unresolvable member spends the owner's
+/// twenty daily key lookups every sixty seconds, forever — and the org never rotates at all.
+/// A rotation that DOES learn a key keeps its place in the queue, because a first rotation of an
+/// org invited before keys were remembered converges a few members at a time and throttling that
+/// would turn hours into weeks.
+#[test]
+fn a_rotation_that_learns_nothing_backs_off_and_one_that_learns_does_not() {
+    let db = fresh_db("rotate-backoff");
+    db.mark_org_rotation_pending(ORG).unwrap();
+    assert_eq!(db.list_org_rotations_due().unwrap(), vec![ORG.to_string()]);
+
+    db.record_org_rotation_failure(ORG, "unavailable", false)
+        .unwrap();
+    assert_eq!(db.org_rotation_pending_attempts(ORG).unwrap(), Some(1));
+    assert!(
+        db.list_org_rotations_due().unwrap().is_empty(),
+        "a fruitless attempt must not be re-driven on the very next tick"
+    );
+    assert_eq!(
+        db.list_org_rotations_pending().unwrap(),
+        vec![ORG.to_string()],
+        "backing off must not DROP the debt — the window it protects is the whole point"
+    );
+
+    db.record_org_rotation_failure(ORG, "unavailable", true)
+        .unwrap();
+    assert_eq!(db.org_rotation_pending_attempts(ORG).unwrap(), Some(2));
+    assert_eq!(
+        db.list_org_rotations_due().unwrap(),
+        vec![ORG.to_string()],
+        "an attempt that learned a key is converging and must be retried at once"
+    );
+}
+
+/// Only an owner can rotate. Journaling a debt on a device that can never settle it would leave a
+/// permanent row whose every retry spends key lookups — and the relay answers a non-owner's removal
+/// with a uniform 404 that the client maps to `Ok`, so nothing later in the flow would notice.
+#[tokio::test]
+async fn a_non_owner_removal_is_refused_before_any_debt_is_written() {
+    let state = AppState::for_tests(fresh_db("rotate-non-owner"));
+    seed_live_session(&state);
+    state
+        .db
+        .upsert_org_state(&crate::storage::OrgState {
+            org_id: ORG.into(),
+            name: "Acme".into(),
+            role: "member".into(),
+            joined_at: "2026-07-11T00:00:00Z".into(),
+            consented: true,
+            last_seq: 0,
+            generation: 1,
+            context_enabled: true,
+        })
+        .unwrap();
+    state.config.lock().unwrap().share_base_url = "http://127.0.0.1:1/".into();
+
+    let err = org_remove_member_inner(&state, ORG.into(), REMOVED_UID.into())
+        .await
+        .expect_err("a member must not be able to drive a removal");
+    assert!(matches!(err, AppError::InvalidArg(_)), "got {err}");
+    assert_eq!(
+        state.db.org_rotation_pending_attempts(ORG).unwrap(),
+        None,
+        "no debt may be written that this device could never settle"
+    );
+}
+
+/// The generation to target is the RELAY's, never this device's cached one.
+///
+/// A device that missed a rotation holds a stale local generation. Aiming at `local + 1` would ask
+/// for a generation the relay already passed, and the monotonic check answers 409 — forever, on
+/// every sweep, with the org never rotating again. Nothing else in this file distinguishes the two
+/// readings, because everywhere else the relay and the local cache happen to agree.
+#[tokio::test]
+async fn the_rotation_targets_the_relay_s_generation_not_the_stale_local_one() {
+    let relay = RotationRelay::start_at_generation(roster(), published_keys(), 3);
+    let state = AppState::for_tests(fresh_db("rotate-stale-local-gen"));
+    wire_state(&state, &relay); // seeds the LOCAL org at generation 1
+    seed_cached_member_key(&state);
+    assert_eq!(state.db.get_org_state(ORG).unwrap().unwrap().generation, 1);
+
+    org_remove_member_inner(&state, ORG.into(), REMOVED_UID.into())
+        .await
+        .expect("a device behind on generations must still be able to rotate");
+
+    assert_eq!(
+        relay.log().bump_body.as_deref(),
+        Some("{\"generation\":4}"),
+        "the bump must follow the RELAY's live generation (3), not the local cache (1)"
+    );
+    assert_eq!(relay.log().committed_generation, Some(4));
+    assert_eq!(
+        relay.granted_at(4).len(),
+        3,
+        "the grants must cover the remaining members at the generation actually being committed"
+    );
+    assert_eq!(state.db.get_org_state(ORG).unwrap().unwrap().generation, 4);
 }

--- a/src-tauri/src/commands/tests/org_rotation_tests.rs
+++ b/src-tauri/src/commands/tests/org_rotation_tests.rs
@@ -1,0 +1,643 @@
+//! Oracles for the org key rotation that follows a member removal.
+//!
+//! Removing somebody from a Shared Brain is two operations wearing one button: drop their
+//! membership, and rotate the org content key so nothing published from then on is readable with
+//! the key they still hold. On trunk the second half had never once run.
+//!
+//! Three independent defects, each sufficient on its own:
+//!
+//! 1. `share::client::org_bump_generation` POSTed `/v1/orgs/{id}/generation` with **no body**. The
+//!    server extracts it with axum's `Json<BumpGenerationRequest>`, which rejects a request with no
+//!    `Content-Type: application/json` at **415, before the handler runs** — so the call never even
+//!    reached the owner check.
+//! 2. Even with a body, the client prepared a grant for the OWNER ONLY, while the relay commits a
+//!    generation only when a grant for it exists for EVERY active member, checked inside the same
+//!    transaction. An owner-only rotation is not a partial rotation; it is a 409 and no rotation.
+//! 3. The rotation ran after the removal with no journal, so any interruption — a dropped
+//!    connection, a quit — left the org permanently on the generation the removed member could
+//!    open, with nothing to re-drive it.
+//!
+//! The fixture below therefore does NOT just record calls. `RotationRelay` implements the relay's
+//! real coverage rule: a bump whose grants miss any active member is refused with 409, exactly as
+//! Postgres does it. Without that, "we called PUT key-grants" would pass for an owner-only rotation
+//! and the oracle would be decorative. `the_relay_fixture_refuses_a_bump_that_misses_a_member` is
+//! the control that proves the rule in the fixture is real, so this guard cannot go vacuous.
+
+use super::*;
+use crate::error::AppError;
+use crate::storage::db::Db;
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use zeroize::Zeroizing;
+
+/// The fixed 64-hex dev key every test DB in this crate opens with, BUILT rather than written out
+/// so this file carries no literal in DEK/KEK shape.
+fn test_dek() -> String {
+    "0123456789abcdef".repeat(4)
+}
+
+fn fresh_db(label: &str) -> Db {
+    let path = crate::storage::db::unique_temp_path(&format!("murmur-orgrot-{label}"), "sqlite");
+    let _ = std::fs::remove_file(&path);
+    Db::open_with_key(&path, &test_dek()).unwrap()
+}
+
+const ORG: &str = "8f14e45f-ea6f-4b6d-9c1a-2f2b1c0d3e40";
+const OWNER_UID: &str = "c534b6d2-02c1-4c2c-a256-3af8592b1567";
+const STAYS_CACHED_UID: &str = "11111111-2222-3333-4444-555555555555";
+const STAYS_LOOKED_UP_UID: &str = "66666666-7777-8888-9999-000000000000";
+const REMOVED_UID: &str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+/// A member's published identity, derived the same way a real account's is, so the OCK wrap that
+/// rotation performs is exercised against a genuine X25519 key rather than arbitrary bytes.
+fn member_identity(seed: u8, account: &str) -> crate::e2ee::keys::IdentityKeypair {
+    crate::e2ee::keys::derive_identity(&Zeroizing::new([seed; 32]), account, 1).unwrap()
+}
+
+fn seed_live_session(state: &AppState) {
+    *state.account_session.lock().unwrap() = Some(crate::share::AccountSession {
+        account_id: "owner@example.com".into(),
+        email: "owner@example.com".into(),
+        server_user_id: Some(OWNER_UID.into()),
+        device_id: "dev-1".into(),
+        mk: Zeroizing::new([7u8; 32]),
+        generation: 1,
+        access_token: "a".into(),
+        access_expires_at: Some("2099-01-01T00:00:00Z".into()),
+        refresh_token: "r".into(),
+    });
+}
+
+fn seed_org(db: &Db, generation: u32) {
+    db.upsert_org_state(&crate::storage::OrgState {
+        org_id: ORG.into(),
+        name: "Acme".into(),
+        role: "owner".into(),
+        joined_at: "2026-07-11T00:00:00Z".into(),
+        consented: true,
+        last_seq: 0,
+        generation,
+        context_enabled: true,
+    })
+    .unwrap();
+}
+
+// ── The relay fixture ────────────────────────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct MockMember {
+    user_id: String,
+    role: String,
+    email: Option<String>,
+}
+
+#[derive(Default)]
+struct RelayLog {
+    /// `METHOD /path`, in the order the client issued them — the only place request ORDER is
+    /// observable, and ordering is half of what this change is about.
+    requests: Vec<String>,
+    /// The `Content-Type` the generation bump carried, if any. `None` here is defect 1 exactly.
+    bump_content_type: Option<String>,
+    bump_body: Option<String>,
+    /// Every `(user_id, generation)` a key-grant PUT covered, across all calls.
+    granted: Vec<(String, u32)>,
+    removed: Vec<String>,
+    lookups: Vec<String>,
+    /// The bump the relay actually committed, if it committed one.
+    committed_generation: Option<u32>,
+    /// 409 the next bump regardless of coverage — models a relay that refuses for its own reasons.
+    refuse_bump: bool,
+}
+
+struct RotationRelay {
+    base: String,
+    log: Arc<Mutex<RelayLog>>,
+    shutdown: Arc<AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl RotationRelay {
+    /// `members` is the live roster; `keys` maps an email to the identity the lookup publishes.
+    fn start(members: Vec<MockMember>, keys: HashMap<String, (Vec<u8>, Vec<u8>)>) -> Self {
+        let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+        let base = format!("http://{}/", server.server_addr().to_ip().unwrap());
+        let log = Arc::new(Mutex::new(RelayLog::default()));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let log_t = Arc::clone(&log);
+        let shutdown_t = Arc::clone(&shutdown);
+
+        let handle = std::thread::spawn(move || {
+            // The relay's own state: the roster and the live generation it would keep in Postgres.
+            let mut roster = members;
+            let mut generation: u32 = 1;
+            loop {
+                if shutdown_t.load(Ordering::SeqCst) {
+                    break;
+                }
+                let Ok(Some(mut req)) = server.recv_timeout(std::time::Duration::from_millis(50))
+                else {
+                    continue;
+                };
+                let method = req.method().clone();
+                let url = req.url().to_string();
+                let path = url.split('?').next().unwrap_or("").to_string();
+                let content_type = req
+                    .headers()
+                    .iter()
+                    .find(|h| h.field.equiv("Content-Type"))
+                    .map(|h| h.value.as_str().to_string());
+                let mut body = String::new();
+                let _ = req.as_reader().read_to_string(&mut body);
+                log_t
+                    .lock()
+                    .unwrap()
+                    .requests
+                    .push(format!("{method} {path}"));
+
+                let json = |b: String| {
+                    tiny_http::Response::from_string(b).with_header(
+                        "Content-Type: application/json"
+                            .parse::<tiny_http::Header>()
+                            .unwrap(),
+                    )
+                };
+
+                // GET /v1/orgs/{id} — the caller's view, including the LIVE generation.
+                if method == tiny_http::Method::Get && path == format!("/v1/orgs/{ORG}") {
+                    let _ = req.respond(json(format!(
+                        "{{\"orgId\":\"{ORG}\",\"name\":\"Acme\",\"role\":\"owner\",\
+                          \"createdAt\":\"2026-07-11T00:00:00Z\",\"currentGeneration\":{generation}}}"
+                    )));
+                    continue;
+                }
+
+                // GET /v1/orgs/{id}/members — ACTIVE members only, as the real route does.
+                if method == tiny_http::Method::Get && path == format!("/v1/orgs/{ORG}/members") {
+                    let rows = roster
+                        .iter()
+                        .map(|m| {
+                            let email = match &m.email {
+                                Some(e) => format!(",\"email\":\"{e}\""),
+                                None => String::new(),
+                            };
+                            format!(
+                                "{{\"userId\":\"{}\",\"role\":\"{}\",\
+                                  \"createdAt\":\"2026-07-11T00:00:00Z\"{}}}",
+                                m.user_id, m.role, email
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    let _ = req.respond(json(format!("{{\"members\":[{rows}]}}")));
+                    continue;
+                }
+
+                // DELETE /v1/orgs/{id}/members/{uid} — drops them from the ACTIVE roster, which is
+                // what makes the coverage rule below stop counting them.
+                if method == tiny_http::Method::Delete
+                    && path.starts_with(&format!("/v1/orgs/{ORG}/members/"))
+                {
+                    let uid = path.rsplit('/').next().unwrap_or("").to_string();
+                    roster.retain(|m| m.user_id != uid);
+                    log_t.lock().unwrap().removed.push(uid);
+                    let _ = req.respond(tiny_http::Response::empty(200));
+                    continue;
+                }
+
+                // POST /v1/keys/lookup {email}
+                if method == tiny_http::Method::Post && path == "/v1/keys/lookup" {
+                    let email = serde_json::from_str::<serde_json::Value>(&body)
+                        .ok()
+                        .and_then(|v| {
+                            v.get("email")
+                                .and_then(serde_json::Value::as_str)
+                                .map(str::to_string)
+                        })
+                        .unwrap_or_default();
+                    log_t.lock().unwrap().lookups.push(email.clone());
+                    let reply = match keys.get(&email) {
+                        Some((pk_enc, pk_sig)) => format!(
+                            "{{\"registered\":true,\"key\":{{\"userId\":\"{}\",\"generation\":1,\
+                              \"pkEnc\":\"{}\",\"pkSig\":\"{}\",\"fingerprint\":\"fp-{}\"}}}}",
+                            roster
+                                .iter()
+                                .find(|m| m.email.as_deref() == Some(email.as_str()))
+                                .map(|m| m.user_id.clone())
+                                .unwrap_or_default(),
+                            murmur_protocol::b64::encode(pk_enc),
+                            murmur_protocol::b64::encode(pk_sig),
+                            email
+                        ),
+                        None => "{\"registered\":false}".to_string(),
+                    };
+                    let _ = req.respond(json(reply));
+                    continue;
+                }
+
+                // PUT /v1/orgs/{id}/key-grants — opaque bytes, recorded by (user, generation).
+                if method == tiny_http::Method::Put && path == format!("/v1/orgs/{ORG}/key-grants")
+                {
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&body) {
+                        if let Some(grants) = v.get("grants").and_then(serde_json::Value::as_array) {
+                            let mut guard = log_t.lock().unwrap();
+                            for g in grants {
+                                let uid = g
+                                    .get("userId")
+                                    .and_then(serde_json::Value::as_str)
+                                    .unwrap_or_default()
+                                    .to_string();
+                                let gen = g
+                                    .get("generation")
+                                    .and_then(serde_json::Value::as_u64)
+                                    .unwrap_or(0) as u32;
+                                guard.granted.push((uid, gen));
+                            }
+                        }
+                    }
+                    let _ = req.respond(tiny_http::Response::empty(200));
+                    continue;
+                }
+
+                // POST /v1/orgs/{id}/generation {generation} — the whole point.
+                if method == tiny_http::Method::Post && path == format!("/v1/orgs/{ORG}/generation")
+                {
+                    {
+                        let mut guard = log_t.lock().unwrap();
+                        guard.bump_content_type = content_type.clone();
+                        guard.bump_body = Some(body.clone());
+                    }
+                    // Defect 1, modelled exactly: axum's `Json` extractor rejects a request that
+                    // does not declare JSON with 415 BEFORE the handler runs.
+                    if !content_type
+                        .as_deref()
+                        .is_some_and(|c| c.starts_with("application/json"))
+                    {
+                        let _ = req.respond(tiny_http::Response::empty(415));
+                        continue;
+                    }
+                    let Some(requested) = serde_json::from_str::<serde_json::Value>(&body)
+                        .ok()
+                        .and_then(|v| v.get("generation").and_then(serde_json::Value::as_u64))
+                        .map(|g| g as u32)
+                    else {
+                        let _ = req.respond(tiny_http::Response::empty(422));
+                        continue;
+                    };
+                    let refuse = log_t.lock().unwrap().refuse_bump;
+                    // Monotonic-by-one, then FULL COVERAGE — the two conditions
+                    // `store::orgs::bump_generation` checks in one transaction.
+                    let covered: HashSet<String> = log_t
+                        .lock()
+                        .unwrap()
+                        .granted
+                        .iter()
+                        .filter(|(_, g)| *g == requested)
+                        .map(|(u, _)| u.clone())
+                        .collect();
+                    let all_covered = !roster.is_empty()
+                        && roster.iter().all(|m| covered.contains(&m.user_id));
+                    if refuse || requested != generation + 1 || !all_covered {
+                        let _ = req.respond(tiny_http::Response::empty(409));
+                        continue;
+                    }
+                    generation = requested;
+                    log_t.lock().unwrap().committed_generation = Some(generation);
+                    let _ = req.respond(json(format!(
+                        "{{\"currentGeneration\":{generation}}}"
+                    )));
+                    continue;
+                }
+
+                let _ = req.respond(tiny_http::Response::empty(404));
+            }
+        });
+
+        Self {
+            base,
+            log,
+            shutdown,
+            handle: Some(handle),
+        }
+    }
+
+    fn log(&self) -> std::sync::MutexGuard<'_, RelayLog> {
+        self.log.lock().unwrap()
+    }
+
+    fn set_refuse_bump(&self, refuse: bool) {
+        self.log.lock().unwrap().refuse_bump = refuse;
+    }
+
+    /// Every user id granted at `generation`, deduplicated and sorted — the set the coverage rule
+    /// cares about.
+    fn granted_at(&self, generation: u32) -> Vec<String> {
+        let mut v: Vec<String> = self
+            .log()
+            .granted
+            .iter()
+            .filter(|(_, g)| *g == generation)
+            .map(|(u, _)| u.clone())
+            .collect();
+        v.sort();
+        v.dedup();
+        v
+    }
+}
+
+impl Drop for RotationRelay {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+/// One owner + three members; the removal target plus two who stay — one whose key this device
+/// already remembers, one it must look up.
+fn roster() -> Vec<MockMember> {
+    vec![
+        MockMember {
+            user_id: OWNER_UID.into(),
+            role: "owner".into(),
+            email: Some("owner@example.com".into()),
+        },
+        MockMember {
+            user_id: STAYS_CACHED_UID.into(),
+            role: "member".into(),
+            email: Some("cached@example.com".into()),
+        },
+        MockMember {
+            user_id: STAYS_LOOKED_UP_UID.into(),
+            role: "member".into(),
+            email: Some("lookedup@example.com".into()),
+        },
+        MockMember {
+            user_id: REMOVED_UID.into(),
+            role: "member".into(),
+            email: Some("removed@example.com".into()),
+        },
+    ]
+}
+
+fn published_keys() -> HashMap<String, (Vec<u8>, Vec<u8>)> {
+    let mut keys = HashMap::new();
+    for (seed, email) in [
+        (3u8, "cached@example.com"),
+        (4u8, "lookedup@example.com"),
+        (5u8, "removed@example.com"),
+    ] {
+        let id = member_identity(seed, email);
+        keys.insert(email.to_string(), (id.pk_enc.to_vec(), id.pk_sig.to_vec()));
+    }
+    keys
+}
+
+fn wire_state(state: &AppState, relay: &RotationRelay) {
+    seed_live_session(state);
+    seed_org(&state.db, 1);
+    state.config.lock().unwrap().share_base_url = relay.base.clone();
+}
+
+/// Remember the "cached" member's key, as an invite would have.
+fn seed_cached_member_key(state: &AppState) {
+    let id = member_identity(3, "cached@example.com");
+    let fp = crate::e2ee::key_fingerprint(&id.pk_enc, &id.pk_sig);
+    state
+        .db
+        .upsert_org_member_key(
+            ORG,
+            STAYS_CACHED_UID,
+            Some("cached@example.com"),
+            &id.pk_enc,
+            &id.pk_sig,
+            &fp,
+        )
+        .unwrap();
+}
+
+// ── The oracles ──────────────────────────────────────────────────────────────────────────────────
+
+/// THE headline oracle. RED on trunk three times over: the bump carried no `Content-Type` (415),
+/// the grants covered only the owner (409 on coverage), and nothing recorded the debt.
+#[tokio::test]
+async fn removing_a_member_rotates_the_key_for_every_remaining_member() {
+    let relay = RotationRelay::start(roster(), published_keys());
+    let state = AppState::for_tests(fresh_db("rotate-covers-all"));
+    wire_state(&state, &relay);
+    seed_cached_member_key(&state);
+
+    org_remove_member_inner(&state, ORG.into(), REMOVED_UID.into())
+        .await
+        .expect("removal + rotation must succeed");
+
+    // 1. The bump is a real JSON request the server's extractor accepts, carrying gen 2.
+    assert_eq!(
+        relay.log().bump_content_type.as_deref().map(|c| c
+            .split(';')
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_string()),
+        Some("application/json".to_string()),
+        "the generation bump must declare JSON — without it axum answers 415 before the handler"
+    );
+    assert_eq!(
+        relay.log().bump_body.as_deref(),
+        Some("{\"generation\":2}"),
+        "the bump must name the generation it is committing"
+    );
+
+    // 2. Coverage: every REMAINING member, and nobody who was removed.
+    assert_eq!(
+        relay.granted_at(2),
+        {
+            let mut expected = vec![
+                OWNER_UID.to_string(),
+                STAYS_CACHED_UID.to_string(),
+                STAYS_LOOKED_UP_UID.to_string(),
+            ];
+            expected.sort();
+            expected
+        },
+        "gen 2 must be wrapped for every remaining member (owner-only is what the relay 409s)"
+    );
+    assert!(
+        !relay
+            .granted_at(2)
+            .iter()
+            .any(|u| u == REMOVED_UID),
+        "the removed member must not be granted the new key"
+    );
+
+    // 3. The relay committed it, and the local view agrees.
+    assert_eq!(relay.log().committed_generation, Some(2));
+    assert_eq!(state.db.get_org_state(ORG).unwrap().unwrap().generation, 2);
+
+    // 4. Order: the member is out, then the grants land, then the generation flips. Granting before
+    //    the removal would mean granting the new key to the person being removed.
+    let requests = relay.log().requests.clone();
+    let pos = |needle: &str| requests.iter().position(|r| r.contains(needle)).unwrap();
+    assert!(
+        pos("DELETE /v1/orgs") < pos("PUT /v1/orgs") && pos("PUT /v1/orgs") < pos("POST /v1/orgs"),
+        "expected remove → grants → bump, got {requests:?}"
+    );
+
+    // 5. Only the member whose key was NOT remembered cost a lookup — the quota is 20/day against
+    //    orgs of up to 50, so re-looking-up everybody would fail on quota, not on correctness.
+    assert_eq!(
+        relay.log().lookups,
+        vec!["lookedup@example.com".to_string()],
+        "a remembered key must not be re-fetched"
+    );
+
+    // 6. Debt settled, and the departing member's key is forgotten.
+    assert_eq!(state.db.org_rotation_pending_attempts(ORG).unwrap(), None);
+    assert!(state
+        .db
+        .get_org_member_key(ORG, REMOVED_UID)
+        .unwrap()
+        .is_none());
+}
+
+/// A rotation that cannot finish must leave a debt that a later sweep settles — the window between
+/// "removed" and "rotated" is exactly when new posts are still readable with the old key.
+#[tokio::test]
+async fn an_unfinished_rotation_leaves_a_debt_a_later_sweep_settles() {
+    let relay = RotationRelay::start(roster(), published_keys());
+    let state = AppState::for_tests(fresh_db("rotate-redrive"));
+    wire_state(&state, &relay);
+    seed_cached_member_key(&state);
+    relay.set_refuse_bump(true);
+
+    let err = org_remove_member_inner(&state, ORG.into(), REMOVED_UID.into())
+        .await
+        .expect_err("a refused bump must be reported, not swallowed");
+    assert!(
+        matches!(&err, AppError::Unavailable(m) if m.contains(crate::errcode::ORG_ROTATION_PENDING)),
+        "the failure must carry the rotation-pending code, not read as a failed removal: {err}"
+    );
+
+    // The member IS gone; the generation is NOT rotated; the debt is recorded.
+    assert_eq!(relay.log().removed, vec![REMOVED_UID.to_string()]);
+    assert_eq!(
+        state.db.get_org_state(ORG).unwrap().unwrap().generation,
+        1,
+        "no generation may be recorded locally that the relay did not commit"
+    );
+    assert!(
+        state
+            .db
+            .org_rotation_pending_attempts(ORG)
+            .unwrap()
+            .is_some_and(|n| n >= 1),
+        "the debt must survive with its attempt recorded"
+    );
+
+    // The relay recovers; the retry closes the window without any user action.
+    relay.set_refuse_bump(false);
+    let settled = drive_pending_org_rotations(&state)
+        .await
+        .unwrap();
+    assert_eq!(settled, 1);
+    assert_eq!(relay.log().committed_generation, Some(2));
+    assert_eq!(state.db.get_org_state(ORG).unwrap().unwrap().generation, 2);
+    assert_eq!(state.db.org_rotation_pending_attempts(ORG).unwrap(), None);
+}
+
+/// THE CONTROL. If the fixture did not enforce the relay's coverage rule, the oracle above would
+/// pass for an owner-only rotation — which is precisely the shipped bug. This asserts the rule in
+/// the fixture is real, so the guard cannot quietly go vacuous.
+#[tokio::test]
+async fn the_relay_fixture_refuses_a_bump_that_misses_a_member() {
+    let relay = RotationRelay::start(roster(), published_keys());
+    let client = crate::share::client::ShareClient::new(&relay.base).unwrap();
+
+    // Grant gen 2 to the OWNER ONLY — exactly what trunk sent.
+    client
+        .org_put_key_grants(
+            "a",
+            ORG,
+            vec![crate::share::org_dto::KeyGrantInput {
+                user_id: OWNER_UID.into(),
+                generation: 2,
+                wrapped_key: vec![1, 2, 3],
+                grant_sig: vec![4, 5, 6],
+            }],
+        )
+        .await
+        .unwrap();
+
+    let err = client
+        .org_bump_generation("a", ORG, 2)
+        .await
+        .expect_err("an owner-only rotation must be refused");
+    // A 409 is a REFUSAL of the request, and the client maps it to the tagged `sharing-rejected`
+    // shape the frontend already has copy for. What matters to this control is that the fixture
+    // said 409 at all — the variant is the client's mapping, not the rule under test.
+    assert!(
+        err.to_string().contains("409"),
+        "expected the coverage refusal the real relay gives, got {err}"
+    );
+    assert_eq!(relay.log().committed_generation, None);
+}
+
+/// The journal is written BEFORE the removal call, so an interruption between the two still leaves
+/// a re-drivable debt. Asserted by driving a removal against a relay that answers nothing: the
+/// removal fails, and the debt is still on the books.
+#[tokio::test]
+async fn the_rotation_debt_is_journaled_before_the_member_is_removed() {
+    let state = AppState::for_tests(fresh_db("rotate-journal-first"));
+    seed_live_session(&state);
+    seed_org(&state.db, 1);
+    // A port nothing listens on: every request fails, including the removal.
+    state.config.lock().unwrap().share_base_url = "http://127.0.0.1:1/".into();
+
+    let _ = org_remove_member_inner(&state, ORG.into(), REMOVED_UID.into())
+        .await;
+
+    assert!(
+        state
+            .db
+            .org_rotation_pending_attempts(ORG)
+            .unwrap()
+            .is_some(),
+        "the debt must be recorded before the removal is attempted — a lost response is \
+         indistinguishable from a success, and a redundant rotation is far cheaper than a skipped one"
+    );
+}
+
+/// The member-key cache stores PUBLIC material and is keyed per org, so one org's view of a member
+/// cannot answer for another's.
+#[test]
+fn remembered_member_keys_are_scoped_to_their_org() {
+    let db = fresh_db("member-key-scope");
+    let id = member_identity(3, "cached@example.com");
+    let fp = crate::e2ee::key_fingerprint(&id.pk_enc, &id.pk_sig);
+    db.upsert_org_member_key(
+        ORG,
+        STAYS_CACHED_UID,
+        Some("cached@example.com"),
+        &id.pk_enc,
+        &id.pk_sig,
+        &fp,
+    )
+    .unwrap();
+
+    let here = db.get_org_member_key(ORG, STAYS_CACHED_UID).unwrap();
+    assert_eq!(here.as_ref().map(|k| k.fingerprint.clone()), Some(fp));
+    assert_eq!(here.map(|k| k.pk_enc), Some(id.pk_enc.to_vec()));
+    assert!(
+        db.get_org_member_key("other-org", STAYS_CACHED_UID)
+            .unwrap()
+            .is_none(),
+        "a key learned in one org must not answer for another"
+    );
+
+    db.forget_org_member_key(ORG, STAYS_CACHED_UID).unwrap();
+    assert!(db
+        .get_org_member_key(ORG, STAYS_CACHED_UID)
+        .unwrap()
+        .is_none());
+}

--- a/src-tauri/src/errcode.rs
+++ b/src-tauri/src/errcode.rs
@@ -171,6 +171,15 @@ pub const CONTAINER_UNAVAILABLE: &str = "container-unavailable";
 /// wedged holder left "Loading organizations…" on screen until the app was restarted.
 pub const SHARE_BUSY: &str = "share-busy";
 
+/// A member was removed, but the key rotation that must follow did not complete.
+///
+/// The removal itself SUCCEEDED — this is not a failed operation, it is a half-finished one, and
+/// saying "couldn't remove them" would be a lie that invites the user to try again on a member who
+/// is already gone. The org still owes a new generation, the debt is journaled in
+/// `org_rotation_pending`, and the org sync tick re-drives it. Until it lands, anything published
+/// stays readable to the removed member's old key.
+pub const ORG_ROTATION_PENDING: &str = "org-rotation-pending";
+
 /// Every code this crate emits, in declaration order. The frontend's allowlist mirrors it;
 /// `error_codes_are_unique_and_kebab_case` keeps the shape a machine can rely on.
 pub const ALL: &[&str] = &[
@@ -207,6 +216,7 @@ pub const ALL: &[&str] = &[
     FOLDER_CLOSING,
     SHARE_BUSY,
     CONTAINER_UNAVAILABLE,
+    ORG_ROTATION_PENDING,
 ];
 
 #[cfg(test)]
@@ -305,6 +315,10 @@ mod tests {
             // Added 2026-09-01 with the bounded org-refresh wait. See `SHARE_BUSY`.
             "share-busy",
             "container-unavailable",
+            // Added 2026-09-02 with the member-removal key rotation. See `ORG_ROTATION_PENDING`:
+            // the removal succeeded and the rotation is owed, which is a different sentence from
+            // any existing failure code and the only one that must not read as "try again".
+            "org-rotation-pending",
         ];
         assert_eq!(ALL, expected);
     }

--- a/src-tauri/src/share/client.rs
+++ b/src-tauri/src/share/client.rs
@@ -1095,25 +1095,41 @@ impl ShareClient {
         Err(Self::status_err("org-tombstone-item", resp.status()))
     }
 
-    /// `POST /v1/orgs/{id}/generation` (owner) — bump the OCK generation (monotonic +1). The owner
-    /// must have already PUT grants for gen N+1 for every active member (the server checks counts).
-    pub async fn org_bump_generation(&self, access_token: &str, org_id: &str) -> Result<()> {
+    /// `POST /v1/orgs/{id}/generation {generation}` (owner) — bump the OCK generation (monotonic
+    /// +1). The owner must have already PUT grants for gen `generation` for EVERY active member;
+    /// the server checks that coverage in the same transaction and answers 409 otherwise.
+    ///
+    /// The JSON body is REQUIRED. This call used to send none, and the server extracts it with
+    /// axum's `Json<BumpGenerationRequest>` — an extractor that rejects a body-less POST with 415
+    /// *before* the handler runs. So the rotation that follows every member removal always failed,
+    /// the org never left the generation the removed member held a key for, and the user saw only
+    /// an untagged refusal. Returns the server's new live generation so the caller records what the
+    /// relay actually committed rather than what it hoped for.
+    pub async fn org_bump_generation(
+        &self,
+        access_token: &str,
+        org_id: &str,
+        generation: u32,
+    ) -> Result<u32> {
         Self::guard_id(org_id)?;
         let url = self.url(&format!("/v1/orgs/{org_id}/generation"))?;
         let resp = self
             .http
             .post(url)
             .bearer_auth(access_token)
+            .json(&super::org_dto::BumpGenerationRequest { generation })
             .send()
             .await
             .map_err(|_| {
                 AppError::Unavailable("org-bump-generation: could not reach the server".into())
             })?;
-        if resp.status().is_success() {
-            Ok(())
-        } else {
-            Err(Self::status_err("org-bump-generation", resp.status()))
+        if !resp.status().is_success() {
+            return Err(Self::status_err("org-bump-generation", resp.status()));
         }
+        let body: super::org_dto::BumpGenerationResponse = resp.json().await.map_err(|_| {
+            AppError::Unavailable("org-bump-generation: malformed server response".into())
+        })?;
+        Ok(body.current_generation)
     }
 
     /// Guard a path segment that we mint (a UUID) against traversal / query injection. A stray `/`

--- a/src-tauri/src/share/org_dto.rs
+++ b/src-tauri/src/share/org_dto.rs
@@ -106,6 +106,27 @@ pub struct OrgMembersResponse {
     pub members: Vec<OrgMemberEntry>,
 }
 
+/// `POST /v1/orgs/{id}/generation {generation}` — bump the org's live OCK generation.
+///
+/// The body is NOT optional. The server extracts it with axum's `Json`, which rejects a request
+/// carrying no `Content-Type: application/json` with **415 before the handler runs** — so a
+/// body-less POST here never reached the owner check, let alone the rotation. That was the whole
+/// of the dead-rotation defect: every member removal ended in a refusal the user could not act on,
+/// and the org stayed on the generation the removed member still held a key for.
+#[derive(Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct BumpGenerationRequest {
+    /// MUST equal the server's `current_generation + 1`; anything else is a content-free 409.
+    pub generation: u32,
+}
+
+/// Response to a successful bump: the org's new live generation, as the server recorded it.
+#[derive(Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct BumpGenerationResponse {
+    pub current_generation: u32,
+}
+
 /// `PUT /v1/orgs/{id}/key-grants` — upload/replace opaque wrapped-OCK grants for a generation.
 #[derive(Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -2313,10 +2313,16 @@ impl Db {
              -- row says only that this org owes a rotation; the members list at drive time says to
              -- whom.
              CREATE TABLE IF NOT EXISTS org_rotation_pending (
-               org_id       TEXT PRIMARY KEY,
-               requested_at TEXT NOT NULL,
-               attempts     INTEGER NOT NULL DEFAULT 0,
-               last_error   TEXT
+               org_id          TEXT PRIMARY KEY,
+               requested_at    TEXT NOT NULL,
+               attempts        INTEGER NOT NULL DEFAULT 0,
+               last_error      TEXT,
+               -- When the retry may next run. Without it a debt that can never settle -- a member
+               -- whose account was deactivated while their membership stayed active, say -- is
+               -- re-driven every 60s forever, and each attempt spends one of the owner's 20 daily
+               -- key lookups on the same doomed member. An attempt that LEARNS something resets
+               -- this to now, so a slow-but-progressing rotation is never throttled.
+               next_attempt_at TEXT
              );
              CREATE TABLE IF NOT EXISTS org_shares (
                id             TEXT PRIMARY KEY,

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -2286,6 +2286,38 @@ impl Db {
                last_seq   INTEGER NOT NULL DEFAULT 0,
                generation INTEGER NOT NULL DEFAULT 1
              );
+             -- The org's member identity keys, as this device learned them. PUBLIC key material
+             -- only: `pk_enc`/`pk_sig` are exactly what `POST /v1/keys/lookup` publishes, plus the
+             -- fingerprint the safety-word check already shows the user. No OCK, no private key,
+             -- no note content ever lands here.
+             --
+             -- It exists because rotation needs EVERY remaining member's key at once and the only
+             -- directory is the email-keyed lookup, capped at 20 calls a day against orgs of up to
+             -- 50 members. Learning each key once, at the invite that already looks it up, turns a
+             -- rotation from a burst of quota-limited lookups into a local read.
+             CREATE TABLE IF NOT EXISTS org_member_keys (
+               org_id      TEXT NOT NULL,
+               user_id     TEXT NOT NULL,
+               email       TEXT,
+               pk_enc      BLOB NOT NULL,
+               pk_sig      BLOB NOT NULL,
+               fingerprint TEXT NOT NULL,
+               updated_at  TEXT NOT NULL,
+               PRIMARY KEY (org_id, user_id)
+             );
+             -- One row per org that OWES a key rotation: a member was removed and the new
+             -- generation has not been committed yet. Written BEFORE the removal call, so an
+             -- interruption anywhere after it is re-drivable rather than silently forgotten --
+             -- the difference between a rotation that is merely late and one that never happens,
+             -- leaving the removed member holding a working key. Carries no member identity: the
+             -- row says only that this org owes a rotation; the members list at drive time says to
+             -- whom.
+             CREATE TABLE IF NOT EXISTS org_rotation_pending (
+               org_id       TEXT PRIMARY KEY,
+               requested_at TEXT NOT NULL,
+               attempts     INTEGER NOT NULL DEFAULT 0,
+               last_error   TEXT
+             );
              CREATE TABLE IF NOT EXISTS org_shares (
                id             TEXT PRIMARY KEY,
                org_id         TEXT NOT NULL,

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -1952,6 +1952,28 @@ pub struct OrgState {
     pub context_enabled: bool,
 }
 
+/// One org member's PUBLIC identity key, as this device learned it (`org_member_keys`).
+///
+/// Public material only — the same bytes `POST /v1/keys/lookup` publishes to any authenticated
+/// caller, plus the fingerprint the safety-word check already shows. Cached because a key rotation
+/// has to wrap the new OCK for every remaining member in one pass, while the only key directory is
+/// the email-keyed lookup capped at 20 calls per day for orgs of up to 50 members.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrgMemberKey {
+    pub org_id: String,
+    /// The member's STABLE server user id — the same identity `org_members.user_id` and a key grant
+    /// are keyed on. Never the email.
+    pub user_id: String,
+    /// The address the key was learned from, when one was known. Diagnostic only; the lookup path
+    /// prefers this over asking the server again.
+    pub email: Option<String>,
+    pub pk_enc: Vec<u8>,
+    pub pk_sig: Vec<u8>,
+    /// `key_fingerprint(pk_enc, pk_sig)` — the value a grant binds as `recipient_acct_id`.
+    pub fingerprint: String,
+    pub updated_at: String,
+}
+
 /// M6 Shared Brain — one row of the outbound org-share state machine (`org_shares`). Anchors on a
 /// local `meeting_id` XOR `document_id`; carries the item kind, the content-hash dedup key, the
 /// server `item_id` once published, and the current `state`. NO note title/body/OCK.

--- a/src-tauri/src/storage/org_store.rs
+++ b/src-tauri/src/storage/org_store.rs
@@ -451,9 +451,11 @@ impl Db {
     pub fn mark_org_rotation_pending(&self, org_id: &str) -> Result<()> {
         let conn = self.lock();
         conn.execute(
-            "INSERT INTO org_rotation_pending (org_id, requested_at, attempts, last_error)
-             VALUES (?1, ?2, 0, NULL)
-             ON CONFLICT(org_id) DO UPDATE SET attempts = 0, last_error = NULL",
+            "INSERT INTO org_rotation_pending
+               (org_id, requested_at, attempts, last_error, next_attempt_at)
+             VALUES (?1, ?2, 0, NULL, NULL)
+             ON CONFLICT(org_id) DO UPDATE SET
+               attempts = 0, last_error = NULL, next_attempt_at = NULL",
             rusqlite::params![org_id, chrono::Utc::now().to_rfc3339()],
         )
         .map_err(map_err)?;
@@ -471,21 +473,56 @@ impl Db {
         Ok(())
     }
 
-    /// Note a failed rotation attempt. `error` is a short non-PII label (an `errcode` tag or an
-    /// HTTP stage/status), never a message body that could carry content.
-    pub fn record_org_rotation_failure(&self, org_id: &str, error: &str) -> Result<()> {
+    /// Note a failed rotation attempt and decide when the retry may run again. `error` is a short
+    /// non-PII label (an `errcode` tag or an HTTP stage/status), never a message body that could
+    /// carry content.
+    ///
+    /// `learned_something` is the difference between "this attempt is going nowhere" and "this
+    /// attempt is converging slowly". A first rotation of an org invited before member keys were
+    /// remembered has to resolve them a few at a time against a 20-a-day lookup quota, and
+    /// throttling THAT would turn a two-hour convergence into a two-week one. A doomed attempt --
+    /// a member whose account is gone but whose membership is not -- learns nothing, and gets an
+    /// exponential back-off capped at six hours so it cannot spend the quota every minute forever.
+    pub fn record_org_rotation_failure(
+        &self,
+        org_id: &str,
+        error: &str,
+        learned_something: bool,
+    ) -> Result<()> {
         let conn = self.lock();
+        // `attempts` counts attempts, always. Only the BACK-OFF is conditional: an attempt that
+        // learned a key it did not have keeps its place at the front of the queue.
+        let attempts: i64 = conn
+            .query_row(
+                "SELECT attempts FROM org_rotation_pending WHERE org_id = ?1",
+                rusqlite::params![org_id],
+                |r| r.get(0),
+            )
+            .optional()
+            .map_err(map_err)?
+            .unwrap_or(0)
+            + 1;
+        let next_attempt_at = if learned_something {
+            None
+        } else {
+            let minutes = 2i64
+                .checked_pow(u32::try_from(attempts.clamp(1, 16)).unwrap_or(16))
+                .unwrap_or(360)
+                .min(360);
+            Some((chrono::Utc::now() + chrono::Duration::minutes(minutes)).to_rfc3339())
+        };
         conn.execute(
             "UPDATE org_rotation_pending
-                SET attempts = attempts + 1, last_error = ?2
+                SET attempts = ?2, last_error = ?3, next_attempt_at = ?4
               WHERE org_id = ?1",
-            rusqlite::params![org_id, error],
+            rusqlite::params![org_id, attempts, error, next_attempt_at],
         )
         .map_err(map_err)?;
         Ok(())
     }
 
-    /// Every org that still owes a rotation, oldest debt first — the drive order for the retry.
+    /// Every org that still owes a rotation, oldest debt first — regardless of back-off. The
+    /// diagnostic view; the retry drives [`Self::list_org_rotations_due`] instead.
     pub fn list_org_rotations_pending(&self) -> Result<Vec<String>> {
         let conn = self.lock();
         let mut stmt = conn
@@ -493,6 +530,29 @@ impl Db {
             .map_err(map_err)?;
         let rows = stmt
             .query_map([], |r| r.get::<_, String>(0))
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// The owed rotations whose back-off has elapsed, oldest debt first. A row with no
+    /// `next_attempt_at` has never failed (or last made progress) and is always due.
+    pub fn list_org_rotations_due(&self) -> Result<Vec<String>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT org_id FROM org_rotation_pending
+                  WHERE next_attempt_at IS NULL OR next_attempt_at <= ?1
+                  ORDER BY requested_at ASC",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![chrono::Utc::now().to_rfc3339()], |r| {
+                r.get::<_, String>(0)
+            })
             .map_err(map_err)?;
         let mut out = Vec::new();
         for row in rows {
@@ -532,6 +592,20 @@ impl Db {
                 rusqlite::params![org_id],
             )
             .map_err(map_err)?;
+        // The org's remembered member keys and any owed rotation go with it, in the SAME
+        // transaction. A debt outliving its org is retried by every sweep forever against an org
+        // `resolve_org` can no longer find, and remembered addresses have no reason to survive a
+        // membership this device no longer holds.
+        tx.execute(
+            "DELETE FROM org_member_keys WHERE org_id = ?1",
+            rusqlite::params![org_id],
+        )
+        .map_err(map_err)?;
+        tx.execute(
+            "DELETE FROM org_rotation_pending WHERE org_id = ?1",
+            rusqlite::params![org_id],
+        )
+        .map_err(map_err)?;
         if removed > 0 {
             // Membership withdrawal invalidates global-derived Ask even when the decrypted org
             // replica was already empty and the durable conversation is the only derived copy.

--- a/src-tauri/src/storage/org_store.rs
+++ b/src-tauri/src/storage/org_store.rs
@@ -358,6 +358,161 @@ impl Db {
         Ok(())
     }
 
+    // ── Member identity keys + the rotation journal ─────────────────────────────────────────────
+    //
+    // Rotation needs every REMAINING member's public key in one pass. The only directory the relay
+    // offers is `POST /v1/keys/lookup`, keyed by email and capped at `KEY_LOOKUPS_PER_DAY = 20`,
+    // against orgs of up to `MAX_ORG_MEMBERS = 50`. So keys are learned once — at the invite that
+    // already looks the member up — and read locally afterwards. Nothing secret is stored: these
+    // are the bytes the relay publishes to any authenticated caller.
+
+    /// Remember a member's published identity key for this org. Replaces the row on a key change,
+    /// so the caller (never this method) is the place that decides whether a CHANGED key is
+    /// acceptable — storage must not be the thing that silently accepts a substituted key.
+    pub fn upsert_org_member_key(
+        &self,
+        org_id: &str,
+        user_id: &str,
+        email: Option<&str>,
+        pk_enc: &[u8],
+        pk_sig: &[u8],
+        fingerprint: &str,
+    ) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "INSERT INTO org_member_keys
+               (org_id, user_id, email, pk_enc, pk_sig, fingerprint, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             ON CONFLICT(org_id, user_id) DO UPDATE SET
+               email       = excluded.email,
+               pk_enc      = excluded.pk_enc,
+               pk_sig      = excluded.pk_sig,
+               fingerprint = excluded.fingerprint,
+               updated_at  = excluded.updated_at",
+            rusqlite::params![
+                org_id,
+                user_id,
+                email,
+                pk_enc,
+                pk_sig,
+                fingerprint,
+                chrono::Utc::now().to_rfc3339()
+            ],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// This device's remembered key for one member, if it has ever learned one.
+    pub fn get_org_member_key(
+        &self,
+        org_id: &str,
+        user_id: &str,
+    ) -> Result<Option<crate::storage::OrgMemberKey>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT org_id, user_id, email, pk_enc, pk_sig, fingerprint, updated_at
+               FROM org_member_keys WHERE org_id = ?1 AND user_id = ?2",
+            rusqlite::params![org_id, user_id],
+            |r| {
+                Ok(crate::storage::OrgMemberKey {
+                    org_id: r.get(0)?,
+                    user_id: r.get(1)?,
+                    email: r.get(2)?,
+                    pk_enc: r.get(3)?,
+                    pk_sig: r.get(4)?,
+                    fingerprint: r.get(5)?,
+                    updated_at: r.get(6)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
+    /// Drop a member's remembered key — used when they leave the org, so a later re-invite has to
+    /// learn the key afresh instead of trusting one this device kept while they were gone.
+    pub fn forget_org_member_key(&self, org_id: &str, user_id: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "DELETE FROM org_member_keys WHERE org_id = ?1 AND user_id = ?2",
+            rusqlite::params![org_id, user_id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Record that this org OWES a key rotation. Written BEFORE the server-side removal, so an
+    /// interruption at any later point leaves a re-drivable debt rather than an org sitting on a
+    /// generation the removed member still holds a key for. Idempotent: a second removal before the
+    /// first rotation lands keeps one row and the ORIGINAL timestamp (the debt is the org's, not the
+    /// individual removal's), while resetting `attempts` so a fresh removal is not throttled by an
+    /// older failure streak.
+    pub fn mark_org_rotation_pending(&self, org_id: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "INSERT INTO org_rotation_pending (org_id, requested_at, attempts, last_error)
+             VALUES (?1, ?2, 0, NULL)
+             ON CONFLICT(org_id) DO UPDATE SET attempts = 0, last_error = NULL",
+            rusqlite::params![org_id, chrono::Utc::now().to_rfc3339()],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// The rotation debt is settled — the relay committed the new generation.
+    pub fn clear_org_rotation_pending(&self, org_id: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "DELETE FROM org_rotation_pending WHERE org_id = ?1",
+            rusqlite::params![org_id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Note a failed rotation attempt. `error` is a short non-PII label (an `errcode` tag or an
+    /// HTTP stage/status), never a message body that could carry content.
+    pub fn record_org_rotation_failure(&self, org_id: &str, error: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "UPDATE org_rotation_pending
+                SET attempts = attempts + 1, last_error = ?2
+              WHERE org_id = ?1",
+            rusqlite::params![org_id, error],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Every org that still owes a rotation, oldest debt first — the drive order for the retry.
+    pub fn list_org_rotations_pending(&self) -> Result<Vec<String>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare("SELECT org_id FROM org_rotation_pending ORDER BY requested_at ASC")
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |r| r.get::<_, String>(0))
+            .map_err(map_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(map_err)?);
+        }
+        Ok(out)
+    }
+
+    /// Whether one org owes a rotation (with its attempt count), for tests and diagnostics.
+    pub fn org_rotation_pending_attempts(&self, org_id: &str) -> Result<Option<i64>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT attempts FROM org_rotation_pending WHERE org_id = ?1",
+            rusqlite::params![org_id],
+            |r| r.get::<_, i64>(0),
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
     /// Atomically withdraw local membership AND purge its decrypted replica. Idempotent; leaves
     /// `org_shares` alone (a leave doesn't retroactively un-share — the items stay published unless
     /// explicitly revoked).

--- a/src/app/core/copy/error-copy.service.ts
+++ b/src/app/core/copy/error-copy.service.ts
@@ -134,6 +134,7 @@ export const ERROR_CODES = [
   "share-active",
   "folder-closing",
   "container-unavailable",
+  "org-rotation-pending",
 ] as const;
 
 export type ErrorCode = (typeof ERROR_CODES)[number];
@@ -237,6 +238,12 @@ const BASE_COPY: Readonly<Record<ErrorCode, string>> = {
     "This note is shared. Revoke its share first, then try again.",
   "folder-closing":
     "That folder is being prepared for sharing. Try again in a moment.",
+  // Deliberately NOT phrased as a failure. The removal SUCCEEDED; what is outstanding is the key
+  // rotation that locks the removed person out of anything published from now on. Telling the user
+  // to "try again" would invite them to re-remove somebody who is already gone, and hide the one
+  // fact that matters: until the rotation lands, new posts are still readable with their old key.
+  "org-rotation-pending":
+    "Removed. Their access key is still being rotated — until that finishes, anything new you share here could still be readable by them. Murmur keeps retrying.",
   "container-unavailable":
     "This recording isn’t in a folder Murmur can add a note to. Move it, then try again.",
 };

--- a/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.ts
+++ b/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.ts
@@ -358,7 +358,16 @@ export class SettingsOrganizationSectionComponent {
     }
   }
 
-  /** Remove a member from the expanded org (owner) — rotates the OCK. Then refresh. */
+  /**
+   * Remove a member from the expanded org (owner). The backend also rotates the org key, and those
+   * two halves can land separately: `org-rotation-pending` means the person IS gone and only the
+   * key rotation is still outstanding.
+   *
+   * So the roster is reloaded on BOTH paths. Reloading only on success left the removed member
+   * listed underneath a message saying they had been removed, and a second click then re-ran the
+   * whole removal against a relay that answers 404-as-success — a redundant rotation driven by a
+   * screen that had not caught up with its own backend.
+   */
   async removeMember(orgId: string, member: OrgMember): Promise<void> {
     if (this._removingId() !== null) {
       return;
@@ -367,11 +376,12 @@ export class SettingsOrganizationSectionComponent {
     this._membersError.set(null);
     try {
       await this.ipc.orgRemoveMember(orgId, member.userId);
-      await this.loadMembers(orgId);
-      this.reload();
+      this._membersError.set(null);
     } catch (e) {
       this._membersError.set(this.errorCopy.humanize(e));
     } finally {
+      await this.loadMembers(orgId).catch(() => undefined);
+      this.reload();
       this._removingId.set(null);
     }
   }


### PR DESCRIPTION
Removing somebody from a Shared Brain is two operations wearing one button: drop their membership, and rotate the org content key so nothing published afterwards is readable with the key they still hold. The second half had never once run.

Three independent defects, each sufficient on its own:

1. The generation bump POSTed with **no request body**. The server extracts it with axum's `Json`, which refuses a request that does not declare JSON before the handler runs — so the call never reached the owner check.
2. Even with a body it would have been refused. The client prepared a grant for the **owner only**, while the relay commits a generation only when a grant for it exists for every active member, checked inside the transaction that flips it. An owner-only rotation is not a partial rotation; it is a refusal and no rotation. The comment calling this an "HONEST V1 BOUNDARY" was stale: the member list has carried `email` since 2026-07-14, so the directory it said was missing had been there for months.
3. Nothing recorded that a rotation was owed, so any interruption left the org permanently on the old generation with nothing to re-drive it.

## The order looks wrong and is not

While the departing member is still active the relay counts them in the coverage check, so "rotate first, then remove" could only succeed by granting the new key to the person being removed. The debt is therefore journaled **before** the removal and settled after — and deliberately kept when the removal itself fails, because a lost response is indistinguishable from a success, and a redundant rotation costs one generation while a skipped one costs the whole point of the removal.

## What else changed

Member keys are learned once, at the invite that already looks them up, and read locally afterwards. That keeps a 50-member org inside the 20-lookups-a-day quota, and it means the relay cannot substitute a key for someone this device has already met.

A half-finished removal reports `org-rotation-pending` rather than reading as a failure. The member **is** gone; telling the user to try again would invite them to remove somebody twice and hide the only fact that matters — that until the rotation lands, new posts stay readable with the old key.

## Review

Two reviewers on a different model from the implementer. Both returned PASS, and both independently found the same defect in the **first round's tests**: every assertion checked the predicate the relay checks — that a grant row exists per member — so wrapping every grant to the owner's own key satisfied all five oracles while locking every remaining member out. One reviewer proved it by mutation.

The second commit closes that and everything else they found:

- an oracle that **opens** each grant with the member's own identity — verified to be the only one of the eleven that fails under that mutation;
- an oracle pinning that the rotation targets the relay's generation, not a stale local one (a device behind by one rotation would otherwise take a conflict forever);
- exponential back-off on a rotation that learns nothing, with no back-off when it learns a key, so a doomed retry stops spending the daily lookup quota every minute while a slowly-converging first rotation is not throttled;
- eight lookups per attempt;
- no caching of a key under a generation this device merely hopes was committed — a second owner device could have had its own grants committed instead;
- a non-owner refused before a debt is written, since the relay answers their removal with a 404 the client maps to success;
- leaving an org drops its remembered keys and any owed rotation in the same transaction;
- the members list reloads on both paths, so a removed member no longer stays on screen under a message saying they were removed.

Reviewers' remaining follow-ups, deliberately out of scope: trust-on-first-use for a member key at invite time, and invalidation when a member's identity key rotates. Both belong to the TOFU task.

## Verification

- `cargo test --lib`: 3584 passed, 0 failed.
- `ng lint`, `ng build`: green.
- RED-before-GREEN proved separately for each of the three defects, by reintroducing each one and observing the named oracle fail for its stated reason.
- The test fixture implements the relay's real coverage rule rather than recording calls, and carries a control asserting that rule fires, so the guard cannot go vacuous.
