### PR TITLE
fix(lock): a link the user made by hand survives lock and unlock

### DIFF
--- a/src-tauri/src/audio/recorder.rs
+++ b/src-tauri/src/audio/recorder.rs
@@ -22,6 +22,23 @@ static CALLBACK_RACE_HOOK: Mutex<Option<RecorderRaceHook>> = Mutex::new(None);
 #[cfg(test)]
 static READER_RACE_HOOK: Mutex<Option<RecorderRaceHook>> = Mutex::new(None);
 
+/// Serializes the two tests that drive [`READER_RACE_HOOK`], which is ONE global slot shared by
+/// both while libtest runs them on parallel threads.
+///
+/// Each test publishes `(its own reader thread id, arrived, resume)` into that slot and then blocks
+/// on a two-party barrier until its reader trips it. Run concurrently, the second writer overwrites
+/// the first's entry, so the first test's reader finds an id that is not its own, sails past without
+/// tripping anything, and its `arrived.wait()` waits on a barrier no one else will ever reach — a
+/// permanent hang, not a failure: the run prints every test as passing and then never terminates.
+/// The clear-to-`None` at the end of each test is a second way to lose the other's entry.
+///
+/// Observed twice in a row on a loaded machine, and passing on the same commit when the machine was
+/// quiet, which is exactly the shape that gets re-run rather than fixed. The mutex is poison-
+/// tolerant because a panic in one of these tests must surface as that test's own failure, not as a
+/// second, misleading failure in the other.
+#[cfg(test)]
+static READER_RACE_HOOK_SERIAL: Mutex<()> = Mutex::new(());
+
 #[cfg(test)]
 fn callback_race_hook() {
     let hook = CALLBACK_RACE_HOOK
@@ -1562,6 +1579,11 @@ mod tests {
     fn reader_crossed_by_full_slot_reuse_rejects_mixed_generation() {
         use std::sync::Barrier;
 
+        // ONE global hook slot, two tests, parallel threads — see `READER_RACE_HOOK_SERIAL`.
+        let _serial = READER_RACE_HOOK_SERIAL
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
         let shared = test_shared(4);
         accumulate_frames(&shared, &[0.0f32, 1.0, 2.0, 3.0], 1);
         let reader = SampleReader {
@@ -1611,6 +1633,11 @@ mod tests {
     #[test]
     fn tail_snapshot_retries_trim_race_and_returns_absolute_generation_bounds() {
         use std::sync::Barrier;
+
+        // ONE global hook slot, two tests, parallel threads — see `READER_RACE_HOOK_SERIAL`.
+        let _serial = READER_RACE_HOOK_SERIAL
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         let shared = test_shared(4);
         accumulate_frames(&shared, &[0.0f32, 1.0, 2.0, 3.0], 1);

--- a/src-tauri/src/commands/links.rs
+++ b/src-tauri/src/commands/links.rs
@@ -136,16 +136,12 @@ pub(crate) fn accept_link_inner(state: &AppState, id: i64) -> Result<(), AppErro
         else {
             return Err(AppError::InvalidArg(format!("no link {id}")));
         };
-        // ── Fix 5 (brain-v3 audit): accept is ONLY for an unconfirmed SUGGESTION. Refuse anything else
-        //    (a deterministic wikilink/companion, an already-active manual/accepted, or a dismissed
-        //    tombstone) — "accepting" those is meaningless and would let a caller flip arbitrary rows. ──
-        if !(et == "semantic" && status == "suggested") {
-            return Err(AppError::InvalidArg(format!(
-                "link {id} is not an acceptable suggestion (edge_type={et}, status={status})"
-            )));
-        }
-        // ── GATE both endpoints BEFORE flipping the row (never accept behind a lock, never reveal a
-        //    locked neighbour by activating an edge to it). Fail-closed on a sealed/unknown endpoint. ──
+        // ── GATE both endpoints FIRST — before the row is described back to the caller. The type
+        //    refusal below names `edge_type` and `status`, so running it first answered "this id is
+        //    an active manual edge" for a row whose endpoint is sealed. That mattered little while a
+        //    seal purged manual rows outright; now that a manual decision SURVIVES a seal, the ids
+        //    outlive the lock and the ordering becomes the difference between a probe that answers
+        //    and one that refuses. Fail-closed on a sealed/unknown endpoint. ──
         let (Some(sk), Some(dk)) = (
             crate::links::LinkKind::parse(&src_kind),
             crate::links::LinkKind::parse(&dst_kind),
@@ -160,6 +156,14 @@ pub(crate) fn accept_link_inner(state: &AppState, id: i64) -> Result<(), AppErro
             return Err(AppError::Locked(
                 "one of these items is locked — unlock it to accept the link".into(),
             ));
+        }
+        // ── Fix 5 (brain-v3 audit): accept is ONLY for an unconfirmed SUGGESTION. Refuse anything else
+        //    (a deterministic wikilink/companion, an already-active manual/accepted, or a dismissed
+        //    tombstone) — "accepting" those is meaningless and would let a caller flip arbitrary rows. ──
+        if !(et == "semantic" && status == "suggested") {
+            return Err(AppError::InvalidArg(format!(
+                "link {id} is not an acceptable suggestion (edge_type={et}, status={status})"
+            )));
         }
         // Flip the row active — that edge is the AUTHORITATIVE link. The accept is GRAPH-ONLY: we do
         // NOT materialize the neighbour's `[[Title]]` / `murmur:links` block into any note body (that
@@ -192,15 +196,8 @@ pub(crate) fn dismiss_link_inner(state: &AppState, id: i64) -> Result<(), AppErr
     let Some((src_kind, src_id, dst_kind, dst_id, et, _status)) = state.db.link_by_id(id)? else {
         return Err(AppError::InvalidArg(format!("no link {id}")));
     };
-    // Only a suggestion (semantic) or an accepted-then-regretted semantic edge is dismissable. A
-    // deterministic wikilink/companion edge is NOT (it would just come back); a manual edge is
-    // removed by `unlink_items`. Refuse the rest with a clear InvalidArg.
-    if et != "semantic" {
-        return Err(AppError::InvalidArg(format!(
-            "link {id} is a deterministic {et} edge — dismissal is for semantic suggestions (remove a manual link via unlink)"
-        )));
-    }
-    // ── GATE both endpoints (fail-closed on a sealed/unknown endpoint). ──
+    // ── GATE both endpoints FIRST, for the reason spelled out in `accept_link_inner`: the type
+    //    refusal below names `edge_type`, and preserved manual rows now outlive a seal. ──
     let (Some(sk), Some(dk)) = (
         crate::links::LinkKind::parse(&src_kind),
         crate::links::LinkKind::parse(&dst_kind),
@@ -215,6 +212,14 @@ pub(crate) fn dismiss_link_inner(state: &AppState, id: i64) -> Result<(), AppErr
         return Err(AppError::Locked(
             "one of these items is locked — unlock it to dismiss the suggestion".into(),
         ));
+    }
+    // Only a suggestion (semantic) or an accepted-then-regretted semantic edge is dismissable. A
+    // deterministic wikilink/companion edge is NOT (it would just come back); a manual edge is
+    // removed by `unlink_items`. Refuse the rest with a clear InvalidArg.
+    if et != "semantic" {
+        return Err(AppError::InvalidArg(format!(
+            "link {id} is a deterministic {et} edge — dismissal is for semantic suggestions (remove a manual link via unlink)"
+        )));
     }
     state.db.dismiss_link(id)?;
     tracing::info!(target: "links", link_id = id, "dismiss_link");

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5959,9 +5959,15 @@ pub(crate) fn rederive_links_for_folder(
             }
             // Fix 4 (brain-v3 audit, INVERSE): re-materialize the `[[Title]]` markers the seal stripped,
             // from the PRESERVED accepted rows (Fix 1) incident on the just-unlocked items, into the
-            // source notes' managed blocks, then re-export those sources' `.md`. A wikilink/manual
-            // marker re-materializes via the source's own body re-index above; an accepted SEMANTIC
-            // marker has no body wikilink to re-derive from, so this explicit re-add restores it.
+            // source notes' managed blocks, then re-export those sources' `.md`. A wikilink marker
+            // re-materializes via the source's own body re-index above; an accepted SEMANTIC marker
+            // has no body wikilink to re-derive from, so this explicit re-add restores it.
+            //
+            // This used to say "wikilink/manual". A manual link has no marker to re-materialize and
+            // no body to re-derive from: `link_items` deliberately stopped writing a `[[Title]]`
+            // block, so the `links` row IS the record. Naming it here made the row's destruction on
+            // seal look recoverable, which is why it went unnoticed that it was not — the row is now
+            // preserved instead (see `LINK_DECISION_KEEP`), and nothing has to be re-materialized.
             match state
                 .db
                 .rematerialize_accepted_markers_for_folder(folder_id, &mids, unlocked)

--- a/src-tauri/src/storage/db_tests/tests.rs
+++ b/src-tauri/src/storage/db_tests/tests.rs
@@ -13063,10 +13063,19 @@ fn links_for_visible_non_manual_pair_not_flagged() {
     );
 }
 
-/// PURGE-ON-SEAL is edge-type-AGNOSTIC: a `manual` edge is dropped at rest exactly like a
-/// wikilink when either endpoint's folder is sealed (the `purge_links_tx` leg on relock reblank).
+/// PURGE-ON-SEAL is NOT edge-type-agnostic, and this test used to say it was.
+///
+/// It pinned the behaviour that sealing a folder destroys every `manual` edge touching it, and by
+/// pinning it made the loss look deliberate. It is not survivable: a manual edge is the ONLY record
+/// of a link the user made by hand — `link_items` writes the row and no body marker — so nothing
+/// re-derives it on unlock. Locking a folder for an afternoon silently deleted the connections the
+/// user built, and returned the automatic ones.
+///
+/// What must hold instead, and what this test now checks: the row SURVIVES the seal at rest, stays
+/// INVISIBLE through the gated reader from the still-open side while the neighbour is sealed, and is
+/// visible again once the folder is unlocked. Only the decision survives, never its visibility.
 #[test]
-fn purge_links_tx_drops_manual_on_seal() {
+fn a_manual_link_survives_a_seal_at_rest_but_stays_invisible_until_unlock() {
     let db = mem_db();
     seed_folder(&db, "f-open", "Open");
     seed_folder(&db, "f-secret", "Secret");
@@ -13075,11 +13084,7 @@ fn purge_links_tx_drops_manual_on_seal() {
 
     db.upsert_manual_link("note", "open", "note", "secret")
         .unwrap();
-    assert_eq!(
-        link_count(&db, "note", "secret", "manual"),
-        1,
-        "manual edge exists pre-seal"
-    );
+    assert_eq!(link_count(&db, "note", "secret", "manual"), 1);
 
     // Seal the SECRET folder and run the relock reblank (carries the `purge_links_tx` leg).
     db.set_folder_locked("f-secret", true, None).unwrap();
@@ -13087,16 +13092,139 @@ fn purge_links_tx_drops_manual_on_seal() {
     folders.insert("f-secret".to_string());
     db.blank_sealed_notes_in_folders(&folders).unwrap();
 
-    // The manual row is GONE at rest — both directions (the sealed dst side and the open src side).
+    // AT REST: the user's decision is still on the books. It carries ids only — no title, no body.
     assert_eq!(
         link_count(&db, "note", "secret", "manual"),
-        0,
-        "sealed endpoint's manual edge purged (dst side)"
+        1,
+        "a hand-made link is not derivable from anything else, so the seal must not destroy it"
     );
+
+    // THROUGH THE GATE: from the still-open side the sealed neighbour is not disclosed at all —
+    // neither its title nor the fact that an edge reaches it.
+    let sealed = HashSet::new();
+    let edges = db
+        .links_for_visible(crate::links::LinkKind::Note, "open", &sealed)
+        .unwrap();
+    assert!(
+        !edges.iter().any(|e| e.other_id == "secret"),
+        "the preserved row must stay invisible while its neighbour is sealed — got {edges:?}"
+    );
+
+    // UNLOCKED: the same edge the user made is back, unchanged.
+    db.set_folder_locked("f-secret", false, None).unwrap();
+    let mut unlocked = HashSet::new();
+    unlocked.insert("f-secret".to_string());
+    let edges = db
+        .links_for_visible(crate::links::LinkKind::Note, "open", &unlocked)
+        .unwrap();
+    let restored = edges
+        .iter()
+        .find(|e| e.other_id == "secret")
+        .expect("the manual link must be visible again after unlock");
+    assert_eq!(restored.edge_type, "manual");
+    assert!(restored.manual, "and it must still read as a removable link");
+}
+
+/// The invisibility above is checked from the OPEN side; this checks the other three surfaces a
+/// preserved row could escape through, because "the row survives" and "the row is hidden" are
+/// separate properties and only the first is obvious from the constant.
+#[test]
+fn a_preserved_manual_link_is_hidden_from_the_sealed_side_and_from_the_graph() {
+    let db = mem_db();
+    seed_folder(&db, "f-open", "Open");
+    seed_folder(&db, "f-secret", "Secret");
+    seed_note_doc(&db, "open", "f-open", "Open Note", "");
+    seed_note_doc(&db, "secret", "f-secret", "Secret Note", "");
+    db.upsert_manual_link("note", "open", "note", "secret")
+        .unwrap();
+
+    db.set_folder_locked("f-secret", true, None).unwrap();
+    let mut folders = HashSet::new();
+    folders.insert("f-secret".to_string());
+    db.blank_sealed_notes_in_folders(&folders).unwrap();
+    let sealed = HashSet::new();
+
+    // The SEALED side answers nothing at all — GATE 1 refuses before any edge is considered, so the
+    // open neighbour's id never appears either.
+    assert!(
+        db.links_for_visible(crate::links::LinkKind::Note, "secret", &sealed)
+            .unwrap()
+            .is_empty(),
+        "querying the sealed item itself must disclose no edges"
+    );
+
+    // The full-brain graph reads `links` raw and filters in the caller, so it is the surface where a
+    // preserved row is most likely to escape. No node for the sealed note, and no edge touching it.
+    let graph = db
+        .build_full_graph(&sealed, crate::storage::models::FullGraphOpts::default())
+        .unwrap();
+    assert!(
+        !graph.nodes.iter().any(|n| n.id == "secret"),
+        "the sealed note must not be a graph node"
+    );
+    assert!(
+        !graph
+            .edges
+            .iter()
+            .any(|e| e.src == "secret" || e.dst == "secret"),
+        "no edge may touch the sealed note — got {:?}",
+        graph.edges
+    );
+}
+
+/// The other three edge kinds are genuinely derived, so the seal must STILL purge them — otherwise a
+/// wikilink the user deleted from a note body while the folder was closed would come back on unlock.
+/// This is the control that keeps the fix above from widening into "seals stop purging links".
+#[test]
+fn a_seal_still_purges_the_derived_edge_kinds() {
+    let db = mem_db();
+    seed_folder(&db, "f-open", "Open");
+    seed_folder(&db, "f-secret", "Secret");
+    seed_note_doc(&db, "open", "f-open", "Open Note", "links [[Secret Note]]");
+    seed_note_doc(&db, "secret", "f-secret", "Secret Note", "body");
+
+    let nothing = HashSet::new();
+    db.index_wikilinks_for_source(
+        crate::links::LinkKind::Note,
+        "open",
+        "links [[Secret Note]]",
+        &nothing,
+    )
+    .unwrap();
+    assert_eq!(link_count(&db, "note", "open", "wikilink"), 1);
+
+    db.set_folder_locked("f-secret", true, None).unwrap();
+    let mut folders = HashSet::new();
+    folders.insert("f-secret".to_string());
+    db.blank_sealed_notes_in_folders(&folders).unwrap();
+
     assert_eq!(
-        link_count(&db, "note", "open", "manual"),
+        link_count(&db, "note", "open", "wikilink"),
         0,
-        "open source's manual edge to the sealed note purged (src side)"
+        "a wikilink is re-derived from the body on unlock, so it must not be preserved"
+    );
+
+    // Companion is the other `created_by='user'` derived kind, and the one that would silently ride
+    // along if the preserved class were ever keyed on `created_by` instead of `edge_type`.
+    let db2 = mem_db();
+    seed_folder(&db2, "f-locked", "Secret");
+    db2.insert_meeting(&sample_meeting("m1", "2026-06-24T10:00:00Z"))
+        .unwrap();
+    note_for(&db2, "m1", "claude_code", "meeting note body");
+    db2.set_note_folder("m1", Some("f-locked")).unwrap();
+    seed_note_doc(&db2, "companion", "f-locked", "Companion", "typed notes");
+    db2.set_document_meeting_id("companion", "m1").unwrap();
+    db2.set_companion_link("companion", "m1").unwrap();
+    assert_eq!(link_count(&db2, "meeting", "m1", "companion"), 1);
+
+    db2.set_folder_locked("f-locked", true, None).unwrap();
+    let mut folders2 = HashSet::new();
+    folders2.insert("f-locked".to_string());
+    db2.blank_sealed_notes_in_folders(&folders2).unwrap();
+    assert_eq!(
+        link_count(&db2, "meeting", "m1", "companion"),
+        0,
+        "a companion edge is structural and re-derived on unlock — it must not be preserved"
     );
 }
 

--- a/src-tauri/src/storage/links.rs
+++ b/src-tauri/src/storage/links.rs
@@ -1052,7 +1052,8 @@ impl Db {
 
     /// Brain-v3 audit Fix 2 — RE-ASSERT the `companion` edges of a JUST-UNSEALED folder that the seal
     /// purge dropped. A `companion` edge (`note → meeting`, `created_by='user'`) is NOT a preserved
-    /// decision row ([`LINK_DECISION_KEEP`] keeps only dismissed/accepted), and `set_companion_link`
+    /// decision row ([`LINK_DECISION_KEEP`] keeps dismissed tombstones, accepted edges and manual
+    /// links), and `set_companion_link`
     /// only fires at the recording-time write site — so ONE lock cycle permanently deletes it (the
     /// one-time backfill sentinel is spent). This restores both legs in ONE tx on unlock:
     ///
@@ -1627,18 +1628,41 @@ impl Db {
     /// lock→unlock RESURRECTS a dismissed suggestion (the semantic pass re-proposes it) and forgets an
     /// accepted edge, contradicting the spec ("a rejected suggestion never reappears").
     ///
-    /// Two decision classes survive:
+    /// Three decision classes survive:
     ///   - `status='dismissed'` — the tombstone that stops a re-suggest (its `upsert_link_tx`
-    ///     DO-UPDATE guard skips dismissed rows), and
-    ///   - `status='active' AND created_by='accepted'` — a user-CONFIRMED semantic link.
+    ///     DO-UPDATE guard skips dismissed rows),
+    ///   - `status='active' AND created_by='accepted'` — a user-CONFIRMED semantic link, and
+    ///   - `status='active' AND edge_type='manual'` — a link the user MADE.
+    ///
+    /// # Why `manual` had to join them
+    ///
+    /// This list used to end "everything else (wikilink/companion/manual/auto-suggested) is DERIVED
+    /// and re-derivable on unlock, so it is purged". That was true of three of those four and false
+    /// of `manual`, and the sentence is what made the loss look deliberate. A wikilink is re-derived
+    /// by re-indexing the note body; a companion edge from the meeting↔note relation; a semantic
+    /// suggestion by re-running the kNN pass. A manual edge has NO such source:
+    /// `commands::links::link_items` writes the row and DELIBERATELY writes no `[[Title]]` marker
+    /// into the body (that machine block went stale and rendered as junk, so it was removed), which
+    /// its own comment states — "the manual edge is the AUTHORITATIVE record of the link".
+    ///
+    /// So sealing a folder destroyed every hand-made connection touching it, `rederive_links_for_folder`
+    /// brought back only the derivable kinds, and unlocking returned an item with its automatic edges
+    /// intact and the user's own ones gone. Silently: nothing failed, nothing was reported.
+    ///
+    /// The key is `edge_type = 'manual'` and NOT `created_by = 'user'`, though every manual row
+    /// carries both. `created_by='user'` is also written for wikilink and companion edges, and those
+    /// MUST still die on seal — preserving a wikilink across a seal would resurrect a link the user
+    /// had removed from the body while the folder was closed.
     ///
     /// A preserved row carries ONLY ids/kind/edge_type/score inside the SQLCipher DB — NO titles, NO
-    /// plaintext — so keeping it leaks nothing at rest; and the read gate ([`links_for_visible`]) still
-    /// hides it (both-endpoint-gated) while an endpoint is sealed, so only the DECISION STATE survives,
-    /// never its visibility. Everything else (wikilink/companion/manual/auto-suggested) is DERIVED and
-    /// re-derivable on unlock, so it is purged.
-    pub(crate) const LINK_DECISION_KEEP: &'static str =
-        "status = 'dismissed' OR (status = 'active' AND created_by = 'accepted')";
+    /// plaintext — so keeping it leaks nothing at rest; and every reader is both-endpoint-gated, so
+    /// only the DECISION STATE survives, never its visibility: [`links_for_visible`] drops an edge
+    /// whose neighbour is not visible (GATE 2), and the full-brain graph re-checks both endpoints
+    /// against its visible-node set before emitting an edge. Everything genuinely DERIVED
+    /// (wikilink/companion/auto-suggested) is still purged and re-derived on unlock.
+    pub(crate) const LINK_DECISION_KEEP: &'static str = "status = 'dismissed' \
+         OR (status = 'active' AND created_by = 'accepted') \
+         OR (status = 'active' AND edge_type = 'manual')";
 
     fn enqueue_marker_export_cleanup_tx(
         tx: &rusqlite::Transaction<'_>,
@@ -2342,14 +2366,14 @@ impl Db {
 
     /// PURGE every DERIVED link row whose SRC OR DST is a sealed/deleted meeting or document (a note id
     /// IS a `documents` id, so `document_ids` covers the `note` kind too), PRESERVING a user's decision
-    /// rows ([`LINK_DECISION_KEEP`] — dismissed tombstones + accepted edges). Runs INSIDE an existing
+    /// rows ([`LINK_DECISION_KEEP`] — dismissed tombstones, accepted edges, manual links). Runs INSIDE an existing
     /// seal / delete tx so a derived link — which reveals a neighbour's existence + title — never
     /// outlives the plaintext it was derived from. BOTH endpoint kinds for a meeting id are matched
     /// (`src`/`dst`); likewise for a document/note id across `document`/`note` kinds. Re-derived on
     /// unlock. Mirrors the `purge_chunks_tx` / `purge_doc_chunks_tx` choke-point idiom.
     ///
     /// `preserve_decisions`: a SEAL (reversible — the item returns on unlock) passes `true` so a
-    /// user's dismissed/accepted DECISION rows survive ([`LINK_DECISION_KEEP`], Fix 1). A permanent
+    /// user's dismissed/accepted/manual DECISION rows survive ([`LINK_DECISION_KEEP`]). A permanent
     /// DELETE (`delete_meeting`/`delete_document`/the delete-folder derived-doc leg) passes `false` —
     /// the endpoint is gone for good, so leaving a dangling decision row (that a future id reuse could
     /// resurface) would be a bug; purge EVERYTHING incident on it.

--- a/src-tauri/src/storage/seal_store.rs
+++ b/src-tauri/src/storage/seal_store.rs
@@ -944,7 +944,7 @@ impl Db {
         // id, so the document leg's `IN ('note','document')` covers both kinds.
         //
         // Brain-v3 audit Fix 1: PRESERVE a user's decision rows (`LINK_DECISION_KEEP` — dismissed
-        // tombstones + accepted edges) across this reconcile, mirroring `purge_links_tx`, so a restart
+        // tombstones, accepted edges and manual links) across this reconcile, mirroring `purge_links_tx`, so a restart
         // (like a lock→unlock) never resurrects a dismissed suggestion or forgets an accepted edge.
         // These rows carry ids/kind/edge_type/score only — no titles/plaintext — and stay invisible
         // via the both-endpoint read gate while an endpoint is sealed.


### PR DESCRIPTION
Sealing a folder purged every `links` row incident on a sealed item, except two preserved "decision" classes: dismissed tombstones and accepted semantic edges. A **manual** link — one the user made by hand — went with the rest, and nothing brings it back.

A wikilink is re-derived by re-indexing the note body. A companion edge comes from the meeting-note relation. A semantic suggestion comes from re-running the kNN pass. But `link_items` writes the `links` row and deliberately writes no `[[Title]]` marker into the body — its own comment calls the edge "the AUTHORITATIVE record of the link". So locking a folder for an afternoon deleted every connection the user had built by hand, and unlocking returned the item with its automatic edges intact and the user's own ones gone. Silently: nothing failed, nothing was reported.

It looked deliberate because the constant's documentation said *"everything else (wikilink/companion/manual/auto-suggested) is DERIVED and re-derivable on unlock"*, a test named `purge_links_tx_drops_manual_on_seal` pinned it, and a comment in `commands/mod.rs` repeated the claim. That sentence was true of three of those four.

## Why `edge_type`, not `created_by`

Every manual row carries both `edge_type='manual'` and `created_by='user'`. The key had to be the first: wikilink and companion rows are **also** written `created_by='user'`, and those must still die on seal — otherwise a wikilink the user removed from a body while the folder was closed would reappear on unlock. A new control test pins exactly that, for both derived kinds.

## Why keeping the row leaks nothing

It carries ids, kind, edge type and score — no title, no body — inside the SQLCipher file, and every reader gates **both** endpoints. `links_for_visible` refuses the queried item, then separately drops any edge whose neighbour is not visible. The full-brain graph reads raw and re-checks both ends against its visible-node set. So only the decision survives a seal, never its visibility.

A lock-security review on a different model enumerated the reader set independently — including MCP tools, the Ask source-scope expansion, backlinks, export and analytics — and found no path that surfaces a preserved row while an endpoint is sealed. Verdict: PASS.

That review also caught a consequence of preserving the rows: `accept_link` and `dismiss_link` described a row back to the caller (`edge_type=manual, status=active`) **before** gating its endpoints. That mattered little while a seal purged manual rows outright, since a stale id simply answered "no link". Now that the ids outlive the lock, the ordering is the difference between a probe that answers and one that refuses. The endpoint gate moves first in both paths.

Its one remaining finding is recorded and deliberately **not** fixed here: the full graph computes its "edges trimmed" flag before the endpoint gate, so rows incident on sealed items consume cap slots. It discloses only the bit "at least 4001 active edges exist" — never an id or a title — and fixing it properly means gating that query in SQL.

## The second commit

Unrelated defect, found while running this one's gate and fixed here because it blocks every full local run. Two audio ring-buffer tests share a single global hook slot and libtest runs them in parallel, so the second writer overwrites the first's entry and the first waits forever on a barrier nobody reaches. The symptom is not a failure but a **hang**: every test prints as passing and the process never terminates, which is why it was re-run rather than fixed. Diagnosed by sampling the stuck process. A dedicated poison-tolerant mutex serializes the pair.

Worth knowing for the neighbouring class: CI runs the suite through `cargo nextest` (a process per test), so this and every other process-global collision in the suite is invisible on CI and reproduces only under the `cargo test` fallback `scripts/ci.sh` uses on dev Macs.

## Verification

- `cargo nextest run` (the runner CI uses): 3585 passed, 18 skipped. The single failure is `collaborator_advanced_head_is_terminal_even_when_head_scan_is_unavailable`, a pre-existing flake that also failed on the trunk CI run for #647 and passed on rerun; it passes 9 times out of 9 in isolation here and is unrelated to this diff.
- `ng lint` green; the diff is Rust-only.
- RED-before-GREEN: restoring the old constant fails the survival oracle while the derived-kinds control still passes.
