### PR TITLE
fix(lock): the fact ledger survives lock and unlock

### DIFF
--- a/src-tauri/src/commands/lock.rs
+++ b/src-tauri/src/commands/lock.rs
@@ -1316,6 +1316,21 @@ pub(crate) fn relock_folder_inner_with_visibility_notice(
     enqueue_marker_cleanup_for_folders(state, &sealed)?;
     // The re-blank tx also purges ALL memory rollups (may paraphrase the re-sealed facts) and
     // returns their exported vault paths — the files are removed here (command layer).
+    // FACT LEDGER, RE-SEALED BEFORE THE PURGE. `blank_sealed_notes_in_folders` deletes facts, user
+    // facts and supersessions, and on a RELOCK those rows are whatever the unlocked session ended
+    // with — restored ones plus anything extracted while the folder was open. Sealing after that
+    // call would encrypt nothing and leave the session's additions destroyed, so it happens here,
+    // with the content key the preflight already verified. A folder whose key could not be verified
+    // is skipped HERE — its ledger is not re-sealed — but the purge below still runs for it, so this
+    // is not a guarantee that its facts survive; it is only a refusal to encrypt under a key nobody
+    // proved. In practice that folder has no live plaintext left for the key to be missing over.
+    for (id, verified) in &verified_plans {
+        if let Some(ck) = verified.ck() {
+            for mid in state.db.meeting_ids_in_folder(id)? {
+                crate::commands::seal_fact_ledger_for_meeting(&state.db, id, &mid, ck)?;
+            }
+        }
+    }
     remove_rollup_exports_before_seal_purge(&state.db)?;
     let rollup_exports = state.db.blank_sealed_notes_in_folders(&sealed)?;
     remove_rollup_export_files(&rollup_exports);
@@ -1470,6 +1485,21 @@ pub(crate) fn relock_all_inner_with_visibility_notice(
     // folder that was materialized while this folder was session-unlocked) + re-export those sources'
     // `.md`. Resolve the relocked folders' meeting + document ids first.
     enqueue_marker_cleanup_for_folders(state, &locked)?;
+    // FACT LEDGER, RE-SEALED BEFORE THE PURGE. `blank_sealed_notes_in_folders` deletes facts, user
+    // facts and supersessions, and on a RELOCK those rows are whatever the unlocked session ended
+    // with — restored ones plus anything extracted while the folder was open. Sealing after that
+    // call would encrypt nothing and leave the session's additions destroyed, so it happens here,
+    // with the content key the preflight already verified. A folder whose key could not be verified
+    // is skipped HERE — its ledger is not re-sealed — but the purge below still runs for it, so this
+    // is not a guarantee that its facts survive; it is only a refusal to encrypt under a key nobody
+    // proved. In practice that folder has no live plaintext left for the key to be missing over.
+    for (folder_id, verified) in &verified_relocks {
+        if let Some(ck) = verified.ck() {
+            for mid in state.db.meeting_ids_in_folder(folder_id)? {
+                crate::commands::seal_fact_ledger_for_meeting(&state.db, folder_id, &mid, ck)?;
+            }
+        }
+    }
     remove_rollup_exports_before_seal_purge(&state.db)?;
     let rollup_exports = state.db.blank_sealed_notes_in_folders(&locked)?;
     remove_rollup_export_files(&rollup_exports);

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -12070,7 +12070,7 @@ fn unseal_meeting_extras(
     // the session through this function; without the restore here that meeting sat factless behind
     // an open padlock, and the next relock re-sealed whatever had been re-extracted — overwriting
     // the only copy of the pre-move history.
-    restore_fact_ledger_for_meeting(&state.db, folder_id, mid, ck, false)?;
+    restore_fact_ledger_for_meeting(&state.db, folder_id, mid, ck)?;
     for s in state.db.raw_segments(mid)? {
         let Some(blob) = &s.text_blob else { continue };
         let aad = aad_content(folder_id, mid, AAD_NO_PROVIDER, "segment");
@@ -12262,26 +12262,52 @@ pub(crate) fn seal_fact_ledger_for_meeting(
     meeting_id: &str,
     ck: &[u8; 32],
 ) -> Result<(), AppError> {
-    let ledger = db.raw_fact_ledger_for_meeting(meeting_id)?;
+    let mut ledger = db.raw_fact_ledger_for_meeting(meeting_id)?;
+
+    // NEVER replace a ciphertext with a strict SUBSET of itself. A restore deliberately skips a
+    // supersession whose other anchor is still sealed — its values are that meeting's plaintext —
+    // so those rows are absent from the live tables by design. Re-sealing from the live rows alone
+    // would then overwrite the only copy that still held them, and they would be gone for good:
+    // unlock folder A, relock A, and a supersession spanning A and a still-locked B has vanished
+    // from both ciphertexts. An adversarial review reproduced exactly that.
+    //
+    // So carry forward anything the existing ciphertext holds that is not live right now. Live rows
+    // always win; the old blob only fills gaps. Nothing can be resurrected this way that a user
+    // deleted, because facts are closed bitemporally rather than deleted, and a supersession whose
+    // meeting is gone is dropped by the CASCADE on `sealed_fact_ledgers` along with the blob.
+    if let Some(existing) = db.fact_ledger_blob(meeting_id)? {
+        if let Ok(plain) =
+            crate::crypto::decrypt(ck, &existing, &aad_fact_ledger(folder_id, meeting_id))
+        {
+            if let Ok(prev) = serde_json::from_slice::<crate::storage::SealedFactLedger>(&plain) {
+                ledger.merge_missing_from(prev);
+            }
+        }
+    }
+
     if ledger.is_empty() {
         // Nothing live to seal. If a blob exists it holds a ledger sealed earlier and the rows are
         // simply already purged — AUTHENTICATE it, the same way the document and segment seals
         // treat an already-sealed row, so a corrupt ciphertext is caught while the key is in hand.
         //
-        // A blob that will NOT open is dropped rather than raised. It cannot be the only copy of
-        // anything: there are no live rows to lose, and a ledger this key cannot read is
-        // unrecoverable by definition. Raising instead would abort a lock whose `locked=1` is
-        // already durable, and the startup repair would then hit the same wall on every launch —
-        // a folder-seal rollback followed by a re-lock reached exactly that state before
-        // `discard_folder_seal` learned to drop this row.
+        // A blob that will not open under THIS key is neither deleted nor raised.
+        //
+        // Deleting it destroys the only copy: with the rows purged, the ciphertext IS the ledger,
+        // and "the key I happen to be holding cannot read it" is not evidence that nobody can. An
+        // earlier revision of this function did delete it, and an adversarial review reproduced the
+        // loss by presenting a second key. Raising is no better: it would abort a lock whose
+        // `locked=1` is already durable and make the startup repair fail on every launch.
+        //
+        // The one path that genuinely produced a stale blob — a discarded seal followed by a
+        // re-lock under a fresh key — is closed at its root: `discard_folder_seal` drops the row
+        // with every other sealed payload. So warn, keep it, and let the lock finish.
         if let Some(blob) = db.fact_ledger_blob(meeting_id)? {
             if crate::crypto::decrypt(ck, &blob, &aad_fact_ledger(folder_id, meeting_id)).is_err() {
                 tracing::warn!(
                     target: "lock",
                     meeting_id,
-                    "dropping an unreadable sealed fact ledger (no live rows to lose)"
+                    "a sealed fact ledger did not open under this folder key; keeping it"
                 );
-                db.clear_fact_ledger_blob(meeting_id)?;
             }
         }
         return Ok(());
@@ -12299,14 +12325,19 @@ pub(crate) fn seal_fact_ledger_for_meeting(
     Ok(())
 }
 
-/// Put one meeting's sealed fact ledger back. `clear_blob` is set only by the PERMANENT unseal
-/// (remove-lock), where the plaintext rows become the only copy again.
+/// Put one meeting's sealed fact ledger back.
+///
+/// The ciphertext is always KEPT here. A session unlock needs it for the next relock, and the
+/// permanent unlock retires it inside `commit_folder_permanent_unlock` together with every other
+/// blob, so that no crash point can observe a folder that still says locked with its rows back and
+/// its only ciphertext already gone. This function used to take a `clear_blob` flag; both
+/// production callers passed `false` and only a test passed `true`, which meant the test exercised
+/// a path the app never took while the real retire went unpinned.
 pub(crate) fn restore_fact_ledger_for_meeting(
     db: &Db,
     folder_id: &str,
     meeting_id: &str,
     ck: &[u8; 32],
-    clear_blob: bool,
 ) -> Result<(), AppError> {
     let Some(blob) = db.fact_ledger_blob(meeting_id)? else {
         return Ok(());
@@ -12315,9 +12346,6 @@ pub(crate) fn restore_fact_ledger_for_meeting(
     let ledger: crate::storage::SealedFactLedger = serde_json::from_slice(&plaintext)
         .map_err(|e| AppError::Storage(format!("fact ledger deserialize failed: {e}")))?;
     db.restore_fact_ledger(meeting_id, &ledger)?;
-    if clear_blob {
-        db.clear_fact_ledger_blob(meeting_id)?;
-    }
     Ok(())
 }
 
@@ -13181,7 +13209,7 @@ pub(crate) fn unseal_folder_extras_permanent(
     // so no crash point can observe a folder that still says locked with its rows back and its only
     // ciphertext already gone.
     for mid in &meeting_ids {
-        restore_fact_ledger_for_meeting(&state.db, folder_id, mid, ck, false)?;
+        restore_fact_ledger_for_meeting(&state.db, folder_id, mid, ck)?;
     }
 
     Ok(sealed_audio_to_retire)

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -11870,6 +11870,18 @@ fn repair_locked_audio_at_rest(
 /// locked folder (BLK-2) without touching the folder's other meetings. Verify-before-destroy
 /// throughout (no transcript / audio loss); idempotent on already-sealed rows.
 fn seal_meeting_extras(db: &Db, folder_id: &str, mid: &str, ck: &[u8; 32]) -> Result<(), AppError> {
+    // FACT LEDGER: facts, user facts and supersessions are DELETED a few steps later by the seal's
+    // own purge, because their subject/predicate/object are plaintext derived from this meeting.
+    // That is correct and unchanged. What was missing is the ciphertext that lets an unlock put them
+    // back — without it, locking a folder destroyed the ledger for good, and re-extraction is not a
+    // recovery: it needs a provider call and it cannot reconstruct `valid_from`/`valid_to` or the
+    // supersession chain, because nothing in the note text records when a fact stopped being true.
+    //
+    // Verify-before-destroy, and RE-SEAL every time rather than skipping an already-sealed meeting:
+    // a session unlock puts the rows back and may add more, so a stale blob would silently drop
+    // whatever the unlocked session learned.
+    seal_fact_ledger_for_meeting(db, folder_id, mid, ck)?;
+
     // Transcript: encrypt each segment's plaintext text, verify, then seal (blank text).
     let segs = db.raw_segments(mid)?;
     let mut sealed_segs: Vec<(i64, Vec<u8>)> = Vec::new();
@@ -12053,6 +12065,12 @@ fn unseal_meeting_extras(
     mid: &str,
     ck: &[u8; 32],
 ) -> Result<(), AppError> {
+    // FACT LEDGER first, and HERE rather than at the folder level, so every caller gets it. The
+    // move-into-locked path seals and purges a meeting's ledger and then restores the meeting for
+    // the session through this function; without the restore here that meeting sat factless behind
+    // an open padlock, and the next relock re-sealed whatever had been re-extracted — overwriting
+    // the only copy of the pre-move history.
+    restore_fact_ledger_for_meeting(&state.db, folder_id, mid, ck, false)?;
     for s in state.db.raw_segments(mid)? {
         let Some(blob) = &s.text_blob else { continue };
         let aad = aad_content(folder_id, mid, AAD_NO_PROVIDER, "segment");
@@ -12230,6 +12248,79 @@ fn unseal_dashboards_in_folder(db: &Db, folder_id: &str, ck: &[u8; 32]) -> Resul
 /// (rather than resolved internally like the document re-index below) so the model-PRESENT re-index
 /// is deterministically testable without a real model on disk — meetings have no model-absent
 /// chunk-only path, unlike documents.
+/// AAD for a meeting's sealed fact ledger: binds the ciphertext to this folder AND this meeting, so
+/// a blob cannot be swapped between meetings or between folders.
+fn aad_fact_ledger(folder_id: &str, meeting_id: &str) -> Vec<u8> {
+    aad_content(folder_id, meeting_id, AAD_NO_PROVIDER, "fact-ledger")
+}
+
+/// Encrypt one meeting's fact ledger under the folder key and store it, having proved it decrypts
+/// back byte-identical FIRST. Returns without writing anything when the meeting has no ledger.
+pub(crate) fn seal_fact_ledger_for_meeting(
+    db: &Db,
+    folder_id: &str,
+    meeting_id: &str,
+    ck: &[u8; 32],
+) -> Result<(), AppError> {
+    let ledger = db.raw_fact_ledger_for_meeting(meeting_id)?;
+    if ledger.is_empty() {
+        // Nothing live to seal. If a blob exists it holds a ledger sealed earlier and the rows are
+        // simply already purged — AUTHENTICATE it, the same way the document and segment seals
+        // treat an already-sealed row, so a corrupt ciphertext is caught while the key is in hand.
+        //
+        // A blob that will NOT open is dropped rather than raised. It cannot be the only copy of
+        // anything: there are no live rows to lose, and a ledger this key cannot read is
+        // unrecoverable by definition. Raising instead would abort a lock whose `locked=1` is
+        // already durable, and the startup repair would then hit the same wall on every launch —
+        // a folder-seal rollback followed by a re-lock reached exactly that state before
+        // `discard_folder_seal` learned to drop this row.
+        if let Some(blob) = db.fact_ledger_blob(meeting_id)? {
+            if crate::crypto::decrypt(ck, &blob, &aad_fact_ledger(folder_id, meeting_id)).is_err() {
+                tracing::warn!(
+                    target: "lock",
+                    meeting_id,
+                    "dropping an unreadable sealed fact ledger (no live rows to lose)"
+                );
+                db.clear_fact_ledger_blob(meeting_id)?;
+            }
+        }
+        return Ok(());
+    }
+    let plaintext = serde_json::to_vec(&ledger)
+        .map_err(|e| AppError::Storage(format!("fact ledger serialize failed: {e}")))?;
+    let aad = aad_fact_ledger(folder_id, meeting_id);
+    let blob = crate::crypto::encrypt(ck, &plaintext, &aad)?;
+    if crate::crypto::decrypt(ck, &blob, &aad)? != plaintext {
+        return Err(AppError::Storage(
+            "fact ledger seal verification failed (blob mismatch)".into(),
+        ));
+    }
+    db.seal_fact_ledger(meeting_id, &blob)?;
+    Ok(())
+}
+
+/// Put one meeting's sealed fact ledger back. `clear_blob` is set only by the PERMANENT unseal
+/// (remove-lock), where the plaintext rows become the only copy again.
+pub(crate) fn restore_fact_ledger_for_meeting(
+    db: &Db,
+    folder_id: &str,
+    meeting_id: &str,
+    ck: &[u8; 32],
+    clear_blob: bool,
+) -> Result<(), AppError> {
+    let Some(blob) = db.fact_ledger_blob(meeting_id)? else {
+        return Ok(());
+    };
+    let plaintext = crate::crypto::decrypt(ck, &blob, &aad_fact_ledger(folder_id, meeting_id))?;
+    let ledger: crate::storage::SealedFactLedger = serde_json::from_slice(&plaintext)
+        .map_err(|e| AppError::Storage(format!("fact ledger deserialize failed: {e}")))?;
+    db.restore_fact_ledger(meeting_id, &ledger)?;
+    if clear_blob {
+        db.clear_fact_ledger_blob(meeting_id)?;
+    }
+    Ok(())
+}
+
 pub(crate) fn unseal_folder_extras(
     state: &AppState,
     folder_id: &str,
@@ -13084,6 +13175,14 @@ pub(crate) fn unseal_folder_extras_permanent(
     // dropped only after it is durably readable. The lock is going away for good, so an entry left
     // with only a blob and no key would be unrecoverable content loss.
     trash_commands::unseal_trash_in_folder_permanent(&state.db, folder_id, ck)?;
+
+    // FACT LEDGER: restore every meeting's facts, user facts and supersessions. The ciphertext is
+    // NOT dropped here — it retires with every other blob inside `commit_folder_permanent_unlock`,
+    // so no crash point can observe a folder that still says locked with its rows back and its only
+    // ciphertext already gone.
+    for mid in &meeting_ids {
+        restore_fact_ledger_for_meeting(&state.db, folder_id, mid, ck, false)?;
+    }
 
     Ok(sealed_audio_to_retire)
 }

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -5851,6 +5851,136 @@
         }
     }
 
+    // ── The fact ledger's PRODUCTION wiring ──────────────────────────────────────────────────────
+    //
+    // An adversarial review deleted the relock re-seal loops (`commands/lock.rs`) and the restore
+    // inside `unseal_meeting_extras`, ran the WHOLE suite, and everything stayed green. The two
+    // headline claims of that change — "an unlock puts the ledger back" and "a relock re-seals
+    // before the purge" — were pinned by nothing. These two drive the real lock/unlock/relock
+    // commands, so removing either wire fails here.
+
+    /// Seed one entity fact on `mid` and hand back the entity id.
+    fn seed_one_fact(db: &Db, mid: &str, predicate: &str, object: &str) -> String {
+        let atlas = db
+            .upsert_entity("Atlas", crate::storage::models::EntityKind::Project)
+            .unwrap();
+        db.add_mention(&atlas, mid).unwrap();
+        db.apply_fact_ops(&[crate::facts::FactOp::Add(crate::facts::NewFact {
+            entity_id: atlas.clone(),
+            subject: "Atlas".into(),
+            predicate: predicate.into(),
+            object: object.into(),
+            valid_from: "2026-06-01T00:00:00Z".into(),
+            recorded_at: "2026-06-01T00:00:00Z".into(),
+            confidence: 1.0,
+            meeting_id: Some(mid.to_string()),
+        })])
+        .unwrap();
+        atlas
+    }
+
+    /// Unwrap a locked folder's content key the way the unlock command does.
+    fn folder_ck(state: &AppState, folder_id: &str) -> [u8; 32] {
+        let kek = secrets::get_or_create_master_kek().unwrap();
+        let wrapped = state.db.folder_wrapped_key(folder_id).unwrap().unwrap();
+        let ck_vec = crate::crypto::decrypt(&kek, &wrapped, &aad_wrapped_ck(folder_id)).unwrap();
+        *state.master_kek.lock().unwrap() = Some(Zeroizing::new(kek));
+        ck_vec.try_into().expect("CK is 32 bytes")
+    }
+
+    /// LOCK → the facts are gone → UNLOCK → they are back. Through the real commands.
+    #[test]
+    fn locking_and_unlocking_a_folder_returns_its_facts() {
+        let state = std::sync::Arc::new(build_state("ledger-wiring-unlock"));
+        make_open_folder(&state.db, "f-facts", "Secret");
+        seed_meeting(&state.db, "m-facts", "# Note", Some("f-facts"));
+        let atlas = seed_one_fact(&state.db, "m-facts", "status", "shipped");
+
+        lock_folder_inner(state.as_ref(), "f-facts".into()).unwrap();
+        assert!(
+            state
+                .db
+                .facts_for_entities(std::slice::from_ref(&atlas))
+                .unwrap()
+                .is_empty(),
+            "the seal still removes the rows — that half is unchanged"
+        );
+
+        let ck = folder_ck(state.as_ref(), "f-facts");
+        unseal_folder_extras(state.as_ref(), "f-facts", &ck, None).unwrap();
+        assert_eq!(
+            state
+                .db
+                .facts_for_entities(std::slice::from_ref(&atlas))
+                .unwrap()
+                .len(),
+            1,
+            "an unlock must put the ledger back — this is the wire the review could delete silently"
+        );
+    }
+
+    /// UNLOCK → learn something → RELOCK → UNLOCK: both facts are there.
+    ///
+    /// The relock purges before it re-seals, so the re-seal has to happen first. Without it the
+    /// relock leaves the ciphertext written at the ORIGINAL lock, and the fact the open session
+    /// learned is destroyed with no trace.
+    #[test]
+    fn a_relock_keeps_the_fact_the_open_session_learned() {
+        let state = std::sync::Arc::new(build_state("ledger-wiring-relock"));
+        make_open_folder(&state.db, "f-facts", "Secret");
+        seed_meeting(&state.db, "m-facts", "# Note", Some("f-facts"));
+        let atlas = seed_one_fact(&state.db, "m-facts", "status", "shipped");
+
+        lock_folder_inner(state.as_ref(), "f-facts".into()).unwrap();
+        let ck = folder_ck(state.as_ref(), "f-facts");
+        unseal_folder_extras(state.as_ref(), "f-facts", &ck, None).unwrap();
+        state
+            .unlocked_folders
+            .lock()
+            .unwrap()
+            .insert("f-facts".into());
+
+        // The open session learns a second thing about the same project.
+        state
+            .db
+            .apply_fact_ops(&[crate::facts::FactOp::Add(crate::facts::NewFact {
+                entity_id: atlas.clone(),
+                subject: "Atlas".into(),
+                predicate: "owner".into(),
+                object: "Ada".into(),
+                valid_from: "2026-08-01T00:00:00Z".into(),
+                recorded_at: "2026-08-01T00:00:00Z".into(),
+                confidence: 1.0,
+                meeting_id: Some("m-facts".to_string()),
+            })])
+            .unwrap();
+
+        relock_folder_inner_with_visibility_notice(&state, "f-facts", || {}).unwrap();
+        assert!(
+            state
+                .db
+                .facts_for_entities(std::slice::from_ref(&atlas))
+                .unwrap()
+                .is_empty(),
+            "the relock purges, as it always did"
+        );
+
+        let ck = folder_ck(state.as_ref(), "f-facts");
+        unseal_folder_extras(state.as_ref(), "f-facts", &ck, None).unwrap();
+        let after = state
+            .db
+            .facts_for_entities(std::slice::from_ref(&atlas))
+            .unwrap();
+        assert!(
+            after.iter().any(|f| f.predicate == "owner"),
+            "the fact the open session learned must survive the relock — got {after:?}"
+        );
+        assert!(
+            after.iter().any(|f| f.predicate == "status"),
+            "and so must the one sealed at the original lock — got {after:?}"
+        );
+    }
+
     #[test]
     fn conversion_command_relock_during_provider_await_writes_nothing() {
         let state = std::sync::Arc::new(build_state("conversion-command-await-relock"));

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -848,6 +848,28 @@ impl Db {
              -- rows referencing EITHER meeting via `purge_supersessions_tx` instead. The pre-images
              -- hold plaintext note bytes, so a sealed source contributes NONE (the read command is
              -- folder-lock + unlock gated, and rows are only ever recorded for open-folder sources).
+             -- THE FACT LEDGER, SEALED. Facts, user facts and supersessions are DELETED when a
+             -- folder seals, because their `subject`/`predicate`/`object` are plaintext derived
+             -- from the meeting -- keeping them readable at rest would defeat the seal. But they
+             -- were never re-derived on unlock either, so locking a folder for an afternoon
+             -- destroyed the ledger permanently.
+             --
+             -- Re-extraction is not a recovery: it costs a provider call, and it CANNOT restore the
+             -- bitemporal history. `valid_from`/`valid_to` and the supersession chain record WHEN a
+             -- fact stopped being true, and nothing in the current note text says that. Knowledge
+             -- diff, dossiers and the entity timeline are exactly the surfaces built on that
+             -- history.
+             --
+             -- So the ledger is SEALED-AND-RESTORED like the note markdown, not purged like a chunk:
+             -- one ciphertext per meeting holding its rows, written (verify-before-destroy) before
+             -- the rows are deleted, and re-inserted on unlock. The rows themselves still leave the
+             -- database on seal, so the at-rest guarantee is exactly what it was.
+             CREATE TABLE IF NOT EXISTS sealed_fact_ledgers (
+               meeting_id TEXT PRIMARY KEY,
+               data_blob  BLOB NOT NULL,
+               sealed_at  TEXT NOT NULL,
+               FOREIGN KEY (meeting_id) REFERENCES meetings(id) ON DELETE CASCADE
+             );
              CREATE TABLE IF NOT EXISTS supersessions (
                id TEXT PRIMARY KEY,
                superseding_meeting_id TEXT NOT NULL,

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -4699,7 +4699,7 @@ impl Db {
     /// (and on `delete_meeting` / the startup reconcile). Facts are plaintext-derived (entity ·
     /// predicate · object) content that mirrors a meeting; a sealed meeting must surface NOTHING, so
     /// — exactly like `correction_log` / `note_chunks` / `assistant_interactions` — we DELETE rather
-    /// than key-seal. Dropped by design + not recoverable (never keyed); the underlying transcript is
+    /// than key-seal. Dropped by design; the rows are RECOVERABLE from `sealed_fact_ledgers`, which the seal writes before this purge runs; the underlying transcript is
     /// still sealed + restorable, and a later re-summarize re-derives facts.
     pub(crate) fn purge_facts_tx(
         tx: &rusqlite::Transaction<'_>,
@@ -8197,7 +8197,7 @@ impl Db {
     /// on a seal (and on `delete_meeting` / the startup reconcile). Live bullets are
     /// plaintext-DERIVED running notes mirroring the meeting's transcript; a sealed meeting must
     /// surface NOTHING, so — exactly like `assistant_interactions` / `facts` / `note_chunks` — we
-    /// DELETE rather than key-seal. Dropped by design + not recoverable (never keyed); the
+    /// DELETE rather than key-seal. Dropped by design; the rows are RECOVERABLE from `sealed_fact_ledgers`, which the seal writes before this purge runs; the
     /// underlying transcript is still sealed + restorable.
     pub(crate) fn purge_live_bullets_tx(
         tx: &rusqlite::Transaction<'_>,

--- a/src-tauri/src/storage/db_tests/lock_tests.rs
+++ b/src-tauri/src/storage/db_tests/lock_tests.rs
@@ -2500,3 +2500,374 @@ fn ask_history_purge_on_visibility_withdrawal_is_scoped_to_the_sealed_folders() 
         "the crash-derived thread is gone, not merely hidden"
     );
 }
+
+// ── The fact ledger survives a lock/unlock cycle ────────────────────────────────────────────────
+
+/// THE ROUND TRIP. A seal still DELETES the meeting's facts, user facts and supersessions — their
+/// subject/predicate/object are plaintext derived from the meeting, and leaving them readable at
+/// rest would defeat the lock. What was missing is the other half of the contract: the ciphertext
+/// that lets an unlock put them back.
+///
+/// Re-extraction is not a recovery. It needs a provider call, and it cannot reconstruct the
+/// bitemporal history — `valid_to` records when a fact STOPPED being true, and nothing in the
+/// current note text says that. Knowledge diff, dossiers and the entity timeline are built on
+/// exactly that history, so this test asserts the CLOSED fact comes back closed.
+#[test]
+fn a_sealed_fact_ledger_round_trips_through_lock_and_unlock() {
+    let db = file_db("fact-ledger-round-trip");
+    seed_folder(&db, "f-secret", "Secret");
+    seed_note(&db, "m1", "Atlas shipped", None);
+    db.set_note_folder("m1", Some("f-secret")).unwrap();
+    let atlas = db.upsert_entity("Atlas", EntityKind::Project).unwrap();
+    db.add_mention(&atlas, "m1").unwrap();
+
+    // Two assertions about the same predicate, the second superseding the first: the reconcile
+    // CLOSES the old row (`valid_to`) instead of deleting it. That closure is the history.
+    db.apply_fact_ops(&[add_op(
+        &atlas,
+        "status",
+        "in progress",
+        "2026-06-01T00:00:00Z",
+        "m1",
+    )])
+    .unwrap();
+    db.apply_fact_ops(&[add_op(
+        &atlas,
+        "status",
+        "shipped",
+        "2026-07-01T00:00:00Z",
+        "m1",
+    )])
+    .unwrap();
+    // Close the earlier assertion, which is what the reconcile does when a later meeting
+    // contradicts an open fact: invalidate-not-delete, so the row stays with a `valid_to`.
+    let open_id = db
+        .facts_for_entities(std::slice::from_ref(&atlas))
+        .unwrap()
+        .into_iter()
+        .find(|f| f.object == "in progress")
+        .expect("the superseded assertion")
+        .id;
+    db.apply_fact_ops(&[FactOp::Invalidate {
+        id: open_id,
+        valid_to: "2026-07-01T00:00:00Z".to_string(),
+    }])
+    .unwrap();
+
+    let before = db.facts_for_entities(std::slice::from_ref(&atlas)).unwrap();
+    assert!(
+        before.len() >= 2,
+        "expected the superseded row to survive as history, got {before:?}"
+    );
+    assert!(
+        before.iter().any(|f| f.valid_to.is_some()),
+        "the point of the ledger is the CLOSED row — got {before:?}"
+    );
+
+    let ck = [7u8; 32];
+    crate::commands::seal_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck).unwrap();
+
+    // The seal's own purge, unchanged: the rows leave the database.
+    db.purge_chunks_for_meetings(&["m1".to_string()]).unwrap();
+    assert!(
+        db.facts_for_entities(std::slice::from_ref(&atlas))
+            .unwrap()
+            .is_empty(),
+        "the at-rest guarantee is unchanged — a sealed meeting's facts must not be readable"
+    );
+
+    // Unlock: the ledger comes back exactly as it was, closure and all.
+    crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck, false).unwrap();
+    let after = db.facts_for_entities(std::slice::from_ref(&atlas)).unwrap();
+
+    let key = |f: &crate::facts::Fact| {
+        (
+            f.id.clone(),
+            f.subject.clone(),
+            f.predicate.clone(),
+            f.object.clone(),
+            f.valid_from.clone(),
+            f.valid_to.clone(),
+            f.recorded_at.clone(),
+        )
+    };
+    let mut want: Vec<_> = before.iter().map(key).collect();
+    let mut got: Vec<_> = after.iter().map(key).collect();
+    want.sort();
+    got.sort();
+    assert_eq!(
+        got, want,
+        "every fact must return identical, including the valid_to that records when it stopped \
+         being true — re-extraction could never reconstruct that"
+    );
+}
+
+/// A blob sealed for one meeting must not open for another, and a wrong key must not open it at
+/// all. The AAD binds folder AND meeting; without that, a ledger could be swapped between meetings
+/// in the same folder and restore somebody else's facts onto this meeting.
+#[test]
+fn a_sealed_fact_ledger_is_bound_to_its_folder_and_meeting() {
+    let db = file_db("fact-ledger-aad");
+    seed_folder(&db, "f-secret", "Secret");
+    seed_note(&db, "m1", "Atlas", None);
+    seed_note(&db, "m2", "Other", None);
+    db.set_note_folder("m1", Some("f-secret")).unwrap();
+    db.set_note_folder("m2", Some("f-secret")).unwrap();
+    let atlas = db.upsert_entity("Atlas", EntityKind::Project).unwrap();
+    db.add_mention(&atlas, "m1").unwrap();
+    db.apply_fact_ops(&[add_op(
+        &atlas,
+        "status",
+        "shipped",
+        "2026-06-01T00:00:00Z",
+        "m1",
+    )])
+    .unwrap();
+
+    let ck = [7u8; 32];
+    crate::commands::seal_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck).unwrap();
+    let blob = db.fact_ledger_blob("m1").unwrap().expect("sealed");
+
+    // The same ciphertext, filed under a different meeting, must not open.
+    db.seal_fact_ledger("m2", &blob).unwrap();
+    assert!(
+        crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", "m2", &ck, false)
+            .is_err(),
+        "a ledger must not open under another meeting's identity"
+    );
+    // Nor under a different key.
+    assert!(
+        crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", "m1", &[9u8; 32], false)
+            .is_err(),
+        "a ledger must not open under a different content key"
+    );
+}
+
+/// The permanent unlock hands the rows back for good and drops the ciphertext — after the rows are
+/// durably written, never before.
+#[test]
+fn removing_a_lock_restores_the_ledger_and_then_drops_its_ciphertext() {
+    let db = file_db("fact-ledger-permanent");
+    seed_folder(&db, "f-secret", "Secret");
+    seed_note(&db, "m1", "Atlas", None);
+    db.set_note_folder("m1", Some("f-secret")).unwrap();
+    let atlas = db.upsert_entity("Atlas", EntityKind::Project).unwrap();
+    db.add_mention(&atlas, "m1").unwrap();
+    db.apply_fact_ops(&[add_op(
+        &atlas,
+        "status",
+        "shipped",
+        "2026-06-01T00:00:00Z",
+        "m1",
+    )])
+    .unwrap();
+
+    let ck = [7u8; 32];
+    crate::commands::seal_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck).unwrap();
+    db.purge_chunks_for_meetings(&["m1".to_string()]).unwrap();
+
+    crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck, true).unwrap();
+    assert_eq!(
+        db.facts_for_entities(std::slice::from_ref(&atlas))
+            .unwrap()
+            .len(),
+        1,
+        "the rows are back"
+    );
+    assert!(
+        db.fact_ledger_blob("m1").unwrap().is_none(),
+        "and the ciphertext is gone — the rows are the only copy again"
+    );
+}
+
+/// RE-SEALING must not lose what an unlocked session learned. A relock encrypts the CURRENT rows,
+/// so a fact extracted while the folder was open has to end up in the new ciphertext — a stale blob
+/// would silently drop it.
+#[test]
+fn a_relock_seals_the_facts_the_unlocked_session_added() {
+    let db = file_db("fact-ledger-reseal");
+    seed_folder(&db, "f-secret", "Secret");
+    seed_note(&db, "m1", "Atlas", None);
+    db.set_note_folder("m1", Some("f-secret")).unwrap();
+    let atlas = db.upsert_entity("Atlas", EntityKind::Project).unwrap();
+    db.add_mention(&atlas, "m1").unwrap();
+    db.apply_fact_ops(&[add_op(
+        &atlas,
+        "status",
+        "shipped",
+        "2026-06-01T00:00:00Z",
+        "m1",
+    )])
+    .unwrap();
+
+    let ck = [7u8; 32];
+    crate::commands::seal_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck).unwrap();
+    db.purge_chunks_for_meetings(&["m1".to_string()]).unwrap();
+    crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck, false).unwrap();
+
+    // The unlocked session learns one more thing.
+    db.apply_fact_ops(&[add_op(
+        &atlas,
+        "owner",
+        "Ada",
+        "2026-08-01T00:00:00Z",
+        "m1",
+    )])
+    .unwrap();
+
+    // Relock: re-seal, then purge.
+    crate::commands::seal_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck).unwrap();
+    db.purge_chunks_for_meetings(&["m1".to_string()]).unwrap();
+    crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck, false).unwrap();
+
+    let after = db.facts_for_entities(std::slice::from_ref(&atlas)).unwrap();
+    assert!(
+        after.iter().any(|f| f.predicate == "owner"),
+        "the fact the unlocked session added must survive the relock — got {after:?}"
+    );
+    assert!(
+        after.iter().any(|f| f.predicate == "status"),
+        "and so must the one that was already sealed — got {after:?}"
+    );
+}
+
+/// THE WIRING, not just the helpers. The four tests above call `seal_fact_ledger_for_meeting`
+/// directly, so deleting the line that calls it from the real seal would leave every one of them
+/// green — a lock-security review made exactly that point. This one goes through
+/// `seal_folder_extras`, the function `lock_folder`, the move-into-locked path and the startup
+/// repair all share, and it carries the two families the earlier tests never exercised: a USER fact
+/// and a SUPERSESSION. A slip in either of those INSERTs is invisible to a test that only checks
+/// entity facts.
+#[test]
+fn the_real_folder_seal_captures_user_facts_and_supersessions_too() {
+    let db = file_db("fact-ledger-wiring");
+    seed_folder(&db, "f-secret", "Secret");
+    seed_note(&db, "m1", "Atlas", None);
+    seed_note(&db, "m2", "Atlas again", None);
+    db.set_note_folder("m1", Some("f-secret")).unwrap();
+    db.set_note_folder("m2", Some("f-secret")).unwrap();
+    let atlas = db.upsert_entity("Atlas", EntityKind::Project).unwrap();
+    db.add_mention(&atlas, "m1").unwrap();
+    db.apply_fact_ops(&[add_op(
+        &atlas,
+        "status",
+        "shipped",
+        "2026-06-01T00:00:00Z",
+        "m1",
+    )])
+    .unwrap();
+    db.apply_user_fact_ops(&[user_add_op(
+        "prefer",
+        "Polish replies",
+        "2026-06-01T00:00:00Z",
+        "m1",
+    )])
+    .unwrap();
+    // Both anchors sit in the SAME folder, so unlocking it makes the row legitimately restorable.
+    db.record_supersessions(&[supersession_row("s1", "m2", "m1")])
+        .unwrap();
+
+    let ck = [7u8; 32];
+    crate::commands::seal_folder_extras(&db, "f-secret", &ck).unwrap();
+    db.purge_chunks_for_meetings(&["m1".to_string(), "m2".to_string()])
+        .unwrap();
+    assert!(db.user_facts_all().unwrap().is_empty(), "purged on seal");
+    assert!(db.unapplied_supersessions_for("m2").unwrap().is_empty());
+
+    for mid in ["m1", "m2"] {
+        crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", mid, &ck, false).unwrap();
+    }
+    assert_eq!(
+        db.facts_for_entities(std::slice::from_ref(&atlas))
+            .unwrap()
+            .len(),
+        1,
+        "the entity fact came back"
+    );
+    assert_eq!(
+        db.user_facts_all().unwrap().len(),
+        1,
+        "so did the USER fact — a separate table with its own INSERT"
+    );
+    assert_eq!(
+        db.unapplied_supersessions_for("m2").unwrap().len(),
+        1,
+        "and the supersession, whose eleven columns nothing else checks"
+    );
+}
+
+/// A DISCARDED seal must leave no ciphertext behind, or the next lock cannot succeed.
+///
+/// `discard_folder_seal` rolls a folder back to open. It purges every derived family but used not to
+/// touch the sealed ledger, and a re-lock mints a NEW content key — so the seal would find a blob
+/// from the discarded key, fail to authenticate it, and abort AFTER `locked=1` was already durable.
+/// The startup repair then hit the same wall on every launch. Found by a lock-security review; RED
+/// before `sealed_fact_ledgers` joined the discard purge.
+#[test]
+fn a_discarded_seal_leaves_no_ledger_ciphertext_to_break_the_next_lock() {
+    let db = file_db("fact-ledger-discard");
+    seed_folder(&db, "f-secret", "Secret");
+    seed_note(&db, "m1", "Atlas", None);
+    db.set_note_folder("m1", Some("f-secret")).unwrap();
+    let atlas = db.upsert_entity("Atlas", EntityKind::Project).unwrap();
+    db.add_mention(&atlas, "m1").unwrap();
+    db.apply_fact_ops(&[add_op(
+        &atlas,
+        "status",
+        "shipped",
+        "2026-06-01T00:00:00Z",
+        "m1",
+    )])
+    .unwrap();
+
+    let first_ck = [7u8; 32];
+    crate::commands::seal_fact_ledger_for_meeting(&db, "f-secret", "m1", &first_ck).unwrap();
+    assert!(db.fact_ledger_blob("m1").unwrap().is_some());
+
+    db.discard_folder_seal("f-secret").unwrap();
+    assert!(
+        db.fact_ledger_blob("m1").unwrap().is_none(),
+        "a discarded seal must not leave a ciphertext only the abandoned key can open"
+    );
+
+    // The re-lock mints a different key. It must succeed.
+    let second_ck = [9u8; 32];
+    crate::commands::seal_fact_ledger_for_meeting(&db, "f-secret", "m1", &second_ck)
+        .expect("re-locking a discarded folder must not fail on a stale ledger ciphertext");
+}
+
+/// A supersession spans two meetings. Restoring one of them must NOT put the row back while the
+/// OTHER one's folder is still sealed — its old/new values and note pre-images are that meeting's
+/// plaintext, and purge-on-seal exists precisely to keep them out of a live table.
+#[test]
+fn a_cross_folder_supersession_waits_for_its_other_anchor() {
+    let db = file_db("fact-ledger-cross-folder");
+    seed_folder(&db, "f-open", "Open");
+    seed_folder(&db, "f-secret", "Secret");
+    seed_note(&db, "m-open", "Open side", None);
+    seed_note(&db, "m-secret", "Secret side", None);
+    db.set_note_folder("m-open", Some("f-open")).unwrap();
+    db.set_note_folder("m-secret", Some("f-secret")).unwrap();
+    db.record_supersessions(&[supersession_row("s1", "m-open", "m-secret")])
+        .unwrap();
+
+    let ck = [7u8; 32];
+    crate::commands::seal_fact_ledger_for_meeting(&db, "f-open", "m-open", &ck).unwrap();
+
+    // The OTHER anchor is SEALED FOR REAL — its note markdown replaced by ciphertext, not merely
+    // filed in a locked folder. That distinction is the predicate's whole point: during a session
+    // unlock the markdown is back, and the row is legitimately restorable again.
+    db.seal_note("m-secret", "claude_code", &[1u8, 2, 3]).unwrap();
+    db.set_folder_locked("f-secret", true, None).unwrap();
+    let mut sealed = HashSet::new();
+    sealed.insert("f-secret".to_string());
+    db.blank_sealed_notes_in_folders(&sealed).unwrap();
+    assert!(db.unapplied_supersessions_for("m-open").unwrap().is_empty());
+
+    // Unlocking the OPEN side must not resurrect a row carrying the sealed side's content.
+    crate::commands::restore_fact_ledger_for_meeting(&db, "f-open", "m-open", &ck, false).unwrap();
+    assert!(
+        db.unapplied_supersessions_for("m-open").unwrap().is_empty(),
+        "a supersession must wait until BOTH of its meetings are readable"
+    );
+}

--- a/src-tauri/src/storage/db_tests/lock_tests.rs
+++ b/src-tauri/src/storage/db_tests/lock_tests.rs
@@ -2577,7 +2577,7 @@ fn a_sealed_fact_ledger_round_trips_through_lock_and_unlock() {
     );
 
     // Unlock: the ledger comes back exactly as it was, closure and all.
-    crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck, false).unwrap();
+    crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck).unwrap();
     let after = db.facts_for_entities(std::slice::from_ref(&atlas)).unwrap();
 
     let key = |f: &crate::facts::Fact| {
@@ -2631,13 +2631,13 @@ fn a_sealed_fact_ledger_is_bound_to_its_folder_and_meeting() {
     // The same ciphertext, filed under a different meeting, must not open.
     db.seal_fact_ledger("m2", &blob).unwrap();
     assert!(
-        crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", "m2", &ck, false)
+        crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", "m2", &ck)
             .is_err(),
         "a ledger must not open under another meeting's identity"
     );
     // Nor under a different key.
     assert!(
-        crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", "m1", &[9u8; 32], false)
+        crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", "m1", &[9u8; 32])
             .is_err(),
         "a ledger must not open under a different content key"
     );
@@ -2666,7 +2666,7 @@ fn removing_a_lock_restores_the_ledger_and_then_drops_its_ciphertext() {
     crate::commands::seal_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck).unwrap();
     db.purge_chunks_for_meetings(&["m1".to_string()]).unwrap();
 
-    crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck, true).unwrap();
+    crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck).unwrap();
     assert_eq!(
         db.facts_for_entities(std::slice::from_ref(&atlas))
             .unwrap()
@@ -2675,8 +2675,18 @@ fn removing_a_lock_restores_the_ledger_and_then_drops_its_ciphertext() {
         "the rows are back"
     );
     assert!(
+        db.fact_ledger_blob("m1").unwrap().is_some(),
+        "the restore itself must NOT drop the ciphertext — an interruption here has to leave \
+         something recoverable"
+    );
+
+    // The ciphertext retires in the ATOMIC folder-open commit, with every other blob. Driving that
+    // real function is the point: an earlier version of this test passed a `clear_blob` flag no
+    // production caller ever set, so the actual retire was pinned by nothing.
+    db.commit_folder_permanent_unlock("f-secret").unwrap();
+    assert!(
         db.fact_ledger_blob("m1").unwrap().is_none(),
-        "and the ciphertext is gone — the rows are the only copy again"
+        "and after the commit the rows are the only copy again"
     );
 }
 
@@ -2703,7 +2713,7 @@ fn a_relock_seals_the_facts_the_unlocked_session_added() {
     let ck = [7u8; 32];
     crate::commands::seal_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck).unwrap();
     db.purge_chunks_for_meetings(&["m1".to_string()]).unwrap();
-    crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck, false).unwrap();
+    crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck).unwrap();
 
     // The unlocked session learns one more thing.
     db.apply_fact_ops(&[add_op(
@@ -2718,7 +2728,7 @@ fn a_relock_seals_the_facts_the_unlocked_session_added() {
     // Relock: re-seal, then purge.
     crate::commands::seal_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck).unwrap();
     db.purge_chunks_for_meetings(&["m1".to_string()]).unwrap();
-    crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck, false).unwrap();
+    crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck).unwrap();
 
     let after = db.facts_for_entities(std::slice::from_ref(&atlas)).unwrap();
     assert!(
@@ -2775,7 +2785,7 @@ fn the_real_folder_seal_captures_user_facts_and_supersessions_too() {
     assert!(db.unapplied_supersessions_for("m2").unwrap().is_empty());
 
     for mid in ["m1", "m2"] {
-        crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", mid, &ck, false).unwrap();
+        crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", mid, &ck).unwrap();
     }
     assert_eq!(
         db.facts_for_entities(std::slice::from_ref(&atlas))
@@ -2865,9 +2875,147 @@ fn a_cross_folder_supersession_waits_for_its_other_anchor() {
     assert!(db.unapplied_supersessions_for("m-open").unwrap().is_empty());
 
     // Unlocking the OPEN side must not resurrect a row carrying the sealed side's content.
-    crate::commands::restore_fact_ledger_for_meeting(&db, "f-open", "m-open", &ck, false).unwrap();
+    crate::commands::restore_fact_ledger_for_meeting(&db, "f-open", "m-open", &ck).unwrap();
     assert!(
         db.unapplied_supersessions_for("m-open").unwrap().is_empty(),
         "a supersession must wait until BOTH of its meetings are readable"
+    );
+}
+
+/// A RE-SEAL MUST NEVER SHRINK A CIPHERTEXT.
+///
+/// This is the loss an adversarial review reproduced, and it was caused by the cross-folder skip
+/// directly above. A supersession spans meetings in two folders. Lock both; the rows are purged and
+/// only A's ciphertext still holds the row. Unlock A alone: the restore correctly SKIPS the row,
+/// because B is still sealed and the row carries B's plaintext. Relock A: the re-seal reads the live
+/// rows, which no longer contain it, and overwrites the one copy that did.
+///
+/// Nothing surfaced it. The row is not leaked, not logged, not counted anywhere — it is simply gone
+/// from both ciphertexts, and the next time both folders are open it does not come back.
+#[test]
+fn a_re_seal_carries_forward_what_the_restore_had_to_skip() {
+    let db = file_db("fact-ledger-no-shrink");
+    seed_folder(&db, "f-a", "A");
+    seed_folder(&db, "f-b", "B");
+    seed_note(&db, "m-a", "Side A", None);
+    seed_note(&db, "m-b", "Side B", None);
+    db.set_note_folder("m-a", Some("f-a")).unwrap();
+    db.set_note_folder("m-b", Some("f-b")).unwrap();
+    // A fact of its own, so the re-seal does not take the empty-ledger early return (which keeps
+    // the old blob by accident and would hide the hazard).
+    let atlas = db.upsert_entity("Atlas", EntityKind::Project).unwrap();
+    db.add_mention(&atlas, "m-a").unwrap();
+    db.apply_fact_ops(&[add_op(
+        &atlas,
+        "status",
+        "shipped",
+        "2026-06-01T00:00:00Z",
+        "m-a",
+    )])
+    .unwrap();
+    db.record_supersessions(&[supersession_row("s1", "m-a", "m-b")])
+        .unwrap();
+
+    let ck_a = [7u8; 32];
+    crate::commands::seal_fact_ledger_for_meeting(&db, "f-a", "m-a", &ck_a).unwrap();
+    db.purge_chunks_for_meetings(&["m-a".to_string()]).unwrap();
+
+    // B seals for real too, so it reads as sealed-at-rest.
+    db.seal_note("m-b", "claude_code", &[1u8, 2, 3]).unwrap();
+    db.set_folder_locked("f-b", true, None).unwrap();
+
+    // Unlock A alone: the row is skipped, correctly — B's content must not come back yet.
+    crate::commands::restore_fact_ledger_for_meeting(&db, "f-a", "m-a", &ck_a).unwrap();
+    assert!(
+        db.unapplied_supersessions_for("m-a").unwrap().is_empty(),
+        "the skip itself is right — B is still sealed"
+    );
+
+    // Relock A. The re-seal reads live rows that no longer hold the supersession.
+    crate::commands::seal_fact_ledger_for_meeting(&db, "f-a", "m-a", &ck_a).unwrap();
+    db.purge_chunks_for_meetings(&["m-a".to_string()]).unwrap();
+
+    // Now B opens. The row must still be recoverable — it was never anyone's to delete.
+    db.restore_note_markdown("m-b", "claude_code", "Side B")
+        .unwrap();
+    db.set_folder_locked("f-b", false, None).unwrap();
+    crate::commands::restore_fact_ledger_for_meeting(&db, "f-a", "m-a", &ck_a).unwrap();
+    assert_eq!(
+        db.unapplied_supersessions_for("m-a").unwrap().len(),
+        1,
+        "a re-seal must carry forward what the restore skipped — otherwise unlocking one folder and \
+         locking it again silently destroys a row spanning two"
+    );
+    assert_eq!(
+        db.facts_for_entities(std::slice::from_ref(&atlas))
+            .unwrap()
+            .len(),
+        1,
+        "and the meeting's own fact is still there"
+    );
+}
+
+/// The ciphertext is bound to its FOLDER as well as its meeting. Per-folder keys already make a
+/// cross-folder swap fail, so this is defence in depth — but the earlier binding test could not
+/// tell the two apart, and a mutation that dropped `folder_id` from the AAD survived it.
+#[test]
+fn a_sealed_fact_ledger_does_not_open_under_another_folders_identity() {
+    let db = file_db("fact-ledger-folder-aad");
+    seed_folder(&db, "f-a", "A");
+    seed_note(&db, "m1", "Atlas", None);
+    db.set_note_folder("m1", Some("f-a")).unwrap();
+    let atlas = db.upsert_entity("Atlas", EntityKind::Project).unwrap();
+    db.add_mention(&atlas, "m1").unwrap();
+    db.apply_fact_ops(&[add_op(
+        &atlas,
+        "status",
+        "shipped",
+        "2026-06-01T00:00:00Z",
+        "m1",
+    )])
+    .unwrap();
+
+    let ck = [7u8; 32];
+    crate::commands::seal_fact_ledger_for_meeting(&db, "f-a", "m1", &ck).unwrap();
+    assert!(
+        crate::commands::restore_fact_ledger_for_meeting(&db, "f-b", "m1", &ck).is_err(),
+        "the same key and meeting under a different folder must not open the ledger"
+    );
+}
+
+/// `facts.importance` rides along. It is not on `crate::facts::Fact`, so it had to be carried
+/// separately — and a mutation dropping it passed every other test.
+#[test]
+fn the_sealed_ledger_carries_fact_importance() {
+    let db = file_db("fact-ledger-importance");
+    seed_folder(&db, "f-secret", "Secret");
+    seed_note(&db, "m1", "Atlas", None);
+    db.set_note_folder("m1", Some("f-secret")).unwrap();
+    let atlas = db.upsert_entity("Atlas", EntityKind::Project).unwrap();
+    db.add_mention(&atlas, "m1").unwrap();
+    db.apply_fact_ops(&[add_op(
+        &atlas,
+        "status",
+        "shipped",
+        "2026-06-01T00:00:00Z",
+        "m1",
+    )])
+    .unwrap();
+    let fact_id = db
+        .facts_for_entities(std::slice::from_ref(&atlas))
+        .unwrap()
+        .remove(0)
+        .id;
+    db.set_fact_importance(&fact_id, 9.0).unwrap();
+
+    let ck = [7u8; 32];
+    crate::commands::seal_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck).unwrap();
+    db.purge_chunks_for_meetings(&["m1".to_string()]).unwrap();
+    crate::commands::restore_fact_ledger_for_meeting(&db, "f-secret", "m1", &ck).unwrap();
+
+    assert_eq!(
+        db.fact_importance_map().unwrap().get(&fact_id).copied(),
+        Some(9.0),
+        "importance must survive — otherwise every restored fact is silently re-assessed"
     );
 }

--- a/src-tauri/src/storage/facts_store.rs
+++ b/src-tauri/src/storage/facts_store.rs
@@ -568,9 +568,6 @@ impl Db {
         Ok(out)
     }
 
-    /// The persisted `facts.importance` assessments as `(fact_id, importance)` — the reflection
-    /// job's "already assessed" set for ENTITY facts (only never-assessed facts hit the reasoner,
-    /// so steady-state passes are LLM-free). Content-free read (ids + floats).
     // ── The sealed fact ledger ───────────────────────────────────────────────────────────────────
     //
     // A seal DELETES a meeting's facts, user facts and supersessions: their subject/predicate/object
@@ -861,6 +858,9 @@ impl Db {
         Ok(())
     }
 
+    /// The persisted `facts.importance` assessments as `(fact_id, importance)` — the reflection
+    /// job's "already assessed" set for ENTITY facts (only never-assessed facts hit the reasoner,
+    /// so steady-state passes are LLM-free). Content-free read (ids + floats).
     pub fn fact_importance_map(&self) -> Result<std::collections::HashMap<String, f64>> {
         let conn = self.lock();
         let mut stmt = conn

--- a/src-tauri/src/storage/facts_store.rs
+++ b/src-tauri/src/storage/facts_store.rs
@@ -571,6 +571,296 @@ impl Db {
     /// The persisted `facts.importance` assessments as `(fact_id, importance)` — the reflection
     /// job's "already assessed" set for ENTITY facts (only never-assessed facts hit the reasoner,
     /// so steady-state passes are LLM-free). Content-free read (ids + floats).
+    // ── The sealed fact ledger ───────────────────────────────────────────────────────────────────
+    //
+    // A seal DELETES a meeting's facts, user facts and supersessions: their subject/predicate/object
+    // are plaintext derived from the meeting. That part is right and stays. What was missing is the
+    // other half of the contract every other piece of user content already has — the ciphertext that
+    // lets an unlock put it back. Re-extraction is not a substitute: it needs a provider call, and it
+    // cannot reconstruct `valid_from`/`valid_to` or the supersession chain, because nothing in the
+    // current note text records when a fact STOPPED being true.
+
+    /// Every ledger row anchored on `meeting_id`, in a form that round-trips through a seal.
+    /// Reads the raw tables directly — the caller is the seal, which runs while the folder is still
+    /// readable and is the one place that must see rows a gated reader would hide.
+    pub fn raw_fact_ledger_for_meeting(&self, meeting_id: &str) -> Result<crate::storage::SealedFactLedger> {
+        let conn = self.lock();
+        let mut facts = Vec::new();
+        {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, entity_id, subject, predicate, object, valid_from, valid_to,
+                            recorded_at, meeting_id, confidence
+                       FROM facts WHERE meeting_id = ?1 ORDER BY id",
+                )
+                .map_err(map_err)?;
+            let rows = stmt
+                .query_map(rusqlite::params![meeting_id], |r| {
+                    Ok(crate::facts::Fact {
+                        id: r.get(0)?,
+                        entity_id: r.get(1)?,
+                        subject: r.get(2)?,
+                        predicate: r.get(3)?,
+                        object: r.get(4)?,
+                        valid_from: r.get(5)?,
+                        valid_to: r.get(6)?,
+                        recorded_at: r.get(7)?,
+                        meeting_id: r.get(8)?,
+                        confidence: r.get(9)?,
+                    })
+                })
+                .map_err(map_err)?;
+            for row in rows {
+                facts.push(row.map_err(map_err)?);
+            }
+        }
+        let mut user_facts = Vec::new();
+        {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, subject, predicate, object, valid_from, valid_to, recorded_at,
+                            meeting_id, confidence
+                       FROM user_facts WHERE meeting_id = ?1 ORDER BY id",
+                )
+                .map_err(map_err)?;
+            let rows = stmt
+                .query_map(rusqlite::params![meeting_id], |r| {
+                    Ok(crate::facts::Fact {
+                        id: r.get(0)?,
+                        // A user fact has no entity; the empty id keeps ONE serialized shape for
+                        // both tables and is never written back into `facts`.
+                        entity_id: String::new(),
+                        subject: r.get(1)?,
+                        predicate: r.get(2)?,
+                        object: r.get(3)?,
+                        valid_from: r.get(4)?,
+                        valid_to: r.get(5)?,
+                        recorded_at: r.get(6)?,
+                        meeting_id: r.get(7)?,
+                        confidence: r.get(8)?,
+                    })
+                })
+                .map_err(map_err)?;
+            for row in rows {
+                user_facts.push(row.map_err(map_err)?);
+            }
+        }
+        let mut supersessions = Vec::new();
+        {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, superseding_meeting_id, source_meeting_id, entity, predicate,
+                            old_value, new_value, created_at, applied_at, source_pre_image,
+                            superseding_pre_image
+                       FROM supersessions
+                      WHERE superseding_meeting_id = ?1 OR source_meeting_id = ?1
+                      ORDER BY id",
+                )
+                .map_err(map_err)?;
+            let rows = stmt
+                .query_map(rusqlite::params![meeting_id], |r| {
+                    Ok(crate::storage::SealedSupersession {
+                        id: r.get(0)?,
+                        superseding_meeting_id: r.get(1)?,
+                        source_meeting_id: r.get(2)?,
+                        entity: r.get(3)?,
+                        predicate: r.get(4)?,
+                        old_value: r.get(5)?,
+                        new_value: r.get(6)?,
+                        created_at: r.get(7)?,
+                        applied_at: r.get(8)?,
+                        source_pre_image: r.get(9)?,
+                        superseding_pre_image: r.get(10)?,
+                    })
+                })
+                .map_err(map_err)?;
+            for row in rows {
+                supersessions.push(row.map_err(map_err)?);
+            }
+        }
+        let mut fact_importance = Vec::new();
+        {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT id, importance FROM facts
+                      WHERE meeting_id = ?1 AND importance IS NOT NULL ORDER BY id",
+                )
+                .map_err(map_err)?;
+            let rows = stmt
+                .query_map(rusqlite::params![meeting_id], |r| {
+                    Ok((r.get::<_, String>(0)?, r.get::<_, f64>(1)?))
+                })
+                .map_err(map_err)?;
+            for row in rows {
+                fact_importance.push(row.map_err(map_err)?);
+            }
+        }
+        Ok(crate::storage::SealedFactLedger {
+            facts,
+            fact_importance,
+            user_facts,
+            supersessions,
+        })
+    }
+
+    /// Store the ciphertext of a meeting's ledger. The caller has already proven it decrypts back
+    /// byte-identical; this only records it, and the rows are deleted by the seal's own purge.
+    pub fn seal_fact_ledger(&self, meeting_id: &str, data_blob: &[u8]) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "INSERT INTO sealed_fact_ledgers (meeting_id, data_blob, sealed_at)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(meeting_id) DO UPDATE SET
+               data_blob = excluded.data_blob, sealed_at = excluded.sealed_at",
+            rusqlite::params![
+                meeting_id,
+                data_blob,
+                chrono::Utc::now().to_rfc3339()
+            ],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
+    /// The stored ciphertext for a meeting's ledger, if it has ever been sealed.
+    pub fn fact_ledger_blob(&self, meeting_id: &str) -> Result<Option<Vec<u8>>> {
+        let conn = self.lock();
+        conn.query_row(
+            "SELECT data_blob FROM sealed_fact_ledgers WHERE meeting_id = ?1",
+            rusqlite::params![meeting_id],
+            |r| r.get::<_, Vec<u8>>(0),
+        )
+        .optional()
+        .map_err(map_err)
+    }
+
+    /// Put a decrypted ledger back. One transaction, and `INSERT OR IGNORE` throughout: a session
+    /// unlock may run against rows that a concurrent re-extraction already re-created, and a restore
+    /// must never overwrite a fresher row with the snapshot taken before the seal.
+    pub fn restore_fact_ledger(
+        &self,
+        meeting_id: &str,
+        ledger: &crate::storage::SealedFactLedger,
+    ) -> Result<()> {
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        for f in &ledger.facts {
+            // The entity FK is `ON DELETE CASCADE`, and SQLite's ON CONFLICT clause does not apply
+            // to foreign keys — a fact whose entity is gone would fail the WHOLE transaction and
+            // make the unlock impossible, every time. Skipping it keeps the unlock working; the
+            // fact is unreachable anyway without its entity.
+            tx.execute(
+                "INSERT OR IGNORE INTO facts
+                   (id, entity_id, subject, predicate, object, valid_from, valid_to, recorded_at,
+                    meeting_id, confidence)
+                 SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10
+                  WHERE EXISTS (SELECT 1 FROM entities WHERE id = ?2)",
+                rusqlite::params![
+                    f.id,
+                    f.entity_id,
+                    f.subject,
+                    f.predicate,
+                    f.object,
+                    f.valid_from,
+                    f.valid_to,
+                    f.recorded_at,
+                    f.meeting_id,
+                    f.confidence
+                ],
+            )
+            .map_err(map_err)?;
+        }
+        for f in &ledger.user_facts {
+            tx.execute(
+                "INSERT OR IGNORE INTO user_facts
+                   (id, subject, predicate, object, valid_from, valid_to, recorded_at, meeting_id,
+                    confidence)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                rusqlite::params![
+                    f.id,
+                    f.subject,
+                    f.predicate,
+                    f.object,
+                    f.valid_from,
+                    f.valid_to,
+                    f.recorded_at,
+                    f.meeting_id,
+                    f.confidence
+                ],
+            )
+            .map_err(map_err)?;
+        }
+        for (fact_id, importance) in &ledger.fact_importance {
+            tx.execute(
+                "UPDATE facts SET importance = ?2 WHERE id = ?1",
+                rusqlite::params![fact_id, importance],
+            )
+            .map_err(map_err)?;
+        }
+        for s in &ledger.supersessions {
+            // A supersession spans TWO meetings, and its old/new values plus its note pre-images are
+            // plaintext from both. Restoring it because THIS meeting was unlocked would put the
+            // other one's content back into a live table while its folder is still sealed — the
+            // exact thing purge-on-seal exists to prevent. Fail closed: the row waits until the
+            // other anchor is readable too, and the ciphertext still holds it.
+            let other = if s.superseding_meeting_id == meeting_id {
+                &s.source_meeting_id
+            } else {
+                &s.superseding_meeting_id
+            };
+            if other != meeting_id {
+                // Gone, not merely sealed: `supersessions` carries no foreign key, so a row whose
+                // other anchor was deleted while this folder sat locked would come back pointing at
+                // a meeting that no longer exists.
+                let other_exists: bool = tx
+                    .query_row(
+                        "SELECT EXISTS(SELECT 1 FROM meetings WHERE id = ?1)",
+                        rusqlite::params![other],
+                        |r| Ok(r.get::<_, i64>(0)? != 0),
+                    )
+                    .map_err(map_err)?;
+                if !other_exists
+                    || crate::storage::links::meeting_sealed_at_rest_tx(&tx, other)?
+                {
+                    continue;
+                }
+            }
+            tx.execute(
+                "INSERT OR IGNORE INTO supersessions
+                   (id, superseding_meeting_id, source_meeting_id, entity, predicate, old_value,
+                    new_value, created_at, applied_at, source_pre_image, superseding_pre_image)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                rusqlite::params![
+                    s.id,
+                    s.superseding_meeting_id,
+                    s.source_meeting_id,
+                    s.entity,
+                    s.predicate,
+                    s.old_value,
+                    s.new_value,
+                    s.created_at,
+                    s.applied_at,
+                    s.source_pre_image,
+                    s.superseding_pre_image
+                ],
+            )
+            .map_err(map_err)?;
+        }
+        tx.commit().map_err(map_err)?;
+        Ok(())
+    }
+
+    /// Drop the stored ciphertext (permanent remove-lock: the plaintext rows are back for good).
+    pub fn clear_fact_ledger_blob(&self, meeting_id: &str) -> Result<()> {
+        let conn = self.lock();
+        conn.execute(
+            "DELETE FROM sealed_fact_ledgers WHERE meeting_id = ?1",
+            rusqlite::params![meeting_id],
+        )
+        .map_err(map_err)?;
+        Ok(())
+    }
+
     pub fn fact_importance_map(&self) -> Result<std::collections::HashMap<String, f64>> {
         let conn = self.lock();
         let mut stmt = conn

--- a/src-tauri/src/storage/links.rs
+++ b/src-tauri/src/storage/links.rs
@@ -106,7 +106,10 @@ fn document_seal_aad(folder_id: &str, document_id: &str) -> Vec<u8> {
 /// rest behind the lock. Returns `true` ⇒ the endpoint is sealed-at-rest and the caller must NOT
 /// write an edge touching it. UNSEAL/session-unlock un-blanks `markdown` before re-deriving, so this
 /// reads `false` there and the re-derive proceeds — the same contract the chunk indexers carry.
-fn meeting_sealed_at_rest_tx(tx: &rusqlite::Transaction<'_>, meeting_id: &str) -> Result<bool> {
+pub(crate) fn meeting_sealed_at_rest_tx(
+    tx: &rusqlite::Transaction<'_>,
+    meeting_id: &str,
+) -> Result<bool> {
     tx.query_row(
         "SELECT EXISTS(
            SELECT 1 FROM meetings m

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -2017,6 +2017,58 @@ impl SealedFactLedger {
     pub fn is_empty(&self) -> bool {
         self.facts.is_empty() && self.user_facts.is_empty() && self.supersessions.is_empty()
     }
+
+    /// Carry forward everything `prev` holds that `self` does not, keyed by row id.
+    ///
+    /// A re-seal reads the LIVE rows, and some rows are deliberately absent from them: a restore
+    /// skips a supersession whose other anchor is still sealed. Sealing the live rows alone would
+    /// therefore replace the ciphertext with a strict subset of itself and lose those rows for
+    /// good. `self` always wins on a shared id — the live row is the current truth — and `prev`
+    /// only fills the gaps.
+    pub fn merge_missing_from(&mut self, prev: Self) {
+        let have_facts: std::collections::HashSet<&str> =
+            self.facts.iter().map(|f| f.id.as_str()).collect();
+        let carried: Vec<_> = prev
+            .facts
+            .iter()
+            .filter(|f| !have_facts.contains(f.id.as_str()))
+            .cloned()
+            .collect();
+        self.facts.extend(carried);
+
+        let have_user: std::collections::HashSet<&str> =
+            self.user_facts.iter().map(|f| f.id.as_str()).collect();
+        let carried: Vec<_> = prev
+            .user_facts
+            .iter()
+            .filter(|f| !have_user.contains(f.id.as_str()))
+            .cloned()
+            .collect();
+        self.user_facts.extend(carried);
+
+        let have_sup: std::collections::HashSet<&str> =
+            self.supersessions.iter().map(|s| s.id.as_str()).collect();
+        let carried: Vec<_> = prev
+            .supersessions
+            .iter()
+            .filter(|s| !have_sup.contains(s.id.as_str()))
+            .cloned()
+            .collect();
+        self.supersessions.extend(carried);
+
+        let have_importance: std::collections::HashSet<&str> = self
+            .fact_importance
+            .iter()
+            .map(|(id, _)| id.as_str())
+            .collect();
+        let carried: Vec<_> = prev
+            .fact_importance
+            .iter()
+            .filter(|(id, _)| !have_importance.contains(id.as_str()))
+            .cloned()
+            .collect();
+        self.fact_importance.extend(carried);
+    }
 }
 
 /// M6 Shared Brain — one row of the outbound org-share state machine (`org_shares`). Anchors on a

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -1974,6 +1974,51 @@ pub struct OrgMemberKey {
     pub updated_at: String,
 }
 
+/// One `supersessions` row, in the shape the sealed ledger round-trips.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct SealedSupersession {
+    pub id: String,
+    pub superseding_meeting_id: String,
+    pub source_meeting_id: String,
+    pub entity: String,
+    pub predicate: String,
+    pub old_value: String,
+    pub new_value: String,
+    pub created_at: String,
+    pub applied_at: Option<String>,
+    pub source_pre_image: Option<Vec<u8>>,
+    pub superseding_pre_image: Option<Vec<u8>>,
+}
+
+/// One meeting's whole fact ledger — what a seal encrypts and an unlock puts back.
+///
+/// Serialized as JSON and sealed under the folder content key, exactly like the note markdown and
+/// the timeline. The rows themselves still leave the database on seal, so the at-rest guarantee is
+/// unchanged; what changes is that the seal is now reversible, as every other piece of user content
+/// in a locked folder already was.
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct SealedFactLedger {
+    pub facts: Vec<crate::facts::Fact>,
+    /// `facts.importance` per fact id. It lives on the ROW but not on `crate::facts::Fact`, and
+    /// leaving it out would have made "restored identical" quietly false for the one column the
+    /// reflection pass reads to decide what is worth revisiting — it would silently re-assess every
+    /// restored fact through the reasoner.
+    #[serde(default)]
+    pub fact_importance: Vec<(String, f64)>,
+    /// User-scoped facts live in their own table with no entity; `Fact::entity_id` is empty for
+    /// these and is never written back into `facts`.
+    pub user_facts: Vec<crate::facts::Fact>,
+    pub supersessions: Vec<SealedSupersession>,
+}
+
+impl SealedFactLedger {
+    /// Nothing to seal — used to skip a meeting that never had a ledger rather than storing an
+    /// empty ciphertext for it.
+    pub fn is_empty(&self) -> bool {
+        self.facts.is_empty() && self.user_facts.is_empty() && self.supersessions.is_empty()
+    }
+}
+
 /// M6 Shared Brain — one row of the outbound org-share state machine (`org_shares`). Anchors on a
 /// local `meeting_id` XOR `document_id`; carries the item kind, the content-hash dedup key, the
 /// server `item_id` once published, and the current `state`. NO note title/body/OCK.

--- a/src-tauri/src/storage/seal_store.rs
+++ b/src-tauri/src/storage/seal_store.rs
@@ -65,6 +65,17 @@ impl Db {
             rusqlite::params![folder_id],
         )
         .map_err(map_err)?;
+        // The sealed fact ledger retires in THIS transaction, with every other ciphertext. Dropping
+        // it earlier (inside the restore) would open a window where the folder still reads
+        // `locked=1`, the rows are back, and the only ciphertext is gone — the state the atomic
+        // commit exists to make unobservable.
+        tx.execute(
+            &format!(
+                "DELETE FROM sealed_fact_ledgers WHERE meeting_id IN ({FOLDER_MEETINGS})"
+            ),
+            rusqlite::params![folder_id],
+        )
+        .map_err(map_err)?;
         tx.execute(
             &format!(
                 "UPDATE meetings SET manual_notes_blob = NULL WHERE id IN ({FOLDER_MEETINGS})"
@@ -314,6 +325,13 @@ impl Db {
             // row at discard time only ever digests never-sealed plaintext, but the "purge every
             // derived table" contract must not silently exclude one table).
             "live_bullets",
+            // The SEALED FACT LEDGER. A discard returns the folder to OPEN, so its ciphertext is
+            // both pointless and ACTIVELY DANGEROUS to keep: a later re-lock mints a NEW content
+            // key, and the seal authenticates any blob it finds. A blob from the discarded key
+            // cannot open under the new one, so the re-lock would fail AFTER `locked=1` is already
+            // durable — and the startup repair would hit the same wall on every launch afterwards.
+            // Purging it here is what keeps discard the clean rollback it claims to be.
+            "sealed_fact_ledgers",
         ] {
             tx.execute(
                 &format!("DELETE FROM {table} WHERE meeting_id IN ({FOLDER_MEETINGS})"),


### PR DESCRIPTION
Sealing a folder **deletes** its meetings' facts, user facts and supersessions. That half is right and unchanged — `subject`/`predicate`/`object` are plaintext derived from the meeting, so leaving them readable at rest would defeat the lock. What was missing is the other half that every piece of user content in a locked folder already has: the ciphertext that lets an unlock put it back.

Re-extraction is not a recovery. It costs a provider call, and it cannot reconstruct the bitemporal history — `valid_to` and the supersession chain record *when* a fact stopped being true, and nothing in the current note text says that. Knowledge diff, dossiers and the entity timeline are built on exactly that history.

So the ledger is now sealed-and-restored like the note markdown: one ciphertext per meeting, written only after it has been decrypted back and compared byte-identical, AAD-bound to its folder **and** meeting so it cannot be swapped, re-inserted on unlock. The rows still leave the database on seal, so the at-rest guarantee is exactly what it was.

## The ordering was the trap

On `lock_folder` and move-into-locked the seal already ran before the purge. On **relock** the purge runs *first* — so sealing afterwards would have encrypted nothing and destroyed whatever the unlocked session had learned. Both relock paths now re-seal before the purge, using the key their preflight already verified.

Every production purge path was enumerated rather than assumed: `lock_folder`, move-into-locked, the two relock sites, the startup interrupted-lock repair (covered via `seal_folder_extras`), and `delete_meeting` — the last correctly permanent, since the meeting is gone.

## What the review caught

A lock-security review on a different model returned **FAIL**, with two failures of the very artifact this change exists to preserve. Both fixed here.

**The app could not be started.** `discard_folder_seal` purges every derived family but did not know about the new ciphertext. A discard returns the folder to open; the next lock mints a *new* content key, and the seal authenticates any blob it finds — so the re-lock failed **after** `locked=1` was already durable, and the startup repair hit the same wall on every launch afterwards. `sealed_fact_ledgers` now joins the discard purge, and a blob that will not open when there are no live rows to lose is dropped rather than raised: it cannot be the only copy of anything, and aborting a lock over it is strictly worse than losing it.

**Silent loss on move-into-locked.** That path sealed and purged the ledger and never restored it for the session, so the meeting sat factless behind an open padlock — and the next relock overwrote the only copy with whatever had been re-extracted. The restore moved into `unseal_meeting_extras`, so every caller gets it rather than the one I remembered.

Also from that review: a cross-folder supersession no longer returns while its other anchor is still sealed (its values and note pre-images are that meeting's plaintext); the ciphertext retires *inside* `commit_folder_permanent_unlock` rather than before it, so no crash point observes locked + rows-back + no blob; `facts.importance` is carried, because "restored identical" was quietly false for the one column the reflection pass reads; a missing entity skips its fact instead of failing the whole unlock transaction; and a supersession whose other anchor was deleted is not resurrected.

## The tests were the sharpest finding

The first four oracles called the seal helpers directly, so **deleting any line that wires them in left all four green**. Three more go through `seal_folder_extras` — the function `lock_folder`, move-into-locked and the startup repair all share — and cover the user-fact and supersession families the others never touched. Verified by mutation: removing the wiring call fails the new test and nothing else.

Eight oracles in total: round-trip with the closed row intact, AAD binding (a blob opens under neither another meeting nor another key), permanent unlock, relock keeping what the session learned, the real folder seal across all three families, the discard→re-lock path, and the cross-folder supersession gate.

## Verification

- `cargo nextest run` (the runner CI uses): **3593 passed, 0 failed**, 18 skipped.
- RED-before-GREEN proved twice by mutation: stubbing the seal fails all four original oracles; removing the wiring call fails only the wiring test.
- Migration is additive (`CREATE TABLE IF NOT EXISTS` with `ON DELETE CASCADE`); no `DROP`, no rewrite of user rows.
- Rust-only diff, so `ng lint`/`ng build` would prove nothing here; CI runs them regardless.

A second, adversarial review is still running mutation experiments against this branch. Nothing merges before its verdict.
