### PR TITLE
fix(ui): offer "Transcribe again" for a failed recording

### DIFF
--- a/e2e/detail/retry-transcription-list.spec.ts
+++ b/e2e/detail/retry-transcription-list.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * The same recovery, reachable without opening the broken meeting first.
+ *
+ * Somebody scanning the list for the recording that failed should not have to open it to find out
+ * that it can be run again. The row's ⋯ menu carries the offer under the same two conditions the
+ * backend refuses on: the status is still Error, and there is audio to work from.
+ *
+ * As in the meeting-view spec, the FIRST test is the control: the two absence assertions below
+ * would pass against a build with no menu item at all.
+ */
+
+const ROW = `{
+  id: "m-failed",
+  startedAt: "2026-09-01T09:00:00Z",
+  endedAt: "2026-09-01T09:42:00Z",
+  title: "Planning sync",
+  durationS: 2520,
+  audioPath: "/Users/demo/audio/m-failed.wav",
+  status: "ERROR",
+  folderId: null,
+}`;
+
+test("a failed row offers the retry in its actions menu, and the list re-reads after it runs", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    list_meetings: new Function(
+      "args",
+      `globalThis.__listReads = (globalThis.__listReads || 0) + 1;
+       return [${ROW}];`,
+    ) as (args: unknown) => unknown,
+    retry_transcription: new Function(
+      "args",
+      `globalThis.__retried = globalThis.__retried || [];
+       globalThis.__retried.push(args.meetingId);
+       return { meetingId: args.meetingId, notePath: null };`,
+    ) as (args: unknown) => unknown,
+  });
+
+  await page.goto("/library");
+  await expect(page.getByText("Planning sync")).toBeVisible({ timeout: 10_000 });
+
+  await page.locator("li.row-item").first().hover();
+  await page.getByRole("button", { name: "Meeting actions" }).first().click();
+  const retry = page.getByRole("menuitem", { name: "Transcribe again" });
+  await expect(retry).toBeVisible();
+
+  const readsBefore = await page.evaluate(
+    () => (globalThis as unknown as { __listReads?: number }).__listReads ?? 0,
+  );
+  await retry.click();
+
+  // The id sent must be the meeting's own, not the `meeting:`-namespaced row key the list tracks by.
+  await expect
+    .poll(() =>
+      page.evaluate(() => (globalThis as unknown as { __retried?: string[] }).__retried ?? []),
+    )
+    .toEqual(["m-failed"]);
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => (globalThis as unknown as { __listReads?: number }).__listReads ?? 0),
+    )
+    .toBeGreaterThan(readsBefore);
+});
+
+test("a row with no audio left offers nothing to run again", async ({ page }) => {
+  await mockTauri(page, {
+    list_meetings: new Function(
+      "args",
+      `const r = ${ROW};
+       r.audioPath = null;
+       return [r];`,
+    ) as (args: unknown) => unknown,
+  });
+
+  await page.goto("/library");
+  await expect(page.getByText("Planning sync")).toBeVisible({ timeout: 10_000 });
+  await page.locator("li.row-item").first().hover();
+  await page.getByRole("button", { name: "Meeting actions" }).first().click();
+  await expect(page.getByRole("menuitem", { name: "Move to folder…" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "Transcribe again" })).toHaveCount(0);
+});
+
+test("a healthy row offers nothing to run again", async ({ page }) => {
+  await mockTauri(page, {
+    list_meetings: new Function(
+      "args",
+      `const r = ${ROW};
+       r.status = "SUMMARIZED";
+       return [r];`,
+    ) as (args: unknown) => unknown,
+  });
+
+  await page.goto("/library");
+  await expect(page.getByText("Planning sync")).toBeVisible({ timeout: 10_000 });
+  await page.locator("li.row-item").first().hover();
+  await page.getByRole("button", { name: "Meeting actions" }).first().click();
+  await expect(page.getByRole("menuitem", { name: "Move to folder…" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "Transcribe again" })).toHaveCount(0);
+});

--- a/e2e/detail/retry-transcription.spec.ts
+++ b/e2e/detail/retry-transcription.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * A recording whose transcription failed has to be recoverable from the app.
+ *
+ * The backend command existed all along, and both the ASR watchdog and the pipeline's terminal
+ * guard tell the user in as many words to "use Retry transcription" — but nothing in the frontend
+ * ever called it. So the one piece of advice on screen pointed at a control that did not exist, and
+ * a meeting that failed mid-transcription was unrecoverable through the interface while its audio
+ * sat intact on disk.
+ *
+ * The offer's two conditions are the backend's own refusals: the status is still Error, and there
+ * is audio to work from.
+ *
+ * NOTE on the shape of these tests. The two "no offer" cases below would pass against a build where
+ * the banner does not exist at all — absence is easy to satisfy. The FIRST test is what makes them
+ * mean anything, so if it ever goes red, treat the other two as uninformative rather than green.
+ * Overrides are serialized and run page-side, so each fixture is inlined rather than closed over.
+ */
+
+const ERRORED_DETAIL = `{
+  meeting: {
+    id: "m-failed",
+    startedAt: "2026-09-01T09:00:00Z",
+    endedAt: "2026-09-01T09:42:00Z",
+    title: "Planning sync",
+    durationS: 2520,
+    audioPath: "/Users/demo/audio/m-failed.wav",
+    status: "ERROR",
+    folderId: null,
+  },
+  note: null,
+  segments: [],
+  assistantInteractions: [],
+  aiProvider: null,
+  aiModelRequested: null,
+  aiModelServed: null,
+}`;
+
+test("a failed recording with audio on disk offers a retry, and the view re-reads after it runs", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    get_meeting_detail: new Function(
+      "args",
+      `globalThis.__detailReads = (globalThis.__detailReads || 0) + 1;
+       return ${ERRORED_DETAIL};`,
+    ) as (args: unknown) => unknown,
+    retry_transcription: new Function(
+      "args",
+      `globalThis.__retried = globalThis.__retried || [];
+       globalThis.__retried.push(args.meetingId);
+       return { meetingId: args.meetingId, notePath: null };`,
+    ) as (args: unknown) => unknown,
+  });
+
+  await page.goto("/meeting/m-failed");
+
+  const retry = page.getByRole("button", { name: "Transcribe again" });
+  await expect(retry).toBeVisible();
+
+  const readsBefore = await page.evaluate(
+    () => (globalThis as unknown as { __detailReads?: number }).__detailReads ?? 0,
+  );
+  await retry.click();
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => (globalThis as unknown as { __retried?: string[] }).__retried ?? []),
+    )
+    .toEqual(["m-failed"]);
+
+  // Calling the command is only half of it. Without the re-read the user is left staring at the
+  // failed state after a retry that worked.
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (globalThis as unknown as { __detailReads?: number }).__detailReads ?? 0,
+      ),
+    )
+    .toBeGreaterThan(readsBefore);
+});
+
+test("a failed recording with no audio left offers nothing — there is nothing to run again", async ({
+  page,
+}) => {
+  await mockTauri(page, {
+    get_meeting_detail: new Function(
+      "args",
+      `const d = ${ERRORED_DETAIL};
+       d.meeting.id = "m-no-audio";
+       d.meeting.audioPath = null;
+       return d;`,
+    ) as (args: unknown) => unknown,
+  });
+
+  await page.goto("/meeting/m-no-audio");
+  await expect(page.getByRole("heading", { name: "Planning sync" }).first()).toBeVisible();
+  await expect(page.getByRole("button", { name: "Transcribe again" })).toHaveCount(0);
+});
+
+test("a healthy meeting shows no retry offer", async ({ page }) => {
+  await mockTauri(page, {
+    get_meeting_detail: new Function(
+      "args",
+      `const d = ${ERRORED_DETAIL};
+       d.meeting.id = "m-ok";
+       d.meeting.status = "SUMMARIZED";
+       return d;`,
+    ) as (args: unknown) => unknown,
+  });
+
+  await page.goto("/meeting/m-ok");
+  await expect(page.getByRole("heading", { name: "Planning sync" }).first()).toBeVisible();
+  await expect(page.getByRole("button", { name: "Transcribe again" })).toHaveCount(0);
+});

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -16321,6 +16321,68 @@
         let _ = std::fs::remove_file(&wav);
     }
 
+    /// RETRY FROM A DUAL-STREAM ARCHIVE — it is accepted, and it comes back MONO.
+    ///
+    /// A live recording keeps `Me` and `Others` apart by transcribing the microphone and the system
+    /// capture separately and merging them on wall-clock. A retry has neither: the raw per-stream
+    /// files are unlinked once the archive is proven durable (`cleanup_completed_archived_generation`
+    /// runs on the failure path too), so all a retry ever gets is the single archived WAV — and
+    /// `run_salvage_from_disk` opens it through `WavMonoSource`, which AVERAGES whatever channels it
+    /// finds into one.
+    ///
+    /// So a recovered transcript legitimately loses its speaker split. This test pins that as the
+    /// behaviour rather than leaving it to be discovered from a user's transcript: retry must keep
+    /// WORKING for a two-channel archive (the row is claimed, the path resolves), and the audio it
+    /// hands the pipeline is the channel mean, not a stream pair. If retry is ever taught to keep the
+    /// separation, the second half of this test is the assertion that has to go red first.
+    #[test]
+    fn retry_prep_accepts_a_two_channel_archive_and_salvage_reads_it_as_the_channel_mean() {
+        use crate::audio::source::MonoSource;
+
+        let state = build_state("retry-dual-stream-archive");
+        let wav = std::env::temp_dir().join(format!(
+            "murmur-retry-dual-{}-{}.wav",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        // Interleaved L/R: the microphone hard left, the system capture hard right — the most
+        // separable two-channel archive there could be.
+        let interleaved: Vec<f32> = vec![1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0];
+        crate::audio::write_wav_f32(&wav, &interleaved, 48_000, 2).unwrap();
+
+        let mid = uuid::Uuid::new_v4().to_string();
+        seed_meeting(&state.db, &mid, "# err", None);
+        state
+            .db
+            .finalize_meeting(&mid, "2026-09-02T10:00:00Z", 60, &wav.to_string_lossy())
+            .unwrap();
+        state
+            .db
+            .update_meeting_status(&mid, MeetingStatus::Error)
+            .unwrap();
+
+        // A two-channel archive is still a retryable archive: nothing in the gate rejects it.
+        let got = retry_transcription_prep(&state, &mid).unwrap();
+        assert_eq!(got, wav);
+        assert_eq!(
+            state.db.get_meeting(&mid).unwrap().unwrap().status,
+            MeetingStatus::Recording,
+        );
+
+        // And what salvage will actually feed Whisper is one mono track at the channel mean —
+        // 0.5 everywhere, with neither the 1.0 microphone nor the 0.0 system side recoverable.
+        let mut source = crate::audio::source::WavMonoSource::open(&wav).unwrap();
+        assert_eq!(source.frames(), 4, "4 interleaved stereo frames");
+        let frames = source.read_frames(0, 4).unwrap();
+        assert_eq!(
+            frames,
+            vec![0.5, 0.5, 0.5, 0.5],
+            "salvage averages the two streams together — the speaker split does not survive a retry"
+        );
+
+        let _ = std::fs::remove_file(&wav);
+    }
+
     /// LOCK MODEL — a salvage/retry pins the folder CK at entry. If screen-share relock lands while
     /// Whisper is running, the finalizer seals and decrypt-verifies the exact new transcript/audio;
     /// it never deletes transcript rows merely because old audio exists. An open folder is a no-op.

--- a/src/app/features/detail/detail/detail.component.html
+++ b/src/app/features/detail/detail/detail.component.html
@@ -279,6 +279,33 @@
         }
       </div>
     } @else {
+
+      <!-- ============================================================= -->
+      <!-- RETRY TRANSCRIPTION — a recording whose transcription failed  -->
+      <!-- with its audio still on disk. The backend command existed all -->
+      <!-- along, and the ASR watchdog's own message tells the user to   -->
+      <!-- "use Retry transcription" — but nothing ever called it, so    -->
+      <!-- the advice pointed at a control that did not exist.           -->
+      <!-- ============================================================= -->
+      @if (canRetryTranscription()) {
+        <div class="card banner retry-banner" role="group">
+          <div class="retry-banner-copy">
+            <p class="retry-banner-title">Transcription didn’t finish</p>
+            <p class="empty">
+              The recording is still on disk. You can run it again.
+            </p>
+          </div>
+          <button
+            type="button"
+            class="btn btn-primary"
+            (click)="retryTranscription(d.meeting.id)"
+            [disabled]="retryingTranscription()"
+          >
+            {{ retryingTranscription() ? "Transcribing…" : "Transcribe again" }}
+          </button>
+        </div>
+      }
+
       <app-meeting-command-bar
         [meetingId]="d.meeting.id"
         [folderId]="d.meeting.folderId ?? null"

--- a/src/app/features/detail/detail/detail.component.scss
+++ b/src/app/features/detail/detail/detail.component.scss
@@ -317,3 +317,24 @@
   }
 }
     
+
+/* The retry-transcription offer: a banner, not a buried menu item — it is the only route back for
+   a recording whose transcription failed, and the watchdog's own message points at it. */
+.retry-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.retry-banner-copy {
+  display: grid;
+  gap: var(--space-1);
+}
+
+.retry-banner-title {
+  margin: 0;
+  font-weight: 600;
+  color: var(--text-primary);
+}

--- a/src/app/features/detail/detail/detail.component.ts
+++ b/src/app/features/detail/detail/detail.component.ts
@@ -112,6 +112,22 @@ export class DetailComponent implements OnInit {
   );
   readonly loading = signal(true);
   readonly busy = signal(false);
+  /** A retry is in flight — the offer disables itself rather than allowing a second claim. */
+  readonly retryingTranscription = signal(false);
+  /**
+   * Offer the retry only for a failed recording whose audio is still on disk. Both conditions come
+   * straight from `retry_transcription_prep`'s refusals, so the button appears exactly where the
+   * command can actually do something.
+   */
+  readonly canRetryTranscription = computed(() => {
+    const meeting = this.detail()?.meeting;
+    return (
+      !!meeting &&
+      meeting.status === "ERROR" &&
+      !!meeting.audioPath &&
+      meeting.audioPath.trim().length > 0
+    );
+  });
   private readonly conversionRequest = signal<{
     meetingId: string;
     sequence: number;
@@ -1468,6 +1484,41 @@ export class DetailComponent implements OnInit {
       this.graphError.set(this.errorCopy.because("Couldn’t connect to graph", e));
     } finally {
       this.linking.set(false);
+    }
+  }
+
+  /**
+   * Re-run transcription for a recording that failed, from the audio still on disk.
+   *
+   * The backend command has existed all along, and both the ASR watchdog and the pipeline's
+   * terminal guard tell the user in as many words to "use Retry transcription" — but nothing in the
+   * app ever called it. A meeting that failed during transcription was therefore unrecoverable from
+   * the interface, with its audio sitting intact on disk, and the only advice on screen pointed at
+   * a control that did not exist.
+   *
+   * Every precondition is the backend's: no recording in flight, folder unlocked, status still
+   * Error, plaintext audio present, and a single-flight claim that flips Error → Recording. This
+   * only decides whether the offer is worth showing.
+   */
+  async retryTranscription(id: string): Promise<void> {
+    if (this.retryingTranscription()) {
+      return;
+    }
+    this.retryingTranscription.set(true);
+    this.msg.set("Transcribing again…");
+    try {
+      await this.ipc.retryTranscription(id);
+      const fresh = await this.ipc.getMeetingDetail(id);
+      // Same stale-result guard as `resummarize`: transcription is long, and the user may have
+      // navigated away and opened another meeting while it ran.
+      if (this.detail()?.meeting?.id === id) {
+        this.detail.set(fresh);
+      }
+      this.msg.set("Done.");
+    } catch (e) {
+      this.msg.set(this.errorCopy.because("Couldn’t transcribe this recording", e));
+    } finally {
+      this.retryingTranscription.set(false);
     }
   }
 

--- a/src/app/features/library/library/library.component.html
+++ b/src/app/features/library/library/library.component.html
@@ -578,6 +578,24 @@
                    click closes via onDocumentClick. -->
               @if (rowMenuId() === m.id) {
                 <div class="menu row-menu" role="menu" aria-label="Meeting actions">
+                  <!-- Recovery comes first, and only for a row that actually failed with its audio
+                       still on disk — the two conditions the backend itself refuses on. -->
+                  @if (it.canRetryTranscription) {
+                    <div class="menu-group">
+                      <button
+                        type="button"
+                        class="menu-item"
+                        role="menuitem"
+                        [disabled]="retryingId() !== null"
+                        (click)="
+                          $event.stopPropagation();
+                          retryTranscriptionFromMenu(m.id)
+                        "
+                      >
+                        Transcribe again
+                      </button>
+                    </div>
+                  }
                   <div class="menu-group">
                     <button
                       type="button"

--- a/src/app/features/library/library/library.component.ts
+++ b/src/app/features/library/library/library.component.ts
@@ -97,6 +97,12 @@ export interface MeetingsListItem {
   /** Pre-derived pill presentation — the template must not call helpers per row. */
   statusPillClass: string;
   statusLabel: string;
+  /**
+   * The recording failed and its audio is still on disk, so re-running transcription can actually
+   * do something. Pre-derived for the same reason as the pill: no helper calls per row under
+   * zoneless change detection.
+   */
+  canRetryTranscription: boolean;
 }
 
 /**
@@ -496,9 +502,39 @@ export class LibraryComponent implements OnInit {
         meeting,
         statusPillClass: meetingStatusPillClass(meeting.status),
         statusLabel: meetingStatusLabel(meeting.status),
+        canRetryTranscription:
+          meeting.status === "ERROR" && !!meeting.audioPath?.trim(),
       }))
       .sort((a, b) => b.sortAt - a.sortAt),
   );
+
+  /** The row whose retry is in flight, so only that one's menu item disables. */
+  readonly retryingId = signal<string | null>(null);
+
+  /**
+   * Re-run transcription for a failed recording straight from the list.
+   *
+   * The meeting view carries the same offer as a banner; this is the reach for somebody scanning
+   * the list who does not want to open a broken meeting first. The backend re-checks every
+   * precondition, so a row that has gone stale simply refuses.
+   */
+  async retryTranscriptionFromMenu(meetingId: string): Promise<void> {
+    if (this.retryingId() !== null) {
+      return;
+    }
+    this.retryingId.set(meetingId);
+    this.rowMenuId.set(null);
+    try {
+      await this.ipc.retryTranscription(meetingId);
+      // The row's status pill is derived from the list, so the list has to be re-read for the
+      // meeting to stop claiming it failed.
+      await this.reloadMeetings();
+    } catch {
+      this.toast.danger("Could not start transcription again. Try opening the meeting.");
+    } finally {
+      this.retryingId.set(null);
+    }
+  }
 
   /** True when the no-query list has zero rows (drives the empty state). */
   readonly listEmpty = computed(() => this.listItems().length === 0);


### PR DESCRIPTION
## Co to naprawia

Nagranie, któremu nie udała się transkrypcja, było **nieodzyskiwalne z poziomu interfejsu** — mimo że audio leżało nietknięte na dysku, a komenda `retry_transcription` istniała w backendzie od dawna, z kompletem bramek fail-closed.

Gorzej: zarówno watchdog ASR, jak i terminalny guard pipeline'u mówią użytkownikowi wprost, żeby użył „Retry transcription". Jedyna podpowiedź na ekranie wskazywała na kontrolkę, której nie było.

## Zakres

Oferta pojawia się dokładnie pod tymi dwoma warunkami, na których odmawia sam backend: status wciąż `Error` **i** jest audio do pracy.

- **Widok spotkania** (`features/detail`) — banner z przyciskiem, stan pending, ponowny odczyt ze strażnikiem nieaktualnego wyniku.
- **Wiersz listy** (`features/library`) — pozycja w menu ⋯, żeby nie trzeba było otwierać zepsutego spotkania, by się dowiedzieć, że da się je puścić jeszcze raz. Wysyłane jest `m.id` spotkania, nie klucz wiersza z prefiksem `meeting:`.

## Retry wraca MONO — i to jest teraz przypięte testem

To najważniejsze ustalenie tej zmiany. Żywe nagranie trzyma `Me` i `Others` osobno, bo transkrybuje mikrofon i przechwyt systemowy oddzielnie i scala je po zegarze. Retry nie ma czym: surowe pliki per-strumień są odlinkowywane, gdy archiwum zostanie uznane za trwałe — `cleanup_completed_archived_generation` odpala się **także na ścieżce porażki** — więc retry dostaje wyłącznie jeden zarchiwizowany WAV, a `run_salvage_from_disk` otwiera go przez `WavMonoSource`, który **uśrednia** znalezione kanały.

Odzyskana transkrypcja legalnie traci podział na mówców. Nowy test rustowy przypina to jako zachowanie, zamiast zostawiać do odkrycia w transkrypcie użytkownika: retry musi **działać** dla archiwum dwukanałowego (wiersz zaklepany, ścieżka rozwiązana), a audio podawane pipeline'owi to średnia kanałów, nie para strumieni.

Nauczenie retry zachowywania separacji oznacza trzymanie surowych strumieni **poza etap notatki** — czyli zmianę w crash-safe ledgerze sprzątania. To osobne zadanie i osobny przegląd pod kątem utraty treści.

## RED przed GREEN

Oba pliki e2e zaczynają się testem kontrolnym, bo dwa przypadki „braku oferty" przeszłyby też na buildzie bez żadnego przycisku. Obie kontrolki potwierdzone na czerwono przeciwko wyzerowanemu warunkowi, zanim zmiana została zachowana:

| powierzchnia | mutacja | wynik |
| --- | --- | --- |
| widok spotkania | `@if (false)` zamiast warunku | 1 failed / 2 passed |
| wiersz listy | `@if (false)` zamiast warunku | 1 failed / 2 passed |

## Bramki

| bramka | wynik |
| --- | --- |
| `cargo nextest run --lib` | 3598/3599 |
| `cargo clippy --lib --tests` | czysto |
| `npx ng lint` | czysto |
| `npx ng build` | czysto |
| e2e (chromium + webkit) | 12/12 |

Jedyna porażka rustowa to `task_stable_post_and_put_vectors_match_pinned_server_protocol`, który przypina SHA checkoutu `murmur-server`. Lokalny sąsiedni katalog stoi na gałęzi z PR murmur-server#22, stąd `ae94afa` zamiast `3ef670d`. Środowiskowe, poza diffem tej zmiany — na CI świeży checkout ma przypięty commit.
