### PR TITLE
test: one debug KEK for the whole test process

### DIFF
--- a/src-tauri/src/commands/import/tests.rs
+++ b/src-tauri/src/commands/import/tests.rs
@@ -5,18 +5,16 @@
 use super::*;
 
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex, Once};
+use std::sync::{Arc, Mutex};
 
 use crate::settings::AppConfig;
 use crate::storage::{Db, NoteFolder};
 use zeroize::Zeroizing;
 
 const DB_KEY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-const DEV_KEK: &str = "1111111111111111111111111111111111111111111111111111111111111111";
-static KEK_ENV: Once = Once::new();
 
 fn build_state(tag: &str) -> AppState {
-    KEK_ENV.call_once(|| std::env::set_var("MURMUR_DEV_KEK", DEV_KEK));
+    crate::commands::dev_kek_fixture::ensure_dev_kek();
     let db_path = crate::storage::db::unique_temp_path(&format!("murmur-import-{tag}"), "sqlite");
     let _ = std::fs::remove_file(&db_path);
     AppState {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -14491,6 +14491,11 @@ mod org_rotation_tests;
 #[path = "tests/container_share_tests.rs"]
 mod container_share_tests;
 
+// ── The ONE debug KEK the whole test process runs under (see the module doc for why) ─────────────
+#[cfg(test)]
+#[path = "tests/dev_kek_fixture.rs"]
+mod dev_kek_fixture;
+
 // ── BLK-1 lifecycle-race + BLK-2 move-into-locked + BLK-3/BLK-4 config tests ──────────────────────
 #[cfg(test)]
 #[path = "tests/lifecycle_tests.rs"]

--- a/src-tauri/src/commands/reminders.rs
+++ b/src-tauri/src/commands/reminders.rs
@@ -3419,7 +3419,7 @@ mod smart_audit_command_tests {
     use std::collections::HashSet;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::mpsc;
-    use std::sync::{Condvar, Mutex, Once};
+    use std::sync::{Condvar, Mutex};
     use std::time::Duration;
 
     use serde_json::{json, Value};
@@ -3431,11 +3431,8 @@ mod smart_audit_command_tests {
     use crate::storage::{AttachmentOwner, Db, NewAttachment};
 
     const TEST_DB_KEY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-    const TEST_DEV_KEK: &str = "1111111111111111111111111111111111111111111111111111111111111111";
-    static TEST_KEK_ENV: Once = Once::new();
-
     fn ensure_test_dev_kek() {
-        TEST_KEK_ENV.call_once(|| std::env::set_var("MURMUR_DEV_KEK", TEST_DEV_KEK));
+        crate::commands::dev_kek_fixture::ensure_dev_kek();
     }
 
     fn test_state(tag: &str, reasoner: Arc<dyn LocalReasoner>) -> Arc<AppState> {

--- a/src-tauri/src/commands/reminders.rs
+++ b/src-tauri/src/commands/reminders.rs
@@ -167,11 +167,13 @@ pub(crate) fn reminder_runtime_probe_requested() -> bool {
 pub(crate) fn prepare_reminder_runtime_probe_environment() {
     #[cfg(debug_assertions)]
     if reminder_runtime_probe_requested() {
-        if std::env::var_os("MURMUR_DEV_KEK").is_none() {
+        if std::env::var_os(crate::secrets::keychain::DEV_KEK_ENV).is_none() {
             // SAFETY: `lib::run` calls this at process entry, before Tauri or any app worker starts.
+            // Name and value both come from the hatch's own module, so this writer cannot drift
+            // from the test fixture or from the reader.
             std::env::set_var(
-                "MURMUR_DEV_KEK",
-                "1111111111111111111111111111111111111111111111111111111111111111",
+                crate::secrets::keychain::DEV_KEK_ENV,
+                crate::secrets::keychain::dev_kek_hatch_value(),
             );
         }
         runtime_probe::prepare_process_environment();

--- a/src-tauri/src/commands/tests/attachment_tests.rs
+++ b/src-tauri/src/commands/tests/attachment_tests.rs
@@ -1,18 +1,16 @@
 use super::*;
 
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex, Once};
+use std::sync::{Arc, Mutex};
 
 use crate::settings::AppConfig;
 use crate::storage::{AttachmentOwner, Db, Folder, Meeting, MeetingStatus, NoteRecord};
 use zeroize::Zeroizing;
 
 const DB_KEY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-const DEV_KEK: &str = "1111111111111111111111111111111111111111111111111111111111111111";
-static KEK_ENV: Once = Once::new();
 
 fn build_state(tag: &str, vault: Option<&std::path::Path>) -> AppState {
-    KEK_ENV.call_once(|| std::env::set_var("MURMUR_DEV_KEK", DEV_KEK));
+    crate::commands::dev_kek_fixture::ensure_dev_kek();
     let db_path =
         crate::storage::db::unique_temp_path(&format!("murmur-attachments-{tag}"), "sqlite");
     let _ = std::fs::remove_file(&db_path);

--- a/src-tauri/src/commands/tests/dev_kek_fixture.rs
+++ b/src-tauri/src/commands/tests/dev_kek_fixture.rs
@@ -1,0 +1,144 @@
+//! The ONE debug-KEK every test in this crate runs under.
+//!
+//! # Why this module exists
+//!
+//! `MURMUR_DEV_KEK` is process-global. Under `cargo nextest` that is harmless, because nextest gives
+//! every test its own process — which is exactly why CI never saw the problem. But the documented
+//! inner loop in `CLAUDE.md` is `cargo test --lib`, which runs the whole suite in ONE process with
+//! many threads. Five modules used to install the hatch themselves, each behind its own `Once`, and
+//! four of them agreed on one key while `trash_tests` installed a different one. Whichever `Once`
+//! happened to fire first won the variable for every test that followed, so a test could fail with
+//! `Locked("decryption failed (wrong key…)")` purely because of thread scheduling — and pass on its
+//! own. A suite that fails for reasons unrelated to the code under test is a suite people learn to
+//! ignore.
+//!
+//! The value matches the one `prepare_reminder_runtime_probe_environment` already installs at
+//! process entry for the harness runtime probe, so the test hatch and the probe hatch cannot
+//! disagree either.
+//!
+//! # Why it is built rather than written out
+//!
+//! A literal 64-hex string in a diff is the shape this repo's secret scanner exists to catch. These
+//! are throwaway keys for temp SQLCipher files, but they must not LOOK like a real DEK/KEK. (The
+//! rationale is inherited verbatim from `trash_tests`, which got this right.)
+
+use std::sync::Once;
+
+/// The single debug KEK for the whole test process.
+pub(crate) fn dev_kek() -> String {
+    "1".repeat(64)
+}
+
+static KEK_ENV: Once = Once::new();
+
+/// Install the debug KEK exactly once per process. Safe to call from any test's setup.
+pub(crate) fn ensure_dev_kek() {
+    KEK_ENV.call_once(|| {
+        // SAFETY: installed before any test builds an `AppState`, and only ever to this one value —
+        // the invariant `one_dev_kek_for_the_whole_test_process` below is what keeps it that way.
+        std::env::set_var("MURMUR_DEV_KEK", dev_kek());
+    });
+}
+
+/// Every `MURMUR_DEV_KEK` writer in the crate must agree on one value.
+///
+/// This is a SOURCE invariant on purpose. The bug it guards is real by construction — two different
+/// values written to one process-global — but its symptom depends on which thread wins a race, so a
+/// behavioural test would be a coin flip and a useless oracle. Reproducing the original failure took
+/// a specific interleaving that a later run did not reproduce at all. Scanning the source is
+/// deterministic: it fails the moment somebody adds a second key, whatever the scheduler does.
+#[test]
+fn one_dev_kek_for_the_whole_test_process() {
+    use std::path::Path;
+
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut writers: Vec<(String, String)> = Vec::new();
+
+    fn walk(dir: &Path, out: &mut Vec<(String, String)>) {
+        for entry in std::fs::read_dir(dir).expect("read src dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                walk(&path, out);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                let text = std::fs::read_to_string(&path).expect("read source file");
+                for (i, line) in text.lines().enumerate() {
+                    if line.contains("\"MURMUR_DEV_KEK\"") && text_sets_var(&text, i) {
+                        // Record the file plus the 64-char run of a single repeated digit that this
+                        // writer installs, if the key is spelled out nearby.
+                        let window: String = text
+                            .lines()
+                            .skip(i)
+                            .take(4)
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        out.push((
+                            path.strip_prefix(dir.parent().unwrap())
+                                .unwrap_or(&path)
+                                .display()
+                                .to_string(),
+                            distinct_key_shape(line, &window),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    /// True when the `"MURMUR_DEV_KEK"` on line `i` belongs to a `set_var` call rather than a read
+    /// (`var_os`) or a mention in prose.
+    fn text_sets_var(text: &str, i: usize) -> bool {
+        let lines: Vec<&str> = text.lines().collect();
+        // A comment that merely NAMES the variable is not a writer — including this module's own
+        // prose, which would otherwise make the scanner flag itself.
+        if lines[i].trim_start().starts_with("//") {
+            return false;
+        }
+        // `set_var` may sit on the line itself or on the line above (rustfmt splits long calls).
+        let start = i.saturating_sub(1);
+        lines[start..=i].iter().any(|l| l.contains("set_var"))
+    }
+
+    /// Collapse a writer's key to a comparable shape: a 64-long run of one repeated character, or
+    /// the `repeat(64)` form, or `"fixture"` when it defers to this module.
+    ///
+    /// The fixture check reads the `set_var` LINE, never the window. Reading the window made this
+    /// scanner vacuous: a writer sitting one line above a `ensure_dev_kek()` call was classified as
+    /// the fixture and filtered out, so a deliberately planted second key passed. Mutation is how
+    /// that surfaced — the first version of this test happily accepted the exact bug it exists to
+    /// catch.
+    fn distinct_key_shape(set_var_line: &str, window: &str) -> String {
+        if set_var_line.contains("dev_kek()") {
+            return "fixture".to_string();
+        }
+        for digit in '0'..='9' {
+            let literal: String = std::iter::repeat(digit).take(64).collect();
+            if window.contains(&literal) {
+                return format!("literal:{digit}x64");
+            }
+            if window.contains(&format!("\"{digit}\".repeat(64)")) {
+                return format!("repeat:{digit}x64");
+            }
+        }
+        "unknown".to_string()
+    }
+
+    walk(&src, &mut writers);
+
+    assert!(
+        !writers.is_empty(),
+        "the scanner found no MURMUR_DEV_KEK writers at all — it has gone vacuous, fix the scan \
+         before trusting this test"
+    );
+
+    let shapes: std::collections::BTreeSet<&str> = writers
+        .iter()
+        .map(|(_, shape)| shape.as_str())
+        .filter(|shape| *shape != "fixture")
+        .collect();
+
+    assert!(
+        shapes.len() <= 1,
+        "every MURMUR_DEV_KEK writer must install the SAME key — `cargo test --lib` runs one \
+         process, so a second value silently re-keys whichever tests lose the race. Found: {writers:?}"
+    );
+}

--- a/src-tauri/src/commands/tests/dev_kek_fixture.rs
+++ b/src-tauri/src/commands/tests/dev_kek_fixture.rs
@@ -12,133 +12,123 @@
 //! own. A suite that fails for reasons unrelated to the code under test is a suite people learn to
 //! ignore.
 //!
-//! The value matches the one `prepare_reminder_runtime_probe_environment` already installs at
-//! process entry for the harness runtime probe, so the test hatch and the probe hatch cannot
-//! disagree either.
-//!
-//! # Why it is built rather than written out
-//!
-//! A literal 64-hex string in a diff is the shape this repo's secret scanner exists to catch. These
-//! are throwaway keys for temp SQLCipher files, but they must not LOOK like a real DEK/KEK. (The
-//! rationale is inherited verbatim from `trash_tests`, which got this right.)
+//! The name and the value both come from [`crate::secrets::keychain`], next to the code that READS
+//! the hatch, so this fixture and the harness runtime probe in `commands::reminders` cannot drift
+//! apart. An earlier version of this module merely *claimed* they could not disagree while both
+//! hand-typed their own literal; a reviewer changed one of them and nothing failed.
 
+use crate::secrets::keychain::{dev_kek_hatch_value, DEV_KEK_ENV};
 use std::sync::Once;
 
 /// The single debug KEK for the whole test process.
 pub(crate) fn dev_kek() -> String {
-    "1".repeat(64)
+    dev_kek_hatch_value()
 }
 
 static KEK_ENV: Once = Once::new();
 
 /// Install the debug KEK exactly once per process. Safe to call from any test's setup.
+///
+/// The assertion afterwards is deliberate defence in depth. The source guard below cannot see a
+/// writer that spells the variable in some way it does not recognise, but ANY such writer shows up
+/// here as a live value that is not ours — so the first test to call this after a rogue write fails
+/// with a message that names the problem, instead of some unrelated test failing on a wrong key.
 pub(crate) fn ensure_dev_kek() {
     KEK_ENV.call_once(|| {
-        // SAFETY: installed before any test builds an `AppState`, and only ever to this one value —
-        // the invariant `one_dev_kek_for_the_whole_test_process` below is what keeps it that way.
-        std::env::set_var("MURMUR_DEV_KEK", dev_kek());
+        // SAFETY: installed before any test builds an `AppState`, and only ever to this one value.
+        std::env::set_var(DEV_KEK_ENV, dev_kek());
     });
+    let live = std::env::var(DEV_KEK_ENV).unwrap_or_default();
+    assert_eq!(
+        live,
+        dev_kek(),
+        "something else installed a different {DEV_KEK_ENV} in this process — `cargo test --lib` \
+         runs one process, so that silently re-keys whichever tests lose the race"
+    );
 }
 
-/// Every `MURMUR_DEV_KEK` writer in the crate must agree on one value.
+/// The hatch may be NAMED in exactly these files, and nowhere else.
 ///
-/// This is a SOURCE invariant on purpose. The bug it guards is real by construction — two different
-/// values written to one process-global — but its symptom depends on which thread wins a race, so a
-/// behavioural test would be a coin flip and a useless oracle. Reproducing the original failure took
-/// a specific interleaving that a later run did not reproduce at all. Scanning the source is
-/// deterministic: it fails the moment somebody adds a second key, whatever the scheduler does.
+/// # Why a file allowlist rather than parsing the writers
+///
+/// The first version of this guard tried to recognise writers and compare the keys they installed.
+/// A reviewer broke it three separate ways in minutes: a module that re-declared its own local
+/// `dev_kek()` (a plain `git revert` of one file) was classified as this fixture and skipped; a
+/// writer that named the variable through a `const` was invisible, because the literal and the
+/// `set_var` sat on different lines; and `use std::env::set_var as sv` defeated the substring test
+/// for the call itself. Each bypass was cheaper to write than the check that was supposed to catch
+/// it — which is the general shape of scanning source for a *pattern*.
+///
+/// Naming the small set of files that may mention the hatch at all inverts that. It does not try to
+/// understand the code; it fails on any new mention anywhere else, whatever the mention looks like.
+/// Every one of those three bypasses re-introduces the literal into a file that is not on this list.
+///
+/// A determined author can still assemble the string (`concat!("MURMUR", "_DEV_KEK")`). That is not
+/// worth defending against: this guard exists to catch the accidental second writer — a revert, a
+/// cherry-pick, a copied test-setup block — not somebody working around it on purpose. This module
+/// itself is not on the list, and does not need to be: it reaches the hatch through `DEV_KEK_ENV`
+/// like every other caller should, and builds its search needle in pieces so it cannot match its
+/// own source.
+const FILES_THAT_MAY_NAME_THE_HATCH: &[&str] = &[
+    // Owns the hatch: declares its name and value, and reads it.
+    "secrets/keychain.rs",
+    // Strips it from every spawned provider's environment (`NEVER_INHERIT_ENV`).
+    "summarize/claude_code.rs",
+];
+
 #[test]
-fn one_dev_kek_for_the_whole_test_process() {
-    use std::path::Path;
+fn only_the_fixture_and_the_hatch_owner_may_name_the_dev_kek() {
+    use std::path::{Path, PathBuf};
 
     let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
-    let mut writers: Vec<(String, String)> = Vec::new();
+    let needle = concat!("\"MURMUR", "_DEV_KEK\"");
 
-    fn walk(dir: &Path, out: &mut Vec<(String, String)>) {
+    fn walk(dir: &Path, needle: &str, out: &mut Vec<PathBuf>) {
         for entry in std::fs::read_dir(dir).expect("read src dir") {
             let path = entry.expect("dir entry").path();
             if path.is_dir() {
-                walk(&path, out);
-            } else if path.extension().is_some_and(|e| e == "rs") {
-                let text = std::fs::read_to_string(&path).expect("read source file");
-                for (i, line) in text.lines().enumerate() {
-                    if line.contains("\"MURMUR_DEV_KEK\"") && text_sets_var(&text, i) {
-                        // Record the file plus the 64-char run of a single repeated digit that this
-                        // writer installs, if the key is spelled out nearby.
-                        let window: String = text
-                            .lines()
-                            .skip(i)
-                            .take(4)
-                            .collect::<Vec<_>>()
-                            .join(" ");
-                        out.push((
-                            path.strip_prefix(dir.parent().unwrap())
-                                .unwrap_or(&path)
-                                .display()
-                                .to_string(),
-                            distinct_key_shape(line, &window),
-                        ));
-                    }
-                }
+                walk(&path, needle, out);
+            } else if path.extension().is_some_and(|e| e == "rs")
+                && std::fs::read_to_string(&path)
+                    .expect("read source file")
+                    .contains(needle)
+            {
+                out.push(path);
             }
         }
     }
 
-    /// True when the `"MURMUR_DEV_KEK"` on line `i` belongs to a `set_var` call rather than a read
-    /// (`var_os`) or a mention in prose.
-    fn text_sets_var(text: &str, i: usize) -> bool {
-        let lines: Vec<&str> = text.lines().collect();
-        // A comment that merely NAMES the variable is not a writer — including this module's own
-        // prose, which would otherwise make the scanner flag itself.
-        if lines[i].trim_start().starts_with("//") {
-            return false;
-        }
-        // `set_var` may sit on the line itself or on the line above (rustfmt splits long calls).
-        let start = i.saturating_sub(1);
-        lines[start..=i].iter().any(|l| l.contains("set_var"))
-    }
-
-    /// Collapse a writer's key to a comparable shape: a 64-long run of one repeated character, or
-    /// the `repeat(64)` form, or `"fixture"` when it defers to this module.
-    ///
-    /// The fixture check reads the `set_var` LINE, never the window. Reading the window made this
-    /// scanner vacuous: a writer sitting one line above a `ensure_dev_kek()` call was classified as
-    /// the fixture and filtered out, so a deliberately planted second key passed. Mutation is how
-    /// that surfaced — the first version of this test happily accepted the exact bug it exists to
-    /// catch.
-    fn distinct_key_shape(set_var_line: &str, window: &str) -> String {
-        if set_var_line.contains("dev_kek()") {
-            return "fixture".to_string();
-        }
-        for digit in '0'..='9' {
-            let literal: String = std::iter::repeat(digit).take(64).collect();
-            if window.contains(&literal) {
-                return format!("literal:{digit}x64");
-            }
-            if window.contains(&format!("\"{digit}\".repeat(64)")) {
-                return format!("repeat:{digit}x64");
-            }
-        }
-        "unknown".to_string()
-    }
-
-    walk(&src, &mut writers);
-
-    assert!(
-        !writers.is_empty(),
-        "the scanner found no MURMUR_DEV_KEK writers at all — it has gone vacuous, fix the scan \
-         before trusting this test"
-    );
-
-    let shapes: std::collections::BTreeSet<&str> = writers
+    let mut found = Vec::new();
+    walk(&src, needle, &mut found);
+    let found: std::collections::BTreeSet<String> = found
         .iter()
-        .map(|(_, shape)| shape.as_str())
-        .filter(|shape| *shape != "fixture")
+        .map(|p| {
+            p.strip_prefix(&src)
+                .unwrap_or(p)
+                .display()
+                .to_string()
+                .replace('\\', "/")
+        })
+        .collect();
+    let allowed: std::collections::BTreeSet<String> = FILES_THAT_MAY_NAME_THE_HATCH
+        .iter()
+        .map(|s| (*s).to_string())
         .collect();
 
+    // Anti-vacuity, in BOTH directions. A scanner that finds nothing would otherwise pass forever,
+    // and an allowlist entry whose file stopped naming the hatch is a stale rule pretending to
+    // guard something.
     assert!(
-        shapes.len() <= 1,
-        "every MURMUR_DEV_KEK writer must install the SAME key — `cargo test --lib` runs one \
-         process, so a second value silently re-keys whichever tests lose the race. Found: {writers:?}"
+        !found.is_empty(),
+        "the scanner found no mention of the hatch at all — it has gone vacuous, fix the scan \
+         before trusting this test"
+    );
+    assert_eq!(
+        found, allowed,
+        "the debug KEK hatch may be named only by the files that own it and by this fixture. A new \
+         file naming it is a second writer, and in a one-process `cargo test --lib` run a second \
+         writer silently re-keys whichever tests lose the race. Install it with \
+         `dev_kek_fixture::ensure_dev_kek()` instead — or, if this really is a legitimate new home \
+         for the hatch, add it to FILES_THAT_MAY_NAME_THE_HATCH with a reason."
     );
 }

--- a/src-tauri/src/commands/tests/dev_kek_fixture.rs
+++ b/src-tauri/src/commands/tests/dev_kek_fixture.rs
@@ -65,13 +65,17 @@ pub(crate) fn ensure_dev_kek() {
 ///
 /// # What this scan is, and what it is NOT
 ///
-/// It is a best-effort EARLY WARNING, not a proof. Three rounds of review established that the
-/// question "where could a writer live?" has no bounded answer in Rust: `#[path]` compiles a file
-/// from anywhere on disk into this binary, so any walker rooted at any directory is trusting a
-/// boundary the language does not honour. Each round closed one escape (`.rs`-only filtering, then
-/// `src/`-only rooting) and the next appeared. Rooting at the crate covers every escape that stays
-/// inside the crate, which is where an accident actually lands; it does not cover a `#[path]` that
-/// leaves it, and no amount of walking will.
+/// It is a best-effort EARLY WARNING, not a proof, and five rounds of review are why that sentence
+/// is worded so carefully. The question "where could a writer live?" has no bounded answer in Rust:
+/// `#[path]` compiles a file from anywhere on disk into this binary. Each round closed one escape
+/// and the next appeared — `.rs`-only filtering, then `src/`-only rooting, then a rogue file inside
+/// `target/`, which never leaves the crate at all and defeats the exclusions below.
+///
+/// So the scan is NOT a fence and no version of it will be. It covers the directories where source
+/// realistically lives, which is where an accidental second writer — a revert, a cherry-pick, a
+/// copied setup block — actually lands. A file placed in `target/`, `gen/`, `binaries/` or a dot
+/// directory and pulled in with `#[path]` is not caught, and closing that would mean walking
+/// gigabytes on every run to defend against something nobody does by accident.
 ///
 /// The ACTUAL guard is the runtime assertion in [`ensure_dev_kek`]: it compares the live value and
 /// therefore catches any writer, however it spells the call and wherever it lives, as soon as one
@@ -85,14 +89,25 @@ pub(crate) fn ensure_dev_kek() {
 ///
 /// - A name assembled at compile time (`concat!("MURMUR", "_DEV_KEK")`). Defending against this
 ///   means parsing, which is the approach that already failed.
+/// - Anything under an excluded directory (`target/`, `gen/`, `binaries/`, dotfiles), reachable
+///   with `#[path]`. Excluded for cost and artifact noise, as above.
 /// - A second `set_var` inside a file that is ALREADY on the list. Trust here is file-grained, not
 ///   call-site-grained, so an allowlisted file is immune for its whole length — and `keychain.rs`,
 ///   the one place a careless KEK-adjacent `set_var` is most likely to be added, is exactly that
 ///   file. Review demonstrated both, and in both the runtime assertion caught it.
 ///
+/// The read is a HARD failure rather than a skip, and that trade is deliberate: an unreadable file
+/// is one this guard cannot clear, so it stops instead of guessing. It will therefore also fire on
+/// an innocent unreadable file — a dangling symlink, a permission-mangled CI cache restore — and
+/// that is accepted. The panic names the path and the OS error, so it cannot be mistaken for a real
+/// key collision.
+///
 /// This module itself is not on the list, and does not need to be: it reaches the hatch through
 /// `DEV_KEK_ENV` like every other caller should, and builds its search needle in pieces so it
 /// cannot match its own source.
+/// Directories the scan does not enter. See the module doc: cost and artifact noise, not safety.
+const EXCLUDED_DIRS: &[&str] = &["target", "gen", "binaries"];
+
 const FILES_THAT_MAY_NAME_THE_HATCH: &[&str] = &[
     // Owns the hatch: declares its name and value, and reads it.
     "src/secrets/keychain.rs",
@@ -122,9 +137,12 @@ fn only_the_fixture_and_the_hatch_owner_may_name_the_dev_kek() {
         for entry in std::fs::read_dir(dir).expect("read src dir") {
             let path = entry.expect("dir entry").path();
             let name = path.file_name().unwrap_or_default().to_string_lossy().to_string();
-            // Build output and VCS/tooling directories are not compiled into this binary and are
-            // enormous; everything else under the crate root is fair game.
-            if name == "target" || name == "gen" || name.starts_with('.') {
+            // Skipped for cost and for noise, NOT because nothing there can compile: `target` is
+            // multiple gigabytes in this crate, and `binaries` holds bundled Mach-O helpers whose
+            // embedded strings would be read and lossily decoded on every run. See the module doc —
+            // a `#[path]` into any of these defeats the scan, and that is a known limit rather than
+            // an oversight.
+            if EXCLUDED_DIRS.contains(&name.as_str()) || name.starts_with('.') {
                 continue;
             }
             if path.is_dir() {

--- a/src-tauri/src/commands/tests/dev_kek_fixture.rs
+++ b/src-tauri/src/commands/tests/dev_kek_fixture.rs
@@ -63,12 +63,21 @@ pub(crate) fn ensure_dev_kek() {
 /// understand the code; it fails on any new mention anywhere else, whatever the mention looks like.
 /// Every one of those three bypasses re-introduces the literal into a file that is not on this list.
 ///
-/// A determined author can still assemble the string (`concat!("MURMUR", "_DEV_KEK")`). That is not
-/// worth defending against: this guard exists to catch the accidental second writer — a revert, a
-/// cherry-pick, a copied test-setup block — not somebody working around it on purpose. This module
-/// itself is not on the list, and does not need to be: it reaches the hatch through `DEV_KEK_ENV`
-/// like every other caller should, and builds its search needle in pieces so it cannot match its
-/// own source.
+/// # What this deliberately does NOT catch
+///
+/// Two gaps are known and accepted, because in both the runtime assertion in `ensure_dev_kek` fires
+/// deterministically on the next call and names the problem:
+///
+/// - A name assembled at compile time (`concat!("MURMUR", "_DEV_KEK")`). Defending against this
+///   means parsing, which is the approach that already failed.
+/// - A second `set_var` inside a file that is ALREADY on the list. Trust here is file-grained, not
+///   call-site-grained, so an allowlisted file is immune for its whole length — and `keychain.rs`,
+///   the one place a careless KEK-adjacent `set_var` is most likely to be added, is exactly that
+///   file. Review demonstrated both, and in both the runtime assertion caught it.
+///
+/// This module itself is not on the list, and does not need to be: it reaches the hatch through
+/// `DEV_KEK_ENV` like every other caller should, and builds its search needle in pieces so it
+/// cannot match its own source.
 const FILES_THAT_MAY_NAME_THE_HATCH: &[&str] = &[
     // Owns the hatch: declares its name and value, and reads it.
     "secrets/keychain.rs",
@@ -83,15 +92,21 @@ fn only_the_fixture_and_the_hatch_owner_may_name_the_dev_kek() {
     let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
     let needle = concat!("\"MURMUR", "_DEV_KEK\"");
 
+    // EVERY regular file, not just `*.rs`. Filtering by extension was a real hole: `#[path =
+    // "tests/whatever.inc"] mod x;` is ordinary Rust, compiles into this very test binary, and its
+    // `set_var` runs in this very process — while a `.rs`-only walker never even opens it. Review
+    // built exactly that and watched the guard report `ok` while 620 of 3618 tests failed on the
+    // corrupted key. A scanner whose blind spot is reachable by a normal language feature is worse
+    // than no scanner, because it is trusted. Bytes rather than `read_to_string`, so a non-UTF-8
+    // file is skipped over rather than panicking the guard.
     fn walk(dir: &Path, needle: &str, out: &mut Vec<PathBuf>) {
         for entry in std::fs::read_dir(dir).expect("read src dir") {
             let path = entry.expect("dir entry").path();
             if path.is_dir() {
                 walk(&path, needle, out);
-            } else if path.extension().is_some_and(|e| e == "rs")
-                && std::fs::read_to_string(&path)
-                    .expect("read source file")
-                    .contains(needle)
+            } else if std::fs::read(&path)
+                .map(|bytes| String::from_utf8_lossy(&bytes).contains(needle))
+                .unwrap_or(false)
             {
                 out.push(path);
             }

--- a/src-tauri/src/commands/tests/dev_kek_fixture.rs
+++ b/src-tauri/src/commands/tests/dev_kek_fixture.rs
@@ -63,6 +63,21 @@ pub(crate) fn ensure_dev_kek() {
 /// understand the code; it fails on any new mention anywhere else, whatever the mention looks like.
 /// Every one of those three bypasses re-introduces the literal into a file that is not on this list.
 ///
+/// # What this scan is, and what it is NOT
+///
+/// It is a best-effort EARLY WARNING, not a proof. Three rounds of review established that the
+/// question "where could a writer live?" has no bounded answer in Rust: `#[path]` compiles a file
+/// from anywhere on disk into this binary, so any walker rooted at any directory is trusting a
+/// boundary the language does not honour. Each round closed one escape (`.rs`-only filtering, then
+/// `src/`-only rooting) and the next appeared. Rooting at the crate covers every escape that stays
+/// inside the crate, which is where an accident actually lands; it does not cover a `#[path]` that
+/// leaves it, and no amount of walking will.
+///
+/// The ACTUAL guard is the runtime assertion in [`ensure_dev_kek`]: it compares the live value and
+/// therefore catches any writer, however it spells the call and wherever it lives, as soon as one
+/// test calls the fixture after it. This scan exists to fail EARLIER and more legibly than that —
+/// naming the offending file instead of surfacing as a wrong-key error somewhere unrelated.
+///
 /// # What this deliberately does NOT catch
 ///
 /// Two gaps are known and accepted, because in both the runtime assertion in `ensure_dev_kek` fires
@@ -80,16 +95,20 @@ pub(crate) fn ensure_dev_kek() {
 /// cannot match its own source.
 const FILES_THAT_MAY_NAME_THE_HATCH: &[&str] = &[
     // Owns the hatch: declares its name and value, and reads it.
-    "secrets/keychain.rs",
+    "src/secrets/keychain.rs",
     // Strips it from every spawned provider's environment (`NEVER_INHERIT_ENV`).
-    "summarize/claude_code.rs",
+    "src/summarize/claude_code.rs",
 ];
 
 #[test]
 fn only_the_fixture_and_the_hatch_owner_may_name_the_dev_kek() {
     use std::path::{Path, PathBuf};
 
-    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    // The CRATE ROOT, not `src/`. `#[path = "../../elsewhere.rs"]` is ordinary Rust and compiles a
+    // file from anywhere into this very binary, so a walker rooted at `src/` trusts a directory
+    // boundary the language does not honour. Review escaped to `src-tauri/` and watched the guard
+    // report `ok` while the rogue test ran.
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf();
     let needle = concat!("\"MURMUR", "_DEV_KEK\"");
 
     // EVERY regular file, not just `*.rs`. Filtering by extension was a real hole: `#[path =
@@ -102,13 +121,32 @@ fn only_the_fixture_and_the_hatch_owner_may_name_the_dev_kek() {
     fn walk(dir: &Path, needle: &str, out: &mut Vec<PathBuf>) {
         for entry in std::fs::read_dir(dir).expect("read src dir") {
             let path = entry.expect("dir entry").path();
+            let name = path.file_name().unwrap_or_default().to_string_lossy().to_string();
+            // Build output and VCS/tooling directories are not compiled into this binary and are
+            // enormous; everything else under the crate root is fair game.
+            if name == "target" || name == "gen" || name.starts_with('.') {
+                continue;
+            }
             if path.is_dir() {
                 walk(&path, needle, out);
-            } else if std::fs::read(&path)
-                .map(|bytes| String::from_utf8_lossy(&bytes).contains(needle))
-                .unwrap_or(false)
-            {
-                out.push(path);
+            } else {
+                // A read failure is NOT "no match". Collapsing those two is the exact shape that
+                // cost a reviewer 19 of 20 hits in an unrelated sweep this same week, and it is
+                // reachable here without any adversarial code at all: review built a rogue file
+                // while it was readable, ran `chmod 000`, and the guard went green while the
+                // already-compiled test kept corrupting the key. Permission bits are not part of
+                // Cargo's fingerprint, so nothing even rebuilds.
+                let bytes = std::fs::read(&path).unwrap_or_else(|e| {
+                    panic!(
+                        "could not read {} while scanning for the debug-KEK hatch ({e}). Fix its \
+                         permissions or exclude it deliberately — a file this guard cannot read is \
+                         a file it cannot clear.",
+                        path.display()
+                    )
+                });
+                if String::from_utf8_lossy(&bytes).contains(needle) {
+                    out.push(path);
+                }
             }
         }
     }

--- a/src-tauri/src/commands/tests/dev_kek_fixture.rs
+++ b/src-tauri/src/commands/tests/dev_kek_fixture.rs
@@ -71,11 +71,13 @@ pub(crate) fn ensure_dev_kek() {
 /// and the next appeared — `.rs`-only filtering, then `src/`-only rooting, then a rogue file inside
 /// `target/`, which never leaves the crate at all and defeats the exclusions below.
 ///
-/// So the scan is NOT a fence and no version of it will be. It covers the directories where source
-/// realistically lives, which is where an accidental second writer — a revert, a cherry-pick, a
-/// copied setup block — actually lands. A file placed in `target/`, `gen/`, `binaries/` or a dot
-/// directory and pulled in with `#[path]` is not caught, and closing that would mean walking
-/// gigabytes on every run to defend against something nobody does by accident.
+/// So the scan is NOT a fence and no version of it will be — a `#[path]` pointing outside the crate
+/// is unreachable by any walker. What it does cover is now wider than "where source lives", because
+/// review MEASURED the objection I had raised instead of accepting it: walking `target/` (8.1 GB,
+/// 21,957 files) with an extension filter costs 0.055-0.068s, the same order as this guard already
+/// costs, since the price is directory entries rather than bytes never read. Build output is
+/// therefore walked, source-only. `binaries/` stays out for the opposite reason — false positives
+/// from embedded strings in bundled Mach-O helpers, which an extension filter would skip regardless.
 ///
 /// The ACTUAL guard is the runtime assertion in [`ensure_dev_kek`]: it compares the live value and
 /// therefore catches any writer, however it spells the call and wherever it lives, as soon as one
@@ -89,8 +91,9 @@ pub(crate) fn ensure_dev_kek() {
 ///
 /// - A name assembled at compile time (`concat!("MURMUR", "_DEV_KEK")`). Defending against this
 ///   means parsing, which is the approach that already failed.
-/// - Anything under an excluded directory (`target/`, `gen/`, `binaries/`, dotfiles), reachable
-///   with `#[path]`. Excluded for cost and artifact noise, as above.
+/// - A NON-`.rs` file placed specifically inside `target/` or `gen/`, or anything under
+///   `binaries/` or a dot directory. Two unusual choices stacked, where the hole this replaced
+///   needed none.
 /// - A second `set_var` inside a file that is ALREADY on the list. Trust here is file-grained, not
 ///   call-site-grained, so an allowlisted file is immune for its whole length — and `keychain.rs`,
 ///   the one place a careless KEK-adjacent `set_var` is most likely to be added, is exactly that
@@ -105,8 +108,8 @@ pub(crate) fn ensure_dev_kek() {
 /// This module itself is not on the list, and does not need to be: it reaches the hatch through
 /// `DEV_KEK_ENV` like every other caller should, and builds its search needle in pieces so it
 /// cannot match its own source.
-/// Directories the scan does not enter. See the module doc: cost and artifact noise, not safety.
-const EXCLUDED_DIRS: &[&str] = &["target", "gen", "binaries"];
+/// Build output: walked, but only `.rs` files are read there. See the module doc.
+const SOURCE_ONLY_DIRS: &[&str] = &["target", "gen"];
 
 const FILES_THAT_MAY_NAME_THE_HATCH: &[&str] = &[
     // Owns the hatch: declares its name and value, and reads it.
@@ -133,7 +136,7 @@ fn only_the_fixture_and_the_hatch_owner_may_name_the_dev_kek() {
     // corrupted key. A scanner whose blind spot is reachable by a normal language feature is worse
     // than no scanner, because it is trusted. Bytes rather than `read_to_string`, so a non-UTF-8
     // file is skipped over rather than panicking the guard.
-    fn walk(dir: &Path, needle: &str, out: &mut Vec<PathBuf>) {
+    fn walk(dir: &Path, needle: &str, out: &mut Vec<PathBuf>, source_only: bool) {
         for entry in std::fs::read_dir(dir).expect("read src dir") {
             let path = entry.expect("dir entry").path();
             let name = path.file_name().unwrap_or_default().to_string_lossy().to_string();
@@ -142,11 +145,25 @@ fn only_the_fixture_and_the_hatch_owner_may_name_the_dev_kek() {
             // embedded strings would be read and lossily decoded on every run. See the module doc —
             // a `#[path]` into any of these defeats the scan, and that is a known limit rather than
             // an oversight.
-            if EXCLUDED_DIRS.contains(&name.as_str()) || name.starts_with('.') {
+            // `binaries` stays out entirely: it holds bundled Mach-O helpers whose embedded
+            // strings would be read and lossily decoded on every run, so the risk there is a
+            // FALSE POSITIVE, not cost, and an extension filter would skip them anyway.
+            if name == "binaries" || name.starts_with('.') {
                 continue;
             }
+            // Build output IS walked, just source-only. Review measured the alternative rather
+            // than arguing it: 8.1 GB, 21,957 files, 1,519 directories → 0.055-0.068s, the same
+            // order as this guard already costs, because the price is directory entries and not
+            // the bytes an extension filter never reads. My earlier claim that covering `target`
+            // would hurt the loop was simply wrong.
+            let source_only = source_only || SOURCE_ONLY_DIRS.contains(&name.as_str());
             if path.is_dir() {
-                walk(&path, needle, out);
+                walk(&path, needle, out, source_only);
+            } else if source_only && path.extension().is_none_or(|e| e != "rs") {
+                // Inside build output we read only Rust sources. Residual, stated plainly: a
+                // non-`.rs` file hidden specifically in `target`/`gen` stays invisible. That needs
+                // two unusual choices stacked, where the round-5 hole needed none.
+                continue;
             } else {
                 // A read failure is NOT "no match". Collapsing those two is the exact shape that
                 // cost a reviewer 19 of 20 hits in an unrelated sweep this same week, and it is
@@ -170,7 +187,7 @@ fn only_the_fixture_and_the_hatch_owner_may_name_the_dev_kek() {
     }
 
     let mut found = Vec::new();
-    walk(&src, needle, &mut found);
+    walk(&src, needle, &mut found, false);
     let found: std::collections::BTreeSet<String> = found
         .iter()
         .map(|p| {

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -4,13 +4,10 @@
     use crate::transcribe::types::Segment;
     use std::collections::HashSet;
     use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::{Arc, Mutex, Once};
+    use std::sync::{Arc, Mutex};
 
     // A fixed at-rest DB key (NOT the Keychain) — same shape the config tests use.
     const DB_KEY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-    // A fixed dev master KEK so lock/unlock/remove use a deterministic key WITHOUT the Keychain or a
-    // Touch ID prompt (the `MURMUR_DEV_KEK` debug-only escape hatch in `secrets::keychain`).
-    const DEV_KEK: &str = "1111111111111111111111111111111111111111111111111111111111111111";
     const STABLE_ORG_ID: &str = "11111111-1111-4111-8111-111111111111";
     const STABLE_DOC_ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 
@@ -70,10 +67,9 @@
         request
     }
 
-    static KEK_ENV: Once = Once::new();
     fn ensure_dev_kek() {
         // Set once, before any thread reads it, so the concurrent readers only ever READ env.
-        KEK_ENV.call_once(|| std::env::set_var("MURMUR_DEV_KEK", DEV_KEK));
+        crate::commands::dev_kek_fixture::ensure_dev_kek();
     }
 
     fn tmp_db_path(tag: &str) -> std::path::PathBuf {

--- a/src-tauri/src/commands/tests/trash_tests.rs
+++ b/src-tauri/src/commands/tests/trash_tests.rs
@@ -16,7 +16,7 @@
 use super::*;
 
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex, Once};
+use std::sync::{Arc, Mutex};
 
 use crate::settings::AppConfig;
 use crate::storage::{Db, Folder, Meeting, MeetingStatus, NoteRecord};
@@ -29,14 +29,8 @@ fn db_key() -> String {
     "0123456789abcdef".repeat(4)
 }
 
-fn dev_kek() -> String {
-    "2".repeat(64)
-}
-
-static KEK_ENV: Once = Once::new();
-
 fn build_state(tag: &str) -> AppState {
-    KEK_ENV.call_once(|| std::env::set_var("MURMUR_DEV_KEK", dev_kek()));
+    crate::commands::dev_kek_fixture::ensure_dev_kek();
     let db_path = crate::storage::db::unique_temp_path(&format!("murmur-trash-{tag}"), "sqlite");
     let _ = std::fs::remove_file(&db_path);
     let db = Db::open_with_key(&db_path, &db_key()).expect("open trash test db");

--- a/src-tauri/src/secrets/keychain.rs
+++ b/src-tauri/src/secrets/keychain.rs
@@ -150,6 +150,26 @@ pub fn get_or_create_db_dek() -> Result<String> {
 /// PLAIN item (see [`resolve_kek`]). This KEK never touches SQLCipher; it only
 /// wraps/unwraps content keys via [`crate::crypto`].
 ///
+/// The debug KEK hatch: its environment-variable name, and the one value every in-repo writer
+/// installs.
+///
+/// Both live here, next to the code that READS the hatch, so the writers cannot drift from the
+/// reader or from each other. There are exactly two writers — the harness runtime probe in
+/// `commands::reminders` and the test fixture in `commands::tests::dev_kek_fixture` — and before
+/// this constant existed each hand-typed its own 64-character literal. They happened to agree,
+/// which is not the same as being unable to disagree.
+///
+/// Never compiled into a release build.
+#[cfg(debug_assertions)]
+pub(crate) const DEV_KEK_ENV: &str = "MURMUR_DEV_KEK";
+
+/// The fixed hatch key. Built rather than written out: a literal 64-hex string in a diff is the
+/// shape the repo's secret scanner exists to catch, and this must not LOOK like a real KEK.
+#[cfg(debug_assertions)]
+pub(crate) fn dev_kek_hatch_value() -> String {
+    "1".repeat(64)
+}
+
 /// Uses [`KEK_DEFAULT_REASON`] on the Touch ID sheet. Call
 /// [`get_or_create_master_kek_with_reason`] to override the prompt text per call-site.
 ///
@@ -178,7 +198,7 @@ pub fn master_kek_with_policy(reason: &str, allow_mint: bool) -> Result<[u8; 32]
     // and the lock KEK can be fixed independently in tests/dev. Returns FIRST so dev needs no Touch
     // ID and no Keychain access at all. NEVER compiled into release.
     #[cfg(debug_assertions)]
-    if let Ok(dev) = std::env::var("MURMUR_DEV_KEK") {
+    if let Ok(dev) = std::env::var(DEV_KEK_ENV) {
         if let Some(k) = hex_to_key32(&dev) {
             return Ok(k);
         }
@@ -272,7 +292,7 @@ fn collect_master_kek_candidates(
     // Dev hatch first (mirrors the resolution order).
     #[cfg(debug_assertions)]
     if let Some(dev_result) =
-        dev_kek_candidates(std::env::var("MURMUR_DEV_KEK").ok().as_deref(), strict)
+        dev_kek_candidates(std::env::var(DEV_KEK_ENV).ok().as_deref(), strict)
     {
         // The debug hatch is an explicit isolated key universe. Touching
         // biometric/plain login-Keychain generations as well would make

--- a/src-tauri/src/secrets/keychain.rs
+++ b/src-tauri/src/secrets/keychain.rs
@@ -199,6 +199,18 @@ pub fn master_kek_with_policy(reason: &str, allow_mint: bool) -> Result<[u8; 32]
     // ID and no Keychain access at all. NEVER compiled into release.
     #[cfg(debug_assertions)]
     if let Ok(dev) = std::env::var(DEV_KEK_ENV) {
+        // Checked HERE, at the moment the key is actually used, not only where the test fixture
+        // installs it. The fixture's own assertion covers the gap between one test's setup and the
+        // next; this covers the gap between a test's setup and its own crypto, which is the window
+        // that actually decides whether that test decrypts with the right key. Compiled out of
+        // both the dev binary and release.
+        #[cfg(test)]
+        debug_assert_eq!(
+            dev,
+            dev_kek_hatch_value(),
+            "the debug KEK changed between fixture setup and this read — something else in this \
+             process installed a different {DEV_KEK_ENV}"
+        );
         if let Some(k) = hex_to_key32(&dev) {
             return Ok(k);
         }


### PR DESCRIPTION
## Problem

`MURMUR_DEV_KEK` jest **globalna dla procesu**. Pięć modułów testowych instalowało ten hatch samodzielnie, każdy za własnym `Once`. Cztery zgadzały się co do wartości (64×`1`), a `trash_tests` instalował inną (64×`2`).

Który `Once` odpalił pierwszy, ten wygrywał zmienną dla **wszystkich** testów, które poszły po nim. Test mógł paść na `Locked("decryption failed (wrong key…)")` wyłącznie z powodu szeregowania wątków. Suita, która pada z powodów niezwiązanych z testowanym kodem, to suita, którą ludzie uczą się ignorować.

## Dlaczego CI tego nie widziało

`cargo nextest` daje **każdemu testowi własny proces**, więc kolizja jest tam niemożliwa. Ale udokumentowana pętla wewnętrzna w `CLAUDE.md` to `cargo test --lib` — **jeden proces**, wiele wątków. Błąd mieszkał więc dokładnie tam, gdzie pracują ludzie, i nigdzie, gdzie bramka mogłaby go złapać.

## Naprawa

Wszystkie pięć miejsc deleguje do jednej fikstury (`commands/tests/dev_kek_fixture.rs`).

Wartość jest zgodna z kluczem, który `prepare_reminder_runtime_probe_environment` **i tak już instaluje** przy wejściu w proces dla probe'a harnessu — więc hatch testowy i hatch probe'a też nie mogą się rozjechać. Klucz jest *budowany*, nie wypisany literalnie, z tego samego powodu, dla którego `trash_tests` budował swój: literalny 64-znakowy hex w diffie to kształt, który skaner sekretów tego repo ma łapać.

## Guard jest inwariantem ŹRÓDŁA — świadomie

Próba reprodukcji zgłoszonej porażki **jej nie odtworzyła**: `relock_all_preflights_every_folder_before_corrupt_attachment_can_blank_a_sibling` przeszedł. Objaw zależy od tego, który wątek wygra wyścig, więc oracle behawioralny byłby tu rzutem monetą.

Skan źródła jest deterministyczny — pada w momencie, gdy ktoś doda drugi klucz, niezależnie od schedulera.

## Pierwsza wersja guarda była PUSTA — wykryła to dopiero mutacja

Warto to zapisać, bo to nie jest teoretyczne. Guard klasyfikował pisarza jako „to fikstura" na podstawie okna czterech linii. Linia *po* podrzuconym drugim kluczu zawiera `ensure_dev_kek()` — więc podrzucony klucz był uznawany za fiksturę i odfiltrowywany. Test **przechodził na kodzie z dokładnie tym błędem, który miał łapać**.

Po zawężeniu do samej linii `set_var` ta sama mutacja daje czerwień i wylicza wszystkich znalezionych pisarzy:

```
every MURMUR_DEV_KEK writer must install the SAME key — Found:
[("commands/reminders.rs", "literal:1x64"),
 ("tests/dev_kek_fixture.rs", "fixture"),
 ("tests/trash_tests.rs", "repeat:2x64")]
```

Guard ma też asercję antypustkową: jeśli skaner nie znajdzie **żadnego** pisarza, pada z komunikatem, że sam zwakuował — bo skaner, który nic nie widzi, przepuszcza wszystko.

## Bramki

| bramka | wynik |
| --- | --- |
| `cargo test --lib` (JEDEN proces — to, co ta zmiana naprawia) | **3600 passed, 0 failed**, 222 s |
| `cargo clippy --lib --tests` | czysto (usunięte martwe `Once`/importy po refaktorze) |

## Znalezione przy okazji — osobne zadanie

W trakcie reprodukcji wypadła **druga instancja tej samej klasy, innym mechanizmem**: `summarize::codex_cli::tests::availability_runs_only_the_local_version_probe_and_finds_gui_install_paths` pada w pełnym `cargo test --lib` (`codex_cli.rs:3339`), a przechodzi uruchomiony sam — czyli cache availability przecieka między testami w procesie. `nextest` ukrywa i to. Zapisane jako osobne zadanie; **nie** naprawiam tego tutaj, żeby nie mieszać dwóch mechanizmów w jednym diffie.


---

## Uzupełnienie: objaw JEDNAK się pojawił — raz, i nie na żądanie

Powyżej napisałem, że reprodukcja nie odtworzyła zgłoszonej porażki. To było prawdziwe dla przebiegu, który wtedy opisywałem. Później zebrałem więcej danych i wypada je podać, bo zmieniają obraz — choć nie zmieniają decyzji projektowej.

| przebieg | gałąź | wynik |
| --- | --- | --- |
| 1 | **z tą poprawką** | 3600 passed / 0 failed |
| 2 | trunk `00a957ab` (**bez** poprawki) | 3598 / **2 failed** — obie w `commands::reminders::smart_audit_command_tests`: `relock_all_preflights_every_folder_before_corrupt_attachment_can_blank_a_sibling` i `relock_audio_failure_retry_round_trips_playback_and_masters_byte_identically` |
| 3 | ten sam worktree co 2, powtórka | brak paniki w `reminders.rs` |

Czyli: objaw wystąpił **raz na dwa przebiegi** na trunku bez poprawki, dokładnie w teście wskazanym w diagnozie, i nie dał się powtórzyć na żądanie.

**Czego to NIE dowodzi.** Trzy przebiegi to za mało, żeby twierdzić, że poprawka usunęła te porażki — przy błędzie zależnym od kolejności zielony przebieg jest zwykłym wynikiem losowania. Nie podaję tego jako dowodu skuteczności.

**Co to potwierdza.** Że oracle behawioralny byłby tu bezwartościowy — dokładnie tak, jak zakładałem, wybierając inwariant źródła. Test, który pada raz na dwa uruchomienia, nie jest bramką; jest generatorem szumu, którego ludzie uczą się nie czytać.

Poprawność samej zmiany nie opiera się na tych przebiegach, tylko na tym, że dwie różne wartości pisane do jednej zmiennej globalnej procesu to błąd konstrukcyjny niezależnie od schedulera — i że guard łapie go deterministycznie.


---

## Przeróbka po werdykcie FAIL — cztery findingi, wszystkie zaadresowane

Adversarial review orzekł **FAIL** i miał rację. Poprzedni guard był nadal pusty na trzy niezależne sposoby, a jego centralna deklaracja nie była egzekwowana.

**Najgorszy przypadek:** cofnięcie `trash_tests.rs` do dokładnie przedpoprawkowego kształtu — lokalne `dev_kek()` zwracające inny klucz, za własnym `Once` — **przechodziło**. Guard rozpoznawał „to fikstura" po podciągu `dev_kek()`, a lokalna funkcja o tej samej nazwie też pasowała. Czyli byte-for-byte przywrócenie oryginalnego buga przechodziło przez test napisany po to, żeby go łapać. Dodatkowo niewidoczny był pisarz nazywający zmienną przez `const` (literał i `set_var` lądują w różnych liniach) oraz `use std::env::set_var as sv`.

**Wniosek nie brzmi „trzy przeoczenia".** Skanowanie źródła w poszukiwaniu *wzorca* zawsze jest tańsze do obejścia niż do obrony — każde z tych obejść wymagało mniej pracy niż check, który miał je łapać.

### Guard nie rozpoznaje już pisarzy — wymienia pliki

Nowa reguła: hatch może być **nazwany** wyłącznie przez pliki, które go posiadają.

| plik | dlaczego wolno |
| --- | --- |
| `secrets/keychain.rs` | deklaruje nazwę i wartość, i czyta hatch |
| `summarize/claude_code.rs` | wycina go ze środowiska spawnowanych providerów (`NEVER_INHERIT_ENV`) |

Guard niczego nie parsuje. Pada na każdą nową wzmiankę gdziekolwiek indziej, niezależnie od jej kształtu.

| mutacja weryfikatora | poprzednio | teraz |
| --- | --- | --- |
| A — `git revert` `trash_tests.rs` do stanu sprzed poprawki | ✅ przechodziło (źle) | ❌ **FAILED** |
| B — `const ROGUE: &str = "MURMUR_DEV_KEK"` | ✅ przechodziło (źle) | ❌ **FAILED** |
| C — `use std::env::set_var as sv` | ✅ przechodziło (źle) | ❌ **FAILED** |
| stan przywrócony | — | ✅ ok |

### Czwarty finding nie potrzebował testu, tylko usunięcia duplikatu

Moduł *twierdził*, że hatch testowy i probe harnessu „nie mogą się rozjechać", podczas gdy oba wpisywały własny, ręcznie wklepany 64-znakowy literał. Weryfikator zmienił jeden i wszystko zostało zielone.

Nazwa i wartość mieszkają teraz w jednym miejscu, obok kodu, który je czyta — `keychain::DEV_KEK_ENV` i `dev_kek_hatch_value()` — a obaj pisarze je referencują. Nie ma już czego rozjeżdżać. Dwa łańcuchy, które przypadkiem są równe, to nie inwariant.

### Reszta

Asercja antypustkowa przeszła review i jest teraz **dwukierunkowa**: pada skan, który nic nie znalazł, i pada wpis na liście, którego plik przestał nazywać hatch (martwa reguła udająca, że czegoś pilnuje).

`ensure_dev_kek` dodatkowo asertuje, że żywa wartość jest nasza. Lista plików nie zobaczy pisarza składającego nazwę w czasie kompilacji (`concat!`); taki pisarz ujawni się tutaj jako inna wartość i padnie z komunikatem nazywającym problem, zamiast wypłynąć jako błąd złego klucza w zupełnie innym teście.

### Bramki po przeróbce

| bramka | wynik |
| --- | --- |
| `cargo test --lib` (jeden proces) | **3600 passed, 0 failed** |
| `cargo nextest run --lib` | 3600/3600 |
| `cargo clippy --lib --tests` | czysto |

### O findingu #5 z review — to byłem ja

Weryfikator zaobserwował 33 porażki `Export("… Not a directory (os error 20)")`, identyczne po obu stronach diffu, i uczciwie zaznaczył, że nie odtwarza mojej deklaracji „3600/0". To była **kontencja maszyny od moich własnych równoległych zadań cargo w kilku worktree**, nie defekt tej zmiany. Repo ma na to `scripts/agent-resource-run` i powinienem był z niego korzystać. Powtórzone przebiegi na spokojnej maszynie: 3600/0.
