### PR TITLE
test: read the whole request in the collaborator-head conflict test

### DIFF
--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -30533,10 +30533,13 @@
             let (mut put, _) = accept_with_timeout(&listener);
             // `read_http_request` rather than a bare `read`, for the two reasons its own comment
             // gives. `accept_with_timeout` polls a NONBLOCKING listener and the accepted stream can
-            // inherit that mode, so a raw `read().unwrap()` panics on `WouldBlock` the moment the
-            // request has not landed yet — which is precisely how this test failed on CI for #647
-            // and passed on the re-run. And a single `read` returns whatever bytes have arrived, so
-            // asserting `starts_with` on it is a second race even once the socket blocks properly.
+            // inherit that mode, so a raw `read().unwrap()` panics on `WouldBlock` before the
+            // request has landed. That is not a theory: CI run 33550375752 — the `murmur` trunk run
+            // for the #647 merge, not one of its PR runs — died here with
+            // `Os { code: 35, kind: WouldBlock }`. Reproduced locally at roughly 8 in 300 sequential
+            // runs of the pre-fix code, and 0 in 600 after it. And a single `read` returns whatever
+            // bytes have arrived, so asserting `starts_with` on it is a second race even once the
+            // socket blocks properly.
             let request = read_http_request(&mut put);
             assert!(String::from_utf8_lossy(&request).starts_with(&format!(
                 "PUT /v1/orgs/{STABLE_ORG_ID}/documents/{doc_for_server}"

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -30496,7 +30496,7 @@
 
     #[test]
     fn collaborator_advanced_head_is_terminal_even_when_head_scan_is_unavailable() {
-        use std::io::{Read, Write};
+        use std::io::Write;
 
         let initial = MockOrgServer::start();
         let state = build_state("org-collaborator-head-conflict");
@@ -30531,9 +30531,14 @@
         let doc_for_server = doc_id.clone();
         let server = std::thread::spawn(move || {
             let (mut put, _) = accept_with_timeout(&listener);
-            let mut request = [0u8; 16384];
-            let n = put.read(&mut request).unwrap();
-            assert!(String::from_utf8_lossy(&request[..n]).starts_with(&format!(
+            // `read_http_request` rather than a bare `read`, for the two reasons its own comment
+            // gives. `accept_with_timeout` polls a NONBLOCKING listener and the accepted stream can
+            // inherit that mode, so a raw `read().unwrap()` panics on `WouldBlock` the moment the
+            // request has not landed yet — which is precisely how this test failed on CI for #647
+            // and passed on the re-run. And a single `read` returns whatever bytes have arrived, so
+            // asserting `starts_with` on it is a second race even once the socket blocks properly.
+            let request = read_http_request(&mut put);
+            assert!(String::from_utf8_lossy(&request).starts_with(&format!(
                 "PUT /v1/orgs/{STABLE_ORG_ID}/documents/{doc_for_server}"
             )));
             write!(


### PR DESCRIPTION
## Flake jest realny, premisa zadania była poprawna, a ja pomyliłem się dwa razy

Ten opis przechodził dwie rewizje. Zostawiam ślad, bo to, gdzie leżała porażka, jest pouczające.

**Run `33550375752`** — konkluzja `failure`, gałąź **`murmur`**, tytuł *„Merge pull request #647 from murmur-io/fix/org-diagnosability"*:

```
test commands::lifecycle_tests::collaborator_advanced_head_is_terminal_even_when_head_scan_is_unavailable ... FAILED

panicked at src-tauri/src/commands/tests/lifecycle_tests.rs:30343:44:
called `Result::unwrap()` on an `Err` value:
  Os { code: 35, kind: WouldBlock, message: "Resource temporarily unavailable" }
```

Linia `30343:44` to `put.read(&mut request).unwrap()`, który ta zmiana usuwa.

**Dlaczego dwoje ludzi to przegapiło.** Porażka jest na **merge-runie na trunku**, nie na przebiegach gałęzi PR-owej. Ja sprawdziłem przebiegi `fix/org-diagnosability` (obie ich czerwienie to faktycznie błędy kompilacji — `E0425`/`E0599` i brakujący `org_diagnosability_tests.rs`) i ogłosiłem premisę błędną. Adversarial review, przeszukując 67 przebiegów, też zaraportował zero. Dopiero skan po pełnej liście trafił na run trunkowy. **Premisa zadania — „padł na CI dla #647" — była poprawna od początku.**

## Mechanizm: potwierdzony trzema niezależnymi drogami

`WouldBlock` to nie krótki odczyt. To `read()` na gnieździe, które odziedziczyło tryb nieblokujący po odpytywanym listenerze, zanim dotarł jakikolwiek bajt.

| dowód | wynik |
| --- | --- |
| CI, run `33550375752` | panic `WouldBlock` w tej linii |
| review: 300 sekwencyjnych przebiegów kodu **sprzed** poprawki | **8 porażek**, identyczny panic |
| review: 600 przebiegów **po** poprawce | **0 porażek** |
| review: sonda jądrowa (`std::net` + `fcntl`) | zaakceptowany strumień dziedziczy `O_NONBLOCK` **200/200** |

`read_http_request` istnieje dokładnie po to i jego pierwszą instrukcją jest `set_nonblocking(false)`. Jego komentarz w repo mówi wprost: *„a scheduled full-suite run can fail immediately with `WouldBlock` mid-request"*. Ktoś rozpoznał to i naprawił dla 71 innych wywołań; to jedno zostało pominięte.

## Rodzeństwo — sprawdzone, dwa niuanse warte zapisania

Review przeszło osiem pozostałych gołych `read` w pliku:

- **27538, 27645, 27659, 27735, 31955, 32036** — blokujące `listener.accept()`, wynik odrzucany, bez asercji. Bezpieczne, inny kształt.
- **27936 i 28270** — te *łączą* nieblokujący accept z pojedynczym `read`, którego treść jest sprawdzana. **Nie są narażone na ten wyścig**, bo oba wołają `set_nonblocking(false)` przed odczytem (27936 dodatkowo ustawia timeout). Zachowują drugie, niższego rzędu ryzyko (żądanie rozbite na segmenty TCP) — istniejące wcześniej, poza zakresem tego PR-a.

## Bramki

| bramka | wynik |
| --- | --- |
| ten test ×20 lokalnie | 20/20 |
| `cargo nextest run --lib` (review, niezależnie) | 3599/3599 |
| `cargo clippy --lib --tests -D warnings` (review) | czysto |

**Werdykt adversarial review: PASS**, z jednym findingiem LOW — komentarz w kodzie podawał atrybucję „#647" jako fakt, gdy review nie mogło jej potwierdzić. Rozstrzygnięte na korzyść atrybucji: commit `241f2a6b` nazywa teraz konkretny run i konkretną gałąź, bo właśnie ta różnica sprawiła, że dwie osoby to przeoczyły.
