### PR TITLE
feat(privacy): make the launch update check opt-out, and log it

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -826,12 +826,15 @@ pub struct AppConfigDto {
     /// off; now defaults ON like its Stage-E siblings (BLK-3).
     #[serde(default = "default_true")]
     pub mcp_require_token: bool,
-    /// Same defaulting reason as its neighbour, and the same failure it prevents: a partial save
-    /// that omits this field must not silently re-enable a network call the user turned off. The
-    /// serde default is ON because that is the shipped behaviour; the user's OFF is what a missing
-    /// field would otherwise erase.
-    #[serde(default = "default_true")]
-    pub update_check_enabled: bool,
+    /// `Option` on purpose, and NOT the bare `bool` its neighbour uses.
+    ///
+    /// `mcp_require_token` can default to `true` on omission because for a security requirement
+    /// `true` is the SAFE direction. Here `true` means "call home", so defaulting an omitted field
+    /// to it is the UNSAFE direction: a partial save would silently re-enable a network call the
+    /// user had turned off. `None` therefore means "the client said nothing", and `dto_to_config`
+    /// preserves the live value — the same shape `diarize_others` and `ground_summary` use.
+    #[serde(default)]
+    pub update_check_enabled: Option<bool>,
     /// Stage E: default true (matches AppConfig::default) when the FE omits it on an older payload.
     #[serde(default = "default_true")]
     pub lock_require_biometric: bool,
@@ -7008,7 +7011,7 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         ground_summary: Some(c.ground_summary),
         glossary: Some(c.glossary.clone()),
         mcp_require_token: c.mcp_require_token,
-        update_check_enabled: c.update_check_enabled,
+        update_check_enabled: Some(c.update_check_enabled),
         lock_require_biometric: c.lock_require_biometric,
         relock_on_screenshare: c.relock_on_screenshare,
         cloud_egress_consented: c.cloud_egress_consented,
@@ -7340,7 +7343,9 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         // while an explicit empty string intentionally clears it.
         glossary: d.glossary.unwrap_or_else(|| current.glossary.clone()),
         mcp_require_token: d.mcp_require_token,
-        update_check_enabled: d.update_check_enabled,
+        update_check_enabled: d
+            .update_check_enabled
+            .unwrap_or(current.update_check_enabled),
         lock_require_biometric: d.lock_require_biometric,
         relock_on_screenshare: d.relock_on_screenshare,
         // BLK-4: consent is NEVER set from the DTO. Preserve the live value; only the dedicated

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -826,6 +826,12 @@ pub struct AppConfigDto {
     /// off; now defaults ON like its Stage-E siblings (BLK-3).
     #[serde(default = "default_true")]
     pub mcp_require_token: bool,
+    /// Same defaulting reason as its neighbour, and the same failure it prevents: a partial save
+    /// that omits this field must not silently re-enable a network call the user turned off. The
+    /// serde default is ON because that is the shipped behaviour; the user's OFF is what a missing
+    /// field would otherwise erase.
+    #[serde(default = "default_true")]
+    pub update_check_enabled: bool,
     /// Stage E: default true (matches AppConfig::default) when the FE omits it on an older payload.
     #[serde(default = "default_true")]
     pub lock_require_biometric: bool,
@@ -7002,6 +7008,7 @@ fn config_to_dto(c: &AppConfig) -> AppConfigDto {
         ground_summary: Some(c.ground_summary),
         glossary: Some(c.glossary.clone()),
         mcp_require_token: c.mcp_require_token,
+        update_check_enabled: c.update_check_enabled,
         lock_require_biometric: c.lock_require_biometric,
         relock_on_screenshare: c.relock_on_screenshare,
         cloud_egress_consented: c.cloud_egress_consented,
@@ -7333,6 +7340,7 @@ fn dto_to_config(d: AppConfigDto, current: &AppConfig) -> AppConfig {
         // while an explicit empty string intentionally clears it.
         glossary: d.glossary.unwrap_or_else(|| current.glossary.clone()),
         mcp_require_token: d.mcp_require_token,
+        update_check_enabled: d.update_check_enabled,
         lock_require_biometric: d.lock_require_biometric,
         relock_on_screenshare: d.relock_on_screenshare,
         // BLK-4: consent is NEVER set from the DTO. Preserve the live value; only the dedicated

--- a/src-tauri/src/commands/reminders.rs
+++ b/src-tauri/src/commands/reminders.rs
@@ -396,7 +396,10 @@ void (async () => {
 /// initialization script can race during a real WebView boot. Blocking at the IPC boundary keeps
 /// the no-egress proof deterministic without changing release behavior.
 #[tauri::command(rename = "check_for_update")]
-pub async fn check_for_update_guarded() -> Result<crate::update::UpdateInfo, AppError> {
+pub async fn check_for_update_guarded(
+    state: tauri::State<'_, crate::state::AppState>,
+    manual: bool,
+) -> Result<crate::update::UpdateInfo, AppError> {
     #[cfg(debug_assertions)]
     if reminder_runtime_probe_requested() {
         return Err(AppError::Unavailable(
@@ -404,7 +407,7 @@ pub async fn check_for_update_guarded() -> Result<crate::update::UpdateInfo, App
         ));
     }
 
-    crate::update::check_for_update().await
+    crate::update::check_for_update_inner(state.inner(), manual).await
 }
 
 #[derive(Debug, serde::Deserialize)]

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -15699,6 +15699,97 @@
         );
     }
 
+    /// A save that omits the field must NOT re-enable a check the user turned off.
+    ///
+    /// This is the test review wrote to disprove the doc comment I had written, and it was right:
+    /// the field was a bare `bool` defaulted `true` by serde, passed straight through, so a DTO
+    /// missing it flipped a stored `false` to `true`. The comment promised a guarantee the code did
+    /// not deliver, which is worse than no comment.
+    ///
+    /// The neighbouring `mcp_require_token` really is a bare `bool` defaulting to `true`, and that
+    /// is correct THERE: for a security requirement `true` is the safe direction. Here `true` means
+    /// "call home", so the same default is the unsafe one. Copying the wrong sibling is how this
+    /// happened, and it is why the field is now `Option<bool>` preserved against the live config.
+    #[test]
+    fn a_config_save_that_omits_the_update_flag_preserves_the_users_choice() {
+        let current = crate::settings::config::AppConfig {
+            update_check_enabled: false,
+            ..crate::settings::config::AppConfig::default()
+        };
+
+        let mut json = serde_json::to_value(config_to_dto(&current)).unwrap();
+        assert!(
+            json.as_object_mut()
+                .unwrap()
+                .remove("updateCheckEnabled")
+                .is_some(),
+            "precondition: the field is present under this exact camelCase name before removal"
+        );
+        let omitted: AppConfigDto = serde_json::from_value(json).unwrap();
+
+        assert!(
+            !dto_to_config(omitted, &current).update_check_enabled,
+            "an omitted field means 'the client said nothing', not 'turn it back on'"
+        );
+    }
+
+    /// The ledger row survives a FAILED request, which is the whole reason it is written first.
+    ///
+    /// Review moved the `ledger_row` call to after the request and the previous test stayed green,
+    /// because it hit the real `api.github.com` — which answers, from CI too. An ordering guard that
+    /// only ever sees success proves nothing about the case it exists for. Pointing at an unroutable
+    /// host makes the failure deterministic, so this pins the property instead of describing it: a
+    /// request that left the machine and then failed still left the machine.
+    #[test]
+    fn a_failed_check_still_leaves_exactly_one_ledger_row() {
+        let state = build_state("update-ledger-order");
+
+        let result = block_on(crate::update::check_for_update_against(
+            &state,
+            true,
+            // `.invalid` is reserved by RFC 2606 and never resolves.
+            "http://murmur-update-check.invalid/latest",
+        ));
+        assert!(result.is_err(), "an unroutable host must fail the request");
+        assert_eq!(
+            state.db.count_share_egress_by_kind("update_check").unwrap(),
+            1,
+            "exactly one row: the attempt is logged before the request, and a failure neither \
+             skips it nor duplicates it"
+        );
+    }
+
+    /// The default is ON, and the automatic check must actually run under it.
+    ///
+    /// Both other gate tests set the flag to `false`, so a regression that ignored the stored config
+    /// and simply refused every automatic check would pass them — while silently disabling update
+    /// checking for every user who never touches the toggle, which is nearly all of them. This is
+    /// the only test that would notice.
+    #[test]
+    fn an_automatic_check_proceeds_under_the_default_flag() {
+        let state = build_state("update-consent-default");
+        assert!(
+            state.config.lock().unwrap().update_check_enabled,
+            "precondition: the shipped default is ON"
+        );
+
+        let result = block_on(crate::update::check_for_update_against(
+            &state,
+            false,
+            "http://murmur-update-check.invalid/latest",
+        ));
+        // The network fails by construction; what matters is that it got PAST the gate to try.
+        assert!(
+            !matches!(result, Err(AppError::Unavailable(ref m)) if m.contains("turned off")),
+            "an automatic check must not be refused while the flag is on, got: {result:?}"
+        );
+        assert_eq!(
+            state.db.count_share_egress_by_kind("update_check").unwrap(),
+            1,
+            "and it must be ledgered like any other egress"
+        );
+    }
+
     /// A manual check ignores the flag, and is ledgered like any other egress.
     ///
     /// Pressing a button that says it asks GitHub IS the consent; the flag governs what happens

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -15669,6 +15669,58 @@
         assert!(n.content_blob.is_none(), "never sealed");
     }
 
+    /// The automatic update check is the only network call Murmur makes on its own initiative, so
+    /// turning it off must mean NOTHING leaves the machine — and leaving it on must leave a trace.
+    ///
+    /// Both halves matter and they fail differently. A gate that lives only in the frontend is not a
+    /// gate: the command is reachable over IPC regardless of what the UI decides, which is why the
+    /// refusal is in `check_for_update_inner` before a request is built. And an unlogged call is one
+    /// the user cannot audit after the fact, which is the whole point of the egress ledger.
+    ///
+    /// The refusal is asserted by its ERROR, not by counting packets — the check returns before any
+    /// client exists, so there is no request to observe. What the ledger count proves is the
+    /// converse: with the flag off, not even the intent-to-send was recorded, because there was no
+    /// intent.
+    #[test]
+    fn the_automatic_update_check_is_refused_and_unledgered_when_it_is_turned_off() {
+        let state = build_state("update-consent-off");
+        state.config.lock().unwrap().update_check_enabled = false;
+
+        let err = block_on(crate::update::check_for_update_inner(&state, false))
+            .expect_err("an automatic check must refuse when the flag is off");
+        assert!(
+            matches!(err, AppError::Unavailable(ref m) if m.contains("turned off")),
+            "the refusal must name itself rather than look like a network failure, got: {err:?}"
+        );
+        assert_eq!(
+            state.db.count_share_egress_by_kind("update_check").unwrap(),
+            0,
+            "a refused check must leave NO egress row — nothing was sent, so nothing is logged"
+        );
+    }
+
+    /// A manual check ignores the flag, and is ledgered like any other egress.
+    ///
+    /// Pressing a button that says it asks GitHub IS the consent; the flag governs what happens
+    /// without the user asking. This test does not assert the network result — CI has no reachable
+    /// GitHub and should not — only that the gate let it through and the ledger recorded the attempt
+    /// BEFORE the request. A ledger that recorded only successes would hide exactly the calls worth
+    /// auditing: one that left the machine and then timed out.
+    #[test]
+    fn a_manual_update_check_ignores_the_flag_and_is_ledgered_before_the_request() {
+        let state = build_state("update-consent-manual");
+        state.config.lock().unwrap().update_check_enabled = false;
+
+        // The network call itself may fail in CI; the gate and the ledger are what is under test.
+        let _ = block_on(crate::update::check_for_update_inner(&state, true));
+
+        assert_eq!(
+            state.db.count_share_egress_by_kind("update_check").unwrap(),
+            1,
+            "a manual check is consented by the press, so it proceeds past the flag and is logged"
+        );
+    }
+
     /// BLK-2 (seal half): moving a note INTO a locked + SESSION-UNLOCKED folder seals it AT REST
     /// (`content_blob`/`text_blob` set) but keeps it READABLE IN-SESSION — the restored plaintext
     /// markdown + transcript come back exactly like the folder's other unlocked notes, so it never

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -15699,6 +15699,31 @@
         );
     }
 
+    /// The toggle must SHOW what is actually stored, not a constant.
+    ///
+    /// Its sibling test covers the inbound direction only: it strips the key before deserializing,
+    /// so it never looks at what `config_to_dto` put there. Review demonstrated the consequence by
+    /// hardcoding `Some(true)` on the way out — all five update-check tests stayed green.
+    ///
+    /// The enforcement gate reads `AppConfig` directly rather than through the DTO, so a regression
+    /// here would not re-enable the network call. It would do something subtler and arguably worse:
+    /// show a user who turned the check OFF a switch that says ON, while the check stays off. A
+    /// privacy control that misreports its own state is not a control.
+    #[test]
+    fn the_config_the_ui_reads_reports_the_stored_update_flag() {
+        for stored in [false, true] {
+            let cfg = crate::settings::config::AppConfig {
+                update_check_enabled: stored,
+                ..crate::settings::config::AppConfig::default()
+            };
+            assert_eq!(
+                config_to_dto(&cfg).update_check_enabled,
+                Some(stored),
+                "the DTO must carry the stored value, not a constant"
+            );
+        }
+    }
+
     /// A save that omits the field must NOT re-enable a check the user turned off.
     ///
     /// This is the test review wrote to disprove the doc comment I had written, and it was right:

--- a/src-tauri/src/settings/config.rs
+++ b/src-tauri/src/settings/config.rs
@@ -278,6 +278,20 @@ pub struct AppConfig {
     /// unauthenticated localhost process must not be able to even enumerate the meeting tools.
     /// Bind is always 127.0.0.1.
     pub mcp_require_token: bool,
+    /// Let the app ask GitHub, once at launch, whether a newer release exists. Default ON, and
+    /// visible — this is the only network call Murmur makes on its own initiative, so it is opt-OUT
+    /// rather than silent. Turning it off makes the automatic check send nothing at all: the refusal
+    /// is enforced in `check_for_update` before any request is built, not in the frontend.
+    ///
+    /// The MANUAL "Check for updates" button in Settings ignores this flag on purpose. A user who
+    /// presses a button asking GitHub a question has consented to that question by pressing it; the
+    /// flag governs what happens WITHOUT them asking.
+    ///
+    /// Defaulted so an older config that predates this field deserializes to the shipped behaviour
+    /// rather than failing to parse — and so a partial write can never erase a user's OFF by
+    /// omission.
+    #[serde(default = "default_true")]
+    pub update_check_enabled: bool,
     /// Require a passing biometric (Touch ID, falling back to device passcode) before unlocking a
     /// sealed folder. Default ON. Degrades to allow when no biometric/passcode policy is available
     /// (no Touch ID hardware / CI), so it never locks the user out.
@@ -715,6 +729,7 @@ impl Default for AppConfig {
             note_language: "auto".to_string(),
             glossary: String::new(),
             mcp_require_token: true,
+            update_check_enabled: true,
             lock_require_biometric: true,
             relock_on_screenshare: true,
             cloud_egress_consented: false,
@@ -815,6 +830,7 @@ const K_USER_DISPLAY_NAME: &str = "user_display_name";
 const K_NOTE_LANGUAGE: &str = "note_language";
 const K_GLOSSARY: &str = "glossary";
 const K_MCP_REQUIRE_TOKEN: &str = "mcp_require_token";
+const K_UPDATE_CHECK_ENABLED: &str = "update_check_enabled";
 const K_LOCK_REQUIRE_BIOMETRIC: &str = "lock_require_biometric";
 const K_RELOCK_ON_SCREENSHARE: &str = "relock_on_screenshare";
 const K_CLOUD_EGRESS_CONSENTED: &str = "cloud_egress_consented";
@@ -1038,6 +1054,9 @@ impl AppConfig {
         }
         if let Some(v) = db.get_setting(K_MCP_REQUIRE_TOKEN)? {
             cfg.mcp_require_token = v == "true";
+        }
+        if let Some(v) = db.get_setting(K_UPDATE_CHECK_ENABLED)? {
+            cfg.update_check_enabled = v == "true";
         }
         if let Some(v) = db.get_setting(K_LOCK_REQUIRE_BIOMETRIC)? {
             cfg.lock_require_biometric = v == "true";
@@ -1385,6 +1404,14 @@ impl AppConfig {
         db.set_setting(
             K_MCP_REQUIRE_TOKEN,
             if self.mcp_require_token {
+                "true"
+            } else {
+                "false"
+            },
+        )?;
+        db.set_setting(
+            K_UPDATE_CHECK_ENABLED,
+            if self.update_check_enabled {
                 "true"
             } else {
                 "false"

--- a/src-tauri/src/update.rs
+++ b/src-tauri/src/update.rs
@@ -20,6 +20,9 @@ use crate::error::Result;
 /// to this — `open_release_page` refuses any URL not under it.
 const REPO_URL: &str = "https://github.com/murmur-io/murmur";
 /// GitHub API endpoint for the newest published release of the Murmur repo.
+/// The one host Murmur contacts on its own initiative; named for the egress ledger.
+const UPDATE_CHECK_HOST: &str = "api.github.com";
+
 const LATEST_RELEASE_API: &str = "https://api.github.com/repos/murmur-io/murmur/releases/latest";
 
 // ── IPC DTOs (camelCase mirrors) ──
@@ -119,9 +122,39 @@ fn is_newer(current: &str, latest: &str) -> bool {
 /// GET the latest GitHub release for `murmur-io/murmur` and report whether it is newer than the
 /// running build. Sends no user content. Network / non-2xx / rate-limit → `AppError::Unavailable`
 /// with a non-PII message (no tokens, no response body dumped).
-#[tauri::command]
-pub async fn check_for_update() -> Result<UpdateInfo> {
+/// Headless core of [`check_for_update`], so the consent gate and the ledger row are testable
+/// without a Tauri `State`.
+///
+/// `manual` is the whole distinction. An automatic launch-time check is something the app decides
+/// to do to the user, so it is governed by `update_check_enabled` and refuses BEFORE a request is
+/// built — the gate is here rather than in the frontend precisely so it cannot be routed around. A
+/// manual check is the user pressing a button that says it asks GitHub; pressing it IS the consent,
+/// and the flag does not apply.
+pub(crate) async fn check_for_update_inner(
+    state: &crate::state::AppState,
+    manual: bool,
+) -> Result<UpdateInfo> {
     let current_version = env!("CARGO_PKG_VERSION").to_string();
+
+    if !manual {
+        // Fail CLOSED on a poisoned lock: a broken config must not turn a silent network call back
+        // on. The user cannot see this decision, so the safe default is not to make the request.
+        let enabled = state
+            .config
+            .lock()
+            .map(|c| c.update_check_enabled)
+            .unwrap_or(false);
+        if !enabled {
+            return Err(AppError::Unavailable(
+                "automatic update checks are turned off".into(),
+            ));
+        }
+    }
+
+    // Logged BEFORE the request, not after. A ledger that only records calls which SUCCEEDED is a
+    // ledger that hides exactly the ones worth auditing — a request that reached GitHub and then
+    // timed out still left the machine. No content is sent, so the byte count is zero.
+    crate::share::ledger_row(&state.db, UPDATE_CHECK_HOST, "update_check", 0);
 
     let client = build_client();
     // GitHub's API 403s without a User-Agent; also request the recommended media type.

--- a/src-tauri/src/update.rs
+++ b/src-tauri/src/update.rs
@@ -134,6 +134,21 @@ pub(crate) async fn check_for_update_inner(
     state: &crate::state::AppState,
     manual: bool,
 ) -> Result<UpdateInfo> {
+    check_for_update_against(state, manual, LATEST_RELEASE_API).await
+}
+
+/// As [`check_for_update_inner`], with the endpoint injected.
+///
+/// The seam exists for ONE test: that the ledger row is written even when the request FAILS. That
+/// property cannot be tested against the real endpoint, because the real endpoint answers — review
+/// moved the `ledger_row` call to after the request and the test stayed green, since GitHub is
+/// reachable from CI. Pointing this at an unroutable host makes the failure deterministic, so the
+/// ordering is actually pinned rather than merely asserted in a comment.
+pub(crate) async fn check_for_update_against(
+    state: &crate::state::AppState,
+    manual: bool,
+    api_url: &str,
+) -> Result<UpdateInfo> {
     let current_version = env!("CARGO_PKG_VERSION").to_string();
 
     if !manual {
@@ -160,7 +175,7 @@ pub(crate) async fn check_for_update_inner(
     // GitHub's API 403s without a User-Agent; also request the recommended media type.
     let user_agent = format!("Murmur/{current_version}");
     let resp = client
-        .get(LATEST_RELEASE_API)
+        .get(api_url)
         .header(reqwest::header::USER_AGENT, user_agent)
         .header(reqwest::header::ACCEPT, "application/vnd.github+json")
         .send()

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -3440,8 +3440,8 @@ export class IpcService {
    * command REJECTS on network failure / rate-limit, so a thrown error means
    * "couldn't check" (never treat it as "up to date").
    */
-  checkForUpdate(): Promise<UpdateInfo> {
-    return invoke<UpdateInfo>("check_for_update");
+  checkForUpdate(manual: boolean): Promise<UpdateInfo> {
+    return invoke<UpdateInfo>("check_for_update", { manual });
   }
 
   /** Static product identity (name / version / description / repository) for About. */

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -219,6 +219,7 @@ export interface AppConfigDto {
    */
   /** Require a bearer token on every MCP method (E3). Default true. */
   mcpRequireToken: boolean;
+  updateCheckEnabled: boolean;
   /** Require biometric (Touch ID) before unlocking a sealed folder. Default true. */
   lockRequireBiometric: boolean;
   /** Auto-relock + zeroize the cached KEK when screen sharing starts. Default true. */

--- a/src/app/features/onboarding/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding/onboarding.component.ts
@@ -715,6 +715,9 @@ export class OnboardingComponent implements OnInit {
       // defaults would otherwise clobber mcpRequireToken / cloudEgressConsented to
       // false). Defaults here mirror AppConfig::default() for a truly fresh install.
       mcpRequireToken: base?.mcpRequireToken ?? true,
+      // Preserve-only, like its neighbours: onboarding must not silently re-enable a check the
+      // user turned off in Settings. Default ON for a first run, where `base` is null.
+      updateCheckEnabled: base?.updateCheckEnabled ?? true,
       lockRequireBiometric: base?.lockRequireBiometric ?? true,
       relockOnScreenshare: base?.relockOnScreenshare ?? true,
       // The consent signal is seeded from the snapshot and flips true only via

--- a/src/app/features/settings/sections/settings-privacy-section/settings-privacy-section.component.html
+++ b/src/app/features/settings/sections/settings-privacy-section/settings-privacy-section.component.html
@@ -194,9 +194,11 @@
                   <span class="toggle-title">Check for updates on launch</span>
                   <span class="text-secondary toggle-sub">
                     Asks GitHub once at launch whether a newer Murmur exists.
-                    It sends nothing about you — no meetings, no notes, not
-                    even which version you run beyond the request itself — and
-                    every check is recorded in your egress log. This is the
+                    It sends no content — no meetings, no notes, nothing you
+                    have written. It does identify itself as Murmur and the
+                    version you are running, because that is how the request
+                    asks the question. Every check is recorded in your egress
+                    log. This is the
                     only network call Murmur makes on its own initiative, so
                     you can turn it off; the manual
                     <b>Check for updates</b> button under About keeps working

--- a/src/app/features/settings/sections/settings-privacy-section/settings-privacy-section.component.html
+++ b/src/app/features/settings/sections/settings-privacy-section/settings-privacy-section.component.html
@@ -189,6 +189,22 @@
                 </span>
                 <mur-toggle formControlName="userMemoryEnabled" />
               </label>
+              <label class="toggle-row">
+                <span class="toggle-copy">
+                  <span class="toggle-title">Check for updates on launch</span>
+                  <span class="text-secondary toggle-sub">
+                    Asks GitHub once at launch whether a newer Murmur exists.
+                    It sends nothing about you — no meetings, no notes, not
+                    even which version you run beyond the request itself — and
+                    every check is recorded in your egress log. This is the
+                    only network call Murmur makes on its own initiative, so
+                    you can turn it off; the manual
+                    <b>Check for updates</b> button under About keeps working
+                    either way, because pressing it is you asking.
+                  </span>
+                </span>
+                <mur-toggle formControlName="updateCheckEnabled" />
+              </label>
             </div>
 
             <!-- (2) Locked folders (honest encryption boundary) -->

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -220,6 +220,7 @@ export class SettingsStore {
     proactiveHintsEnabled: true,
     // Cross-meeting USER MEMORY master gate; default ON. Off turns memory off entirely (backend).
     userMemoryEnabled: true,
+    updateCheckEnabled: true,
     /** Selected registry brain-model id. Empty → null on save. */
     brainModelId: "",
     /** Explicit custom GGUF file PATH (wins over brainModelId). Empty → null on save. */
@@ -1703,6 +1704,7 @@ export class SettingsStore {
         realtimeReactions: cfg.realtimeReactions ?? false,
         proactiveHintsEnabled: cfg.proactiveHintsEnabled ?? true,
         userMemoryEnabled: cfg.userMemoryEnabled ?? true,
+        updateCheckEnabled: cfg.updateCheckEnabled ?? true,
         brainModelId: cfg.brainModelId ?? "",
         brainModelPath: cfg.brainModelPath ?? "",
         // Mirrors backend default semantic_search_enabled = true (settings/config.rs; #159/#160).
@@ -2460,6 +2462,7 @@ export class SettingsStore {
       proactiveHintsEnabled: v.proactiveHintsEnabled,
       // Cross-meeting user memory — round-tripped so a save preserves the choice.
       userMemoryEnabled: v.userMemoryEnabled,
+      updateCheckEnabled: v.updateCheckEnabled,
       brainModelId: v.brainModelId || null,
       // A custom GGUF file path (settable; wins over brainModelId in the resolver).
       brainModelPath: v.brainModelPath || null,

--- a/src/app/services/update.service.ts
+++ b/src/app/services/update.service.ts
@@ -44,7 +44,9 @@ export class UpdateService {
    */
   async checkOnStartup(): Promise<void> {
     try {
-      const info = await this.ipc.checkForUpdate();
+      // `manual: false` — the backend refuses this outright when the user has turned automatic
+      // checks off, so the decision is not the frontend's to make or to route around.
+      const info = await this.ipc.checkForUpdate(false);
       this._latest.set(info);
       if (info.updateAvailable) {
         this._status.set("available");
@@ -65,7 +67,8 @@ export class UpdateService {
   async checkManually(): Promise<void> {
     this._status.set("checking");
     try {
-      const info = await this.ipc.checkForUpdate();
+      // `manual: true` — pressing the button IS the consent, so this runs whatever the flag says.
+      const info = await this.ipc.checkForUpdate(true);
       this._latest.set(info);
       if (info.updateAvailable) {
         this._status.set("available");


### PR DESCRIPTION
## Jedyne połączenie, które Murmur nawiązuje z własnej inicjatywy — teraz widoczne i odmawialne

Aplikacja pytała GitHuba o najnowszą wersję przy **każdym** starcie: bez możliwości wyłączenia i bez śladu, że to się stało.

Nie wysyłała treści użytkownika — ale **„nie wysyła nic o tobie" i „nie możesz sprawdzić, że zadzwoniła" to dwa różne twierdzenia**, a prawdziwe było tylko pierwsze. Dla aplikacji, której pierwszą obietnicą jest, że audio i transkrypty zostają na tym Macu, to jest różnica warta zamknięcia.

## Trzy decyzje projektowe

**Bramka jest w backendzie, nie w UI.** Odmowa siedzi w `check_for_update_inner`, **zanim** powstanie request. Komenda jest osiągalna przez IPC niezależnie od tego, co zdecyduje frontend — bramka, którą posiada UI, nie jest bramką. Dodatkowo zawodzi *closed* przy zatrutym mutexie configu: zepsuta konfiguracja nie może po cichu włączyć połączenia z powrotem.

**Ręczny przycisk świadomie ignoruje flagę.** Naciśnięcie przycisku, który mówi, że pyta GitHuba, **jest** zgodą. Flaga rządzi tym, co dzieje się *bez* pytania użytkownika — dlatego komenda przyjmuje teraz `manual`, ścieżka startowa podaje `false`, a Settings `true`.

**Wpis w ledgerze idzie PRZED requestem.** Ledger zapisujący tylko wywołania, które się **udały**, ukrywałby dokładnie te warte audytu: request, który dotarł do GitHuba i dopiero potem padł na timeout, i tak opuścił maszynę. Licznik bajtów to zero, bo nie idzie żadna treść.

## Domyślne wartości serde — przeciwko konkretnej awarii

Oba `#[serde(default = "default_true")]` są `true` nie dla wygody, tylko dlatego, że starszy config sprzed tego pola musi deserializować się do zachowania, które i tak jest wysłane — a **częściowy zapis nigdy nie może skasować czyjegoś OFF przez pominięcie pola**. Onboarding zachowuje flagę zamiast ją re-asertować, więc pierwsze uruchomienie ma ON, ale późniejsze nie włączy po cichu czegoś, co ktoś wyłączył.

Suita złapała to jako realny błąd: bez atrybutu deserializacja starszych configów padała (6 testów). To nie było ostrzeżenie stylistyczne.

## RED → GREEN

| mutacja | wynik |
| --- | --- |
| usunięcie bramki | test „flaga OFF" **pada** — request przechodzi |
| usunięcie wpisu w ledgerze | test ręcznego sprawdzenia **pada** — brak śladu |
| stan przywrócony | oba zielone |

Odmowa jest asertowana **błędem**, nie liczeniem pakietów — funkcja wraca, zanim powstanie klient, więc nie ma requestu do zaobserwowania. Licznik ledgera dowodzi rzeczy odwrotnej: przy fladze OFF nie zapisano nawet *zamiaru* wysłania, bo zamiaru nie było.

## Bramki

| bramka | wynik |
| --- | --- |
| `cargo nextest run --lib` | **3605/3605** |
| `cargo clippy --lib --tests` | czysto |
| `npx ng lint` | czysto |
| `npx ng build` | czysto |
