### PR TITLE
fix(secrets): never mint a DEK while an encrypted database exists

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1230,12 +1230,25 @@ fn show_fatal_init_dialog(handle: tauri::AppHandle, err: &crate::error::AppError
 
     const TITLE: &str = "Murmur can't open your library";
 
-    let (body, log_reason) = match err {
+    let (body, log_reason): (String, &str) = match err {
+        // `Secrets` carries guidance the user has to ACT on — which key to restore, and from where.
+        // Every other arm here is a hardcoded body, so before this the crafted message reached the
+        // log and nothing else: the one place a locked-out person needs it was the one place it did
+        // not appear. `AppError` messages on this path are content-free by construction (no note
+        // text, no paths, no key material), so showing this one is safe.
+        AppError::Secrets(detail) => (
+            format!(
+                "Murmur couldn't unlock its encrypted database.\n\n{detail}\n\nYour notes have \
+                 NOT been changed or deleted."
+            ),
+            "database key unavailable — refused to replace it",
+        ),
         AppError::KeychainDenied(_) => (
             "macOS didn't grant access to your keychain, so Murmur couldn't unlock its encrypted \
              database.\n\nYour notes are safe and have not been changed. Please reopen Murmur and \
              choose \"Always Allow\" when macOS asks for keychain access. If this keeps happening, \
-             contact support.",
+             contact support."
+                .to_string(),
             "keychain access denied or unavailable",
         ),
         AppError::Locked(_) => (
@@ -1245,14 +1258,16 @@ fn show_fatal_init_dialog(handle: tauri::AppHandle, err: &crate::error::AppError
              content, and audio files have NOT been changed or deleted. Murmur may have recorded a \
              recovery marker. For authenticated recovery, reopen Murmur v1.0.1 (or the dedicated \
              recovery build), use Touch ID to unlock the affected folder, then relaunch this Murmur \
-             build.",
+             build."
+                .to_string(),
             "unfinished legacy recording recovery is locked or ambiguous",
         ),
         _ => (
             "Murmur couldn't unlock its encrypted database. This can happen if the database key \
              doesn't match the data on this Mac (for example after restoring from a backup or \
              another computer) or if the file is damaged.\n\nYour notes have NOT been changed or \
-             deleted. Please reopen Murmur, and if this keeps happening, contact support.",
+             deleted. Please reopen Murmur, and if this keeps happening, contact support."
+                .to_string(),
             "database could not be opened (key mismatch / corruption)",
         ),
     };
@@ -1269,7 +1284,6 @@ fn show_fatal_init_dialog(handle: tauri::AppHandle, err: &crate::error::AppError
     // blocking_show() MUST run off the main thread — it dispatches the native dialog to the main
     // run loop and blocks the caller, so calling it on the main thread would deadlock. Spawn a
     // worker that shows the modal, then exits cleanly (code 1) once the user clicks OK.
-    let body = body.to_string();
     std::thread::spawn(move || {
         handle
             .dialog()

--- a/src-tauri/src/secrets/keychain.rs
+++ b/src-tauri/src/secrets/keychain.rs
@@ -124,6 +124,29 @@ pub fn get_or_create_db_dek() -> Result<String> {
     if let Some(dek) = existing {
         return Ok(dek);
     }
+    // LAST LINE OF DEFENCE before an irreversible mint. The `-34018` refusal above covers one
+    // known way a read wrongly reports "absent"; this covers every other way, by asking the only
+    // question that actually matters — is there already an encrypted database whose sole key is the
+    // one we are about to replace? If so, minting does not "recover" anything: it permanently
+    // orphans the user's entire history, and no later fix can undo it.
+    //
+    // Deliberately NOT refused: a PLAINTEXT database. That is the pre-encryption shape, and
+    // `storage::migration` encrypts it with the freshly-minted key by design.
+    //
+    // The dev hatch returned long before this point, so `MURMUR_DEV_DEK` is unaffected.
+    if crate::state::encrypted_db_exists() {
+        tracing::error!(
+            target: "secrets",
+            "the database key read as absent while an ENCRYPTED database exists — REFUSING to mint a replacement (it would orphan every meeting)"
+        );
+        return Err(AppError::Secrets(
+            "your database is encrypted but its key could not be read. Murmur refuses to create a \
+             new key, because that would make every existing meeting permanently unreadable. \
+             Restore the key from your recovery export, or from a Keychain backup."
+                .into(),
+        ));
+    }
+
     // Mint a fresh DEK. Zeroize the raw byte buffer once the hex form is derived (the hex is the
     // returned secret — the caller is responsible for its lifetime, e.g. wrapping in Zeroizing at
     // the PRAGMA-key site in db.rs/migration.rs, C6).

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -703,12 +703,13 @@ impl AppState {
     /// `<app-data>/<app_dir_name()>/meetnotes.sqlite`, creating the directory if absent.
     /// The folder is `MeetNotes` for release and `MeetNotes-dev` for dev/debug ([`app_dir_name`]).
     fn db_path() -> Result<PathBuf> {
-        let base = dirs::data_dir()
+        let path = db_file_path()
             .ok_or_else(|| AppError::Storage("could not resolve app-data directory".into()))?;
-        let dir = base.join(app_dir_name());
-        std::fs::create_dir_all(&dir)
-            .map_err(|e| AppError::Storage(format!("create app-data dir: {e}")))?;
-        Ok(dir.join(DB_FILE))
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir)
+                .map_err(|e| AppError::Storage(format!("create app-data dir: {e}")))?;
+        }
+        Ok(path)
     }
 }
 
@@ -899,13 +900,22 @@ pub(crate) fn minting_would_orphan_db(path: &std::path::Path) -> bool {
 /// Read-only on purpose: unlike `Db::db_path` this never creates the directory, because it runs on
 /// the pre-mint path where creating anything would be a side effect of asking a question.
 pub(crate) fn encrypted_db_exists() -> bool {
-    let Some(base) = dirs::data_dir() else {
-        // No resolvable app-data directory means no database to orphan. Returning false here is the
-        // permissive answer, and it is the right one: a fresh install on a machine this improbable
-        // still deserves to work, and there is provably nothing to lose.
-        return false;
-    };
-    minting_would_orphan_db(&base.join(app_dir_name()).join(DB_FILE))
+    // No resolvable app-data directory means no database to orphan. The permissive answer is the
+    // right one: a fresh install on a machine this improbable still deserves to work, and there is
+    // provably nothing to lose.
+    db_file_path().is_some_and(|p| minting_would_orphan_db(&p))
+}
+
+/// Where the database lives — the SINGLE construction of that path.
+///
+/// `Db::db_path` and [`encrypted_db_exists`] both go through here on purpose. Review pointed out
+/// that the guard's own composition had no test: a wrong constant, a missing `app_dir_name()`, or a
+/// stray early return in it would leave the guard permanently inert while the whole suite stayed
+/// green, because the decision logic it wraps is tested and it is not. Rather than test for that
+/// drift, this removes the possibility of it — there is now one place to get the path wrong, and
+/// the opener would fail loudly with it.
+pub(crate) fn db_file_path() -> Option<PathBuf> {
+    Some(dirs::data_dir()?.join(app_dir_name()).join(DB_FILE))
 }
 
 /// Does `path` start with the plaintext-SQLite magic ("SQLite format 3\0")? A SQLCipher-encrypted

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -881,6 +881,33 @@ fn assert_locked_audio_at_rest(path: Option<&str>, stream: &str) -> Result<()> {
     Ok(())
 }
 
+/// Would minting a fresh DEK orphan an existing database?
+///
+/// True when `path` is a file that is NOT plaintext SQLite — i.e. an already-SQLCipher-encrypted
+/// database, whose only key is the DEK we are about to replace. A plaintext file is deliberately
+/// NOT a refusal: that is the pre-encryption shape, and `storage::migration` encrypts it with the
+/// newly-minted key on purpose.
+///
+/// Split from [`encrypted_db_exists`] so the decision is testable without reaching for the real
+/// app-data directory.
+pub(crate) fn minting_would_orphan_db(path: &std::path::Path) -> bool {
+    path.is_file() && !is_plaintext_sqlite_file(path)
+}
+
+/// Is there already an encrypted database in the app-data directory?
+///
+/// Read-only on purpose: unlike `Db::db_path` this never creates the directory, because it runs on
+/// the pre-mint path where creating anything would be a side effect of asking a question.
+pub(crate) fn encrypted_db_exists() -> bool {
+    let Some(base) = dirs::data_dir() else {
+        // No resolvable app-data directory means no database to orphan. Returning false here is the
+        // permissive answer, and it is the right one: a fresh install on a machine this improbable
+        // still deserves to work, and there is provably nothing to lose.
+        return false;
+    };
+    minting_would_orphan_db(&base.join(app_dir_name()).join(DB_FILE))
+}
+
 /// Does `path` start with the plaintext-SQLite magic ("SQLite format 3\0")? A SQLCipher-encrypted
 /// file begins with random salt, so the magic is absent. Used by the B4 sweep to delete ONLY the
 /// genuinely-plaintext recovery snapshots an older build leaked — never a keyed (encrypted) one.
@@ -1585,5 +1612,61 @@ mod tests {
             let RecordingStopResult { meeting_id } = result.unwrap();
             assert_eq!(meeting_id, "meeting-42");
         }
+    }
+}
+
+#[cfg(test)]
+mod dek_mint_guard_tests {
+    use super::minting_would_orphan_db;
+
+    /// The three cases the mint decision has to tell apart — and getting any of them wrong is a
+    /// different disaster.
+    ///
+    /// An ENCRYPTED database must refuse: minting there replaces the only key its contents have,
+    /// which is silent, total, unrecoverable loss of every meeting. A PLAINTEXT database must NOT
+    /// refuse: that is the pre-encryption shape and `storage::migration` encrypts it with the newly
+    /// minted key on purpose, so refusing would brick every upgrading install. And NO file must not
+    /// refuse: that is a fresh install, where refusing would mean the app never starts at all.
+    ///
+    /// A single "does the file exist" check would conflate the first two; a single "is it missing"
+    /// check would conflate the last two. That is why this asserts each separately rather than
+    /// asserting one predicate twice.
+    #[test]
+    fn only_an_encrypted_database_refuses_the_mint() {
+        let dir = std::env::temp_dir().join(format!("murmur-dek-guard-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let missing = dir.join("absent.sqlite");
+        assert!(
+            !minting_would_orphan_db(&missing),
+            "a fresh install has no database — refusing here would stop the app from ever starting"
+        );
+
+        let plaintext = dir.join("plain.sqlite");
+        std::fs::write(&plaintext, b"SQLite format 3\0and then some payload").unwrap();
+        assert!(
+            !minting_would_orphan_db(&plaintext),
+            "a plaintext database is the pre-encryption shape; migration encrypts it WITH the new \
+             key, so refusing would brick every upgrading install"
+        );
+
+        let encrypted = dir.join("encrypted.sqlite");
+        // A SQLCipher file opens with random salt, so the plaintext magic is absent.
+        std::fs::write(&encrypted, b"\x9f\x2c\x7e\x01random salt then ciphertext").unwrap();
+        assert!(
+            minting_would_orphan_db(&encrypted),
+            "an encrypted database's ONLY key is the DEK about to be replaced — minting here is \
+             silent, total, unrecoverable loss"
+        );
+
+        // A directory is not a database, however it is named.
+        let dir_named_like_a_db = dir.join("looks-like.sqlite");
+        std::fs::create_dir_all(&dir_named_like_a_db).unwrap();
+        assert!(
+            !minting_would_orphan_db(&dir_named_like_a_db),
+            "a directory is not a file to orphan"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }


### PR DESCRIPTION
## Mintowanie DEK-a przy istniejącej zaszyfrowanej bazie = trwała utrata wszystkiego

DEK jest kluczem SQLCipher **całej** bazy. Zmintowanie zastępczego, gdy zaszyfrowana baza leży na dysku, niczego nie odzyskuje — **trwale sieroci każde nagranie, jakie użytkownik kiedykolwiek zrobił**. Po cichu, bez możliwości cofnięcia jakąkolwiek późniejszą poprawką.

Jeden sposób, w jaki to mogło zajść, był już chroniony: `errSecMissingEntitlement` (`-34018`) na źle podpisanym buildzie, gdzie odczyt mówiący „brak" jest w rzeczywistości odczytem, który **padł**. Każdy inny sposób, w jaki odczyt może błędnie zgłosić brak, nadal przechodził do mintu.

KEK ma porównywalny guard od dawna. DEK — groźniejszy z tych dwóch — nie miał.

## Bramka zadaje jedyne pytanie, które to rozstrzyga

*Czy istnieje już zaszyfrowana baza, której jedynym kluczem jest ten, który mam zastąpić?* Jeśli tak — odmowa, z komunikatem, na podstawie którego użytkownik może działać.

## Ciekawsza połowa: czego NIE wolno zablokować

| stan na dysku | decyzja | dlaczego |
| --- | --- | --- |
| zaszyfrowana baza | **odmowa** | jej jedynym kluczem jest ten mintowany — cicha, całkowita, nieodwracalna strata |
| baza w **plaintekście** | przepuść | to kształt sprzed szyfrowania; `storage::migration` szyfruje ją **nowo zmintowanym** kluczem *by design* — odmowa zablokowałaby każdy upgrade |
| brak pliku | przepuść | świeża instalacja; odmowa oznaczałaby, że aplikacja nigdy nie startuje |

Test sprawdza wszystkie trzy **osobno**, a nie jeden predykat dwa razy. Sprawdzenie „czy plik istnieje" pomyliłoby dwa pierwsze wiersze; „czy pliku brak" — dwa ostatnie. Dorzucony jest też katalog nazwany jak baza.

## RED w obu kierunkach

| mutacja | skutek |
| --- | --- |
| usunięcie sprawdzenia plaintextu (`path.is_file()`) | **pada** — blokowałaby upgrade |
| bramka zawsze przepuszcza (`false`) | **pada** — nie chroniłaby niczego |

To rozróżnienie jest sednem: zbyt luźna bramka blokuje upgrade, zbyt szczelna nie chroni. Jedna mutacja by tego nie pokazała.

## Szczegóły implementacji

- Sonda wydzielona jako `minting_would_orphan_db(path)`, żeby decyzja była testowalna **bez** sięgania po prawdziwy katalog app-data.
- `encrypted_db_exists()` jest **tylko do odczytu** — w przeciwieństwie do `Db::db_path` nigdy nie tworzy katalogu, bo biegnie na ścieżce przed mintem, gdzie tworzenie czegokolwiek byłoby efektem ubocznym zadania pytania.
- `MURMUR_DEV_DEK` wraca długo przed tym miejscem i jest **nietknięty** — tego zadanie wymagało wprost.
- Klucz nie trafia do logów; komunikat błędu i wpis `tracing` mówią o stanie, nie o wartości.

## Zakres, uczciwie

Druga połowa zadania — eksport i przywracanie klucza odzyskiwania — to osobna funkcja UI i **nie ma jej w tym PR**. To jest ta połowa, która **zapobiega** stracie, a nie ta, która pomaga komuś już dotkniętemu.

## Bramki

| bramka | wynik |
| --- | --- |
| `cargo nextest run --lib` | **3604/3604** |
| `cargo clippy --lib --tests` | czysto |
