### PR TITLE
fix(trash): restore brings back a meeting's links and mentions

### DIFF
--- a/src-tauri/src/commands/tests/trash_tests.rs
+++ b/src-tauri/src/commands/tests/trash_tests.rs
@@ -660,3 +660,71 @@ fn restoring_a_meeting_brings_back_its_links_and_mentions() {
          the top of the entity's timeline"
     );
 }
+
+/// A DERIVED edge to a neighbour sealed since the delete must not come back; a user's own must.
+///
+/// `purge_links_tx` strips derived edges when a folder seals, but a meeting sitting in the trash is
+/// invisible to that pass — so a plain verbatim restore resurrects a `wikilink`/`companion`/
+/// suggested `semantic` edge pointing at something that has been sealed meanwhile, which the
+/// ordinary lifecycle would have removed. Lock-security review traced that such a row is INERT today
+/// (every reader re-gates both endpoints live) — but inertness is a property of today's readers, and
+/// the row still should not exist.
+///
+/// The manual edge is the control, and it is the half that makes this test mean something: it proves
+/// the filter is discriminating between derived and decided rather than simply dropping edges to
+/// sealed folders. A seal already preserves user decisions (`LINK_DECISION_KEEP`); a restore must
+/// not be stricter than a seal.
+#[test]
+fn restore_drops_derived_edges_to_a_since_sealed_neighbour_but_keeps_the_users_own() {
+    let state = build_state("trash-derived-sealed");
+    open_folder(&state, "f1", "Work");
+    open_folder(&state, "f2", "Later-sealed");
+    seed_meeting(&state, "m1", Some("f1"));
+    state
+        .db
+        .insert_note("n-far", "f2", "Far", "Far", "body", 1_760_000_000_000)
+        .expect("note in the folder that will be sealed");
+
+    state
+        .db
+        .upsert_manual_link("meeting", "m1", "document", "n-far")
+        .expect("the user's own link");
+    {
+        let mut conn = state.db.lock();
+        let tx = conn.transaction().unwrap();
+        crate::storage::Db::upsert_link_tx(
+            &tx, "meeting", "m1", "document", "n-far", "semantic", 0.9, "auto", "active",
+            1_760_000_000_000,
+        )
+        .expect("a derived suggestion between the same pair");
+        tx.commit().unwrap();
+    }
+    assert_eq!(
+        state.db.link_rows_for_meeting("m1").unwrap().len(),
+        2,
+        "one decided edge and one derived one"
+    );
+
+    block_on(delete_meeting_inner(&state, "m1")).expect("delete to trash");
+
+    // The far side seals while the meeting sits in the trash, and stays NOT session-unlocked.
+    state
+        .db
+        .set_folder_locked_for_test("f2", true)
+        .expect("seal the neighbour's folder");
+
+    let entries = state.db.list_trash_entries().unwrap();
+    block_on(restore_trash_item_inner(&state, &entries[0].id)).expect("restore");
+
+    let after = state.db.link_rows_for_meeting("m1").unwrap();
+    let kinds: Vec<&str> = after.iter().map(|r| r.edge_type.as_str()).collect();
+    assert!(
+        kinds.contains(&"manual"),
+        "the user's own link survives, exactly as a seal preserves it. Got {kinds:?}"
+    );
+    assert!(
+        !kinds.contains(&"semantic"),
+        "the DERIVED edge must not be resurrected into a folder that sealed meanwhile — the \
+         ordinary lifecycle would have purged it. Got {kinds:?}"
+    );
+}

--- a/src-tauri/src/commands/tests/trash_tests.rs
+++ b/src-tauri/src/commands/tests/trash_tests.rs
@@ -594,3 +594,69 @@ fn attachment_hex_codec_round_trips_and_rejects_malformed_input() {
     assert!(hex_decode("zz").is_none(), "non-hex digit is refused");
     assert!(hex_decode("00ff0g").is_none(), "a late bad digit is refused");
 }
+
+/// Trash → restore must bring back the graph edges too, not just the recording.
+///
+/// Before this, the snapshot carried the row, its segments, notes, timeline and tags — everything
+/// that renders the meeting itself — and nothing that connects it to anything. Deleting a meeting
+/// purges its links outright (`preserve_decisions=false`, because the endpoint is gone) and cascades
+/// away its `entity_mentions`, so restore produced a meeting that looked perfectly intact and had
+/// silently forgotten every person it mentioned and every note it was linked to. Re-indexing does
+/// not bring those back: it rebuilds what can be INFERRED from text, so a manual link somebody drew
+/// by hand, or an inbound edge from another note, is gone for good.
+///
+/// The assertions deliberately cover BOTH link directions. An inbound edge is somebody else's link
+/// into this meeting, and losing only that would leave the meeting looking connected while the rest
+/// of the vault had forgotten it.
+#[test]
+fn restoring_a_meeting_brings_back_its_links_and_mentions() {
+    let state = build_state("trash-graph-restore");
+    open_folder(&state, "f1", "Work");
+    seed_meeting(&state, "m1", Some("f1"));
+    state
+        .db
+        .insert_note("n-other", "f1", "Other", "Other", "body", 1_760_000_000_000)
+        .expect("insert the note on the far side of the inbound edge");
+
+    let entity_id = state
+        .db
+        .upsert_entity("Anna", crate::storage::models::EntityKind::Person)
+        .expect("entity");
+    state.db.add_mention(&entity_id, "m1").expect("mention");
+
+    // One edge OUT of the meeting and one INTO it.
+    state
+        .db
+        .upsert_manual_link("meeting", "m1", "document", "n-other")
+        .expect("outbound manual link");
+    state
+        .db
+        .upsert_manual_link("document", "n-other", "meeting", "m1")
+        .expect("inbound manual link");
+
+    let links_before = state.db.link_rows_for_meeting("m1").unwrap();
+    let mentions_before = state.db.entity_mentions_for_meeting("m1").unwrap();
+    assert_eq!(links_before.len(), 2, "one edge each way");
+    assert_eq!(mentions_before.len(), 1, "one mention");
+
+    block_on(delete_meeting_inner(&state, "m1")).expect("delete to trash");
+    assert!(
+        state.db.link_rows_for_meeting("m1").unwrap().is_empty(),
+        "precondition: the delete really does purge the edges — otherwise this test proves nothing"
+    );
+
+    let entries = state.db.list_trash_entries().unwrap();
+    block_on(restore_trash_item_inner(&state, &entries[0].id)).expect("restore");
+
+    let links_after = state.db.link_rows_for_meeting("m1").unwrap();
+    let mentions_after = state.db.entity_mentions_for_meeting("m1").unwrap();
+    assert_eq!(
+        links_after, links_before,
+        "every edge comes back, in both directions, byte-for-byte"
+    );
+    assert_eq!(
+        mentions_after, mentions_before,
+        "and the mention keeps its ORIGINAL created_at — re-dating it would move an old meeting to \
+         the top of the entity's timeline"
+    );
+}

--- a/src-tauri/src/commands/trash.rs
+++ b/src-tauri/src/commands/trash.rs
@@ -86,6 +86,17 @@ struct MeetingSnapshot {
     /// `notes` rows, so the snapshot is their only copy.
     #[serde(default)]
     attachments: Vec<AttachmentSnapshot>,
+    /// Graph edges touching this meeting on EITHER side. Deleting a meeting purges its links
+    /// outright rather than cascading them, so the snapshot is their only copy — and an inbound
+    /// edge matters as much as an outbound one: it is somebody else's link INTO this meeting, and
+    /// losing it is what makes a restored meeting look connected to nothing.
+    #[serde(default)]
+    links: Vec<crate::storage::links::LinkRowSnapshot>,
+    /// `(entity_id, created_at)` for every person/project this meeting mentioned. These cascade off
+    /// `meetings`, so they are gone the moment it is deleted. Their loss is quieter than the note's:
+    /// the meeting comes back intact while every entity's timeline has forgotten it.
+    #[serde(default)]
+    entity_mentions: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -279,6 +290,10 @@ pub(crate) fn capture_meeting(state: &AppState, meeting_id: &str) -> Result<Stri
         .get_meeting_master_paths(meeting_id)
         .unwrap_or((None, None));
 
+    // Read BEFORE the caller's destructive cascade, like every other field here.
+    let links = state.db.link_rows_for_meeting(meeting_id)?;
+    let entity_mentions = state.db.entity_mentions_for_meeting(meeting_id)?;
+
     let snapshot = MeetingSnapshot {
         version: SNAPSHOT_VERSION,
         id: meeting.id.clone(),
@@ -320,6 +335,8 @@ pub(crate) fn capture_meeting(state: &AppState, meeting_id: &str) -> Result<Stri
             .iter()
             .map(attachment_to_snapshot)
             .collect(),
+        links,
+        entity_mentions,
     };
 
     let label = meeting
@@ -1544,6 +1561,53 @@ fn restore_meeting(state: &AppState, payload: &str) -> Result<(), AppError> {
         },
         &s.attachments,
     );
+
+    // Graph edges. These are NOT re-derivable: deleting a meeting purges its links outright and
+    // cascades away its mentions, and re-indexing only rebuilds what can be inferred from text — a
+    // manual link somebody drew, or an inbound edge from another note, is gone for good otherwise.
+    // Restored BEFORE the re-index so the wikilink pass sees the edges that already exist and does
+    // not duplicate them.
+    //
+    // Best-effort, like the re-export below and for the same reason: the meeting itself is already
+    // back, and failing the whole restore over an edge would trade a large loss for a small one.
+    match state.db.restore_link_rows(&s.links) {
+        Ok(n) => {
+            if n < s.links.len() {
+                // Not an error. `INSERT OR IGNORE` skips an edge the user has since dismissed or
+                // re-created, and a decision made after the delete outranks the snapshot.
+                tracing::info!(
+                    target: "trash",
+                    meeting_id = %s.id,
+                    restored = n,
+                    snapshotted = s.links.len(),
+                    "some snapshotted links were superseded by later decisions"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(target: "trash", meeting_id = %s.id, error = %e, "link restore failed")
+        }
+    }
+    match state
+        .db
+        .restore_entity_mentions(&s.id, &s.entity_mentions)
+    {
+        Ok(n) => {
+            if n < s.entity_mentions.len() {
+                // An entity deleted while the meeting sat in the trash takes its mention with it.
+                tracing::info!(
+                    target: "trash",
+                    meeting_id = %s.id,
+                    restored = n,
+                    snapshotted = s.entity_mentions.len(),
+                    "some mentions were dropped — their entity no longer exists"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(target: "trash", meeting_id = %s.id, error = %e, "mention restore failed")
+        }
+    }
 
     // Derived state: re-export the vault `.md` and re-derive chunks/vectors. Best-effort BY DESIGN —
     // the canonical rows are already back, so a failure here degrades search/Obsidian, never content.

--- a/src-tauri/src/commands/trash.rs
+++ b/src-tauri/src/commands/trash.rs
@@ -397,6 +397,17 @@ pub(crate) fn capture_meeting(state: &AppState, meeting_id: &str) -> Result<Stri
             if restored.timeline != snapshot.timeline {
                 return Some("the speaker timeline did not round-trip".to_string());
             }
+            // Named explicitly for the same reason every sibling field is. The generic
+            // byte-identical payload check in `store_and_verify` already proves these survived the
+            // SQLCipher round-trip, so this adds no safety — it adds a diagnosis. A corruption here
+            // would otherwise report "the payload did not store byte-identically", which tells the
+            // next person nothing about which of a dozen fields went wrong.
+            if restored.links != snapshot.links {
+                return Some("the meeting's graph edges did not round-trip".to_string());
+            }
+            if restored.entity_mentions != snapshot.entity_mentions {
+                return Some("the meeting's entity mentions did not round-trip".to_string());
+            }
             None
         },
     )
@@ -1570,7 +1581,7 @@ fn restore_meeting(state: &AppState, payload: &str) -> Result<(), AppError> {
     //
     // Best-effort, like the re-export below and for the same reason: the meeting itself is already
     // back, and failing the whole restore over an edge would trade a large loss for a small one.
-    match state.db.restore_link_rows(&s.links) {
+    match state.db.restore_link_rows(&s.links, &state.unlocked_folders.lock().map(|g| g.clone()).unwrap_or_default()) {
         Ok(n) => {
             if n < s.links.len() {
                 // Not an error. `INSERT OR IGNORE` skips an edge the user has since dismissed or

--- a/src-tauri/src/storage/graph_store.rs
+++ b/src-tauri/src/storage/graph_store.rs
@@ -79,8 +79,6 @@ impl Db {
         Ok(resolved)
     }
 
-    /// Record that `entity_id` was mentioned in `meeting_id`. Idempotent via the PK
-    /// `(entity_id, meeting_id)` — re-summarize / re-extract never double-counts.
     /// This meeting's entity mentions, for a trash snapshot: `(entity_id, created_at)` pairs.
     ///
     /// These cascade off `meetings` on delete, so after the delete there is nothing to read. Their
@@ -150,6 +148,8 @@ impl Db {
         Ok(restored)
     }
 
+    /// Record that `entity_id` was mentioned in `meeting_id`. Idempotent via the PK
+    /// `(entity_id, meeting_id)` — re-summarize / re-extract never double-counts.
     pub fn add_mention(&self, entity_id: &str, meeting_id: &str) -> Result<()> {
         let conn = self.lock();
         let created_at = chrono::Utc::now().to_rfc3339();

--- a/src-tauri/src/storage/graph_store.rs
+++ b/src-tauri/src/storage/graph_store.rs
@@ -81,6 +81,75 @@ impl Db {
 
     /// Record that `entity_id` was mentioned in `meeting_id`. Idempotent via the PK
     /// `(entity_id, meeting_id)` — re-summarize / re-extract never double-counts.
+    /// This meeting's entity mentions, for a trash snapshot: `(entity_id, created_at)` pairs.
+    ///
+    /// These cascade off `meetings` on delete, so after the delete there is nothing to read. Their
+    /// loss is what makes a restored meeting vanish from every person's and project's timeline while
+    /// the meeting itself looks fine — the entity is still there, the meeting is still there, and
+    /// the edge between them is silently gone.
+    pub fn entity_mentions_for_meeting(&self, meeting_id: &str) -> Result<Vec<(String, String)>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT entity_id, created_at FROM entity_mentions
+                  WHERE meeting_id = ?1 ORDER BY entity_id",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![meeting_id], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .map_err(map_err)?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(map_err)?;
+        Ok(rows)
+    }
+
+    /// Re-insert snapshotted mentions, preserving their ORIGINAL `created_at`.
+    ///
+    /// `add_mention` stamps "now", which would be wrong here: these mentions were made when the
+    /// meeting happened, and the graph orders timelines by that stamp. A restore that re-dated them
+    /// would put an old meeting at the top of every entity's history.
+    ///
+    /// A mention whose entity has since been deleted is skipped rather than failing the restore —
+    /// the FK would refuse it, and losing one edge is better than refusing to bring the meeting
+    /// back at all.
+    pub fn restore_entity_mentions(
+        &self,
+        meeting_id: &str,
+        mentions: &[(String, String)],
+    ) -> Result<usize> {
+        if mentions.is_empty() {
+            return Ok(0);
+        }
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let mut restored = 0usize;
+        for (entity_id, created_at) in mentions {
+            let exists: bool = tx
+                .query_row(
+                    "SELECT 1 FROM entities WHERE id = ?1",
+                    rusqlite::params![entity_id],
+                    |_| Ok(true),
+                )
+                .optional()
+                .map_err(map_err)?
+                .unwrap_or(false);
+            if !exists {
+                continue;
+            }
+            restored += tx
+                .execute(
+                    "INSERT OR IGNORE INTO entity_mentions (entity_id, meeting_id, created_at)
+                     VALUES (?1, ?2, ?3)",
+                    rusqlite::params![entity_id, meeting_id, created_at],
+                )
+                .map_err(map_err)?;
+        }
+        tx.commit().map_err(map_err)?;
+        Ok(restored)
+    }
+
     pub fn add_mention(&self, entity_id: &str, meeting_id: &str) -> Result<()> {
         let conn = self.lock();
         let created_at = chrono::Utc::now().to_rfc3339();

--- a/src-tauri/src/storage/links.rs
+++ b/src-tauri/src/storage/links.rs
@@ -943,20 +943,78 @@ impl Db {
         Ok(rows)
     }
 
-    /// Re-insert snapshotted link rows verbatim.
+    /// Is the far endpoint of a snapshotted row visible right now?
+    ///
+    /// "Far" is whichever side is not the meeting being restored — and a row may name it on either
+    /// side, which is the whole reason the snapshot carries both directions. An endpoint kind this
+    /// does not know how to check is treated as NOT visible: refusing to restore an edge is a
+    /// smaller mistake than restoring one that points somewhere sealed.
+    fn endpoints_visible(&self, row: &LinkRowSnapshot, unlocked: &HashSet<String>) -> Result<bool> {
+        for (kind, id) in [
+            (row.src_kind.as_str(), row.src_id.as_str()),
+            (row.dst_kind.as_str(), row.dst_id.as_str()),
+        ] {
+            let visible = match kind {
+                "meeting" => self.meeting_is_visible(id, unlocked)?,
+                "document" => self.document_is_visible(id, unlocked)?,
+                _ => false,
+            };
+            if !visible {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    /// Is this snapshotted row one the USER decided on, rather than one the app derived?
+    ///
+    /// Mirrors `LINK_DECISION_KEEP`, which is what a seal already preserves across a lock of either
+    /// endpoint: a dismissal, an accepted suggestion, or a hand-drawn link. Those carry only ids and
+    /// an edge type — no titles, no plaintext — and every reader gates both endpoints live, which is
+    /// why keeping them is safe. Derived rows have no such standing.
+    fn is_user_decision(row: &LinkRowSnapshot) -> bool {
+        row.status == "dismissed" || row.created_by == "accepted" || row.edge_type == "manual"
+    }
+
+    /// Re-insert snapshotted link rows.
     ///
     /// `INSERT OR IGNORE` rather than the usual upsert: a restore must not overwrite a decision the
     /// user has made since the delete. If an identical edge was re-derived and then dismissed while
     /// the meeting sat in the trash, the dismissal wins — resurrecting it would undo a choice the
     /// user made after the fact.
-    pub fn restore_link_rows(&self, rows: &[LinkRowSnapshot]) -> Result<usize> {
+    ///
+    /// A DERIVED row whose far endpoint is no longer visible is dropped. Lock-security review found
+    /// the gap: `purge_links_tx` strips derived edges when a folder seals, but a meeting sitting in
+    /// the trash is invisible to that pass — so a plain restore would resurrect a `wikilink`,
+    /// `companion` or suggested `semantic` edge pointing at a neighbour that has been sealed
+    /// meanwhile, which the ordinary lifecycle would have removed. Every reader re-gates both
+    /// endpoints live, so such a row is inert rather than a leak, but "inert" is a property of
+    /// today's readers and not something to lean on: the row should not exist. The outbound
+    /// `wikilink` leg self-heals through the re-index that follows a restore; the inbound leg and
+    /// the companion/semantic rows do not, which is what this filter is for.
+    ///
+    /// User decisions are kept regardless — exactly as a seal keeps them.
+    pub fn restore_link_rows(
+        &self,
+        rows: &[LinkRowSnapshot],
+        unlocked: &HashSet<String>,
+    ) -> Result<usize> {
         if rows.is_empty() {
             return Ok(0);
         }
+        // Decided BEFORE the connection lock: the visibility helpers take it themselves, and this
+        // one holds it for the whole insert transaction.
+        let mut keep: Vec<&LinkRowSnapshot> = Vec::with_capacity(rows.len());
+        for row in rows {
+            if Self::is_user_decision(row) || self.endpoints_visible(row, unlocked)? {
+                keep.push(row);
+            }
+        }
+
         let mut conn = self.lock();
         let tx = conn.transaction().map_err(map_err)?;
         let mut restored = 0usize;
-        for row in rows {
+        for row in keep {
             restored += tx
                 .execute(
                     "INSERT OR IGNORE INTO links

--- a/src-tauri/src/storage/links.rs
+++ b/src-tauri/src/storage/links.rs
@@ -170,6 +170,24 @@ fn link_endpoint_sealed_at_rest_tx(
     }
 }
 
+/// One `links` row, verbatim, for a trash snapshot.
+///
+/// Deliberately its own type rather than a reuse of a query DTO: this is an AT-REST format that
+/// ships inside a user's trash entry, so it must stay stable independently of anything the UI or
+/// IPC layer decides to rename. Snake_case for the same reason the snapshot payloads are.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct LinkRowSnapshot {
+    pub src_kind: String,
+    pub src_id: String,
+    pub dst_kind: String,
+    pub dst_id: String,
+    pub edge_type: String,
+    pub score: f64,
+    pub created_by: String,
+    pub status: String,
+    pub created_at: i64,
+}
+
 impl Db {
     /// Brain v3 PR-3 — idempotent LINK-ENGINE schema: the `links` table records DERIVED, content-
     /// revealing relations between `meeting|note|document` rows. Three edge kinds:
@@ -885,6 +903,83 @@ impl Db {
     // is a DERIVED, content-revealing relation, so: PURGED on seal (`purge_links_tx`), RE-DERIVED on
     // unlock, and read with BOTH endpoints visibility-gated (`links_for_visible`). SQL only — the
     // pure edge math (canonicalization, kNN selection) lives in `crate::links`.
+
+    /// Every link row touching `meeting_id` on EITHER side, for a trash snapshot.
+    ///
+    /// Deleting a meeting purges its links outright (`purge_links_tx` with `preserve_decisions=false`,
+    /// because the endpoint is gone), so unlike the cascade-driven tables there is nothing left to
+    /// find afterwards. The snapshot is the only copy, and it has to carry both directions: a link
+    /// naming this meeting as its DESTINATION is somebody else's edge into it, and losing that is
+    /// what makes a restored meeting look connected to nothing.
+    pub fn link_rows_for_meeting(&self, meeting_id: &str) -> Result<Vec<LinkRowSnapshot>> {
+        let conn = self.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT src_kind, src_id, dst_kind, dst_id, edge_type, score, created_by, status,
+                        created_at
+                   FROM links
+                  WHERE (src_kind = 'meeting' AND src_id = ?1)
+                     OR (dst_kind = 'meeting' AND dst_id = ?1)
+                  ORDER BY src_kind, src_id, dst_kind, dst_id, edge_type",
+            )
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map(rusqlite::params![meeting_id], |r| {
+                Ok(LinkRowSnapshot {
+                    src_kind: r.get(0)?,
+                    src_id: r.get(1)?,
+                    dst_kind: r.get(2)?,
+                    dst_id: r.get(3)?,
+                    edge_type: r.get(4)?,
+                    score: r.get(5)?,
+                    created_by: r.get(6)?,
+                    status: r.get(7)?,
+                    created_at: r.get(8)?,
+                })
+            })
+            .map_err(map_err)?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(map_err)?;
+        Ok(rows)
+    }
+
+    /// Re-insert snapshotted link rows verbatim.
+    ///
+    /// `INSERT OR IGNORE` rather than the usual upsert: a restore must not overwrite a decision the
+    /// user has made since the delete. If an identical edge was re-derived and then dismissed while
+    /// the meeting sat in the trash, the dismissal wins — resurrecting it would undo a choice the
+    /// user made after the fact.
+    pub fn restore_link_rows(&self, rows: &[LinkRowSnapshot]) -> Result<usize> {
+        if rows.is_empty() {
+            return Ok(0);
+        }
+        let mut conn = self.lock();
+        let tx = conn.transaction().map_err(map_err)?;
+        let mut restored = 0usize;
+        for row in rows {
+            restored += tx
+                .execute(
+                    "INSERT OR IGNORE INTO links
+                       (src_kind, src_id, dst_kind, dst_id, edge_type, score, created_by, status,
+                        created_at)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                    rusqlite::params![
+                        row.src_kind,
+                        row.src_id,
+                        row.dst_kind,
+                        row.dst_id,
+                        row.edge_type,
+                        row.score,
+                        row.created_by,
+                        row.status,
+                        row.created_at
+                    ],
+                )
+                .map_err(map_err)?;
+        }
+        tx.commit().map_err(map_err)?;
+        Ok(restored)
+    }
 
     /// Upsert ONE edge (idempotent on the UNIQUE key). For an UNDIRECTED (semantic) edge the caller
     /// MUST have canonicalized endpoints (`src<dst`) so A~B and B~A collapse to one row. On a


### PR DESCRIPTION
## Meeting wracał z kosza nienaruszony — i bez żadnych połączeń

Snapshot kosza niósł wiersz, segmenty, notatki, oś czasu i tagi. Czyli wszystko, co **renderuje** meeting, i nic, co go z czymkolwiek **łączy**.

Skasowanie meetingu usuwa jego linki wprost (`preserve_decisions=false`, bo endpoint znika) i kaskadowo zabiera `entity_mentions`. Przywrócenie dawało więc nagranie wyglądające na kompletne, które po cichu zapomniało **każdą osobę, o której mówiło, i każdą notatkę, z którą było powiązane**.

**Reindeksacja tego nie odzyska** — i to czyni z tego stratę, a nie opóźnienie. Odbudowuje to, co da się *wywnioskować z tekstu*, więc link narysowany ręcznie albo krawędź przychodząca z innej notatki przepada bezpowrotnie.

## Trzy szczegóły nośne

**Obie strony krawędzi.** Edge przychodzący to czyjś link **do** tego meetingu. Przywrócenie tylko wychodzących zostawiłoby meeting wyglądający na połączony, podczas gdy reszta skarbca o nim zapomniała.

**`INSERT OR IGNORE`, nie zwykły upsert.** Jeśli identyczna krawędź została w międzyczasie ponownie wyprowadzona i **odrzucona** przez użytkownika, wygrywa odrzucenie — decyzja podjęta po skasowaniu przebija snapshot.

**Wzmianki zachowują ORYGINALNY `created_at`.** `add_mention` stempluje „teraz", a graf porządkuje osie czasu encji po tym stemplu — przywrócenie z nową datą wypchnęłoby stare nagranie na szczyt historii każdej osoby.

## Best-effort, świadomie

Oba przywracania są best-effort, z tego samego powodu co istniejący re-eksport do skarbca: meeting już wrócił, a wywalenie całego przywracania przez jedną krawędź zamieniałoby dużą stratę na małą. Wzmianka, której encja została w międzyczasie skasowana, jest pomijana, nie odrzucana.

## Czego tu świadomie NIE ma

**Fakty i supersesje.** Są bitemporalne, więc ich przywrócenie to nie kopia wierszy: to odtworzenie łańcuchów supersesji i rozstrzygnięcie, co znaczy ponownie otwarte `valid_to` wobec faktów zapisanych od tamtej pory. To osobny projekt, nie dopisek do tego snapshotu.

## RED → GREEN

Test asertuje **warunek wstępny**, że delete naprawdę czyści krawędzie — bez tego mógłby przechodzić pusto:

```rust
assert!(state.db.link_rows_for_meeting("m1").unwrap().is_empty(),
    "precondition: the delete really does purge the edges — otherwise this test proves nothing");
```

Po usunięciu przywracania test pada.

## Zgodność wsteczna

Nowe pola mają `#[serde(default)]`, więc wpisy już leżące w czyimś koszu nadal się parsują — wracają bez krawędzi, jak dotąd, zamiast zawieść przy odczycie.

## Bramki

| bramka | wynik |
| --- | --- |
| `cargo nextest run --lib` | **3611/3611** |
| `cargo clippy --lib --tests` | czysto |

Uwaga z przebiegu: pierwsze clippy zgłosiło ostrzeżenie w funkcji, której nie dotykałem — moja wstawka rozdzieliła `#[allow(clippy::too_many_arguments)]` od jego funkcji. Naprawione przez przeniesienie bloku nad komentarz dokumentacyjny. Testy tego nie widziały.
