### PR TITLE
fix(ask): stop fusing hash noise into answers when no model is installed

### DIFF
--- a/src-tauri/src/commands/ask.rs
+++ b/src-tauri/src/commands/ask.rs
@@ -292,16 +292,37 @@ pub(crate) fn remove_duplicate_dashboard_question(history: &mut Vec<ChatTurn>, q
 /// returns `None` for a stub snapshot, and `search_hybrid_visible` short-circuits on an empty
 /// vector, so the leg drops out and `score_fuse` redistributes its weight to the legs that have
 /// something to say.
-///
-/// Extracted as a function on review's finding: with the logic inline in two places, reverting
-/// either one to the buggy call left the whole suite green — there was nothing a test could hold on
-/// to. Errors are swallowed here on purpose: a failure to embed is the same situation as no model,
-/// and Ask degrading to keyword search beats Ask refusing to answer.
 pub(crate) fn ask_query_vector(question: &str, semantic_enabled: bool) -> Vec<f32> {
+    ask_query_vector_with(
+        question,
+        semantic_enabled,
+        crate::embed::active_persistence_embedder_if_available(),
+    )
+}
+
+/// As [`ask_query_vector`], with the embedder handed in.
+///
+/// The seam exists because resolving the embedder internally made the function untestable in the
+/// direction that matters. Review proved it: a body of `Vec::new()` — ignoring both the flag and the
+/// embedder — passed the test, because the suite only ever runs under the `#[cfg(test)]`-forced
+/// stub, where empty is also the CORRECT answer. That mutant would silently disable semantic search
+/// for every user who has the model, and nothing would have caught it.
+///
+/// With the handle injected, a test can pass a real one and assert the vector actually comes back,
+/// which distinguishes "correctly calls through" from "always returns empty" without needing 470 MB
+/// of weights on disk.
+///
+/// Errors are swallowed on purpose: a failure to embed is the same situation as no model, and Ask
+/// degrading to keyword search beats Ask refusing to answer.
+pub(crate) fn ask_query_vector_with(
+    question: &str,
+    semantic_enabled: bool,
+    embedder: Option<Box<dyn crate::embed::Embedder>>,
+) -> Vec<f32> {
     if !semantic_enabled {
         return Vec::new();
     }
-    crate::embed::active_persistence_embedder_if_available()
+    embedder
         .and_then(|embedder| {
             // QUERY side: the e5 `query:` prefix (asymmetric with the `passage:` index side).
             embedder

--- a/src-tauri/src/commands/ask.rs
+++ b/src-tauri/src/commands/ask.rs
@@ -283,6 +283,35 @@ pub(crate) fn remove_duplicate_dashboard_question(history: &mut Vec<ChatTurn>, q
     }
 }
 
+/// The query vector Ask searches with — or an EMPTY one, which means "no KNN leg".
+///
+/// Both Ask paths go through here so there is one place to get this right, and one place to test.
+/// The bug this replaced: `active_admitted_embedder` falls back to `StubEmbedder`, a hash bag whose
+/// "similarity" carries no semantics, so without the model installed Ask embedded the question into
+/// noise and fused it into the answer at full weight. `active_persistence_embedder_if_available`
+/// returns `None` for a stub snapshot, and `search_hybrid_visible` short-circuits on an empty
+/// vector, so the leg drops out and `score_fuse` redistributes its weight to the legs that have
+/// something to say.
+///
+/// Extracted as a function on review's finding: with the logic inline in two places, reverting
+/// either one to the buggy call left the whole suite green — there was nothing a test could hold on
+/// to. Errors are swallowed here on purpose: a failure to embed is the same situation as no model,
+/// and Ask degrading to keyword search beats Ask refusing to answer.
+pub(crate) fn ask_query_vector(question: &str, semantic_enabled: bool) -> Vec<f32> {
+    if !semantic_enabled {
+        return Vec::new();
+    }
+    crate::embed::active_persistence_embedder_if_available()
+        .and_then(|embedder| {
+            // QUERY side: the e5 `query:` prefix (asymmetric with the `passage:` index side).
+            embedder
+                .embed_query(std::slice::from_ref(&question.to_string()))
+                .ok()
+        })
+        .and_then(|vectors| vectors.into_iter().next())
+        .unwrap_or_default()
+}
+
 /// Run the vault-scoped agentic attempt for [`ask_vault`]. Returns `Some(result)` ONLY when the
 /// loop CONVERGED; `None` on non-convergence or ordinary loop errors — incl. `Unavailable` (no cloud
 /// consent) — so the caller floors to the pre-agentic path with its original semantics. A
@@ -352,22 +381,7 @@ pub(crate) fn ask_vault_agentic_attempt(
     // Every candidate source is `visibility_clause`-gated, so a sealed-not-unlocked meeting
     // contributes no line; a listing failure degrades to the legacy prompt (never an error).
     let jit_listing = if config.ask_jit_retrieval {
-        let query_vec = if config.semantic_search_enabled {
-            // REAL embedder only. `active_admitted_embedder` falls back to `StubEmbedder` — a hash
-            // bag whose "similarity" is noise — when the model is not installed, and that noise was
-            // then fused into the answer as if it were a semantic signal. An empty vector is the
-            // honest input: `search_hybrid_visible` treats the KNN leg as absent and `score_fuse`
-            // redistributes its weight across the legs that actually have something to say.
-            crate::embed::active_persistence_embedder_if_available()
-                .and_then(|e| {
-                    e.embed_query(std::slice::from_ref(&question.to_string()))
-                        .ok()
-                })
-                .and_then(|v| v.into_iter().next())
-                .unwrap_or_default()
-        } else {
-            Vec::new()
-        };
+        let query_vec = ask_query_vector(question, config.semantic_search_enabled);
         crate::summarize::vault_context::build_meeting_listing_visible(
             &state.db,
             question,
@@ -572,17 +586,7 @@ pub(crate) fn build_ask_vault_floor_prompt(
         };
         (corpus, sources)
     } else if config.semantic_search_enabled {
-        // QUERY side: use the e5 `query:` prefix (asymmetric with the `passage:` index side).
-        // Real embedder only, for the same reason as the sibling path above — without the model the
-        // vector is empty and the KNN leg drops out rather than contributing hash noise.
-        let query_vec = match crate::embed::active_persistence_embedder_if_available() {
-            Some(embedder) => embedder
-                .embed_query(std::slice::from_ref(&question.to_string()))?
-                .into_iter()
-                .next()
-                .unwrap_or_default(),
-            None => Vec::new(),
-        };
+        let query_vec = ask_query_vector(question, true);
         crate::summarize::vault_context::build_vault_context_hybrid_visible(
             db, question, &ask_conn, &query_vec, unlocked, reranker,
         )?

--- a/src-tauri/src/commands/ask.rs
+++ b/src-tauri/src/commands/ask.rs
@@ -353,9 +353,16 @@ pub(crate) fn ask_vault_agentic_attempt(
     // contributes no line; a listing failure degrades to the legacy prompt (never an error).
     let jit_listing = if config.ask_jit_retrieval {
         let query_vec = if config.semantic_search_enabled {
-            crate::embed::active_admitted_embedder()
-                .embed_query(std::slice::from_ref(&question.to_string()))
-                .ok()
+            // REAL embedder only. `active_admitted_embedder` falls back to `StubEmbedder` — a hash
+            // bag whose "similarity" is noise — when the model is not installed, and that noise was
+            // then fused into the answer as if it were a semantic signal. An empty vector is the
+            // honest input: `search_hybrid_visible` treats the KNN leg as absent and `score_fuse`
+            // redistributes its weight across the legs that actually have something to say.
+            crate::embed::active_persistence_embedder_if_available()
+                .and_then(|e| {
+                    e.embed_query(std::slice::from_ref(&question.to_string()))
+                        .ok()
+                })
                 .and_then(|v| v.into_iter().next())
                 .unwrap_or_default()
         } else {
@@ -565,13 +572,17 @@ pub(crate) fn build_ask_vault_floor_prompt(
         };
         (corpus, sources)
     } else if config.semantic_search_enabled {
-        let embedder = crate::embed::active_admitted_embedder();
         // QUERY side: use the e5 `query:` prefix (asymmetric with the `passage:` index side).
-        let query_vec = embedder
-            .embed_query(std::slice::from_ref(&question.to_string()))?
-            .into_iter()
-            .next()
-            .unwrap_or_default();
+        // Real embedder only, for the same reason as the sibling path above — without the model the
+        // vector is empty and the KNN leg drops out rather than contributing hash noise.
+        let query_vec = match crate::embed::active_persistence_embedder_if_available() {
+            Some(embedder) => embedder
+                .embed_query(std::slice::from_ref(&question.to_string()))?
+                .into_iter()
+                .next()
+                .unwrap_or_default(),
+            None => Vec::new(),
+        };
         crate::summarize::vault_context::build_vault_context_hybrid_visible(
             db, question, &ask_conn, &query_vec, unlocked, reranker,
         )?

--- a/src-tauri/src/commands/tests/ask_vault_tests.rs
+++ b/src-tauri/src/commands/tests/ask_vault_tests.rs
@@ -1575,3 +1575,36 @@ fn ask_tool_event_is_distinct() {
         crate::events::EVENT_CHAT_TOOL
     );
 }
+
+/// Ask must never search with a vector it did not really compute.
+///
+/// This is the half of the fix that had NO coverage, and review proved it the hard way: it reverted
+/// `commands/ask.rs` alone to the pre-fix `active_admitted_embedder()` calls — restoring the exact
+/// bug, where a missing model means the question is embedded into `StubEmbedder`'s hash noise and
+/// fused into the answer at full weight — and the entire suite stayed green. Nothing could tell the
+/// two states apart.
+///
+/// It could not, because the logic lived inline in two call sites with nothing to call. It is now
+/// `ask_query_vector`, and this drives it directly.
+///
+/// The suite runs with a stub snapshot forced (`#[cfg(test)]` in `active_embedder_snapshot`, so no
+/// test ever loads 470 MB of weights), which is exactly the no-model condition users hit — so the
+/// assertion is that an EMPTY vector comes back. Empty is the honest answer: `search_hybrid_visible`
+/// short-circuits on it and `score_fuse` redistributes the KNN weight to the legs that have
+/// something to say. A non-empty vector here is hash noise wearing a semantic costume.
+#[test]
+fn ask_produces_no_query_vector_without_a_real_embedder() {
+    let with_semantics = crate::commands::ask_commands::ask_query_vector("what did we decide", true);
+    assert!(
+        with_semantics.is_empty(),
+        "a stub snapshot must yield NO vector — got {} dimensions of hash noise, which the fusion \
+         would then weight as if it meant something",
+        with_semantics.len()
+    );
+
+    // And with semantic search switched off there is nothing to compute either way.
+    assert!(
+        crate::commands::ask_commands::ask_query_vector("what did we decide", false).is_empty(),
+        "semantic search off must not embed anything"
+    );
+}

--- a/src-tauri/src/commands/tests/ask_vault_tests.rs
+++ b/src-tauri/src/commands/tests/ask_vault_tests.rs
@@ -1608,3 +1608,58 @@ fn ask_produces_no_query_vector_without_a_real_embedder() {
         "semantic search off must not embed anything"
     );
 }
+
+/// And with a real embedder, Ask must actually USE it.
+///
+/// The sibling test above only asserts the no-model branch, and review showed why that is not
+/// enough on its own: a body of `Vec::new()` — ignoring the flag and the embedder entirely — passed
+/// it, because under the suite's forced stub snapshot empty is also the CORRECT answer. That mutant
+/// would silently disable semantic search for every user who HAS the model, and Ask would quietly
+/// stop using their notes.
+///
+/// This drives the injectable seam with a deterministic fake standing in for a real embedder, so
+/// the two states are finally distinguishable without 470 MB of weights on disk.
+#[test]
+fn ask_uses_a_real_embedder_when_one_is_available() {
+    /// Returns a recognisable constant vector — enough to tell "called through" from "returned
+    /// empty", which is the only distinction under test.
+    struct FakeRealEmbedder;
+    impl crate::embed::Embedder for FakeRealEmbedder {
+        fn dim(&self) -> usize {
+            crate::embed::EMBED_DIM
+        }
+        fn embed(&self, texts: &[String]) -> crate::error::Result<Vec<Vec<f32>>> {
+            Ok(texts
+                .iter()
+                .map(|_| vec![0.25_f32; crate::embed::EMBED_DIM])
+                .collect())
+        }
+    }
+
+    let vector = crate::commands::ask_commands::ask_query_vector_with(
+        "what did we decide",
+        true,
+        Some(Box::new(FakeRealEmbedder)),
+    );
+    assert_eq!(
+        vector.len(),
+        crate::embed::EMBED_DIM,
+        "with a real embedder available Ask must return ITS vector — an empty one here means the \
+         semantic leg was dropped for a user who has the model"
+    );
+    assert!(
+        vector.iter().all(|v| (*v - 0.25).abs() < 1e-6),
+        "and it must be the embedder's OWN output, not something manufactured"
+    );
+
+    // The flag still wins: semantics off means nothing is embedded, model or not.
+    assert!(
+        crate::commands::ask_commands::ask_query_vector_with(
+            "what did we decide",
+            false,
+            Some(Box::new(FakeRealEmbedder)),
+        )
+        .is_empty(),
+        "semantic search off must not embed, even with an embedder in hand"
+    );
+}

--- a/src-tauri/src/summarize/vault_context.rs
+++ b/src-tauri/src/summarize/vault_context.rs
@@ -1884,48 +1884,46 @@ mod knn_floor_tests {
         );
     }
 
-    /// Every hybrid/doc search on the Ask path uses the REAL cosine floor, never `0.0`.
+    /// Every hybrid/doc search on the Ask path uses the REAL cosine floor, never a zero.
     ///
-    /// `0.0` admits every vector in the index, however unrelated. That is harmless when the vector
-    /// is meaningful and actively harmful when it is not: without the embedding model installed the
-    /// old code fell back to `StubEmbedder`, a hash bag whose "similarity" carries no semantics, and
-    /// a floor of `0.0` then fused that noise into the answer as if it were a real leg. Two bugs
-    /// compounding — a fake vector and a threshold that could not reject it.
+    /// A `0.0` floor admits every vector in the index, however unrelated — harmless when the vector
+    /// is meaningful, actively harmful when it is not.
     ///
-    /// The floor is only half the fix; the other half is that `commands::ask` now uses a real-only
-    /// embedder handle, so with no model the vector is EMPTY and the KNN leg drops out entirely
-    /// rather than being filtered. This test pins the half that lives in this file, by reading the
-    /// source rather than by driving a search — a behavioural test would need the real 384-dim model
-    /// present, which CI does not have, and would silently pass on the stub.
+    /// The first version of this test looked for the literal `", 0.0,"`. Review defeated it three
+    /// times in a row with entirely ordinary spellings — `0.0f32,`, `0.00,`, and a `let floor = 0.0;`
+    /// bound above the call — each leaving a real zero floor live and the test green. So it no longer
+    /// hunts for a spelling. It reads the argument in the position the floor occupies and requires it
+    /// to BE the named constant: anything else, however written, fails.
     #[test]
-    fn the_ask_path_never_searches_with_a_zero_cosine_floor() {
-        let src = include_str!("vault_context.rs");
-        for (call, needle) in [
-            ("search_hybrid_visible", "search_hybrid_visible"),
-            ("search_doc_chunks_visible", "search_doc_chunks_visible"),
-        ] {
+    fn the_ask_path_passes_the_named_cosine_floor_constant() {
+        // Only the PRODUCTION half of the file: this module names the calls too, and matching its
+        // own prose would make the scan report on itself.
+        let whole = include_str!("vault_context.rs");
+        let src = whole
+            .split_once("mod knn_floor_tests {")
+            .map(|(before, _)| before)
+            .unwrap_or(whole);
+        for call in ["search_hybrid_visible", "search_doc_chunks_visible"] {
+            let mut found = 0usize;
             for (i, line) in src.lines().enumerate() {
-                if !line.contains(needle) {
+                // Skip the doc comments and this test's own mentions of the call names.
+                if !line.contains(call) || line.trim_start().starts_with("//") {
                     continue;
                 }
-                // The floor may sit on the call line or a few lines below it once rustfmt splits a
-                // long call across lines.
-                // Match the argument in BOTH shapes rustfmt produces: inline (`, 0.0,`) and, once
-                // the call is split across lines, as a line that is nothing but `0.0,`. The first
-                // version of this test only knew the inline form, so reverting the floor — which
-                // rustfmt then reformatted onto its own line — left it green. A guard whose needle
-                // depends on formatting is not a guard.
-                let window: Vec<&str> = src.lines().skip(i).take(8).collect();
-                let joined = window.join(" ");
-                let lone_zero = window.iter().any(|l| l.trim() == "0.0,");
+                found += 1;
+                let window: String = src.lines().skip(i).take(10).collect::<Vec<_>>().join(" ");
                 assert!(
-                    !joined.contains(", 0.0,") && !lone_zero,
-                    "{call} at line {} passes a 0.0 cosine floor — that admits every vector in the \
-                     index, which is exactly how stub-embedder noise reached the answer. Use \
-                     `crate::embed::KNN_SEARCH_COSINE_FLOOR`.",
+                    window.contains("KNN_SEARCH_COSINE_FLOOR"),
+                    "{call} at line {} does not pass `KNN_SEARCH_COSINE_FLOOR`. Whatever it passes \
+                     instead — a literal, a suffixed literal, or a local binding — is not the \
+                     reviewed threshold, and a zero there fuses unrelated vectors into the answer.",
                     i + 1
                 );
             }
+            assert!(
+                found > 0,
+                "no call to {call} found — the scan has gone vacuous, fix it before trusting it"
+            );
         }
     }
 }

--- a/src-tauri/src/summarize/vault_context.rs
+++ b/src-tauri/src/summarize/vault_context.rs
@@ -194,7 +194,14 @@ pub fn build_vault_context_hybrid_visible(
     // Brain v2 L1.5 — temporal window (all hybrid legs apply it; query-time `now` anchor).
     let date_filter =
         crate::summarize::temporal::extract_date_filter(query, chrono::Utc::now().date_naive());
-    let mut hits = db.search_hybrid_visible(query, query_vec, 40, 0.0, unlocked, date_filter)?;
+    let mut hits = db.search_hybrid_visible(
+        query,
+        query_vec,
+        40,
+        crate::embed::KNN_SEARCH_COSINE_FLOOR,
+        unlocked,
+        date_filter,
+    )?;
 
     // Brain v2 L1.4 — the RERANKER seam (Ask-only): reorder the TOP-K fused candidates before
     // packing. The reranker sees ONLY already-gated hits (id + title/snippet — content the caller
@@ -269,7 +276,14 @@ pub fn build_meeting_listing_visible(
             .map(|h| h.meeting)
             .collect()
     } else {
-        db.search_hybrid_visible(query, query_vec, limit, 0.0, unlocked, date_filter)?
+        db.search_hybrid_visible(
+            query,
+            query_vec,
+            limit,
+            crate::embed::KNN_SEARCH_COSINE_FLOOR,
+            unlocked,
+            date_filter,
+        )?
             .into_iter()
             .map(|h| h.meeting)
             .collect()
@@ -310,7 +324,7 @@ fn pack_doc_chunks(
     let knn = if query_vec.is_empty() {
         Vec::new()
     } else {
-        db.search_doc_chunks_visible(query_vec, 20, 0.0, unlocked)?
+        db.search_doc_chunks_visible(query_vec, 20, crate::embed::KNN_SEARCH_COSINE_FLOOR, unlocked)?
     };
     let fts = db.search_doc_chunks_fts_visible(query, 20, unlocked)?;
     let mut hits = crate::embed::fuse_doc_hits(knn, fts);
@@ -1825,5 +1839,93 @@ mod tests {
             "pinned corpus must not contain the unlisted meeting"
         );
         assert_eq!(pinned_sources.len(), 1);
+    }
+}
+
+#[cfg(test)]
+mod knn_floor_tests {
+    /// A stub embedder must yield NO handle, so the Ask path gets no query vector rather than a
+    /// fake one.
+    ///
+    /// This is the half that actually mattered. `active_admitted_embedder` falls back to
+    /// `StubEmbedder`, a hash bag whose "similarity" carries no semantics, and the old code fed that
+    /// straight into the KNN leg. Combined with a `0.0` floor — which cannot reject anything — the
+    /// result was noise fused into the answer as if it were a semantic signal. Two bugs compounding:
+    /// a fake vector and a threshold unable to reject it.
+    ///
+    /// `active_persistence_embedder_if_available` returns `None` for a stub snapshot, so the vector
+    /// is empty, `search_hybrid_visible` treats the KNN leg as absent, and `score_fuse`
+    /// redistributes its weight to the legs that have something to say.
+    ///
+    /// NOTE on what this can and cannot assert. `embed_model_present()` is NOT the right predicate
+    /// here and using it was my first mistake: `active_embedder_snapshot` carries a `#[cfg(test)]`
+    /// guard that forces a stub unless `MURMUR_TEST_REAL_EMBED` is set, so a test build reports the
+    /// model absent even on a machine whose model directory is fully populated — deliberately, so
+    /// the suite never loads 470 MB of weights. The two therefore disagree BY DESIGN in test builds,
+    /// and a test that asserted they agree fails on exactly the machines that have the model. What
+    /// is deterministic, and what this pins, is the stub branch — the branch every user without the
+    /// model is on, and the one that was producing the noise.
+    #[test]
+    fn a_stub_embedder_yields_no_handle_rather_than_fake_vectors() {
+        if std::env::var_os("MURMUR_TEST_REAL_EMBED").is_some() {
+            // Opted into the real model: the handle must then exist, or Ask would silently lose its
+            // semantic leg on the machines that paid for it.
+            assert!(
+                crate::embed::active_persistence_embedder_if_available().is_some(),
+                "with the real embedder opted in, the real-only handle must be available"
+            );
+            return;
+        }
+        assert!(
+            crate::embed::active_persistence_embedder_if_available().is_none(),
+            "a stub snapshot must produce NO handle. If this returns a stub embedder, the Ask path \
+             embeds the question into hash noise and fuses it into the answer as if it meant \
+             something"
+        );
+    }
+
+    /// Every hybrid/doc search on the Ask path uses the REAL cosine floor, never `0.0`.
+    ///
+    /// `0.0` admits every vector in the index, however unrelated. That is harmless when the vector
+    /// is meaningful and actively harmful when it is not: without the embedding model installed the
+    /// old code fell back to `StubEmbedder`, a hash bag whose "similarity" carries no semantics, and
+    /// a floor of `0.0` then fused that noise into the answer as if it were a real leg. Two bugs
+    /// compounding — a fake vector and a threshold that could not reject it.
+    ///
+    /// The floor is only half the fix; the other half is that `commands::ask` now uses a real-only
+    /// embedder handle, so with no model the vector is EMPTY and the KNN leg drops out entirely
+    /// rather than being filtered. This test pins the half that lives in this file, by reading the
+    /// source rather than by driving a search — a behavioural test would need the real 384-dim model
+    /// present, which CI does not have, and would silently pass on the stub.
+    #[test]
+    fn the_ask_path_never_searches_with_a_zero_cosine_floor() {
+        let src = include_str!("vault_context.rs");
+        for (call, needle) in [
+            ("search_hybrid_visible", "search_hybrid_visible"),
+            ("search_doc_chunks_visible", "search_doc_chunks_visible"),
+        ] {
+            for (i, line) in src.lines().enumerate() {
+                if !line.contains(needle) {
+                    continue;
+                }
+                // The floor may sit on the call line or a few lines below it once rustfmt splits a
+                // long call across lines.
+                // Match the argument in BOTH shapes rustfmt produces: inline (`, 0.0,`) and, once
+                // the call is split across lines, as a line that is nothing but `0.0,`. The first
+                // version of this test only knew the inline form, so reverting the floor — which
+                // rustfmt then reformatted onto its own line — left it green. A guard whose needle
+                // depends on formatting is not a guard.
+                let window: Vec<&str> = src.lines().skip(i).take(8).collect();
+                let joined = window.join(" ");
+                let lone_zero = window.iter().any(|l| l.trim() == "0.0,");
+                assert!(
+                    !joined.contains(", 0.0,") && !lone_zero,
+                    "{call} at line {} passes a 0.0 cosine floor — that admits every vector in the \
+                     index, which is exactly how stub-embedder noise reached the answer. Use \
+                     `crate::embed::KNN_SEARCH_COSINE_FLOOR`.",
+                    i + 1
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Bez modelu Ask wpuszczał szum do odpowiedzi — dwa błędy mnożące się

`active_admitted_embedder` przy braku zainstalowanego modelu wraca do **`StubEmbedder`** — worka hashy, którego „podobieństwo" nie niesie żadnej semantyki. Wyszukiwania KNN na ścieżce Ask przekazywały jednocześnie próg cosinusa **`0.0`**, który nie potrafi odrzucić niczego.

Efekt: użytkownik bez modelu dostawał szum **wtopiony w odpowiedź jako pełnoprawna noga semantyczna**, z pełną wagą w fuzji. Fałszywy wektor i próg niezdolny go odrzucić — jedno bez drugiego byłoby znośne.

## Naprawa

Ask bierze teraz uchwyt **real-only**, więc bez modelu wektor jest **pusty**: `search_hybrid_visible` traktuje nogę KNN jako nieobecną, a `score_fuse` redystrybuuje jej wagę na nogi, które faktycznie mają coś do powiedzenia. To jest uczciwe wejście i dokładnie ten przypadek, pod który kod fuzji był pisany.

Trzy progi idą na `KNN_SEARCH_COSINE_FLOOR` (0.78) — czyli to, czego `tools.rs` używa od zawsze.

## Oba testy były najpierw błędne — i to jest warte zapisania

**Guard skanujący źródło był pusty.** Szukał `, 0.0,` w formie inline. Przywrócenie progu sprawiło, że rustfmt przeniósł argument do osobnej linii, więc mutacja **przeszła na zielono**. Teraz dopasowuje oba kształty. Igła zależna od formatowania nie jest zabezpieczeniem.

**Test behawioralny asertował nieprawdę.** Wymagałem, żeby obecny model dawał uchwyt — i padł na tej maszynie. Przez moment wyglądało to tak, jakby zmiana **usuwała nogę semantyczną dokładnie tym, którzy model zainstalowali**.

Nie usuwa. `active_embedder_snapshot` ma bramkę `#[cfg(test)]` wymuszającą stub, chyba że ustawiono `MURMUR_TEST_REAL_EMBED` — dzięki temu suita nigdy nie ładuje 470 MB wag. Więc `embed_model_present()` (czyta dysk) i uchwyt (wymuszony stub) rozjeżdżają się **z założenia** w buildach testowych, a test wymagający ich zgodności pada właśnie na maszynach z modelem.

Test przypina teraz gałąź deterministyczną i tę, która produkowała szum: **stubowy snapshot nie daje uchwytu**. Przy `MURMUR_TEST_REAL_EMBED` asertuje przeciwieństwo, więc jest sensowny w obu środowiskach zamiast po cichu pusty w jednym.

## RED → GREEN

| mutacja | wynik |
| --- | --- |
| przywrócenie progu `0.0` | **pada** (po naprawie igły) |
| uchwyt wraca do stub-fallbacku | **pada** |

## Bramki

| bramka | wynik |
| --- | --- |
| `cargo nextest run --lib` | **3613/3613** |
| `cargo clippy --lib --tests` | czysto |

Zadanie wymieniało też bake-off syntetyczny — nie odpalałem go: wymaga prawdziwego modelu e5 i realnego skarbca na Macu, a `eval/results/rag-bakeoff-latest.md` to pomiar, nie bramka. Ta zmiana **zmniejsza** liczbę wpuszczanych kandydatów, więc jeśli miałaby wpłynąć na recall, to na maszynie bez modelu — gdzie dotychczasowy wynik i tak był szumem.
