### PR TITLE
fix(org): pin the invitee's key, so a relay cannot substitute its own

### DIFF
--- a/src-tauri/src/commands/org.rs
+++ b/src-tauri/src/commands/org.rs
@@ -3559,12 +3559,13 @@ pub(crate) async fn org_invite_member_inner(
     let (account_id, gen_id, mk, access_token) = require_session_mk(state).await?;
     let client = crate::share::client::ShareClient::new(&base)?;
 
-    // Resolve the new member's account id (server-side email lookup).
-    let added = client
-        .org_add_member(&access_token, &org.org_id, &email)
-        .await?;
-
-    // Look up the member's published identity key to wrap the OCK to them.
+    // Look up and VERIFY the key BEFORE adding the member.
+    //
+    // The order matters, on review's finding. Adding first left a refused invite with an active
+    // member row server-side, and the relay counts every active member toward a rotation's coverage
+    // regardless of whether they hold a grant — so a refused invitee silently blocked every future
+    // rotation until removed, and re-drove the rotation path against the very key just refused.
+    // Verifying first means a refusal leaves no server-side trace at all.
     let lookup = client.lookup_key(&access_token, &email).await?;
     let key = lookup
         .key
@@ -3598,6 +3599,11 @@ pub(crate) async fn org_invite_member_inner(
             &chrono::Utc::now().to_rfc3339(),
         )?,
     }
+
+    // Only now does the member row exist server-side.
+    let added = client
+        .org_add_member(&access_token, &org.org_id, &email)
+        .await?;
 
     let generation = org.generation;
     let ock = acquire_org_ock(state, &org.org_id, generation).await?;
@@ -3824,6 +3830,36 @@ pub(crate) async fn rotate_org_generation(
                 )));
             };
             let fp = crate::e2ee::key_fingerprint(&key.pk_enc, &key.pk_sig);
+            // SAME gate as the invite path, and for a sharper reason: without it, gating the invite
+            // alone was FALSE ASSURANCE. A refused invite still leaves the member row active
+            // server-side, the relay's coverage check counts every active member regardless of
+            // whether they hold a grant, so the next ordinary removal schedules a rotation that
+            // re-drives this very branch — cache misses, ungated lookup fires, and the brand-new OCK
+            // is wrapped to the same substituted key the invite had just refused. The attack simply
+            // arrived one admin action later.
+            //
+            // The cached branch above needs no check because a cached key is one this device already
+            // TOFU-verified. This branch is the cold-cache case: a second Mac, a reinstall, or an org
+            // whose members predate the key cache — all of which land here.
+            //
+            // Refusing keeps the rotation OWED rather than granting to an unverified key. The debt is
+            // journalled and retried, so a legitimate re-key resolves once a human has verified it,
+            // while a substitution never silently completes.
+            match crate::commands::tofu_check(&state.db, &member.user_id, &fp)? {
+                crate::commands::TofuState::Changed => {
+                    return Err(AppError::Auth(crate::errcode::tag(
+                        crate::errcode::ORG_INVITE_KEY_CHANGED,
+                        "a remaining member's key changed since you last verified it — re-verify the \
+                         safety words with them out of band before this rotation can complete",
+                    )));
+                }
+                _ => state.db.pin_contact(
+                    &member.user_id,
+                    Some(email),
+                    &fp,
+                    &chrono::Utc::now().to_rfc3339(),
+                )?,
+            }
             state.db.upsert_org_member_key(
                 &org.org_id,
                 &member.user_id,

--- a/src-tauri/src/commands/org.rs
+++ b/src-tauri/src/commands/org.rs
@@ -3571,6 +3571,34 @@ pub(crate) async fn org_invite_member_inner(
         .filter(|_| lookup.registered)
         .ok_or_else(|| AppError::InvalidArg("that address is not a registered account".into()))?;
 
+    // TOFU on the invitee's key, BEFORE the OCK is wrapped to it.
+    //
+    // `lookup_key` answers with whatever the relay says the address's key is. Without this check a
+    // relay that substitutes `pk_enc` between the lookup and the wrap receives the org content key
+    // wrapped to a key it holds — the exact substitution the mode-B share path already refuses
+    // (`share_note_with_account`). This path skipped it, so the org's whole shared brain was one
+    // dishonest lookup away from a stranger.
+    //
+    // First contact PINS. A change REFUSES and sends nothing: a changed key is either a legitimate
+    // re-key or an attack, and the two are indistinguishable from here, so the only honest move is
+    // to stop and ask the human to re-verify out of band.
+    let member_fp_pre = crate::e2ee::key_fingerprint(&key.pk_enc, &key.pk_sig);
+    match crate::commands::tofu_check(&state.db, &key.user_id, &member_fp_pre)? {
+        crate::commands::TofuState::Changed => {
+            return Err(AppError::Auth(crate::errcode::tag(
+                crate::errcode::ORG_INVITE_KEY_CHANGED,
+                "this person's key changed since you last invited them — re-verify the safety words \
+                 with them out of band, then invite again",
+            )));
+        }
+        _ => state.db.pin_contact(
+            &key.user_id,
+            Some(&email),
+            &member_fp_pre,
+            &chrono::Utc::now().to_rfc3339(),
+        )?,
+    }
+
     let generation = org.generation;
     let ock = acquire_org_ock(state, &org.org_id, generation).await?;
     let owner = crate::e2ee::keys::derive_identity(&mk, &account_id, gen_id)?;

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -42740,3 +42740,102 @@ fn recording_filing_attachment_rollback_preserves_replacement_symlink_and_unknow
         // changed only its test-helper wording; the production tool path above delegates to the
         // canonical `search_visible` gate exercised directly and through `execute_tool`.
     }
+
+    /// A relay that swaps the invitee's key between invites must not get the OCK wrapped to it.
+    ///
+    /// `lookup_key` answers with whatever the relay says an address's key is, and the invite path
+    /// fed that straight into `wrap_ock_for_member`. So a dishonest relay could hand back its OWN
+    /// `pk_enc` and receive the org content key wrapped for itself — the whole shared brain, one
+    /// substituted lookup away. The mode-B share path has refused this for a while via `tofu_check`;
+    /// the invite path did not.
+    ///
+    /// The two halves are asserted separately on purpose. Refusing is not enough on its own: what
+    /// matters is that NOTHING was sent, so the assertion on the relay's side (no key-grant request
+    /// arrived) is the one that actually pins the security property. A version that returned the
+    /// error after posting the grant would satisfy the first assertion and none of the point.
+    #[test]
+    fn an_invite_refuses_when_the_relay_swaps_the_invitees_key() {
+        use std::io::Write;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (saw_tx, saw_rx) = std::sync::mpsc::channel();
+        let server = std::thread::spawn(move || {
+            // POST /v1/orgs/{id}/members — the FIRST request on this path: `resolve_org` reads
+            // locally and the seeded session's token is unexpired, so nothing precedes it.
+            let (mut add, _) = accept_with_timeout(&listener);
+            let _ = read_http_request(&mut add);
+            let body = r#"{"userId":"u-invitee"}"#;
+            write!(add,"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",body.len()).unwrap();
+
+            // POST /v1/keys/lookup — the SUBSTITUTED key (all 0x02, vs the 0x01 already pinned).
+            let (mut lookup, _) = accept_with_timeout(&listener);
+            let request = read_http_request(&mut lookup);
+            assert!(String::from_utf8_lossy(&request).starts_with("POST /v1/keys/lookup "));
+            // `pk_enc`/`pk_sig` cross the wire as base64URL with NO padding (`b64` in the shared
+            // protocol crate) — not hex, and not standard base64. 32 bytes of 0x02, against the
+            // 0x01 key this device already pinned.
+            let swapped = "AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI";
+            let body = format!(
+                r#"{{"registered":true,"key":{{"userId":"u-invitee","generation":1,"pkEnc":"{swapped}","pkSig":"{swapped}","fingerprint":"whatever-the-relay-claims"}}}}"#
+            );
+            write!(lookup,"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",body.len()).unwrap();
+
+            // Anything further would be the key grant leaving — which must NOT happen.
+            listener
+                .set_nonblocking(true)
+                .expect("poll for an unexpected follow-up");
+            let deadline = std::time::Instant::now() + std::time::Duration::from_millis(400);
+            while std::time::Instant::now() < deadline {
+                if listener.accept().is_ok() {
+                    saw_tx.send(true).unwrap();
+                    return;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10));
+            }
+            saw_tx.send(false).unwrap();
+        });
+
+        let state = build_state("org-invite-tofu");
+        seed_org(&state.db, STABLE_ORG_ID, "Acme", "owner", 1);
+        seed_live_session(&state);
+        seed_ock(&state, STABLE_ORG_ID, 1);
+        state.config.lock().unwrap().org_egress_consented = true;
+        state.config.lock().unwrap().share_base_url = format!("http://{addr}/");
+
+        // The invitee's key as this device first saw it: all 0x01.
+        let original = crate::e2ee::key_fingerprint(&[0x01u8; 32], &[0x01u8; 32]);
+        state
+            .db
+            .pin_contact(
+                "u-invitee",
+                Some("invitee@example.com"),
+                &original,
+                "2026-09-01T00:00:00Z",
+            )
+            .unwrap();
+
+        let err = block_on(org_invite_member_inner(
+            &state,
+            STABLE_ORG_ID.to_string(),
+            "invitee@example.com".to_string(),
+        ))
+        .expect_err("a swapped key must refuse the invite");
+        assert!(
+            matches!(err, AppError::Auth(ref m) if m.contains(crate::errcode::ORG_INVITE_KEY_CHANGED)),
+            "the refusal must carry the stable code so the UI can say the right thing, got: {err:?}"
+        );
+
+        assert!(
+            !saw_rx.recv().unwrap(),
+            "NOTHING may leave after the refusal — a key grant posted before erroring would hand \
+             the org content key to whoever supplied the substituted public key"
+        );
+        server.join().unwrap();
+
+        assert_eq!(
+            state.db.get_pinned_contact("u-invitee").unwrap().unwrap().1,
+            original,
+            "and the pin still holds the ORIGINAL key — a refusal must never quietly re-pin"
+        );
+    }

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -42761,14 +42761,8 @@ fn recording_filing_attachment_rollback_preserves_replacement_symlink_and_unknow
         let addr = listener.local_addr().unwrap();
         let (saw_tx, saw_rx) = std::sync::mpsc::channel();
         let server = std::thread::spawn(move || {
-            // POST /v1/orgs/{id}/members — the FIRST request on this path: `resolve_org` reads
-            // locally and the seeded session's token is unexpired, so nothing precedes it.
-            let (mut add, _) = accept_with_timeout(&listener);
-            let _ = read_http_request(&mut add);
-            let body = r#"{"userId":"u-invitee"}"#;
-            write!(add,"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",body.len()).unwrap();
-
-            // POST /v1/keys/lookup — the SUBSTITUTED key (all 0x02, vs the 0x01 already pinned).
+            // POST /v1/keys/lookup is now the FIRST request: the key is verified BEFORE the member
+            // is added, so a refusal leaves nothing behind server-side. — the SUBSTITUTED key (all 0x02, vs the 0x01 already pinned).
             let (mut lookup, _) = accept_with_timeout(&listener);
             let request = read_http_request(&mut lookup);
             assert!(String::from_utf8_lossy(&request).starts_with("POST /v1/keys/lookup "));
@@ -42781,7 +42775,7 @@ fn recording_filing_attachment_rollback_preserves_replacement_symlink_and_unknow
             );
             write!(lookup,"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",body.len()).unwrap();
 
-            // Anything further would be the key grant leaving — which must NOT happen.
+            // Anything further — the member add OR the key grant — must NOT happen.
             listener
                 .set_nonblocking(true)
                 .expect("poll for an unexpected follow-up");
@@ -42828,8 +42822,9 @@ fn recording_filing_attachment_rollback_preserves_replacement_symlink_and_unknow
 
         assert!(
             !saw_rx.recv().unwrap(),
-            "NOTHING may leave after the refusal — a key grant posted before erroring would hand \
-             the org content key to whoever supplied the substituted public key"
+            "NOTHING may leave after the refusal — not the key grant, which would hand the org \
+             content key to whoever supplied the substituted key, and not even the member add, \
+             which would leave a row that blocks every future rotation"
         );
         server.join().unwrap();
 

--- a/src-tauri/src/commands/tests/org_rotation_tests.rs
+++ b/src-tauri/src/commands/tests/org_rotation_tests.rs
@@ -855,3 +855,86 @@ async fn the_rotation_targets_the_relay_s_generation_not_the_stale_local_one() {
     );
     assert_eq!(state.db.get_org_state(ORG).unwrap().unwrap().generation, 4);
 }
+
+/// A rotation must REFUSE when a looked-up member's key changed since it was pinned — and must
+/// send nothing at all when it does.
+///
+/// Gating the invite alone was false assurance, and this is the branch that made it so. A refused
+/// invitee stays an active member server-side, the relay counts every active member toward a
+/// rotation's coverage regardless of whether they hold a grant, so the next ordinary removal
+/// schedules a rotation that re-drives THIS loop — where a cache miss sends the ungated lookup back
+/// to the same dishonest relay, and the brand-new OCK gets wrapped to the very key the invite just
+/// refused. The attack completed one admin action later.
+///
+/// Lock-security review traced the gate as correct but noted nothing would fail if a refactor moved
+/// it. That is the gap this closes.
+///
+/// The two assertions carry different weight. Refusing is the visible half; sending nothing is the
+/// security property. `rotate_org_generation` builds every grant into a local vec and posts once
+/// after the loop, so an early return drops the partial work — but that is a property of the
+/// current shape, not a law, and it is exactly what a future refactor could break silently.
+#[tokio::test]
+async fn a_rotation_refuses_and_sends_nothing_when_a_members_key_changed() {
+    let relay = RotationRelay::start(roster(), published_keys());
+    let state = AppState::for_tests(fresh_db("rotate-tofu-changed"));
+    wire_state(&state, &relay);
+    seed_cached_member_key(&state);
+
+    // The looked-up member was pinned earlier with a DIFFERENT key than the relay now publishes.
+    // Seed 9 vs the roster's seed 4: same person, a key this device has never agreed to.
+    let stale = member_identity(9, "lookedup@example.com");
+    state
+        .db
+        .pin_contact(
+            STAYS_LOOKED_UP_UID,
+            Some("lookedup@example.com"),
+            &crate::e2ee::key_fingerprint(&stale.pk_enc, &stale.pk_sig),
+            "2026-09-01T00:00:00Z",
+        )
+        .unwrap();
+
+    let err = org_remove_member_inner(&state, ORG.into(), REMOVED_UID.into())
+        .await
+        .expect_err("a changed key must stop the rotation");
+    // The REMOVAL succeeds and the rotation debt is journalled — `org_remove_member_inner`
+    // deliberately converts any rotation failure into `ORG_ROTATION_PENDING`, because the member is
+    // already gone and the retry is what eventually completes it. So the surfaced code is the
+    // pending one, not the TOFU one; what this test pins is that the rotation itself sent nothing.
+    assert!(
+        matches!(err, AppError::Unavailable(ref m) if m.contains(crate::errcode::ORG_ROTATION_PENDING)),
+        "removal succeeds and the debt is recorded, got: {err:?}"
+    );
+    assert!(
+        state
+            .db
+            .list_org_rotations_pending()
+            .unwrap()
+            .contains(&ORG.to_string()),
+        "the rotation must stay OWED so a retry can complete it once the key is verified"
+    );
+
+    let log = relay.log();
+    assert!(
+        log.granted.is_empty(),
+        "NO grant may be posted after the refusal — a grant here hands the new org key to whoever \
+         supplied the substituted public key. Got {:?}",
+        log.granted
+    );
+    assert!(
+        log.bump_body.is_none(),
+        "and the generation must not be committed: a bumped generation nobody holds a key for \
+         strands the whole org"
+    );
+
+    // The pin still names the key this device agreed to — a refusal must never re-pin.
+    assert_eq!(
+        state
+            .db
+            .get_pinned_contact(STAYS_LOOKED_UP_UID)
+            .unwrap()
+            .unwrap()
+            .1,
+        crate::e2ee::key_fingerprint(&stale.pk_enc, &stale.pk_sig),
+        "the refusal must leave the original pin intact"
+    );
+}

--- a/src-tauri/src/errcode.rs
+++ b/src-tauri/src/errcode.rs
@@ -182,6 +182,13 @@ pub const ORG_ROTATION_PENDING: &str = "org-rotation-pending";
 
 /// Every code this crate emits, in declaration order. The frontend's allowlist mirrors it;
 /// `error_codes_are_unique_and_kebab_case` keeps the shape a machine can rely on.
+/// The invitee's published identity key differs from the one this device pinned on first contact.
+///
+/// A relay that can substitute `pk_enc` between the lookup and the wrap gets the org content key
+/// wrapped to a key IT holds. Refusing is the only safe answer: the invite is not sent, and the user
+/// is told to re-verify out of band rather than being asked to trust a key that changed silently.
+pub const ORG_INVITE_KEY_CHANGED: &str = "org-invite-key-changed";
+
 pub const ALL: &[&str] = &[
     CLOUD_CONSENT,
     SHARE_CONSENT,
@@ -217,6 +224,7 @@ pub const ALL: &[&str] = &[
     SHARE_BUSY,
     CONTAINER_UNAVAILABLE,
     ORG_ROTATION_PENDING,
+    ORG_INVITE_KEY_CHANGED,
 ];
 
 #[cfg(test)]
@@ -319,6 +327,10 @@ mod tests {
             // the removal succeeded and the rotation is owed, which is a different sentence from
             // any existing failure code and the only one that must not read as "try again".
             "org-rotation-pending",
+            // Added 2026-09-03 with TOFU on org invites. See `ORG_INVITE_KEY_CHANGED`: the invite
+            // was NOT sent, and unlike every other failure here the remedy is not "try again" —
+            // retrying is precisely what must not happen until a human has verified the key.
+            "org-invite-key-changed",
         ];
         assert_eq!(ALL, expected);
     }

--- a/src/app/core/copy/error-copy.service.ts
+++ b/src/app/core/copy/error-copy.service.ts
@@ -135,6 +135,7 @@ export const ERROR_CODES = [
   "folder-closing",
   "container-unavailable",
   "org-rotation-pending",
+  "org-invite-key-changed",
 ] as const;
 
 export type ErrorCode = (typeof ERROR_CODES)[number];
@@ -246,6 +247,11 @@ const BASE_COPY: Readonly<Record<ErrorCode, string>> = {
     "Removed. Their access key is still being rotated — until that finishes, anything new you share here could still be readable by them. Murmur keeps retrying.",
   "container-unavailable":
     "This recording isn’t in a folder Murmur can add a note to. Move it, then try again.",
+  // Deliberately does NOT offer "try again": retrying is the one thing that must not happen here.
+  // A changed key is either an honest re-key or somebody in the middle, and nothing this app can
+  // see tells the two apart — so the copy asks for out-of-band verification instead.
+  "org-invite-key-changed":
+    "This person’s security key has changed since you last invited them. That can happen after they reinstall — or if someone is impersonating them. Check the safety words with them another way before inviting again.",
 };
 
 /**


### PR DESCRIPTION
## Relay mógł podstawić własny klucz i dostać cały wspólny mózg organizacji

Ścieżka zaproszenia brała klucz publiczny **prosto z odpowiedzi `lookup_key`** i owijała nim klucz zawartości organizacji (OCK). A `lookup_key` odpowiada tym, co **relay** twierdzi, że jest kluczem danego adresu.

Nieuczciwy relay mógł więc zwrócić **własny** `pk_enc` i otrzymać OCK zaszyfrowany dla siebie. Bez kompromitacji jakiegokolwiek urządzenia — wystarczyło jedno podmienione zapytanie.

## Sprawdzenie już istniało i już było używane

`tofu_check` chroni ścieżkę udostępniania trybu B, odmawiając, gdy klucz kontaktu zmienił się od czasu przypięcia. Ścieżka zaproszenia po prostu **nigdy go nie wołała** — i na tym polega cały błąd. Ta zmiana nie wprowadza nowego mechanizmu, tylko domyka lukę w stosowaniu istniejącego.

## Pierwszy kontakt pinuje, zmiana ODMAWIA

Ta surowość jest zamierzona. Zmieniony klucz to albo uczciwe przegenerowanie, albo ktoś w środku — a **nic widoczne z tego miejsca ich nie rozróżnia**. Jedynym uczciwym ruchem jest zatrzymać się i poprosić człowieka o weryfikację poza pasmem.

Nowy stabilny kod `org-invite-key-changed` ma treść, która celowo **nie proponuje „spróbuj ponownie"** — ponowna próba jest dokładnie tym, co nie może tu nastąpić.

## Test: dwie asercje, bo tylko druga niesie własność bezpieczeństwa

Test prowadzi prawdziwe zaproszenie przeciwko mockowi relaya, który podmienia klucz.

| asercja | co pilnuje |
| --- | --- |
| błąd niesie stabilny kod | UI powie właściwą rzecz |
| **żadne żądanie grantu nie dotarło** | ← **to jest własność bezpieczeństwa** |
| pin nadal trzyma ORYGINALNY klucz | odmowa nie może po cichu re-pinować |

Implementacja, która wysłałaby grant, a potem zwróciła błąd, spełniłaby pierwszą asercję i minęła się z całym sensem. Dlatego strona relaya sprawdza, że nic nie przyszło.

## Dwie rzeczy z przebiegu

**Dodanie kodu wywaliło `errcode::tests::the_code_set_is_pinned`** — i to jest ten test **działający**: zestaw jest przypięty, żeby nowy kod trzeba było dopisać świadomie, a nie przemycić. Wpis w kopiach FE też jest wymagany, bo jego brak wywala `ng build`.

**Nie zgaduje się formatu drutu.** Mój mock szedł najpierw hexem, potem zwykłym base64, zanim przeczytałem `murmur-protocol` i zobaczyłem, że pola idą jako **base64url bez dopełnienia**.

## Bramki

| bramka | wynik |
| --- | --- |
| `cargo nextest run --lib` | **3612/3612** |
| `cargo clippy --lib --tests` | czysto |
