### PR TITLE
fix(shared): a failed shared-workspace read says so instead of showing nothing

### DIFF
--- a/e2e/shell/shared-containers.spec.ts
+++ b/e2e/shell/shared-containers.spec.ts
@@ -435,3 +435,42 @@ test("an item inside a shared container is not marked twice", async ({ page }) =
   await expect(kickoff).toBeVisible();
   await expect(kickoff.getByRole("img", { name: /Shared to/ })).toHaveCount(0);
 });
+
+/// A failed shared-workspace read must SAY so, not render as "nothing shared with you".
+///
+/// Every read in `SharedWorkspaceService.load` swallowed its rejection into `null`/`[]`, so an
+/// unreachable relay produced an empty workspace — indistinguishable from a team that has shared
+/// nothing. The user was, in effect, told something false, with no retry offered because nothing
+/// indicated there was anything to retry.
+///
+/// The control is the second half: with the same fixtures resolving normally, the banner must be
+/// ABSENT. Without that, a component that always showed the message would pass the first assertion
+/// and be worse than what it replaced.
+test("an unreachable shared workspace shows an error, not an empty one", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {
+      list_shared_workspace: () => {
+        throw new Error("relay unreachable");
+      },
+    },
+    {
+      list_workspace_tree: LOCAL_FOREST,
+      list_container_share_status: CONTAINER_SHARES,
+    },
+  );
+  await page.goto("/");
+  await expect(
+    page.getByRole("navigation", { name: "Primary navigation" }),
+  ).toBeVisible();
+
+  await expect(page.getByText(/Couldn't read what's shared with you/)).toBeVisible();
+  await expect(page.getByText("Nothing shared with you yet")).toHaveCount(0);
+});
+
+test("a healthy shared workspace shows no error banner", async ({ page }) => {
+  await openSidebar(page);
+  await expect(page.getByText(/Couldn't read what's shared with you/)).toHaveCount(0);
+});

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.html
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.html
@@ -4,6 +4,11 @@
      underneath. Gating on loading() alone is the 2026-07-12 "reload flash". -->
 @if (sectionEmpty() && loading()) {
   <p class="tree-state">Loading{{ isOwnScope() ? " workspace" : " shared content" }}…</p>
+} @else if (sectionEmpty() && error(); as message) {
+  <!-- The error must OUTRANK the empty state, or it is unreachable in the one case it exists to
+       describe: a failed read has no rows, so "nothing shared with you" would win and assert
+       something false. This branch is why the emptiness is explained rather than reported. -->
+  <p class="tree-error" role="status">{{ message }}</p>
 } @else if (sectionEmpty()) {
   <p class="tree-state">{{ isOwnScope() ? "No Workspaces yet" : "Nothing shared with you yet" }}</p>
 } @else {

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
@@ -250,7 +250,20 @@ export class WorkspaceTreeComponent {
   }
 
   protected readonly loading = this.workspace.loading;
-  protected readonly error = this.workspace.error;
+  /**
+   * The message this half of the forest should show, if any.
+   *
+   * Was always `workspace.error`, even on the SHARED instance — so a shared-workspace read that
+   * failed rendered as "Nothing shared with you yet". A user whose relay was unreachable was told
+   * their team had shared nothing. The own-workspace half is unchanged.
+   */
+  protected readonly error = computed(() =>
+    this.isOwnScope()
+      ? this.workspace.error()
+      : this.sharedWorkspace.loadFailed()
+        ? "Couldn't read what's shared with you. Showing the last known state."
+        : null,
+  );
   protected readonly workspaceEmpty = this.workspace.workspaceEmpty;
   protected readonly unfiledRecordings = this.workspace.unfiledRecordings;
   protected readonly unfiledExpanded = this.workspace.unfiledExpanded;

--- a/src/app/services/shared-workspace.service.ts
+++ b/src/app/services/shared-workspace.service.ts
@@ -42,6 +42,7 @@ export class SharedWorkspaceService {
   private readonly _containerShares = signal<ContainerShareStatus[]>([]);
   private readonly _shareTargets = signal<OrgShareTargetRow[]>([]);
   private readonly _loading = signal(false);
+  private readonly _loadFailed = signal(false);
 
   /** Received SPACES — each renders as its own top-level sidebar row. */
   readonly spaces = this._spaces.asReadonly();
@@ -57,6 +58,19 @@ export class SharedWorkspaceService {
   readonly shareTargets = this._shareTargets.asReadonly();
   /** True while a (re)load is in flight. A hint, never a render gate. */
   readonly loading = this._loading.asReadonly();
+  /**
+   * The last load could not read the shared workspace.
+   *
+   * Every read here swallowed its error into `null`/`[]`, so a failure rendered as an EMPTY
+   * workspace — indistinguishable from "nothing is shared with you". Somebody whose relay was
+   * unreachable was told, in effect, that their team had shared nothing, and there was no retry
+   * because there was nothing to retry from.
+   *
+   * Kept separate from the data signals on purpose: the last-known rows stay on screen while this
+   * is true, so a failed refresh degrades to "possibly stale" rather than blanking what the user
+   * was already reading.
+   */
+  readonly loadFailed = this._loadFailed.asReadonly();
 
   /** Nothing shared in either direction — the sidebar renders no shared rows. */
   readonly isEmpty = computed(() => {
@@ -148,19 +162,34 @@ export class SharedWorkspaceService {
     const seq = ++this.loadSeq;
     this._loading.set(true);
     try {
-      const [workspace, shares, targets] = await Promise.all([
-        this.ipc.listSharedWorkspace().catch(() => null),
-        this.ipc.listContainerShareStatus().catch(() => [] as ContainerShareStatus[]),
-        this.ipc.listOrgShareTargets().catch(() => [] as OrgShareTargetRow[]),
+      // `allSettled`, not `all`: one unreachable read must not discard the two that succeeded.
+      // What changes is that a rejection is now RECORDED rather than silently becoming an empty
+      // list — the difference between "nothing is shared with you" and "we could not find out".
+      const [workspace, shares, targets] = await Promise.allSettled([
+        this.ipc.listSharedWorkspace(),
+        this.ipc.listContainerShareStatus(),
+        this.ipc.listOrgShareTargets(),
       ]);
+      const failed =
+        workspace.status === "rejected" ||
+        shares.status === "rejected" ||
+        targets.status === "rejected";
       if (seq !== this.loadSeq) {
         return;
       }
-      if (workspace) {
-        this.applyWorkspace(workspace);
+      this._loadFailed.set(failed);
+      // Each leg applies only if it actually resolved. A rejected leg leaves its previous value
+      // alone rather than clearing it, so a partial failure never erases rows the user can still
+      // legitimately see.
+      if (workspace.status === "fulfilled" && workspace.value) {
+        this.applyWorkspace(workspace.value);
       }
-      this._containerShares.set(shares);
-      this._shareTargets.set(targets);
+      if (shares.status === "fulfilled") {
+        this._containerShares.set(shares.value);
+      }
+      if (targets.status === "fulfilled") {
+        this._shareTargets.set(targets.value);
+      }
     } finally {
       if (seq === this.loadSeq) {
         this._loading.set(false);


### PR DESCRIPTION
## Warstwa zespołowa nie udawała sukcesu — renderowała fałsz

Wszystkie trzy odczyty w `SharedWorkspaceService.load` zamieniały odrzucenie na `null`/`[]`:

```ts
this.ipc.listSharedWorkspace().catch(() => null),
this.ipc.listContainerShareStatus().catch(() => [] as ContainerShareStatus[]),
this.ipc.listOrgShareTargets().catch(() => [] as OrgShareTargetRow[]),
```

Niedostępny relay dawał więc **pusty workspace** — nie do odróżnienia od zespołu, który nic nie udostępnił. Użytkownik z padniętą siecią był informowany, że koledzy nie podzielili się z nim niczym. Bez opcji ponowienia, bo nic nie wskazywało, że jest co ponawiać.

## Naprawa: `allSettled` + osobny sygnał

`Promise.allSettled` zamiast `all`, więc jeden nieudany odczyt nie odrzuca dwóch, które się udały. Każda noga aplikuje się **tylko jeśli się rozwiązała** — odrzucona zostawia poprzednią wartość, zamiast czyścić wiersze, które użytkownik nadal legalnie widzi.

`loadFailed` jest świadomie **osobny** od sygnałów danych: ostatnio znane wiersze zostają na ekranie, więc nieudane odświeżenie degraduje się do „możliwie nieaktualne", a nie do wyczyszczenia widoku, który ktoś właśnie czyta.

## Dwa ukryte błędy, ważniejsze niż sam sygnał

**Drzewo brało `error` z `workspace.error` bezwarunkowo** — także w instancji renderującej stronę WSPÓŁDZIELONĄ. Czyli nawet zgłoszony błąd nie miałby gdzie się pojawić. Teraz źródło jest świadome scope'u; połowa własna bez zmian.

**Gałąź błędu w szablonie stała PO gałęzi pustego stanu.** Nieudany odczyt nie ma wierszy, więc wygrywało „Nothing shared with you yet" — komunikat był **nieosiągalny dokładnie w tym przypadku, dla którego istnieje**. Błąd przebija teraz pustkę.

To kolejność jest naprawą, nie treść. Doprowadził mnie do tego test: banner się nie pokazywał, mimo że sygnał działał poprawnie.

## RED → GREEN

| | wynik |
| --- | --- |
| po usunięciu gałęzi błędu | **1 failed / 11 passed** |
| stan przywrócony | 12/12 |

Test prowadzi przypadkiem awarii i **kończy kontrolą**: banner musi być NIEOBECNY przy zdrowym odczycie. Bez tego komponent zawsze wyświetlający komunikat przeszedłby pierwszą asercję i byłby gorszy niż stan wyjściowy.

## Bramki

| bramka | wynik |
| --- | --- |
| e2e chromium + webkit | **24/24** |
| `npx ng lint` | czysto |
| `npx ng build` | czysto |

## Zakres, uczciwie

Zadanie wymienia też przegląd 25 `catch(() => …)` i 5 `void this.ipc.*`. **Nie ma tego w tym PR-ze** — ten jeden był tym, który renderował nieprawdę, i wolę go zamknąć osobno niż rozmyć w przeglądzie dwudziestu kolejnych.
