### PR TITLE
test(mcp): stop two socket assertions demanding guarantees the gate does not make

### DIFF
--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -2890,10 +2890,22 @@ mod tests {
         });
         revoked_rx.recv_timeout(Duration::from_secs(1)).unwrap();
         release_tx.send(()).unwrap();
-        assert!(
-            writer.join().unwrap().is_err(),
-            "the writer continued after response revocation"
-        );
+        // This used to assert `is_err()` on the writer, which contradicted the gate's own
+        // documented contract and flaked on CI (2026-09-03).
+        //
+        // `close_and_shutdown` runs in three steps: cancel every response, THEN `shutdown(2)`
+        // every socket clone, THEN wait for admitted chunks to drain. The writer here is
+        // released while the revoker sits in step 3, so it usually writes into an
+        // already-shut-down socket and fails — measured on this platform: a write after
+        // `shutdown(2)` reliably returns BrokenPipe, including through a `try_clone`d handle,
+        // so this was never kernel buffering. But a writer released in the gap between step 1
+        // and step 2 writes to a LIVE socket and succeeds, and that is not a leak: the chunk was
+        // admitted while the client was still authorized, and the gate's own comment says so —
+        // "A successful pre-cancel syscall is already a disclosure to the then-authorized
+        // client; TCP cannot retract it." So the assertion demanded a guarantee the product
+        // deliberately does not make. What the product DOES guarantee is asserted below and does
+        // not race: what the CLIENT receives, and how many write syscalls our own code started.
+        let _ = writer.join().unwrap();
         revoker.join().unwrap();
         assert_eq!(
             writes.load(Ordering::SeqCst),
@@ -2901,9 +2913,16 @@ mod tests {
             "a second write syscall started after response revocation"
         );
 
-        client
-            .set_read_timeout(Some(Duration::from_millis(250)))
-            .unwrap();
+        // Best-effort, because this call FAILING cannot make the assertion below false, and
+        // `.unwrap()` here panicked on CI (2026-09-03, `Os { code: 22, InvalidInput }`).
+        // HONEST LIMIT: I could not reproduce that EINVAL from this test's shape. A socket probe
+        // on this platform shows a PEER shutdown — even with megabytes left unread, which should
+        // force an RST — leaves `set_read_timeout` returning Ok; only shutting down one's OWN
+        // socket produces EINVAL, and no test does that. So the trigger is still unexplained, and
+        // this comment says so rather than inventing a mechanism. Making the call best-effort is
+        // right regardless: the timeout only bounds how long the read may block, and the read is
+        // already bounded by the EOF the revocation produces.
+        let _ = client.set_read_timeout(Some(Duration::from_millis(250)));
         let mut delivered = Vec::new();
         let _ = client.read_to_end(&mut delivered);
         assert_eq!(delivered, b"A");
@@ -3198,16 +3217,35 @@ mod tests {
             );
 
             release_tx.send(()).unwrap();
-            assert!(
-                writer.join().unwrap().is_err(),
-                "a chunk admitted before cancellation wrote after socket shutdown"
-            );
+            // This used to assert `is_err()` on the writer, which contradicted the gate's own
+            // documented contract and flaked on CI (2026-09-03).
+            //
+            // `close_and_shutdown` runs in three steps: cancel every response, THEN `shutdown(2)`
+            // every socket clone, THEN wait for admitted chunks to drain. The writer here is
+            // released while the revoker sits in step 3, so it usually writes into an
+            // already-shut-down socket and fails — measured on this platform: a write after
+            // `shutdown(2)` reliably returns BrokenPipe, including through a `try_clone`d handle,
+            // so this was never kernel buffering. But a writer released in the gap between step 1
+            // and step 2 writes to a LIVE socket and succeeds, and that is not a leak: the chunk was
+            // admitted while the client was still authorized, and the gate's own comment says so —
+            // "A successful pre-cancel syscall is already a disclosure to the then-authorized
+            // client; TCP cannot retract it." So the assertion demanded a guarantee the product
+            // deliberately does not make. What the product DOES guarantee is asserted below and does
+            // not race: what the CLIENT receives, and how many write syscalls our own code started.
+            let _ = writer.join().unwrap();
             revoked_rx.recv_timeout(Duration::from_secs(1)).unwrap();
             revoker.join().unwrap();
 
-            client
-                .set_read_timeout(Some(Duration::from_millis(250)))
-                .unwrap();
+            // Best-effort, because this call FAILING cannot make the assertion below false, and
+            // `.unwrap()` here panicked on CI (2026-09-03, `Os { code: 22, InvalidInput }`).
+            // HONEST LIMIT: I could not reproduce that EINVAL from this test's shape. A socket probe
+            // on this platform shows a PEER shutdown — even with megabytes left unread, which should
+            // force an RST — leaves `set_read_timeout` returning Ok; only shutting down one's OWN
+            // socket produces EINVAL, and no test does that. So the trigger is still unexplained, and
+            // this comment says so rather than inventing a mechanism. Making the call best-effort is
+            // right regardless: the timeout only bounds how long the read may block, and the read is
+            // already bounded by the EOF the revocation produces.
+            let _ = client.set_read_timeout(Some(Duration::from_millis(250)));
             let mut delivered = Vec::new();
             let _ = client.read_to_end(&mut delivered);
             assert!(
@@ -3256,9 +3294,16 @@ mod tests {
         drop(_lifecycle);
         writer.join().unwrap();
 
-        client
-            .set_read_timeout(Some(Duration::from_secs(1)))
-            .unwrap();
+        // Best-effort, because this call FAILING cannot make the assertion below false, and
+        // `.unwrap()` here panicked on CI (2026-09-03, `Os { code: 22, InvalidInput }`).
+        // HONEST LIMIT: I could not reproduce that EINVAL from this test's shape. A socket probe
+        // on this platform shows a PEER shutdown — even with megabytes left unread, which should
+        // force an RST — leaves `set_read_timeout` returning Ok; only shutting down one's OWN
+        // socket produces EINVAL, and no test does that. So the trigger is still unexplained, and
+        // this comment says so rather than inventing a mechanism. Making the call best-effort is
+        // right regardless: the timeout only bounds how long the read may block, and the read is
+        // already bounded by the EOF the revocation produces.
+        let _ = client.set_read_timeout(Some(Duration::from_secs(1)));
         let mut delivered = Vec::new();
         let _ = client.read_to_end(&mut delivered);
         assert!(
@@ -3323,9 +3368,16 @@ mod tests {
         assert!(state.db.folder_by_id("private").unwrap().unwrap().locked);
         writer.join().unwrap();
 
-        client
-            .set_read_timeout(Some(Duration::from_secs(1)))
-            .unwrap();
+        // Best-effort, because this call FAILING cannot make the assertion below false, and
+        // `.unwrap()` here panicked on CI (2026-09-03, `Os { code: 22, InvalidInput }`).
+        // HONEST LIMIT: I could not reproduce that EINVAL from this test's shape. A socket probe
+        // on this platform shows a PEER shutdown — even with megabytes left unread, which should
+        // force an RST — leaves `set_read_timeout` returning Ok; only shutting down one's OWN
+        // socket produces EINVAL, and no test does that. So the trigger is still unexplained, and
+        // this comment says so rather than inventing a mechanism. Making the call best-effort is
+        // right regardless: the timeout only bounds how long the read may block, and the read is
+        // already bounded by the EOF the revocation produces.
+        let _ = client.set_read_timeout(Some(Duration::from_secs(1)));
         let mut delivered = Vec::new();
         let _ = client.read_to_end(&mut delivered);
         assert!(


### PR DESCRIPTION
## Problem

Two different `mcp.rs` socket tests flaked on CI **in one afternoon**, on unrelated PRs:

- `revocation_drains_admitted_chunk_before_visibility_can_change` (run 33763170723, on a
  frontend-only PR)
- `initial_lock_cancels_slow_response_before_lifecycle_and_leaks_no_tail` (run 33773905927)

Both have the same shape: an assertion about the **mechanism**, followed by the assertion about the
**property**. Only the first kind flaked. A gate that reddens on unrelated work erodes the one thing
that is supposed to be the merge authority.

## The write-result assertion demanded something the gate does not promise

`writer.join().unwrap().is_err()` insisted that a write after revocation must fail.

`close_and_shutdown` runs in three steps: cancel every response → `shutdown(2)` every socket clone →
wait for admitted chunks to drain. The writer here is released while the revoker sits in step 3, so
it usually writes into an already-shut-down socket and fails.

**My first explanation was wrong and I checked it rather than shipping it.** I assumed kernel
buffering made a post-shutdown write's result nondeterministic. A socket probe on this platform says
otherwise: a write after `shutdown(2)` returns `BrokenPipe` **reliably**, including when the shutdown
arrived through a `try_clone`d handle — which is exactly how the gate does it.

The real window is between step 1 and step 2: a writer released there writes to a **live** socket and
succeeds. That is not a leak, and the gate's own comment settles it:

> A successful pre-cancel syscall is already a disclosure to the then-authorized client; TCP cannot
> retract it.

The chunk was admitted while the client was still authorized. So the assertion demanded a guarantee
the product **deliberately does not make** — this is a wrong assertion, not merely a flaky one.

## The read-timeout unwrap — and what I could not explain

`client.set_read_timeout(...).unwrap()` panicked with `Os { code: 22, InvalidInput }`.

**I could not reproduce that EINVAL from this test's shape, and the code now says so** rather than
inventing a plausible mechanism. What the probe actually shows:

| situation | `set_read_timeout` |
| --- | --- |
| healthy socket | Ok |
| peer did `shutdown(Both)` + drop | **Ok** |
| peer shut down with 8 MB left unread (should force RST) | **Ok** |
| **own `shutdown(Both)`** | **EINVAL** |

Only shutting down one's *own* socket reproduces it, and no test does that. So the trigger is still
unexplained. Making the call best-effort is right regardless: its failure cannot make the assertion
below it false, and the read is already bounded by the EOF the revocation produces.

I am flagging this explicitly because this repo has paid for the opposite before — rule T5 in
`angular-zoneless.md` records three fixes built on a hypothesis nobody could falsify.

## What did not change

Every assertion about **delivered bytes**, **syscall counts** and **cancellation flags** is untouched.
Those are what the product guarantees, they are computed by our own code rather than by the kernel's
timing, and they carry the security property. The diff is comments plus six changed lines.

## Gates

`cargo test --lib` **3625 passed, 0 failed** · `mcp::tests` 60 passed · `.agents/h/mirror-check` OK.

## Honest limit

Removing a timing dependence cannot be proven by a green run — a flake is green most of the time by
definition. The argument is structural: no remaining assertion in these two tests depends on when the
kernel propagates a shutdown. If a reviewer can find one that still does, that is the finding worth
having.
