### PR TITLE
fix(org): stop holding the org mutation mutex across a human and across four HTTP phases

### DIFF
--- a/src-tauri/src/commands/lock.rs
+++ b/src-tauri/src/commands/lock.rs
@@ -822,7 +822,8 @@ pub async fn unlock_folder(
     state: State<'_, AppState>,
     folder_id: String,
 ) -> Result<FolderNode, AppError> {
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    // NOTE: `org_share_mutation_lock` is acquired LATER, just before the restore — see the comment
+    // at that acquisition. Taking it here held it across the Touch ID sheet.
     // v0.3.2 — the master KEK is a BIOMETRIC-GATED keychain item. Reading it makes macOS present the
     // Touch ID / passcode sheet directly (with our reason string) and hand back the key — THAT single
     // sheet IS the unlock auth, so there is no separate app-side authentication step (which would
@@ -965,6 +966,21 @@ pub async fn unlock_folder(
             .try_into()
             .map_err(|_| AppError::Storage("unwrapped content key has wrong length".into()))?,
     );
+
+    // Serialize against org mutation/revoke from HERE, not from the top of the command.
+    //
+    // This lock guards one thing in this function: `clear_org_folder_closure` at the end, which
+    // lifts the org barrier for this folder. Everything before this point is a read plus the
+    // biometric KEK release — and that release BLOCKS ON A HUMAN. Acquiring the lock at the top of
+    // the command therefore held a process-wide org mutex across the Touch ID sheet, for as long as
+    // the user took to answer (or not answer) it: org sync, share dispatch and revoke all stalled
+    // behind a dialog. It is taken here instead, immediately before the first mutation, so the
+    // barrier it exists for is unchanged while the unbounded human wait is outside it.
+    //
+    // The lock-state race this does NOT need to cover is covered elsewhere: the restore below takes
+    // `lifecycle_guard` for its whole synchronous body, which is what serializes against a
+    // concurrent `lock_folder` / `relock_all_inner`.
+    let _org_mutation = state.org_share_mutation_lock.lock().await;
 
     // The rest of the restore (decrypt every note/segment/timeline blob, materialize the session
     // WAV, re-embed the folder's meetings) is synchronous CPU/AES/Candle-Metal work that used to

--- a/src-tauri/src/commands/lock.rs
+++ b/src-tauri/src/commands/lock.rs
@@ -824,6 +824,12 @@ pub async fn unlock_folder(
 ) -> Result<FolderNode, AppError> {
     // NOTE: `org_share_mutation_lock` is acquired LATER, just before the restore — see the comment
     // at that acquisition. Taking it here held it across the Touch ID sheet.
+    //
+    // Capture the content-authorization generation FIRST, before any read below is trusted. Moving
+    // the lock later widens the window in which a concurrent `lock_folder` can run, and this
+    // snapshot is what makes that window safe rather than merely narrow — see the re-validation at
+    // the acquisition point.
+    let visibility = capture_content_visibility_snapshot(state.inner());
     // v0.3.2 — the master KEK is a BIOMETRIC-GATED keychain item. Reading it makes macOS present the
     // Touch ID / passcode sheet directly (with our reason string) and hand back the key — THAT single
     // sheet IS the unlock auth, so there is no separate app-side authentication step (which would
@@ -981,6 +987,20 @@ pub async fn unlock_folder(
     // `lifecycle_guard` for its whole synchronous body, which is what serializes against a
     // concurrent `lock_folder` / `relock_all_inner`.
     let _org_mutation = state.org_share_mutation_lock.lock().await;
+
+    // RE-VALIDATE: everything above — `folder`, the `folder.locked` refusal,
+    // `preflight_unlock_subtree`, `folder_wrapped_key` — was read BEFORE this lock was held, with an
+    // unbounded human wait in between. Serializing the write is not enough; the DECISION has to be
+    // fresh too.
+    //
+    // Concretely (found in review, 2026-09-03): while the Touch ID sheet is up, a `lock_folder` for
+    // this folder or an ancestor is no longer blocked. It takes the already-locked idempotent branch,
+    // bumps the seal epoch, and returns Ok — the user sees a successful "Lock". Without this check
+    // the unlock then resumes on its stale reads, decrypts plaintext back and re-adds the folder to
+    // the session unlock set, silently undoing that Lock: the UI says sealed and the bytes say
+    // otherwise. The old top-of-function acquisition prevented this only by accident, because it
+    // forced the racing `lock_folder` to queue behind the entire unlock.
+    require_current_content_visibility_snapshot(state.inner(), visibility)?;
 
     // The rest of the restore (decrypt every note/segment/timeline blob, materialize the session
     // WAV, re-embed the folder's meetings) is synchronous CPU/AES/Candle-Metal work that used to

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -14486,6 +14486,10 @@ mod lock_read_gate_tests;
 #[path = "tests/main_thread_offload_tests.rs"]
 mod main_thread_offload_tests;
 
+#[cfg(test)]
+#[path = "tests/org_mutex_scope_tests.rs"]
+mod org_mutex_scope_tests;
+
 // ── Workspace hierarchy read surface: the container forest, its per-kind groups, and the gate ─────
 #[cfg(test)]
 #[path = "tests/workspace_tree_tests.rs"]

--- a/src-tauri/src/commands/org.rs
+++ b/src-tauri/src/commands/org.rs
@@ -9522,21 +9522,39 @@ pub const ORG_SYNC_TICK_SECS: u64 = 60;
 /// production callers so productive visibility reductions can emit the history invalidation while
 /// the lifecycle guard is still held.
 pub(crate) async fn org_background_sync_tick(state: &AppState, app: Option<AppHandle>) -> bool {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    // The org mutex is taken PER PHASE below, not once around the whole tick.
+    //
+    // This tick runs four phases and every one of them makes network round trips. Holding
+    // `org_share_mutation_lock` across all four meant a user action that needs it — sharing,
+    // revoking, "sync now" — waited behind up to four consecutive HTTP timeouts on a tick that
+    // fires every 60 s. Per phase, the worst case is one.
+    //
+    // Safe because per-phase acquisition is, for EVERY phase, at least as strong as that phase's
+    // existing manual path: `org_sweep_pending` and `org_sync_now` are commands that already take
+    // this lock around exactly one phase, and `sync_container_shares` /
+    // `org_reconcile_memberships_notifying` already run their phase with no acquisition at all. So
+    // this introduces no interleaving the app does not already perform. The `policy.is_current()`
+    // checks between phases already assumed the tick is interruptible at these boundaries.
     let policy = OrgWorkPolicy::background(crate::perf::background_epoch());
     if !policy.is_current() {
         return false;
     }
     // Reconcile membership FIRST so a newly-invited org is present (and synced this same tick) and a
     // departed org is dropped before we pull its feed. Best-effort — a failure never blocks the sync.
-    if let Err(e) = org_reconcile_memberships_with_policy(state, policy, app.as_ref()).await {
-        tracing::warn!(target: "org", error = %brief_err(&e), "org membership reconcile tick failed");
+    {
+        let _mutation = state.org_share_mutation_lock.lock().await;
+        if let Err(e) = org_reconcile_memberships_with_policy(state, policy, app.as_ref()).await {
+            tracing::warn!(target: "org", error = %brief_err(&e), "org membership reconcile tick failed");
+        }
     }
     if !policy.is_current() {
         return false;
     }
-    if let Err(e) = org_sweep_pending_with_policy(state, policy, app.as_ref()).await {
-        tracing::warn!(target: "org", error = %e, "org outbound sweep tick failed");
+    {
+        let _mutation = state.org_share_mutation_lock.lock().await;
+        if let Err(e) = org_sweep_pending_with_policy(state, policy, app.as_ref()).await {
+            tracing::warn!(target: "org", error = %e, "org outbound sweep tick failed");
+        }
     }
     if !policy.is_current() {
         return false;
@@ -9544,19 +9562,25 @@ pub(crate) async fn org_background_sync_tick(state: &AppState, app: Option<AppHa
     // Keep every shared container in step with the local tree. Best-effort for the same reason the
     // outbound sweep is: a container that cannot reconcile right now is retried next tick, and must
     // never stop the feed pull that follows.
-    if let Err(e) =
-        crate::commands::org_containers::reconcile_container_shares(state, app.as_ref()).await
     {
-        tracing::warn!(target: "org", error = %brief_err(&e), "container share reconcile tick failed");
+        let _mutation = state.org_share_mutation_lock.lock().await;
+        if let Err(e) =
+            crate::commands::org_containers::reconcile_container_shares(state, app.as_ref()).await
+        {
+            tracing::warn!(target: "org", error = %brief_err(&e), "container share reconcile tick failed");
+        }
     }
     if !policy.is_current() {
         return false;
     }
-    let report = match org_sync_now_inner_with_policy(state, policy, app.clone()).await {
-        Ok(r) => r,
-        Err(e) => {
-            tracing::warn!(target: "org", error = %e, "org feed sync tick failed");
-            return false;
+    let report = {
+        let _mutation = state.org_share_mutation_lock.lock().await;
+        match org_sync_now_inner_with_policy(state, policy, app.clone()).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(target: "org", error = %e, "org feed sync tick failed");
+                return false;
+            }
         }
     };
     let live_changed = report.ingested > 0 || report.tombstoned > 0;

--- a/src-tauri/src/commands/org.rs
+++ b/src-tauri/src/commands/org.rs
@@ -9562,13 +9562,25 @@ pub(crate) async fn org_background_sync_tick(state: &AppState, app: Option<AppHa
     // Keep every shared container in step with the local tree. Best-effort for the same reason the
     // outbound sweep is: a container that cannot reconcile right now is retried next tick, and must
     // never stop the feed pull that follows.
+    // NO acquisition around this phase — taking it here DEADLOCKS.
+    //
+    // `reconcile_container_shares` -> `reconcile_one_container_root` -> `share_to_org_placed_notifying`,
+    // whose FIRST statement is `org_share_mutation_lock.lock().await`. `tokio::sync::Mutex` is not
+    // reentrant, so a caller that already holds the guard awaits a second acquisition of the same
+    // mutex on the same task and never returns — the guard is never dropped either, so the mutex is
+    // held for the rest of the process and every later org command, `unlock_folder` included, blocks
+    // forever. The tick has no timeout around it, so this does not recover.
+    //
+    // This is why `sync_container_shares` (the FE's explicit "sync now") takes NO lock before calling
+    // the same function: the serialization is already inside `share_to_org_placed_notifying`. The
+    // pre-2026-09-03 tick held one lock from its top across all four phases and so had exactly the
+    // same latent deadlock; per-phase acquisition did not introduce it, but it does not excuse it,
+    // and my "per phase is at least as strong as the manual path" argument was wrong HERE — for this
+    // phase the manual path is lock-free because it must be.
+    if let Err(e) =
+        crate::commands::org_containers::reconcile_container_shares(state, app.as_ref()).await
     {
-        let _mutation = state.org_share_mutation_lock.lock().await;
-        if let Err(e) =
-            crate::commands::org_containers::reconcile_container_shares(state, app.as_ref()).await
-        {
-            tracing::warn!(target: "org", error = %brief_err(&e), "container share reconcile tick failed");
-        }
+        tracing::warn!(target: "org", error = %brief_err(&e), "container share reconcile tick failed");
     }
     if !policy.is_current() {
         return false;

--- a/src-tauri/src/commands/tests/org_mutex_scope_tests.rs
+++ b/src-tauri/src/commands/tests/org_mutex_scope_tests.rs
@@ -1,0 +1,175 @@
+//! Oracles for WHERE `org_share_mutation_lock` is acquired.
+//!
+//! The lock serializes org mutation/revoke against share dispatch, and that job needs it held
+//! across a short durable commit — not across a human or a network. Two acquisitions were doing the
+//! latter (2026-09-02 audit, O4):
+//!
+//!   * `unlock_folder` took it in its FIRST statement, then presented the Touch ID sheet ~30 lines
+//!     later. Every org mutation in the process waited for as long as the user took to answer that
+//!     dialog, or forever if they never did.
+//!   * `org_background_sync_tick` took it once and ran FOUR network phases under it, so a user
+//!     sharing or revoking could wait behind four consecutive HTTP timeouts on a 60 s tick.
+//!
+//! These are SOURCE-ORDER oracles, and that is a deliberate, stated limitation: the properties are
+//! "the lock is not held across X", and there is no in-process way to assert that without a seam
+//! for the human prompt and for each HTTP phase. Asserting the acquisition's POSITION is the honest
+//! proxy, and it catches the regression that actually happens — someone hoists the acquisition back
+//! to the top of the function.
+//!
+//! Comments are stripped before matching. An earlier oracle of mine in this repo asked whether a
+//! body CONTAINED a call's name and was defeated in one move by putting that name in a comment;
+//! searching for text is always cheaper to fool than to defend.
+
+use std::path::PathBuf;
+
+fn commands_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("commands")
+}
+
+/// Blank out `//` and `/* */`, respecting string literals so a `"http://…"` survives intact.
+fn strip_comments(source: &str) -> String {
+    let chars: Vec<char> = source.chars().collect();
+    let mut out = String::with_capacity(source.len());
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        if c == '"' {
+            out.push(c);
+            i += 1;
+            while i < chars.len() {
+                if chars[i] == '\\' {
+                    i += 2;
+                    continue;
+                }
+                out.push(chars[i]);
+                let done = chars[i] == '"';
+                i += 1;
+                if done {
+                    break;
+                }
+            }
+            continue;
+        }
+        if c == '/' && i + 1 < chars.len() && chars[i + 1] == '/' {
+            while i < chars.len() && chars[i] != '\n' {
+                i += 1;
+            }
+            continue;
+        }
+        if c == '/' && i + 1 < chars.len() && chars[i + 1] == '*' {
+            i += 2;
+            while i + 1 < chars.len() && !(chars[i] == '*' && chars[i + 1] == '/') {
+                if chars[i] == '\n' {
+                    out.push('\n');
+                }
+                i += 1;
+            }
+            i += 2;
+            continue;
+        }
+        out.push(c);
+        i += 1;
+    }
+    out
+}
+
+/// The body of `fn <name>(` up to its matching closing brace, comments already stripped.
+fn body_of(file: &str, name: &str) -> String {
+    let source = strip_comments(
+        &std::fs::read_to_string(commands_dir().join(file))
+            .unwrap_or_else(|e| panic!("cannot read {file}: {e}")),
+    );
+    let sig = format!("fn {name}(");
+    let start = source
+        .find(&sig)
+        .unwrap_or_else(|| panic!("{file}: `{name}` not found — update this oracle deliberately"));
+    let open = start + source[start..].find('{').expect("no body");
+    let mut depth = 0usize;
+    for (offset, ch) in source[open..].char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return source[open..=open + offset].to_string();
+                }
+            }
+            _ => {}
+        }
+    }
+    panic!("{file}: `{name}` has no closing brace");
+}
+
+const ACQUIRE: &str = "org_share_mutation_lock";
+
+/// `unlock_folder` must not hold the org mutex across the Touch ID sheet.
+///
+/// RED CONTROL (run 2026-09-03, observed): hoisting the acquisition back to the command's first
+/// statement fails with "acquires `org_share_mutation_lock` at byte 32, BEFORE the biometric KEK
+/// release at 1180".
+#[test]
+fn unlock_folder_takes_the_org_mutex_only_after_the_biometric_kek_release() {
+    let body = body_of("lock.rs", "unlock_folder");
+    let kek = body
+        .find("master_kek_with_policy")
+        .expect("unlock_folder no longer resolves the KEK — this oracle is stale, fix it");
+    let acquire = body
+        .find(ACQUIRE)
+        .expect("unlock_folder no longer takes the org mutex — was that deliberate?");
+    assert!(
+        acquire > kek,
+        "unlock_folder acquires `{ACQUIRE}` at byte {acquire}, BEFORE the biometric KEK release at \
+         {kek}. That holds a process-wide org mutex across the Touch ID sheet — for as long as the \
+         user takes to answer it, and indefinitely if they never do."
+    );
+}
+
+/// The background tick must take the org mutex per phase, never once around all four.
+///
+/// Asserts on brace DEPTH, not on a count: what makes the old shape wrong is that the acquisition
+/// sat at the function's own level and so outlived every phase. A count would pass just as happily
+/// for one acquisition at the top plus one nested.
+///
+/// RED CONTROL (run 2026-09-03, observed): restoring the single top-level acquisition ALONGSIDE the
+/// per-phase ones fails with "depths seen: [1, 2, 2, 2, 2]" — which is exactly why this asserts on
+/// depth and not on a count. A count-based check would have passed that mutation happily (5 >= 2).
+#[test]
+fn the_org_background_tick_never_holds_the_mutex_across_a_network_phase() {
+    let body = body_of("org.rs", "org_background_sync_tick");
+    let mut depth = 0usize;
+    let mut acquisitions = Vec::new();
+    let chars: Vec<char> = body.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        match chars[i] {
+            '{' => depth += 1,
+            '}' => depth = depth.saturating_sub(1),
+            _ => {
+                if body[i..].starts_with(ACQUIRE) {
+                    acquisitions.push(depth);
+                    i += ACQUIRE.len();
+                    continue;
+                }
+            }
+        }
+        i += 1;
+    }
+    assert!(
+        !acquisitions.is_empty(),
+        "the tick no longer takes `{ACQUIRE}` at all — was that deliberate?"
+    );
+    // Depth 1 is the function body itself; anything acquired there is held for the whole tick.
+    assert!(
+        !acquisitions.contains(&1),
+        "the tick acquires `{ACQUIRE}` at the function's own scope (depths seen: {acquisitions:?}), \
+         so it is held across every network phase in the tick. Take it inside each phase's block \
+         instead: a user sharing or revoking then waits behind at most one HTTP timeout, not four."
+    );
+    assert!(
+        acquisitions.len() >= 2,
+        "expected one acquisition per network phase, found {} (depths {acquisitions:?})",
+        acquisitions.len()
+    );
+}

--- a/src-tauri/src/commands/tests/org_mutex_scope_tests.rs
+++ b/src-tauri/src/commands/tests/org_mutex_scope_tests.rs
@@ -173,3 +173,100 @@ fn the_org_background_tick_never_holds_the_mutex_across_a_network_phase() {
         acquisitions.len()
     );
 }
+
+/// Positions in `body` where an `org_share_mutation_lock` guard is still IN SCOPE.
+///
+/// Models the guard's lifetime rather than its mere presence: an acquisition at brace depth `d`
+/// lives until the block at depth `d` closes. Returns every byte offset at which at least one guard
+/// is held.
+fn guard_is_held_at(body: &str) -> Vec<(usize, bool)> {
+    let chars: Vec<char> = body.chars().collect();
+    let mut depth = 0usize;
+    let mut open_guards: Vec<usize> = Vec::new();
+    let mut marks = Vec::with_capacity(chars.len());
+    let mut i = 0;
+    while i < chars.len() {
+        match chars[i] {
+            '{' => depth += 1,
+            '}' => {
+                depth = depth.saturating_sub(1);
+                open_guards.retain(|d| *d <= depth);
+            }
+            _ => {
+                if body[i..].starts_with(ACQUIRE) {
+                    open_guards.push(depth);
+                }
+            }
+        }
+        marks.push((i, !open_guards.is_empty()));
+        i += 1;
+    }
+    marks
+}
+
+/// The container-reconcile phase must NOT run under `org_share_mutation_lock`.
+///
+/// `reconcile_container_shares` -> `reconcile_one_container_root` -> `share_to_org_placed_notifying`,
+/// whose FIRST statement acquires this same mutex. `tokio::sync::Mutex` is not reentrant, so holding
+/// it across this phase makes the task await a second acquisition of a mutex it already holds: it
+/// never returns, the guard is never dropped, and every later org operation blocks for the rest of
+/// the process. There is no timeout around the tick, so it does not recover.
+///
+/// This is why the FE's own "sync now" (`sync_container_shares`) calls the same function with no
+/// lock — the serialization lives inside `share_to_org_placed_notifying`.
+///
+/// RED CONTROL (run 2026-09-03): wrapping the call in `{ let _m = …lock().await; … }` — the shape
+/// this PR shipped before review — fails this test.
+#[test]
+fn the_container_reconcile_phase_does_not_run_under_the_org_mutex() {
+    let body = body_of("org.rs", "org_background_sync_tick");
+    let call = body
+        .find("reconcile_container_shares(")
+        .expect("the tick no longer reconciles container shares — update this oracle deliberately");
+    let held = guard_is_held_at(&body);
+    let (_, holding) = held[call];
+    assert!(
+        !holding,
+        "`reconcile_container_shares` is called while `{ACQUIRE}` is held. Its callee \
+         `share_to_org_placed_notifying` acquires the same non-reentrant mutex as its first \
+         statement, so this deadlocks permanently and takes every later org operation with it."
+    );
+}
+
+/// `unlock_folder` must RE-VALIDATE after taking the mutex, not merely serialize the write.
+///
+/// Its `folder`, `folder.locked` refusal, `preflight_unlock_subtree` and `folder_wrapped_key` are
+/// all read before any lock is held, with an unbounded Touch ID wait in between. A `lock_folder`
+/// landing in that window takes its already-locked idempotent branch, bumps the seal epoch and
+/// returns Ok — the user sees a successful "Lock". Without the re-check the unlock then resumes on
+/// stale reads and restores plaintext, silently undoing it.
+///
+/// RED CONTROL (run 2026-09-03): deleting the
+/// `require_current_content_visibility_snapshot` call fails this test.
+#[test]
+fn unlock_folder_revalidates_the_visibility_snapshot_after_taking_the_org_mutex() {
+    let body = body_of("lock.rs", "unlock_folder");
+    let capture = body
+        .find("capture_content_visibility_snapshot")
+        .expect("unlock_folder no longer captures a visibility snapshot");
+    let first_read = body
+        .find("folder_by_id")
+        .expect("unlock_folder no longer reads the folder — this oracle is stale");
+    let acquire = body.find(ACQUIRE).expect("no org mutex acquisition");
+    let require = body
+        .find("require_current_content_visibility_snapshot")
+        .expect(
+            "unlock_folder takes the org mutex late but never re-validates: a `lock_folder` that \
+             ran during the Touch ID sheet would be silently undone",
+        );
+    assert!(
+        capture < first_read,
+        "the snapshot must be captured BEFORE the reads it protects (capture {capture}, read \
+         {first_read})"
+    );
+    assert!(
+        acquire < require,
+        "the re-validation must happen AFTER the mutex is held (acquire {acquire}, require \
+         {require}), or it can be invalidated again before the restore"
+    );
+}


### PR DESCRIPTION
## Problem

`org_share_mutation_lock` serializes org mutation/revoke against share dispatch. That job needs it
held across a short durable commit. Two acquisitions held it across things with **no bound at all**.

### `unlock_folder` held it across the Touch ID sheet

It took the lock in its **first statement** and presented the biometric sheet about thirty lines
later. Every org mutation in the process — sharing, revoking, sync — waited for as long as the user
took to answer that dialog, and indefinitely if they never did. It was also still held while
`run_heavy` queued for its permit and through the entire restore.

Reading the function settles what the lock is actually for here: the only org mutation in it is
`clear_org_folder_closure`, at the very end. It is now taken immediately before the restore, so the
barrier it exists for is unchanged while the unbounded human wait falls outside it.

The lock-state race it does **not** need to cover is covered elsewhere: the restore already takes
`lifecycle_guard` for its whole synchronous body, and that is what serializes against a concurrent
`lock_folder` / `relock_all_inner`.

### The background tick held it across four network phases

`org_background_sync_tick` took it once and ran four HTTP phases under it, so a user sharing or
revoking could wait behind four consecutive timeouts on a tick that fires every 60 s.

It is now taken **per phase**, and the argument that this is safe comes from the tree rather than
from intuition — per-phase acquisition is, for every phase, at least as strong as that phase's
existing manual path:

| phase | its manual path today |
| --- | --- |
| `org_reconcile_memberships_with_policy` | `org_reconcile_memberships_notifying` — **no acquisition** |
| `org_sweep_pending_with_policy` | `org_sweep_pending` — takes the lock around this one phase |
| `reconcile_container_shares` | `sync_container_shares`, an FE-invoked command — **no acquisition** |
| `org_sync_now_inner_with_policy` | `org_sync_now` — takes the lock around this one phase |

So this introduces no interleaving the app does not already perform, and the `policy.is_current()`
checks between phases already assumed the tick is interruptible at exactly these boundaries.

## Oracles, and their stated limit

Both are **source-order** assertions. That is a limitation I am stating rather than hiding: the
property is "the lock is not held across X", and there is no in-process way to assert it without a
seam for the human prompt and for each HTTP phase. What they do catch is the regression that
actually happens — someone hoists the acquisition back to the top of the function.

**RED controls, both run:**

| mutation | observed failure |
| --- | --- |
| hoist the acquisition back to `unlock_folder`'s first statement | "acquires `org_share_mutation_lock` at byte 32, **BEFORE** the biometric KEK release at 1180" |
| restore the tick's single top-level acquisition alongside the per-phase ones | "depths seen: **[1, 2, 2, 2, 2]**" |

That second control is why the tick oracle asserts brace **depth** and not a count: the mutation
leaves five acquisitions, so a count-based check would have accepted it happily. What makes the old
shape wrong is that one of them sits at the function's own level and therefore outlives every phase.

Comments are stripped before matching. An earlier oracle of mine in this repo asked whether a body
*contained* a call's name, and a reviewer defeated it in one move by writing that name in a comment.

## What is NOT in this PR

The audit's third item — bounding all ~66 holders with a `share-busy` refusal — is not here. It is a
change of a different shape (a user-visible failure mode on every org command) and belongs in its own
PR with its own review, rather than riding along with a lock-ordering fix.

## What a reviewer should attack

The ordering claim. Moving a lock acquisition later is exactly how a TOCTOU gets opened: between the
top of `unlock_folder` and the new acquisition point there are DB reads (`folder_by_id`,
`preflight_unlock_subtree`, `folder_wrapped_key`) whose results are used after the lock is taken. If
a concurrent org mutation can invalidate any of them in that window in a way `lifecycle_guard` does
not already cover, that is the finding that matters.

## Gates

`cargo test --lib` **3629 passed, 0 failed** · `cargo clippy --lib --tests -- -D warnings` clean
(exit 0) · `.agents/h/mirror-check` OK.

---

## Review outcome: FAILED, fixed, then PASSED — and one claim above is corrected below

The first lock-security review **failed** this PR with two findings. I verified both against the call
graph before acting on them; both were real.

### 1. A self-reentrant deadlock (pre-existing on trunk)

`reconcile_container_shares` → `reconcile_one_container_root` → `share_to_org_placed_notifying`,
whose **first statement** is `org_share_mutation_lock.lock().await` (`commands/org.rs:4590`, called
from `org_containers.rs:1048`). `tokio::sync::Mutex` is not reentrant, so holding it across that
phase makes the task await a mutex it already holds. It never returns, the guard is never dropped,
and every later org operation — `unlock_folder` included — blocks for the rest of the process. There
is no timeout around the tick. The pre-existing tick held one lock from its top across all four
phases, so **trunk has this today**; per-phase acquisition did not introduce it.

Phase 3 now runs with no acquisition, exactly like `sync_container_shares`.

### ⚠️ Correction to the table above

My claim that per-phase acquisition is "at least as strong as each phase's manual path" is **correct
for the call that deadlocked and overstated for the phase as a whole.** The re-review walked every
mutating call in `reconcile_one_container_root`: `unshare_container_inner`, `unfile_or_withdraw` and
`publish_container_manifest` mutate org state *without* a self-locking callee, and
`org_containers.rs` references `org_share_mutation_lock` **nowhere**.

Those paths are not newly unserialized — the always-live FE command `sync_container_shares` already
reaches them with no lock. And the sharper point: **no version of the tick ever actually delivered
that serialization**, because it hung at `share_to_org_placed_notifying` before completing. The
protection the old code appeared to provide never existed. Whether those paths are *safe* unlocked
depends on server-side idempotency in `../murmur-server/` and cannot be settled from this repo; it is
recorded as a follow-up rather than asserted either way here.

### 2. A TOCTOU this PR introduced

Moving the acquisition later meant a `lock_folder` during the Touch ID sheet was no longer blocked:
it took the already-locked idempotent branch, bumped the seal epoch, returned Ok — the user saw a
successful "Lock" — and the unlock then resumed on stale reads, restored plaintext and re-added the
folder to the session unlock set, **silently undoing it**. The old acquisition prevented this only by
accident.

Fixed with the pattern already in this codebase: `capture_content_visibility_snapshot` before the
reads, `require_current_content_visibility_snapshot` after the mutex is held.

The re-review then verified the part I could not: **all 25 `bump_seal_epoch` call sites**, confirming
every writer that can invalidate a pre-lock read moves the epoch. Two of my own worries turned out
structurally moot — `relock_folder` and `move_into_locked_folder` both require the folder to be
*already* session-unlocked, which is precisely what it is not during this window — and folder
reparenting does not exist as a command at all. It also confirmed no key material outlives the
refusal: `kek`/`ck` are `Zeroizing` and drop on `?`, and the session-cache writes happen only inside
the `run_heavy` closure, after the check.

### Oracles

Four now, each with a RED control that was run. Under each mutation the other three stayed green, so
they pin distinct properties rather than restating one. The deadlock oracle models guard **scope** —
an acquisition at brace depth *d* lives until that block closes — so it answers "is any guard held at
this call site", which a presence check cannot ask; the re-review confirmed it catches both re-hoist
shapes.

Their stated limit is unchanged and worth repeating: a source-position oracle cannot prove
`seal_epoch` is the *right* invalidation signal. That was established by reading the other writers,
not by running a test — which is why the enumeration above matters more than the green suite.
