### PR TITLE
fix(workspace): a shared tree still loading must say so, not claim nothing is shared

### DIFF
--- a/e2e/shell/shared-containers.spec.ts
+++ b/e2e/shell/shared-containers.spec.ts
@@ -470,6 +470,50 @@ test("an unreachable shared workspace shows an error, not an empty one", async (
   await expect(page.getByText("Nothing shared with you yet")).toHaveCount(0);
 });
 
+/// A shared read still IN FLIGHT must say so, not assert that nothing is shared.
+///
+/// `WorkspaceTreeComponent` renders both halves of the tree, and `loading` read
+/// `WorkspaceService.loading` in BOTH — `SharedWorkspaceService.loading` was never referenced
+/// anywhere in the component. So while the shared fetch was outstanding the shared section fell
+/// through to its empty state and told the user "Nothing shared with you yet" about content that
+/// was still arriving. That is wrong content, not merely a missing spinner, and it is the spinner
+/// half of the same reload-flash contract the template already spells out for cached rows.
+///
+/// RED CONTROL: revert `loading` to `this.workspace.loading` and this fails on the first
+/// assertion — the own-workspace read resolves immediately, so its flag is already false while the
+/// shared one is still true.
+test("a shared workspace still loading says so instead of claiming nothing is shared", async ({
+  page,
+}) => {
+  await mockTauri(
+    page,
+    {
+      // Slow enough to sample mid-flight, short enough not to pad the suite.
+      list_shared_workspace: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+        return SHARED_WORKSPACE;
+      },
+    },
+    {
+      list_workspace_tree: LOCAL_FOREST,
+      list_container_share_status: CONTAINER_SHARES,
+    },
+  );
+  await page.goto("/");
+  await expect(
+    page.getByRole("navigation", { name: "Primary navigation" }),
+  ).toBeVisible();
+
+  await expect(page.getByText("Loading shared content…")).toBeVisible();
+  await expect(page.getByText("Nothing shared with you yet")).toHaveCount(0);
+
+  // And the control: once it resolves, the loading line goes away and the rows arrive — so the
+  // assertion above is about the in-flight window, not about a spinner that never clears.
+  await expect(page.getByText("Loading shared content…")).toHaveCount(0, {
+    timeout: 5000,
+  });
+});
+
 test("a healthy shared workspace shows no error banner", async ({ page }) => {
   await openSidebar(page);
   await expect(page.getByText(/Couldn't read what's shared with you/)).toHaveCount(0);

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
@@ -249,7 +249,20 @@ export class WorkspaceTreeComponent {
     void this.router.navigate(["/notes"]);
   }
 
-  protected readonly loading = this.workspace.loading;
+  /**
+   * Scope-aware, exactly like {@link error}.
+   *
+   * This component renders BOTH halves of the tree — the user's own workspace and the shared one —
+   * and `loading` used to read `WorkspaceService.loading` in both. `SharedWorkspaceService.loading`
+   * was never referenced anywhere in the component, so while a shared fetch was still in flight the
+   * shared section fell through to its empty state and told the user "Nothing shared with you yet"
+   * about content that was still arriving. Wrong content, not just a missing spinner — and the
+   * spinner half of the same 2026-07-12 "reload flash" contract the template comment above
+   * `sectionEmpty() && loading()` already spells out for cached rows.
+   */
+  protected readonly loading = computed(() =>
+    this.isOwnScope() ? this.workspace.loading() : this.sharedWorkspace.loading(),
+  );
   /**
    * The message this half of the forest should show, if any.
    *


### PR DESCRIPTION
## The defect

`WorkspaceTreeComponent` renders **both** halves of the tree — the user's own workspace and the
shared one — and `loading` read `WorkspaceService.loading` in both:

```ts
protected readonly loading = this.workspace.loading;   // both scopes, one flag
```

`SharedWorkspaceService.loading` was never referenced anywhere in the component, despite being
documented *there* as "a HINT, never a render gate". So while a shared fetch was still outstanding,
the own-workspace read resolved first, its flag went false, and the shared section fell through to
its empty state:

> **Nothing shared with you yet**

about content that was still arriving. That is **wrong content**, not a missing spinner.

It is also the other half of a contract this very template already spells out. The comment above the
loading branch explains why cached rows must not be hidden by `loading()` alone (the 2026-07-12
"reload flash"); this is the same bug from the opposite side — the spinner branch never fires for the
scope that is actually loading.

## Provenance

Found by the adversarial review of **#668** and reported there as **pre-existing, explicitly not
introduced by that diff**. The fix mirrors the scope-aware `error` computed that landed in #668:

```ts
protected readonly loading = computed(() =>
  this.isOwnScope() ? this.workspace.loading() : this.sharedWorkspace.loading(),
);
```

## RED before GREEN

| | chromium | webkit |
| --- | --- | --- |
| `loading` reverted to `this.workspace.loading` | **fails** | **fails** |
| with the fix | passes | passes |

The new test also asserts the loading line **clears** once the read resolves, so the assertion is
about the in-flight window rather than a spinner that never finishes — without that control, a
component stuck permanently on "Loading" would pass.

## Gates

`npx ng lint` clean · `npx ng build` clean · `e2e/shell/shared-containers.spec.ts` **26/26** across
both engines.

## Scope

One computed and one test. No service, template branch, or gate changed.
