### PR TITLE
fix(fe): register teardown before the await, and stop stale fetches overwriting fresh ones

### DIFF
--- a/src/app/core/subscribe-until-destroyed.ts
+++ b/src/app/core/subscribe-until-destroyed.ts
@@ -1,0 +1,47 @@
+import type { DestroyRef } from "@angular/core";
+import type { UnlistenFn } from "@tauri-apps/api/event";
+
+/**
+ * Subscribe to an IPC event stream and release it on destroy — correctly across the `await`.
+ *
+ * WHY THIS EXISTS (2026-09-02 audit, L5). Every call site wrote the same shape by hand:
+ *
+ * ```ts
+ * this.unlistenX = await this.ipc.onX(cb);
+ * this.destroyRef.onDestroy(() => this.unlistenX?.());   // ← too late
+ * ```
+ *
+ * and it is wrong twice over when the view is destroyed while that `await` is in flight. The
+ * resumed continuation calls `DestroyRef.onDestroy` on a dead view, which throws **NG0911** ("View
+ * has already been destroyed"); and because the registration never happened, the handle the await
+ * just produced is never released — a live event subscription on a destroyed view, feeding
+ * callbacks that write signals nobody renders.
+ *
+ * The order is the whole fix: register the cleanup FIRST, synchronously, then await. If destruction
+ * wins the race, the flag is already set and the late handle is released immediately instead of
+ * being stored on a corpse. This mirrors `record.component.ts`, which had to learn it the hard way
+ * after an interval kept polling `detect_meeting_app` forever on a dead view.
+ *
+ * Returns the handle when the subscription is live, or `null` when the view was destroyed first —
+ * so a caller that keeps its own field stores `null` rather than a handle it can never use.
+ */
+export async function subscribeUntilDestroyed(
+  destroyRef: DestroyRef,
+  subscribe: () => Promise<UnlistenFn>,
+): Promise<UnlistenFn | null> {
+  let destroyed = false;
+  let unlisten: UnlistenFn | null = null;
+  // Synchronous, before any await: this is the ordering the whole helper exists to guarantee.
+  destroyRef.onDestroy(() => {
+    destroyed = true;
+    unlisten?.();
+    unlisten = null;
+  });
+  const handle = await subscribe();
+  if (destroyed) {
+    handle();
+    return null;
+  }
+  unlisten = handle;
+  return handle;
+}

--- a/src/app/features/brain/brain-enable-card/brain-enable-card.component.ts
+++ b/src/app/features/brain/brain-enable-card/brain-enable-card.component.ts
@@ -15,6 +15,7 @@ import {
   ErrorCopyService,
   UserFacingError,
 } from "../../../core/copy/error-copy.service";
+import { subscribeUntilDestroyed } from "../../../core/subscribe-until-destroyed";
 
 /**
  * "Enable the brain" — the one-click activation card for the two on-device
@@ -93,14 +94,17 @@ export class BrainEnableCardComponent {
    */
   private async subscribeBrainDownload(): Promise<void> {
     try {
-      this.unlistenBrainDownload = await this.ipc.onBrainDownload((p) => {
-        if (this.stage() !== "brain") return;
-        if (p.total && p.total > 0) {
-          this._brainFrac.set(Math.min(1, p.downloaded / p.total));
-        }
-        if (p.done) this._brainFrac.set(1);
-      });
-      this.destroyRef.onDestroy(() => this.unlistenBrainDownload?.());
+      this.unlistenBrainDownload = await subscribeUntilDestroyed(
+        this.destroyRef,
+        () =>
+          this.ipc.onBrainDownload((p) => {
+            if (this.stage() !== "brain") return;
+            if (p.total && p.total > 0) {
+              this._brainFrac.set(Math.min(1, p.downloaded / p.total));
+            }
+            if (p.done) this._brainFrac.set(1);
+          }),
+      );
     } catch {
       // No stream available — progress stays inert.
     }

--- a/src/app/features/detail/stage2-panel/stage2-panel.component.ts
+++ b/src/app/features/detail/stage2-panel/stage2-panel.component.ts
@@ -31,7 +31,6 @@ import { ErrorCopyService } from "../../../core/copy/error-copy.service";
  */
 @Component({
   selector: "app-stage2-panel",
-  standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: "./stage2-panel.component.html",
   styleUrl: "./stage2-panel.component.scss",

--- a/src/app/features/graph/entity-detail/entity-detail.component.ts
+++ b/src/app/features/graph/entity-detail/entity-detail.component.ts
@@ -237,7 +237,13 @@ export class EntityDetailComponent {
    * ledger on, so it's the safe identity.
    */
   protected ledgerKey(c: FactStateChange): string {
-    return `${c.validFrom} ${c.subject} ${c.predicate}`;
+    // Separator written as an ESCAPE, never as a literal control byte: the source used to carry
+    // two raw NULs here, invisible in every editor and diff and liable to truncate in tooling
+    // that treats them as terminators. The CHARACTER is deliberately unchanged — NUL cannot occur
+    // in a subject or predicate, which is what keeps this key collision-free. Substituting a
+    // space, as first proposed, would have introduced one: "a b"+"c" and "a"+"b c" would share a
+    // key. Same convention and same reasoning as `settings/model-id.ts`.
+    return `${c.validFrom}\u0000${c.subject}\u0000${c.predicate}`;
   }
 
   /** Localized short date for a ledger row's `validFrom`; empty on unparseable. */

--- a/src/app/features/graph/graph/graph.component.ts
+++ b/src/app/features/graph/graph/graph.component.ts
@@ -193,10 +193,25 @@ export class GraphComponent {
     }
   });
 
+  /**
+   * Monotonic fetch id, so an out-of-order response cannot overwrite a newer one.
+   *
+   * `_refetchOnLock` re-runs on every folders-tree change — a session unlock, a relock, a
+   * screen-share-triggered relock-all — so two fetches can be in flight at once, and nothing
+   * guarantees they resolve in the order they started. Without this guard the LATER-started fetch
+   * could land first and be overwritten by the older one, which for a visibility refetch is not a
+   * cosmetic race: it can put sealed entities back on screen after a relock, from a response that was
+   * already stale when it arrived. `entity-detail.component.ts` keys the same discipline on the
+   * entity id; there is no such identity here, so the sequence number is the identity.
+   */
+  private fetchSeq = 0;
+
   private async fetchGraph(): Promise<void> {
+    const seq = ++this.fetchSeq;
     this.error.set(null);
     try {
       const data = await this.ipc.getGraph();
+      if (seq !== this.fetchSeq) return;
       this.graphData.set(data);
       // If the selected entity is no longer visible (e.g. its folder re-sealed),
       // close the detail panel so we never point at a vanished node.
@@ -205,10 +220,13 @@ export class GraphComponent {
         this.selectedId.set(null);
       }
     } catch (e) {
+      if (seq !== this.fetchSeq) return;
       this.graphData.set(null);
       this.error.set(this.errorCopy.humanize(e));
     } finally {
-      this.loading.set(false);
+      // Only the newest fetch may clear the spinner; an older one finishing later must not
+      // announce "done" while the current request is still running.
+      if (seq === this.fetchSeq) this.loading.set(false);
     }
   }
 

--- a/src/app/features/onboarding/onboarding/onboarding.component.ts
+++ b/src/app/features/onboarding/onboarding/onboarding.component.ts
@@ -20,6 +20,7 @@ import { MurProgressComponent } from "../../../design-system/progress/progress.c
 import { MurSelectComponent } from "../../../design-system/select/select.component";
 import { ModelPowerComponent } from "../../settings/sections/settings-transcription-section/model-power/model-power.component";
 import { ErrorCopyService } from "../../../core/copy/error-copy.service";
+import { subscribeUntilDestroyed } from "../../../core/subscribe-until-destroyed";
 
 /** The wizard steps, in order. Drives the dot indicator + progress copy. */
 type Step = "welcome" | "model" | "provider" | "brain" | "vault" | "done";
@@ -291,14 +292,17 @@ export class OnboardingComponent implements OnInit {
   async ngOnInit(): Promise<void> {
     // Whisper model-download progress stream (best-effort; drives the progress bar).
     try {
-      this.unlistenModelDownload = await this.ipc.onModelDownload((p) => {
-        if (!this.downloading()) return;
-        if (p.total && p.total > 0) {
-          this.downloadFrac.set(Math.min(1, p.downloaded / p.total));
-        }
-        if (p.done) this.downloadFrac.set(1);
-      });
-      this.destroyRef.onDestroy(() => this.unlistenModelDownload?.());
+      this.unlistenModelDownload = await subscribeUntilDestroyed(
+        this.destroyRef,
+        () =>
+          this.ipc.onModelDownload((p) => {
+            if (!this.downloading()) return;
+            if (p.total && p.total > 0) {
+              this.downloadFrac.set(Math.min(1, p.downloaded / p.total));
+            }
+            if (p.done) this.downloadFrac.set(1);
+          }),
+      );
     } catch {
       // No model-download stream — progress stays inert; the download still resolves.
     }

--- a/src/app/features/people/people/people.component.ts
+++ b/src/app/features/people/people/people.component.ts
@@ -103,10 +103,25 @@ export class PeopleComponent {
     },
   );
 
+  /**
+   * Monotonic fetch id, so an out-of-order response cannot overwrite a newer one.
+   *
+   * `_refetchOnLock` re-runs on every folders-tree change — a session unlock, a relock, a
+   * screen-share-triggered relock-all — so two fetches can be in flight at once, and nothing
+   * guarantees they resolve in the order they started. Without this guard the LATER-started fetch
+   * could land first and be overwritten by the older one, which for a visibility refetch is not a
+   * cosmetic race: it can put sealed people back on screen after a relock, from a response that was
+   * already stale when it arrived. `entity-detail.component.ts` keys the same discipline on the
+   * entity id; there is no such identity here, so the sequence number is the identity.
+   */
+  private fetchSeq = 0;
+
   private async fetch(): Promise<void> {
+    const seq = ++this.fetchSeq;
     this.error.set(null);
     try {
       const { people: rows, totalVisiblePeople } = await this.ipc.listPeople();
+      if (seq !== this.fetchSeq) return;
       this.people.set(rows);
       this.totalVisiblePeople.set(totalVisiblePeople);
       // If the selected person is no longer visible (e.g. their folder re-sealed),
@@ -116,11 +131,14 @@ export class PeopleComponent {
         this.selectedId.set(null);
       }
     } catch (e) {
+      if (seq !== this.fetchSeq) return;
       this.people.set([]);
       this.totalVisiblePeople.set(0);
       this.error.set(this.errorCopy.humanize(e));
     } finally {
-      this.loading.set(false);
+      // Only the newest fetch may clear the spinner; an older one finishing later must not
+      // announce "done" while the current request is still running.
+      if (seq === this.fetchSeq) this.loading.set(false);
     }
   }
 

--- a/src/app/features/settings/settings.store.ts
+++ b/src/app/features/settings/settings.store.ts
@@ -41,6 +41,7 @@ import type {
 import type { UnlistenFn } from "@tauri-apps/api/event";
 import { NOTE_ASSIST_NEW_ACTION_IDS } from "../notes/note-brain-popover/note-assist-catalog";
 import { ErrorCopyService } from "../../core/copy/error-copy.service";
+import { subscribeUntilDestroyed } from "../../core/subscribe-until-destroyed";
 
 /**
  * The provider-backed connection ids — the ones `list_models` serves a
@@ -341,6 +342,12 @@ export class SettingsStore {
     // change still sitting in the 500ms debounce window instead of dropping
     // it (adversarial-verify finding: toggle → ⌘N within 500ms lost the edit).
     this.destroyRef.onDestroy(() => {
+      // The "Copied" flash timers live here, not in their click handlers. Registering an
+      // `onDestroy` per click accumulated one callback per copy for the lifetime of this store —
+      // each clearing the same single handle. One registration, cleared once, is the shape
+      // `toast.service.ts` established for tracked timers (angular-zoneless §5).
+      if (this.copyResetTimer) clearTimeout(this.copyResetTimer);
+      if (this.mcpCopyResetTimer) clearTimeout(this.mcpCopyResetTimer);
       if (this.autoSavePending && this.autoSaveReady && this.form.dirty) {
         this.autoSavePending = false;
         try {
@@ -1839,22 +1846,25 @@ export class SettingsStore {
    */
   private async subscribeModelDownload(): Promise<void> {
     try {
-      this.unlistenModelDownload = await this.ipc.onModelDownload((p) => {
-        // EVENT_MODEL_DOWNLOAD is shared by the whisper AND parakeet downloads; route the
-        // progress to whichever this component started (only one runs at a time).
-        if (this.downloadingModel()) {
-          if (p.total && p.total > 0) {
-            this._modelDownloadFrac.set(Math.min(1, p.downloaded / p.total));
-          }
-          if (p.done) this._modelDownloadFrac.set(1);
-        } else if (this.downloadingParakeet()) {
-          if (p.total && p.total > 0) {
-            this._parakeetDownloadFrac.set(Math.min(1, p.downloaded / p.total));
-          }
-          if (p.done) this._parakeetDownloadFrac.set(1);
-        }
-      });
-      this.destroyRef.onDestroy(() => this.unlistenModelDownload?.());
+      this.unlistenModelDownload = await subscribeUntilDestroyed(
+        this.destroyRef,
+        () =>
+      this.ipc.onModelDownload((p) => {
+            // EVENT_MODEL_DOWNLOAD is shared by the whisper AND parakeet downloads; route the
+            // progress to whichever this component started (only one runs at a time).
+            if (this.downloadingModel()) {
+              if (p.total && p.total > 0) {
+                this._modelDownloadFrac.set(Math.min(1, p.downloaded / p.total));
+              }
+              if (p.done) this._modelDownloadFrac.set(1);
+            } else if (this.downloadingParakeet()) {
+              if (p.total && p.total > 0) {
+                this._parakeetDownloadFrac.set(Math.min(1, p.downloaded / p.total));
+              }
+              if (p.done) this._parakeetDownloadFrac.set(1);
+            }
+          }),
+      );
     } catch {
       // No model-download stream available — progress stays inert.
     }
@@ -1867,20 +1877,23 @@ export class SettingsStore {
    */
   private async subscribeBrainDownload(): Promise<void> {
     try {
-      this.unlistenBrainDownload = await this.ipc.onBrainDownload((p) => {
-        // The backend emits one download at a time and the component already
-        // tracks which model it started (brainDownloadingId), so every progress
-        // event applies to it. (Download errors surface via the command promise.)
-        if (this.brainDownloadingId() === null) return;
-        if (p.total && p.total > 0) {
-          this._brainDownloadFrac.set(Math.min(1, p.downloaded / p.total));
-        }
-        if (p.done) {
-          this._brainDownloadingId.set(null);
-          void this.refreshBrainModels();
-        }
-      });
-      this.destroyRef.onDestroy(() => this.unlistenBrainDownload?.());
+      this.unlistenBrainDownload = await subscribeUntilDestroyed(
+        this.destroyRef,
+        () =>
+      this.ipc.onBrainDownload((p) => {
+            // The backend emits one download at a time and the component already
+            // tracks which model it started (brainDownloadingId), so every progress
+            // event applies to it. (Download errors surface via the command promise.)
+            if (this.brainDownloadingId() === null) return;
+            if (p.total && p.total > 0) {
+              this._brainDownloadFrac.set(Math.min(1, p.downloaded / p.total));
+            }
+            if (p.done) {
+              this._brainDownloadingId.set(null);
+              void this.refreshBrainModels();
+            }
+          }),
+      );
     } catch {
       // No brain-download stream available — progress stays inert; downloads
       // still resolve via the command promise.
@@ -2274,26 +2287,28 @@ export class SettingsStore {
    */
   private async subscribeSemanticStreams(): Promise<void> {
     try {
-      this.unlistenEmbedDownload = await this.ipc.onEmbedDownload((p) => {
-        // Per-file progress: blend the completed files + the current file's fraction
-        // across the whole set so the single bar advances smoothly.
-        if (p.fileCount > 0) {
-          const cur = p.total && p.total > 0 ? p.downloaded / p.total : 0;
-          this._embedDownloadFrac.set(
-            Math.min(1, (p.fileIndex + cur) / p.fileCount),
-          );
-        }
-        if (p.done) this._embedDownloadFrac.set(1);
-      });
-      this.unlistenReindex = await this.ipc.onReindex((p) => {
-        if (p.total > 0) {
-          this._reindexFrac.set(Math.min(1, p.done / p.total));
-        }
-      });
-      this.destroyRef.onDestroy(() => {
-        this.unlistenEmbedDownload?.();
-        this.unlistenReindex?.();
-      });
+      this.unlistenEmbedDownload = await subscribeUntilDestroyed(
+        this.destroyRef,
+        () =>
+      this.ipc.onEmbedDownload((p) => {
+            // Per-file progress: blend the completed files + the current file's fraction
+            // across the whole set so the single bar advances smoothly.
+            if (p.fileCount > 0) {
+              const cur = p.total && p.total > 0 ? p.downloaded / p.total : 0;
+              this._embedDownloadFrac.set(
+                Math.min(1, (p.fileIndex + cur) / p.fileCount),
+              );
+            }
+            if (p.done) this._embedDownloadFrac.set(1);
+          }),
+      );
+      this.unlistenReindex = await subscribeUntilDestroyed(this.destroyRef, () =>
+        this.ipc.onReindex((p) => {
+          if (p.total > 0) {
+            this._reindexFrac.set(Math.min(1, p.done / p.total));
+          }
+        }),
+      );
     } catch {
       // No stream available — progress bars stay inert; commands still resolve.
     }
@@ -2324,18 +2339,21 @@ export class SettingsStore {
    */
   private async subscribeNerDownload(): Promise<void> {
     try {
-      this.unlistenNerDownload = await this.ipc.onNerDownload((p) => {
-        // Per-file progress: blend the completed files + the current file's
-        // fraction across the whole set so the single bar advances smoothly.
-        if (p.fileCount > 0) {
-          const cur = p.total && p.total > 0 ? p.downloaded / p.total : 0;
-          this._nerDownloadFrac.set(
-            Math.min(1, (p.fileIndex + cur) / p.fileCount),
-          );
-        }
-        if (p.done) this._nerDownloadFrac.set(1);
-      });
-      this.destroyRef.onDestroy(() => this.unlistenNerDownload?.());
+      this.unlistenNerDownload = await subscribeUntilDestroyed(
+        this.destroyRef,
+        () =>
+      this.ipc.onNerDownload((p) => {
+            // Per-file progress: blend the completed files + the current file's
+            // fraction across the whole set so the single bar advances smoothly.
+            if (p.fileCount > 0) {
+              const cur = p.total && p.total > 0 ? p.downloaded / p.total : 0;
+              this._nerDownloadFrac.set(
+                Math.min(1, (p.fileIndex + cur) / p.fileCount),
+              );
+            }
+            if (p.done) this._nerDownloadFrac.set(1);
+          }),
+      );
     } catch {
       // No stream available — progress bar stays inert; the command still resolves.
     }
@@ -2999,9 +3017,6 @@ export class SettingsStore {
       this._urlCopied.set(true);
       if (this.copyResetTimer) clearTimeout(this.copyResetTimer);
       this.copyResetTimer = setTimeout(() => this._urlCopied.set(false), 1600);
-      this.destroyRef.onDestroy(() => {
-        if (this.copyResetTimer) clearTimeout(this.copyResetTimer);
-      });
     } catch {
       // Clipboard unavailable — the URL stays visible and selectable as a fallback.
     }
@@ -3029,9 +3044,6 @@ export class SettingsStore {
         () => this._configCopied.set(false),
         1600,
       );
-      this.destroyRef.onDestroy(() => {
-        if (this.mcpCopyResetTimer) clearTimeout(this.mcpCopyResetTimer);
-      });
     } catch {
       // Clipboard unavailable — the config stays visible and selectable as a fallback.
     }


### PR DESCRIPTION
## 1. Teardown registered after the await (NG0911 + a leaked subscription)

Six sites wrote the same shape by hand:

```ts
this.unlistenX = await this.ipc.onX(cb);
this.destroyRef.onDestroy(() => this.unlistenX?.());   // ← too late
```

It is wrong **twice over** when the view is destroyed while that `await` is in flight:

1. the resumed continuation calls `DestroyRef.onDestroy` on a dead view → **NG0911**;
2. because the registration never happened, the handle the await just produced is **never
   released** — a live event subscription on a destroyed view, feeding callbacks that write signals
   nobody renders.

Rather than patch the same lines six times, `core/subscribe-until-destroyed.ts` makes the order
correct by construction: register the cleanup synchronously, *then* await, and release a late handle
immediately if destruction won the race. `record.component.ts` already had to learn this the hard
way, after an interval kept polling `detect_meeting_app` forever on a dead view.

Converted: `onboarding`, `brain-enable-card`, and four in `settings.store.ts`.

**Also found, not in the task list:** two "Copied" flash timers registered an `onDestroy` inside
their *click handlers*, so every copy added another callback, each clearing the same single handle.
The store is component-provided, so this accumulated per visit to Settings rather than for the app's
life — wrong, but smaller than it first looks. Both now clear in the one `onDestroy` the store
already has, the shape `toast.service.ts` established (angular-zoneless §5).

## 2. Stale-result guards in graph + people — a correctness bug, not a flash

`_refetchOnLock` re-runs on **every** folders-tree change: a session unlock, a relock, a
screen-share-triggered relock-all. So two fetches can be in flight at once and nothing orders their
resolution. The older one landing last overwrote the newer — and for a **visibility** refetch that is
not cosmetic:

> it can put sealed people or entities back on screen after a relock, from a response that was
> already stale when it arrived.

Both now carry a monotonic `fetchSeq`, checked after the await *and* in `catch`/`finally`, so only
the newest response writes and only the newest clears the spinner.
`entity-detail.component.ts` keys the same discipline on the entity id; there is no such identity
here, so the sequence number is the identity.

## Two deliberate departures from the task text

**The NUL fix is an escape, not a space.** `ledgerKey` carried two raw NUL bytes — invisible in every
editor and diff, and liable to truncate in tooling that treats them as terminators. But the
*character* is load-bearing: NUL cannot occur in a subject or predicate, which is what keeps the
`track` key collision-free. Substituting `" "` as proposed **would have introduced a collision** —
`"a b"+"c"` and `"a"+"b c"` would share a key. `settings/model-id.ts` already documents exactly this
rule ("every control character written as an ESCAPE, never as the literal").

**The §8 fix for graph/people is not here.** Both hold their list state in component-local signals,
so gating the template on `listEmpty() && loading()` would achieve *nothing* — the signals are wiped
on every destroy and there is no cached row to protect. Doing it properly means moving that state
into signal-holder services, which is a separate reviewable change. This is the exact trap the
2026-07-12 incident records, and half-doing it would look like a fix while changing nothing.

`standalone: true` removed from `stage2-panel` (redundant since v19, banned by the rule).

## Honest gap

**No failing-first test for the sequence guards.** The only in-app trigger for an overlapping refetch
is a sidebar unlock, which needs the whole biometric fixture. A test I could write quickly would pass
without reproducing the race — and a test that passes either way is worth less than saying plainly
that it is missing. This is the thing to attack in review.

## Gates

`npx ng lint` clean · `npx ng build` clean · **182 e2e passed** across both engines (brain, settings,
settings-ai, onboarding).
