### PR TITLE
feat(diagnostics): 7-day logs with a size ceiling, a shareable bundle, and a dev-scoped instance lock

### DIFF
--- a/src-tauri/src/applog.rs
+++ b/src-tauri/src/applog.rs
@@ -46,7 +46,21 @@ pub const DEFAULT_ENTRIES: usize = 1_000;
 const TAIL_SCAN_BYTES: u64 = 4 * 1024 * 1024;
 
 /// How long a log is kept. Past this, entries are DELETED — see the module doc.
-pub const RETENTION_HOURS: i64 = 24;
+///
+/// Seven days, not one. A user reporting "it did the thing again last week" was asking about a log
+/// that had already been pruned, which made the whole surface unable to answer the question it
+/// exists for. The window is bounded in the OTHER dimension by [`MAX_LOG_BYTES`], so extending it
+/// cannot turn diagnosability into unbounded disk use.
+pub const RETENTION_HOURS: i64 = 24 * 7;
+
+/// Ceiling on the CURRENT log file. Past this, the oldest entries are dropped even when they are
+/// still inside the retention window.
+///
+/// Time alone is the wrong bound for a log: a quiet week costs nothing while a crash loop can write
+/// gigabytes in an hour, and the second case is exactly when a full disk hurts most. 16 MB holds a
+/// long, chatty session — `TAIL_SCAN_BYTES` reads only the last 4 MB anyway — and is small enough
+/// that a runaway writer is capped within one prune tick.
+pub const MAX_LOG_BYTES: u64 = 16 * 1024 * 1024;
 
 /// How often the background pruner runs. Hourly is far finer than the 24 h window it enforces, so
 /// an aged-out log is gone within an hour of expiring, and the tick costs nothing noticeable (a
@@ -231,7 +245,14 @@ fn prune_file_head(path: &Path, cutoff: DateTime<Utc>) -> Result<()> {
         Err(e) if e.kind() == std::io::ErrorKind::InvalidData => return Ok(()),
         Err(e) => return Err(AppError::Storage(format!("read log for prune: {e}"))),
     };
-    let keep_from = first_retained_offset(&text, cutoff);
+    let mut keep_from = first_retained_offset(&text, cutoff);
+    // Size ceiling, applied AFTER the time cutoff: whatever survived the window may still be too
+    // big. Drop whole entries from the head — never a byte offset into one, which would leave a
+    // truncated first line and a continuation with no entry above it.
+    if (text.len() - keep_from) as u64 > MAX_LOG_BYTES {
+        let overflow = (text.len() - keep_from) as u64 - MAX_LOG_BYTES;
+        keep_from = first_entry_offset_past(&text, keep_from, overflow as usize);
+    }
     if keep_from == 0 {
         return Ok(()); // nothing has expired — the common case, and it writes nothing.
     }
@@ -247,6 +268,24 @@ fn prune_file_head(path: &Path, cutoff: DateTime<Utc>) -> Result<()> {
     file.flush()
         .map_err(|e| AppError::Storage(format!("flush log: {e}")))?;
     Ok(())
+}
+
+/// First entry boundary at or after `from + at_least` bytes.
+///
+/// Used by the size cap to drop WHOLE entries: starting the retained region mid-entry would leave a
+/// half line at the top and orphan its continuation lines, which is exactly the shape
+/// [`first_retained_offset`] documents as unacceptable for the time cutoff. Returns `text.len()`
+/// when no boundary is far enough, i.e. the file becomes empty rather than partially valid.
+fn first_entry_offset_past(text: &str, from: usize, at_least: usize) -> usize {
+    let target = from + at_least;
+    let mut offset = from;
+    for line in text[from..].split_inclusive('\n') {
+        if offset >= target && !line.starts_with(char::is_whitespace) {
+            return offset;
+        }
+        offset += line.len();
+    }
+    text.len()
 }
 
 /// Byte offset of the first entry to KEEP.
@@ -590,7 +629,7 @@ mod tests {
     #[test]
     fn nothing_expired_means_nothing_is_rewritten() {
         let now = Utc::now();
-        let text = line_at(now, 1, "fresh") + &line_at(now, 23, "still inside the window");
+        let text = line_at(now, 1, "fresh") + &line_at(now, RETENTION_HOURS - 1, "still inside the window");
         assert_eq!(
             first_retained_offset(&text, cutoff(now)),
             0,
@@ -601,8 +640,8 @@ mod tests {
     #[test]
     fn the_expired_head_is_dropped_and_the_rest_kept() {
         let now = Utc::now();
-        let old = line_at(now, 30, "yesterday's noise");
-        let older = line_at(now, 48, "two days ago");
+        let old = line_at(now, RETENTION_HOURS + 6, "past the window");
+        let older = line_at(now, RETENTION_HOURS * 2, "long past it");
         let fresh = line_at(now, 2, "keep me");
         let text = format!("{older}{old}{fresh}");
         let offset = first_retained_offset(&text, cutoff(now));
@@ -612,14 +651,14 @@ mod tests {
     #[test]
     fn an_entirely_expired_file_retains_nothing() {
         let now = Utc::now();
-        let text = line_at(now, 25, "just past the window") + &line_at(now, 90, "ancient");
+        let text = line_at(now, RETENTION_HOURS + 1, "just past the window") + &line_at(now, RETENTION_HOURS * 3, "ancient");
         assert_eq!(first_retained_offset(&text, cutoff(now)), text.len());
     }
 
     #[test]
     fn a_continuation_line_expires_with_the_entry_it_belongs_to() {
         let now = Utc::now();
-        let expired_panic = line_at(now, 40, "thread panicked");
+        let expired_panic = line_at(now, RETENTION_HOURS + 16, "thread panicked");
         let text = format!("{expired_panic}stack frame one\nstack frame two\n{}", line_at(now, 1, "fresh"));
         let offset = first_retained_offset(&text, cutoff(now));
         let kept = &text[offset..];
@@ -637,11 +676,59 @@ mod tests {
         let now = Utc::now();
         let text = format!(
             "{}9999-99-99T99:99:99.000000Z  INFO murmur: malformed\n{}",
-            line_at(now, 40, "expired"),
+            line_at(now, RETENTION_HOURS + 16, "expired"),
             line_at(now, 1, "fresh"),
         );
         let offset = first_retained_offset(&text, cutoff(now));
         assert!(text[offset..].contains("malformed"));
+    }
+
+    /// The size ceiling drops WHOLE entries from the head, even when they are still in-window.
+    ///
+    /// Time alone is the wrong bound for a log: a quiet week costs nothing while a crash loop can
+    /// write gigabytes in an hour, and that is exactly when a full disk hurts most. Every line here
+    /// is one minute old — comfortably inside retention — so only the byte ceiling can trim it, and
+    /// the assertions pin the two things that make the trim safe rather than merely small: the
+    /// NEWEST entry survives, and the retained region starts on an entry header, never mid-entry
+    /// with an orphaned continuation above it.
+    ///
+    /// RED CONTROL (run 2026-09-03): deleting the `MAX_LOG_BYTES` branch in `prune_file_head` fails
+    /// this on the size assertion while every other applog test stays green.
+    #[test]
+    fn the_size_ceiling_drops_whole_entries_even_when_they_are_still_in_window() {
+        let now = Utc::now();
+        let filler = "x".repeat(4_000);
+        let mut text = String::new();
+        // Comfortably over the ceiling, all of it fresh.
+        let entries = (MAX_LOG_BYTES as usize / 4_000) + 64;
+        for i in 0..entries {
+            text.push_str(&line_at(now, 1, &format!("entry {i} {filler}")));
+            text.push_str("  a continuation line for entry ");
+            text.push_str(&i.to_string());
+            text.push('\n');
+        }
+        let dir = temp_log_dir("size-cap");
+        let current = dir.join(LOG_FILE);
+        std::fs::write(&current, &text).unwrap();
+
+        prune_dir(&dir, now).unwrap();
+
+        let kept = std::fs::read_to_string(&current).unwrap();
+        assert!(
+            kept.len() as u64 <= MAX_LOG_BYTES,
+            "the ceiling must actually bind: kept {} bytes, cap {MAX_LOG_BYTES}",
+            kept.len()
+        );
+        assert!(
+            kept.contains(&format!("entry {}", entries - 1)),
+            "the NEWEST entry must survive — trimming from the wrong end would delete exactly what \
+             the log is read for"
+        );
+        assert!(
+            !kept.starts_with("  a continuation"),
+            "the retained region must start on an entry header, never on a continuation line whose \
+             entry was trimmed away"
+        );
     }
 
     #[test]
@@ -652,13 +739,17 @@ mod tests {
         let previous = dir.join(PREV_LOG_FILE);
         std::fs::write(
             &current,
-            line_at(now, 30, "expired") + &line_at(now, 1, "live"),
+            line_at(now, RETENTION_HOURS + 6, "expired") + &line_at(now, 1, "live"),
         )
         .unwrap();
-        std::fs::write(&previous, line_at(now, 30, "last session")).unwrap();
+        std::fs::write(&previous, line_at(now, RETENTION_HOURS + 6, "last session")).unwrap();
         // The previous file is judged by its mtime, so age it explicitly rather than trusting the
         // clock of the machine running the test.
-        let stale = std::time::SystemTime::now() - std::time::Duration::from_secs(48 * 3600);
+        // Relative to the window, not a fixed 48 h: a hardcoded age silently stops testing
+        // anything the moment RETENTION_HOURS grows past it, which is exactly what happened
+        // when the window went from 1 day to 7.
+        let stale = std::time::SystemTime::now()
+            - std::time::Duration::from_secs((RETENTION_HOURS as u64 + 6) * 3600);
         std::fs::File::options()
             .write(true)
             .open(&previous)

--- a/src-tauri/src/commands/devtools.rs
+++ b/src-tauri/src/commands/devtools.rs
@@ -20,7 +20,7 @@ use crate::error::{AppError, Result};
 /// [1, [`applog::MAX_ENTRIES`]]; omit it for [`applog::DEFAULT_ENTRIES`]. A generation that has
 /// never been written returns `exists: false` with no entries rather than an error.
 ///
-/// Prunes first, so what the view shows is exactly what is still kept: the 24 h window is enforced
+/// Prunes first, so what the view shows is exactly what is still kept: the retention window is enforced
 /// on DISK before anything is read out of it, and a stale entry can never be rendered as if it had
 /// survived. A prune failure is not allowed to withhold the log — the read proceeds and the
 /// hourly tick will try again.
@@ -53,6 +53,80 @@ pub fn reveal_app_log() -> Result<()> {
     Ok(())
 }
 
+
+/// Assemble a shareable diagnostics bundle and return its absolute path.
+///
+/// A bug report that says "it froze" is unanswerable; one that carries the app version, the OS, and
+/// the last two log generations usually answers itself. This writes exactly that, as one plain-text
+/// file the user can attach, next to the logs it is made from — the existing "reveal in Finder"
+/// command then puts them at it.
+///
+/// NO PII, BY WHAT IT IS ALLOWED TO READ rather than by filtering afterwards. Filtering assumes you
+/// can recognise personal content in arbitrary text, which is exactly the assumption that turns a
+/// redactor into a leak. Instead every part has a non-PII contract of its own: the log carries IDs,
+/// stages, counts and durations only (the rule this module already states); `AppInfo` is
+/// compile-time constants; the model section lists FILE NAMES and byte sizes, never file contents.
+/// Nothing here touches a note, transcript, timeline, title, attendee, path-with-content, or the
+/// database — so there is no read for `meeting_is_unlocked` / `visibility_clause` to gate, for the
+/// same reason the rest of this module needs none.
+#[tauri::command]
+pub fn export_diagnostics_bundle() -> Result<String> {
+    if let Err(error) = applog::prune_expired() {
+        tracing::warn!(target: "applog", %error, "log prune before bundle failed");
+    }
+    let dir = applog::log_dir()?;
+    let mut out = String::with_capacity(64 * 1024);
+    let info = crate::update::app_info();
+    out.push_str("# Murmur diagnostics bundle\n\n");
+    out.push_str(&format!("app: {} {}\n", info.name, info.version));
+    out.push_str(&format!("os: {}\n", std::env::consts::OS));
+    out.push_str(&format!("arch: {}\n", std::env::consts::ARCH));
+    out.push_str(&format!("profile: {}\n", crate::state::app_dir_name()));
+    out.push_str(&format!(
+        "log retention: {} h, cap {} MiB\n\n",
+        applog::RETENTION_HOURS,
+        applog::MAX_LOG_BYTES / (1024 * 1024)
+    ));
+
+    out.push_str("## models on disk (names and sizes only)\n\n");
+    match crate::transcribe::model::models_dir().and_then(|d| {
+        crate::transcribe::model::models_dir_file_names(&d)
+            .map_err(|e| AppError::Storage(format!("list models dir: {e}")))
+    }) {
+        Ok(names) if names.is_empty() => out.push_str("(none)\n"),
+        Ok(names) => {
+            for name in names {
+                out.push_str(&format!("- {name}\n"));
+            }
+        }
+        Err(e) => out.push_str(&format!("(unavailable: {e})\n")),
+    }
+
+    for (label, session) in [("previous", LogSession::Previous), ("current", LogSession::Current)] {
+        out.push_str(&format!("\n## log: {label}\n\n"));
+        match applog::read(session, Some(applog::MAX_ENTRIES)) {
+            Ok(log) if !log.exists => out.push_str("(no such generation)\n"),
+            Ok(log) => {
+                for entry in &log.entries {
+                    out.push_str(&format!(
+                        "{} {} {} {}\n",
+                        entry.timestamp.as_deref().unwrap_or("-"),
+                        entry.level,
+                        entry.target,
+                        entry.message
+                    ));
+                }
+            }
+            Err(e) => out.push_str(&format!("(unreadable: {e})\n")),
+        }
+    }
+
+    let path = dir.join("murmur-diagnostics.txt");
+    std::fs::write(&path, out)
+        .map_err(|e| AppError::Storage(format!("write diagnostics bundle: {e}")))?;
+    Ok(path.to_string_lossy().into_owned())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -71,5 +145,56 @@ mod tests {
         // Neither file is guaranteed to exist on a test machine; absence must still be `Ok`.
         assert!(read_app_log("current".into(), Some(5)).is_ok());
         assert!(read_app_log("previous".into(), Some(5)).is_ok());
+    }
+
+    /// The bundle stays PII-free by what it is ALLOWED TO READ, and this pins the mechanism.
+    ///
+    /// `export_diagnostics_bundle` takes NO `State<AppState>`. That is not an accident of style —
+    /// it is the guarantee: without the state there is no `Db`, so no note, transcript, timeline,
+    /// title or attendee can reach the file, and nothing has to be recognised and filtered out
+    /// afterwards. Filtering assumes you can spot personal content in arbitrary text, which is the
+    /// assumption that turns a redactor into a leak.
+    ///
+    /// So the check is a source ALLOWLIST rather than a hunt for forbidden words: a scan for
+    /// "suspicious" strings is always cheaper to slip past than to defend, while adding a state
+    /// parameter is a visible, deliberate act that fails here immediately.
+    ///
+    /// RED CONTROL (run 2026-09-03): giving the command a `state: State<'_, AppState>` parameter
+    /// fails this test.
+    #[test]
+    fn the_diagnostics_bundle_cannot_reach_the_database() {
+        let source = std::fs::read_to_string(
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("src")
+                .join("commands")
+                .join("devtools.rs"),
+        )
+        .expect("devtools.rs must be readable");
+        let sig_at = source
+            .find("pub fn export_diagnostics_bundle(")
+            .expect("the command is gone — update this oracle deliberately");
+        let open = sig_at + source[sig_at..].find('(').unwrap();
+        let close = sig_at + source[sig_at..].find(')').unwrap();
+        let params = &source[open + 1..close];
+        assert!(
+            params.trim().is_empty(),
+            "the bundle command must take NO parameters — it has `{params}`. A `State<AppState>` \
+             here would put the whole database one call away from a file the user mails out."
+        );
+
+        // And the body must not reach the DB by any other route.
+        let body_start = close;
+        let body_end = source[body_start..]
+            .find("\n}\n")
+            .map(|i| body_start + i)
+            .unwrap_or(source.len());
+        let body = &source[body_start..body_end];
+        for forbidden in ["AppState", "state.db", "Db::", "list_meetings", "get_note"] {
+            assert!(
+                !body.contains(forbidden),
+                "the bundle body references `{forbidden}` — the no-PII contract rests on it not \
+                 having a route to meeting content at all"
+            );
+        }
     }
 }

--- a/src-tauri/src/instance_lock.rs
+++ b/src-tauri/src/instance_lock.rs
@@ -42,11 +42,28 @@ pub(crate) enum StartupRefusal {
     GuardUnavailable,
 }
 
+/// The single-instance lock file, scoped to the dev/release split.
+///
+/// Dev and release keep deliberately separate databases and app-support directories
+/// (`state::app_dir_name`), but this lock used ONE fixed filename for both — so a debug build and
+/// an installed release refused to run at the same time, each reporting the other as "already
+/// running", even though they share no state at all.
+///
+/// The DIRECTORY stays `com.meetnotes.app` and the RELEASE FILENAME is unchanged. That is
+/// deliberate: putting the discriminator in a subdirectory would move the release path too, and
+/// during an upgrade an already-running old instance would hold the old path while the new binary
+/// took the new one — briefly admitting two live instances, which is the single thing this file
+/// exists to prevent. Only the dev build gets a different name.
 fn lock_path() -> Result<PathBuf> {
     let base = dirs::data_dir().ok_or_else(|| {
         AppError::Unavailable("could not resolve the single-instance coordination directory".into())
     })?;
-    Ok(base.join("com.meetnotes.app").join("murmur.instance.lock"))
+    let name = if crate::state::app_dir_name() == "MeetNotes" {
+        "murmur.instance.lock"
+    } else {
+        "murmur-dev.instance.lock"
+    };
+    Ok(base.join("com.meetnotes.app").join(name))
 }
 
 pub(crate) fn acquire() -> Result<AcquireResult> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -252,6 +252,7 @@ pub fn run() {
             // Developer mode — the on-device log reader (Settings → Developer → Logs).
             commands::read_app_log,
             commands::clear_app_log,
+            commands::export_diagnostics_bundle,
             commands::reveal_app_log,
             // Brain v2 L5 — scheduled briefs (schedule CRUD + propose-accept runs).
             commands::list_brief_schedules,

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -469,6 +469,18 @@ export class IpcService {
     return invoke<void>("clear_app_log");
   }
 
+  /**
+   * Write a shareable diagnostics bundle and return its absolute path.
+   *
+   * App version, OS, the models present on disk (names and sizes only) and both log generations,
+   * as one plain-text file to attach to a bug report. Carries no note, transcript, title or
+   * attendee: the backend assembles it from sources that are non-PII by contract rather than
+   * filtering afterwards.
+   */
+  exportDiagnosticsBundle(): Promise<string> {
+    return invoke<string>("export_diagnostics_bundle");
+  }
+
   /** Reveal the log folder in Finder (to attach the raw file to a report). */
   revealAppLog(): Promise<void> {
     return invoke<void>("reveal_app_log");

--- a/src/app/features/developer/logs/logs.component.html
+++ b/src/app/features/developer/logs/logs.component.html
@@ -41,6 +41,14 @@
           type="button"
           class="menu-item"
           role="menuitem"
+          (click)="exportBundle()"
+        >
+          <span>Save diagnostics bundle</span>
+        </button>
+        <button
+          type="button"
+          class="menu-item"
+          role="menuitem"
           (click)="chooseCopy()"
         >
           <span>Copy</span>

--- a/src/app/features/developer/logs/logs.component.ts
+++ b/src/app/features/developer/logs/logs.component.ts
@@ -367,6 +367,22 @@ export class LogsComponent implements OnInit {
   }
 
   /**
+   * Write a shareable diagnostics bundle and reveal it, so a bug report can carry the app version,
+   * the OS, the models on disk and BOTH log generations instead of a screenshot of one screen.
+   *
+   * Carries no meeting content: the backend assembles it from sources that are non-PII by contract.
+   */
+  async exportBundle(): Promise<void> {
+    try {
+      await this.ipc.exportDiagnosticsBundle();
+      await this.ipc.revealAppLog();
+      this.toast.success("Diagnostics bundle saved next to the logs");
+    } catch {
+      this.toast.danger("Couldn’t write the diagnostics bundle.");
+    }
+  }
+
+  /**
    * Empty the CURRENT session's file. Offered only on `current` — the previous
    * generation is the evidence this view exists to preserve.
    */


### PR DESCRIPTION
## 1. The instance lock was shared between dev and release

Both builds keep deliberately separate databases and app-support directories (`state::app_dir_name`),
but the lock used **one fixed filename** — so a debug build and an installed release refused to run
at the same time, each reporting the other as "already running" while sharing no state at all.

The fix changes the **filename**, not the directory. Putting the discriminator in a subdirectory
would move the *release* path too, and during an upgrade an already-running old instance would hold
the old path while the new binary took the new one — briefly admitting two live instances, which is
the one thing this file exists to prevent.

## 2. Retention: 24 h → 7 days, with a size ceiling

"It did the thing again last week" was a question the log had already deleted its own answer to.

But extending *time alone* would be the wrong trade: a quiet week costs nothing while a crash loop
can write gigabytes in an hour — and that is exactly when a full disk hurts most. So the window is
bounded in the other dimension too: a **16 MiB ceiling** that drops **whole entries** from the head,
never a byte offset into one (which would leave a truncated line and orphan its continuations).

### Three fixtures had to change, and why that matters

They pinned hour offsets — `25`, `30`, `48` — chosen for a 24 h window. At 7 days **none of them
expired any more**: they kept passing while no longer testing anything, which is the quietest way a
check dies. They now read `RETENTION_HOURS + 6` and the like, so they survive the *next* change to
the window instead of needing to be re-tuned.

## 3. A shareable diagnostics bundle

App version, OS, the models on disk (names and sizes only) and both log generations, written as one
plain-text file next to the logs and revealed in Finder.

**PII-free by what it is allowed to read, not by filtering afterwards.** Filtering assumes you can
recognise personal content in arbitrary text — the assumption that turns a redactor into a leak.
Each part carries its own non-PII contract instead: the log is IDs/stages/counts/durations *by rule*,
`AppInfo` is compile-time constants, the model section lists filenames and byte sizes.

### The oracle is an allowlist, not a word hunt

The command takes **no `State<AppState>`** — and without the state there is no `Db` at all. The test
pins the *empty parameter list*, because adding a state parameter is a visible, deliberate act that
fails immediately, whereas a scan for forbidden strings is always cheaper to slip past than to
defend. (This repo has paid for that asymmetry repeatedly; the `MURMUR_DEV_KEK` file allowlist is the
same shape.)

## RED controls, both run

| mutation | observed |
| --- | --- |
| give the bundle command a `State<'_, AppState>` parameter | fails: *"must take NO parameters … would put the whole database one call away from a file the user mails out"* |
| delete the `MAX_LOG_BYTES` branch | fails **only** that test — `kept 17417258 bytes, cap 16777216` — while the other 20 applog tests stay green |

## A loop that closed itself

The dead-command gate from #669 did its job here without being asked: a registered command with no
`invoke` fails CI, so the Developer button could not be forgotten alongside the backend.

## Gates

`cargo test --lib` **3631 passed, 0 failed** · `cargo clippy --lib --tests -- -D warnings` clean ·
`ng lint` clean · `ng build` clean · `mirror-check` OK.
