### PR TITLE
chore(copy): one name per level of the hierarchy, and a gate that can see the difference

### DIFF
--- a/.vocabulary-allowlist.json
+++ b/.vocabulary-allowlist.json
@@ -84,6 +84,11 @@
       "file": "src/app/features/settings/settings/settings.component.ts",
       "term": "\\bDEK\\b|\\bKEK\\b|\\bCK\\b",
       "reason": "Hidden search synonym, never rendered. No key MATERIAL is ever shown; this is only a term someone might search for."
+    },
+    {
+      "file": "src/app/services/note-attachment.service.ts",
+      "term": "\\bcontainers?\\b",
+      "reason": "Ordinary English, not the hierarchy: an image's decoded dimensions are compared against its CONTAINER FORMAT. The banned sense is the code's word for 'a Workspace or a folder'; here the user is better off with the precise term, and rewriting it to 'Workspace or folder' would say something false."
     }
   ]
 }

--- a/.vocabulary-baseline.json
+++ b/.vocabulary-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Transitional debt only. This number must never grow. Entries are removed by rewriting the copy, never by adding to the allowlist without a reason.",
-  "count": 165,
+  "count": 160,
   "files": {
     "src/app/features/analytics/analytics/analytics.component.html": 1,
     "src/app/features/analytics/egress-ledger/egress-ledger.component.html": 9,

--- a/e2e/notes/typed-properties.spec.ts
+++ b/e2e/notes/typed-properties.spec.ts
@@ -220,7 +220,11 @@ test("a LOCKED folder shows the lock gate and hides the Saved Views bar", async 
     .click();
 
   await expect(page).toHaveURL(/\/container\/nf2$/);
-  await expect(page.getByText("This container is locked")).toBeVisible();
+  // "folder", not "container": the code's word for "a Workspace or a folder" used to leak into
+  // this state, where it named nothing the user ever created. `core/hierarchy-vocabulary.ts`
+  // is the one source now — and this assertion failing on the rename is what proved the old
+  // word really was on screen rather than only in the source.
+  await expect(page.getByText("This folder is locked")).toBeVisible();
   // No view controls and no counts: the backend refuses to describe a sealed container, and
   // "0" would be a claim about contents nobody is entitled to read.
   await expect(page.locator("app-notes-view-switcher")).toHaveCount(0);

--- a/scripts/check-vocabulary.mjs
+++ b/scripts/check-vocabulary.mjs
@@ -51,6 +51,20 @@ const BANNED = [
   ["prefix cache|KV cache", "(drop it)"],
   ["\\bRAG\\b", "search"],
   ["reranker", "result ordering"],
+  // The hierarchy's CODE word. A user never made a "container" — they made a Workspace or a
+  // folder — and it leaked into three of `container-view`'s own empty and error states while
+  // every other surface said something else. `core/hierarchy-vocabulary.ts` is the one source.
+  //
+  // Deliberately NOT banning "space": it is ordinary English used correctly elsewhere ("Free up
+  // space"), and banning it would train people to ignore this list. What stops "space" being used
+  // as a HIERARCHY noun is the `ContainerNoun` type — a domain identifier no longer typechecks
+  // where a sentence is written, which is a guard a word list cannot provide.
+  // FE ONLY, for now. `core/hierarchy-vocabulary.ts` made the frontend consistent, but the
+  // BACKEND still says "container" in 69 `AppError` bodies that reach the user as toasts
+  // ("unlock this container before moving a dashboard into it"). Those live in files another PR
+  // is currently rewriting, and silently widening the baseline to admit them would be the exact
+  // rubber stamp this gate exists to prevent — so they are a recorded task, not a hidden pass.
+  ["\\bcontainers?\\b", "Workspace or folder", ["fe"]],
 ];
 
 /** Files whose strings a user can actually read. */
@@ -85,7 +99,12 @@ function visibleText(file, source) {
     // prose comment ("doesn't") opens a bogus string literal that swallows the next few
     // hundred characters of code, and the whole comment then reads as user-facing copy.
     while ((m = re.exec(text))) {
-      const value = m[2];
+      // An interpolated expression is CODE, not copy: in `Created a folder in ${container.name}`
+      // the user reads "Created a folder in Projects" — `container` is a variable name that
+      // happens to sit inside a string. Leaving these in made every hierarchy term look like it
+      // leaked into 80 sentences it never reached, which is precisely the noise this function's
+      // own comment warns teaches people to ignore the tool.
+      const value = m[2].replace(/\$\{[^}]*\}/g, " ");
       // Prose, not an identifier / path / css class / event name.
       if (!/\s/.test(value)) continue;
       if (/^[./#@]/.test(value)) continue;
@@ -100,6 +119,16 @@ function visibleText(file, source) {
       /^\s(?:aria-label|title|placeholder|alt|matTooltip)=/.test(m) ? m : " ",
     );
     text = text.replace(/<!--[\s\S]*?-->/g, " ");
+    // Angular control flow and interpolation EXPRESSIONS are code. A user reading
+    // `{{ container.name }}` sees "Projects"; `@if (node(); as container)` they never see at all.
+    // Left in, they made every hierarchy term look like it leaked into dozens of sentences it
+    // never reached — the same false-positive class the `.ts` branch already strips for `${…}`.
+    text = text.replace(/\{\{[\s\S]*?\}\}/g, " ");
+    text = text.replace(/@(?:if|else if|for|switch|case|defer|placeholder|loading|empty)\s*\([^)]*\)/g, " ");
+    // Element NAMES are never copy — `<app-container-share-sheet>` is a selector. The attribute
+    // pass above deliberately keeps aria-label/title/placeholder/alt, so whole tags cannot simply
+    // be stripped; the tag NAME can.
+    text = text.replace(/<\/?[a-zA-Z][\w-]*/g, " ");
   }
   if (file.endsWith(".rs")) {
     // Only strings that can REACH a user: AppError bodies and role/map display fields.
@@ -123,7 +152,9 @@ function scan() {
       const text = visibleText(file, source);
       if (!text.trim()) continue;
       const lines = text.split("\n");
-      for (const [term, replacement] of BANNED) {
+      for (const [term, replacement, kinds] of BANNED) {
+        // A term may name a surface it applies to; the default is every surface.
+        if (kinds && !kinds.includes(kind)) continue;
         const re = new RegExp(term, "i");
         lines.forEach((line, i) => {
           if (re.test(line)) {

--- a/src/app/core/hierarchy-vocabulary.ts
+++ b/src/app/core/hierarchy-vocabulary.ts
@@ -1,0 +1,47 @@
+import type { ContainerNode } from "./models";
+
+/**
+ * A word the USER reads for a level of the hierarchy.
+ *
+ * Deliberately distinct from the code's `level` (`"project" | "folder"`) and from a `kind`
+ * (`"space" | "note" | …`): a domain identifier must not typecheck where a sentence is written,
+ * which is how the two vocabularies drifted apart in the first place.
+ */
+export type ContainerNoun = "Workspace" | "folder";
+
+/**
+ * The ONE user-facing name for each level of the workspace hierarchy.
+ *
+ * WHY THIS EXISTS (2026-09-02 audit, F5). The same `level === "project"` test was written in four
+ * places and produced four different words for two concepts: `"Workspace" / "Folder"` in the create
+ * sheet, `"Workspace" / "folder"` in the share sheet, `"space" / "folder"` in the tree's menus and
+ * toasts, and a bare `"container"` in the container view's own empty and error states. A user
+ * renaming a thing was told they renamed a "space"; the sheet that made it called it a "Workspace";
+ * the view of it called it a "container". Same object, three names, one session.
+ *
+ * `Workspace` is capitalised because that is what the product already calls it where it names it
+ * most — "No Workspaces yet", "Created Workspace" — and `folder` is lowercase for the same reason
+ * ("Move to Workspace or folder…"). The choice is which existing word wins, not a new one.
+ *
+ * The DTO's own term is `"project"`, and `container` is the code's word for "either of these". Both
+ * are fine in code and neither belongs in a sentence a user reads; `scripts/check-vocabulary.mjs`
+ * now fails a build that puts them there.
+ */
+export function containerNoun(
+  container: Pick<ContainerNode, "level">,
+): ContainerNoun {
+  return container.level === "project" ? "Workspace" : "folder";
+}
+
+/**
+ * The same noun at the start of a sentence.
+ *
+ * Only `folder` changes — `Workspace` is a proper noun and is already capitalised, so a naive
+ * `charAt(0).toUpperCase()` at each call site would have been right by accident here and wrong the
+ * moment the vocabulary gains a term that is capitalised mid-sentence.
+ */
+export function containerNounLeading(
+  container: Pick<ContainerNode, "level">,
+): "Workspace" | "Folder" {
+  return container.level === "project" ? "Workspace" : "Folder";
+}

--- a/src/app/features/workspace/container-share-sheet/container-share-sheet.component.ts
+++ b/src/app/features/workspace/container-share-sheet/container-share-sheet.component.ts
@@ -25,13 +25,14 @@ import type {
 } from "../../../core/models";
 import { MurSelectComponent } from "../../../design-system/select/select.component";
 import { SharedWorkspaceService } from "../../../services/shared-workspace.service";
+import { containerNoun } from "../../../core/hierarchy-vocabulary";
 
 /** The local container this sheet is publishing. */
 export interface ContainerShareTarget {
   /** The local `folders.id`. */
   id: string;
   name: string;
-  /** `"project"` renders as "Workspace"; anything else as "Folder". */
+  /** `"project"` renders as "Workspace"; anything else as "folder" (`containerNoun`). */
   level: "project" | "folder";
 }
 
@@ -107,10 +108,8 @@ export class ContainerShareSheetComponent {
     return total > 0 ? Math.round((this.progressDone() / total) * 100) : 0;
   });
 
-  /** "Workspace" or "Folder" — the word the user sees for this container. */
-  readonly noun = computed(() =>
-    this.target().level === "project" ? "Workspace" : "folder",
-  );
+  /** The word the user sees for this level — the ONE source is `core/hierarchy-vocabulary.ts`. */
+  readonly noun = computed(() => containerNoun(this.target()));
 
   /** The container's existing share in the CHOSEN org, if any. */
   readonly existingShare = computed<ContainerShareStatus | null>(() => {

--- a/src/app/features/workspace/container-view/container-view.component.html
+++ b/src/app/features/workspace/container-view/container-view.component.html
@@ -17,7 +17,7 @@
          holds. Saying "empty" here would be a claim about contents nobody is
          entitled to read. -->
     <div class="state-card">
-      <p><strong>This container is locked</strong></p>
+      <p><strong>This {{ noun() }} is locked</strong></p>
       <p>Unlock it to see what it holds.</p>
     </div>
   } @else if (error(); as message) {
@@ -27,7 +27,7 @@
   } @else if (isEmpty() && loading()) {
     <p class="state">Loading…</p>
   } @else if (isEmpty()) {
-    <p class="state">This container is empty.</p>
+    <p class="state">This {{ noun() }} is empty.</p>
   } @else {
     @for (page of pages(); track page.kind) {
       @if (page.total > 0) {
@@ -60,5 +60,5 @@
 } @else if (loading()) {
   <p class="state">Loading…</p>
 } @else {
-  <p class="state">That container was not found.</p>
+  <p class="state">That {{ noun() }} was not found.</p>
 }

--- a/src/app/features/workspace/container-view/container-view.component.ts
+++ b/src/app/features/workspace/container-view/container-view.component.ts
@@ -12,6 +12,7 @@ import { map } from "rxjs";
 
 import type { ContainerNode, ItemKind, ItemRow } from "../../../core/models";
 import { WorkspaceService } from "../workspace.service";
+import { containerNoun } from "../../../core/hierarchy-vocabulary";
 
 /** The kinds a container can hold, in render order. */
 const KINDS: readonly ItemKind[] = ["meeting", "note", "task", "dashboard"];
@@ -61,6 +62,19 @@ export class ContainerViewComponent {
   private readonly workspace = inject(WorkspaceService);
 
   private readonly _container = signal<ContainerNode | null>(null);
+
+  /**
+   * The word the user reads for this thing.
+   *
+   * These states used to say "container" — the CODE's word for "either a Workspace or a folder",
+   * which no other surface shows and which names nothing the user ever created. Falls back to
+   * "folder" only before the node has loaded, where the sentence has to say something and the
+   * narrower word is the safer guess.
+   */
+  protected readonly noun = computed(() => {
+    const c = this._container();
+    return c ? containerNoun(c) : "folder";
+  });
   private readonly _pages = signal<KindPage[]>([]);
   private readonly _loading = signal(false);
   private readonly _error = signal<string | null>(null);

--- a/src/app/features/workspace/workspace-create-sheet/workspace-create-sheet.component.html
+++ b/src/app/features/workspace/workspace-create-sheet/workspace-create-sheet.component.html
@@ -164,7 +164,7 @@
               <mur-icon [icon]="target.container.level === 'project' ? 'spaces' : 'folder'" />
               <span>
                 <strong>{{ target.label }}</strong>
-                <small>{{ target.container.level === "project" ? "Workspace" : "Folder" }}</small>
+                <small>{{ containerNounLeading(target.container) }}</small>
               </span>
               @if (selectedTargetId() === target.container.id) {
                 <span class="selected-mark" aria-hidden="true">✓</span>

--- a/src/app/features/workspace/workspace-create-sheet/workspace-create-sheet.component.ts
+++ b/src/app/features/workspace/workspace-create-sheet/workspace-create-sheet.component.ts
@@ -15,6 +15,7 @@ import {
 
 import { MurIconComponent } from "../../../design-system/icon/icon.component";
 import type { WorkspaceDestination } from "../workspace-destination";
+import { containerNounLeading } from "../../../core/hierarchy-vocabulary";
 
 export type WorkspaceCreateKind = "space" | "note" | "folder" | "dashboard";
 
@@ -46,6 +47,9 @@ export interface WorkspaceCreateRequest {
   styleUrl: "./workspace-create-sheet.component.scss",
 })
 export class WorkspaceCreateSheetComponent {
+  /** The ONE user-facing noun for this level — see `core/hierarchy-vocabulary.ts`. */
+  protected readonly containerNounLeading = containerNounLeading;
+
   private readonly injector = inject(Injector);
 
   readonly targets = input.required<readonly WorkspaceDestination[]>();

--- a/src/app/features/workspace/workspace-manage-sheet/workspace-manage-sheet.component.ts
+++ b/src/app/features/workspace/workspace-manage-sheet/workspace-manage-sheet.component.ts
@@ -11,6 +11,7 @@ import {
 } from "@angular/core";
 
 import { MurIconComponent } from "../../../design-system/icon/icon.component";
+import type { ContainerNoun } from "../../../core/hierarchy-vocabulary";
 
 export type WorkspaceManageMode = "rename" | "delete";
 
@@ -27,7 +28,15 @@ export class WorkspaceManageSheetComponent {
 
   readonly mode = input.required<WorkspaceManageMode>();
   readonly name = input.required<string>();
-  readonly noun = input.required<"space" | "folder">();
+  /**
+   * The DISPLAY word, from `core/hierarchy-vocabulary.ts` — not a kind or a level.
+   *
+   * This used to be typed `"space" | "folder"`, which is the code's vocabulary; the sheet then
+   * told the user it was deleting a "space" while the sheet that created the same thing called
+   * it a Workspace. `ContainerNoun` keeps the two vocabularies from drifting again: a domain
+   * identifier no longer typechecks where a sentence is being written.
+   */
+  readonly noun = input.required<ContainerNoun>();
   readonly busy = input(false);
   readonly error = input<string | null>(null);
   readonly renamed = output<string>();

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
@@ -58,6 +58,7 @@ import {
   WorkspaceManageSheetComponent,
   type WorkspaceManageMode,
 } from "../workspace-manage-sheet/workspace-manage-sheet.component";
+import { containerNoun } from "../../../core/hierarchy-vocabulary";
 
 /** A flattened tree line, so one `@for` renders the whole forest. */
 export interface TreeLine {
@@ -1190,11 +1191,8 @@ export class WorkspaceTreeComponent {
     }
   }
 
-  protected containerNoun(
-    container: Pick<ContainerNode, "level">,
-  ): "space" | "folder" {
-    return container.level === "project" ? "space" : "folder";
-  }
+  /** The ONE user-facing noun for this level — see `core/hierarchy-vocabulary.ts`. */
+  protected readonly containerNoun = containerNoun;
 
   protected canCreateNote(container: ContainerNode): boolean {
     return this.canCreateIn(container);


### PR DESCRIPTION
## The same object had three names in one session

The `level === "project"` test was written in four places and produced four words for two concepts:

| surface | what the user was told |
| --- | --- |
| create sheet | "Workspace" / "Folder" |
| share sheet | "Workspace" / "folder" |
| tree menus and toasts | **"space"** / "folder" |
| container view's empty + error states | **"container"** |

So a user renaming a thing was told they renamed a *space*; the sheet that created it called it a
*Workspace*; the view of it called it a *container*.

`core/hierarchy-vocabulary.ts` is now the one source. The choice is **which existing word wins**, not
a new one: the product already says "No Workspaces yet", "Created Workspace" and "Move to Workspace
or folder…", so `Workspace` (capitalised — a proper noun) and `folder` (lowercase) were already the
majority.

**The `ContainerNoun` type is what keeps this from drifting back.** A domain identifier — a `level`,
or a `kind` like `"space"` — no longer typechecks where a sentence is written. That is a guard a word
list cannot provide, and it is why `"space"` is deliberately **not** banned: it is ordinary English
used correctly elsewhere ("Free up space"), and banning it would train people to ignore the list.

The compiler found the last one for me: `workspace-manage-sheet`'s `noun` input was typed
`"space" | "folder"`, so the old vocabulary was baked into a component contract.

## The gate could not see any of this — and fixing that helps every term

`check-vocabulary.mjs` scanned string literals without stripping `${…}`, and template text without
stripping `{{ … }}`, `@if (…)` or element names. So `Created a folder in ${container.name}` counted
as a sentence containing "container" — when the user reads *"Created a folder in Projects"*.

Those false positives were **80 of the first 80 hits**. With them gone the real number is one, and it
is a legitimate use (an image's container *format*), now allowlisted with that reason. The baseline
shrinks **165 → 160** as a side effect: the same noise was inflating every other term too.

This is the gate's own stated failure mode — its comments record an earlier version that produced
"774 findings of which almost none were copy", and note that "a checker that noisy teaches people to
ignore it, which is worse than not having one".

## Scoped to the frontend, deliberately

The backend still says "container" in **69 `AppError` bodies that reach users as toasts** — *"unlock
this container before moving a dashboard into it"*, *"this container is locked — unlock it to see
what is inside"*. My first, frontend-only measurement missed those entirely.

Those files were being rewritten by #672 while this was in flight, and widening the baseline to admit
them would be exactly the rubber stamp this gate exists to prevent. So the term carries a **surface
scope** (a new one-line capability in the checker) and the backend is a recorded follow-up rather
than a hidden pass.

## Gates

`ng lint` clean · `ng build` clean · vocabulary gate **exit 0** (160 hits, baseline 160) · **190 e2e
passed**.
