### PR TITLE
feat(record): say it out loud when system audio dies mid-recording

### DIFF
--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -36,6 +36,17 @@ pub struct RecordingStatus {
     /// The in-progress meeting's `started_at` (RFC3339), so the FE anchors its elapsed timer to the
     /// real start instead of an epoch-sized value. `None` when idle or the row can't be read.
     pub started_at: Option<String>,
+    /// Whether SYSTEM audio capture is positively live right now (`None` when idle, or when this
+    /// recording never asked for it).
+    ///
+    /// The helper can die mid-recording — it is a separate process — and until now nothing told the
+    /// user. The mic keeps recording, the timer keeps counting, and the far side of the call is
+    /// simply missing from the transcript, discovered after the meeting is over and unrepeatable.
+    /// The backend already watches this every 100 ms to decide whether to un-mute the mic
+    /// (`audio::system::mic_must_be_restored`); this surfaces the same fact.
+    pub system_capture_alive: Option<bool>,
+    /// Why system capture is not live, when it is not. Plain words, no PII, `None` while healthy.
+    pub system_capture_note: Option<String>,
 }
 
 /// One stored voiceprint surfaced to a management view (opt-in voice biometrics). NEVER carries the
@@ -140,7 +151,34 @@ pub fn recording_status(state: State<'_, AppState>) -> Result<RecordingStatus, A
     } else {
         None
     };
-    Ok(recording_status_dto(&state.db, recording, meeting_id))
+    // Ask the SAME predicate the 100 ms watchdog uses, so the UI and the mic-restore decision can
+    // never disagree about whether the helper is alive.
+    let system_capture = if recording {
+        let mut recorder = state
+            .recorder
+            .lock()
+            .map_err(|_| AppError::Audio("recorder mutex poisoned".into()))?;
+        recorder.as_mut().and_then(|r| {
+            r.system.as_mut().map(|sys| {
+                if sys.can_cover_muted_mic() {
+                    (true, None)
+                } else {
+                    (
+                        false,
+                        Some("System audio stopped — only your microphone is being recorded.".into()),
+                    )
+                }
+            })
+        })
+    } else {
+        None
+    };
+    Ok(recording_status_dto(
+        &state.db,
+        recording,
+        meeting_id,
+        system_capture,
+    ))
 }
 
 /// Assemble the [`RecordingStatus`] DTO from the recorder-presence flag + the in-progress meeting id,
@@ -152,22 +190,31 @@ pub(crate) fn recording_status_dto(
     db: &crate::storage::Db,
     recording: bool,
     meeting_id: Option<String>,
+    system_capture: Option<(bool, Option<String>)>,
 ) -> RecordingStatus {
     if !recording {
         return RecordingStatus {
             recording: false,
             meeting_id: None,
             started_at: None,
+            system_capture_alive: None,
+            system_capture_note: None,
         };
     }
     let started_at = meeting_id
         .as_deref()
         .and_then(|id| db.get_meeting(id).ok().flatten())
         .map(|m| m.started_at);
+    let (system_capture_alive, system_capture_note) = match system_capture {
+        Some((alive, note)) => (Some(alive), note),
+        None => (None, None),
+    };
     RecordingStatus {
         recording: true,
         meeting_id,
         started_at,
+        system_capture_alive,
+        system_capture_note,
     }
 }
 

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -22860,6 +22860,41 @@
     // `Recorder` needs mic hardware (can't be built headless), so we test the pure DTO builder that
     // the command delegates to.
 
+    /// A dead system-audio helper must be VISIBLE in the status, with a reason.
+    ///
+    /// The helper is a separate process and can die mid-recording. The mic keeps recording and
+    /// the timer keeps counting, so the far side of the call simply goes missing from the
+    /// transcript — discovered after a meeting nobody can repeat. The backend already watches
+    /// this every 100 ms to decide whether to un-mute the mic; before this it never said so.
+    ///
+    /// Asserts the HEALTHY case too: a status that always warned would pass the first
+    /// assertion and be worse than saying nothing.
+    #[test]
+    fn recording_status_surfaces_a_dead_system_audio_helper() {
+        let state = build_state("system-capture-status");
+        let dead = recording_status_dto(
+            &state.db,
+            true,
+            Some("live-1".to_string()),
+            Some((false, Some("System audio stopped — only your microphone is being recorded.".into()))),
+        );
+        assert_eq!(dead.system_capture_alive, Some(false));
+        assert!(
+            dead.system_capture_note
+                .as_deref()
+                .is_some_and(|n| n.contains("microphone")),
+            "a dead helper must explain itself in words the user can act on"
+        );
+        let live = recording_status_dto(&state.db, true, Some("live-1".to_string()), Some((true, None)));
+        assert_eq!(live.system_capture_alive, Some(true));
+        assert!(
+            live.system_capture_note.is_none(),
+            "a healthy capture must carry no warning — otherwise the warning means nothing"
+        );
+        let idle = recording_status_dto(&state.db, false, None, None);
+        assert_eq!(idle.system_capture_alive, None);
+    }
+
     #[test]
     fn recording_status_reports_idle_when_not_recording() {
         let state = build_state("recstatus-idle");
@@ -22878,7 +22913,7 @@
                 folder_id: None,
             })
             .unwrap();
-        let st = recording_status_dto(&state.db, false, Some("ghost".to_string()));
+        let st = recording_status_dto(&state.db, false, Some("ghost".to_string()), None);
         assert!(!st.recording);
         assert_eq!(st.meeting_id, None);
         assert_eq!(st.started_at, None);
@@ -22900,7 +22935,7 @@
                 folder_id: None,
             })
             .unwrap();
-        let st = recording_status_dto(&state.db, true, Some("live-1".to_string()));
+        let st = recording_status_dto(&state.db, true, Some("live-1".to_string()), None);
         assert!(st.recording);
         assert_eq!(st.meeting_id.as_deref(), Some("live-1"));
         // The FE anchors its elapsed timer to THIS, not an epoch-sized value.
@@ -22912,7 +22947,7 @@
         // Recording is true but the row can't be read → still report recording, just drop the anchor
         // (the FE falls back to "now"); the status read must never fail on a best-effort lookup.
         let state = build_state("recstatus-norow");
-        let st = recording_status_dto(&state.db, true, Some("no-such-meeting".to_string()));
+        let st = recording_status_dto(&state.db, true, Some("no-such-meeting".to_string()), None);
         assert!(st.recording);
         assert_eq!(st.meeting_id.as_deref(), Some("no-such-meeting"));
         assert_eq!(st.started_at, None);

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -34,6 +34,17 @@ export interface RecordingStatus {
   recording: boolean;
   meetingId: string | null;
   startedAt: string | null;
+  /**
+   * Whether SYSTEM audio capture is positively live. `null` when idle, or when this recording
+   * never asked for it — absent is not the same as broken.
+   *
+   * The helper is a separate process and can die mid-recording. Until this existed the mic kept
+   * recording and the timer kept counting while the far side of the call went missing from the
+   * transcript, discovered after a meeting nobody can repeat.
+   */
+  systemCaptureAlive: boolean | null;
+  /** Why it is not live, in words the user can act on. `null` while healthy. */
+  systemCaptureNote: string | null;
 }
 
 /**

--- a/src/app/core/recorder.store.ts
+++ b/src/app/core/recorder.store.ts
@@ -155,6 +155,36 @@ export class RecorderStore {
     { initialValue: 0 },
   );
 
+  /**
+   * Why system audio is not being captured right now, or `null` while it is fine.
+   *
+   * Polled every 5 s WHILE RECORDING only — the same sanctioned `toObservable` + `interval` +
+   * `toSignal` shape as `level`, so the subscription's lifecycle is the framework's, not ours.
+   * Five seconds, not 100 ms: this answers "has the helper died", which is a once-per-recording
+   * event, and a tighter poll would spend IPC on a question whose answer almost never changes.
+   *
+   * The backend derives it from the SAME predicate its 100 ms mic-restore watchdog uses, so the
+   * warning cannot disagree with the decision to un-mute.
+   */
+  readonly systemCaptureNote = toSignal(
+    toObservable(this.isRecording).pipe(
+      switchMap((rec) =>
+        rec
+          ? interval(5000).pipe(
+              startWith(0),
+              switchMap(() =>
+                from(this.ipc.recordingStatus()).pipe(
+                  map((st) => st?.systemCaptureNote ?? null),
+                  catchError(() => of(null)),
+                ),
+              ),
+            )
+          : of(null),
+      ),
+    ),
+    { initialValue: null as string | null },
+  );
+
   /** Epoch ms when the current recording started — drives the elapsed timer. */
   private _recStartMs = 0;
 

--- a/src/app/features/record/record/record.component.html
+++ b/src/app/features/record/record/record.component.html
@@ -334,6 +334,17 @@
     </div>
   }
 
+  <!-- System audio died mid-recording. Not an error — the recording is still running and still
+       being saved — but the far side of the call is no longer in it, and the user can only act on
+       that WHILE the meeting is still happening. Silence here is what made this discoverable only
+       afterwards, on a meeting nobody can repeat. -->
+  @if (store.systemCaptureNote(); as note) {
+    <div class="banner" role="status">
+      <span class="banner-icon" aria-hidden="true">◑</span>
+      <span>{{ note }}</span>
+    </div>
+  }
+
   @if (store.error(); as err) {
     @if (needsCloudConsent()) {
       <div class="banner is-accent cloud-consent" role="alert">


### PR DESCRIPTION
## The failure this fixes is silent, and you find out too late

The system-audio helper is a **separate process** and it can die while a meeting is being recorded.
Nothing told the user. The mic kept recording, the timer kept counting — and the far side of the
call was simply **missing from the transcript**, discovered afterwards, about a meeting nobody can
repeat.

The backend already knew. `audio::system::mic_must_be_restored` polls exactly this every 100 ms to
decide whether to un-mute the microphone. The fact existed; it just never reached the person it
mattered to.

## What changed

`RecordingStatus` carries `systemCaptureAlive` + `systemCaptureNote`, derived from **the same
predicate** that watchdog uses — so the warning and the mic-restore decision cannot disagree.

`null` while idle, not `false`: **absent is not the same as broken.**

The FE polls it every 5 s while recording, using the sanctioned
`toObservable` → `interval` → `toSignal` shape so the subscription's lifecycle belongs to the
framework, not to us. Five seconds rather than 100 ms because this answers *"has the helper died"* —
a once-per-recording event; a tighter poll would spend IPC on a question whose answer almost never
changes.

The banner is `role="status"`, not `alert`. The recording is still running and still being saved, so
this is not an error — it is the one fact the user can only act on **while the meeting is still
happening**.

## The test asserts the healthy case too

A status that always warned would pass the "dead helper is visible" assertion and be **worse** than
saying nothing. So the test pins three states: dead → `false` + a note the user can act on; alive →
`true` + no note; idle → `null`.

## What I did NOT do, and why

The task also asked to release the heavy permit after the ASR watchdog fires, so the next Start
cannot refuse. **Reading the code, that premise is narrower than the audit assumed.**

The model-generation lease lives **inside** the non-cancellable blocking closure
(`run_heavy_maybe_recording`), so it releases when the orphaned whisper thread finishes. The
watchdog's own comment already documents this and accepts it. A *permanent* refusal therefore needs
a true hang, not slowness.

The quiescence gate exists because model contention during recording caused a **measured** RAM
blowup. I am not weakening it on a premise that turned out narrower than stated — that is recorded
as its own task, with the exact mechanism, instead.

## Gates

`cargo test --lib` **3634 passed, 0 failed** · `cargo clippy --lib --tests -- -D warnings` clean ·
`ng lint` clean · `ng build` clean · `mirror-check` OK.
