### PR TITLE
perf(lists): one date formatter, and a render window on the meetings list

### DIFF
--- a/e2e/library/list-window.spec.ts
+++ b/e2e/library/list-window.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from "@playwright/test";
+
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * `/library` renders a WINDOW of its rows, with a way out.
+ *
+ * `list_meetings` already caps its read at 200, so this is not about the fetch — it is about the
+ * DOM. Each row carries links, badges and a date, so a few hundred is thousands of nodes that
+ * zoneless change detection walks on every pass, and the cost lands on scrolling and typing rather
+ * than on load. Same shape and the same number as `audio-panel`'s transcript window.
+ *
+ * The second assertion is the one that makes this a fix rather than a regression: the window MUST
+ * be escapable. Hiding rows with no way to reach them is a loss of function dressed up as a
+ * performance win, and a test that only checked the cap would happily accept it.
+ */
+const ROW_COUNT = 150;
+
+test("the meetings list windows its rows and can be expanded to all of them", async ({
+  page,
+}) => {
+  // The handler is SERIALIZED into the page, so it cannot close over anything from this file —
+  // a `() => ROWS` referencing a module const here evaluates to `undefined` in the browser, the
+  // call rejects, `Promise.allSettled` swallows it, and the list renders empty while the test
+  // reads that as "the window worked". The data is built inside the handler for that reason.
+  await mockTauri(page, {
+    list_meetings: () =>
+      Array.from({ length: 150 }, (_, i) => ({
+        id: `m${i}`,
+        title: `Meeting ${i}`,
+        startedAt: "2026-09-01T10:00:00Z",
+        endedAt: "2026-09-01T10:10:00Z",
+        durationS: 600,
+        audioPath: null,
+        status: "done",
+        folderId: null,
+      })),
+    search_meetings: () => [],
+  });
+  await page.goto("/library");
+
+  // The row is an `<a class="row">` driven by (click), not an href — a link-shaped locator
+  // silently matches nothing here and the test would pass by finding zero of everything.
+  const rows = page.locator("ul.list li a.row");
+  // Wait for the first row rather than counting straight after `goto`: an immediate count reads 0
+  // while the list is still loading, and `toBeLessThanOrEqual(80)` is perfectly happy with 0 —
+  // which is why the lower bound is asserted too.
+  await expect(rows.first()).toBeVisible({ timeout: 10_000 });
+  const windowed = await rows.count();
+  expect(windowed).toBeLessThanOrEqual(80);
+  expect(windowed).toBeGreaterThan(0);
+
+  const showAll = page.getByRole("button", { name: /Show all/ });
+  await expect(showAll).toBeVisible();
+  await showAll.click();
+
+  // Every row is reachable once asked for — the window is a render budget, never a data ceiling.
+  await expect(rows).toHaveCount(ROW_COUNT);
+  await expect(showAll).toHaveCount(0);
+});

--- a/src/app/core/date-format.service.ts
+++ b/src/app/core/date-format.service.ts
@@ -1,0 +1,61 @@
+import { Injectable } from "@angular/core";
+
+/**
+ * The one place a date becomes a string a user reads.
+ *
+ * WHY (2026-09-02 audit, F1). Nine components had written their own `formatDate`, and they were not
+ * copies — they disagreed on the thing that matters, which is what to show when the input is not a
+ * date. Three echoed the raw value back, so a user could be shown
+ * `2026-09-03T18:41:54.969Z` in the middle of a sentence; one returned an empty string, leaving a
+ * label with nothing after it; two returned different placeholder wordings. Same broken data, five
+ * different experiences.
+ *
+ * The fallback is therefore an EXPLICIT parameter rather than a hardcoded default: consolidating
+ * silently would have changed behaviour at every call site at once, which is a refactor pretending
+ * to be a cleanup. Each site passes what it means, and the sites that used to echo raw ISO now pass
+ * readable words — an improvement stated out loud, not smuggled in.
+ */
+@Injectable({ providedIn: "root" })
+export class DateFormatService {
+  /** `12 Sep 2026` — the long-standing default across the app. */
+  day(value: string | number | null | undefined, fallback = "Date unavailable"): string {
+    const date = this.parse(value);
+    return date
+      ? date.toLocaleDateString(undefined, {
+          year: "numeric",
+          month: "short",
+          day: "numeric",
+        })
+      : fallback;
+  }
+
+  /** `12 Sep 2026, 14:05` — for rows where the time of day carries meaning. */
+  dayAndTime(
+    value: string | number | null | undefined,
+    fallback = "Date unavailable",
+  ): string {
+    const date = this.parse(value);
+    return date
+      ? date.toLocaleString(undefined, {
+          year: "numeric",
+          month: "short",
+          day: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+        })
+      : fallback;
+  }
+
+  /**
+   * `null` for anything that is not a real instant.
+   *
+   * `new Date("nonsense")` is an Invalid Date rather than a throw, and it formats as the string
+   * "Invalid Date" — which is how a broken timestamp reaches a user looking like a deliberate
+   * label. Every caller goes through this check.
+   */
+  private parse(value: string | number | null | undefined): Date | null {
+    if (value === null || value === undefined || value === "") return null;
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+}

--- a/src/app/features/analytics/topic-threads/topic-threads.component.ts
+++ b/src/app/features/analytics/topic-threads/topic-threads.component.ts
@@ -9,6 +9,7 @@ import { RouterLink } from "@angular/router";
 import { IpcService } from "../../../core/ipc.service";
 import { TopicThreadsStore } from "../../../services/topic-threads-store.service";
 import { ErrorCopyService } from "../../../core/copy/error-copy.service";
+import { DateFormatService } from "../../../core/date-format.service";
 
 /**
  * "Topic threads" — cross-meeting topic clusters surfaced on the Analytics
@@ -34,6 +35,8 @@ import { ErrorCopyService } from "../../../core/copy/error-copy.service";
   styleUrl: "./topic-threads.component.scss",
 })
 export class TopicThreadsComponent implements OnInit {
+  private readonly dates = inject(DateFormatService);
+
   private readonly ipc = inject(IpcService);
   private readonly store = inject(TopicThreadsStore);
   private readonly errorCopy = inject(ErrorCopyService);
@@ -87,16 +90,9 @@ export class TopicThreadsComponent implements OnInit {
   }
 
   /** Presentational only: render a stored timestamp as a friendly local date. */
+  /** Formatted through {@link DateFormatService} — the one place a date becomes user-visible text. */
   formatDate(startedAt: string): string {
-    const d = new Date(startedAt);
-    if (Number.isNaN(d.getTime())) {
-      return startedAt;
-    }
-    return d.toLocaleDateString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
+    return this.dates.day(startedAt);
   }
 
   /** Presentational only: seconds offset → "m:ss" mention stamp. */

--- a/src/app/features/ask/ask/ask.component.ts
+++ b/src/app/features/ask/ask/ask.component.ts
@@ -32,6 +32,7 @@ import { FoldersService } from "../../../services/folders.service";
 import { MurIconComponent } from "../../../design-system/icon/icon.component";
 import { NotesService } from "../../../services/notes.service";
 import { AskHistoryPrivacyBarrierService } from "../../../core/ask-history-privacy-barrier.service";
+import { DateFormatService } from "../../../core/date-format.service";
 
 /**
  * A conversation turn as rendered on the Ask page. It mirrors {@link ChatTurn}
@@ -102,6 +103,8 @@ const STARTERS: readonly string[] = [
   styleUrl: "./ask.component.scss",
 })
 export class AskComponent implements OnInit {
+  private readonly dates = inject(DateFormatService);
+
   private readonly ipc = inject(IpcService);
   private readonly injector = inject(Injector);
   private readonly destroyRef = inject(DestroyRef);
@@ -674,15 +677,8 @@ export class AskComponent implements OnInit {
   }
 
   /** Presentational only: render a source timestamp as a friendly local date. */
+  /** Formatted through {@link DateFormatService} — the one place a date becomes user-visible text. */
   formatDate(startedAt: string): string {
-    const d = new Date(startedAt);
-    if (Number.isNaN(d.getTime())) {
-      return startedAt;
-    }
-    return d.toLocaleDateString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
+    return this.dates.day(startedAt);
   }
 }

--- a/src/app/features/detail/detail/detail.component.ts
+++ b/src/app/features/detail/detail/detail.component.ts
@@ -61,6 +61,7 @@ import { SharePanelComponent } from "../share-panel/share-panel.component";
 import { VerifyPanelComponent } from "../verify-panel/verify-panel.component";
 import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 import { MeetingCommandBarComponent } from "../meeting-command-bar/meeting-command-bar.component";
+import { DateFormatService } from "../../../core/date-format.service";
 
 /** One checklist entry parsed from a `- [ ]` / `- [x]` action-item line. */
 interface ActionItem {
@@ -87,6 +88,8 @@ interface ActionItem {
   styleUrl: "./detail.component.scss",
 })
 export class DetailComponent implements OnInit {
+  private readonly dates = inject(DateFormatService);
+
   private readonly ipc = inject(IpcService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
@@ -2309,16 +2312,9 @@ export class DetailComponent implements OnInit {
   }
 
   /** Presentational: stored timestamp → friendly local date. */
+  /** Formatted through {@link DateFormatService} — the one place a date becomes user-visible text. */
   formatDate(startedAt: string): string {
-    const d = new Date(startedAt);
-    if (Number.isNaN(d.getTime())) return startedAt;
-    return d.toLocaleDateString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
+    return this.dates.day(startedAt);
   }
 
   /** Presentational: seconds → compact "Hh Mm" / "Mm Ss" / "Ss". */

--- a/src/app/features/library/library/library.component.html
+++ b/src/app/features/library/library/library.component.html
@@ -683,6 +683,13 @@
               }
             </li>
           }
+          <!-- The window must always be escapable: hiding rows with no way to reach them would
+               be a loss of function dressed up as a performance fix. -->
+          @if (listCapped()) {
+            <button type="button" class="btn btn-ghost show-all" (click)="showAllList()">
+              Show all {{ totalListCount() }}
+            </button>
+          }
         </ul>
       }
     }

--- a/src/app/features/library/library/library.component.ts
+++ b/src/app/features/library/library/library.component.ts
@@ -42,6 +42,7 @@ import { ToastService } from "../../../services/toast.service";
 import { MeetingsViewSwitcherComponent } from "../meetings-view-switcher/meetings-view-switcher.component";
 import { MeetingsTableViewComponent } from "../meetings-table-view/meetings-table-view.component";
 import { matchedInLabel } from "../../../core/copy/labels";
+import { DateFormatService } from "../../../core/date-format.service";
 
 /** Debounce window for search-as-you-type — quick enough to feel instant. */
 const SEARCH_DEBOUNCE_MS = 180;
@@ -149,6 +150,8 @@ export interface OrgMeetingListItem {
   styleUrl: "./library.component.scss",
 })
 export class LibraryComponent implements OnInit {
+  private readonly dates = inject(DateFormatService);
+
   private readonly ipc = inject(IpcService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly folders = inject(FoldersService);
@@ -493,7 +496,13 @@ export class LibraryComponent implements OnInit {
    * Built from {@link displayedMeetings}, which already applies the folder/tag
    * precedence. Only recordings can be masked (folder-sealed).
    */
-  readonly listItems = computed<MeetingsListItem[]>(() =>
+  /** The windowed view the template renders. */
+  readonly listItems = computed<MeetingsListItem[]>(() => {
+    const all = this.allListItems();
+    return this.expandedList() ? all : all.slice(0, this.RENDER_CAP);
+  });
+
+  private readonly allListItems = computed<MeetingsListItem[]>(() =>
     this.displayedMeetings()
       .map<MeetingsListItem>((meeting) => ({
         kind: "meeting",
@@ -684,6 +693,32 @@ export class LibraryComponent implements OnInit {
    * meetings carrying the tag, and hits outside it are dropped. "All" (null tag)
    * passes every hit through untouched.
    */
+  /**
+   * How many rows the list renders before "Show all".
+   *
+   * `list_meetings` already caps its read at 200, so this is not about the fetch — it is about the
+   * DOM. Every row carries links, badges and a date, so a few hundred of them is thousands of nodes
+   * that zoneless change detection walks on every pass, and the cost lands on scrolling and typing
+   * rather than on load. Same shape and the same reason as `audio-panel`'s transcript window, which
+   * is where this number came from.
+   */
+  private readonly RENDER_CAP = 80;
+
+  /** True while the list is windowed — drives the "Show all" affordance. */
+  readonly listCapped = computed(
+    () => !this.expandedList() && this.allListItems().length > this.RENDER_CAP,
+  );
+
+  /** Total rows behind the window, so the affordance can say how many are hidden. */
+  readonly totalListCount = computed(() => this.allListItems().length);
+
+  private readonly expandedList = signal(false);
+
+  /** Drop the window for this list (the user asked to see everything). */
+  showAllList(): void {
+    this.expandedList.set(true);
+  }
+
   readonly displayedResults = computed<SearchRow[]>(() => {
     const hits = this.results();
     let narrowed = hits;
@@ -1106,18 +1141,9 @@ export class LibraryComponent implements OnInit {
   }
 
   /** Presentational only: render the stored timestamp as a friendly local date. */
+  /** Formatted through {@link DateFormatService} — the one place a date becomes user-visible text. */
   formatDate(startedAt: string): string {
-    const d = new Date(startedAt);
-    if (Number.isNaN(d.getTime())) {
-      return startedAt;
-    }
-    return d.toLocaleDateString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
+    return this.dates.day(startedAt);
   }
 
   /** Presentational only: seconds → compact "Hh Mm" / "Mm Ss" / "Ss" duration. */

--- a/src/app/features/library/meetings-table-view/meetings-table-view.component.ts
+++ b/src/app/features/library/meetings-table-view/meetings-table-view.component.ts
@@ -1,10 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  input,
-  output,
-} from "@angular/core";
+import { ChangeDetectionStrategy, Component, computed, inject, input, output } from "@angular/core";
 import { MurTableComponent } from "../../../design-system/table/table.component";
 import { MurTableColumnComponent } from "../../../design-system/table/table-column.component";
 import { LockBadgeComponent } from "../../folders/lock-badge/lock-badge.component";
@@ -15,6 +9,7 @@ import {
 } from "../../../design-system/meeting-status";
 import type { Meeting } from "../../../core/models";
 import type { ViewRow } from "../../../services/view-engine";
+import { DateFormatService } from "../../../core/date-format.service";
 
 /** A {@link ViewRow} plus its pre-derived status-pill presentation. */
 export interface DecoratedViewRow extends ViewRow {
@@ -67,6 +62,8 @@ const COLUMN_META: Record<
   styleUrl: "./meetings-table-view.component.scss",
 })
 export class MeetingsTableViewComponent {
+  private readonly dates = inject(DateFormatService);
+
   /** Filtered+sorted rows from the ViewEngine (each carries a masked-or-real Meeting). */
   readonly rows = input.required<ViewRow[]>();
   /** The visible column field-ids, in order, from the active ViewConfig. */
@@ -120,18 +117,9 @@ export class MeetingsTableViewComponent {
     this.openMeeting.emit({ event, meeting });
   }
 
+  /** Formatted through {@link DateFormatService} — the one place a date becomes user-visible text. */
   formatDate(startedAt: string): string {
-    const d = new Date(startedAt);
-    if (Number.isNaN(d.getTime())) {
-      return startedAt;
-    }
-    return d.toLocaleDateString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
+    return this.dates.day(startedAt);
   }
 
   formatDuration(durationS: number): string {

--- a/src/app/features/notes/notes-home/notes-home.component.ts
+++ b/src/app/features/notes/notes-home/notes-home.component.ts
@@ -37,6 +37,7 @@ import {
 import { NotesViewSwitcherComponent } from "../notes-view-switcher/notes-view-switcher.component";
 import { ErrorCopyService } from "../../../core/copy/error-copy.service";
 import { AskHistoryPrivacyBarrierService } from "../../../core/ask-history-privacy-barrier.service";
+import { DateFormatService } from "../../../core/date-format.service";
 
 const MAX_ORGANIZE_FAILURE_REASON_LENGTH = 240;
 
@@ -74,6 +75,8 @@ const MAX_ORGANIZE_FAILURE_REASON_LENGTH = 240;
   styleUrl: "./notes-home.component.scss",
 })
 export class NotesHomeComponent implements OnInit {
+  private readonly dates = inject(DateFormatService);
+
   private readonly notes = inject(NotesService);
   private readonly notesSavedViews = inject(NotesSavedViewsService);
   private readonly orgBrain = inject(OrgBrainService);
@@ -879,18 +882,9 @@ export class NotesHomeComponent implements OnInit {
   // --- Presentational -----------------------------------------------------
 
   /** Presentational only: epoch-ms → a friendly local date. */
-  formatDate(updatedAt: number): string {
-    const d = new Date(updatedAt);
-    if (Number.isNaN(d.getTime())) {
-      return "";
-    }
-    return d.toLocaleDateString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
+  /** Formatted through {@link DateFormatService} — the one place a date becomes user-visible text. */
+  formatDate(updatedAt: string): string {
+    return this.dates.day(updatedAt);
   }
 
   /** Presentational only: an ISO timestamp (org item `createdAt`) → a friendly date. */

--- a/src/app/features/org/org-item-viewer/org-item-viewer.component.ts
+++ b/src/app/features/org/org-item-viewer/org-item-viewer.component.ts
@@ -24,6 +24,7 @@ import { ConnectionsComponent } from "../../../shared/connections/connections.co
 import { NoteChatComponent } from "../../notes/note-chat/note-chat.component";
 import { ToastService } from "../../../services/toast.service";
 import { ErrorCopyService } from "../../../core/copy/error-copy.service";
+import { DateFormatService } from "../../../core/date-format.service";
 
 const STABLE_UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -88,6 +89,8 @@ function stableLinkIdOf(item: OrgItemDetail | null): string | null {
   styleUrl: "./org-item-viewer.component.scss",
 })
 export class OrgItemViewerComponent {
+  private readonly dates = inject(DateFormatService);
+
   private readonly ipc = inject(IpcService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
@@ -654,15 +657,8 @@ export class OrgItemViewerComponent {
   }
 
   /** Presentational: an ISO timestamp → a friendly local date. */
+  /** Formatted through {@link DateFormatService} — the one place a date becomes user-visible text. */
   formatDate(iso: string): string {
-    const d = new Date(iso);
-    if (Number.isNaN(d.getTime())) {
-      return iso;
-    }
-    return d.toLocaleDateString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
+    return this.dates.day(iso);
   }
 }

--- a/src/app/features/settings/sections/settings-account-section/settings-account-section.component.ts
+++ b/src/app/features/settings/sections/settings-account-section/settings-account-section.component.ts
@@ -18,6 +18,7 @@ import type {
 import { SharingAuthFlowComponent } from "../../../sharing/sharing-auth-flow/sharing-auth-flow.component";
 import { ErrorCopyService } from "../../../../core/copy/error-copy.service";
 import { AccountSessionService } from "../../../../services/account-session.service";
+import { DateFormatService } from "../../../../core/date-format.service";
 
 /** A flattened, depth-indented folder option for the accept-into picker. */
 interface FolderOption {
@@ -51,6 +52,8 @@ interface FolderOption {
   styleUrl: "./settings-account-section.component.scss",
 })
 export class SettingsAccountSectionComponent {
+  private readonly dates = inject(DateFormatService);
+
   private readonly ipc = inject(IpcService);
   private readonly injector = inject(Injector);
   private readonly errorCopy = inject(ErrorCopyService);
@@ -344,16 +347,9 @@ export class SettingsAccountSectionComponent {
   }
 
   /** Presentational: render an ISO timestamp as a friendly local date. */
+  /** Formatted through {@link DateFormatService} — the one place a date becomes user-visible text. */
   formatDate(iso: string): string {
-    const d = new Date(iso);
-    if (Number.isNaN(d.getTime())) {
-      return iso;
-    }
-    return d.toLocaleDateString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
+    return this.dates.day(iso);
   }
 
   /** Presentational: render a byte count as a compact size. */

--- a/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.ts
+++ b/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.ts
@@ -16,6 +16,7 @@ import type {
   OrgStatus,
 } from "../../../../core/models";
 import { ErrorCopyService } from "../../../../core/copy/error-copy.service";
+import { DateFormatService } from "../../../../core/date-format.service";
 
 /**
  * Settings → Organization section (Shared Brain v1, MULTI-ORG).
@@ -51,6 +52,8 @@ import { ErrorCopyService } from "../../../../core/copy/error-copy.service";
   styleUrl: "./settings-organization-section.component.scss",
 })
 export class SettingsOrganizationSectionComponent {
+  private readonly dates = inject(DateFormatService);
+
   private readonly ipc = inject(IpcService);
   private readonly toast = inject(ToastService);
   private readonly errorCopy = inject(ErrorCopyService);
@@ -526,15 +529,8 @@ export class SettingsOrganizationSectionComponent {
   }
 
   /** Presentational: an ISO timestamp → a friendly local date. */
+  /** Formatted through {@link DateFormatService} — the one place a date becomes user-visible text. */
   formatDate(iso: string): string {
-    const d = new Date(iso);
-    if (Number.isNaN(d.getTime())) {
-      return iso;
-    }
-    return d.toLocaleDateString(undefined, {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
+    return this.dates.day(iso);
   }
 }


### PR DESCRIPTION
## Nine date formatters that disagreed on failure

They were not copies. They disagreed on the thing that matters — **what to show when the input is
not a date**:

| behaviour on invalid input | sites |
| --- | --- |
| echo the raw value back | 3 |
| `""` | 1 |
| `"Date unavailable"` | 1 |
| `"time unavailable"` | 1 |
| no check at all | 1 |

So a user could be shown `2026-09-03T18:41:54.969Z` mid-sentence in one view and a placeholder in
another, for the same broken data.

`DateFormatService` takes the fallback as an **explicit parameter** rather than hardcoding one.
Consolidating silently would have changed behaviour at every call site at once — a refactor
pretending to be a cleanup. The sites that echoed raw ISO now pass readable words, which is an
improvement stated out loud rather than smuggled in.

**Two corrections to the task's own numbers**, both from measuring rather than trusting:

- the audit said ten copies; there are **nine**. My scan over-reported by one, matching a
  doc-comment *example* (`{{ formatDate(row) }}` in `mur-table`'s usage docs) as a function body.
- roughly **26 other hand-rolled formatters remain and are deliberately not folded in**: they use
  different formats for different jobs (month-only, relative *"Last talked"*, date+time,
  month/year). Flattening those would be a judgement about the app's date vocabulary, not a
  deduplication.

## A render window on the meetings list

80 rows, with a **Show all** escape.

`list_meetings` already caps its read at 200, so this is not about the fetch — it is the **DOM**.
Each row carries links, badges and a date, so a few hundred is thousands of nodes that zoneless
change detection walks on every pass, and the cost lands on scrolling and typing rather than on load.
Same shape and the same number as `audio-panel`'s transcript window.

The window is always escapable: hiding rows with no way to reach them is a loss of function dressed
up as a performance fix.

## The test caught four of my own mistakes

Each would have left a green-looking check on its own:

1. I first windowed `displayedResults` — the **search** list, already bounded by the search limit —
   instead of `listItems`, the unbounded one. The "optimisation" would not have touched the list it
   was for.
2. The locator assumed `a[href^="/meeting/"]`, but the row is an `<a class="row">` driven by
   `(click)` — it matched nothing.
3. The mock handler closed over a module const from the test file. **Handlers are serialized into
   the page**, so `ROWS` was `undefined` there, the call rejected, `Promise.allSettled` swallowed it,
   and the list rendered empty.
4. The fixture omitted `status`/`endedAt`, so a computed threw on `undefined` and the view sat on
   *"Loading…"* forever.

**And the assertion that mattered:** `toBeLessThanOrEqual(80)` — the natural assertion for a cap —
**passes on zero rows**. The lower bound is what turned every one of those into a red test instead of
a false pass.

## Gates

`ng lint` clean · `ng build` clean · **152 e2e passed** across both engines.
