### PR TITLE
fix(org): make a re-entrant org-mutex acquisition panic in debug instead of hanging forever

### DIFF
--- a/src-tauri/src/commands/documents.rs
+++ b/src-tauri/src/commands/documents.rs
@@ -494,7 +494,7 @@ async fn delete_document_inner_notifying(
             "task sources must be deleted through the task lifecycle".into(),
         ));
     }
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     state.db.begin_org_source_closure("document", id)?;
     // REVOKE-BEFORE-DELETE (Bug A root cause): tear down every LIVE org share of this exact source
     // BEFORE the local row disappears, so the background org-sync tick can never re-pull a still-live

--- a/src-tauri/src/commands/folders.rs
+++ b/src-tauri/src/commands/folders.rs
@@ -677,7 +677,7 @@ pub async fn delete_folder(
     state: State<'_, AppState>,
     folder_id: String,
 ) -> Result<(), AppError> {
-    let _share_mutation = state.org_share_mutation_lock.lock().await;
+    let _share_mutation = state.lock_org_mutation().await;
     delete_folder_inner(state.inner(), folder_id)?;
     emit_ask_history_invalidated_fail_closed(&app);
     Ok(())

--- a/src-tauri/src/commands/lock.rs
+++ b/src-tauri/src/commands/lock.rs
@@ -163,7 +163,7 @@ pub async fn lock_folder(
             "the task folder cannot be locked".into(),
         ));
     }
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     // PRE-FLIGHT the whole subtree before anything seals. A container can hold containers now, so
     // locking one seals everything inside it (see `lock_container_subtree`) — and this refusal is
     // a property the caller can fix and would want to fix before any container changed state.
@@ -227,7 +227,7 @@ pub async fn lock_folder_allow_remote_access(
             "the task folder cannot be locked".into(),
         ));
     }
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     // The WHOLE subtree, because this command now seals the whole subtree. A descendant already
     // mid-revocation is the same race the target's check exists to refuse, and the cascade would
     // otherwise walk straight into it. This command deliberately opens NO closure of its own — it
@@ -986,7 +986,7 @@ pub async fn unlock_folder(
     // The lock-state race this does NOT need to cover is covered elsewhere: the restore below takes
     // `lifecycle_guard` for its whole synchronous body, which is what serializes against a
     // concurrent `lock_folder` / `relock_all_inner`.
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
 
     // RE-VALIDATE: everything above — `folder`, the `folder.locked` refusal,
     // `preflight_unlock_subtree`, `folder_wrapped_key` — was read BEFORE this lock was held, with an
@@ -1576,7 +1576,7 @@ pub(crate) fn relock_all_inner_with_visibility_notice(
 /// `.md` to the vault. The folder returns to the default OPEN state.
 #[tauri::command]
 pub async fn remove_lock(state: State<'_, AppState>, folder_id: String) -> Result<(), AppError> {
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     remove_lock_inner(state.inner(), folder_id)
 }
 
@@ -1840,7 +1840,7 @@ pub async fn discard_unrecoverable_folder_lock(
     state: State<'_, AppState>,
     folder_id: String,
 ) -> Result<FolderNode, AppError> {
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     let node =
         discard_unrecoverable_folder_lock_with_enumeration(state.inner(), folder_id, None, || {
             emit_ask_history_invalidated_fail_closed(&app)
@@ -2034,7 +2034,7 @@ pub async fn discard_unrecoverable_meeting_lock(
     state: State<'_, AppState>,
     meeting_id: String,
 ) -> Result<Option<FolderNode>, AppError> {
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     let Some(folder_id) = state.db.folder_for_meeting(&meeting_id)? else {
         return Ok(None);
     };

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1391,7 +1391,7 @@ pub async fn start_recording(
     // Same lock order as the lock/share commands. The first check above makes invalid starts
     // side-effect-free; this authoritative check closes reparent/lock/closure races after the long
     // model-quiescence awaits and stays held through the canonical meeting insert.
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     let _recording_lifecycle = state
         .lifecycle
         .lock()
@@ -3731,7 +3731,7 @@ async fn convert_meeting_to_note_inner_with(
     // Canonical order shared by every note move/share mutation: org mutation first, then the short
     // non-reentrant lock lifecycle interval inside persistence. Provider work has already finished,
     // so neither mutex is held across inference/network awaits.
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     persist_converted_companion_under_snapshot(
         state,
         &meeting_id,
@@ -4055,7 +4055,7 @@ async fn delete_companion_note_if_empty_inner_notifying(
     if !companion_body_is_empty(&row.text) {
         return Ok(false);
     }
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     // The first snapshot was taken before waiting for the async mutation authority. Re-establish
     // emptiness under lifecycle immediately before installing the durable close barrier: an editor
     // that won the wait must keep both its content and its shares.
@@ -4557,7 +4557,7 @@ async fn delete_meeting_inner_notifying(
             ));
         }
     }
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     state.db.begin_org_source_closure("meeting", meeting_id)?;
     // REVOKE-BEFORE-DELETE (Bug A root cause): tear down every LIVE org share of this exact meeting
     // BEFORE the local rows disappear, so the background org-sync tick can never re-pull a still-live
@@ -9959,7 +9959,7 @@ async fn move_note_under_org_share_mutation_lock<T>(
     state: &AppState,
     operation: impl FnOnce(&AppState) -> Result<T, AppError>,
 ) -> Result<T, AppError> {
-    let _share_mutation = state.org_share_mutation_lock.lock().await;
+    let _share_mutation = state.lock_org_mutation().await;
     operation(state)
 }
 

--- a/src-tauri/src/commands/note_organize.rs
+++ b/src-tauri/src/commands/note_organize.rs
@@ -835,7 +835,7 @@ pub async fn apply_organize_plan(
     state: State<'_, AppState>,
     plan: OrganizePlan,
 ) -> Result<OrganizeApplyResult, AppError> {
-    let _share_mutation = state.org_share_mutation_lock.lock().await;
+    let _share_mutation = state.lock_org_mutation().await;
     apply_organize_plan_inner(state.inner(), plan)
 }
 

--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -619,7 +619,7 @@ pub async fn move_note_doc(
     id: String,
     folder_id: String,
 ) -> Result<(), AppError> {
-    let _share_mutation = state.org_share_mutation_lock.lock().await;
+    let _share_mutation = state.lock_org_mutation().await;
     let target_locked = state
         .db
         .folder_by_id(&folder_id)?
@@ -853,7 +853,7 @@ async fn delete_note_inner_notifying(
             "unlock this folder to delete a note",
         )));
     }
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     state.db.begin_org_source_closure("document", id)?;
     // REVOKE-BEFORE-DELETE (Bug A root cause): tear down every LIVE org share of this exact note
     // BEFORE the local row disappears, so the background org-sync tick can never re-pull a still-live
@@ -1243,7 +1243,7 @@ pub async fn delete_note_folder(
     state: State<'_, AppState>,
     id: String,
 ) -> Result<(), AppError> {
-    let _share_mutation = state.org_share_mutation_lock.lock().await;
+    let _share_mutation = state.lock_org_mutation().await;
     if state.db.note_folder_by_id(&id)?.is_none() {
         return Err(AppError::InvalidArg(format!("no note folder {id}")));
     }
@@ -1261,7 +1261,7 @@ pub async fn move_note_folder(
     id: String,
     parent_id: Option<String>,
 ) -> Result<(), AppError> {
-    let _share_mutation = state.org_share_mutation_lock.lock().await;
+    let _share_mutation = state.lock_org_mutation().await;
     move_note_folder_inner(state.inner(), &id, parent_id.as_deref())
 }
 

--- a/src-tauri/src/commands/org.rs
+++ b/src-tauri/src/commands/org.rs
@@ -435,7 +435,7 @@ pub async fn share_note_to_link(
     password: Option<String>,
     max_downloads: Option<u32>,
 ) -> Result<String, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     share_note_to_link_inner(
         state.inner(),
         meeting_id,
@@ -634,7 +634,7 @@ pub async fn share_note_to_link_doc(
     password: Option<String>,
     max_downloads: Option<u32>,
 ) -> Result<String, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     share_note_to_link_doc_inner(state.inner(), id, expires_days, password, max_downloads).await
 }
 
@@ -935,7 +935,7 @@ fn my_share_local_title_under_lifecycle(
 /// `revoke_share(share_id)` — DELETE the server ciphertext + flip the local state. Idempotent.
 #[tauri::command]
 pub async fn revoke_share(state: State<'_, AppState>, share_id: String) -> Result<(), AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     revoke_share_inner(state.inner(), share_id).await
 }
 
@@ -1379,7 +1379,7 @@ pub async fn share_note_to_user(
     recipient_email: String,
     expires_days: Option<u32>,
 ) -> Result<ShareToUserResult, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     share_note_to_user_inner(state.inner(), meeting_id, recipient_email, expires_days).await
 }
 
@@ -1657,7 +1657,7 @@ pub(crate) fn assemble_user_share_request(
 /// number of shares advanced to `sent`.
 #[tauri::command]
 pub async fn share_rewrap_pending(state: State<'_, AppState>) -> Result<u32, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     share_rewrap_pending_inner(state.inner()).await
 }
 
@@ -2813,7 +2813,7 @@ pub(crate) async fn acquire_org_ock_for_test(
 /// the owner can immediately seal items. Caches the org + generation-1 OCK locally.
 #[tauri::command]
 pub async fn org_create(state: State<'_, AppState>, name: String) -> Result<OrgStatus, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     org_create_inner(state.inner(), name).await
 }
 
@@ -3203,10 +3203,13 @@ pub(crate) const SHARE_MUTATION_WAIT: std::time::Duration = std::time::Duration:
 pub(crate) async fn acquire_share_mutation_within(
     state: &AppState,
     wait: std::time::Duration,
-) -> Result<tokio::sync::MutexGuard<'_, ()>, AppError> {
-    match tokio::time::timeout(wait, state.org_share_mutation_lock.lock()).await {
-        Ok(guard) => Ok(guard),
-        Err(_) => Err(AppError::Unavailable(crate::errcode::tag(
+) -> Result<crate::state::OrgMutationGuard<'_>, AppError> {
+    // Through the guard like every other door: this bounded-wait variant is a SECOND way to
+    // take the same mutex, and a re-entrancy check that misses it misses exactly the kind of
+    // path the deadlock it exists for was reached through.
+    match state.lock_org_mutation_within(wait).await {
+        Some(guard) => Ok(guard),
+        None => Err(AppError::Unavailable(crate::errcode::tag(
             crate::errcode::SHARE_BUSY,
             "another sharing operation is still running",
         ))),
@@ -3541,7 +3544,7 @@ pub async fn org_invite_member(
     org_id: String,
     email: String,
 ) -> Result<(), AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     org_invite_member_inner(state.inner(), org_id, email).await
 }
 
@@ -3957,7 +3960,7 @@ pub async fn org_remove_member(
     org_id: String,
     user_id: String,
 ) -> Result<(), AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     org_remove_member_inner(state.inner(), org_id, user_id).await
 }
 
@@ -4033,7 +4036,7 @@ pub async fn org_leave(
     state: State<'_, AppState>,
     org_id: String,
 ) -> Result<(), AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     let org = resolve_org(state.inner(), &org_id)?;
     let base = share_base_url(state.inner())?;
     let access = valid_access_token(state.inner()).await?;
@@ -4587,7 +4590,7 @@ pub(crate) async fn share_to_org_placed_notifying(
     placement: Option<ContainerPlacement>,
     app: Option<&AppHandle>,
 ) -> Result<OrgShareEntry, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     share_to_org_inner_with_policy(
         state,
         org_id,
@@ -7675,7 +7678,7 @@ pub(crate) async fn republish_org_shares_for_source(
     meeting_id: Option<&str>,
     document_id: Option<&str>,
 ) -> Result<u32, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     republish_org_shares_for_source_with_policy(
         state,
         meeting_id,
@@ -7692,7 +7695,7 @@ pub(crate) async fn republish_org_shares_for_source_notifying(
     document_id: Option<&str>,
     app: &AppHandle,
 ) -> Result<u32, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     republish_org_shares_for_source_with_policy(
         state,
         meeting_id,
@@ -8987,7 +8990,7 @@ pub async fn revoke_org_share(
     state: State<'_, AppState>,
     item_id: String,
 ) -> Result<(), AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     revoke_org_share_inner_with_policy(state.inner(), item_id, OrgWorkPolicy::manual(), Some(&app))
         .await?;
     crate::events::emit_org_feed_updated(&app, 1);
@@ -9004,7 +9007,7 @@ pub(crate) async fn revoke_org_share_notifying(
     item_id: String,
     notifier: &dyn OrgFeedNotifier,
 ) -> Result<(), AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     revoke_org_share_inner_with_policy(state, item_id, OrgWorkPolicy::manual(), None).await?;
     notifier.org_feed_updated(1);
     Ok(())
@@ -9015,7 +9018,7 @@ pub(crate) async fn revoke_org_share_inner(
     state: &AppState,
     item_id: String,
 ) -> Result<(), AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     revoke_org_share_inner_with_policy(state, item_id, OrgWorkPolicy::manual(), None).await
 }
 
@@ -9373,7 +9376,7 @@ pub async fn revoke_shares_for_folder(
     state: State<'_, AppState>,
     folder_id: String,
 ) -> Result<(), AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     state.db.begin_org_folder_closure(&folder_id)?;
     revoke_shares_for_folder_inner(state.inner(), &folder_id, Some(&app)).await
 }
@@ -9542,7 +9545,7 @@ pub(crate) async fn org_background_sync_tick(state: &AppState, app: Option<AppHa
     // Reconcile membership FIRST so a newly-invited org is present (and synced this same tick) and a
     // departed org is dropped before we pull its feed. Best-effort — a failure never blocks the sync.
     {
-        let _mutation = state.org_share_mutation_lock.lock().await;
+        let _mutation = state.lock_org_mutation().await;
         if let Err(e) = org_reconcile_memberships_with_policy(state, policy, app.as_ref()).await {
             tracing::warn!(target: "org", error = %brief_err(&e), "org membership reconcile tick failed");
         }
@@ -9551,7 +9554,7 @@ pub(crate) async fn org_background_sync_tick(state: &AppState, app: Option<AppHa
         return false;
     }
     {
-        let _mutation = state.org_share_mutation_lock.lock().await;
+        let _mutation = state.lock_org_mutation().await;
         if let Err(e) = org_sweep_pending_with_policy(state, policy, app.as_ref()).await {
             tracing::warn!(target: "org", error = %e, "org outbound sweep tick failed");
         }
@@ -9586,7 +9589,7 @@ pub(crate) async fn org_background_sync_tick(state: &AppState, app: Option<AppHa
         return false;
     }
     let report = {
-        let _mutation = state.org_share_mutation_lock.lock().await;
+        let _mutation = state.lock_org_mutation().await;
         match org_sync_now_inner_with_policy(state, policy, app.clone()).await {
             Ok(r) => r,
             Err(e) => {
@@ -9643,13 +9646,13 @@ pub async fn org_sweep_pending(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<u32, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     org_sweep_pending_with_policy(state.inner(), OrgWorkPolicy::manual(), Some(&app)).await
 }
 
 #[cfg(test)]
 pub(crate) async fn org_sweep_pending_inner(state: &AppState) -> Result<u32, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     org_sweep_pending_with_policy(state, OrgWorkPolicy::manual(), None).await
 }
 
@@ -9657,7 +9660,7 @@ pub(crate) async fn org_sweep_pending_inner(state: &AppState) -> Result<u32, App
 pub(crate) async fn org_sweep_pending_background_once_inner(
     state: &AppState,
 ) -> Result<u32, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     org_sweep_pending_with_policy(
         state,
         OrgWorkPolicy::background(crate::perf::background_epoch()),
@@ -10218,7 +10221,7 @@ pub async fn org_sync_now(
     state: State<'_, AppState>,
     org_id: Option<String>,
 ) -> Result<crate::storage::models::OrgSyncReport, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     // The FE passes a SPECIFIC org id (→ sync only that org); the background tick / internal callers
     // pass `None` (→ sync the next round-robin org). This is the command-boundary
     // dispatch of the multi-org fix: a user-triggered "Sync now" from a picked org must not sync (or
@@ -10367,7 +10370,7 @@ pub(crate) async fn org_sync_one_now_inner(
     state: &AppState,
     org_id: &str,
 ) -> Result<crate::storage::models::OrgSyncReport, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     org_sync_one_now_with_app(state, org_id, None).await
 }
 
@@ -10384,7 +10387,7 @@ pub(crate) async fn org_sync_one_now_with_pre_task_reader(
     state: &AppState,
     org_id: &str,
 ) -> Result<crate::storage::models::OrgSyncReport, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     org_sync_one_now_with_app_and_policy(state, org_id, None, OrgWorkPolicy::pre_task_reader()).await
 }
 
@@ -10434,7 +10437,7 @@ async fn org_sync_one_now_with_app_and_policy(
 pub(crate) async fn org_sync_now_inner(
     state: &AppState,
 ) -> Result<crate::storage::models::OrgSyncReport, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     org_sync_now_inner_with_policy(state, OrgWorkPolicy::manual(), None).await
 }
 
@@ -11084,7 +11087,7 @@ async fn org_sync_one(
 /// `org_background_sync_tick`; this is the direct entry point for internal callers and for the
 /// regression tests that drive the sweep against a mock feed.
 pub async fn org_reconcile_now_inner(state: &AppState) -> Result<u32, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     org_reconcile_tick_with_policy(state, OrgWorkPolicy::manual(), None).await
 }
 
@@ -11850,7 +11853,7 @@ pub async fn add_org_item_to_container(
     item_id: String,
     container_id: String,
 ) -> Result<crate::storage::models::OrgItemImportResult, AppError> {
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     add_org_item_to_container_inner(state.inner(), &item_id, &container_id)
 }
 
@@ -11967,7 +11970,7 @@ pub(crate) async fn org_set_item_access_inner(
     item_id: &str,
     access: crate::share::org_dto::OrgItemAccess,
 ) -> Result<(), AppError> {
-    let _mutation = st.org_share_mutation_lock.lock().await;
+    let _mutation = st.lock_org_mutation().await;
     let ctx = match st.db.org_item_edit_ctx(item_id)? {
         Some(ctx) => ctx,
         None => {
@@ -12157,7 +12160,7 @@ pub(crate) async fn org_update_own_item_notifying(
     markdown: &str,
     app: Option<&AppHandle>,
 ) -> Result<String, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     // Resolve the item's edit context (org, current rev, original created_at/source_kind, author id).
     let ctx = state
         .db
@@ -12624,7 +12627,7 @@ pub(crate) async fn delete_org_item_as_author_notifying(
     item_id: &str,
     app: Option<&AppHandle>,
 ) -> Result<(), AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     let item_id = item_id.trim();
     if item_id.is_empty() {
         return Err(AppError::InvalidArg("item id required".into()));

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -7388,7 +7388,7 @@
             |_ck: &[u8; 32], _blob: &[u8], _aad: &[u8]| -> Result<Vec<u8>, AppError> {
                 Ok(b"not the attachment plaintext".to_vec())
             };
-        let _org_mutation = block_on(state.org_share_mutation_lock.lock());
+        let _org_mutation = block_on(state.lock_org_mutation());
         let error = persist_converted_companion_under_snapshot_with_attachment_verifier(
             &state,
             MEETING,
@@ -8368,7 +8368,7 @@
 
         // Keep cleanup queued before its authoritative recheck. The editor wins while cleanup is
         // waiting, so the recheck must return false without touching the remote-share journal.
-        let mutation = block_on(state.org_share_mutation_lock.lock());
+        let mutation = block_on(state.lock_org_mutation());
         let cleanup_state = state.clone();
         let (started_tx, started_rx) = std::sync::mpsc::channel();
         let cleanup = std::thread::spawn(move || {

--- a/src-tauri/src/commands/tests/org_diagnosability_tests.rs
+++ b/src-tauri/src/commands/tests/org_diagnosability_tests.rs
@@ -88,7 +88,7 @@ fn brief_err_still_classifies_the_other_arms() {
 async fn a_held_share_mutation_lock_yields_busy_rather_than_hanging() {
     let state = AppState::for_tests(fresh_db("busy-lock"));
 
-    let held = state.org_share_mutation_lock.lock().await;
+    let held = state.lock_org_mutation().await;
 
     let started = std::time::Instant::now();
     let outcome = acquire_share_mutation_within(&state, std::time::Duration::from_millis(50)).await;

--- a/src-tauri/src/commands/tests/org_mutex_scope_tests.rs
+++ b/src-tauri/src/commands/tests/org_mutex_scope_tests.rs
@@ -102,7 +102,11 @@ fn body_of(file: &str, name: &str) -> String {
     panic!("{file}: `{name}` has no closing brace");
 }
 
-const ACQUIRE: &str = "org_share_mutation_lock";
+/// Every acquisition now goes through the ONE helper (see
+/// `nothing_takes_the_org_mutex_except_the_one_helper`), so that call — not the field name — is
+/// what these oracles look for. Matching the field would silently stop finding anything the moment
+/// the door was renamed, which is how a source oracle goes quietly vacuous.
+const ACQUIRE: &str = "lock_org_mutation(";
 
 /// `unlock_folder` must not hold the org mutex across the Touch ID sheet.
 ///
@@ -268,5 +272,53 @@ fn unlock_folder_revalidates_the_visibility_snapshot_after_taking_the_org_mutex(
         acquire < require,
         "the re-validation must happen AFTER the mutex is held (acquire {acquire}, require \
          {require}), or it can be invalidated again before the restore"
+    );
+}
+
+/// Every acquisition of the org mutex goes through `AppState::lock_org_mutation`.
+///
+/// The debug re-entrancy guard lives in that one helper, and a guard that covers SOME call sites
+/// covers none of the ones that matter: the deadlock it exists for was reached three levels deep,
+/// through a callee nobody was thinking about (`reconcile_container_shares` ->
+/// `reconcile_one_container_root` -> `share_to_org_placed_notifying`). One raw `.lock()` anywhere
+/// is a hole in exactly the place a future author will not be looking.
+///
+/// `state.rs` is the sole exemption — it is where the helper takes the real lock.
+///
+/// RED CONTROL (run 2026-09-03): rewriting any single call site back to
+/// `state.org_share_mutation_lock.lock().await` fails this test naming that file and line.
+#[test]
+fn nothing_takes_the_org_mutex_except_the_one_helper() {
+    let src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut raw = Vec::new();
+    let mut stack = vec![src.clone()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).unwrap_or_else(|e| panic!("read {dir:?}: {e}")) {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if !(name.ends_with(".rs") || name.ends_with(".inc")) || name == "state.rs" {
+                continue;
+            }
+            let text = strip_comments(&std::fs::read_to_string(&path).unwrap_or_default());
+            for (i, line) in text.lines().enumerate() {
+                // Skip STRING LITERALS: this test's own assertion message names both the field
+                // and `.lock()`, and so does prose in error copy. A check that flags itself is a
+                // check nobody will keep.
+                let code = line.split('"').step_by(2).collect::<String>();
+                if code.contains("org_share_mutation_lock") && code.contains(".lock()") {
+                    let rel = path.strip_prefix(&src).unwrap_or(&path).display().to_string();
+                    raw.push(format!("{rel}:{}", i + 1));
+                }
+            }
+        }
+    }
+    assert!(
+        raw.is_empty(),
+        "these take `org_share_mutation_lock` directly instead of `lock_org_mutation()`, so the \
+         debug re-entrancy guard cannot see them: {raw:?}"
     );
 }

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -887,7 +887,7 @@ pub async fn apply_workspace_organization(
     state: State<'_, AppState>,
     moves: Vec<WorkspaceOrganizeMove>,
 ) -> Result<WorkspaceOrganizeApplyResult, AppError> {
-    let _share_mutation = state.org_share_mutation_lock.lock().await;
+    let _share_mutation = state.lock_org_mutation().await;
     apply_workspace_organization_inner(&state.db, moves, |item_id, target_id| {
         file_recording_command_body(&app, state.inner(), item_id, Some(target_id))
     })

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -389,6 +389,139 @@ pub struct AppState {
     pub heavy_inference: Arc<tokio::sync::Semaphore>,
 }
 
+/// Debug-only bookkeeping that turns a SELF-REENTRANT acquisition of
+/// [`AppState::org_share_mutation_lock`] into a loud panic instead of a silent, permanent hang.
+///
+/// WHY (found 2026-09-03, on trunk). `org_background_sync_tick` held the mutex across
+/// `reconcile_container_shares`, whose callee `share_to_org_placed_notifying` acquires the SAME
+/// mutex as its first statement. `tokio::sync::Mutex` is not reentrant, so the task awaited a lock
+/// it already held: it never returned, its guard was never dropped, and every later org operation —
+/// sharing, revoking, `unlock_folder` — blocked for the rest of the process. The symptom was
+/// SILENCE. No error, no failing test, no log line; org sync simply stopped forever.
+///
+/// Nothing could have caught it. A green suite proves nothing about a deadlock that needs one
+/// specific call path, and a source-level oracle only sees the site it was written for. This sees
+/// the class: any path, any depth, any future author.
+///
+/// Debug-only on purpose. In release the check would cost a lock and a set lookup on every
+/// acquisition to defend against a bug that, once found, is fixed in the code — and a panic is the
+/// wrong response to ship to a user regardless.
+#[cfg(debug_assertions)]
+mod org_mutex_reentrancy {
+    use std::collections::HashSet;
+    use std::sync::{Mutex, OnceLock};
+
+    /// One id per in-flight holder. A tokio task id where there is one, else the OS thread id —
+    /// `run_heavy`'s blocking closures have no task id, and they hold this lock too.
+    fn holder_id() -> u64 {
+        match tokio::task::try_id() {
+            // `Id` has no numeric accessor, and its Display is the number.
+            Some(id) => id.to_string().parse().unwrap_or(u64::MAX),
+            None => {
+                let t = std::thread::current().id();
+                // Thread ids are opaque too; hash them into the same space. A collision between a
+                // thread and a task id would only ever cause a FALSE panic in a debug build, which
+                // is loud and immediately investigable — never a missed deadlock.
+                use std::hash::{Hash, Hasher};
+                let mut h = std::collections::hash_map::DefaultHasher::new();
+                t.hash(&mut h);
+                h.finish() | (1 << 63)
+            }
+        }
+    }
+
+    fn holders() -> &'static Mutex<HashSet<u64>> {
+        static HOLDERS: OnceLock<Mutex<HashSet<u64>>> = OnceLock::new();
+        HOLDERS.get_or_init(|| Mutex::new(HashSet::new()))
+    }
+
+    pub(super) fn enter() {
+        let id = holder_id();
+        let mut set = holders()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(
+            set.insert(id),
+            "org_share_mutation_lock acquired re-entrantly by the same task/thread. \
+             tokio::sync::Mutex is not reentrant: this would hang forever and hold the mutex for \
+             the rest of the process, stopping every org operation with no error. Take the lock \
+             around the durable commit only, or let the callee that already takes it do so."
+        );
+    }
+
+    pub(super) fn leave() {
+        let id = holder_id();
+        let mut set = holders()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        set.remove(&id);
+    }
+}
+
+/// The ONLY way to take [`AppState::org_share_mutation_lock`].
+///
+/// Routing every acquisition through one place is what makes the debug re-entrancy check possible
+/// at all — a check that only covers some call sites covers none of the ones that matter, since the
+/// deadlock this exists for was reached three levels deep through a callee nobody was thinking
+/// about. `commands/tests/org_mutex_scope_tests.rs` fails the build if a raw `.lock()` reappears.
+pub struct OrgMutationGuard<'a> {
+    _inner: tokio::sync::MutexGuard<'a, ()>,
+    /// Whether this guard registered itself with the re-entrancy bookkeeping, so only guards that
+    /// entered ever leave. A bounded acquisition never enters, and must not remove an id the
+    /// unbounded holder on the same thread put there.
+    #[cfg(debug_assertions)]
+    checked: bool,
+}
+
+#[cfg(debug_assertions)]
+impl Drop for OrgMutationGuard<'_> {
+    fn drop(&mut self) {
+        if self.checked {
+            org_mutex_reentrancy::leave();
+        }
+    }
+}
+
+impl AppState {
+    /// Acquire the org mutation lock, waiting indefinitely. See [`OrgMutationGuard`].
+    ///
+    /// This is the door the re-entrancy check guards, because this is the one that can HANG: an
+    /// unbounded wait for a lock the caller already holds never returns and never releases.
+    pub(crate) async fn lock_org_mutation(&self) -> OrgMutationGuard<'_> {
+        #[cfg(debug_assertions)]
+        org_mutex_reentrancy::enter();
+        OrgMutationGuard {
+            _inner: self.org_share_mutation_lock.lock().await,
+            #[cfg(debug_assertions)]
+            checked: true,
+        }
+    }
+
+    /// Acquire it, or give up after `wait`.
+    ///
+    /// DELIBERATELY NOT re-entrancy-checked, and the distinction is the whole point: a BOUNDED
+    /// attempt cannot deadlock. If the caller already holds the lock the timeout simply elapses and
+    /// the caller is told the resource is busy — which is a correct, recoverable outcome, and one
+    /// the suite asserts on purpose in
+    /// `org_diagnosability_tests::a_held_share_mutation_lock_yields_busy_rather_than_hanging`.
+    ///
+    /// Panicking there would have been the guard mistaking "an attempt designed to be refused" for
+    /// "a hang", which is exactly the false positive that gets a check deleted rather than fixed.
+    pub(crate) async fn lock_org_mutation_within(
+        &self,
+        wait: std::time::Duration,
+    ) -> Option<OrgMutationGuard<'_>> {
+        tokio::time::timeout(wait, self.org_share_mutation_lock.lock())
+            .await
+            .ok()
+            .map(|inner| OrgMutationGuard {
+                _inner: inner,
+                #[cfg(debug_assertions)]
+                checked: false,
+            })
+    }
+}
+
 type ContentDispatchValidator = dyn Fn(&AppState) -> Result<()> + Send + Sync + 'static;
 
 /// An owned authorization capability for a model/provider dispatch that derives from visible


### PR DESCRIPTION
## The deadlock found on trunk had no detector

`org_background_sync_tick` held `org_share_mutation_lock` across
`reconcile_container_shares`, whose callee `share_to_org_placed_notifying` takes the **same** mutex
as its first statement. `tokio::sync::Mutex` is not reentrant, so the task awaited a lock it already
held: it never returned, its guard was never dropped, and every later org operation blocked **for the
rest of the process**.

The symptom was **silence**. No error, no failing test, no log line. Org sync simply stopped, forever.

Nothing in the repo could have caught it. A green suite says nothing about a deadlock that needs one
specific call path, and the source oracle I wrote for that fix only sees the site it was written for.

## This sees the class, not the site

In debug, a second acquisition by the same task or thread **panics**, with what to do about it. Any
path, any depth, any future author. The ~3600 existing tests become a detector for a failure mode
none of them was written for.

**Debug-only deliberately.** In release the check would cost a lock and a set lookup on every
acquisition, to defend against a bug that is fixed in code once found — and a panic is the wrong
thing to ship to a user regardless.

All **51** acquisitions now go through `AppState::lock_org_mutation`, and an oracle fails the build
if a raw `.lock()` reappears. That is not tidiness: a guard covering *some* call sites covers none of
the ones that matter, since the deadlock was reached three levels deep through a callee nobody was
thinking about.

## What the oracle found immediately

`acquire_share_mutation_within` — a **second, bounded-wait door** to the same mutex that my
mechanical migration missed, because it does not match `.lock().await`. Without the oracle I would
have left a hole in exactly the place nobody looks.

## What an existing test found, and it was right

`a_held_share_mutation_lock_yields_busy_rather_than_hanging` deliberately holds the lock and attempts
it again, asserting `SHARE_BUSY` rather than a hang. My guard called that re-entrancy and panicked —
**mistaking "an attempt designed to be refused" for "a hang"**, which is precisely the false positive
that gets a check deleted rather than fixed.

The distinction I was missing: **a bounded attempt cannot deadlock.** The timeout elapses and the
caller is told the resource is busy, which is correct and recoverable. The class is *unbounded*
waiting for a lock you already hold.

So the guard now covers only `lock_org_mutation`; `lock_org_mutation_within` is exempt with that
reason stated in the code, and a `checked` flag on the guard stops a bounded holder from removing an
id the unbounded one registered.

## Gates

`cargo test --lib` **3634 passed, 0 failed** · `cargo clippy --lib --tests -- -D warnings` clean ·
`mirror-check` OK · 5 org-mutex oracles green.
