### PR TITLE
integrate: six reviewed prod-ready changes as one gate run

### DIFF
--- a/.vocabulary-allowlist.json
+++ b/.vocabulary-allowlist.json
@@ -84,6 +84,11 @@
       "file": "src/app/features/settings/settings/settings.component.ts",
       "term": "\\bDEK\\b|\\bKEK\\b|\\bCK\\b",
       "reason": "Hidden search synonym, never rendered. No key MATERIAL is ever shown; this is only a term someone might search for."
+    },
+    {
+      "file": "src/app/services/note-attachment.service.ts",
+      "term": "\\bcontainers?\\b",
+      "reason": "Ordinary English, not the hierarchy: an image's decoded dimensions are compared against its CONTAINER FORMAT. The banned sense is the code's word for 'a Workspace or a folder'; here the user is better off with the precise term, and rewriting it to 'Workspace or folder' would say something false."
     }
   ]
 }

--- a/.vocabulary-baseline.json
+++ b/.vocabulary-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Transitional debt only. This number must never grow. Entries are removed by rewriting the copy, never by adding to the allowlist without a reason.",
-  "count": 165,
+  "count": 160,
   "files": {
     "src/app/features/analytics/analytics/analytics.component.html": 1,
     "src/app/features/analytics/egress-ledger/egress-ledger.component.html": 9,

--- a/e2e/notes/typed-properties.spec.ts
+++ b/e2e/notes/typed-properties.spec.ts
@@ -220,7 +220,11 @@ test("a LOCKED folder shows the lock gate and hides the Saved Views bar", async 
     .click();
 
   await expect(page).toHaveURL(/\/container\/nf2$/);
-  await expect(page.getByText("This container is locked")).toBeVisible();
+  // "folder", not "container": the code's word for "a Workspace or a folder" used to leak into
+  // this state, where it named nothing the user ever created. `core/hierarchy-vocabulary.ts`
+  // is the one source now — and this assertion failing on the rename is what proved the old
+  // word really was on screen rather than only in the source.
+  await expect(page.getByText("This folder is locked")).toBeVisible();
   // No view controls and no counts: the backend refuses to describe a sealed container, and
   // "0" would be a claim about contents nobody is entitled to read.
   await expect(page.locator("app-notes-view-switcher")).toHaveCount(0);

--- a/e2e/shell/workspace-tree.spec.ts
+++ b/e2e/shell/workspace-tree.spec.ts
@@ -333,7 +333,7 @@ test("audits the complete sidebar at tall and short viewports", async ({
       testInfo,
       `workspace-sidebar-${viewport.name}-overflow-menu`,
     );
-    await expectMenuItemAtHitPoint(page, "Rename space");
+    await expectMenuItemAtHitPoint(page, "Rename Workspace");
     await page.keyboard.press("Escape");
     await expect(overflowMenu).toHaveCount(0);
     await expect(overflowTrigger).toBeFocused();
@@ -370,13 +370,13 @@ test("keeps the single contextual container menu above following tree rows", asy
       .getByRole("menuitem", { name: "Create folder here" })
       .locator("mur-icon"),
   ).toHaveAttribute("data-icon", "folder-add");
-  await expectMenuItemAtHitPoint(page, "Rename space");
+  await expectMenuItemAtHitPoint(page, "Rename Workspace");
   await expect(page.getByText("Workspace actions", { exact: true })).toBeVisible();
   await expect(
-    page.getByRole("menuitem", { name: "Rename space" }).locator("mur-icon"),
+    page.getByRole("menuitem", { name: "Rename Workspace" }).locator("mur-icon"),
   ).toHaveAttribute("data-icon", "rename");
   await expect(
-    page.getByRole("menuitem", { name: "Delete space" }).locator("mur-icon"),
+    page.getByRole("menuitem", { name: "Delete Workspace" }).locator("mur-icon"),
   ).toHaveAttribute("data-icon", "trash");
 
   await page.keyboard.press("Escape");
@@ -495,8 +495,8 @@ test("rename and delete use explicit contextual confirmation instead of native p
   await page.goto("/");
 
   await page.getByRole("button", { name: "Actions for Acme" }).click();
-  await page.getByRole("menuitem", { name: "Rename space" }).click();
-  const rename = page.getByRole("dialog", { name: "Rename space Acme" });
+  await page.getByRole("menuitem", { name: "Rename Workspace" }).click();
+  const rename = page.getByRole("dialog", { name: "Rename Workspace Acme" });
   await expect(rename).toBeVisible();
   await rename.getByLabel("Name").fill("Acme Studio");
   await rename.getByRole("button", { name: "Rename", exact: true }).click();
@@ -509,15 +509,15 @@ test("rename and delete use explicit contextual confirmation instead of native p
     .toEqual([{ folderId: "p-acme", newName: "Acme Studio" }]);
 
   await page.getByRole("button", { name: "Actions for Acme" }).click();
-  await page.getByRole("menuitem", { name: "Delete space" }).click();
-  const remove = page.getByRole("dialog", { name: "Delete space Acme" });
+  await page.getByRole("menuitem", { name: "Delete Workspace" }).click();
+  const remove = page.getByRole("dialog", { name: "Delete Workspace Acme" });
   await expect(remove).toContainText("Its items are kept and moved out");
   expect(
     await page.evaluate(
       () => (window as unknown as { __deletes?: unknown[] }).__deletes ?? [],
     ),
   ).toEqual([]);
-  await remove.getByRole("button", { name: "Delete space" }).click();
+  await remove.getByRole("button", { name: "Delete Workspace" }).click();
   await expect
     .poll(() =>
       page.evaluate(

--- a/scripts/check-vocabulary.mjs
+++ b/scripts/check-vocabulary.mjs
@@ -51,6 +51,20 @@ const BANNED = [
   ["prefix cache|KV cache", "(drop it)"],
   ["\\bRAG\\b", "search"],
   ["reranker", "result ordering"],
+  // The hierarchy's CODE word. A user never made a "container" — they made a Workspace or a
+  // folder — and it leaked into three of `container-view`'s own empty and error states while
+  // every other surface said something else. `core/hierarchy-vocabulary.ts` is the one source.
+  //
+  // Deliberately NOT banning "space": it is ordinary English used correctly elsewhere ("Free up
+  // space"), and banning it would train people to ignore this list. What stops "space" being used
+  // as a HIERARCHY noun is the `ContainerNoun` type — a domain identifier no longer typechecks
+  // where a sentence is written, which is a guard a word list cannot provide.
+  // FE ONLY, for now. `core/hierarchy-vocabulary.ts` made the frontend consistent, but the
+  // BACKEND still says "container" in 69 `AppError` bodies that reach the user as toasts
+  // ("unlock this container before moving a dashboard into it"). Those live in files another PR
+  // is currently rewriting, and silently widening the baseline to admit them would be the exact
+  // rubber stamp this gate exists to prevent — so they are a recorded task, not a hidden pass.
+  ["\\bcontainers?\\b", "Workspace or folder", ["fe"]],
 ];
 
 /** Files whose strings a user can actually read. */
@@ -85,7 +99,12 @@ function visibleText(file, source) {
     // prose comment ("doesn't") opens a bogus string literal that swallows the next few
     // hundred characters of code, and the whole comment then reads as user-facing copy.
     while ((m = re.exec(text))) {
-      const value = m[2];
+      // An interpolated expression is CODE, not copy: in `Created a folder in ${container.name}`
+      // the user reads "Created a folder in Projects" — `container` is a variable name that
+      // happens to sit inside a string. Leaving these in made every hierarchy term look like it
+      // leaked into 80 sentences it never reached, which is precisely the noise this function's
+      // own comment warns teaches people to ignore the tool.
+      const value = m[2].replace(/\$\{[^}]*\}/g, " ");
       // Prose, not an identifier / path / css class / event name.
       if (!/\s/.test(value)) continue;
       if (/^[./#@]/.test(value)) continue;
@@ -100,6 +119,16 @@ function visibleText(file, source) {
       /^\s(?:aria-label|title|placeholder|alt|matTooltip)=/.test(m) ? m : " ",
     );
     text = text.replace(/<!--[\s\S]*?-->/g, " ");
+    // Angular control flow and interpolation EXPRESSIONS are code. A user reading
+    // `{{ container.name }}` sees "Projects"; `@if (node(); as container)` they never see at all.
+    // Left in, they made every hierarchy term look like it leaked into dozens of sentences it
+    // never reached — the same false-positive class the `.ts` branch already strips for `${…}`.
+    text = text.replace(/\{\{[\s\S]*?\}\}/g, " ");
+    text = text.replace(/@(?:if|else if|for|switch|case|defer|placeholder|loading|empty)\s*\([^)]*\)/g, " ");
+    // Element NAMES are never copy — `<app-container-share-sheet>` is a selector. The attribute
+    // pass above deliberately keeps aria-label/title/placeholder/alt, so whole tags cannot simply
+    // be stripped; the tag NAME can.
+    text = text.replace(/<\/?[a-zA-Z][\w-]*/g, " ");
   }
   if (file.endsWith(".rs")) {
     // Only strings that can REACH a user: AppError bodies and role/map display fields.
@@ -123,7 +152,9 @@ function scan() {
       const text = visibleText(file, source);
       if (!text.trim()) continue;
       const lines = text.split("\n");
-      for (const [term, replacement] of BANNED) {
+      for (const [term, replacement, kinds] of BANNED) {
+        // A term may name a surface it applies to; the default is every surface.
+        if (kinds && !kinds.includes(kind)) continue;
         const re = new RegExp(term, "i");
         lines.forEach((line, i) => {
           if (re.test(line)) {

--- a/src-tauri/src/applog.rs
+++ b/src-tauri/src/applog.rs
@@ -46,7 +46,21 @@ pub const DEFAULT_ENTRIES: usize = 1_000;
 const TAIL_SCAN_BYTES: u64 = 4 * 1024 * 1024;
 
 /// How long a log is kept. Past this, entries are DELETED — see the module doc.
-pub const RETENTION_HOURS: i64 = 24;
+///
+/// Seven days, not one. A user reporting "it did the thing again last week" was asking about a log
+/// that had already been pruned, which made the whole surface unable to answer the question it
+/// exists for. The window is bounded in the OTHER dimension by [`MAX_LOG_BYTES`], so extending it
+/// cannot turn diagnosability into unbounded disk use.
+pub const RETENTION_HOURS: i64 = 24 * 7;
+
+/// Ceiling on the CURRENT log file. Past this, the oldest entries are dropped even when they are
+/// still inside the retention window.
+///
+/// Time alone is the wrong bound for a log: a quiet week costs nothing while a crash loop can write
+/// gigabytes in an hour, and the second case is exactly when a full disk hurts most. 16 MB holds a
+/// long, chatty session — `TAIL_SCAN_BYTES` reads only the last 4 MB anyway — and is small enough
+/// that a runaway writer is capped within one prune tick.
+pub const MAX_LOG_BYTES: u64 = 16 * 1024 * 1024;
 
 /// How often the background pruner runs. Hourly is far finer than the 24 h window it enforces, so
 /// an aged-out log is gone within an hour of expiring, and the tick costs nothing noticeable (a
@@ -231,7 +245,14 @@ fn prune_file_head(path: &Path, cutoff: DateTime<Utc>) -> Result<()> {
         Err(e) if e.kind() == std::io::ErrorKind::InvalidData => return Ok(()),
         Err(e) => return Err(AppError::Storage(format!("read log for prune: {e}"))),
     };
-    let keep_from = first_retained_offset(&text, cutoff);
+    let mut keep_from = first_retained_offset(&text, cutoff);
+    // Size ceiling, applied AFTER the time cutoff: whatever survived the window may still be too
+    // big. Drop whole entries from the head — never a byte offset into one, which would leave a
+    // truncated first line and a continuation with no entry above it.
+    if (text.len() - keep_from) as u64 > MAX_LOG_BYTES {
+        let overflow = (text.len() - keep_from) as u64 - MAX_LOG_BYTES;
+        keep_from = first_entry_offset_past(&text, keep_from, overflow as usize);
+    }
     if keep_from == 0 {
         return Ok(()); // nothing has expired — the common case, and it writes nothing.
     }
@@ -247,6 +268,24 @@ fn prune_file_head(path: &Path, cutoff: DateTime<Utc>) -> Result<()> {
     file.flush()
         .map_err(|e| AppError::Storage(format!("flush log: {e}")))?;
     Ok(())
+}
+
+/// First entry boundary at or after `from + at_least` bytes.
+///
+/// Used by the size cap to drop WHOLE entries: starting the retained region mid-entry would leave a
+/// half line at the top and orphan its continuation lines, which is exactly the shape
+/// [`first_retained_offset`] documents as unacceptable for the time cutoff. Returns `text.len()`
+/// when no boundary is far enough, i.e. the file becomes empty rather than partially valid.
+fn first_entry_offset_past(text: &str, from: usize, at_least: usize) -> usize {
+    let target = from + at_least;
+    let mut offset = from;
+    for line in text[from..].split_inclusive('\n') {
+        if offset >= target && !line.starts_with(char::is_whitespace) {
+            return offset;
+        }
+        offset += line.len();
+    }
+    text.len()
 }
 
 /// Byte offset of the first entry to KEEP.
@@ -590,7 +629,7 @@ mod tests {
     #[test]
     fn nothing_expired_means_nothing_is_rewritten() {
         let now = Utc::now();
-        let text = line_at(now, 1, "fresh") + &line_at(now, 23, "still inside the window");
+        let text = line_at(now, 1, "fresh") + &line_at(now, RETENTION_HOURS - 1, "still inside the window");
         assert_eq!(
             first_retained_offset(&text, cutoff(now)),
             0,
@@ -601,8 +640,8 @@ mod tests {
     #[test]
     fn the_expired_head_is_dropped_and_the_rest_kept() {
         let now = Utc::now();
-        let old = line_at(now, 30, "yesterday's noise");
-        let older = line_at(now, 48, "two days ago");
+        let old = line_at(now, RETENTION_HOURS + 6, "past the window");
+        let older = line_at(now, RETENTION_HOURS * 2, "long past it");
         let fresh = line_at(now, 2, "keep me");
         let text = format!("{older}{old}{fresh}");
         let offset = first_retained_offset(&text, cutoff(now));
@@ -612,14 +651,14 @@ mod tests {
     #[test]
     fn an_entirely_expired_file_retains_nothing() {
         let now = Utc::now();
-        let text = line_at(now, 25, "just past the window") + &line_at(now, 90, "ancient");
+        let text = line_at(now, RETENTION_HOURS + 1, "just past the window") + &line_at(now, RETENTION_HOURS * 3, "ancient");
         assert_eq!(first_retained_offset(&text, cutoff(now)), text.len());
     }
 
     #[test]
     fn a_continuation_line_expires_with_the_entry_it_belongs_to() {
         let now = Utc::now();
-        let expired_panic = line_at(now, 40, "thread panicked");
+        let expired_panic = line_at(now, RETENTION_HOURS + 16, "thread panicked");
         let text = format!("{expired_panic}stack frame one\nstack frame two\n{}", line_at(now, 1, "fresh"));
         let offset = first_retained_offset(&text, cutoff(now));
         let kept = &text[offset..];
@@ -637,11 +676,59 @@ mod tests {
         let now = Utc::now();
         let text = format!(
             "{}9999-99-99T99:99:99.000000Z  INFO murmur: malformed\n{}",
-            line_at(now, 40, "expired"),
+            line_at(now, RETENTION_HOURS + 16, "expired"),
             line_at(now, 1, "fresh"),
         );
         let offset = first_retained_offset(&text, cutoff(now));
         assert!(text[offset..].contains("malformed"));
+    }
+
+    /// The size ceiling drops WHOLE entries from the head, even when they are still in-window.
+    ///
+    /// Time alone is the wrong bound for a log: a quiet week costs nothing while a crash loop can
+    /// write gigabytes in an hour, and that is exactly when a full disk hurts most. Every line here
+    /// is one minute old — comfortably inside retention — so only the byte ceiling can trim it, and
+    /// the assertions pin the two things that make the trim safe rather than merely small: the
+    /// NEWEST entry survives, and the retained region starts on an entry header, never mid-entry
+    /// with an orphaned continuation above it.
+    ///
+    /// RED CONTROL (run 2026-09-03): deleting the `MAX_LOG_BYTES` branch in `prune_file_head` fails
+    /// this on the size assertion while every other applog test stays green.
+    #[test]
+    fn the_size_ceiling_drops_whole_entries_even_when_they_are_still_in_window() {
+        let now = Utc::now();
+        let filler = "x".repeat(4_000);
+        let mut text = String::new();
+        // Comfortably over the ceiling, all of it fresh.
+        let entries = (MAX_LOG_BYTES as usize / 4_000) + 64;
+        for i in 0..entries {
+            text.push_str(&line_at(now, 1, &format!("entry {i} {filler}")));
+            text.push_str("  a continuation line for entry ");
+            text.push_str(&i.to_string());
+            text.push('\n');
+        }
+        let dir = temp_log_dir("size-cap");
+        let current = dir.join(LOG_FILE);
+        std::fs::write(&current, &text).unwrap();
+
+        prune_dir(&dir, now).unwrap();
+
+        let kept = std::fs::read_to_string(&current).unwrap();
+        assert!(
+            kept.len() as u64 <= MAX_LOG_BYTES,
+            "the ceiling must actually bind: kept {} bytes, cap {MAX_LOG_BYTES}",
+            kept.len()
+        );
+        assert!(
+            kept.contains(&format!("entry {}", entries - 1)),
+            "the NEWEST entry must survive — trimming from the wrong end would delete exactly what \
+             the log is read for"
+        );
+        assert!(
+            !kept.starts_with("  a continuation"),
+            "the retained region must start on an entry header, never on a continuation line whose \
+             entry was trimmed away"
+        );
     }
 
     #[test]
@@ -652,13 +739,17 @@ mod tests {
         let previous = dir.join(PREV_LOG_FILE);
         std::fs::write(
             &current,
-            line_at(now, 30, "expired") + &line_at(now, 1, "live"),
+            line_at(now, RETENTION_HOURS + 6, "expired") + &line_at(now, 1, "live"),
         )
         .unwrap();
-        std::fs::write(&previous, line_at(now, 30, "last session")).unwrap();
+        std::fs::write(&previous, line_at(now, RETENTION_HOURS + 6, "last session")).unwrap();
         // The previous file is judged by its mtime, so age it explicitly rather than trusting the
         // clock of the machine running the test.
-        let stale = std::time::SystemTime::now() - std::time::Duration::from_secs(48 * 3600);
+        // Relative to the window, not a fixed 48 h: a hardcoded age silently stops testing
+        // anything the moment RETENTION_HOURS grows past it, which is exactly what happened
+        // when the window went from 1 day to 7.
+        let stale = std::time::SystemTime::now()
+            - std::time::Duration::from_secs((RETENTION_HOURS as u64 + 6) * 3600);
         std::fs::File::options()
             .write(true)
             .open(&previous)

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -36,6 +36,17 @@ pub struct RecordingStatus {
     /// The in-progress meeting's `started_at` (RFC3339), so the FE anchors its elapsed timer to the
     /// real start instead of an epoch-sized value. `None` when idle or the row can't be read.
     pub started_at: Option<String>,
+    /// Whether SYSTEM audio capture is positively live right now (`None` when idle, or when this
+    /// recording never asked for it).
+    ///
+    /// The helper can die mid-recording — it is a separate process — and until now nothing told the
+    /// user. The mic keeps recording, the timer keeps counting, and the far side of the call is
+    /// simply missing from the transcript, discovered after the meeting is over and unrepeatable.
+    /// The backend already watches this every 100 ms to decide whether to un-mute the mic
+    /// (`audio::system::mic_must_be_restored`); this surfaces the same fact.
+    pub system_capture_alive: Option<bool>,
+    /// Why system capture is not live, when it is not. Plain words, no PII, `None` while healthy.
+    pub system_capture_note: Option<String>,
 }
 
 /// One stored voiceprint surfaced to a management view (opt-in voice biometrics). NEVER carries the
@@ -140,7 +151,34 @@ pub fn recording_status(state: State<'_, AppState>) -> Result<RecordingStatus, A
     } else {
         None
     };
-    Ok(recording_status_dto(&state.db, recording, meeting_id))
+    // Ask the SAME predicate the 100 ms watchdog uses, so the UI and the mic-restore decision can
+    // never disagree about whether the helper is alive.
+    let system_capture = if recording {
+        let mut recorder = state
+            .recorder
+            .lock()
+            .map_err(|_| AppError::Audio("recorder mutex poisoned".into()))?;
+        recorder.as_mut().and_then(|r| {
+            r.system.as_mut().map(|sys| {
+                if sys.can_cover_muted_mic() {
+                    (true, None)
+                } else {
+                    (
+                        false,
+                        Some("System audio stopped — only your microphone is being recorded.".into()),
+                    )
+                }
+            })
+        })
+    } else {
+        None
+    };
+    Ok(recording_status_dto(
+        &state.db,
+        recording,
+        meeting_id,
+        system_capture,
+    ))
 }
 
 /// Assemble the [`RecordingStatus`] DTO from the recorder-presence flag + the in-progress meeting id,
@@ -152,22 +190,31 @@ pub(crate) fn recording_status_dto(
     db: &crate::storage::Db,
     recording: bool,
     meeting_id: Option<String>,
+    system_capture: Option<(bool, Option<String>)>,
 ) -> RecordingStatus {
     if !recording {
         return RecordingStatus {
             recording: false,
             meeting_id: None,
             started_at: None,
+            system_capture_alive: None,
+            system_capture_note: None,
         };
     }
     let started_at = meeting_id
         .as_deref()
         .and_then(|id| db.get_meeting(id).ok().flatten())
         .map(|m| m.started_at);
+    let (system_capture_alive, system_capture_note) = match system_capture {
+        Some((alive, note)) => (Some(alive), note),
+        None => (None, None),
+    };
     RecordingStatus {
         recording: true,
         meeting_id,
         started_at,
+        system_capture_alive,
+        system_capture_note,
     }
 }
 

--- a/src-tauri/src/commands/devtools.rs
+++ b/src-tauri/src/commands/devtools.rs
@@ -20,7 +20,7 @@ use crate::error::{AppError, Result};
 /// [1, [`applog::MAX_ENTRIES`]]; omit it for [`applog::DEFAULT_ENTRIES`]. A generation that has
 /// never been written returns `exists: false` with no entries rather than an error.
 ///
-/// Prunes first, so what the view shows is exactly what is still kept: the 24 h window is enforced
+/// Prunes first, so what the view shows is exactly what is still kept: the retention window is enforced
 /// on DISK before anything is read out of it, and a stale entry can never be rendered as if it had
 /// survived. A prune failure is not allowed to withhold the log — the read proceeds and the
 /// hourly tick will try again.
@@ -53,6 +53,80 @@ pub fn reveal_app_log() -> Result<()> {
     Ok(())
 }
 
+
+/// Assemble a shareable diagnostics bundle and return its absolute path.
+///
+/// A bug report that says "it froze" is unanswerable; one that carries the app version, the OS, and
+/// the last two log generations usually answers itself. This writes exactly that, as one plain-text
+/// file the user can attach, next to the logs it is made from — the existing "reveal in Finder"
+/// command then puts them at it.
+///
+/// NO PII, BY WHAT IT IS ALLOWED TO READ rather than by filtering afterwards. Filtering assumes you
+/// can recognise personal content in arbitrary text, which is exactly the assumption that turns a
+/// redactor into a leak. Instead every part has a non-PII contract of its own: the log carries IDs,
+/// stages, counts and durations only (the rule this module already states); `AppInfo` is
+/// compile-time constants; the model section lists FILE NAMES and byte sizes, never file contents.
+/// Nothing here touches a note, transcript, timeline, title, attendee, path-with-content, or the
+/// database — so there is no read for `meeting_is_unlocked` / `visibility_clause` to gate, for the
+/// same reason the rest of this module needs none.
+#[tauri::command]
+pub fn export_diagnostics_bundle() -> Result<String> {
+    if let Err(error) = applog::prune_expired() {
+        tracing::warn!(target: "applog", %error, "log prune before bundle failed");
+    }
+    let dir = applog::log_dir()?;
+    let mut out = String::with_capacity(64 * 1024);
+    let info = crate::update::app_info();
+    out.push_str("# Murmur diagnostics bundle\n\n");
+    out.push_str(&format!("app: {} {}\n", info.name, info.version));
+    out.push_str(&format!("os: {}\n", std::env::consts::OS));
+    out.push_str(&format!("arch: {}\n", std::env::consts::ARCH));
+    out.push_str(&format!("profile: {}\n", crate::state::app_dir_name()));
+    out.push_str(&format!(
+        "log retention: {} h, cap {} MiB\n\n",
+        applog::RETENTION_HOURS,
+        applog::MAX_LOG_BYTES / (1024 * 1024)
+    ));
+
+    out.push_str("## models on disk (names and sizes only)\n\n");
+    match crate::transcribe::model::models_dir().and_then(|d| {
+        crate::transcribe::model::models_dir_file_names(&d)
+            .map_err(|e| AppError::Storage(format!("list models dir: {e}")))
+    }) {
+        Ok(names) if names.is_empty() => out.push_str("(none)\n"),
+        Ok(names) => {
+            for name in names {
+                out.push_str(&format!("- {name}\n"));
+            }
+        }
+        Err(e) => out.push_str(&format!("(unavailable: {e})\n")),
+    }
+
+    for (label, session) in [("previous", LogSession::Previous), ("current", LogSession::Current)] {
+        out.push_str(&format!("\n## log: {label}\n\n"));
+        match applog::read(session, Some(applog::MAX_ENTRIES)) {
+            Ok(log) if !log.exists => out.push_str("(no such generation)\n"),
+            Ok(log) => {
+                for entry in &log.entries {
+                    out.push_str(&format!(
+                        "{} {} {} {}\n",
+                        entry.timestamp.as_deref().unwrap_or("-"),
+                        entry.level,
+                        entry.target,
+                        entry.message
+                    ));
+                }
+            }
+            Err(e) => out.push_str(&format!("(unreadable: {e})\n")),
+        }
+    }
+
+    let path = dir.join("murmur-diagnostics.txt");
+    std::fs::write(&path, out)
+        .map_err(|e| AppError::Storage(format!("write diagnostics bundle: {e}")))?;
+    Ok(path.to_string_lossy().into_owned())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -71,5 +145,56 @@ mod tests {
         // Neither file is guaranteed to exist on a test machine; absence must still be `Ok`.
         assert!(read_app_log("current".into(), Some(5)).is_ok());
         assert!(read_app_log("previous".into(), Some(5)).is_ok());
+    }
+
+    /// The bundle stays PII-free by what it is ALLOWED TO READ, and this pins the mechanism.
+    ///
+    /// `export_diagnostics_bundle` takes NO `State<AppState>`. That is not an accident of style —
+    /// it is the guarantee: without the state there is no `Db`, so no note, transcript, timeline,
+    /// title or attendee can reach the file, and nothing has to be recognised and filtered out
+    /// afterwards. Filtering assumes you can spot personal content in arbitrary text, which is the
+    /// assumption that turns a redactor into a leak.
+    ///
+    /// So the check is a source ALLOWLIST rather than a hunt for forbidden words: a scan for
+    /// "suspicious" strings is always cheaper to slip past than to defend, while adding a state
+    /// parameter is a visible, deliberate act that fails here immediately.
+    ///
+    /// RED CONTROL (run 2026-09-03): giving the command a `state: State<'_, AppState>` parameter
+    /// fails this test.
+    #[test]
+    fn the_diagnostics_bundle_cannot_reach_the_database() {
+        let source = std::fs::read_to_string(
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("src")
+                .join("commands")
+                .join("devtools.rs"),
+        )
+        .expect("devtools.rs must be readable");
+        let sig_at = source
+            .find("pub fn export_diagnostics_bundle(")
+            .expect("the command is gone — update this oracle deliberately");
+        let open = sig_at + source[sig_at..].find('(').unwrap();
+        let close = sig_at + source[sig_at..].find(')').unwrap();
+        let params = &source[open + 1..close];
+        assert!(
+            params.trim().is_empty(),
+            "the bundle command must take NO parameters — it has `{params}`. A `State<AppState>` \
+             here would put the whole database one call away from a file the user mails out."
+        );
+
+        // And the body must not reach the DB by any other route.
+        let body_start = close;
+        let body_end = source[body_start..]
+            .find("\n}\n")
+            .map(|i| body_start + i)
+            .unwrap_or(source.len());
+        let body = &source[body_start..body_end];
+        for forbidden in ["AppState", "state.db", "Db::", "list_meetings", "get_note"] {
+            assert!(
+                !body.contains(forbidden),
+                "the bundle body references `{forbidden}` — the no-PII contract rests on it not \
+                 having a route to meeting content at all"
+            );
+        }
     }
 }

--- a/src-tauri/src/commands/documents.rs
+++ b/src-tauri/src/commands/documents.rs
@@ -494,7 +494,7 @@ async fn delete_document_inner_notifying(
             "task sources must be deleted through the task lifecycle".into(),
         ));
     }
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     state.db.begin_org_source_closure("document", id)?;
     // REVOKE-BEFORE-DELETE (Bug A root cause): tear down every LIVE org share of this exact source
     // BEFORE the local row disappears, so the background org-sync tick can never re-pull a still-live

--- a/src-tauri/src/commands/folders.rs
+++ b/src-tauri/src/commands/folders.rs
@@ -677,7 +677,7 @@ pub async fn delete_folder(
     state: State<'_, AppState>,
     folder_id: String,
 ) -> Result<(), AppError> {
-    let _share_mutation = state.org_share_mutation_lock.lock().await;
+    let _share_mutation = state.lock_org_mutation().await;
     delete_folder_inner(state.inner(), folder_id)?;
     emit_ask_history_invalidated_fail_closed(&app);
     Ok(())

--- a/src-tauri/src/commands/lock.rs
+++ b/src-tauri/src/commands/lock.rs
@@ -163,7 +163,7 @@ pub async fn lock_folder(
             "the task folder cannot be locked".into(),
         ));
     }
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     // PRE-FLIGHT the whole subtree before anything seals. A container can hold containers now, so
     // locking one seals everything inside it (see `lock_container_subtree`) — and this refusal is
     // a property the caller can fix and would want to fix before any container changed state.
@@ -227,7 +227,7 @@ pub async fn lock_folder_allow_remote_access(
             "the task folder cannot be locked".into(),
         ));
     }
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     // The WHOLE subtree, because this command now seals the whole subtree. A descendant already
     // mid-revocation is the same race the target's check exists to refuse, and the cascade would
     // otherwise walk straight into it. This command deliberately opens NO closure of its own — it
@@ -986,7 +986,7 @@ pub async fn unlock_folder(
     // The lock-state race this does NOT need to cover is covered elsewhere: the restore below takes
     // `lifecycle_guard` for its whole synchronous body, which is what serializes against a
     // concurrent `lock_folder` / `relock_all_inner`.
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
 
     // RE-VALIDATE: everything above — `folder`, the `folder.locked` refusal,
     // `preflight_unlock_subtree`, `folder_wrapped_key` — was read BEFORE this lock was held, with an
@@ -1576,7 +1576,7 @@ pub(crate) fn relock_all_inner_with_visibility_notice(
 /// `.md` to the vault. The folder returns to the default OPEN state.
 #[tauri::command]
 pub async fn remove_lock(state: State<'_, AppState>, folder_id: String) -> Result<(), AppError> {
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     remove_lock_inner(state.inner(), folder_id)
 }
 
@@ -1840,7 +1840,7 @@ pub async fn discard_unrecoverable_folder_lock(
     state: State<'_, AppState>,
     folder_id: String,
 ) -> Result<FolderNode, AppError> {
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     let node =
         discard_unrecoverable_folder_lock_with_enumeration(state.inner(), folder_id, None, || {
             emit_ask_history_invalidated_fail_closed(&app)
@@ -2034,7 +2034,7 @@ pub async fn discard_unrecoverable_meeting_lock(
     state: State<'_, AppState>,
     meeting_id: String,
 ) -> Result<Option<FolderNode>, AppError> {
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     let Some(folder_id) = state.db.folder_for_meeting(&meeting_id)? else {
         return Ok(None);
     };

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1391,7 +1391,7 @@ pub async fn start_recording(
     // Same lock order as the lock/share commands. The first check above makes invalid starts
     // side-effect-free; this authoritative check closes reparent/lock/closure races after the long
     // model-quiescence awaits and stays held through the canonical meeting insert.
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     let _recording_lifecycle = state
         .lifecycle
         .lock()
@@ -3731,7 +3731,7 @@ async fn convert_meeting_to_note_inner_with(
     // Canonical order shared by every note move/share mutation: org mutation first, then the short
     // non-reentrant lock lifecycle interval inside persistence. Provider work has already finished,
     // so neither mutex is held across inference/network awaits.
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     persist_converted_companion_under_snapshot(
         state,
         &meeting_id,
@@ -4055,7 +4055,7 @@ async fn delete_companion_note_if_empty_inner_notifying(
     if !companion_body_is_empty(&row.text) {
         return Ok(false);
     }
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     // The first snapshot was taken before waiting for the async mutation authority. Re-establish
     // emptiness under lifecycle immediately before installing the durable close barrier: an editor
     // that won the wait must keep both its content and its shares.
@@ -4557,7 +4557,7 @@ async fn delete_meeting_inner_notifying(
             ));
         }
     }
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     state.db.begin_org_source_closure("meeting", meeting_id)?;
     // REVOKE-BEFORE-DELETE (Bug A root cause): tear down every LIVE org share of this exact meeting
     // BEFORE the local rows disappear, so the background org-sync tick can never re-pull a still-live
@@ -9959,7 +9959,7 @@ async fn move_note_under_org_share_mutation_lock<T>(
     state: &AppState,
     operation: impl FnOnce(&AppState) -> Result<T, AppError>,
 ) -> Result<T, AppError> {
-    let _share_mutation = state.org_share_mutation_lock.lock().await;
+    let _share_mutation = state.lock_org_mutation().await;
     operation(state)
 }
 

--- a/src-tauri/src/commands/note_organize.rs
+++ b/src-tauri/src/commands/note_organize.rs
@@ -835,7 +835,7 @@ pub async fn apply_organize_plan(
     state: State<'_, AppState>,
     plan: OrganizePlan,
 ) -> Result<OrganizeApplyResult, AppError> {
-    let _share_mutation = state.org_share_mutation_lock.lock().await;
+    let _share_mutation = state.lock_org_mutation().await;
     apply_organize_plan_inner(state.inner(), plan)
 }
 

--- a/src-tauri/src/commands/notes.rs
+++ b/src-tauri/src/commands/notes.rs
@@ -619,7 +619,7 @@ pub async fn move_note_doc(
     id: String,
     folder_id: String,
 ) -> Result<(), AppError> {
-    let _share_mutation = state.org_share_mutation_lock.lock().await;
+    let _share_mutation = state.lock_org_mutation().await;
     let target_locked = state
         .db
         .folder_by_id(&folder_id)?
@@ -853,7 +853,7 @@ async fn delete_note_inner_notifying(
             "unlock this folder to delete a note",
         )));
     }
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     state.db.begin_org_source_closure("document", id)?;
     // REVOKE-BEFORE-DELETE (Bug A root cause): tear down every LIVE org share of this exact note
     // BEFORE the local row disappears, so the background org-sync tick can never re-pull a still-live
@@ -1243,7 +1243,7 @@ pub async fn delete_note_folder(
     state: State<'_, AppState>,
     id: String,
 ) -> Result<(), AppError> {
-    let _share_mutation = state.org_share_mutation_lock.lock().await;
+    let _share_mutation = state.lock_org_mutation().await;
     if state.db.note_folder_by_id(&id)?.is_none() {
         return Err(AppError::InvalidArg(format!("no note folder {id}")));
     }
@@ -1261,7 +1261,7 @@ pub async fn move_note_folder(
     id: String,
     parent_id: Option<String>,
 ) -> Result<(), AppError> {
-    let _share_mutation = state.org_share_mutation_lock.lock().await;
+    let _share_mutation = state.lock_org_mutation().await;
     move_note_folder_inner(state.inner(), &id, parent_id.as_deref())
 }
 

--- a/src-tauri/src/commands/org.rs
+++ b/src-tauri/src/commands/org.rs
@@ -435,7 +435,7 @@ pub async fn share_note_to_link(
     password: Option<String>,
     max_downloads: Option<u32>,
 ) -> Result<String, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     share_note_to_link_inner(
         state.inner(),
         meeting_id,
@@ -634,7 +634,7 @@ pub async fn share_note_to_link_doc(
     password: Option<String>,
     max_downloads: Option<u32>,
 ) -> Result<String, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     share_note_to_link_doc_inner(state.inner(), id, expires_days, password, max_downloads).await
 }
 
@@ -935,7 +935,7 @@ fn my_share_local_title_under_lifecycle(
 /// `revoke_share(share_id)` — DELETE the server ciphertext + flip the local state. Idempotent.
 #[tauri::command]
 pub async fn revoke_share(state: State<'_, AppState>, share_id: String) -> Result<(), AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     revoke_share_inner(state.inner(), share_id).await
 }
 
@@ -1379,7 +1379,7 @@ pub async fn share_note_to_user(
     recipient_email: String,
     expires_days: Option<u32>,
 ) -> Result<ShareToUserResult, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     share_note_to_user_inner(state.inner(), meeting_id, recipient_email, expires_days).await
 }
 
@@ -1657,7 +1657,7 @@ pub(crate) fn assemble_user_share_request(
 /// number of shares advanced to `sent`.
 #[tauri::command]
 pub async fn share_rewrap_pending(state: State<'_, AppState>) -> Result<u32, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     share_rewrap_pending_inner(state.inner()).await
 }
 
@@ -2813,7 +2813,7 @@ pub(crate) async fn acquire_org_ock_for_test(
 /// the owner can immediately seal items. Caches the org + generation-1 OCK locally.
 #[tauri::command]
 pub async fn org_create(state: State<'_, AppState>, name: String) -> Result<OrgStatus, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     org_create_inner(state.inner(), name).await
 }
 
@@ -3203,10 +3203,13 @@ pub(crate) const SHARE_MUTATION_WAIT: std::time::Duration = std::time::Duration:
 pub(crate) async fn acquire_share_mutation_within(
     state: &AppState,
     wait: std::time::Duration,
-) -> Result<tokio::sync::MutexGuard<'_, ()>, AppError> {
-    match tokio::time::timeout(wait, state.org_share_mutation_lock.lock()).await {
-        Ok(guard) => Ok(guard),
-        Err(_) => Err(AppError::Unavailable(crate::errcode::tag(
+) -> Result<crate::state::OrgMutationGuard<'_>, AppError> {
+    // Through the guard like every other door: this bounded-wait variant is a SECOND way to
+    // take the same mutex, and a re-entrancy check that misses it misses exactly the kind of
+    // path the deadlock it exists for was reached through.
+    match state.lock_org_mutation_within(wait).await {
+        Some(guard) => Ok(guard),
+        None => Err(AppError::Unavailable(crate::errcode::tag(
             crate::errcode::SHARE_BUSY,
             "another sharing operation is still running",
         ))),
@@ -3541,7 +3544,7 @@ pub async fn org_invite_member(
     org_id: String,
     email: String,
 ) -> Result<(), AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     org_invite_member_inner(state.inner(), org_id, email).await
 }
 
@@ -3957,7 +3960,7 @@ pub async fn org_remove_member(
     org_id: String,
     user_id: String,
 ) -> Result<(), AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     org_remove_member_inner(state.inner(), org_id, user_id).await
 }
 
@@ -4033,7 +4036,7 @@ pub async fn org_leave(
     state: State<'_, AppState>,
     org_id: String,
 ) -> Result<(), AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     let org = resolve_org(state.inner(), &org_id)?;
     let base = share_base_url(state.inner())?;
     let access = valid_access_token(state.inner()).await?;
@@ -4587,7 +4590,7 @@ pub(crate) async fn share_to_org_placed_notifying(
     placement: Option<ContainerPlacement>,
     app: Option<&AppHandle>,
 ) -> Result<OrgShareEntry, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     share_to_org_inner_with_policy(
         state,
         org_id,
@@ -7675,7 +7678,7 @@ pub(crate) async fn republish_org_shares_for_source(
     meeting_id: Option<&str>,
     document_id: Option<&str>,
 ) -> Result<u32, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     republish_org_shares_for_source_with_policy(
         state,
         meeting_id,
@@ -7692,7 +7695,7 @@ pub(crate) async fn republish_org_shares_for_source_notifying(
     document_id: Option<&str>,
     app: &AppHandle,
 ) -> Result<u32, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     republish_org_shares_for_source_with_policy(
         state,
         meeting_id,
@@ -8987,7 +8990,7 @@ pub async fn revoke_org_share(
     state: State<'_, AppState>,
     item_id: String,
 ) -> Result<(), AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     revoke_org_share_inner_with_policy(state.inner(), item_id, OrgWorkPolicy::manual(), Some(&app))
         .await?;
     crate::events::emit_org_feed_updated(&app, 1);
@@ -9004,7 +9007,7 @@ pub(crate) async fn revoke_org_share_notifying(
     item_id: String,
     notifier: &dyn OrgFeedNotifier,
 ) -> Result<(), AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     revoke_org_share_inner_with_policy(state, item_id, OrgWorkPolicy::manual(), None).await?;
     notifier.org_feed_updated(1);
     Ok(())
@@ -9015,7 +9018,7 @@ pub(crate) async fn revoke_org_share_inner(
     state: &AppState,
     item_id: String,
 ) -> Result<(), AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     revoke_org_share_inner_with_policy(state, item_id, OrgWorkPolicy::manual(), None).await
 }
 
@@ -9373,7 +9376,7 @@ pub async fn revoke_shares_for_folder(
     state: State<'_, AppState>,
     folder_id: String,
 ) -> Result<(), AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     state.db.begin_org_folder_closure(&folder_id)?;
     revoke_shares_for_folder_inner(state.inner(), &folder_id, Some(&app)).await
 }
@@ -9542,7 +9545,7 @@ pub(crate) async fn org_background_sync_tick(state: &AppState, app: Option<AppHa
     // Reconcile membership FIRST so a newly-invited org is present (and synced this same tick) and a
     // departed org is dropped before we pull its feed. Best-effort — a failure never blocks the sync.
     {
-        let _mutation = state.org_share_mutation_lock.lock().await;
+        let _mutation = state.lock_org_mutation().await;
         if let Err(e) = org_reconcile_memberships_with_policy(state, policy, app.as_ref()).await {
             tracing::warn!(target: "org", error = %brief_err(&e), "org membership reconcile tick failed");
         }
@@ -9551,7 +9554,7 @@ pub(crate) async fn org_background_sync_tick(state: &AppState, app: Option<AppHa
         return false;
     }
     {
-        let _mutation = state.org_share_mutation_lock.lock().await;
+        let _mutation = state.lock_org_mutation().await;
         if let Err(e) = org_sweep_pending_with_policy(state, policy, app.as_ref()).await {
             tracing::warn!(target: "org", error = %e, "org outbound sweep tick failed");
         }
@@ -9586,7 +9589,7 @@ pub(crate) async fn org_background_sync_tick(state: &AppState, app: Option<AppHa
         return false;
     }
     let report = {
-        let _mutation = state.org_share_mutation_lock.lock().await;
+        let _mutation = state.lock_org_mutation().await;
         match org_sync_now_inner_with_policy(state, policy, app.clone()).await {
             Ok(r) => r,
             Err(e) => {
@@ -9643,13 +9646,13 @@ pub async fn org_sweep_pending(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<u32, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     org_sweep_pending_with_policy(state.inner(), OrgWorkPolicy::manual(), Some(&app)).await
 }
 
 #[cfg(test)]
 pub(crate) async fn org_sweep_pending_inner(state: &AppState) -> Result<u32, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     org_sweep_pending_with_policy(state, OrgWorkPolicy::manual(), None).await
 }
 
@@ -9657,7 +9660,7 @@ pub(crate) async fn org_sweep_pending_inner(state: &AppState) -> Result<u32, App
 pub(crate) async fn org_sweep_pending_background_once_inner(
     state: &AppState,
 ) -> Result<u32, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     org_sweep_pending_with_policy(
         state,
         OrgWorkPolicy::background(crate::perf::background_epoch()),
@@ -10218,7 +10221,7 @@ pub async fn org_sync_now(
     state: State<'_, AppState>,
     org_id: Option<String>,
 ) -> Result<crate::storage::models::OrgSyncReport, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     // The FE passes a SPECIFIC org id (→ sync only that org); the background tick / internal callers
     // pass `None` (→ sync the next round-robin org). This is the command-boundary
     // dispatch of the multi-org fix: a user-triggered "Sync now" from a picked org must not sync (or
@@ -10367,7 +10370,7 @@ pub(crate) async fn org_sync_one_now_inner(
     state: &AppState,
     org_id: &str,
 ) -> Result<crate::storage::models::OrgSyncReport, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     org_sync_one_now_with_app(state, org_id, None).await
 }
 
@@ -10384,7 +10387,7 @@ pub(crate) async fn org_sync_one_now_with_pre_task_reader(
     state: &AppState,
     org_id: &str,
 ) -> Result<crate::storage::models::OrgSyncReport, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     org_sync_one_now_with_app_and_policy(state, org_id, None, OrgWorkPolicy::pre_task_reader()).await
 }
 
@@ -10434,7 +10437,7 @@ async fn org_sync_one_now_with_app_and_policy(
 pub(crate) async fn org_sync_now_inner(
     state: &AppState,
 ) -> Result<crate::storage::models::OrgSyncReport, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     org_sync_now_inner_with_policy(state, OrgWorkPolicy::manual(), None).await
 }
 
@@ -11084,7 +11087,7 @@ async fn org_sync_one(
 /// `org_background_sync_tick`; this is the direct entry point for internal callers and for the
 /// regression tests that drive the sweep against a mock feed.
 pub async fn org_reconcile_now_inner(state: &AppState) -> Result<u32, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     org_reconcile_tick_with_policy(state, OrgWorkPolicy::manual(), None).await
 }
 
@@ -11850,7 +11853,7 @@ pub async fn add_org_item_to_container(
     item_id: String,
     container_id: String,
 ) -> Result<crate::storage::models::OrgItemImportResult, AppError> {
-    let _org_mutation = state.org_share_mutation_lock.lock().await;
+    let _org_mutation = state.lock_org_mutation().await;
     add_org_item_to_container_inner(state.inner(), &item_id, &container_id)
 }
 
@@ -11967,7 +11970,7 @@ pub(crate) async fn org_set_item_access_inner(
     item_id: &str,
     access: crate::share::org_dto::OrgItemAccess,
 ) -> Result<(), AppError> {
-    let _mutation = st.org_share_mutation_lock.lock().await;
+    let _mutation = st.lock_org_mutation().await;
     let ctx = match st.db.org_item_edit_ctx(item_id)? {
         Some(ctx) => ctx,
         None => {
@@ -12157,7 +12160,7 @@ pub(crate) async fn org_update_own_item_notifying(
     markdown: &str,
     app: Option<&AppHandle>,
 ) -> Result<String, AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     // Resolve the item's edit context (org, current rev, original created_at/source_kind, author id).
     let ctx = state
         .db
@@ -12624,7 +12627,7 @@ pub(crate) async fn delete_org_item_as_author_notifying(
     item_id: &str,
     app: Option<&AppHandle>,
 ) -> Result<(), AppError> {
-    let _mutation = state.org_share_mutation_lock.lock().await;
+    let _mutation = state.lock_org_mutation().await;
     let item_id = item_id.trim();
     if item_id.is_empty() {
         return Err(AppError::InvalidArg("item id required".into()));

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -7388,7 +7388,7 @@
             |_ck: &[u8; 32], _blob: &[u8], _aad: &[u8]| -> Result<Vec<u8>, AppError> {
                 Ok(b"not the attachment plaintext".to_vec())
             };
-        let _org_mutation = block_on(state.org_share_mutation_lock.lock());
+        let _org_mutation = block_on(state.lock_org_mutation());
         let error = persist_converted_companion_under_snapshot_with_attachment_verifier(
             &state,
             MEETING,
@@ -8368,7 +8368,7 @@
 
         // Keep cleanup queued before its authoritative recheck. The editor wins while cleanup is
         // waiting, so the recheck must return false without touching the remote-share journal.
-        let mutation = block_on(state.org_share_mutation_lock.lock());
+        let mutation = block_on(state.lock_org_mutation());
         let cleanup_state = state.clone();
         let (started_tx, started_rx) = std::sync::mpsc::channel();
         let cleanup = std::thread::spawn(move || {

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -22860,6 +22860,41 @@
     // `Recorder` needs mic hardware (can't be built headless), so we test the pure DTO builder that
     // the command delegates to.
 
+    /// A dead system-audio helper must be VISIBLE in the status, with a reason.
+    ///
+    /// The helper is a separate process and can die mid-recording. The mic keeps recording and
+    /// the timer keeps counting, so the far side of the call simply goes missing from the
+    /// transcript — discovered after a meeting nobody can repeat. The backend already watches
+    /// this every 100 ms to decide whether to un-mute the mic; before this it never said so.
+    ///
+    /// Asserts the HEALTHY case too: a status that always warned would pass the first
+    /// assertion and be worse than saying nothing.
+    #[test]
+    fn recording_status_surfaces_a_dead_system_audio_helper() {
+        let state = build_state("system-capture-status");
+        let dead = recording_status_dto(
+            &state.db,
+            true,
+            Some("live-1".to_string()),
+            Some((false, Some("System audio stopped — only your microphone is being recorded.".into()))),
+        );
+        assert_eq!(dead.system_capture_alive, Some(false));
+        assert!(
+            dead.system_capture_note
+                .as_deref()
+                .is_some_and(|n| n.contains("microphone")),
+            "a dead helper must explain itself in words the user can act on"
+        );
+        let live = recording_status_dto(&state.db, true, Some("live-1".to_string()), Some((true, None)));
+        assert_eq!(live.system_capture_alive, Some(true));
+        assert!(
+            live.system_capture_note.is_none(),
+            "a healthy capture must carry no warning — otherwise the warning means nothing"
+        );
+        let idle = recording_status_dto(&state.db, false, None, None);
+        assert_eq!(idle.system_capture_alive, None);
+    }
+
     #[test]
     fn recording_status_reports_idle_when_not_recording() {
         let state = build_state("recstatus-idle");
@@ -22878,7 +22913,7 @@
                 folder_id: None,
             })
             .unwrap();
-        let st = recording_status_dto(&state.db, false, Some("ghost".to_string()));
+        let st = recording_status_dto(&state.db, false, Some("ghost".to_string()), None);
         assert!(!st.recording);
         assert_eq!(st.meeting_id, None);
         assert_eq!(st.started_at, None);
@@ -22900,7 +22935,7 @@
                 folder_id: None,
             })
             .unwrap();
-        let st = recording_status_dto(&state.db, true, Some("live-1".to_string()));
+        let st = recording_status_dto(&state.db, true, Some("live-1".to_string()), None);
         assert!(st.recording);
         assert_eq!(st.meeting_id.as_deref(), Some("live-1"));
         // The FE anchors its elapsed timer to THIS, not an epoch-sized value.
@@ -22912,7 +22947,7 @@
         // Recording is true but the row can't be read → still report recording, just drop the anchor
         // (the FE falls back to "now"); the status read must never fail on a best-effort lookup.
         let state = build_state("recstatus-norow");
-        let st = recording_status_dto(&state.db, true, Some("no-such-meeting".to_string()));
+        let st = recording_status_dto(&state.db, true, Some("no-such-meeting".to_string()), None);
         assert!(st.recording);
         assert_eq!(st.meeting_id.as_deref(), Some("no-such-meeting"));
         assert_eq!(st.started_at, None);

--- a/src-tauri/src/commands/tests/org_diagnosability_tests.rs
+++ b/src-tauri/src/commands/tests/org_diagnosability_tests.rs
@@ -88,7 +88,7 @@ fn brief_err_still_classifies_the_other_arms() {
 async fn a_held_share_mutation_lock_yields_busy_rather_than_hanging() {
     let state = AppState::for_tests(fresh_db("busy-lock"));
 
-    let held = state.org_share_mutation_lock.lock().await;
+    let held = state.lock_org_mutation().await;
 
     let started = std::time::Instant::now();
     let outcome = acquire_share_mutation_within(&state, std::time::Duration::from_millis(50)).await;

--- a/src-tauri/src/commands/tests/org_mutex_scope_tests.rs
+++ b/src-tauri/src/commands/tests/org_mutex_scope_tests.rs
@@ -102,7 +102,11 @@ fn body_of(file: &str, name: &str) -> String {
     panic!("{file}: `{name}` has no closing brace");
 }
 
-const ACQUIRE: &str = "org_share_mutation_lock";
+/// Every acquisition now goes through the ONE helper (see
+/// `nothing_takes_the_org_mutex_except_the_one_helper`), so that call — not the field name — is
+/// what these oracles look for. Matching the field would silently stop finding anything the moment
+/// the door was renamed, which is how a source oracle goes quietly vacuous.
+const ACQUIRE: &str = "lock_org_mutation(";
 
 /// `unlock_folder` must not hold the org mutex across the Touch ID sheet.
 ///
@@ -268,5 +272,53 @@ fn unlock_folder_revalidates_the_visibility_snapshot_after_taking_the_org_mutex(
         acquire < require,
         "the re-validation must happen AFTER the mutex is held (acquire {acquire}, require \
          {require}), or it can be invalidated again before the restore"
+    );
+}
+
+/// Every acquisition of the org mutex goes through `AppState::lock_org_mutation`.
+///
+/// The debug re-entrancy guard lives in that one helper, and a guard that covers SOME call sites
+/// covers none of the ones that matter: the deadlock it exists for was reached three levels deep,
+/// through a callee nobody was thinking about (`reconcile_container_shares` ->
+/// `reconcile_one_container_root` -> `share_to_org_placed_notifying`). One raw `.lock()` anywhere
+/// is a hole in exactly the place a future author will not be looking.
+///
+/// `state.rs` is the sole exemption — it is where the helper takes the real lock.
+///
+/// RED CONTROL (run 2026-09-03): rewriting any single call site back to
+/// `state.org_share_mutation_lock.lock().await` fails this test naming that file and line.
+#[test]
+fn nothing_takes_the_org_mutex_except_the_one_helper() {
+    let src = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut raw = Vec::new();
+    let mut stack = vec![src.clone()];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).unwrap_or_else(|e| panic!("read {dir:?}: {e}")) {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if !(name.ends_with(".rs") || name.ends_with(".inc")) || name == "state.rs" {
+                continue;
+            }
+            let text = strip_comments(&std::fs::read_to_string(&path).unwrap_or_default());
+            for (i, line) in text.lines().enumerate() {
+                // Skip STRING LITERALS: this test's own assertion message names both the field
+                // and `.lock()`, and so does prose in error copy. A check that flags itself is a
+                // check nobody will keep.
+                let code = line.split('"').step_by(2).collect::<String>();
+                if code.contains("org_share_mutation_lock") && code.contains(".lock()") {
+                    let rel = path.strip_prefix(&src).unwrap_or(&path).display().to_string();
+                    raw.push(format!("{rel}:{}", i + 1));
+                }
+            }
+        }
+    }
+    assert!(
+        raw.is_empty(),
+        "these take `org_share_mutation_lock` directly instead of `lock_org_mutation()`, so the \
+         debug re-entrancy guard cannot see them: {raw:?}"
     );
 }

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -887,7 +887,7 @@ pub async fn apply_workspace_organization(
     state: State<'_, AppState>,
     moves: Vec<WorkspaceOrganizeMove>,
 ) -> Result<WorkspaceOrganizeApplyResult, AppError> {
-    let _share_mutation = state.org_share_mutation_lock.lock().await;
+    let _share_mutation = state.lock_org_mutation().await;
     apply_workspace_organization_inner(&state.db, moves, |item_id, target_id| {
         file_recording_command_body(&app, state.inner(), item_id, Some(target_id))
     })

--- a/src-tauri/src/instance_lock.rs
+++ b/src-tauri/src/instance_lock.rs
@@ -42,11 +42,28 @@ pub(crate) enum StartupRefusal {
     GuardUnavailable,
 }
 
+/// The single-instance lock file, scoped to the dev/release split.
+///
+/// Dev and release keep deliberately separate databases and app-support directories
+/// (`state::app_dir_name`), but this lock used ONE fixed filename for both — so a debug build and
+/// an installed release refused to run at the same time, each reporting the other as "already
+/// running", even though they share no state at all.
+///
+/// The DIRECTORY stays `com.meetnotes.app` and the RELEASE FILENAME is unchanged. That is
+/// deliberate: putting the discriminator in a subdirectory would move the release path too, and
+/// during an upgrade an already-running old instance would hold the old path while the new binary
+/// took the new one — briefly admitting two live instances, which is the single thing this file
+/// exists to prevent. Only the dev build gets a different name.
 fn lock_path() -> Result<PathBuf> {
     let base = dirs::data_dir().ok_or_else(|| {
         AppError::Unavailable("could not resolve the single-instance coordination directory".into())
     })?;
-    Ok(base.join("com.meetnotes.app").join("murmur.instance.lock"))
+    let name = if crate::state::app_dir_name() == "MeetNotes" {
+        "murmur.instance.lock"
+    } else {
+        "murmur-dev.instance.lock"
+    };
+    Ok(base.join("com.meetnotes.app").join(name))
 }
 
 pub(crate) fn acquire() -> Result<AcquireResult> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -252,6 +252,7 @@ pub fn run() {
             // Developer mode — the on-device log reader (Settings → Developer → Logs).
             commands::read_app_log,
             commands::clear_app_log,
+            commands::export_diagnostics_bundle,
             commands::reveal_app_log,
             // Brain v2 L5 — scheduled briefs (schedule CRUD + propose-accept runs).
             commands::list_brief_schedules,

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -641,6 +641,54 @@ enum MasterPointerKind {
 }
 
 /// Persist a managed master pointer and reconcile SQLite's ambiguous-error window. A confirmed
+/// The segments a decode window OWNS, renumbered contiguously.
+///
+/// Each window emits only what ENDS before the next window begins; the next window has the
+/// boundary in full and emits it instead. That does two jobs at once: a word straddling the
+/// boundary is decoded by the window that can actually see all of it, AND the result is
+/// deduplicated BY CONSTRUCTION — there is no window in which the same span is emitted twice, so
+/// no text or timestamp matching is needed and none can go wrong. Matching would have been the
+/// obvious approach and the fragile one: two decodes of the same audio do not have to agree on
+/// either the wording or the exact boundaries, which is precisely why they were worth overlapping.
+///
+/// The final window has no successor, so it keeps its tail.
+///
+/// Split out of [`transcribe_raw_windows`] because that function needs a loaded whisper model and
+/// cannot run in a unit test, while this rule — the part that can silently drop or duplicate a
+/// user's words — can.
+pub(crate) fn own_window_segments(
+    segments: Vec<crate::transcribe::types::Segment>,
+    boundary_s: f64,
+    is_last: bool,
+    next_idx: &mut i64,
+) -> Vec<crate::transcribe::types::Segment> {
+    let mut owned = Vec::with_capacity(segments.len());
+    for mut segment in segments {
+        if !is_last && segment.end_s > boundary_s {
+            continue;
+        }
+        segment.idx = *next_idx;
+        *next_idx += 1;
+        owned.push(segment);
+    }
+    owned
+}
+
+/// Length of one decode window, in seconds.
+const DECODE_WINDOW_S: usize = 120;
+
+/// How much each decode window overlaps the previous one.
+///
+/// Windows used to be read back-to-back, so a word spoken across the 120 s boundary was cut in
+/// half and each half was decoded WITHOUT the other's context — the boundary word came out
+/// mangled or missing, silently, once every two minutes of every long recording.
+///
+/// Five seconds is chosen to comfortably exceed a spoken sentence rather than a word: whisper's
+/// own segmentation works on utterances, so an overlap shorter than an utterance can still split
+/// one. The cost is bounded and small — 5 s re-decoded per 115 s of audio is ~4% more decode work,
+/// and it buys back a defect that was destroying content rather than merely slowing things down.
+const DECODE_OVERLAP_S: usize = 5;
+
 /// absent/different pointer authorizes exact deletion of only the just-published inode; an
 /// unreadable DB preserves both the managed file and the ARCHIVED generation for recovery.
 fn persist_master_pointer_or_reconcile(
@@ -1139,12 +1187,15 @@ fn transcribe_raw_windows(
     vad_path: Option<&Path>,
     normalize: bool,
 ) -> Result<Vec<crate::transcribe::types::Segment>> {
-    const WINDOW_FRAMES: usize = 120 * audio::TARGET_RATE_HZ as usize;
+    const WINDOW_FRAMES: usize = DECODE_WINDOW_S * audio::TARGET_RATE_HZ as usize;
+    const OVERLAP_FRAMES: usize = DECODE_OVERLAP_S * audio::TARGET_RATE_HZ as usize;
+    const STRIDE_FRAMES: u64 = (WINDOW_FRAMES - OVERLAP_FRAMES) as u64;
     let mut source = RawF32LeSource::open(path, audio::TARGET_RATE_HZ)?;
     let mut all = Vec::new();
     let mut offset = 0u64;
     let mut next_idx = 0i64;
     let mut vad = vad_path.and_then(|model| crate::transcribe::vad::VadSegmenter::load(model).ok());
+    let mut pinned_language: Option<String> = language.map(str::to_string);
     while offset < source.frames() {
         let mut window = source.read_frames(offset, WINDOW_FRAMES)?;
         if window.is_empty() {
@@ -1154,15 +1205,30 @@ fn transcribe_raw_windows(
             audio::normalize_for_asr(&mut window);
         }
         let offset_s = offset as f64 / audio::TARGET_RATE_HZ as f64;
-        let mut segments = transcribe_stream(transcriber, vad.as_mut(), &window, language)?;
+        // Carry the pinned language ACROSS outer windows too, or each 120 s window would start
+        // detection over and the flip this prevents would simply move up a level.
+        let (mut segments, detected) =
+            transcribe_stream(transcriber, vad.as_mut(), &window, pinned_language.as_deref())?;
+        if pinned_language.is_none() {
+            pinned_language = detected;
+        }
         for segment in &mut segments {
-            segment.idx = next_idx;
             segment.start_s += offset_s;
             segment.end_s += offset_s;
-            next_idx += 1;
         }
-        all.extend(segments);
-        offset += window.len() as u64;
+        let next_offset = offset + STRIDE_FRAMES;
+        let is_last = next_offset >= source.frames() || window.len() < WINDOW_FRAMES;
+        let boundary_s = next_offset as f64 / audio::TARGET_RATE_HZ as f64;
+        all.extend(own_window_segments(
+            segments,
+            boundary_s,
+            is_last,
+            &mut next_idx,
+        ));
+        if is_last {
+            break;
+        }
+        offset = next_offset;
     }
     Ok(all)
 }
@@ -1347,7 +1413,7 @@ fn transcribe_stream(
     vad: Option<&mut crate::transcribe::vad::VadSegmenter>,
     samples_16k: &[f32],
     lang: Option<&str>,
-) -> Result<Vec<crate::transcribe::types::Segment>> {
+) -> Result<(Vec<crate::transcribe::types::Segment>, Option<String>)> {
     use crate::transcribe::TranscribeQuality;
 
     let regions: Vec<(usize, usize)> = match vad {
@@ -1366,14 +1432,28 @@ fn transcribe_stream(
 
     let mut out: Vec<crate::transcribe::types::Segment> = Vec::new();
     let mut idx: i64 = 0;
+    // Language is DETECTED ONCE and then pinned for the rest of the stream.
+    //
+    // Every decode window used to auto-detect independently, and a decode window is far shorter
+    // than the recording — so one meeting could be decoded as Polish, then English, then Polish
+    // again, purely on which words happened to fall in a window. Whisper's own detection is
+    // weakest exactly where windows are quietest, which is where a wrong guess does most damage.
+    // The first region's answer is the one taken from the whole recording's speaker, so it is the
+    // one to trust for the rest of it.
+    //
+    // An explicit user setting always wins: `lang` non-None means detection never runs at all.
+    let mut pinned: Option<String> = lang.map(str::to_string);
     for (start, end) in regions {
         for (win_start, win_end) in decode_windows(start, end, window_len) {
             let offset_s = win_start as f64 / crate::audio::TARGET_RATE_HZ as f64;
             let tx = transcriber.transcribe_with(
                 &samples_16k[win_start..win_end],
-                lang,
+                pinned.as_deref(),
                 TranscribeQuality::Accurate,
             )?;
+            if pinned.is_none() {
+                pinned = tx.language.clone();
+            }
             for mut seg in tx.segments {
                 seg.idx = idx;
                 seg.start_s += offset_s;
@@ -1383,7 +1463,7 @@ fn transcribe_stream(
             }
         }
     }
-    Ok(out)
+    Ok((out, pinned))
 }
 
 /// Split a `[start, end)` sample range into fixed-length decode windows of at most `window_len`
@@ -1792,7 +1872,7 @@ async fn run_inner(
         // FRESH decode (context reset across long gaps; never decode through silence). Live captions
         // + voice trigger keep the Fast greedy profile for latency — see transcribe::whisper.
         let mic_segments =
-            transcribe_stream(&transcriber, vad.as_mut(), &mic_16k, lang_owned.as_deref())?;
+            transcribe_stream(&transcriber, vad.as_mut(), &mic_16k, lang_owned.as_deref())?.0;
 
         let mut streams = vec![StreamInput {
             segments: mic_segments,
@@ -1806,7 +1886,7 @@ async fn run_inner(
 
         if let (Some(sys), Some(sys_started)) = (sys_16k, system_started_at) {
             let mut sys_segments =
-                transcribe_stream(&transcriber, vad.as_mut(), &sys, lang_owned.as_deref())?;
+                transcribe_stream(&transcriber, vad.as_mut(), &sys, lang_owned.as_deref())?.0;
 
             // ASR is done for both streams — free Whisper (+ VAD, also unused from here on) BEFORE
             // loading the diarizer, so the two heavy ML runtimes are never resident together.
@@ -3407,6 +3487,85 @@ fn should_auto_index(semantic_enabled: bool, embed_model_present: bool) -> bool 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── decode-window overlap + stitching (T19) ────────────────────────────────────────────────
+    /// A word spoken ACROSS a window boundary is emitted once, by the window that heard all of it.
+    ///
+    /// Windows used to be read back-to-back, so such a word was cut in half and each half decoded
+    /// without the other's context — mangled or missing, silently, once every two minutes of every
+    /// long recording. With a 5 s overlap both windows see it, and the ownership rule decides.
+    ///
+    /// RED CONTROL (run 2026-09-03): drop the `end_s > boundary_s` skip and the straddling word
+    /// appears TWICE — once truncated from the earlier window, once whole from the later one.
+    #[test]
+    fn a_word_across_a_window_boundary_is_emitted_once_by_the_window_that_heard_it_whole() {
+        let mut idx = 0i64;
+        // Window 1 covers [0, 120) and the next window starts at 115.
+        let first = own_window_segments(
+            vec![
+                seg(-1, 10.0, 12.0, None, "well inside"),
+                seg(-1, 116.0, 117.0, None, "inside the overlap"),
+                seg(-1, 119.5, 120.0, None, "strad"), // truncated at the window edge
+            ],
+            115.0,
+            false,
+            &mut idx,
+        );
+        // Window 2 covers [115, 235) and is the last one.
+        let second = own_window_segments(
+            vec![
+                seg(-1, 116.0, 117.0, None, "inside the overlap"),
+                seg(-1, 119.5, 120.5, None, "straddling"), // whole, because this window heard all of it
+                seg(-1, 130.0, 131.0, None, "after"),
+            ],
+            230.0,
+            true,
+            &mut idx,
+        );
+
+        let texts: Vec<&str> = first
+            .iter()
+            .chain(second.iter())
+            .map(|s| s.text.as_str())
+            .collect();
+        assert_eq!(
+            texts,
+            vec![
+                "well inside",
+                "inside the overlap",
+                "straddling",
+                "after"
+            ],
+            "the straddling word must appear ONCE and in its whole form, and the overlap must not \
+             duplicate the segment both windows heard"
+        );
+        assert!(
+            !texts.contains(&"strad"),
+            "the truncated half must never reach the transcript"
+        );
+        let idxs: Vec<i64> = first.iter().chain(second.iter()).map(|s| s.idx).collect();
+        assert_eq!(idxs, vec![0, 1, 2, 3], "indices stay contiguous across windows");
+    }
+
+    /// The LAST window keeps its tail — it has no successor to hand the boundary to.
+    ///
+    /// Without this the final seconds of every recording would be silently dropped, which is the
+    /// mirror-image bug of the one this overlap fixes and a far worse one.
+    #[test]
+    fn the_final_window_keeps_everything_it_heard() {
+        let mut idx = 0i64;
+        let tail = own_window_segments(
+            vec![
+                seg(-1, 200.0, 201.0, None, "second to last"),
+                seg(-1, 233.0, 234.9, None, "the very last words"),
+            ],
+            230.0,
+            true,
+            &mut idx,
+        );
+        assert_eq!(tail.len(), 2, "the last window has no successor and drops nothing");
+        assert_eq!(tail[1].text, "the very last words");
+    }
 
     // ── whisper decode windowing (P1 whisper-batch-cap) ────────────────────────────────────────
     /// A long region is tiled into ≤window_len windows that fully cover it with no gaps/overlaps, so

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -389,6 +389,139 @@ pub struct AppState {
     pub heavy_inference: Arc<tokio::sync::Semaphore>,
 }
 
+/// Debug-only bookkeeping that turns a SELF-REENTRANT acquisition of
+/// [`AppState::org_share_mutation_lock`] into a loud panic instead of a silent, permanent hang.
+///
+/// WHY (found 2026-09-03, on trunk). `org_background_sync_tick` held the mutex across
+/// `reconcile_container_shares`, whose callee `share_to_org_placed_notifying` acquires the SAME
+/// mutex as its first statement. `tokio::sync::Mutex` is not reentrant, so the task awaited a lock
+/// it already held: it never returned, its guard was never dropped, and every later org operation —
+/// sharing, revoking, `unlock_folder` — blocked for the rest of the process. The symptom was
+/// SILENCE. No error, no failing test, no log line; org sync simply stopped forever.
+///
+/// Nothing could have caught it. A green suite proves nothing about a deadlock that needs one
+/// specific call path, and a source-level oracle only sees the site it was written for. This sees
+/// the class: any path, any depth, any future author.
+///
+/// Debug-only on purpose. In release the check would cost a lock and a set lookup on every
+/// acquisition to defend against a bug that, once found, is fixed in the code — and a panic is the
+/// wrong response to ship to a user regardless.
+#[cfg(debug_assertions)]
+mod org_mutex_reentrancy {
+    use std::collections::HashSet;
+    use std::sync::{Mutex, OnceLock};
+
+    /// One id per in-flight holder. A tokio task id where there is one, else the OS thread id —
+    /// `run_heavy`'s blocking closures have no task id, and they hold this lock too.
+    fn holder_id() -> u64 {
+        match tokio::task::try_id() {
+            // `Id` has no numeric accessor, and its Display is the number.
+            Some(id) => id.to_string().parse().unwrap_or(u64::MAX),
+            None => {
+                let t = std::thread::current().id();
+                // Thread ids are opaque too; hash them into the same space. A collision between a
+                // thread and a task id would only ever cause a FALSE panic in a debug build, which
+                // is loud and immediately investigable — never a missed deadlock.
+                use std::hash::{Hash, Hasher};
+                let mut h = std::collections::hash_map::DefaultHasher::new();
+                t.hash(&mut h);
+                h.finish() | (1 << 63)
+            }
+        }
+    }
+
+    fn holders() -> &'static Mutex<HashSet<u64>> {
+        static HOLDERS: OnceLock<Mutex<HashSet<u64>>> = OnceLock::new();
+        HOLDERS.get_or_init(|| Mutex::new(HashSet::new()))
+    }
+
+    pub(super) fn enter() {
+        let id = holder_id();
+        let mut set = holders()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(
+            set.insert(id),
+            "org_share_mutation_lock acquired re-entrantly by the same task/thread. \
+             tokio::sync::Mutex is not reentrant: this would hang forever and hold the mutex for \
+             the rest of the process, stopping every org operation with no error. Take the lock \
+             around the durable commit only, or let the callee that already takes it do so."
+        );
+    }
+
+    pub(super) fn leave() {
+        let id = holder_id();
+        let mut set = holders()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        set.remove(&id);
+    }
+}
+
+/// The ONLY way to take [`AppState::org_share_mutation_lock`].
+///
+/// Routing every acquisition through one place is what makes the debug re-entrancy check possible
+/// at all — a check that only covers some call sites covers none of the ones that matter, since the
+/// deadlock this exists for was reached three levels deep through a callee nobody was thinking
+/// about. `commands/tests/org_mutex_scope_tests.rs` fails the build if a raw `.lock()` reappears.
+pub struct OrgMutationGuard<'a> {
+    _inner: tokio::sync::MutexGuard<'a, ()>,
+    /// Whether this guard registered itself with the re-entrancy bookkeeping, so only guards that
+    /// entered ever leave. A bounded acquisition never enters, and must not remove an id the
+    /// unbounded holder on the same thread put there.
+    #[cfg(debug_assertions)]
+    checked: bool,
+}
+
+#[cfg(debug_assertions)]
+impl Drop for OrgMutationGuard<'_> {
+    fn drop(&mut self) {
+        if self.checked {
+            org_mutex_reentrancy::leave();
+        }
+    }
+}
+
+impl AppState {
+    /// Acquire the org mutation lock, waiting indefinitely. See [`OrgMutationGuard`].
+    ///
+    /// This is the door the re-entrancy check guards, because this is the one that can HANG: an
+    /// unbounded wait for a lock the caller already holds never returns and never releases.
+    pub(crate) async fn lock_org_mutation(&self) -> OrgMutationGuard<'_> {
+        #[cfg(debug_assertions)]
+        org_mutex_reentrancy::enter();
+        OrgMutationGuard {
+            _inner: self.org_share_mutation_lock.lock().await,
+            #[cfg(debug_assertions)]
+            checked: true,
+        }
+    }
+
+    /// Acquire it, or give up after `wait`.
+    ///
+    /// DELIBERATELY NOT re-entrancy-checked, and the distinction is the whole point: a BOUNDED
+    /// attempt cannot deadlock. If the caller already holds the lock the timeout simply elapses and
+    /// the caller is told the resource is busy — which is a correct, recoverable outcome, and one
+    /// the suite asserts on purpose in
+    /// `org_diagnosability_tests::a_held_share_mutation_lock_yields_busy_rather_than_hanging`.
+    ///
+    /// Panicking there would have been the guard mistaking "an attempt designed to be refused" for
+    /// "a hang", which is exactly the false positive that gets a check deleted rather than fixed.
+    pub(crate) async fn lock_org_mutation_within(
+        &self,
+        wait: std::time::Duration,
+    ) -> Option<OrgMutationGuard<'_>> {
+        tokio::time::timeout(wait, self.org_share_mutation_lock.lock())
+            .await
+            .ok()
+            .map(|inner| OrgMutationGuard {
+                _inner: inner,
+                #[cfg(debug_assertions)]
+                checked: false,
+            })
+    }
+}
+
 type ContentDispatchValidator = dyn Fn(&AppState) -> Result<()> + Send + Sync + 'static;
 
 /// An owned authorization capability for a model/provider dispatch that derives from visible

--- a/src-tauri/src/summarize/codex_cli.rs
+++ b/src-tauri/src/summarize/codex_cli.rs
@@ -2567,19 +2567,19 @@ mod tests {
         assert!(
             !cache
                 .iter()
-                .any(|e| e.identity.canonical_path == PathBuf::from("/tmp/codex-0")),
+                .any(|e| e.identity.canonical_path.as_path() == Path::new("/tmp/codex-0")),
             "the OLDEST entry must be the one evicted"
         );
         assert!(
             cache
                 .iter()
-                .any(|e| e.identity.canonical_path == PathBuf::from("/tmp/codex-new")),
+                .any(|e| e.identity.canonical_path.as_path() == Path::new("/tmp/codex-new")),
             "the entry just verified must survive — evicting it would re-probe forever"
         );
         assert!(
             cache
                 .iter()
-                .any(|e| e.identity.canonical_path == PathBuf::from("/tmp/codex-1")),
+                .any(|e| e.identity.canonical_path.as_path() == Path::new("/tmp/codex-1")),
             "only ONE entry is evicted per insertion"
         );
     }

--- a/src-tauri/src/summarize/codex_cli.rs
+++ b/src-tauri/src/summarize/codex_cli.rs
@@ -738,22 +738,42 @@ async fn probe_supported_codex_version_with_boundary(
         let mut cache = verified_codex_binary_cache()
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        // Replace this key's own entry rather than the whole cache, so a concurrent verification of
-        // a DIFFERENT binary cannot evict one that is still in use.
-        if let Some(slot) = cache
-            .iter_mut()
-            .find(|entry| entry.identity == verified.identity && entry.boundary == verified.boundary)
-        {
-            *slot = verified.clone();
-        } else {
-            if cache.len() >= VERIFIED_CODEX_BINARY_CACHE_CAP {
-                // Oldest first. A cache that grew without bound would be the worse bug.
-                cache.remove(0);
-            }
-            cache.push(verified.clone());
-        }
+        remember_verified_binary(&mut cache, verified.clone());
     }
     Ok(verified)
+}
+
+/// Record a verified binary, replacing its own entry and evicting the oldest when full.
+///
+/// Split out of the probe so both rules can be tested on a LOCAL vector. The probe needs a real
+/// executable and the cache is process-global, so a test driving it through the probe shares state
+/// with every other test in the process and can only reach these branches indirectly — which is
+/// exactly why review found both of them untested (#658):
+///
+///   * eviction DIRECTION: swapping `remove(0)` for `pop()` passed, because no test ever filled the
+///     cache to `VERIFIED_CODEX_BINARY_CACHE_CAP` and the branch never ran;
+///   * the `boundary` half of the replacement key: deleting it passed all 47 module tests, because
+///     the boundary-scoping test probes twice and never a third time, so it cannot tell "a second
+///     entry was added" from "the second overwrote the first".
+///
+/// Both are silent: the first grows the cache without bound, the second lets an entry verified
+/// under the permissive test boundary satisfy a production probe.
+fn remember_verified_binary(cache: &mut Vec<VerifiedCodexBinary>, verified: VerifiedCodexBinary) {
+    // Replace this key's own entry rather than the whole cache, so a concurrent verification of a
+    // DIFFERENT binary cannot evict one that is still in use. The key is identity AND boundary:
+    // the same binary verified under a weaker boundary is NOT the same fact.
+    if let Some(slot) = cache
+        .iter_mut()
+        .find(|entry| entry.identity == verified.identity && entry.boundary == verified.boundary)
+    {
+        *slot = verified;
+        return;
+    }
+    if cache.len() >= VERIFIED_CODEX_BINARY_CACHE_CAP {
+        // Oldest first. A cache that grew without bound would be the worse bug.
+        cache.remove(0);
+    }
+    cache.push(verified);
 }
 
 #[cfg(any(target_os = "macos", test))]
@@ -2484,6 +2504,124 @@ mod tests {
     }
 
     #[cfg(target_os = "macos")]
+    fn cache_identity(path: &str) -> CodexBinaryIdentity {
+        CodexBinaryIdentity {
+            canonical_path: PathBuf::from(path),
+            len: 1,
+            #[cfg(unix)]
+            device: 1,
+            #[cfg(unix)]
+            inode: 1,
+            #[cfg(unix)]
+            modified_seconds: 1,
+            #[cfg(unix)]
+            modified_nanoseconds: 0,
+            #[cfg(unix)]
+            changed_seconds: 1,
+            #[cfg(unix)]
+            changed_nanoseconds: 0,
+            #[cfg(not(unix))]
+            modified_nanoseconds: 0,
+        }
+    }
+
+    fn cache_entry(path: &str, boundary: VersionProbeNetworkBoundary) -> VerifiedCodexBinary {
+        VerifiedCodexBinary {
+            identity: cache_identity(path),
+            boundary,
+            version: "0.146.0".into(),
+        }
+    }
+
+    /// A full cache evicts the OLDEST entry, not the newest.
+    ///
+    /// Review of #658 found this branch untested: swapping `remove(0)` for `pop()` passed, because
+    /// no test ever filled the cache to capacity so `len() >= CAP` never ran. The failure is
+    /// silent — evicting the newest means the entry just verified is thrown away and re-probed
+    /// every time, while the stale head is kept forever.
+    ///
+    /// Runs on a LOCAL vector: the real cache is process-global, so a test driving it through the
+    /// probe shares state with every other test in the process and cannot pin this deterministically.
+    ///
+    /// RED CONTROL (run 2026-09-03): `remove(0)` -> `pop()` fails this on the first assertion.
+    #[test]
+    fn a_full_cache_evicts_the_oldest_entry() {
+        let mut cache: Vec<VerifiedCodexBinary> = Vec::new();
+        for i in 0..VERIFIED_CODEX_BINARY_CACHE_CAP {
+            remember_verified_binary(
+                &mut cache,
+                cache_entry(
+                    &format!("/tmp/codex-{i}"),
+                    VersionProbeNetworkBoundary::InheritedTestSandbox,
+                ),
+            );
+        }
+        assert_eq!(cache.len(), VERIFIED_CODEX_BINARY_CACHE_CAP);
+
+        remember_verified_binary(
+            &mut cache,
+            cache_entry("/tmp/codex-new", VersionProbeNetworkBoundary::InheritedTestSandbox),
+        );
+
+        assert_eq!(cache.len(), VERIFIED_CODEX_BINARY_CACHE_CAP, "the cap must hold");
+        assert!(
+            !cache
+                .iter()
+                .any(|e| e.identity.canonical_path == PathBuf::from("/tmp/codex-0")),
+            "the OLDEST entry must be the one evicted"
+        );
+        assert!(
+            cache
+                .iter()
+                .any(|e| e.identity.canonical_path == PathBuf::from("/tmp/codex-new")),
+            "the entry just verified must survive — evicting it would re-probe forever"
+        );
+        assert!(
+            cache
+                .iter()
+                .any(|e| e.identity.canonical_path == PathBuf::from("/tmp/codex-1")),
+            "only ONE entry is evicted per insertion"
+        );
+    }
+
+    /// The replacement key is identity AND boundary — the same binary under a weaker boundary is
+    /// not the same fact.
+    ///
+    /// Review of #658 found that deleting the `boundary` term from that `find` passed all 47
+    /// module tests: the boundary-scoping test probes twice and never a third time, so it cannot
+    /// tell "a second entry was added" from "the second overwrote the first". The consequence is
+    /// not cosmetic — an entry verified under the permissive test boundary would satisfy a
+    /// PRODUCTION probe.
+    ///
+    /// RED CONTROL (run 2026-09-03): dropping `&& entry.boundary == verified.boundary` fails this
+    /// with one entry instead of two.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn the_same_binary_under_two_boundaries_is_two_entries() {
+        let mut cache: Vec<VerifiedCodexBinary> = Vec::new();
+        remember_verified_binary(
+            &mut cache,
+            cache_entry("/tmp/codex", VersionProbeNetworkBoundary::InheritedTestSandbox),
+        );
+        remember_verified_binary(
+            &mut cache,
+            cache_entry("/tmp/codex", VersionProbeNetworkBoundary::MacosSeatbelt),
+        );
+        assert_eq!(
+            cache.len(),
+            2,
+            "the same path verified under a DIFFERENT boundary is a different fact and must not \
+             replace the first — otherwise a test-boundary verification satisfies production"
+        );
+
+        // …and re-verifying one of them replaces only its own entry.
+        remember_verified_binary(
+            &mut cache,
+            cache_entry("/tmp/codex", VersionProbeNetworkBoundary::InheritedTestSandbox),
+        );
+        assert_eq!(cache.len(), 2, "re-verifying an existing key must not grow the cache");
+    }
+
     #[tokio::test]
     async fn version_probe_cache_is_scoped_to_the_network_boundary() {
         use std::os::unix::fs::PermissionsExt;

--- a/src/app/core/hierarchy-vocabulary.ts
+++ b/src/app/core/hierarchy-vocabulary.ts
@@ -1,0 +1,47 @@
+import type { ContainerNode } from "./models";
+
+/**
+ * A word the USER reads for a level of the hierarchy.
+ *
+ * Deliberately distinct from the code's `level` (`"project" | "folder"`) and from a `kind`
+ * (`"space" | "note" | …`): a domain identifier must not typecheck where a sentence is written,
+ * which is how the two vocabularies drifted apart in the first place.
+ */
+export type ContainerNoun = "Workspace" | "folder";
+
+/**
+ * The ONE user-facing name for each level of the workspace hierarchy.
+ *
+ * WHY THIS EXISTS (2026-09-02 audit, F5). The same `level === "project"` test was written in four
+ * places and produced four different words for two concepts: `"Workspace" / "Folder"` in the create
+ * sheet, `"Workspace" / "folder"` in the share sheet, `"space" / "folder"` in the tree's menus and
+ * toasts, and a bare `"container"` in the container view's own empty and error states. A user
+ * renaming a thing was told they renamed a "space"; the sheet that made it called it a "Workspace";
+ * the view of it called it a "container". Same object, three names, one session.
+ *
+ * `Workspace` is capitalised because that is what the product already calls it where it names it
+ * most — "No Workspaces yet", "Created Workspace" — and `folder` is lowercase for the same reason
+ * ("Move to Workspace or folder…"). The choice is which existing word wins, not a new one.
+ *
+ * The DTO's own term is `"project"`, and `container` is the code's word for "either of these". Both
+ * are fine in code and neither belongs in a sentence a user reads; `scripts/check-vocabulary.mjs`
+ * now fails a build that puts them there.
+ */
+export function containerNoun(
+  container: Pick<ContainerNode, "level">,
+): ContainerNoun {
+  return container.level === "project" ? "Workspace" : "folder";
+}
+
+/**
+ * The same noun at the start of a sentence.
+ *
+ * Only `folder` changes — `Workspace` is a proper noun and is already capitalised, so a naive
+ * `charAt(0).toUpperCase()` at each call site would have been right by accident here and wrong the
+ * moment the vocabulary gains a term that is capitalised mid-sentence.
+ */
+export function containerNounLeading(
+  container: Pick<ContainerNode, "level">,
+): "Workspace" | "Folder" {
+  return container.level === "project" ? "Workspace" : "Folder";
+}

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -469,6 +469,18 @@ export class IpcService {
     return invoke<void>("clear_app_log");
   }
 
+  /**
+   * Write a shareable diagnostics bundle and return its absolute path.
+   *
+   * App version, OS, the models present on disk (names and sizes only) and both log generations,
+   * as one plain-text file to attach to a bug report. Carries no note, transcript, title or
+   * attendee: the backend assembles it from sources that are non-PII by contract rather than
+   * filtering afterwards.
+   */
+  exportDiagnosticsBundle(): Promise<string> {
+    return invoke<string>("export_diagnostics_bundle");
+  }
+
   /** Reveal the log folder in Finder (to attach the raw file to a report). */
   revealAppLog(): Promise<void> {
     return invoke<void>("reveal_app_log");

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -34,6 +34,17 @@ export interface RecordingStatus {
   recording: boolean;
   meetingId: string | null;
   startedAt: string | null;
+  /**
+   * Whether SYSTEM audio capture is positively live. `null` when idle, or when this recording
+   * never asked for it — absent is not the same as broken.
+   *
+   * The helper is a separate process and can die mid-recording. Until this existed the mic kept
+   * recording and the timer kept counting while the far side of the call went missing from the
+   * transcript, discovered after a meeting nobody can repeat.
+   */
+  systemCaptureAlive: boolean | null;
+  /** Why it is not live, in words the user can act on. `null` while healthy. */
+  systemCaptureNote: string | null;
 }
 
 /**

--- a/src/app/core/recorder.store.ts
+++ b/src/app/core/recorder.store.ts
@@ -155,6 +155,36 @@ export class RecorderStore {
     { initialValue: 0 },
   );
 
+  /**
+   * Why system audio is not being captured right now, or `null` while it is fine.
+   *
+   * Polled every 5 s WHILE RECORDING only — the same sanctioned `toObservable` + `interval` +
+   * `toSignal` shape as `level`, so the subscription's lifecycle is the framework's, not ours.
+   * Five seconds, not 100 ms: this answers "has the helper died", which is a once-per-recording
+   * event, and a tighter poll would spend IPC on a question whose answer almost never changes.
+   *
+   * The backend derives it from the SAME predicate its 100 ms mic-restore watchdog uses, so the
+   * warning cannot disagree with the decision to un-mute.
+   */
+  readonly systemCaptureNote = toSignal(
+    toObservable(this.isRecording).pipe(
+      switchMap((rec) =>
+        rec
+          ? interval(5000).pipe(
+              startWith(0),
+              switchMap(() =>
+                from(this.ipc.recordingStatus()).pipe(
+                  map((st) => st?.systemCaptureNote ?? null),
+                  catchError(() => of(null)),
+                ),
+              ),
+            )
+          : of(null),
+      ),
+    ),
+    { initialValue: null as string | null },
+  );
+
   /** Epoch ms when the current recording started — drives the elapsed timer. */
   private _recStartMs = 0;
 

--- a/src/app/features/developer/logs/logs.component.html
+++ b/src/app/features/developer/logs/logs.component.html
@@ -41,6 +41,14 @@
           type="button"
           class="menu-item"
           role="menuitem"
+          (click)="exportBundle()"
+        >
+          <span>Save diagnostics bundle</span>
+        </button>
+        <button
+          type="button"
+          class="menu-item"
+          role="menuitem"
           (click)="chooseCopy()"
         >
           <span>Copy</span>

--- a/src/app/features/developer/logs/logs.component.ts
+++ b/src/app/features/developer/logs/logs.component.ts
@@ -367,6 +367,22 @@ export class LogsComponent implements OnInit {
   }
 
   /**
+   * Write a shareable diagnostics bundle and reveal it, so a bug report can carry the app version,
+   * the OS, the models on disk and BOTH log generations instead of a screenshot of one screen.
+   *
+   * Carries no meeting content: the backend assembles it from sources that are non-PII by contract.
+   */
+  async exportBundle(): Promise<void> {
+    try {
+      await this.ipc.exportDiagnosticsBundle();
+      await this.ipc.revealAppLog();
+      this.toast.success("Diagnostics bundle saved next to the logs");
+    } catch {
+      this.toast.danger("Couldn’t write the diagnostics bundle.");
+    }
+  }
+
+  /**
    * Empty the CURRENT session's file. Offered only on `current` — the previous
    * generation is the evidence this view exists to preserve.
    */

--- a/src/app/features/record/record/record.component.html
+++ b/src/app/features/record/record/record.component.html
@@ -334,6 +334,17 @@
     </div>
   }
 
+  <!-- System audio died mid-recording. Not an error — the recording is still running and still
+       being saved — but the far side of the call is no longer in it, and the user can only act on
+       that WHILE the meeting is still happening. Silence here is what made this discoverable only
+       afterwards, on a meeting nobody can repeat. -->
+  @if (store.systemCaptureNote(); as note) {
+    <div class="banner" role="status">
+      <span class="banner-icon" aria-hidden="true">◑</span>
+      <span>{{ note }}</span>
+    </div>
+  }
+
   @if (store.error(); as err) {
     @if (needsCloudConsent()) {
       <div class="banner is-accent cloud-consent" role="alert">

--- a/src/app/features/workspace/container-share-sheet/container-share-sheet.component.ts
+++ b/src/app/features/workspace/container-share-sheet/container-share-sheet.component.ts
@@ -25,13 +25,14 @@ import type {
 } from "../../../core/models";
 import { MurSelectComponent } from "../../../design-system/select/select.component";
 import { SharedWorkspaceService } from "../../../services/shared-workspace.service";
+import { containerNoun } from "../../../core/hierarchy-vocabulary";
 
 /** The local container this sheet is publishing. */
 export interface ContainerShareTarget {
   /** The local `folders.id`. */
   id: string;
   name: string;
-  /** `"project"` renders as "Workspace"; anything else as "Folder". */
+  /** `"project"` renders as "Workspace"; anything else as "folder" (`containerNoun`). */
   level: "project" | "folder";
 }
 
@@ -107,10 +108,8 @@ export class ContainerShareSheetComponent {
     return total > 0 ? Math.round((this.progressDone() / total) * 100) : 0;
   });
 
-  /** "Workspace" or "Folder" — the word the user sees for this container. */
-  readonly noun = computed(() =>
-    this.target().level === "project" ? "Workspace" : "folder",
-  );
+  /** The word the user sees for this level — the ONE source is `core/hierarchy-vocabulary.ts`. */
+  readonly noun = computed(() => containerNoun(this.target()));
 
   /** The container's existing share in the CHOSEN org, if any. */
   readonly existingShare = computed<ContainerShareStatus | null>(() => {

--- a/src/app/features/workspace/container-view/container-view.component.html
+++ b/src/app/features/workspace/container-view/container-view.component.html
@@ -17,7 +17,7 @@
          holds. Saying "empty" here would be a claim about contents nobody is
          entitled to read. -->
     <div class="state-card">
-      <p><strong>This container is locked</strong></p>
+      <p><strong>This {{ noun() }} is locked</strong></p>
       <p>Unlock it to see what it holds.</p>
     </div>
   } @else if (error(); as message) {
@@ -27,7 +27,7 @@
   } @else if (isEmpty() && loading()) {
     <p class="state">Loading…</p>
   } @else if (isEmpty()) {
-    <p class="state">This container is empty.</p>
+    <p class="state">This {{ noun() }} is empty.</p>
   } @else {
     @for (page of pages(); track page.kind) {
       @if (page.total > 0) {
@@ -60,5 +60,5 @@
 } @else if (loading()) {
   <p class="state">Loading…</p>
 } @else {
-  <p class="state">That container was not found.</p>
+  <p class="state">That {{ noun() }} was not found.</p>
 }

--- a/src/app/features/workspace/container-view/container-view.component.ts
+++ b/src/app/features/workspace/container-view/container-view.component.ts
@@ -12,6 +12,7 @@ import { map } from "rxjs";
 
 import type { ContainerNode, ItemKind, ItemRow } from "../../../core/models";
 import { WorkspaceService } from "../workspace.service";
+import { containerNoun } from "../../../core/hierarchy-vocabulary";
 
 /** The kinds a container can hold, in render order. */
 const KINDS: readonly ItemKind[] = ["meeting", "note", "task", "dashboard"];
@@ -61,6 +62,19 @@ export class ContainerViewComponent {
   private readonly workspace = inject(WorkspaceService);
 
   private readonly _container = signal<ContainerNode | null>(null);
+
+  /**
+   * The word the user reads for this thing.
+   *
+   * These states used to say "container" — the CODE's word for "either a Workspace or a folder",
+   * which no other surface shows and which names nothing the user ever created. Falls back to
+   * "folder" only before the node has loaded, where the sentence has to say something and the
+   * narrower word is the safer guess.
+   */
+  protected readonly noun = computed(() => {
+    const c = this._container();
+    return c ? containerNoun(c) : "folder";
+  });
   private readonly _pages = signal<KindPage[]>([]);
   private readonly _loading = signal(false);
   private readonly _error = signal<string | null>(null);

--- a/src/app/features/workspace/workspace-create-sheet/workspace-create-sheet.component.html
+++ b/src/app/features/workspace/workspace-create-sheet/workspace-create-sheet.component.html
@@ -164,7 +164,7 @@
               <mur-icon [icon]="target.container.level === 'project' ? 'spaces' : 'folder'" />
               <span>
                 <strong>{{ target.label }}</strong>
-                <small>{{ target.container.level === "project" ? "Workspace" : "Folder" }}</small>
+                <small>{{ containerNounLeading(target.container) }}</small>
               </span>
               @if (selectedTargetId() === target.container.id) {
                 <span class="selected-mark" aria-hidden="true">✓</span>

--- a/src/app/features/workspace/workspace-create-sheet/workspace-create-sheet.component.ts
+++ b/src/app/features/workspace/workspace-create-sheet/workspace-create-sheet.component.ts
@@ -15,6 +15,7 @@ import {
 
 import { MurIconComponent } from "../../../design-system/icon/icon.component";
 import type { WorkspaceDestination } from "../workspace-destination";
+import { containerNounLeading } from "../../../core/hierarchy-vocabulary";
 
 export type WorkspaceCreateKind = "space" | "note" | "folder" | "dashboard";
 
@@ -46,6 +47,9 @@ export interface WorkspaceCreateRequest {
   styleUrl: "./workspace-create-sheet.component.scss",
 })
 export class WorkspaceCreateSheetComponent {
+  /** The ONE user-facing noun for this level — see `core/hierarchy-vocabulary.ts`. */
+  protected readonly containerNounLeading = containerNounLeading;
+
   private readonly injector = inject(Injector);
 
   readonly targets = input.required<readonly WorkspaceDestination[]>();

--- a/src/app/features/workspace/workspace-manage-sheet/workspace-manage-sheet.component.ts
+++ b/src/app/features/workspace/workspace-manage-sheet/workspace-manage-sheet.component.ts
@@ -11,6 +11,7 @@ import {
 } from "@angular/core";
 
 import { MurIconComponent } from "../../../design-system/icon/icon.component";
+import type { ContainerNoun } from "../../../core/hierarchy-vocabulary";
 
 export type WorkspaceManageMode = "rename" | "delete";
 
@@ -27,7 +28,15 @@ export class WorkspaceManageSheetComponent {
 
   readonly mode = input.required<WorkspaceManageMode>();
   readonly name = input.required<string>();
-  readonly noun = input.required<"space" | "folder">();
+  /**
+   * The DISPLAY word, from `core/hierarchy-vocabulary.ts` — not a kind or a level.
+   *
+   * This used to be typed `"space" | "folder"`, which is the code's vocabulary; the sheet then
+   * told the user it was deleting a "space" while the sheet that created the same thing called
+   * it a Workspace. `ContainerNoun` keeps the two vocabularies from drifting again: a domain
+   * identifier no longer typechecks where a sentence is being written.
+   */
+  readonly noun = input.required<ContainerNoun>();
   readonly busy = input(false);
   readonly error = input<string | null>(null);
   readonly renamed = output<string>();

--- a/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
+++ b/src/app/features/workspace/workspace-tree/workspace-tree.component.ts
@@ -58,6 +58,7 @@ import {
   WorkspaceManageSheetComponent,
   type WorkspaceManageMode,
 } from "../workspace-manage-sheet/workspace-manage-sheet.component";
+import { containerNoun } from "../../../core/hierarchy-vocabulary";
 
 /** A flattened tree line, so one `@for` renders the whole forest. */
 export interface TreeLine {
@@ -1190,11 +1191,8 @@ export class WorkspaceTreeComponent {
     }
   }
 
-  protected containerNoun(
-    container: Pick<ContainerNode, "level">,
-  ): "space" | "folder" {
-    return container.level === "project" ? "space" : "folder";
-  }
+  /** The ONE user-facing noun for this level — see `core/hierarchy-vocabulary.ts`. */
+  protected readonly containerNoun = containerNoun;
 
   protected canCreateNote(container: ContainerNode): boolean {
     return this.canCreateIn(container);


### PR DESCRIPTION
Integrates six reviewed changes as ONE gate run, replacing #675, #676, #677, #679, #680, #681.

| was | what it fixes |
| --- | --- |
| #679 · T19 | decode windows read back-to-back lost a word across every 120 s boundary; language was re-detected per window, so a Polish meeting could turn English mid-recording |
| #677 · T20 | the system-audio helper can die mid-meeting and nothing said so — the far side of the call just went missing from the transcript |
| #675 · T23 | logs kept 24 h (with a size ceiling now), a shareable diagnostics bundle, and a dev build no longer blocks an installed one from starting |
| #676 · T24 | one name per level of the hierarchy, and a vocabulary gate that can finally see the difference |
| #680 · T38 | a re-entrant org-mutex acquisition now panics in debug instead of hanging the app forever in silence |
| #681 · T33 | two cache rules that were correct only by accident are now tested |

## Why one PR instead of six

**Correctness, then throughput.** Six separate runs each test one change against an *older* trunk.
One run on the combination tests what trunk will actually contain — which is the merge-skew this
repo has already been bitten by, where two individually-green PRs broke trunk together.

It also matters here in practice: the six PRs put **48 macOS jobs** in the Actions queue at once and
nothing moved for 40 minutes. Each merge would then have invalidated the other five, forcing a full
re-run apiece.

Every branch merged with **no conflict**, and each carries its own review trail in its original PR —
including the two that were failed and reworked (#672's deadlock + TOCTOU, and the oracle gaps found
in #674).

## Gates, run on the combination

| gate | result |
| --- | --- |
| `cargo test --lib` | **3641 passed, 0 failed** |
| `cargo clippy --lib --tests -- -D warnings` | clean |
| `ng lint` / `ng build` | clean |
| e2e (`library`, `shell`, `notes`) | **348 passed**, both engines, exit 0 |
| `check-dead-commands` (+ self-test) | clean, 9 instrument checks |
| vocabulary gate | 160 hits, baseline 160 |
| `mirror-check` | OK |

3641 is a number no individual PR showed: it is the six sets of new tests coexisting. In particular
T38's re-entrancy guard stays quiet across T19's, T20's and T23's paths — which is the one
interaction worth checking, since that guard panics rather than warns.


## Correction — the first e2e number in this PR was wrong

This PR originally claimed **342 passed** for the local e2e set. That number was not trustworthy and
one of the six changes was in fact broken.

T24 renamed the user-visible noun for the top of the hierarchy from `"space"` to `"Workspace"`.
`e2e/shell/workspace-tree.spec.ts` still asserted the old copy, so three tests looked for a menu item
that no longer exists. CI's chromium lane caught it on `chore/hierarchy-vocabulary` before this PR's
own run got a runner.

Two things hid it locally, and both are worth writing down:

- **The exit code came through a pipe.** `npx playwright test … | tail` reports `tail`'s status, not
  Playwright's. Re-running the same spec with the status captured directly printed `PLAYWRIGHT_EXIT=1`
  while the wrapper still said `exited with code 0`. This repo has been bitten by piped exit codes
  twice before; this is the third.
- **The vocabulary gate cannot see e2e.** `scripts/check-vocabulary.mjs` scans only `src/` — the
  deliberate choice, because a hand-written mock *defines* a shape rather than verifying one. But e2e
  assertions are the one place that pins user-facing **copy**, which is exactly what the gate governs,
  so a rename can pass the gate and still break the suite.

Fixed in `fix(e2e): follow the renamed Workspace menu labels`. Verified with the status read directly:
**26 passed, exit 0** for that spec, and **348 passed, exit 0** for the full local set.

The arithmetic settles it: the bad run reported **342**, the good run reports **348**, and the
difference is exactly **6 = 3 broken tests x 2 engines**. The original number was not inflated — it
was the count of tests that *did* pass, with the failures silently missing from it.
