### PR TITLE
chore(release): 2.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4637,7 +4637,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "2.3.1"
+version = "2.4.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murmur",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murmur",
-      "version": "2.3.1",
+      "version": "2.4.0",
       "dependencies": {
         "@angular/common": "^22.0.8",
         "@angular/compiler": "^22.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "scripts": {
     "start": "cargo build -p murmur-brain && ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "2.3.1"
+version = "2.4.0"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump for the 2.4.0 release: `package.json`, `package-lock.json` (both the top-level key and
the `""` root-package entry), `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `Cargo.lock`
re-pinned with `cargo update -p murmur --precise 2.4.0`.

Six lines across five files, nothing else. `identifier` stays `com.meetnotes.app`.

`package-lock.json` holds **three** `"version": "2.3.1"` strings — the third is `punycode@2.3.1`, a
real dependency. The replacement is bounded to the first two, which is why the runbook forbids a
repo-wide `sed` here.

`.murmur-server-revision` needed no change: trunk already pins `f46b70f9`, the revision deployed to
production, and `crates/murmur-protocol` is byte-identical between that and the previous pin, so the
client compiles the same against either.

## What 2.4.0 contains

31 changes since v2.3.1 — the 25 already on trunk plus the six integrated in #682. The bulk of it is
a production-readiness audit, so most entries are things that were wrong rather than things that were
missing: org key rotation on member removal, trust-on-first-use for org invites, a database key that
is never re-minted over an existing database, Ask history purged with the note it came from, manual
links and the fact ledger surviving a lock/unlock cycle, overlapping ASR decode windows with a pinned
language, and consent-gated update checks.
