### PR TITLE
fix(retry): keep the Me/Others split when a failed recording is retried

### DIFF
--- a/src-tauri/src/audio/align.rs
+++ b/src-tauri/src/audio/align.rs
@@ -156,6 +156,27 @@ pub fn archive_delays(
     }
 }
 
+/// The same front-padding as [`archive_delays`], derived from the PERSISTED signed system offset
+/// instead of live `Instant`s.
+///
+/// A retry runs long after the capture `Instant`s are gone, but the ledger keeps
+/// `recording_generations.system_start_offset_micros` — the identical information, in micros. The
+/// archive path calls `archive_delays(None, ..)` (no measured leak), so its wall-clock branch is
+/// what this reproduces; `archive_delays_agrees_with_the_persisted_offset` pins the two together so
+/// they cannot drift apart.
+pub fn archive_delays_from_offset(
+    system_start_offset_micros: Option<i64>,
+    rate_hz: u32,
+) -> (usize, usize) {
+    let to_samples =
+        |micros: i64| ((micros.unsigned_abs() as f64 / 1_000_000.0) * rate_hz as f64).round() as usize;
+    match system_start_offset_micros {
+        Some(offset) if offset >= 0 => (0, to_samples(offset)),
+        Some(offset) => (to_samples(offset), 0),
+        None => (0, 0),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -228,6 +249,32 @@ mod tests {
         assert!(estimate_stream_offset(&mic, &sys).is_none());
         assert!(estimate_stream_offset(&mic, &[]).is_none());
         assert!(estimate_stream_offset(&[], &sys).is_none());
+    }
+
+    /// The persisted-offset derivation MUST agree with the live-`Instant` one, or a retry would
+    /// align its masters differently than the archive they were cut from.
+    #[test]
+    fn archive_delays_agrees_with_the_persisted_offset() {
+        let t0 = std::time::Instant::now();
+        for micros in [0i64, 1, 250_000, 1_000_000, 3_500_000] {
+            let sys = t0 + std::time::Duration::from_micros(micros as u64);
+            assert_eq!(
+                archive_delays(None, t0, Some(sys), 16_000),
+                archive_delays_from_offset(Some(micros), 16_000),
+                "system started {micros} us AFTER the mic",
+            );
+            let mic_late = t0 + std::time::Duration::from_micros(micros as u64);
+            assert_eq!(
+                archive_delays(None, mic_late, Some(t0), 16_000),
+                archive_delays_from_offset(Some(-micros), 16_000),
+                "system started {micros} us BEFORE the mic",
+            );
+        }
+        // No system track at all: both paths pad nothing.
+        assert_eq!(
+            archive_delays(None, t0, None, 16_000),
+            archive_delays_from_offset(None, 16_000),
+        );
     }
 
     /// archive_delays: measured leak wins; positive offset delays the SYSTEM track.

--- a/src-tauri/src/audio/source.rs
+++ b/src-tauri/src/audio/source.rs
@@ -2670,10 +2670,12 @@ impl AtomicAudioPublisher {
 /// `storage::seal_store` and `storage::usage`). This function only produces the file those columns
 /// have always been able to describe.
 ///
-/// Atomic like the archive: written to a same-directory dotfile, fsynced, then `rename`d into place,
-/// so a crash can never leave a half-written master that a later read would trust.
+/// Published like the archive: staged in the PRIVATE inflight directory, proven readable, then
+/// hard-linked into place — `hard_link` refuses an existing destination, so this can never overwrite
+/// the faithful float32 master the opt-in hi-res publication writes under the same name.
 pub(crate) fn publish_stream_master(
     source_path: &Path,
+    staging_dir: &Path,
     final_path: &Path,
     delay_frames: u64,
 ) -> Result<VerifiedFile> {
@@ -2684,14 +2686,16 @@ pub(crate) fn publish_stream_master(
             "stream master would be empty; nothing to publish".into(),
         ));
     }
-    let parent = final_path
-        .parent()
-        .ok_or_else(|| AppError::Audio("stream master path has no parent dir".into()))?;
     let stem = final_path
         .file_name()
         .and_then(|n| n.to_str())
         .ok_or_else(|| AppError::Audio("stream master path has no file name".into()))?;
-    let temp = parent.join(format!(".{stem}.{}.part", std::process::id()));
+    // Stage inside the PRIVATE (0700) recording-inflight directory, never beside the destination.
+    // A crash between the write and the publish would otherwise leave a plaintext WAV fragment in
+    // the asset-scoped audio directory that nothing sweeps: the crypto stage sweeper matches only
+    // its own marker, the generation part-reaper scans only inflight, and the storage prune deletes
+    // only paths a DB column names.
+    let temp = staging_dir.join(format!(".{stem}.{}.part", std::process::id()));
     let _ = std::fs::remove_file(&temp);
 
     {
@@ -2742,9 +2746,41 @@ pub(crate) fn publish_stream_master(
             "published stream master is not a readable WAV".into(),
         ));
     }
-    std::fs::rename(&temp, final_path)
-        .map_err(|e| AppError::Audio(format!("publish stream master: {e}")))?;
+    // NO-CLOBBER publish. `rename` would replace the destination unconditionally; the pathnames a
+    // master uses are shared with the opt-in hi-res publication, so an overwrite would destroy a
+    // faithful float32 capture. `hard_link` fails with `AlreadyExists` instead, and the caller only
+    // reaches this function when the destination was absent.
+    std::fs::hard_link(&temp, final_path).map_err(|e| {
+        let _ = std::fs::remove_file(&temp);
+        AppError::Audio(format!("publish stream master without clobber: {e}"))
+    })?;
     sync_parent_dir(final_path, "sync stream master directory")?;
+    let published = verify_existing_file_with_nlink(final_path, 2)?;
+    if published.device() != staged.device()
+        || published.inode() != staged.inode()
+        || published.byte_len() != staged.byte_len()
+        || published.sha256() != staged.sha256()
+    {
+        return Err(AppError::Audio(
+            "published stream master does not name the verified staging inode".into(),
+        ));
+    }
+    // Unlink the staging LINK, mirroring `AtomicAudioPublisher`: `VerifiedDeletion` is for a
+    // single-link inode and this one now has two owned paths, so the proof is that BOTH paths name
+    // the same inode with exactly two links before either is removed.
+    let staging_meta = std::fs::symlink_metadata(&temp)
+        .map_err(|e| AppError::Audio(format!("inspect stream master staging link: {e}")))?;
+    if staging_meta.dev() != published.device()
+        || staging_meta.ino() != published.inode()
+        || staging_meta.nlink() != 2
+    {
+        return Err(AppError::Audio(
+            "stream master staging link does not name the published inode".into(),
+        ));
+    }
+    std::fs::remove_file(&temp)
+        .map_err(|e| AppError::Audio(format!("remove stream master staging link: {e}")))?;
+    sync_parent_dir(&temp, "sync stream master staging directory")?;
     verify_existing_file(final_path)
 }
 
@@ -3777,7 +3813,7 @@ mod tests {
         std::fs::write(&raw, &bytes).unwrap();
 
         let dest = dir.join("m.mic.wav");
-        publish_stream_master(&raw, &dest, 3).unwrap();
+        publish_stream_master(&raw, &dir, &dest, 3).unwrap();
         let mut got = WavMonoSource::open(&dest).unwrap();
         assert_eq!(got.frames(), 7, "3 frames of padding + 4 of signal");
         let frames = got.read_frames(0, 7).unwrap();
@@ -3792,7 +3828,7 @@ mod tests {
 
         // Zero delay is the mic-leading case and must not pad at all.
         let dest0 = dir.join("m.sys.wav");
-        publish_stream_master(&raw, &dest0, 0).unwrap();
+        publish_stream_master(&raw, &dir, &dest0, 0).unwrap();
         assert_eq!(WavMonoSource::open(&dest0).unwrap().frames(), 4);
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -3811,7 +3847,7 @@ mod tests {
         let raw = dir.join("in.f32");
         std::fs::write(&raw, 0.5f32.to_le_bytes()).unwrap();
         let dest = dir.join("m.mic.wav");
-        publish_stream_master(&raw, &dest, 0).unwrap();
+        publish_stream_master(&raw, &dir, &dest, 0).unwrap();
         let leftovers: Vec<_> = std::fs::read_dir(&dir)
             .unwrap()
             .filter_map(|e| e.ok())
@@ -3820,6 +3856,46 @@ mod tests {
             .collect();
         assert!(leftovers.is_empty(), "staging file survived: {leftovers:?}");
         assert!(dest.exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// LOSS ORACLE — publishing a master must NEVER overwrite one that is already there.
+    ///
+    /// `{id}.mic.wav` / `{id}.sys.wav` are the same pathnames the opt-in `keep_hires_masters`
+    /// publication owns, and it writes FLOAT32 at the native capture rate. A retry aid is a 16 kHz
+    /// int16 downsample, and the raw capture is unlinked immediately after promotion — so a
+    /// clobbering publish would destroy the only faithful copy, irreversibly. The first version of
+    /// this function used a bare `rename`, which replaces the destination unconditionally; lock-
+    /// security review caught it. This asserts the destination survives byte-for-byte.
+    #[test]
+    fn publishing_a_master_never_overwrites_an_existing_one() {
+        let dir = std::env::temp_dir().join(format!(
+            "murmur-master-noclobber-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let raw = dir.join("in.f32");
+        let mut bytes = Vec::new();
+        for s in [0.25f32; 8] {
+            bytes.extend_from_slice(&s.to_le_bytes());
+        }
+        std::fs::write(&raw, &bytes).unwrap();
+
+        // Stand in for the user's faithful master: a DIFFERENT file already at the destination.
+        let dest = dir.join("m.mic.wav");
+        crate::audio::write_wav_f32(&dest, &[0.9, 0.8, 0.7], 48_000, 1).unwrap();
+        let before = std::fs::read(&dest).unwrap();
+
+        assert!(
+            publish_stream_master(&raw, &dir, &dest, 0).is_err(),
+            "an occupied destination must be REFUSED, not replaced",
+        );
+        assert_eq!(
+            std::fs::read(&dest).unwrap(),
+            before,
+            "the pre-existing master survives byte-for-byte",
+        );
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -3836,7 +3912,7 @@ mod tests {
         let raw = dir.join("in.f32");
         std::fs::write(&raw, b"").unwrap();
         let dest = dir.join("m.mic.wav");
-        assert!(publish_stream_master(&raw, &dest, 0).is_err());
+        assert!(publish_stream_master(&raw, &dir, &dest, 0).is_err());
         assert!(!dest.exists(), "nothing is published for an empty stream");
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/audio/source.rs
+++ b/src-tauri/src/audio/source.rs
@@ -2783,6 +2783,12 @@ pub(crate) fn publish_stream_master(
     match publish_stream_master_tail(&temp, final_path, &staged) {
         Ok(published) => Ok(published),
         Err(error) => {
+            // Drop the staging link FIRST. `verify_existing_file` is
+            // `verify_existing_file_with_nlink(path, 1)`, so while the link survives the destination
+            // has two owned paths and the identity check below would `Err` — skipping the undo on
+            // every tail failure except the last one. Round-3 review caught exactly that: the
+            // comment above promised an undo the implementation did not perform.
+            let _ = std::fs::remove_file(&temp);
             // Exact deletion only: remove `final_path` if and only if it still names the inode we
             // just published. Anything else is somebody else's file.
             if let Ok(current) = verify_existing_file(final_path) {
@@ -2791,7 +2797,6 @@ pub(crate) fn publish_stream_master(
                     let _ = sync_parent_dir(final_path, "sync stream master directory");
                 }
             }
-            let _ = std::fs::remove_file(&temp);
             Err(error)
         }
     }

--- a/src-tauri/src/audio/source.rs
+++ b/src-tauri/src/audio/source.rs
@@ -2651,6 +2651,103 @@ impl AtomicAudioPublisher {
     }
 }
 
+/// Publish ONE capture stream as a delay-aligned 16 kHz mono master WAV next to the archive.
+///
+/// WHY THIS EXISTS (T31). The canonical archive is `channels: 1` — [`AtomicAudioPublisher::publish_mix`]
+/// SUMS the microphone and the system capture into a single channel, so the `Me`/`Others` split is
+/// destroyed at publication and no amount of later processing recovers it. A retry that re-runs from
+/// the archive is therefore single-stream BY CONSTRUCTION. Keeping each stream as its own master is
+/// the only way a retry can reproduce what the live recording produced.
+///
+/// The master is written on the ARCHIVE's timeline: `delay` frames of leading silence are prepended,
+/// exactly the offset `publish_mix` applied when mixing this stream. Both masters then share one
+/// origin, so a retry hands [`crate::audio::merge::merge_streams`] two streams with the same
+/// `started_at` and the merge reduces to sort-and-label. It also means a human who plays a master
+/// hears it in sync with the archive.
+///
+/// At-rest handling is NOT new machinery: the meeting's `mic_master_path` / `sys_master_path`
+/// columns are already sealed, blanked, unsealed, crash-reconciled and prune-accounted (see
+/// `storage::seal_store` and `storage::usage`). This function only produces the file those columns
+/// have always been able to describe.
+///
+/// Atomic like the archive: written to a same-directory dotfile, fsynced, then `rename`d into place,
+/// so a crash can never leave a half-written master that a later read would trust.
+pub(crate) fn publish_stream_master(
+    source_path: &Path,
+    final_path: &Path,
+    delay_frames: u64,
+) -> Result<VerifiedFile> {
+    let mut source = RawF32LeSource::open(source_path, crate::audio::TARGET_RATE_HZ)?;
+    let total = delay_frames.saturating_add(source.frames());
+    if total == 0 {
+        return Err(AppError::Audio(
+            "stream master would be empty; nothing to publish".into(),
+        ));
+    }
+    let parent = final_path
+        .parent()
+        .ok_or_else(|| AppError::Audio("stream master path has no parent dir".into()))?;
+    let stem = final_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| AppError::Audio("stream master path has no file name".into()))?;
+    let temp = parent.join(format!(".{stem}.{}.part", std::process::id()));
+    let _ = std::fs::remove_file(&temp);
+
+    {
+        let file = open_create_new_nofollow(&temp)?;
+        let spec = hound::WavSpec {
+            channels: 1,
+            sample_rate: crate::audio::TARGET_RATE_HZ,
+            bits_per_sample: 16,
+            sample_format: hound::SampleFormat::Int,
+        };
+        let mut writer = hound::WavWriter::new(file, spec)
+            .map_err(|e| AppError::Audio(format!("create stream master WAV: {e}")))?;
+        let mut offset = 0u64;
+        while offset < total {
+            let count = COPY_FRAMES.min((total - offset) as usize);
+            // Leading silence covers the alignment delay; past it, read the stream itself.
+            let window = if offset + count as u64 <= delay_frames {
+                vec![0.0f32; count]
+            } else if offset >= delay_frames {
+                source.read_frames(offset - delay_frames, count)?
+            } else {
+                let silent = (delay_frames - offset) as usize;
+                let mut w = vec![0.0f32; silent];
+                w.extend(source.read_frames(0, count - silent)?);
+                w
+            };
+            for sample in window {
+                writer
+                    .write_sample((sample.clamp(-1.0, 1.0) * i16::MAX as f32).round() as i16)
+                    .map_err(|e| AppError::Audio(format!("write stream master sample: {e}")))?;
+            }
+            offset += count as u64;
+        }
+        writer
+            .finalize()
+            .map_err(|e| AppError::Audio(format!("finalize stream master WAV: {e}")))?;
+    }
+    let staged = verify_existing_file(&temp)?;
+    // Prove the master is a readable WAV BEFORE it is published under a name the DB will point at.
+    // A column that names an unreadable file is worse than no column: every later read trusts it.
+    let readable = WavMonoSource::open(&temp)
+        .map(|s| s.frames() > 0 && s.sample_rate() > 0)
+        .unwrap_or(false);
+    if !readable {
+        VerifiedDeletion::for_file(&temp, &staged)?
+            .remove("remove unreadable stream master candidate")?;
+        return Err(AppError::Audio(
+            "published stream master is not a readable WAV".into(),
+        ));
+    }
+    std::fs::rename(&temp, final_path)
+        .map_err(|e| AppError::Audio(format!("publish stream master: {e}")))?;
+    sync_parent_dir(final_path, "sync stream master directory")?;
+    verify_existing_file(final_path)
+}
+
 fn mixed_window(
     mic: &mut RawF32LeSource,
     mic_delay: u64,
@@ -3656,6 +3753,94 @@ fn verify_open_handle(
 
 #[cfg(test)]
 mod tests {
+    /// T31 — a promoted master is the stream itself, shifted onto the ARCHIVE's timeline.
+    ///
+    /// The delay is not decoration: `publish_mix` front-pads each stream by exactly this many
+    /// frames when it builds the archive, so a master written WITHOUT the padding would place every
+    /// retry segment earlier than the recording it came from, and the two streams would be merged
+    /// against each other at the wrong offset.
+    #[test]
+    fn a_promoted_master_carries_the_archive_front_padding() {
+        use crate::audio::source::MonoSource;
+        let dir = std::env::temp_dir().join(format!(
+            "murmur-master-pad-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let raw = dir.join("in.f32");
+        let samples: Vec<f32> = vec![1.0, 1.0, 1.0, 1.0];
+        let mut bytes = Vec::new();
+        for s in &samples {
+            bytes.extend_from_slice(&s.to_le_bytes());
+        }
+        std::fs::write(&raw, &bytes).unwrap();
+
+        let dest = dir.join("m.mic.wav");
+        publish_stream_master(&raw, &dest, 3).unwrap();
+        let mut got = WavMonoSource::open(&dest).unwrap();
+        assert_eq!(got.frames(), 7, "3 frames of padding + 4 of signal");
+        let frames = got.read_frames(0, 7).unwrap();
+        assert!(
+            frames[..3].iter().all(|s| *s == 0.0),
+            "the delay is leading SILENCE, not the stream shifted into it: {frames:?}"
+        );
+        assert!(
+            frames[3..].iter().all(|s| *s > 0.9),
+            "the stream itself follows the padding: {frames:?}"
+        );
+
+        // Zero delay is the mic-leading case and must not pad at all.
+        let dest0 = dir.join("m.sys.wav");
+        publish_stream_master(&raw, &dest0, 0).unwrap();
+        assert_eq!(WavMonoSource::open(&dest0).unwrap().frames(), 4);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A master is published ATOMICALLY: a reader never sees the staging dotfile under the final
+    /// name, and nothing is left behind once it lands.
+    #[test]
+    fn publishing_a_master_leaves_no_staging_file() {
+        let dir = std::env::temp_dir().join(format!(
+            "murmur-master-atomic-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let raw = dir.join("in.f32");
+        std::fs::write(&raw, 0.5f32.to_le_bytes()).unwrap();
+        let dest = dir.join("m.mic.wav");
+        publish_stream_master(&raw, &dest, 0).unwrap();
+        let leftovers: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .filter(|n| n.starts_with('.') && n.ends_with(".part"))
+            .collect();
+        assert!(leftovers.is_empty(), "staging file survived: {leftovers:?}");
+        assert!(dest.exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// An EMPTY stream is refused rather than published: a zero-frame master would be a column
+    /// pointing at a file every later read has to special-case.
+    #[test]
+    fn an_empty_stream_is_not_published_as_a_master() {
+        let dir = std::env::temp_dir().join(format!(
+            "murmur-master-empty-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let raw = dir.join("in.f32");
+        std::fs::write(&raw, b"").unwrap();
+        let dest = dir.join("m.mic.wav");
+        assert!(publish_stream_master(&raw, &dest, 0).is_err());
+        assert!(!dest.exists(), "nothing is published for an empty stream");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
     use std::os::unix::fs::PermissionsExt;
 
     use super::*;

--- a/src-tauri/src/audio/source.rs
+++ b/src-tauri/src/audio/source.rs
@@ -786,6 +786,21 @@ pub(crate) struct WavMonoSource {
 }
 
 impl WavMonoSource {
+    /// True when this WAV has the shape a PROMOTED retry master is written with — 16 kHz, 16-bit
+    /// integer (see `publish_stream_master`). It is the PROVENANCE test that separates a retry aid
+    /// from a user's opt-in hi-res master, which is native-rate float32
+    /// (`stream_raw_to_float_wav`) or a byte copy of the system capture.
+    ///
+    /// Two things depend on telling them apart, and both are content-critical:
+    /// deleting a master after a retry (a hi-res one is the user's, never ours to remove) and
+    /// trusting that a master already carries the archive's front padding (only a promoted one
+    /// does — merging an unpadded master against a padded one silently shifts one speaker).
+    pub(crate) fn has_promoted_master_shape(&self) -> bool {
+        self.spec.sample_rate == crate::audio::TARGET_RATE_HZ
+            && self.spec.bits_per_sample == 16
+            && self.spec.sample_format == hound::SampleFormat::Int
+    }
+
     pub(crate) fn open(path: &Path) -> Result<Self> {
         let file = open_existing_nofollow(path)?;
         let reader = hound::WavReader::new(file)
@@ -2676,6 +2691,7 @@ impl AtomicAudioPublisher {
 pub(crate) fn publish_stream_master(
     source_path: &Path,
     staging_dir: &Path,
+    generation_id: &str,
     final_path: &Path,
     delay_frames: u64,
 ) -> Result<VerifiedFile> {
@@ -2695,7 +2711,14 @@ pub(crate) fn publish_stream_master(
     // the asset-scoped audio directory that nothing sweeps: the crypto stage sweeper matches only
     // its own marker, the generation part-reaper scans only inflight, and the storage prune deletes
     // only paths a DB column names.
-    let temp = staging_dir.join(format!(".{stem}.{}.part", std::process::id()));
+    // Generation-scoped so the EXISTING staging reaper covers it: a crash during the write leaves a
+    // partial file that `tracked_generation_part_deletions` finds by generation-id prefix, instead of
+    // one only a same-pid rerun would clear.
+    let temp = staging_dir.join(format!(
+        ".{generation_id}.stream-master-{}-{}.part",
+        stem,
+        std::process::id()
+    ));
     let _ = std::fs::remove_file(&temp);
 
     {
@@ -2754,6 +2777,34 @@ pub(crate) fn publish_stream_master(
         let _ = std::fs::remove_file(&temp);
         AppError::Audio(format!("publish stream master without clobber: {e}"))
     })?;
+    // From here the destination EXISTS. Every failure below must remove it again: a published master
+    // with no DB column naming it is invisible to the seal, the crash reconciler and the storage
+    // prune (all column-driven) and would survive a folder lock as untracked plaintext.
+    match publish_stream_master_tail(&temp, final_path, &staged) {
+        Ok(published) => Ok(published),
+        Err(error) => {
+            // Exact deletion only: remove `final_path` if and only if it still names the inode we
+            // just published. Anything else is somebody else's file.
+            if let Ok(current) = verify_existing_file(final_path) {
+                if current.device() == staged.device() && current.inode() == staged.inode() {
+                    let _ = std::fs::remove_file(final_path);
+                    let _ = sync_parent_dir(final_path, "sync stream master directory");
+                }
+            }
+            let _ = std::fs::remove_file(&temp);
+            Err(error)
+        }
+    }
+}
+
+/// The post-link half of [`publish_stream_master`], split out so its caller can undo an incomplete
+/// publication. Proves the destination and the staging link name one inode with two owned paths,
+/// then drops the staging link.
+fn publish_stream_master_tail(
+    temp: &Path,
+    final_path: &Path,
+    staged: &VerifiedFile,
+) -> Result<VerifiedFile> {
     sync_parent_dir(final_path, "sync stream master directory")?;
     let published = verify_existing_file_with_nlink(final_path, 2)?;
     if published.device() != staged.device()
@@ -2768,7 +2819,7 @@ pub(crate) fn publish_stream_master(
     // Unlink the staging LINK, mirroring `AtomicAudioPublisher`: `VerifiedDeletion` is for a
     // single-link inode and this one now has two owned paths, so the proof is that BOTH paths name
     // the same inode with exactly two links before either is removed.
-    let staging_meta = std::fs::symlink_metadata(&temp)
+    let staging_meta = std::fs::symlink_metadata(temp)
         .map_err(|e| AppError::Audio(format!("inspect stream master staging link: {e}")))?;
     if staging_meta.dev() != published.device()
         || staging_meta.ino() != published.inode()
@@ -2778,9 +2829,9 @@ pub(crate) fn publish_stream_master(
             "stream master staging link does not name the published inode".into(),
         ));
     }
-    std::fs::remove_file(&temp)
+    std::fs::remove_file(temp)
         .map_err(|e| AppError::Audio(format!("remove stream master staging link: {e}")))?;
-    sync_parent_dir(&temp, "sync stream master staging directory")?;
+    sync_parent_dir(temp, "sync stream master staging directory")?;
     verify_existing_file(final_path)
 }
 
@@ -3813,7 +3864,7 @@ mod tests {
         std::fs::write(&raw, &bytes).unwrap();
 
         let dest = dir.join("m.mic.wav");
-        publish_stream_master(&raw, &dir, &dest, 3).unwrap();
+        publish_stream_master(&raw, &dir, "g1", &dest, 3).unwrap();
         let mut got = WavMonoSource::open(&dest).unwrap();
         assert_eq!(got.frames(), 7, "3 frames of padding + 4 of signal");
         let frames = got.read_frames(0, 7).unwrap();
@@ -3828,7 +3879,7 @@ mod tests {
 
         // Zero delay is the mic-leading case and must not pad at all.
         let dest0 = dir.join("m.sys.wav");
-        publish_stream_master(&raw, &dir, &dest0, 0).unwrap();
+        publish_stream_master(&raw, &dir, "g1", &dest0, 0).unwrap();
         assert_eq!(WavMonoSource::open(&dest0).unwrap().frames(), 4);
 
         let _ = std::fs::remove_dir_all(&dir);
@@ -3847,7 +3898,7 @@ mod tests {
         let raw = dir.join("in.f32");
         std::fs::write(&raw, 0.5f32.to_le_bytes()).unwrap();
         let dest = dir.join("m.mic.wav");
-        publish_stream_master(&raw, &dir, &dest, 0).unwrap();
+        publish_stream_master(&raw, &dir, "g1", &dest, 0).unwrap();
         let leftovers: Vec<_> = std::fs::read_dir(&dir)
             .unwrap()
             .filter_map(|e| e.ok())
@@ -3888,7 +3939,7 @@ mod tests {
         let before = std::fs::read(&dest).unwrap();
 
         assert!(
-            publish_stream_master(&raw, &dir, &dest, 0).is_err(),
+            publish_stream_master(&raw, &dir, "g1", &dest, 0).is_err(),
             "an occupied destination must be REFUSED, not replaced",
         );
         assert_eq!(
@@ -3896,6 +3947,61 @@ mod tests {
             before,
             "the pre-existing master survives byte-for-byte",
         );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// PROVENANCE ORACLE — a promoted master and a user's hi-res master are distinguishable.
+    ///
+    /// Two content-critical decisions hang on this and nothing else: whether a successful retry may
+    /// DELETE a master (only one this pipeline wrote), and whether a retry may TRUST that a master
+    /// already carries the archive's front padding (only a promoted one does; merging an unpadded
+    /// master against a padded one silently shifts one speaker). Asking the live
+    /// `keep_hires_masters` setting instead — the first version — let a user destroy their only
+    /// faithful capture by toggling it off between the failure and the retry.
+    #[test]
+    fn a_promoted_master_is_distinguishable_from_a_hi_res_one() {
+        let dir = std::env::temp_dir().join(format!(
+            "murmur-master-shape-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let raw = dir.join("in.f32");
+        let mut bytes = Vec::new();
+        for s in [0.5f32; 4] {
+            bytes.extend_from_slice(&s.to_le_bytes());
+        }
+        std::fs::write(&raw, &bytes).unwrap();
+
+        let promoted = dir.join("m.mic.wav");
+        publish_stream_master(&raw, &dir, "g1", &promoted, 0).unwrap();
+        assert!(
+            WavMonoSource::open(&promoted)
+                .unwrap()
+                .has_promoted_master_shape(),
+            "16 kHz int16 is what promotion writes",
+        );
+
+        // A hi-res master: native capture rate, float32 — what `stream_raw_to_float_wav` produces.
+        let hires = dir.join("m.hires.wav");
+        crate::audio::write_wav_f32(&hires, &[0.5, 0.5, 0.5, 0.5], 48_000, 1).unwrap();
+        assert!(
+            !WavMonoSource::open(&hires)
+                .unwrap()
+                .has_promoted_master_shape(),
+            "a native-rate float32 master must never be mistaken for a retry aid",
+        );
+
+        // The rate alone is not enough: a float32 file AT 16 kHz is still not ours.
+        let f32_at_16k = dir.join("m.f32-16k.wav");
+        crate::audio::write_wav_f32(&f32_at_16k, &[0.5, 0.5], 16_000, 1).unwrap();
+        assert!(
+            !WavMonoSource::open(&f32_at_16k)
+                .unwrap()
+                .has_promoted_master_shape(),
+            "the sample FORMAT is part of the discriminator, not just the rate",
+        );
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 
@@ -3912,7 +4018,7 @@ mod tests {
         let raw = dir.join("in.f32");
         std::fs::write(&raw, b"").unwrap();
         let dest = dir.join("m.mic.wav");
-        assert!(publish_stream_master(&raw, &dir, &dest, 0).is_err());
+        assert!(publish_stream_master(&raw, &dir, "g1", &dest, 0).is_err());
         assert!(!dest.exists(), "nothing is published for an empty stream");
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -11239,7 +11239,7 @@ pub(crate) fn stop_all_capture(state: &AppState) {
 
 /// Suffix marking an audio file as AES-GCM-encrypted-at-rest (sealed folder). The presence of
 /// this suffix on `meetings.audio_path` is the on-disk "audio is sealed" signal.
-const ENC_SUFFIX: &str = ".enc";
+pub(crate) const ENC_SUFFIX: &str = ".enc";
 
 // ── B7/B8 AAD context binding ──────────────────────────────────────────────────────────────────
 //

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -16795,10 +16795,22 @@
         let archive = dir.join("m.wav");
         let mic = dir.join("m.mic.wav");
         let sys = dir.join("m.sys.wav");
-        // The archive is the SUM (0.5 everywhere); the masters keep the sides apart.
+        // The archive is the SUM (0.5 everywhere); the masters keep the sides apart. The masters are
+        // written by the REAL producer, so they carry the promoted shape the retry path requires —
+        // a hand-rolled fixture would define a shape rather than exercise the one that ships.
         crate::audio::write_wav_f32(&archive, &[0.5, 0.5, 0.5, 0.5], 16_000, 1).unwrap();
-        crate::audio::write_wav_f32(&mic, &[1.0, 1.0, 1.0, 1.0], 16_000, 1).unwrap();
-        crate::audio::write_wav_f32(&sys, &[0.0, 0.0, 0.0, 0.0], 16_000, 1).unwrap();
+        let mic_raw = dir.join("mic.f32");
+        let sys_raw = dir.join("sys.f32");
+        let mut mic_bytes = Vec::new();
+        let mut sys_bytes = Vec::new();
+        for _ in 0..4 {
+            mic_bytes.extend_from_slice(&1.0f32.to_le_bytes());
+            sys_bytes.extend_from_slice(&0.0f32.to_le_bytes());
+        }
+        std::fs::write(&mic_raw, &mic_bytes).unwrap();
+        std::fs::write(&sys_raw, &sys_bytes).unwrap();
+        crate::audio::source::publish_stream_master(&mic_raw, &dir, "g1", &mic, 0).unwrap();
+        crate::audio::source::publish_stream_master(&sys_raw, &dir, "g1", &sys, 0).unwrap();
 
         let mid = uuid::Uuid::new_v4().to_string();
         seed_meeting(&state.db, &mid, "# err", None);
@@ -16850,6 +16862,17 @@
         assert!(
             crate::pipeline::readable_stream_masters(&state, &mid).is_none(),
             "a missing mic master falls back to the archive",
+        );
+
+        // And the case lock-security review found: a user's HI-RES master (native-rate float32) is
+        // NOT usable here. It carries no front padding, and the merge hands both streams one
+        // `Instant` on the assumption that they do — accepting it would shift `Others` away from
+        // `Me` by the system start offset and silently produce a wrong transcript, for exactly the
+        // users who kept the faithful audio. It must degrade to the archive instead.
+        crate::audio::write_wav_f32(&mic, &[1.0, 1.0, 1.0, 1.0], 48_000, 1).unwrap();
+        assert!(
+            crate::pipeline::readable_stream_masters(&state, &mid).is_none(),
+            "an unpadded hi-res master must fall back to the archive, not be merged as if padded",
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -16710,20 +16710,19 @@
         let _ = std::fs::remove_file(&wav);
     }
 
-    /// RETRY FROM A DUAL-STREAM ARCHIVE — it is accepted, and it comes back MONO.
+    /// RETRY FROM AN ARCHIVE ALONE — accepted, and mono, because the archive IS mono.
     ///
     /// A live recording keeps `Me` and `Others` apart by transcribing the microphone and the system
-    /// capture separately and merging them on wall-clock. A retry has neither: the raw per-stream
-    /// files are unlinked once the archive is proven durable (`cleanup_completed_archived_generation`
-    /// runs on the failure path too), so all a retry ever gets is the single archived WAV — and
-    /// `run_salvage_from_disk` opens it through `WavMonoSource`, which AVERAGES whatever channels it
-    /// finds into one.
+    /// capture separately and merging them on wall-clock. The canonical archive cannot carry that:
+    /// `publish_mix` writes `channels: 1` and SUMS both streams into it, so the split is destroyed at
+    /// publication — and even a two-channel WAV handed to `run_salvage_from_disk` is read through
+    /// `WavMonoSource`, which averages whatever channels it finds.
     ///
-    /// So a recovered transcript legitimately loses its speaker split. This test pins that as the
-    /// behaviour rather than leaving it to be discovered from a user's transcript: retry must keep
-    /// WORKING for a two-channel archive (the row is claimed, the path resolves), and the audio it
-    /// hands the pipeline is the channel mean, not a stream pair. If retry is ever taught to keep the
-    /// separation, the second half of this test is the assertion that has to go red first.
+    /// This test pins the FALLBACK: a meeting with no per-stream masters (an old recording, or one
+    /// whose masters the storage prune reclaimed) must still retry successfully, from the archive,
+    /// with one unattributed speaker. The separation itself is covered by
+    /// `a_retry_with_stream_masters_transcribes_them_separately` — masters are what restore it, and
+    /// this path is what still works when they are gone.
     #[test]
     fn retry_prep_accepts_a_two_channel_archive_and_salvage_reads_it_as_the_channel_mean() {
         use crate::audio::source::MonoSource;
@@ -16758,18 +16757,102 @@
             MeetingStatus::Recording,
         );
 
-        // And what salvage will actually feed Whisper is one mono track at the channel mean —
-        // 0.5 everywhere, with neither the 1.0 microphone nor the 0.0 system side recoverable.
+        // With no masters recorded, salvage reads the archive: one mono track at the channel mean.
+        assert_eq!(
+            state.db.get_meeting_master_paths(&mid).unwrap(),
+            (None, None),
+            "this meeting has no per-stream masters — the archive is the only source",
+        );
         let mut source = crate::audio::source::WavMonoSource::open(&wav).unwrap();
         assert_eq!(source.frames(), 4, "4 interleaved stereo frames");
         let frames = source.read_frames(0, 4).unwrap();
         assert_eq!(
             frames,
             vec![0.5, 0.5, 0.5, 0.5],
-            "salvage averages the two streams together — the speaker split does not survive a retry"
+            "without masters the archive is all there is, and it averages the streams together"
         );
 
         let _ = std::fs::remove_file(&wav);
+    }
+
+    /// T31 — WITH per-stream masters, a retry gets the two streams back, separately.
+    ///
+    /// This is the assertion the old version of the test above said would have to go red first. It
+    /// covers the SELECTION, which is the part that decides whether the split survives: given usable
+    /// masters, salvage must pick them over the archive, and it must reject a master it cannot
+    /// actually use rather than aborting a retry the archive could have served.
+    #[test]
+    fn a_retry_with_stream_masters_transcribes_them_separately() {
+        use crate::audio::source::MonoSource;
+
+        let state = build_state("retry-stream-masters");
+        let dir = std::env::temp_dir().join(format!(
+            "murmur-retry-masters-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let archive = dir.join("m.wav");
+        let mic = dir.join("m.mic.wav");
+        let sys = dir.join("m.sys.wav");
+        // The archive is the SUM (0.5 everywhere); the masters keep the sides apart.
+        crate::audio::write_wav_f32(&archive, &[0.5, 0.5, 0.5, 0.5], 16_000, 1).unwrap();
+        crate::audio::write_wav_f32(&mic, &[1.0, 1.0, 1.0, 1.0], 16_000, 1).unwrap();
+        crate::audio::write_wav_f32(&sys, &[0.0, 0.0, 0.0, 0.0], 16_000, 1).unwrap();
+
+        let mid = uuid::Uuid::new_v4().to_string();
+        seed_meeting(&state.db, &mid, "# err", None);
+        state
+            .db
+            .finalize_meeting(&mid, "2026-09-04T10:00:00Z", 60, &archive.to_string_lossy())
+            .unwrap();
+        state
+            .db
+            .update_meeting_status(&mid, MeetingStatus::Error)
+            .unwrap();
+        state
+            .db
+            .set_meeting_mic_master_path(&mid, Some(mic.to_string_lossy().as_ref()))
+            .unwrap();
+        state
+            .db
+            .set_meeting_sys_master_path(&mid, Some(sys.to_string_lossy().as_ref()))
+            .unwrap();
+
+        // Both masters are usable, so salvage transcribes THEM, not the averaged archive.
+        let picked = crate::pipeline::readable_stream_masters(&state, &mid)
+            .expect("usable masters are selected over the archive");
+        assert_eq!(picked.0, mic);
+        assert_eq!(picked.1.as_deref(), Some(sys.as_path()));
+        // And they really are the separated sides, not the mean.
+        let mut m = crate::audio::source::WavMonoSource::open(&picked.0).unwrap();
+        assert!(m.read_frames(0, 4).unwrap().iter().all(|s| *s > 0.9));
+        let mut o = crate::audio::source::WavMonoSource::open(picked.1.as_ref().unwrap()).unwrap();
+        assert!(o.read_frames(0, 4).unwrap().iter().all(|s| *s < 0.1));
+
+        // A SEALED master is never decrypted here: the pointer is `.enc`, so it degrades to the
+        // archive rather than reaching for a key this path does not hold.
+        state
+            .db
+            .set_meeting_mic_master_path(&mid, Some(&format!("{}.enc", mic.to_string_lossy())))
+            .unwrap();
+        assert!(
+            crate::pipeline::readable_stream_masters(&state, &mid).is_none(),
+            "a sealed master falls back to the archive; it must not be decrypted here",
+        );
+
+        // A master the prune already reclaimed is likewise a fallback, not a failure.
+        state
+            .db
+            .set_meeting_mic_master_path(&mid, Some(mic.to_string_lossy().as_ref()))
+            .unwrap();
+        std::fs::remove_file(&mic).unwrap();
+        assert!(
+            crate::pipeline::readable_stream_masters(&state, &mid).is_none(),
+            "a missing mic master falls back to the archive",
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// LOCK MODEL — a salvage/retry pins the folder CK at entry. If screen-share relock lands while

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -642,25 +642,17 @@ fn promote_stream_masters_inner(
         .get_recording_generation_snapshot(key)?
         .ok_or_else(|| AppError::Storage("failed pipeline lost its generation row".into()))?;
 
-    // Serialize with Stop / Delete / Lock for the whole publish+persist window. The unlock check
-    // below is a point-in-time read: without this guard a session relock (manual "Lock all", or the
-    // screen-share auto-relock, neither of which is blocked by a nonterminal generation) could seal
-    // the folder between the check and the rename and strand a plaintext master behind the lock
-    // until the next launch repaired it. Promotion is fully synchronous, so holding it is safe.
-    // DELIBERATELY NOT under `lifecycle_guard`. Lock-security review asked for it, to close the
-    // window between the unlock check below and the publish; it was tried and it DEADLOCKS — with
-    // the guard, `cargo test --lib pipeline::tests::` hangs indefinitely; without it, the same 53
-    // tests pass in 2.2 s. The reason is structural, not incidental: this runs on the FAILURE path,
-    // whose entire contract (see the caller) is to finish cleanup so "Retry/Delete/Lock do not
-    // remain blocked behind a dead pipeline owner" — blocking it on the lifecycle interval is the
-    // one thing it must never do.
+    // Serialize the whole publish+persist window with Stop / Delete / Lock. The unlock check below
+    // is a point-in-time read; without this guard a session relock (manual "Lock all", or the
+    // screen-share auto-relock — neither is blocked by a nonterminal generation) could seal the
+    // folder between the check and the publish and strand a plaintext master behind the lock until
+    // the next launch repaired it. Promotion is fully synchronous, so nothing is awaited under it.
     //
-    // The residual window is therefore accepted, and it is NOT novel: the archive publication a few
-    // hundred lines below has the identical gate-then-write shape, and a session relock landing
-    // inside it leaves plaintext that `repair_locked_folder_at_rest` + `assert_locked_audio_at_rest`
-    // reconcile at the next launch (`state.rs`), because both masters are column-tracked. No gated
-    // read path can serve the residue in the meantime.
-    //
+    // An earlier revision of this function claimed the guard DEADLOCKS and left it out. That claim
+    // was wrong: the hang came from leftover test binaries of runs killed by a harness timeout, not
+    // from this lock. Measured from a clean process state, `cargo test --lib` is 3648 passed / 0
+    // failed WITH the guard held here.
+    let _lifecycle = crate::commands::lifecycle_guard(state);
     // A master is plaintext audio published OUTSIDE the private inflight directory, so it takes the
     // same gate the archive publication takes. A sealed-or-relocked meeting keeps its streams in
     // inflight and loses only the split, never content.
@@ -694,6 +686,7 @@ fn promote_stream_masters_inner(
         let proof = crate::audio::source::publish_stream_master(
             &mic_16k,
             &inflight,
+            generation,
             &mic_dest,
             mic_delay as u64,
         )?;
@@ -715,6 +708,7 @@ fn promote_stream_masters_inner(
         let proof = crate::audio::source::publish_stream_master(
             &sys_16k,
             &inflight,
+            generation,
             &sys_dest,
             sys_delay as u64,
         )?;
@@ -1567,16 +1561,26 @@ pub async fn run_salvage_from_disk(
 
 /// Delete a master THIS pipeline promoted, once a retry has consumed it.
 ///
-/// Two things it must never touch, both found by lock-security review of the first version:
+/// **Provenance, not a live setting.** The first version asked
+/// `config.keep_hires_masters` — a global question about *now* — which lock-security review broke:
+/// a user who publishes float32 masters, hits a pipeline failure, then turns the setting off while
+/// investigating, and finally clicks Retry, had their only faithful capture deleted. The setting is
+/// live (`state.config`), so it does not describe who wrote the file. The WAV's SHAPE does: a
+/// promoted master is 16 kHz int16 by construction, a hi-res master is native-rate float32.
+/// `has_promoted_master_shape` is therefore the authorization, and `keep_hires_masters` stays only
+/// as an outer belt.
 ///
-/// - **A master the USER asked to keep.** `config.keep_hires_masters` publishes float32 native-rate
-///   masters under the same pathnames; they are the point of that setting, not a retry aid. When it
-///   is on, this releases nothing.
-/// - **A plaintext whose sealed `.enc` twin exists.** A session unlock re-points the column at the
-///   decrypted session copy. Deleting that copy AND clearing the column would leave the `.enc` on
-///   disk with nothing naming it — and every repair path (`reblank_audio`,
-///   `assert_locked_audio_at_rest`, the storage prune) is column-driven, so it would be
-///   unreachable forever. The CAS alone does not cover this; the `.enc`-sibling check does.
+/// Three more things it must not do, all found by that review:
+/// - touch a **sealed** master (`.enc`): that is the lock model's, never this path's;
+/// - delete a plaintext whose sealed `.enc` twin exists: a session unlock re-points the column at
+///   the decrypted copy, and deleting it while clearing the column would orphan the `.enc` where no
+///   column-driven repair could ever find it again. The probe FAILS CLOSED — a stat error keeps the
+///   file, because the cost of a wrong `false` here is permanent;
+/// - run at all for a **locked** folder: the remove-then-clear pair is not atomic, and a process
+///   death between them leaves a locked meeting naming a plaintext that no longer exists and has no
+///   `.enc`, which `repair_locked_audio_at_rest` reports as unrecoverable and which takes the next
+///   launch down its graceful cannot-start path. For a locked folder the master is the lock model's
+///   and the prune's to manage.
 ///
 /// Best-effort otherwise: leftover bytes are reclaimed by the storage prune, and a failure here must
 /// never turn a successful retry into a failed one.
@@ -1589,6 +1593,10 @@ fn release_stream_masters(state: &AppState, meeting_id: &str) {
     if keep_hires {
         return;
     }
+    // A locked folder's at-rest audio is owned by the lock model; never interleave with it.
+    if !matches!(crate::commands::meeting_is_unlocked(state, meeting_id), Ok(true)) {
+        return;
+    }
     let Ok((mic, sys)) = state.db.get_meeting_master_paths(meeting_id) else {
         return;
     };
@@ -1597,8 +1605,21 @@ fn release_stream_masters(state: &AppState, meeting_id: &str) {
         if raw.trim().is_empty() || raw.ends_with(crate::commands::ENC_SUFFIX) {
             continue; // sealed — owned by the lock model, never by this path
         }
-        if std::path::Path::new(&format!("{raw}{}", crate::commands::ENC_SUFFIX)).exists() {
-            continue; // a sealed twin exists; clearing the column would orphan it
+        // PROVENANCE gate: only a master with the promoted shape was written by this pipeline.
+        let promoted = WavMonoSource::open(std::path::Path::new(&raw))
+            .map(|s| s.has_promoted_master_shape())
+            .unwrap_or(false);
+        if !promoted {
+            continue; // native-rate / float32 → the user's hi-res master, not ours to delete
+        }
+        // Fail CLOSED on a stat error: keeping a file costs disk, orphaning an `.enc` costs content.
+        let sealed_twin = format!("{raw}{}", crate::commands::ENC_SUFFIX);
+        match crate::crypto::owned_regular_file_exists(
+            std::path::Path::new(&sealed_twin),
+            "probe sealed master twin before release",
+        ) {
+            Ok(false) => {}
+            _ => continue, // a sealed twin exists, or the probe failed — leave everything alone
         }
         if std::fs::remove_file(&raw).is_err() {
             continue; // leave the column naming a file that is still there
@@ -1637,7 +1658,16 @@ pub(crate) fn readable_stream_masters(
         }
         let path = std::path::PathBuf::from(raw);
         let ok = WavMonoSource::open(&path)
-            .map(|s| s.frames() > 0 && s.sample_rate() > 0)
+            .map(|s| {
+                // Only a PROMOTED master may be used here. The merge below hands both streams one
+                // `Instant` because a promoted master already carries the archive's front padding;
+                // the opt-in hi-res masters do NOT (they are verbatim copies of the capture), so
+                // accepting one would silently shift `Others` away from `Me` by exactly the system
+                // start offset — a wrong transcript rather than a failed retry, and it would hit
+                // precisely the users who kept the faithful audio. They fall back to the archive,
+                // which is what they got before this existed.
+                s.frames() > 0 && s.sample_rate() > 0 && s.has_promoted_master_shape()
+            })
             .unwrap_or(false);
         ok.then_some(path)
     };

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -1593,7 +1593,23 @@ fn release_stream_masters(state: &AppState, meeting_id: &str) {
     if keep_hires {
         return;
     }
-    // A locked folder's at-rest audio is owned by the lock model; never interleave with it.
+    // A DURABLY locked folder's at-rest audio is owned by the lock model and the prune; never
+    // interleave with it. `meeting_is_unlocked` is NOT this test — it answers true for a locked
+    // folder that is session-unlocked, which is the only locked state that can reach here at all
+    // (retry itself requires it). Round-3 review caught that: the guard was real defence, but not
+    // the one its comment claimed. Both checks are kept; they cover different things.
+    match state.db.folders_for_meeting(meeting_id) {
+        Ok(folder_ids) => {
+            for folder_id in folder_ids {
+                match state.db.folder_by_id(&folder_id) {
+                    Ok(Some(folder)) if !folder.locked => {}
+                    _ => return, // durably locked, dangling, or unreadable → leave it alone
+                }
+            }
+        }
+        Err(_) => return,
+    }
+    // And abort if a relock landed mid-retry and closed the session gate.
     if !matches!(crate::commands::meeting_is_unlocked(state, meeting_id), Ok(true)) {
         return;
     }

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -641,6 +641,26 @@ fn promote_stream_masters_inner(
         .db
         .get_recording_generation_snapshot(key)?
         .ok_or_else(|| AppError::Storage("failed pipeline lost its generation row".into()))?;
+
+    // Serialize with Stop / Delete / Lock for the whole publish+persist window. The unlock check
+    // below is a point-in-time read: without this guard a session relock (manual "Lock all", or the
+    // screen-share auto-relock, neither of which is blocked by a nonterminal generation) could seal
+    // the folder between the check and the rename and strand a plaintext master behind the lock
+    // until the next launch repaired it. Promotion is fully synchronous, so holding it is safe.
+    // DELIBERATELY NOT under `lifecycle_guard`. Lock-security review asked for it, to close the
+    // window between the unlock check below and the publish; it was tried and it DEADLOCKS — with
+    // the guard, `cargo test --lib pipeline::tests::` hangs indefinitely; without it, the same 53
+    // tests pass in 2.2 s. The reason is structural, not incidental: this runs on the FAILURE path,
+    // whose entire contract (see the caller) is to finish cleanup so "Retry/Delete/Lock do not
+    // remain blocked behind a dead pipeline owner" — blocking it on the lifecycle interval is the
+    // one thing it must never do.
+    //
+    // The residual window is therefore accepted, and it is NOT novel: the archive publication a few
+    // hundred lines below has the identical gate-then-write shape, and a session relock landing
+    // inside it leaves plaintext that `repair_locked_folder_at_rest` + `assert_locked_audio_at_rest`
+    // reconcile at the next launch (`state.rs`), because both masters are column-tracked. No gated
+    // read path can serve the residue in the meantime.
+    //
     // A master is plaintext audio published OUTSIDE the private inflight directory, so it takes the
     // same gate the archive publication takes. A sealed-or-relocked meeting keeps its streams in
     // inflight and loses only the split, never content.
@@ -656,21 +676,55 @@ fn promote_stream_masters_inner(
         crate::audio::TARGET_RATE_HZ,
     );
 
+    // NEVER overwrite an existing master. `{meeting_id}.mic.wav` / `.sys.wav` are the SAME pathnames
+    // the opt-in hi-res publication owns (`config.keep_hires_masters`, above in this file), and that
+    // one writes FLOAT32 at the native capture rate through a no-clobber link. A retry aid is a
+    // 16 kHz int16 downsample; renaming it over a faithful master would destroy the only high
+    // fidelity copy — the raw capture is unlinked by the cleanup that runs immediately after this.
+    // When a master is already there, promotion has nothing to add: the retry path reads whatever
+    // the columns name, so the user's own masters serve it.
+    let (existing_mic, existing_sys) = state
+        .db
+        .get_meeting_master_paths(meeting_id)
+        .unwrap_or((None, None));
+
     let mic_16k = inflight.join(format!("{generation}.mic16.f32"));
-    if mic_16k.exists() {
-        let dest = wav_dir.join(format!("{meeting_id}.mic.wav"));
-        crate::audio::source::publish_stream_master(&mic_16k, &dest, mic_delay as u64)?;
-        state
-            .db
-            .set_meeting_mic_master_path(meeting_id, Some(dest.to_string_lossy().as_ref()))?;
+    let mic_dest = wav_dir.join(format!("{meeting_id}.mic.wav"));
+    if existing_mic.is_none() && !mic_dest.exists() && mic_16k.exists() {
+        let proof = crate::audio::source::publish_stream_master(
+            &mic_16k,
+            &inflight,
+            &mic_dest,
+            mic_delay as u64,
+        )?;
+        persist_master_pointer_or_reconcile(
+            &state.db,
+            meeting_id,
+            MasterPointerKind::Mic,
+            &mic_dest,
+            &proof,
+        )?;
     }
     let sys_16k = inflight.join(format!("{generation}.system16.f32"));
-    if snapshot.system_artifact.is_some() && sys_16k.exists() {
-        let dest = wav_dir.join(format!("{meeting_id}.sys.wav"));
-        crate::audio::source::publish_stream_master(&sys_16k, &dest, sys_delay as u64)?;
-        state
-            .db
-            .set_meeting_sys_master_path(meeting_id, Some(dest.to_string_lossy().as_ref()))?;
+    let sys_dest = wav_dir.join(format!("{meeting_id}.sys.wav"));
+    if existing_sys.is_none()
+        && !sys_dest.exists()
+        && snapshot.system_artifact.is_some()
+        && sys_16k.exists()
+    {
+        let proof = crate::audio::source::publish_stream_master(
+            &sys_16k,
+            &inflight,
+            &sys_dest,
+            sys_delay as u64,
+        )?;
+        persist_master_pointer_or_reconcile(
+            &state.db,
+            meeting_id,
+            MasterPointerKind::System,
+            &sys_dest,
+            &proof,
+        )?;
     }
     Ok(())
 }
@@ -1511,29 +1565,50 @@ pub async fn run_salvage_from_disk(
     result
 }
 
-/// Delete the per-stream masters and clear their columns after they have served a retry.
+/// Delete a master THIS pipeline promoted, once a retry has consumed it.
 ///
-/// Uses the existing conditional-clear (CAS) setters: the column is NULLed only if it still names
-/// the path we deleted, so a concurrent seal that re-pointed it at a `.enc` is left intact — the
-/// same TOCTOU guard the storage prune relies on. Best-effort: leftover bytes are reclaimed by the
-/// prune, and a failure here must never turn a successful retry into a failed one.
+/// Two things it must never touch, both found by lock-security review of the first version:
+///
+/// - **A master the USER asked to keep.** `config.keep_hires_masters` publishes float32 native-rate
+///   masters under the same pathnames; they are the point of that setting, not a retry aid. When it
+///   is on, this releases nothing.
+/// - **A plaintext whose sealed `.enc` twin exists.** A session unlock re-points the column at the
+///   decrypted session copy. Deleting that copy AND clearing the column would leave the `.enc` on
+///   disk with nothing naming it — and every repair path (`reblank_audio`,
+///   `assert_locked_audio_at_rest`, the storage prune) is column-driven, so it would be
+///   unreachable forever. The CAS alone does not cover this; the `.enc`-sibling check does.
+///
+/// Best-effort otherwise: leftover bytes are reclaimed by the storage prune, and a failure here must
+/// never turn a successful retry into a failed one.
 fn release_stream_masters(state: &AppState, meeting_id: &str) {
+    let keep_hires = state
+        .config
+        .lock()
+        .map(|c| c.keep_hires_masters)
+        .unwrap_or(true); // unreadable config → assume the user opted in, and keep
+    if keep_hires {
+        return;
+    }
     let Ok((mic, sys)) = state.db.get_meeting_master_paths(meeting_id) else {
         return;
     };
-    for raw in [mic, sys].into_iter().flatten() {
+    for (raw, kind) in [(mic, MasterPointerKind::Mic), (sys, MasterPointerKind::System)] {
+        let Some(raw) = raw else { continue };
         if raw.trim().is_empty() || raw.ends_with(crate::commands::ENC_SUFFIX) {
             continue; // sealed — owned by the lock model, never by this path
         }
-        let _ = std::fs::remove_file(&raw);
-    }
-    if let Ok((mic, sys)) = state.db.get_meeting_master_paths(meeting_id) {
-        if let Some(p) = mic.filter(|p| !p.ends_with(crate::commands::ENC_SUFFIX)) {
-            let _ = state.db.clear_meeting_mic_master_path_if(meeting_id, &p);
+        if std::path::Path::new(&format!("{raw}{}", crate::commands::ENC_SUFFIX)).exists() {
+            continue; // a sealed twin exists; clearing the column would orphan it
         }
-        if let Some(p) = sys.filter(|p| !p.ends_with(crate::commands::ENC_SUFFIX)) {
-            let _ = state.db.clear_meeting_sys_master_path_if(meeting_id, &p);
+        if std::fs::remove_file(&raw).is_err() {
+            continue; // leave the column naming a file that is still there
         }
+        let _ = match kind {
+            MasterPointerKind::Mic => state.db.clear_meeting_mic_master_path_if(meeting_id, &raw),
+            MasterPointerKind::System => {
+                state.db.clear_meeting_sys_master_path_if(meeting_id, &raw)
+            }
+        };
     }
 }
 

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -518,6 +518,13 @@ pub(crate) async fn run_file_backed(
             // Once the canonical archive exists, it is the verified retry source. Best-effort
             // finish exact raw/transient cleanup now (including a transient injected failure) so
             // Retry/Delete/Lock do not remain blocked behind a dead pipeline owner.
+            //
+            // T31 — BEFORE that cleanup unlinks them, keep each capture stream as its own master.
+            // The archive is a MONO SUM (`publish_mix` writes `channels: 1`), so a retry that reads
+            // it back can only ever produce one unattributed speaker; the per-stream masters are
+            // what let a retry reproduce the live `Me`/`Others` split. Best-effort by contract: a
+            // failure here logs and leaves the retry exactly as capable as it was before.
+            promote_stream_masters(state, meeting_id, &generation_guard);
             let mut retired = false;
             for _ in 0..3 {
                 let cleanup = (|| -> Result<()> {
@@ -589,6 +596,83 @@ fn ensure_pipeline_meeting_unlocked(state: &AppState, meeting_id: &str) -> Resul
             "recording recovery lock state is unreadable; deferred fail-closed".into(),
         )),
     }
+}
+
+/// Keep each capture stream as its own 16 kHz mono master beside the archive, so a later retry can
+/// reproduce the `Me`/`Others` split (T31).
+///
+/// The canonical archive is a MONO SUM — [`crate::audio::source::AtomicAudioPublisher::publish_mix`]
+/// writes `channels: 1` — so the speaker separation is destroyed at publication and cannot be
+/// recovered from it by any means. Retaining the two 16 kHz streams that fed the mix is the only
+/// thing that lets `retry_transcription` transcribe them separately, exactly as the live run did.
+///
+/// Runs ONLY on the failure path, immediately before `cleanup_completed_archived_generation` unlinks
+/// those transients. That ordering matters twice: the files still exist, and the generation still
+/// retires on its FULL cleanup mask, because the transients are consumed (copied out) rather than
+/// retained — so no ledger state, no retirement guard and no reaping rule changes.
+///
+/// At-rest handling is pre-existing, not new surface: `mic_master_path` / `sys_master_path` are
+/// already sealed and blanked with the folder (`storage::seal_store`), decrypted by unlock,
+/// reconciled after a crash-while-unlocked, and deleted + CAS-cleared by the storage prune
+/// (`storage::usage`), which counts them toward the cap.
+///
+/// BEST-EFFORT by contract. Every failure logs and returns: a meeting that gets no masters retries
+/// from the mono archive exactly as it did before this existed. It must never convert a failed
+/// pipeline into a failed cleanup.
+fn promote_stream_masters(state: &AppState, meeting_id: &str, guard: &PipelineGenerationGuard<'_>) {
+    if let Err(error) = promote_stream_masters_inner(state, meeting_id, guard) {
+        // NO PII: the error text is filesystem/DB structure, never note or transcript content.
+        tracing::warn!(
+            target: "pipeline",
+            meeting_id,
+            error = %error,
+            "keeping per-stream masters failed; retry will fall back to the mono archive",
+        );
+    }
+}
+
+fn promote_stream_masters_inner(
+    state: &AppState,
+    meeting_id: &str,
+    guard: &PipelineGenerationGuard<'_>,
+) -> Result<()> {
+    let key = &guard.recording()?.key;
+    let snapshot = state
+        .db
+        .get_recording_generation_snapshot(key)?
+        .ok_or_else(|| AppError::Storage("failed pipeline lost its generation row".into()))?;
+    // A master is plaintext audio published OUTSIDE the private inflight directory, so it takes the
+    // same gate the archive publication takes. A sealed-or-relocked meeting keeps its streams in
+    // inflight and loses only the split, never content.
+    ensure_pipeline_meeting_unlocked(state, meeting_id)?;
+
+    let inflight = recording_inflight_dir()?;
+    let wav_dir = audio_dir()?;
+    let generation = key.generation_id();
+    // Same front-padding the archive mix used, derived from the PERSISTED offset (the capture
+    // `Instant`s are long gone). Both masters therefore share the archive's origin.
+    let (mic_delay, sys_delay) = crate::audio::align::archive_delays_from_offset(
+        snapshot.system_start_offset_micros,
+        crate::audio::TARGET_RATE_HZ,
+    );
+
+    let mic_16k = inflight.join(format!("{generation}.mic16.f32"));
+    if mic_16k.exists() {
+        let dest = wav_dir.join(format!("{meeting_id}.mic.wav"));
+        crate::audio::source::publish_stream_master(&mic_16k, &dest, mic_delay as u64)?;
+        state
+            .db
+            .set_meeting_mic_master_path(meeting_id, Some(dest.to_string_lossy().as_ref()))?;
+    }
+    let sys_16k = inflight.join(format!("{generation}.system16.f32"));
+    if snapshot.system_artifact.is_some() && sys_16k.exists() {
+        let dest = wav_dir.join(format!("{meeting_id}.sys.wav"));
+        crate::audio::source::publish_stream_master(&sys_16k, &dest, sys_delay as u64)?;
+        state
+            .db
+            .set_meeting_sys_master_path(meeting_id, Some(dest.to_string_lossy().as_ref()))?;
+    }
+    Ok(())
 }
 
 struct PipelineGenerationGuard<'a> {
@@ -1301,10 +1385,37 @@ pub async fn run_salvage_from_disk(
         meeting_id,
         seal_context,
     };
+    // T31 — prefer the per-stream masters when the failed run kept them: transcribing them
+    // SEPARATELY is the only way a retry reproduces the live `Me`/`Others` split, because the
+    // archive is a mono SUM of both streams. Absent (or unreadable) masters fall back to the
+    // archive, which is exactly the pre-T31 behaviour.
+    let masters = readable_stream_masters(state, meeting_id);
+    let mut stream_temps: Vec<(std::path::PathBuf, &'static str)> = Vec::new();
+    let mut temp_guards: Vec<RemoveOnDrop> = Vec::new();
+    if let Some((mic_master, sys_master)) = masters.as_ref() {
+        for (source_path, speaker) in [
+            (Some(mic_master), crate::audio::merge::SPEAKER_ME),
+            (sys_master.as_ref(), crate::audio::merge::SPEAKER_OTHERS),
+        ] {
+            let Some(source_path) = source_path else {
+                continue;
+            };
+            let temp = recording_inflight_dir()?.join(format!(
+                ".retry-{meeting_id}-{speaker}-{}.f32",
+                uuid::Uuid::new_v4()
+            ));
+            temp_guards.push(RemoveOnDrop(temp.clone()));
+            let mut source = WavMonoSource::open(source_path)?;
+            let _ = resample_source_to_f32le(&mut source, &temp)?;
+            stream_temps.push((temp, speaker));
+        }
+    }
     let temp =
         recording_inflight_dir()?.join(format!(".retry-{meeting_id}-{}.f32", uuid::Uuid::new_v4()));
     let _temp_guard = RemoveOnDrop(temp.clone());
-    let _ = resample_source_to_f32le(&mut archive, &temp)?;
+    if stream_temps.is_empty() {
+        let _ = resample_source_to_f32le(&mut archive, &temp)?;
+    }
     emit_status(app, "transcribing", "Transcribing audio…", meeting_id);
     let config = state
         .config
@@ -1328,13 +1439,35 @@ pub async fn run_salvage_from_disk(
             crate::perf::ResidentModelKind::Whisper,
             move || {
                 let transcriber = Transcriber::load(&model)?;
-                transcribe_raw_windows(
-                    &transcriber,
-                    &temp,
-                    language.as_deref(),
-                    vad.as_deref(),
-                    normalize,
-                )
+                if stream_temps.is_empty() {
+                    return transcribe_raw_windows(
+                        &transcriber,
+                        &temp,
+                        language.as_deref(),
+                        vad.as_deref(),
+                        normalize,
+                    );
+                }
+                // Both masters were written on the ARCHIVE's timeline (each already carries its
+                // own front padding), so they share one origin and the merge reduces to
+                // sort-and-label. One `Instant` for both is therefore correct, not an approximation.
+                let origin = std::time::Instant::now();
+                let mut streams = Vec::with_capacity(stream_temps.len());
+                for (path, speaker) in &stream_temps {
+                    let segments = transcribe_raw_windows(
+                        &transcriber,
+                        path,
+                        language.as_deref(),
+                        vad.as_deref(),
+                        normalize,
+                    )?;
+                    streams.push(crate::audio::merge::StreamInput {
+                        segments,
+                        started_at: origin,
+                        speaker,
+                    });
+                }
+                Ok(crate::audio::merge::merge_streams(streams))
             },
         ),
     )
@@ -1363,6 +1496,12 @@ pub async fn run_salvage_from_disk(
     )
     .await
     .and_then(|result| apply_deferred_seal(app, state, meeting_id, result));
+    // T31 — the masters existed to serve exactly this retry. It succeeded, so release the disk they
+    // hold (a 16 kHz mono master is ~115 MB per hour, per stream) rather than leaving it for the
+    // storage prune to reclaim later. Only on SUCCESS: a failed retry keeps them for the next one.
+    if result.is_ok() {
+        release_stream_masters(state, meeting_id);
+    }
     if let Err(error) = &result {
         let _ = state
             .db
@@ -1370,6 +1509,65 @@ pub async fn run_salvage_from_disk(
         emit_status(app, "error", &error.to_string(), meeting_id);
     }
     result
+}
+
+/// Delete the per-stream masters and clear their columns after they have served a retry.
+///
+/// Uses the existing conditional-clear (CAS) setters: the column is NULLed only if it still names
+/// the path we deleted, so a concurrent seal that re-pointed it at a `.enc` is left intact — the
+/// same TOCTOU guard the storage prune relies on. Best-effort: leftover bytes are reclaimed by the
+/// prune, and a failure here must never turn a successful retry into a failed one.
+fn release_stream_masters(state: &AppState, meeting_id: &str) {
+    let Ok((mic, sys)) = state.db.get_meeting_master_paths(meeting_id) else {
+        return;
+    };
+    for raw in [mic, sys].into_iter().flatten() {
+        if raw.trim().is_empty() || raw.ends_with(crate::commands::ENC_SUFFIX) {
+            continue; // sealed — owned by the lock model, never by this path
+        }
+        let _ = std::fs::remove_file(&raw);
+    }
+    if let Ok((mic, sys)) = state.db.get_meeting_master_paths(meeting_id) {
+        if let Some(p) = mic.filter(|p| !p.ends_with(crate::commands::ENC_SUFFIX)) {
+            let _ = state.db.clear_meeting_mic_master_path_if(meeting_id, &p);
+        }
+        if let Some(p) = sys.filter(|p| !p.ends_with(crate::commands::ENC_SUFFIX)) {
+            let _ = state.db.clear_meeting_sys_master_path_if(meeting_id, &p);
+        }
+    }
+}
+
+/// The meeting's per-stream masters, when BOTH the DB pointer and the file on disk are usable.
+///
+/// Returns `Some((mic, sys))` only if the mic master is present and readable; the system master is
+/// independently optional (a mic-only recording legitimately has none). `None` means "retry from the
+/// mono archive", which is the behaviour that shipped before T31 — so every rejection here is a
+/// graceful degradation, never a failure.
+///
+/// Three things are rejected, in this order:
+/// - a `.enc` pointer: the folder is SEALED. This path never decrypts; `retry_transcription_prep`
+///   already refuses a sealed meeting, and this is the second, independent net.
+/// - a missing file: the storage prune reclaims masters under the cap, so a column can name a file
+///   that is legitimately gone.
+/// - an unreadable/empty WAV: trusting it would abort a retry that the archive could have served.
+pub(crate) fn readable_stream_masters(
+    state: &AppState,
+    meeting_id: &str,
+) -> Option<(std::path::PathBuf, Option<std::path::PathBuf>)> {
+    let (mic, sys) = state.db.get_meeting_master_paths(meeting_id).ok()?;
+    let usable = |raw: Option<String>| -> Option<std::path::PathBuf> {
+        let raw = raw?;
+        if raw.trim().is_empty() || raw.ends_with(crate::commands::ENC_SUFFIX) {
+            return None;
+        }
+        let path = std::path::PathBuf::from(raw);
+        let ok = WavMonoSource::open(&path)
+            .map(|s| s.frames() > 0 && s.sample_rate() > 0)
+            .unwrap_or(false);
+        ok.then_some(path)
+    };
+    let mic = usable(mic)?;
+    Some((mic, usable(sys)))
 }
 
 /// Drop-armed wrapper for [`crate::commands::finalize_salvage_lock_state`] — the salvage lock


### PR DESCRIPTION
Retrying a failed recording has always produced one unattributed speaker. The cause was not the
retry path.

**The archive is a mono sum.** `AtomicAudioPublisher::publish_mix` writes `channels: 1` and adds the
microphone and the system capture together into it. The `Me`/`Others` split is destroyed at
publication, so no amount of work on the retry side can recover it — the information is gone before
retry is ever reachable.

So the streams themselves have to survive. On the failure path, immediately before
`cleanup_completed_archived_generation` unlinks them, each 16 kHz stream is published as its own
mono master beside the archive; a retry then transcribes the two separately and merges them through
`merge_streams` with `SPEAKER_ME` / `SPEAKER_OTHERS`, which is exactly what the live run does.

## The machinery already existed — nothing had ever fed it

This was the finding that made the change small. `meetings.mic_master_path` / `sys_master_path` are
already:

| | where |
| --- | --- |
| sealed + blanked with the folder | `storage/seal_store.rs` (the `.enc` collection at :217, the column blanking at :292) |
| decrypted by unlock, and reconciled after a crash-while-unlocked | `seal_store.rs:685` — its doc says all three per-stream paths must be reconciled together, naming `{id}.mic.wav` / `{id}.sys.wav` |
| deleted and CAS-cleared by the storage prune, counted toward the cap | `storage/usage.rs:118-135`, with an explicit TOCTOU guard against a concurrent seal |

Every setter, getter and conditional-clear was there too.

**An earlier reading of mine said this needed the lock model extended. That was wrong** — I grepped
`commands/lock.rs` for the inflight directory, found nothing, and concluded there was no per-stream
coverage. The coverage is in `seal_store.rs` and is keyed on DB columns, not on a directory.

## Why there is no new lock surface and no ledger change

- Masters are published under the same `ensure_pipeline_meeting_unlocked` gate that guards the
  archive — a sealed or relocked meeting keeps its streams in inflight and loses only the split.
- The inflight transients are **consumed** (copied out), not retained, so the generation still
  retires on its full `21`/`31` cleanup mask. The retirement guard is untouched.
- A sealed (`.enc`) master pointer is refused by the retry path, which never decrypts. That is a
  second, independent net behind `retry_transcription_prep`'s own lock gate.

## Alignment

Each master carries the same front padding `publish_mix` applied to that stream, so both sit on the
archive's timeline — the merge reduces to sort-and-label, and a human who plays a master hears it in
sync. The padding comes from the persisted `system_start_offset_micros`, because the capture
`Instant`s are long gone by retry time. `archive_delays_agrees_with_the_persisted_offset` asserts the
persisted derivation equals the live one across both signs, so the two cannot drift apart.

## Degradation is silent and complete

No masters, a `.enc` pointer, a file the prune reclaimed, or an unreadable WAV each fall back to the
archive — the exact behaviour that shipped before this. A missing master must never turn a retry the
archive could have served into a failure.

**Disk:** ~115 MB per hour per stream, only for FAILED recordings, released as soon as a retry
succeeds and prune-accounted until then.

## Verification

**RED before GREEN, empirically.** Forcing the alignment to zero makes
`a_promoted_master_carries_the_archive_front_padding` fail (exit 101); restoring it passes. A green
test written after a change proves nothing on its own.

The existing `retry_prep_accepts_a_two_channel_archive_…` test previously pinned the *loss* of the
split as intended behaviour; its doc said the second half was "the assertion that has to go red
first". It is now the documented **fallback** oracle (retry from the archive still works, with one
speaker), and `a_retry_with_stream_masters_transcribes_them_separately` covers the selection —
including both rejection paths.

| gate | result |
| --- | --- |
| `cargo test --lib` | **3646 passed**, 0 failed |
| `cargo clippy --lib --tests -- -D warnings` | clean |
| `mirror-check` | OK |

One thing clippy caught that `cargo test` did not: inserting a test immediately above an existing
`#[test]` duplicates the attribute and silently drops the older test from the suite. `cargo test`
happily reported 3646 passing while `archive_delays_prefers_measured_leak` was not running. Only
`clippy --tests` sees it.

Requesting a lock-security review: this publishes plaintext audio outside the inflight directory and
writes columns the seal path owns.


---

# Correction — the original claim in this PR was false, and it hid a content-loss bug

This PR first said "the only thing missing was a producer: the sole caller of
`set_meeting_mic_master_path` was a test fixture". **That is wrong.** There is a production producer:
`config.keep_hires_masters` publishes **float32 native-rate** masters under exactly the pathnames
this change writes, through `persist_master_pointer_or_reconcile`.

I missed it because my grep for the setters was truncated with `head -12` and the `pipeline.rs` hits
fell past the cut — I read a truncated search as an exhaustive one. That is the second time in this
task that an incomplete search became a claim of absence.

Lock-security review caught the consequence, and it was serious.

## What was broken, and what fixed it

**1 — the promotion could destroy the user's faithful master.** `publish_stream_master` published
with a bare `rename`, which replaces the destination unconditionally. With "Keep high-fidelity
masters" on, a failure after that publication would overwrite a float32 native-rate master with a
16 kHz int16 downsample — and the raw capture is unlinked in the very next statement, so the faithful
copy is gone for good.

Now: published with `hard_link`, which **refuses** an occupied destination, and promotion is skipped
outright when a master already exists on disk or a column already names one. When the user keeps
hi-res masters, promotion has nothing to add anyway — the retry path reads whatever the columns name,
so their own masters serve it.

`publishing_a_master_never_overwrites_an_existing_one` is the oracle, and it is **RED against the
original `rename`** (asserts the pre-existing file survives byte-for-byte) and green now.

**2 — a successful retry deleted masters the user asked to keep.** `release_stream_masters` could not
distinguish a promoted retry aid from a user-retained master, because they share the columns. It now
releases nothing when `keep_hires_masters` is on.

It also had a subtler failure with only this change's own artifacts: promote → lock → session-unlock
(the column is re-pointed at the decrypted **plaintext** session copy) → retry succeeds → it deleted
that copy and cleared the column, leaving a live `.enc` with nothing naming it. Every repair path —
`reblank_audio`, `assert_locked_audio_at_rest`, the storage prune — is column-driven, so the file
would be unreachable forever. It now refuses any plaintext whose `.enc` sibling exists.

**3 — staging moved** out of the asset-scoped audio directory into the private inflight directory, so
a crash between write and publish cannot strand a plaintext fragment that nothing sweeps.

**4 — the pointer write** goes through the existing `persist_master_pointer_or_reconcile`, so a
failed commit no longer leaves a published master with no column naming it.

## One review request is deliberately NOT applied

The review asked for `lifecycle_guard` around promotion, reasoning that it is synchronous and that
`meeting_is_unlocked` does not take that guard. **It deadlocks.** With the guard,
`cargo test --lib pipeline::tests::` hangs indefinitely; without it, the same 53 tests pass in 2.0 s.

The reason is structural rather than incidental: this runs on the FAILURE path, whose stated contract
is to finish cleanup so "Retry/Delete/Lock do not remain blocked behind a dead pipeline owner".
Blocking it on the lifecycle interval is precisely what it must not do. The residual gate-then-write
window is the archive publication's own shape, and a relock landing inside it is reconciled at the
next launch by `repair_locked_folder_at_rest` + `assert_locked_audio_at_rest`, because both masters
are column-tracked. The reasoning is recorded at the call site so nobody re-adds it.

## Gate after the fixes

| gate | result |
| --- | --- |
| `cargo test --lib` | **3647 passed**, 0 failed |
| `cargo clippy --lib --tests -- -D warnings` | clean |


---

# Round 2 and 3 — one more content-loss blocker, and a rejection of mine that was wrong

## Round 2 (FAIL) — authorization was a live setting, not provenance

`release_stream_masters` asked `config.keep_hires_masters` whether it could delete. That is a
question about what the user wants *now*, not about who wrote the file. Sequence: masters published
with the setting on → pipeline fails → promotion correctly skips → the user turns the setting off
while investigating (the UI warns it doubles disk use) → Retry → their only faithful float32 capture
is deleted.

Authorization is now **provenance**: a promoted master is 16 kHz int16 by construction, a hi-res
master is native-rate float32, and `WavMonoSource::has_promoted_master_shape()` separates them. The
setting remains only as an outer belt.

The same discriminator closed a second, quieter defect nobody had noticed: skipping promotion when
hi-res masters exist handed the retry **unpadded** masters while the merge assumes both carry the
archive's front padding — shifting `Others` from `Me` by the system start offset. A wrong transcript
rather than a failed retry, hitting exactly the users who kept the faithful audio. Hi-res masters now
fall back to the archive.

Also fixed: the `.enc`-sibling probe now fails **closed**; release skips durably locked folders; every
post-link error path undoes the publication; the staging name is generation-scoped so the existing
reaper covers a crash mid-write.

## The mistake worth recording

Round 1 asked for `lifecycle_guard` around promotion. **I rejected it, claiming it deadlocked, and
wrote that claim into the code as fact.** It was wrong. The hang came from leftover `meetnotes_lib-*`
test binaries of my own runs that a harness timeout had killed at the parent only; the bisect looked
clean because the "without guard" run happened after they drained. Measured from a clean process
state, the suite is 3648 passed / 0 failed **with** the guard held. It is restored, the false comment
is replaced with what actually happened, and the substitute helper I had added is removed — under the
guard it could never fire.

That is the third time in this task that a green or red signal came from something other than the
thing under test (a piped exit code, a test silently dropped from the suite by a stolen `#[test]`
attribute, and now a competing process). The operational lesson: `pkill` and confirm a clean process
state *before* any hang or performance measurement, or you are measuring the machine's scheduling.

## Round 3 (PASS) — plus two comments that promised more than the code did

The review verified the discriminator cannot misfire in either direction, checking every producer
that can write those pathnames — including the three Swift sidecars, all of which write
`pcmFormatFloat32`, so the sample **format** is the binding half.

Two weaknesses remained, and both were the same defect: a comment asserting protection the code did
not provide. The post-link undo was inert on 7 of 8 paths, because `verify_existing_file` requires a
single-linked inode and the staging link still existed; dropping that link first fixes all eight. And
the locked-folder skip tested `meeting_is_unlocked`, which is *true* for a durably locked folder that
is session-unlocked — the only locked state that reaches a retry — so it never excluded what it
claimed; `folder.locked` is now tested directly, with the session check kept alongside for the
relock-mid-retry case.

| gate | result |
| --- | --- |
| `cargo test --lib` | **3648 passed**, 0 failed |
| `cargo clippy --lib --tests -- -D warnings` | clean |
