### PR TITLE
chore(release): 2.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4637,7 +4637,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murmur",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murmur",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "dependencies": {
         "@angular/common": "^22.0.8",
         "@angular/compiler": "^22.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "scripts": {
     "start": "cargo build -p murmur-brain && ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "2.4.0"
+version = "2.5.0"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump for the 2.5.0 release: `package.json`, `package-lock.json` (top-level key and the `""` root-package entry), `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, and `Cargo.lock` re-pinned with `cargo update -p murmur --precise 2.5.0`.

Six lines across five files, nothing else. `identifier` stays `com.meetnotes.app`.

Headline of the release is the Related hierarchy picker (#685): the flat chooser is replaced by a keyboard-accessible hierarchy over Not classified, local Spaces/folders and Shared Brains, opening centred on the current item and searching titles plus full breadcrumbs.

`.murmur-server-revision` needs no change — trunk already pins `f46b70f9`, which is what production runs, and the sibling checkout is clean on `main` at the same revision.