### PR TITLE
feat(ask): scope an answer to a Space or folder, subtree included

### DIFF
--- a/src-tauri/src/audit.rs
+++ b/src-tauri/src/audit.rs
@@ -708,7 +708,7 @@ pub(crate) fn build_explain_prompt(
 fn build_corpus(db: &Db) -> Result<Vec<CorpusDoc>> {
     let no_unlocks: HashSet<String> = HashSet::new();
     let mut corpus = Vec::new();
-    for m in db.list_meetings_visible(AUDIT_MAX_MEETINGS, &no_unlocks)? {
+    for m in db.list_meetings_visible(AUDIT_MAX_MEETINGS, &no_unlocks, None)? {
         let Some(note) = db.get_note_if_visible(&m.id, &no_unlocks)? else {
             continue;
         };

--- a/src-tauri/src/brief_runner.rs
+++ b/src-tauri/src/brief_runner.rs
@@ -98,7 +98,7 @@ pub fn build_brief_corpus(
 
     let mut corpus = String::new();
     let mut meeting_ids = Vec::new();
-    for m in db.list_meetings_visible(300, &no_unlocks)? {
+    for m in db.list_meetings_visible(300, &no_unlocks, None)? {
         if m.started_at.as_str() < cutoff.as_str() {
             continue;
         }

--- a/src-tauri/src/commands/ask.rs
+++ b/src-tauri/src/commands/ask.rs
@@ -559,6 +559,13 @@ pub(crate) fn build_ask_vault_floor_prompt(
     reranker: Option<&dyn crate::rerank::Reranker>,
     explicit_sources: Option<&[crate::storage::models::SourceRef]>,
     pinned_org_item_id: Option<&str>,
+    // CONTAINER SCOPE — folder/Space ids the answer must be drawn from, or `None` for the whole
+    // vault. Deliberately NOT part of `explicit_sources`: those are PINNED CONTENT, packed into the
+    // corpus verbatim, and `LinkKind::Container` is excluded from that set on purpose (a container
+    // holds no text of its own). A scope is the other thing entirely — it narrows RETRIEVAL, so a
+    // folder of a hundred notes costs what a folder of five costs, and ranking still decides what
+    // is relevant inside it.
+    scope_folder_ids: Option<&[String]>,
 ) -> Result<AskFloorPrompt, AppError> {
     // Budget on the ASK-role provider's RESOLVED connection — the corpus egresses to it. With
     // role keys absent this is the legacy `provider_id` for EVERY brain_backend (the pre-role
@@ -571,6 +578,15 @@ pub(crate) fn build_ask_vault_floor_prompt(
     // gated link-expansion) — the user controls the context. Same `unlocked` visibility gate as
     // every search leg (a sealed source/neighbour contributes nothing). `None` ⇒ the exact existing
     // whole-vault search below, byte-for-byte.
+    // Expand each scoped container to its SUBTREE. Scoping to a Space means "everything filed
+    // under it", which is the opposite of what a container RELATION does (that one never fans out)
+    // — the difference is the point: a relation says where something belongs, a scope says where to
+    // look. Resolution is by folder id, so the scope survives a rename or a move of the folder.
+    let scope_ids: Option<Vec<String>> = match scope_folder_ids {
+        Some(ids) if !ids.is_empty() => Some(db.folder_scope_ids(ids)?),
+        _ => None,
+    };
+    let scope = scope_ids.as_deref();
     let has_pinned_sources = explicit_sources.map(|s| !s.is_empty()).unwrap_or(false);
     let (corpus, sources) = if has_pinned_sources || pinned_org_item_id.is_some() {
         // PINNED corpus (deterministic; vault-wide search SKIPPED). Pack the pinned ORG item FIRST
@@ -609,11 +625,11 @@ pub(crate) fn build_ask_vault_floor_prompt(
     } else if config.semantic_search_enabled {
         let query_vec = ask_query_vector(question, true);
         crate::summarize::vault_context::build_vault_context_hybrid_visible(
-            db, question, &ask_conn, &query_vec, unlocked, reranker,
+            db, question, &ask_conn, &query_vec, unlocked, reranker, scope,
         )?
     } else {
         crate::summarize::vault_context::build_vault_context_visible(
-            db, question, &ask_conn, unlocked,
+            db, question, &ask_conn, unlocked, scope,
         )?
     };
     if corpus.trim().is_empty() {

--- a/src-tauri/src/commands/ask.rs
+++ b/src-tauri/src/commands/ask.rs
@@ -588,7 +588,14 @@ pub(crate) fn build_ask_vault_floor_prompt(
     };
     let scope = scope_ids.as_deref();
     let has_pinned_sources = explicit_sources.map(|s| !s.is_empty()).unwrap_or(false);
-    let (corpus, sources) = if has_pinned_sources || pinned_org_item_id.is_some() {
+    // A SCOPE routes to the SEARCH path, because a scope is an instruction about where to look and
+    // the pinned branch skips searching entirely ("vault-wide search SKIPPED"). Taking the pinned
+    // branch while a scope is set discarded it silently — the second half of the unreachability bug.
+    // Pinned items are not lost: with a scope present they are packed FIRST, below, and the scoped
+    // search fills the remaining budget, the same shape the org-item + sources composition uses.
+    let (corpus, sources) = if (has_pinned_sources || pinned_org_item_id.is_some())
+        && scope.is_none()
+    {
         // PINNED corpus (deterministic; vault-wide search SKIPPED). Pack the pinned ORG item FIRST
         // (the shared note being viewed — pinned so it's ALWAYS in context; the local Brain's search
         // never surfaces org-feed content), then the explicit sources (+ their gated link-expansion).
@@ -622,15 +629,55 @@ pub(crate) fn build_ask_vault_floor_prompt(
             Vec::new()
         };
         (corpus, sources)
-    } else if config.semantic_search_enabled {
-        let query_vec = ask_query_vector(question, true);
-        crate::summarize::vault_context::build_vault_context_hybrid_visible(
-            db, question, &ask_conn, &query_vec, unlocked, reranker, scope,
-        )?
     } else {
-        crate::summarize::vault_context::build_vault_context_visible(
-            db, question, &ask_conn, unlocked, scope,
-        )?
+        // SEARCH path. With a scope set, anything the user ALSO pinned is packed first so it cannot
+        // be lost by routing here, and the scoped search fills what is left of the one budget.
+        let (mut corpus, mut sources) = if scope.is_some() {
+            let budget = crate::summarize::vault_context::budget_for(&ask_conn);
+            let mut pinned_corpus = String::new();
+            let mut pinned_sources = Vec::new();
+            if let Some(org_id) = pinned_org_item_id {
+                pinned_corpus.push_str(&crate::summarize::vault_context::pack_pinned_org_item(
+                    db, org_id, &ask_conn,
+                )?);
+            }
+            if let Some(srcs) = explicit_sources.filter(|s| !s.is_empty()) {
+                let (c, s) =
+                    crate::summarize::vault_context::build_vault_context_pinned_visible_with_budget(
+                        db,
+                        srcs,
+                        budget.saturating_sub(pinned_corpus.len()),
+                        unlocked,
+                    )?;
+                if !pinned_corpus.is_empty() && !c.is_empty() {
+                    pinned_corpus.push_str("\n\n");
+                }
+                pinned_corpus.push_str(&c);
+                pinned_sources = s;
+            }
+            (pinned_corpus, pinned_sources)
+        } else {
+            (String::new(), Vec::new())
+        };
+        let (found, found_sources) = if config.semantic_search_enabled {
+            let query_vec = ask_query_vector(question, true);
+            crate::summarize::vault_context::build_vault_context_hybrid_visible(
+                db, question, &ask_conn, &query_vec, unlocked, reranker, scope,
+            )?
+        } else {
+            crate::summarize::vault_context::build_vault_context_visible(
+                db, question, &ask_conn, unlocked, scope,
+            )?
+        };
+        if !corpus.is_empty() && !found.is_empty() {
+            corpus.push_str("\n\n");
+        }
+        // ONE budget across both halves — a scoped Ask on a small local model must not get two.
+        let remaining =
+            crate::summarize::vault_context::budget_for(&ask_conn).saturating_sub(corpus.len());
+        corpus.extend(found.chars().take(remaining));
+        sources.extend(found_sources);
+        (corpus, sources)
     };
     if corpus.trim().is_empty() {
         return Ok(AskFloorPrompt::Empty(AskVaultResult {

--- a/src-tauri/src/commands/ask.rs
+++ b/src-tauri/src/commands/ask.rs
@@ -676,7 +676,18 @@ pub(crate) fn build_ask_vault_floor_prompt(
         let remaining =
             crate::summarize::vault_context::budget_for(&ask_conn).saturating_sub(corpus.len());
         corpus.extend(found.chars().take(remaining));
-        sources.extend(found_sources);
+        // DEDUPE by meeting. Pinning a meeting that also lives inside the scoped Space is a natural
+        // thing to do, and before this composition existed the two halves were mutually exclusive
+        // branches so a repeat was structurally impossible. Now it is not: the same meeting can
+        // arrive from the pinned pack and again from the search. `AskVaultResult.sources` is passed
+        // to the FE unchanged and rendered with `track s.origin?.orgItemId ?? s.meetingId`, so a
+        // duplicate is a duplicate Angular track key (NG0955) — a rendering fault, not just noise.
+        // The PINNED entry is kept: it is the one the user asked for by name.
+        for source in found_sources {
+            if !sources.iter().any(|s| s.meeting_id == source.meeting_id) {
+                sources.push(source);
+            }
+        }
         (corpus, sources)
     };
     if corpus.trim().is_empty() {

--- a/src-tauri/src/commands/ask.rs
+++ b/src-tauri/src/commands/ask.rs
@@ -632,6 +632,11 @@ pub(crate) fn build_ask_vault_floor_prompt(
     } else {
         // SEARCH path. With a scope set, anything the user ALSO pinned is packed first so it cannot
         // be lost by routing here, and the scoped search fills what is left of the one budget.
+        //
+        // DELIBERATE EXCEPTION to "scoped means scoped": a pinned source brings its capped active
+        // neighbours with it, and those can sit outside the scope. That is the user's own explicit
+        // pin, so it is correct — but it means a scope is not a hard egress boundary once pins are
+        // also set. Every neighbour is still visibility-gated and content-source-filtered.
         let (mut corpus, mut sources) = if scope.is_some() {
             let budget = crate::summarize::vault_context::budget_for(&ask_conn);
             let mut pinned_corpus = String::new();
@@ -683,8 +688,19 @@ pub(crate) fn build_ask_vault_floor_prompt(
         // to the FE unchanged and rendered with `track s.origin?.orgItemId ?? s.meetingId`, so a
         // duplicate is a duplicate Angular track key (NG0955) — a rendering fault, not just noise.
         // The PINNED entry is kept: it is the one the user asked for by name.
+        // Dedupe on the SAME expression the FE tracks by — `origin.orgItemId ?? meetingId` — not on
+        // `meeting_id` alone. They are identical today only because `VaultSource.origin` is `None`
+        // at every construction site; the day the org-origin chip is wired, deduping on the meeting
+        // would start DROPPING a distinct org source, which is the opposite failure from the
+        // duplicate this fixes. Matching the track key is immune to that and costs nothing now.
+        let key = |s: &crate::storage::models::VaultSource| -> (Option<String>, String) {
+            (
+                s.origin.as_ref().and_then(|o| o.org_item_id.clone()),
+                s.meeting_id.clone(),
+            )
+        };
         for source in found_sources {
-            if !sources.iter().any(|s| s.meeting_id == source.meeting_id) {
+            if !sources.iter().any(|s| key(s) == key(&source)) {
                 sources.push(source);
             }
         }

--- a/src-tauri/src/commands/ask_history.rs
+++ b/src-tauri/src/commands/ask_history.rs
@@ -658,6 +658,9 @@ pub async fn ask_vault_persisted(
     ask_trace_id: Option<String>,
     explicit_sources: Option<Vec<SourceRef>>,
     dashboard_id: Option<String>,
+    // CONTAINER SCOPE (FE `scopeFolderIds`) — narrow retrieval to these Spaces/folders, subtree
+    // included, instead of pinning items. Empty/absent ⇒ the unchanged whole-vault behaviour.
+    scope_folder_ids: Option<Vec<String>>,
 ) -> Result<Response, AppError> {
     if !matches!(
         scope,
@@ -782,6 +785,7 @@ pub async fn ask_vault_persisted(
         ask_trace_id,
         explicit_sources,
         None,
+        scope_folder_ids,
         dashboard_id.clone(),
         Some(snapshot.clone()),
         dashboard_witness.clone(),

--- a/src-tauri/src/commands/brief.rs
+++ b/src-tauri/src/commands/brief.rs
@@ -3,7 +3,7 @@
 //! Extracted verbatim from `commands/mod.rs` (God-file split, PURE MOVE — every body is
 //! byte-identical, only relocated). Two clusters:
 //!   1. `generate_digest` — synthesizes a Weekly Vault Digest. GATED: the cloud corpus is built from
-//!      VISIBLE meetings + VISIBLE notes only (`list_meetings_visible(unlocked)` +
+//!      VISIBLE meetings + VISIBLE notes only (`list_meetings_visible(unlocked, None, None)` +
 //!      `get_note_if_visible(unlocked)` — the same `visibility_clause` predicate MCP uses), so a
 //!      sealed-and-not-session-unlocked meeting's TITLE and markdown NEVER leave the device. The
 //!      NOTES-role provider is built through `provider_for` (consent gate + redaction firewall).
@@ -63,7 +63,7 @@ pub async fn generate_digest(
     // corpus (the whole-note-or-skip budgeting + the omitted-count marker) is factored into the
     // pure `assemble_digest_corpus` so it is unit-testable without a live provider.
     let mut entries: Vec<DigestEntry> = Vec::new();
-    for m in state.db.list_meetings_visible(300, &unlocked)? {
+    for m in state.db.list_meetings_visible(300, &unlocked, None)? {
         if m.started_at.as_str() < cutoff.as_str() {
             continue;
         }

--- a/src-tauri/src/commands/enrich.rs
+++ b/src-tauri/src/commands/enrich.rs
@@ -885,13 +885,14 @@ pub(crate) fn gather_note_enhance_citations(
                     MAX_CITATIONS as i64,
                     0.0,
                     &unlocked,
+                    None,
                 )?,
                 None => Vec::new(),
             }
         } else {
             state
                 .db
-                .search_doc_chunks_fts_visible(&query, MAX_CITATIONS as i64, &unlocked)?
+                .search_doc_chunks_fts_visible(&query, MAX_CITATIONS as i64, &unlocked, None)?
         };
         for hit in doc_hits {
             if hit.document_id == req.note_id {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6123,7 +6123,15 @@ pub(crate) async fn ask_vault_inner(
     if board_id.is_some() {
         remove_duplicate_dashboard_question(&mut history, &question);
     }
-    if pinned_sources.is_some() || pinned_org.is_some() || board_id.is_some() {
+    // A container SCOPE must reach the floor too. Leaving it out of this condition made the whole
+    // feature unreachable: picking a Space and nothing else left all three of the others `None`, so
+    // the request fell through to the vault-wide path with the scope silently dropped — the exact
+    // failure the board-id comment below records, reintroduced for containers.
+    if pinned_sources.is_some()
+        || pinned_org.is_some()
+        || board_id.is_some()
+        || scope_folders.is_some()
+    {
         // Snapshot AND resolve under ONE guard, exactly as `get_dashboard` does. Sharing
         // the caller's snapshot is not enough on its own: it prevents a second, later
         // snapshot but does not serialize against a relock landing between the snapshot

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6017,6 +6017,14 @@ pub async fn ask_vault(
     // path is used and the item is packed FIRST, gated by `get_org_item` (tombstoned/disabled-org
     // ⇒ nothing). FE camelCase `pinnedOrgItemId`. `None`/empty ⇒ byte-identical to before.
     pinned_org_item_id: Option<String>,
+    // CONTAINER SCOPE (FE camelCase `scopeFolderIds`): answer from what is filed under these
+    // Spaces/folders, subtree included. This is a RETRIEVAL narrowing, not pinned content — the
+    // corpus is still assembled by search and ranking, just inside the scope, so scoping a folder
+    // with a hundred notes costs what five cost. `None`/empty ⇒ byte-identical whole-vault
+    // behaviour. It is a separate parameter from `explicit_sources` on purpose: a container is
+    // deliberately not a content source (`LinkKind::is_content_source`), and overloading that list
+    // would put a place where the packer expects text.
+    scope_folder_ids: Option<Vec<String>>,
     // The BOARD this question was asked from. Present ⇒ its DERIVED tiles (promises, drift,
     // pulse, reminders, person, living answer) are rendered as a labelled brief and prepended to
     // the pinned corpus — the tiles the user is looking at, which `get_dashboard_sources`
@@ -6042,6 +6050,7 @@ pub async fn ask_vault(
         ask_thread_id,
         explicit_sources,
         pinned_org_item_id,
+        scope_folder_ids,
         dashboard_id,
         None,
         None,
@@ -6059,6 +6068,7 @@ pub(crate) async fn ask_vault_inner(
     ask_thread_id: Option<String>,
     explicit_sources: Option<Vec<crate::storage::models::SourceRef>>,
     pinned_org_item_id: Option<String>,
+    scope_folder_ids: Option<Vec<String>>,
     dashboard_id: Option<String>,
     authoritative_snapshot: Option<DurableScopeSnapshot>,
     authoritative_dashboard: Option<dashboards::DashboardContextWitness>,
@@ -6100,6 +6110,9 @@ pub(crate) async fn ask_vault_inner(
     // BYTE-IDENTICAL to before.
     let pinned_sources = explicit_sources.filter(|s| !s.is_empty());
     let pinned_org = pinned_org_item_id.filter(|s| !s.trim().is_empty());
+    // Empty ⇒ None, so "scope with nothing selected" is the whole vault rather than a scope that
+    // matches no folder and would silently answer "I found nothing".
+    let scope_folders = scope_folder_ids.filter(|ids| !ids.is_empty());
     // A BOARD is a scope in its own right. Gating this on `pinned_sources` alone meant a
     // board whose tiles are ALL derived — a Promise ledger and nothing else, which is
     // precisely the case this exists for — produced an empty source list, missed the
@@ -6175,6 +6188,7 @@ pub(crate) async fn ask_vault_inner(
                 &state.heavy_inference,
                 pinned_sources,
                 pinned_org,
+                scope_folders.clone(),
                 dispatch_admission.clone(),
             )
             .await?
@@ -6261,6 +6275,7 @@ pub(crate) async fn ask_vault_inner(
         &state.heavy_inference,
         None, // whole-vault path: no explicit sources ⇒ the existing search corpus, unchanged.
         None, // …and no pinned org item — this is the vault-wide fallthrough.
+        None, // …and no container scope: this fallthrough is the whole vault by definition.
         dispatch_admission,
     )
     .await?;
@@ -6422,6 +6437,7 @@ async fn ask_vault_floor(
         heavy,
         explicit_sources,
         pinned_org_item_id,
+        None, // unauthorized-dispatch helper: no container scope
         None,
     )
     .await
@@ -6439,6 +6455,7 @@ async fn ask_vault_floor_authorized(
     heavy: &std::sync::Arc<tokio::sync::Semaphore>,
     explicit_sources: Option<Vec<crate::storage::models::SourceRef>>,
     pinned_org_item_id: Option<String>,
+    scope_folder_ids: Option<Vec<String>>,
     dispatch_admission: crate::state::ContentDispatchAdmission,
 ) -> Result<AskVaultResult, AppError> {
     ask_vault_floor_core(
@@ -6452,6 +6469,7 @@ async fn ask_vault_floor_authorized(
         heavy,
         explicit_sources,
         pinned_org_item_id,
+        scope_folder_ids,
         Some(dispatch_admission),
     )
     .await
@@ -6529,6 +6547,7 @@ async fn ask_vault_floor_core(
     heavy: &std::sync::Arc<tokio::sync::Semaphore>,
     explicit_sources: Option<Vec<crate::storage::models::SourceRef>>,
     pinned_org_item_id: Option<String>,
+    scope_folder_ids: Option<Vec<String>>,
     dispatch_admission: Option<crate::state::ContentDispatchAdmission>,
 ) -> Result<AskVaultResult, AppError> {
     // `build_ask_vault_floor_prompt` does the LOCAL/on-device work — query embedding (Candle/
@@ -6546,6 +6565,7 @@ async fn ask_vault_floor_core(
     let question_owned = question.to_string();
     let history_owned = history.to_vec();
     let memory_brief_owned = memory_brief.to_string();
+    let scope_folder_ids_owned = scope_folder_ids;
     let prompt = tokio::task::spawn_blocking(move || {
         build_ask_vault_floor_prompt(
             &db_for_prompt,
@@ -6557,6 +6577,7 @@ async fn ask_vault_floor_core(
             reranker.as_deref(),
             explicit_sources.as_deref(),
             pinned_org_item_id.as_deref(),
+            scope_folder_ids_owned.as_deref(),
         )
     })
     .await
@@ -6711,7 +6732,7 @@ pub fn topic_threads(state: State<'_, AppState>) -> Result<Vec<TopicThread>, App
     // blanking (and a sealed meeting's topics never surface cross-meeting).
     let unlocked = unlocked_snapshot(state.inner())?;
     let mut input = Vec::new();
-    for m in state.db.list_meetings_visible(500, &unlocked)? {
+    for m in state.db.list_meetings_visible(500, &unlocked, None)? {
         let Some(json) = state.db.get_timeline_data(&m.id)? else {
             continue;
         };
@@ -7911,7 +7932,7 @@ pub(crate) fn finish_related_meetings_result(
 /// backfill (zero vectors) still runs for visible documents that have no chunks yet, so keyword
 /// retrieval covers the write-only legacy rows.
 ///
-/// GATING (lock-model): the corpus is exactly `list_meetings_visible(unlocked)` — a sealed-and-not-
+/// GATING (lock-model): the corpus is exactly `list_meetings_visible(unlocked, None, None)` — a sealed-and-not-
 /// session-unlocked meeting is NEVER returned, so its plaintext is never chunked/embedded and its
 /// chunks STAY purged. Each meeting's note is re-checked through `get_note_if_visible(unlocked)`
 /// before `index_meeting_chunks` (PURGE-then-reinsert, so stale stub vectors are replaced).
@@ -7955,7 +7976,7 @@ pub(crate) fn reindex_embeddings_inner<F: FnMut(usize, usize)>(
 
     // The corpus is the visibility-gated meeting list. `list_meetings_visible` already excludes
     // sealed-and-not-session-unlocked meetings (their notes are not visible under `visibility_clause`).
-    let meetings = db.list_meetings_visible(100_000, unlocked)?;
+    let meetings = db.list_meetings_visible(100_000, unlocked, None)?;
     let total = meetings.len();
 
     let mut indexed = 0usize;
@@ -8265,7 +8286,7 @@ pub(crate) fn backfill_missing_brain_indexes_capped(
     // MEETING half — flag + model gated (see the gating matrix above).
     let mut meetings = 0usize;
     if semantic_enabled && model_present {
-        for m in db.list_meetings_visible(100_000, &empty)? {
+        for m in db.list_meetings_visible(100_000, &empty, None)? {
             if remaining == 0 {
                 tracing::info!(
                     target: "rag",

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6059,6 +6059,27 @@ pub async fn ask_vault(
     .await
 }
 
+// NOTE FOR THE NEXT INSERTION HERE: anchor on the DOC-COMMENT start of the function below, never
+// on its `pub fn` line — an attribute sits above it and inserting between the two silently steals
+// it. `cargo test` stays green either way; only `clippy --tests` sees it.
+/// Does this Ask need the deterministic FLOOR inputs (a resolved corpus assembled here) rather than
+/// the plain vault-wide path?
+///
+/// Lifted out of the `if` it used to be so the exact expression can be unit-tested. It regressed
+/// once already: the container scope was missing from it, which made the whole feature unreachable —
+/// picking a Space and nothing else left every other flag false, so the request fell through to a
+/// vault-wide search with the scope silently dropped. That is the same failure the board id had
+/// before it, recorded in the comment below. Nothing in the suite could see it, because every test
+/// called the layer underneath.
+fn floor_inputs_required(
+    has_pinned_sources: bool,
+    has_pinned_org: bool,
+    has_board: bool,
+    has_scope: bool,
+) -> bool {
+    has_pinned_sources || has_pinned_org || has_board || has_scope
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn ask_vault_inner(
     app: &AppHandle,
@@ -6127,11 +6148,12 @@ pub(crate) async fn ask_vault_inner(
     // feature unreachable: picking a Space and nothing else left all three of the others `None`, so
     // the request fell through to the vault-wide path with the scope silently dropped — the exact
     // failure the board-id comment below records, reintroduced for containers.
-    if pinned_sources.is_some()
-        || pinned_org.is_some()
-        || board_id.is_some()
-        || scope_folders.is_some()
-    {
+    if floor_inputs_required(
+        pinned_sources.is_some(),
+        pinned_org.is_some(),
+        board_id.is_some(),
+        scope_folders.is_some(),
+    ) {
         // Snapshot AND resolve under ONE guard, exactly as `get_dashboard` does. Sharing
         // the caller's snapshot is not enough on its own: it prevents a second, later
         // snapshot but does not serialize against a relock landing between the snapshot

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6153,7 +6153,12 @@ pub(crate) async fn ask_vault_inner(
             }
         }
         // A dashboard is a closed composite scope. Cross-vault user-memory would silently widen it.
-        let memory_brief = if composite.is_some() {
+        // A CONTAINER SCOPE is the same situation and takes the same answer: user-memory facts are
+        // stamped with the meeting they came from and `search_user_facts_visible` gates them on
+        // visibility but NOT on a folder, so they carry content from exactly the meetings the user
+        // just excluded — and `memory_block` puts them ABOVE the notes in the system prompt. Nothing
+        // sealed escapes either way; the point is that "scoped" has to mean scoped.
+        let memory_brief = if composite.is_some() || scope_folders.is_some() {
             String::new()
         } else {
             gated_memory_brief_for_injection(state, &unlocked, &question)

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -13,7 +13,7 @@
 //!      `download_brain_model`, `download_embed_model`, `reindex_embeddings`). The downloads are
 //!      INBOUND-ONLY model-file fetches (no egress). `reindex_embeddings` IS visibility-aware, but
 //!      it does so entirely through the SHARED `reindex_embeddings_inner` — whose corpus is exactly
-//!      `list_meetings_visible(unlocked)` (a sealed-not-session-unlocked meeting is never indexed) —
+//!      `list_meetings_visible(unlocked, None, None)` (a sealed-not-session-unlocked meeting is never indexed) —
 //!      which STAYS in `commands/mod.rs` (it is also called by the startup repair tick + covered by
 //!      the lifecycle tests). The `ReindexResult` DTO and every reindex/backfill HELPER
 //!      (`reindex_embeddings_inner`, `backfill_document_chunks`, `index_document_row_kind_routed`)
@@ -796,7 +796,7 @@ pub async fn download_embed_model(app: AppHandle) -> Result<String, AppError> {
 /// runs after turning `semantic_search_enabled` on, or after installing the e5 model so the old
 /// STUB-embedded chunks get replaced by real e5 vectors).
 ///
-/// GATING (lock-model): the corpus is exactly `list_meetings_visible(unlocked)` — a sealed-and-not-
+/// GATING (lock-model): the corpus is exactly `list_meetings_visible(unlocked, None, None)` — a sealed-and-not-
 /// session-unlocked meeting is NEVER returned, so its plaintext is never chunked/embedded, and its
 /// chunks STAY purged (the seal already purged them; we don't touch them). For each visible meeting
 /// we re-fetch its note through `get_note_if_visible(unlocked)` (defense-in-depth: skip if the note

--- a/src-tauri/src/commands/tests/ask_vault_tests.rs
+++ b/src-tauri/src/commands/tests/ask_vault_tests.rs
@@ -1666,3 +1666,73 @@ fn ask_uses_a_real_embedder_when_one_is_available() {
         "semantic search off must not embed, even with an embedder in hand"
     );
 }
+
+/// THE WIRING, not the mechanism — a container scope must actually reach a query.
+///
+/// This is the test whose absence let the whole feature ship inert. The seven SQL-level oracles all
+/// exercised primitives (`folder_scope_ids`, `search_visible_scoped`, `list_meetings_visible`) and
+/// every one of them was green while `scope_folder_ids` could not reach a search leg at all: it was
+/// read only inside a branch gated on pinned sources / a pinned org item / a board id, and the
+/// pinned branch then skipped searching entirely. Picking a Space and nothing else — the FE's
+/// primary flow — dropped the scope silently and answered from the whole vault.
+///
+/// So this asserts through `build_ask_vault_floor_prompt`, the function production calls, with a
+/// scope and NOTHING else set.
+#[test]
+fn a_container_scope_alone_reaches_the_corpus_and_bounds_it() {
+    let db = tmp_db();
+    db.insert_folder(&crate::storage::models::Folder {
+        id: "f-in".into(),
+        name: "Inside".into(),
+        path: "Inside".into(),
+        parent_id: None,
+        locked: false,
+        created_at: "2026-09-04T00:00:00Z".into(),
+    })
+    .unwrap();
+    seed_note(&db, "m-in", "Atlas Inside", "atlas lives inside", Some("f-in"));
+    seed_note(&db, "m-out", "Atlas Outside", "atlas lives outside", None);
+
+    let cfg = AppConfig {
+        semantic_search_enabled: false,
+        ..AppConfig::default()
+    };
+    let unlocked = HashSet::new();
+    let scope = vec!["f-in".to_string()];
+
+    // Unscoped: both meetings are candidates.
+    let all = match build_ask_vault_floor_prompt(
+        &db, &cfg, &unlocked, "atlas", &[], "", None, None, None, None,
+    )
+    .unwrap()
+    {
+        AskFloorPrompt::Ready { sources, .. } => sources,
+        AskFloorPrompt::Empty(_) => panic!("a non-empty vault must yield Ready"),
+    };
+    assert_eq!(all.len(), 2, "unscoped sees both meetings");
+
+    // Scope ONLY — no pinned sources, no org item, no board. This is the case that was unreachable.
+    let scoped = match build_ask_vault_floor_prompt(
+        &db,
+        &cfg,
+        &unlocked,
+        "atlas",
+        &[],
+        "",
+        None,
+        None,
+        None,
+        Some(&scope),
+    )
+    .unwrap()
+    {
+        AskFloorPrompt::Ready { sources, .. } => sources,
+        AskFloorPrompt::Empty(_) => panic!("the scoped folder has matching content"),
+    };
+    let ids: Vec<&str> = scoped.iter().map(|s| s.meeting_id.as_str()).collect();
+    assert_eq!(
+        ids,
+        vec!["m-in"],
+        "a scope on its own must bound the corpus, not be dropped",
+    );
+}

--- a/src-tauri/src/commands/tests/ask_vault_tests.rs
+++ b/src-tauri/src/commands/tests/ask_vault_tests.rs
@@ -1736,3 +1736,102 @@ fn a_container_scope_alone_reaches_the_corpus_and_bounds_it() {
         "a scope on its own must bound the corpus, not be dropped",
     );
 }
+
+/// The SAME assertion on the SHIPPED default path.
+///
+/// The test above pins `semantic_search_enabled: false` to exercise the keyword builder. Semantic
+/// search ships ON, so that left the hybrid builder — which carried two of the four unscoped
+/// paths review found (its "recent meetings" fallback and the L1.5 temporal fallback) — with no
+/// end-to-end coverage at all. This is its twin.
+#[test]
+fn a_container_scope_bounds_the_corpus_on_the_default_semantic_path() {
+    let db = tmp_db();
+    db.insert_folder(&crate::storage::models::Folder {
+        id: "f-in".into(),
+        name: "Inside".into(),
+        path: "Inside".into(),
+        parent_id: None,
+        locked: false,
+        created_at: "2026-09-04T00:00:00Z".into(),
+    })
+    .unwrap();
+    seed_note(&db, "m-in", "Atlas Inside", "atlas lives inside", Some("f-in"));
+    seed_note(&db, "m-out", "Atlas Outside", "atlas lives outside", None);
+
+    // The DEFAULT: semantic search on. With an empty `vec_chunks` the KNN leg contributes nothing,
+    // so this exercises the hybrid builder's FTS + graph legs AND both of its fallbacks.
+    let cfg = AppConfig::default();
+    assert!(cfg.semantic_search_enabled, "the shipped default is semantic ON");
+    let unlocked = HashSet::new();
+    let scope = vec!["f-in".to_string()];
+
+    let scoped = match build_ask_vault_floor_prompt(
+        &db, &cfg, &unlocked, "atlas", &[], "", None, None, None, Some(&scope),
+    )
+    .unwrap()
+    {
+        AskFloorPrompt::Ready { sources, .. } => sources,
+        AskFloorPrompt::Empty(_) => panic!("the scoped folder has matching content"),
+    };
+    let ids: Vec<&str> = scoped.iter().map(|s| s.meeting_id.as_str()).collect();
+    assert_eq!(ids, vec!["m-in"], "the hybrid path is scoped too");
+
+    // A question that matches NOTHING inside the scope must not fall back to the vault. This is the
+    // branch that packed the 30 most recent meetings from everywhere.
+    let no_match = build_ask_vault_floor_prompt(
+        &db, &cfg, &unlocked, "zzzz-nothing-matches", &[], "", None, None, None, Some(&scope),
+    )
+    .unwrap();
+    if let AskFloorPrompt::Ready { sources, .. } = no_match {
+        let ids: Vec<&str> = sources.iter().map(|s| s.meeting_id.as_str()).collect();
+        assert!(
+            !ids.contains(&"m-out"),
+            "the no-match fallback must stay inside the scope, got {ids:?}",
+        );
+    }
+}
+
+/// A meeting that is BOTH pinned and inside the scope appears ONCE.
+///
+/// The pinned+scope composition concatenates two source lists that were mutually exclusive before,
+/// so a repeat became possible for the first time. `AskVaultResult.sources` is rendered with
+/// `track s.origin?.orgItemId ?? s.meetingId`, and a duplicate track key is an Angular fault
+/// (NG0955), not merely a duplicate chip.
+#[test]
+fn a_meeting_pinned_inside_its_own_scope_is_not_listed_twice() {
+    use crate::storage::models::SourceRef;
+
+    let db = tmp_db();
+    db.insert_folder(&crate::storage::models::Folder {
+        id: "f-in".into(),
+        name: "Inside".into(),
+        path: "Inside".into(),
+        parent_id: None,
+        locked: false,
+        created_at: "2026-09-04T00:00:00Z".into(),
+    })
+    .unwrap();
+    seed_note(&db, "m-in", "Atlas Inside", "atlas lives inside", Some("f-in"));
+
+    let cfg = AppConfig {
+        semantic_search_enabled: false,
+        ..AppConfig::default()
+    };
+    let unlocked = HashSet::new();
+    let scope = vec!["f-in".to_string()];
+    let pinned = vec![SourceRef {
+        kind: crate::links::LinkKind::Meeting,
+        id: "m-in".into(),
+    }];
+
+    let sources = match build_ask_vault_floor_prompt(
+        &db, &cfg, &unlocked, "atlas", &[], "", None, Some(&pinned), None, Some(&scope),
+    )
+    .unwrap()
+    {
+        AskFloorPrompt::Ready { sources, .. } => sources,
+        AskFloorPrompt::Empty(_) => panic!("pinned + scoped content exists"),
+    };
+    let hits = sources.iter().filter(|s| s.meeting_id == "m-in").count();
+    assert_eq!(hits, 1, "pinned AND found inside the scope ⇒ one entry, got {sources:?}");
+}

--- a/src-tauri/src/commands/tests/ask_vault_tests.rs
+++ b/src-tauri/src/commands/tests/ask_vault_tests.rs
@@ -22,6 +22,48 @@ fn block_on<F: std::future::Future>(f: F) -> F::Output {
         .block_on(f)
 }
 
+/// `seed_note` at an EXPLICIT `started_at`.
+///
+/// `seed_note` hardcodes a 2026-06-26 timestamp — fine for lexical tests, useless for temporal
+/// ones: `extract_date_filter` anchors on `Utc::now()`, so a fixed-date fixture falls into no
+/// natural-language window and the assertion that depends on it cannot fail. Review caught exactly
+/// that, and a first attempt at fixing it with a hardcoded days-ago offset STILL could not fail,
+/// because "last week" is the previous ISO week and its distance depends on today's weekday. The
+/// caller now computes the window with the real parser and seeds inside it.
+fn seed_note_at(
+    db: &Db,
+    id: &str,
+    title: &str,
+    markdown: &str,
+    folder: Option<&str>,
+    when: &str,
+) {
+    let when = when.to_string();
+    db.insert_meeting(&Meeting {
+        id: id.into(),
+        started_at: when.clone(),
+        ended_at: None,
+        title: Some(title.into()),
+        duration_s: 60,
+        audio_path: None,
+        status: MeetingStatus::Summarized,
+        folder_id: None,
+    })
+    .unwrap();
+    db.upsert_note(&NoteRecord {
+        meeting_id: id.into(),
+        provider_id: "claude_code".into(),
+        markdown: markdown.into(),
+        created_at: when,
+        exported_path: None,
+        model_requested: None,
+        model_served: None,
+        gateway_host: None,
+    })
+    .unwrap();
+    db.set_note_folder(id, folder).unwrap();
+}
+
 fn seed_note(db: &Db, id: &str, title: &str, markdown: &str, folder: Option<&str>) {
     db.insert_meeting(&Meeting {
         id: id.into(),
@@ -1759,11 +1801,9 @@ fn a_container_scope_bounds_the_corpus_on_the_default_semantic_path() {
     seed_note(&db, "m-out", "Atlas Outside", "atlas lives outside", None);
 
     // The DEFAULT: semantic search on. With an empty `vec_chunks` the KNN leg contributes nothing,
-    // so this exercises the hybrid builder's FTS + graph legs and its "recent meetings" fallback.
-    // It does NOT reach the L1.5 temporal fallback: that needs `extract_date_filter` to return a
-    // range, which no query here carries. The temporal fix is code-verified and primitive-tested,
-    // not covered end to end — said plainly, because an oracle that overstates its reach is how the
-    // inert version of this feature passed 8/8.
+    // so this exercises the hybrid builder's FTS + graph legs, its "recent meetings" fallback, and
+    // — via the temporal query below, against a meeting seeded relative to NOW — the L1.5 in-window
+    // fallback as well.
     let cfg = AppConfig::default();
     assert!(cfg.semantic_search_enabled, "the shipped default is semantic ON");
     let unlocked = HashSet::new();
@@ -1782,8 +1822,37 @@ fn a_container_scope_bounds_the_corpus_on_the_default_semantic_path() {
 
     // A question that matches NOTHING inside the scope must not fall back to the vault. This is the
     // branch that packed the 30 most recent meetings from everywhere.
-    // A temporal question with no lexical match: this one DOES carry a date range, so it reaches
-    // the L1.5 in-window fallback as well as the recent-meetings one.
+    // A temporal question with no lexical match reaches the L1.5 in-window fallback. For that
+    // assertion to be able to FAIL, something out of scope has to be IN the window — seeded
+    // relative to now, because `extract_date_filter` anchors on `Utc::now()` and a fixed-date
+    // fixture can never land in "last week".
+    // Compute the window the SAME way production does, then seed inside it. "last week" is the
+    // previous ISO week, so how many days back that is depends on today's weekday — a hardcoded
+    // offset lands in it only sometimes, and a test that only sometimes binds is one that never
+    // does when you need it. Anchoring on the real parser makes the meeting provably in-window.
+    let (from, _to) = crate::summarize::temporal::extract_date_filter(
+        "what did we discuss last week",
+        chrono::Utc::now().date_naive(),
+    )
+    .expect("\"last week\" must parse to a range");
+    let in_window = chrono::DateTime::parse_from_rfc3339(&from)
+        .map(|d| d.with_timezone(&chrono::Utc))
+        .unwrap_or_else(|_| {
+            chrono::NaiveDate::parse_from_str(&from[..10], "%Y-%m-%d")
+                .unwrap()
+                .and_hms_opt(12, 0, 0)
+                .unwrap()
+                .and_utc()
+        })
+        + chrono::Duration::hours(36);
+    seed_note_at(
+        &db,
+        "m-recent-out",
+        "Recent Outside",
+        "unrelated words entirely",
+        None,
+        &in_window.to_rfc3339(),
+    );
     for q in ["zzzz-nothing-matches", "what did we discuss last week"] {
         let no_match = build_ask_vault_floor_prompt(
             &db, &cfg, &unlocked, q, &[], "", None, None, None, Some(&scope),
@@ -1797,7 +1866,7 @@ fn a_container_scope_bounds_the_corpus_on_the_default_semantic_path() {
             AskFloorPrompt::Empty(_) => Vec::new(),
         };
         assert!(
-            !ids.iter().any(|id| id == "m-out"),
+            !ids.iter().any(|id| id == "m-out" || id == "m-recent-out"),
             "no-match fallback for {q:?} must stay inside the scope, got {ids:?}",
         );
     }

--- a/src-tauri/src/commands/tests/ask_vault_tests.rs
+++ b/src-tauri/src/commands/tests/ask_vault_tests.rs
@@ -369,6 +369,7 @@ fn ask_floor_prompt_matches_pre_change_implementation() {
         q,
         &cfg.provider_id,
         &unlocked,
+        None,
     )
     .unwrap();
     assert!(
@@ -378,7 +379,7 @@ fn ask_floor_prompt_matches_pre_change_implementation() {
     // Empty memory brief ⇒ the floor prompt must stay BYTE-IDENTICAL to the pre-memory build.
     let (want_system, want_user) = crate::summarize::vault_chat::build(&corpus, &history, q, "");
 
-    match build_ask_vault_floor_prompt(&db, &cfg, &unlocked, q, &history, "", None, None, None)
+    match build_ask_vault_floor_prompt(&db, &cfg, &unlocked, q, &history, "", None, None, None, None)
         .unwrap()
     {
         AskFloorPrompt::Ready {
@@ -411,7 +412,7 @@ fn ask_floor_prompt_matches_pre_change_implementation() {
 
     // The empty-vault early return keeps the EXACT pre-change canned answer.
     let empty = tmp_db();
-    match build_ask_vault_floor_prompt(&empty, &cfg, &unlocked, q, &[], "", None, None, None)
+    match build_ask_vault_floor_prompt(&empty, &cfg, &unlocked, q, &[], "", None, None, None, None)
         .unwrap()
     {
         AskFloorPrompt::Empty(r) => {
@@ -553,6 +554,7 @@ fn loopback_ollama_ask_paths_revalidate_visibility_before_provider_dispatch() {
     }];
     let prompt = build_ask_vault_floor_prompt(
         &db, &cfg, &unlocked, "atlas", &history, "", None, None, None,
+        None,
     )
     .unwrap();
     let AskFloorPrompt::Ready { system, user, .. } = prompt else {
@@ -582,6 +584,7 @@ fn loopback_ollama_ask_paths_revalidate_visibility_before_provider_dispatch() {
         "",
         None,
         &std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
+        None,
         None,
         None,
         floor_admission,

--- a/src-tauri/src/commands/tests/ask_vault_tests.rs
+++ b/src-tauri/src/commands/tests/ask_vault_tests.rs
@@ -1759,7 +1759,11 @@ fn a_container_scope_bounds_the_corpus_on_the_default_semantic_path() {
     seed_note(&db, "m-out", "Atlas Outside", "atlas lives outside", None);
 
     // The DEFAULT: semantic search on. With an empty `vec_chunks` the KNN leg contributes nothing,
-    // so this exercises the hybrid builder's FTS + graph legs AND both of its fallbacks.
+    // so this exercises the hybrid builder's FTS + graph legs and its "recent meetings" fallback.
+    // It does NOT reach the L1.5 temporal fallback: that needs `extract_date_filter` to return a
+    // range, which no query here carries. The temporal fix is code-verified and primitive-tested,
+    // not covered end to end — said plainly, because an oracle that overstates its reach is how the
+    // inert version of this feature passed 8/8.
     let cfg = AppConfig::default();
     assert!(cfg.semantic_search_enabled, "the shipped default is semantic ON");
     let unlocked = HashSet::new();
@@ -1778,15 +1782,23 @@ fn a_container_scope_bounds_the_corpus_on_the_default_semantic_path() {
 
     // A question that matches NOTHING inside the scope must not fall back to the vault. This is the
     // branch that packed the 30 most recent meetings from everywhere.
-    let no_match = build_ask_vault_floor_prompt(
-        &db, &cfg, &unlocked, "zzzz-nothing-matches", &[], "", None, None, None, Some(&scope),
-    )
-    .unwrap();
-    if let AskFloorPrompt::Ready { sources, .. } = no_match {
-        let ids: Vec<&str> = sources.iter().map(|s| s.meeting_id.as_str()).collect();
+    // A temporal question with no lexical match: this one DOES carry a date range, so it reaches
+    // the L1.5 in-window fallback as well as the recent-meetings one.
+    for q in ["zzzz-nothing-matches", "what did we discuss last week"] {
+        let no_match = build_ask_vault_floor_prompt(
+            &db, &cfg, &unlocked, q, &[], "", None, None, None, Some(&scope),
+        )
+        .unwrap();
+        let ids: Vec<String> = match no_match {
+            AskFloorPrompt::Ready { sources, .. } => {
+                sources.iter().map(|s| s.meeting_id.clone()).collect()
+            }
+            // Empty is the ideal outcome, and it trivially contains nothing out of scope.
+            AskFloorPrompt::Empty(_) => Vec::new(),
+        };
         assert!(
-            !ids.contains(&"m-out"),
-            "the no-match fallback must stay inside the scope, got {ids:?}",
+            !ids.iter().any(|id| id == "m-out"),
+            "no-match fallback for {q:?} must stay inside the scope, got {ids:?}",
         );
     }
 }
@@ -1834,4 +1846,27 @@ fn a_meeting_pinned_inside_its_own_scope_is_not_listed_twice() {
     };
     let hits = sources.iter().filter(|s| s.meeting_id == "m-in").count();
     assert_eq!(hits, 1, "pinned AND found inside the scope ⇒ one entry, got {sources:?}");
+}
+
+
+/// The BRANCH CONDITION, which had no oracle at all.
+///
+/// The scope reaching a query depends on two independent things: this predicate admitting it, and
+/// `build_ask_vault_floor_prompt` routing it to the search path. The end-to-end test covers the
+/// second. Dropping `has_scope` from the first would leave that test — and all 3700 others — green
+/// while the feature went inert again, which is exactly how it shipped inert the first time.
+#[test]
+fn a_scope_alone_requires_the_floor_inputs() {
+    use crate::commands::floor_inputs_required;
+
+    assert!(
+        floor_inputs_required(false, false, false, true),
+        "a container scope ALONE must take the floor path — this is the regression",
+    );
+    // The three that were already there, unchanged.
+    assert!(floor_inputs_required(true, false, false, false));
+    assert!(floor_inputs_required(false, true, false, false));
+    assert!(floor_inputs_required(false, false, true, false));
+    // And nothing at all is still the plain vault-wide path.
+    assert!(!floor_inputs_required(false, false, false, false));
 }

--- a/src-tauri/src/commands/tests/dashboard_brief_tests.rs
+++ b/src-tauri/src/commands/tests/dashboard_brief_tests.rs
@@ -352,7 +352,8 @@ fn packed_with_provider(
             None,
             sources,
             None,
-        )
+        None,
+    )
         .unwrap()
         {
             AskFloorPrompt::Ready { system, user, .. } => Some(format!("{system}\n{user}")),

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -14372,7 +14372,8 @@
             "fioletowoszary",
             "anthropic",
             &nothing,
-        )
+        None,
+    )
         .unwrap();
         assert!(
             // Assert on a CONTENT word absent from the query — sentinels echo the query itself
@@ -14495,7 +14496,8 @@
                 "TAJNYTOKEN",
                 "anthropic",
                 unlocked,
-            )
+        None,
+    )
             .unwrap();
             assert_eq!(
                 corpus.contains("przejęcia"),
@@ -21470,7 +21472,7 @@
         let emb = crate::embed::StubEmbedder;
         let qv = emb.embed(std::slice::from_ref(&text.to_string())).unwrap();
         let qvec = qv.into_iter().next().unwrap_or_default();
-        db.search_semantic_visible(&qvec, 50, 0.0, unlocked)
+        db.search_semantic_visible(&qvec, 50, 0.0, unlocked, None)
             .unwrap()
             .iter()
             .any(|h| h.meeting.id == mid)
@@ -24751,7 +24753,8 @@
                 None,
                 None,
                 Some("it-p"),
-            )
+        None,
+    )
             .unwrap()
         };
         let assert_empty_without_disclosure = |prompt: AskFloorPrompt| match prompt {
@@ -43602,7 +43605,7 @@ fn recording_filing_attachment_rollback_preserves_replacement_symlink_and_unknow
             .is_empty());
         assert!(state
             .db
-            .list_meetings_visible(200, &none)
+            .list_meetings_visible(200, &none, None)
             .unwrap()
             .is_empty());
         assert!(state.db.list_entities_visible(&none).unwrap().is_empty());

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -12087,7 +12087,7 @@
         let unlocked = HashSet::new();
         let hits = state
             .db
-            .search_doc_chunks_fts_visible("bravo", 10, &unlocked)
+            .search_doc_chunks_fts_visible("bravo", 10, &unlocked, None)
             .unwrap();
         assert!(
             hits.iter().any(|h| h.document_id == id),
@@ -12095,7 +12095,7 @@
         );
         let tag_hits = state
             .db
-            .search_doc_chunks_fts_visible("frontmatteronlyterm", 10, &unlocked)
+            .search_doc_chunks_fts_visible("frontmatteronlyterm", 10, &unlocked, None)
             .unwrap();
         assert!(
             !tag_hits.iter().any(|h| h.document_id == id),
@@ -12108,7 +12108,7 @@
         let d2 = update_note_doc_inner(&state, &id, "Draft", v2).unwrap();
         let old = state
             .db
-            .search_doc_chunks_fts_visible("bravo", 10, &unlocked)
+            .search_doc_chunks_fts_visible("bravo", 10, &unlocked, None)
             .unwrap();
         assert!(
             !old.iter().any(|h| h.document_id == id),
@@ -12116,7 +12116,7 @@
         );
         let new = state
             .db
-            .search_doc_chunks_fts_visible("yankee", 10, &unlocked)
+            .search_doc_chunks_fts_visible("yankee", 10, &unlocked, None)
             .unwrap();
         assert!(
             new.iter().any(|h| h.document_id == id),
@@ -12153,7 +12153,7 @@
         assert!(
             state
                 .db
-                .search_doc_chunks_fts_visible("bravo", 10, &unlocked)
+                .search_doc_chunks_fts_visible("bravo", 10, &unlocked, None)
                 .unwrap()
                 .is_empty(),
             "cheap-saved body is not searchable until the deferred full save indexes it"
@@ -14486,7 +14486,7 @@
         let assert_leg_visibility = |unlocked: &HashSet<String>, expected: bool, phase: &str| {
             let fts_hit = state
                 .db
-                .search_doc_chunks_fts_visible("TAJNYTOKEN", 10, unlocked)
+                .search_doc_chunks_fts_visible("TAJNYTOKEN", 10, unlocked, None)
                 .unwrap()
                 .iter()
                 .any(|h| h.document_id == id);
@@ -15602,7 +15602,7 @@
         assert!(
             state
                 .db
-                .search_doc_chunks_fts_visible("szmaragdowy", 10, &nothing)
+                .search_doc_chunks_fts_visible("szmaragdowy", 10, &nothing, None)
                 .unwrap()
                 .iter()
                 .any(|h| h.document_id == "d-legacy"),
@@ -27509,7 +27509,7 @@
         );
         assert!(state
             .db
-            .search_doc_chunks_fts_visible("Plan", 10, &std::collections::HashSet::new())
+            .search_doc_chunks_fts_visible("Plan", 10, &std::collections::HashSet::new(), None)
             .unwrap()
             .iter()
             .any(|hit| hit.document_id == note.id));

--- a/src-tauri/src/commands/tests/workspace_tree_tests.rs
+++ b/src-tauri/src/commands/tests/workspace_tree_tests.rs
@@ -1065,7 +1065,7 @@ fn a_locked_pre_note_meeting_is_hidden_enumerated_for_seal_and_not_audio_prunabl
     })
     .unwrap();
 
-    assert!(db.list_meetings_visible(50, &HashSet::new()).unwrap().is_empty());
+    assert!(db.list_meetings_visible(50, &HashSet::new(), None).unwrap().is_empty());
     assert_eq!(
         container_items_inner(&db, &HashSet::new(), None, ItemKind::Meeting, 0, 50)
             .unwrap()
@@ -1522,7 +1522,7 @@ fn migration_leaves_conflicting_legacy_folders_ambiguous_and_visibility_fails_cl
     assert!(canonical.is_none());
     assert!(matches!(db.folder_for_meeting("m1"), Err(AppError::Locked(_))));
     assert!(
-        db.list_meetings_visible(50, &HashSet::new())
+        db.list_meetings_visible(50, &HashSet::new(), None)
             .unwrap()
             .iter()
             .all(|meeting| meeting.id != "m1"),

--- a/src-tauri/src/embed.rs
+++ b/src-tauri/src/embed.rs
@@ -3301,7 +3301,7 @@ mod tests {
         for q in &set.0 {
             let df = crate::summarize::temporal::extract_date_filter(&q.query, today);
             let hits = db
-                .search_visible_in_range(&q.query, 40, &empties, df)
+                .search_visible_in_range(&q.query, 40, &empties, df, None)
                 .unwrap();
             if hits.is_empty() {
                 empty += 1;

--- a/src-tauri/src/eval/bakeoff.rs
+++ b/src-tauri/src/eval/bakeoff.rs
@@ -3,7 +3,7 @@
 //!
 //! ## Modes
 //!
-//! - **FTS** — `Db::search_visible_in_range(query, …, temporal-window)` → the meeting ids in BM25
+//! - **FTS** — `Db::search_visible_in_range(query, …, temporal-window, None, None)` → the meeting ids in BM25
 //!   order (with the Brain v2 L1.5 date filter + temporal window fallback, exactly as the
 //!   `search_meetings` tool queries it).
 //! - **Semantic** — embed the query (asymmetric `embed_query`), then
@@ -54,7 +54,7 @@ fn fts_ranked(
     // Fetch a few extra candidates so the top-k cutoff is applied to a full list, not a truncated one.
     let limit = (k.max(1) * 4) as i64;
     let date_filter = extract_date_filter(query, today);
-    let hits = db.search_visible_in_range(query, limit, unlocked, date_filter)?;
+    let hits = db.search_visible_in_range(query, limit, unlocked, date_filter, None)?;
     Ok(hits.into_iter().map(|h| h.meeting.id).collect())
 }
 
@@ -79,7 +79,7 @@ fn semantic_ranked(
     }
     // KNN returns one hit per meeting (nearest chunk) already deduped by `search_semantic_visible`.
     // No S1 floor in the bake-off (0.0) — the committed baseline must stay byte-identical.
-    let hits = db.search_semantic_visible(&query_vec, (k.max(1) * 4) as i64, 0.0, unlocked)?;
+    let hits = db.search_semantic_visible(&query_vec, (k.max(1) * 4) as i64, 0.0, unlocked, None)?;
     Ok(hits.into_iter().map(|h| h.meeting.id).collect())
 }
 
@@ -106,6 +106,7 @@ fn hybrid_hits(
         0.0, // no S1 floor in the bake-off — the committed baseline must stay byte-identical.
         unlocked,
         date_filter,
+        None, // the bake-off measures the WHOLE vault; a container scope would change the baseline
     )
 }
 

--- a/src-tauri/src/eval/calibration.rs
+++ b/src-tauri/src/eval/calibration.rs
@@ -473,7 +473,7 @@ mod tests {
         let unlocked = HashSet::new(); // OPEN content only — the app's gate.
 
         let meetings = db
-            .list_meetings_visible(limit, &unlocked)
+            .list_meetings_visible(limit, &unlocked, None)
             .expect("list visible meetings");
 
         let mut total_receipts = 0usize;

--- a/src-tauri/src/eval/generation_retrieval.rs
+++ b/src-tauri/src/eval/generation_retrieval.rs
@@ -518,7 +518,8 @@ pub(crate) fn build_evidence() -> Result<RetrievalQualityEvidence> {
                 PRODUCT_CANDIDATE_LIMIT,
                 &unlocked,
                 date_filter.clone(),
-            )?
+            None,
+        )?
             .into_iter()
             .map(|hit| hit.meeting.id)
             .collect::<Vec<_>>();
@@ -533,7 +534,8 @@ pub(crate) fn build_evidence() -> Result<RetrievalQualityEvidence> {
                 PRODUCT_CANDIDATE_LIMIT,
                 crate::embed::KNN_SEARCH_COSINE_FLOOR,
                 &unlocked,
-            )?
+        None,
+    )?
             .into_iter()
             .map(|hit| hit.meeting.id)
             .collect::<Vec<_>>();
@@ -545,7 +547,8 @@ pub(crate) fn build_evidence() -> Result<RetrievalQualityEvidence> {
                 crate::embed::KNN_SEARCH_COSINE_FLOOR,
                 &unlocked,
                 date_filter,
-            )?
+        None,
+    )?
             .into_iter()
             .map(|hit| hit.meeting.id)
             .collect::<Vec<_>>();
@@ -873,11 +876,11 @@ mod tests {
 
         let locked = HashSet::new();
         assert!(db
-            .search_visible_in_range(&query, PRODUCT_CANDIDATE_LIMIT, &locked, None)
+            .search_visible_in_range(&query, PRODUCT_CANDIDATE_LIMIT, &locked, None, None)
             .unwrap()
             .is_empty());
         assert!(db
-            .search_semantic_visible(&query_vec, PRODUCT_CANDIDATE_LIMIT, 0.0, &locked,)
+            .search_semantic_visible(&query_vec, PRODUCT_CANDIDATE_LIMIT, 0.0, &locked, None)
             .unwrap()
             .is_empty());
         assert!(db
@@ -888,19 +891,20 @@ mod tests {
                 crate::embed::KNN_SEARCH_COSINE_FLOOR,
                 &locked,
                 None,
-            )
+        None,
+    )
             .unwrap()
             .is_empty());
 
         let mut unlocked = HashSet::new();
         unlocked.insert("f-locked".to_string());
         assert!(db
-            .search_visible_in_range(&query, PRODUCT_CANDIDATE_LIMIT, &unlocked, None)
+            .search_visible_in_range(&query, PRODUCT_CANDIDATE_LIMIT, &unlocked, None, None)
             .unwrap()
             .iter()
             .any(|hit| hit.meeting.id == "locked-meeting"));
         assert!(db
-            .search_semantic_visible(&query_vec, PRODUCT_CANDIDATE_LIMIT, 0.0, &unlocked,)
+            .search_semantic_visible(&query_vec, PRODUCT_CANDIDATE_LIMIT, 0.0, &unlocked, None)
             .unwrap()
             .iter()
             .any(|hit| hit.meeting.id == "locked-meeting"));
@@ -912,7 +916,8 @@ mod tests {
                 crate::embed::KNN_SEARCH_COSINE_FLOOR,
                 &unlocked,
                 None,
-            )
+        None,
+    )
             .unwrap()
             .iter()
             .any(|hit| hit.meeting.id == "locked-meeting"));

--- a/src-tauri/src/pipeline.rs
+++ b/src-tauri/src/pipeline.rs
@@ -5470,7 +5470,7 @@ mod tests {
             ))
             .unwrap();
         let qvec = qv.into_iter().next().unwrap_or_default();
-        db.search_semantic_visible(&qvec, 10, 0.0, unlocked)
+        db.search_semantic_visible(&qvec, 10, 0.0, unlocked, None)
             .unwrap()
             .iter()
             .any(|h| h.meeting.id == mid)

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -5324,7 +5324,7 @@ impl Db {
         if fts_scored.is_empty() && range.is_some() {
             // Temporal fallback (L1.5): no lexical match inside the window ⇒ the window IS the
             // query — visible in-range meetings, newest-first, positionally scored.
-            let in_window = self.meetings_in_range_visible(range, limit, unlocked, None)?;
+            let in_window = self.meetings_in_range_visible(range, limit, unlocked, scope)?;
             fts_scored = in_window
                 .iter()
                 .enumerate()
@@ -6323,12 +6323,17 @@ impl Db {
         k: i64,
         min_cosine: f32,
         unlocked: &HashSet<String>,
+        scope: Option<&[String]>,
     ) -> Result<Vec<DocChunkHit>> {
         if query_vec.is_empty() || k <= 0 {
             return Ok(Vec::new());
         }
         let conn = self.lock();
         let visible = visibility_clause("f", unlocked);
+        // Notes and DOCUMENTS are folder-anchored too, so a container scope must narrow them
+        // exactly as it narrows meetings — otherwise a scoped Ask still appends the whole vault's
+        // notes to a cloud-bound corpus.
+        let scoped = folder_scope_clause("d", scope);
         // KNN isolated to the vec0 table in a CTE; visibility + document columns joined OUTSIDE it.
         // The trailing `knn.distance` column feeds the S1 relevance floor (dropped below-floor).
         let sql = format!(
@@ -6343,7 +6348,7 @@ impl Db {
                JOIN doc_chunks dc ON dc.id = knn.chunk_id
                JOIN documents d ON d.id = dc.document_id
                JOIN folders f ON f.id = d.folder_id
-              WHERE d.kind IN ('note','document') AND {visible}
+              WHERE d.kind IN ('note','document') AND {visible}{scoped}
               ORDER BY knn.distance ASC, d.id ASC"
         );
         let blob = crate::embed::vec_to_blob(query_vec);
@@ -6385,6 +6390,7 @@ impl Db {
         query: &str,
         limit: i64,
         unlocked: &HashSet<String>,
+        scope: Option<&[String]>,
     ) -> Result<Vec<DocChunkHit>> {
         if limit <= 0 {
             return Ok(Vec::new());
@@ -6395,6 +6401,10 @@ impl Db {
         };
         let conn = self.lock();
         let visible = visibility_clause("f", unlocked);
+        // Notes and DOCUMENTS are folder-anchored too, so a container scope must narrow them
+        // exactly as it narrows meetings — otherwise a scoped Ask still appends the whole vault's
+        // notes to a cloud-bound corpus.
+        let scoped = folder_scope_clause("d", scope);
         let sql = format!(
             "SELECT d.id, d.name, d.folder_id, dc.text, d.kind,
                     dc.id, dc.parent_id, dc.section_path, dc.page_no, dc.level
@@ -6403,7 +6413,7 @@ impl Db {
                JOIN documents d ON d.id = dc.document_id
                JOIN folders f ON f.id = d.folder_id
               WHERE fts_doc_chunks MATCH ?1
-                AND d.kind IN ('note','document') AND {visible}
+                AND d.kind IN ('note','document') AND {visible}{scoped}
               ORDER BY bm25(fts_doc_chunks) ASC, d.id ASC"
         );
         let mut stmt = conn.prepare(&sql).map_err(map_err)?;

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -9507,9 +9507,15 @@ pub(crate) fn note_snippet(markdown: &str) -> String {
 /// A meeting with no folder (`folder_id IS NULL` — Not classified) is outside every container and is
 /// therefore excluded by `IN`, which is the intended reading of "search inside this folder".
 ///
-/// Ids are folder UUIDs read back from the database, quoted the same way `visibility_clause` quotes
-/// the session unlock set. They are not user text; the folder NAME never reaches this SQL, which is
-/// why `folder_subtree_ids` resolves the subtree in Rust instead of with a `LIKE` over paths.
+/// Ids are quoted the same way `visibility_clause` quotes the session unlock set, and THAT is what
+/// makes this safe — not their provenance. They are usually folder UUIDs read back from the
+/// database, but `folder_subtree_ids` returns an unknown id verbatim, so a value that reached the
+/// backend from the frontend can land here. Doubling `'` inside a `'…'` literal is complete for
+/// SQLite (it has no backslash escapes in string literals), so `x') OR 1=1 --` renders as one
+/// literal. Do not remove the quoting on the belief that these are always internal ids.
+///
+/// The folder NAME still never reaches this SQL, which is why `folder_subtree_ids` resolves the
+/// subtree in Rust rather than with a `LIKE` over paths.
 pub(crate) fn folder_scope_clause(alias: &str, scope: Option<&[String]>) -> String {
     let Some(ids) = scope.filter(|ids| !ids.is_empty()) else {
         return String::new();

--- a/src-tauri/src/storage/db.rs
+++ b/src-tauri/src/storage/db.rs
@@ -4614,7 +4614,7 @@ impl Db {
         const TOPIC_BACKFILL_BATCH: usize = 20;
         const TOPIC_BACKFILL_MAX_REEMBED_PER_RUN: usize = 50;
         let unlocked: HashSet<String> = HashSet::new();
-        let meetings = self.list_meetings_visible(100_000, &unlocked)?;
+        let meetings = self.list_meetings_visible(100_000, &unlocked, None)?;
         let mut indexed = 0usize;
         let mut reembedded = 0usize;
         'outer: for batch in meetings.chunks(TOPIC_BACKFILL_BATCH) {
@@ -4966,12 +4966,14 @@ impl Db {
         k: i64,
         min_cosine: f32,
         unlocked: &HashSet<String>,
+        scope: Option<&[String]>,
     ) -> Result<Vec<SearchHit>> {
         if query_vec.is_empty() || k <= 0 {
             return Ok(Vec::new());
         }
         let conn = self.lock();
         let meeting_visible = meeting_visibility_clause("m", unlocked);
+        let scoped = folder_scope_clause("m", scope);
         // KNN is isolated to the vec0 table in a CTE (only a single MATCH+k constraint is allowed on
         // a vec0 query); visibility + meeting columns are joined OUTSIDE it.
         let sql = format!(
@@ -4988,7 +4990,7 @@ impl Db {
                FROM knn
                JOIN note_chunks nc ON nc.id = knn.chunk_id
                JOIN meetings m ON m.id = nc.meeting_id
-              WHERE {meeting_visible}
+              WHERE {meeting_visible}{scoped}
               ORDER BY knn.distance ASC, m.id ASC"
         );
         let blob = crate::embed::vec_to_blob(query_vec);
@@ -5100,7 +5102,7 @@ impl Db {
 
         // GATED KNN. Ask for k+1 because self is always the nearest hit; then drop self + truncate.
         // No S1 floor here (0.0) — related-meetings is behaviour-preserving; only the MCP search arms floor.
-        let mut hits = self.search_semantic_visible(&centroid, k + 1, 0.0, unlocked)?;
+        let mut hits = self.search_semantic_visible(&centroid, k + 1, 0.0, unlocked, None)?;
         hits.retain(|h| h.meeting.id != meeting_id);
         hits.truncate(k as usize);
         tracing::debug!(
@@ -5122,6 +5124,7 @@ impl Db {
         limit: i64,
         unlocked: &HashSet<String>,
         date_filter: Option<&(String, String)>,
+        scope: Option<&[String]>,
     ) -> Result<Vec<(String, f64)>> {
         let q = query.trim();
         let Some(and_expr) = fts_match_query(q) else {
@@ -5130,6 +5133,7 @@ impl Db {
         let conn = self.lock();
         let meeting_visible = meeting_visibility_clause("m", unlocked);
         let date = date_clause(date_filter);
+        let scoped = folder_scope_clause("m", scope);
         let sql = format!(
             "WITH hits(meeting_id, rank) AS (
                  SELECT m.id, bm25(fts_meetings)
@@ -5158,7 +5162,7 @@ impl Db {
              SELECT m.id, r.rank
                FROM ranked r
                JOIN meetings m ON m.id = r.meeting_id
-              WHERE {meeting_visible}{date}
+              WHERE {meeting_visible}{date}{scoped}
               ORDER BY r.rank ASC, m.started_at DESC, m.id DESC
               LIMIT ?2"
         );
@@ -5204,6 +5208,7 @@ impl Db {
         min_cosine: f32,
         unlocked: &HashSet<String>,
         date_filter: Option<&(String, String)>,
+        scope: Option<&[String]>,
     ) -> Result<Vec<(String, f64)>> {
         if query_vec.is_empty() || k <= 0 {
             return Ok(Vec::new());
@@ -5211,6 +5216,7 @@ impl Db {
         let conn = self.lock();
         let meeting_visible = meeting_visibility_clause("m", unlocked);
         let date = date_clause(date_filter);
+        let scoped = folder_scope_clause("m", scope);
         // Each vec0 table gets its own single-MATCH CTE (a vec0 query allows exactly one MATCH+k
         // constraint); the union + visibility + window join happen OUTSIDE the KNN CTEs.
         let sql = format!(
@@ -5235,7 +5241,7 @@ impl Db {
              SELECT m.id, b.distance
                FROM best b
                JOIN meetings m ON m.id = b.meeting_id
-              WHERE {meeting_visible}{date}
+              WHERE {meeting_visible}{date}{scoped}
               ORDER BY b.distance ASC, m.id ASC"
         );
         let blob = crate::embed::vec_to_blob(query_vec);
@@ -5280,6 +5286,7 @@ impl Db {
     /// the FTS and graph legs are NEVER floored. Sentinel `0.0` = no floor. When the floor empties
     /// the KNN leg on an irrelevant corpus, `score_fuse`'s empty-leg redistribution rescales the
     /// surviving FTS + graph legs, so an exact-word FTS hit still surfaces (recall safety).
+    #[allow(clippy::too_many_arguments)]
     pub fn search_hybrid_visible(
         &self,
         query: &str,
@@ -5288,6 +5295,7 @@ impl Db {
         min_cosine: f32,
         unlocked: &HashSet<String>,
         date_filter: Option<(String, String)>,
+        scope: Option<&[String]>,
     ) -> Result<Vec<SearchHit>> {
         let range = date_filter.as_ref();
         let in_range = |m: &Meeting| -> bool {
@@ -5300,23 +5308,23 @@ impl Db {
         };
 
         // Snippet-bearing hit lists (each already gated); ordering comes from the scored legs.
-        let fts = self.search_visible_impl(query, limit, unlocked, range)?;
-        let semantic = self.search_semantic_visible(query_vec, limit, min_cosine, unlocked)?;
+        let fts = self.search_visible_impl(query, limit, unlocked, range, scope)?;
+        let semantic = self.search_semantic_visible(query_vec, limit, min_cosine, unlocked, scope)?;
 
         // GraphRAG-lite leg: resolve the query to known VISIBLE entities (deterministic, no LLM),
         // then gather their co-mention neighbourhood. Both the resolver and the neighbour reader
         // apply the same visibility predicate; the temporal window is applied here in Rust.
         let matched_entities = self.entities_matching_query(query, unlocked)?;
-        let mut graph = self.meetings_mentioning_entities_visible(&matched_entities, unlocked)?;
+        let mut graph = self.meetings_mentioning_entities_visible(&matched_entities, unlocked, scope)?;
         graph.retain(|m| in_range(m));
 
         // RAW-SCORED legs (L1.3). FTS: -bm25 higher-better over all four lexical sources. KNN:
         // raw distances over both vector tables. Graph: 1/rank of the neighbourhood ordering.
-        let mut fts_scored = self.fts_meeting_scores(query, limit, unlocked, range)?;
+        let mut fts_scored = self.fts_meeting_scores(query, limit, unlocked, range, scope)?;
         if fts_scored.is_empty() && range.is_some() {
             // Temporal fallback (L1.5): no lexical match inside the window ⇒ the window IS the
             // query — visible in-range meetings, newest-first, positionally scored.
-            let in_window = self.meetings_in_range_visible(range, limit, unlocked)?;
+            let in_window = self.meetings_in_range_visible(range, limit, unlocked, None)?;
             fts_scored = in_window
                 .iter()
                 .enumerate()
@@ -5324,7 +5332,7 @@ impl Db {
                 .collect();
         }
         let knn_scored =
-            self.knn_meeting_distances(query_vec, limit, min_cosine, unlocked, range)?;
+            self.knn_meeting_distances(query_vec, limit, min_cosine, unlocked, range, scope)?;
         let graph_scored: Vec<(String, f64)> = graph
             .iter()
             .enumerate()
@@ -5415,6 +5423,7 @@ impl Db {
         date_filter: Option<&(String, String)>,
         limit: i64,
         unlocked: &HashSet<String>,
+        scope: Option<&[String]>,
     ) -> Result<Vec<Meeting>> {
         let Some(range) = date_filter else {
             return Ok(Vec::new());
@@ -5422,11 +5431,12 @@ impl Db {
         let conn = self.lock();
         let meeting_visible = meeting_visibility_clause("m", unlocked);
         let date = date_clause(Some(range));
+        let scoped = folder_scope_clause("m", scope);
         let sql = format!(
             "SELECT m.id, m.started_at, m.ended_at, m.title, m.duration_s, m.audio_path, m.status,
                     m.folder_id
                FROM meetings m
-              WHERE {meeting_visible}{date}
+              WHERE {meeting_visible}{date}{scoped}
               ORDER BY m.started_at DESC, m.id DESC
               LIMIT ?1"
         );
@@ -7165,7 +7175,7 @@ impl Db {
     ) -> Result<Vec<MeetingActionSummary>> {
         let mut out: Vec<MeetingActionSummary> = Vec::new();
         // GATE 1: only VISIBLE meetings. GATE 2: only the VISIBLE note (None for sealed-not-unlocked).
-        for m in self.list_meetings_visible(1000, unlocked)? {
+        for m in self.list_meetings_visible(1000, unlocked, None)? {
             let Some(note) = self.get_note_if_visible(&m.id, unlocked)? else {
                 continue; // sealed-and-not-unlocked → no row (aggregate posture).
             };
@@ -7712,7 +7722,23 @@ impl Db {
         limit: i64,
         unlocked: &HashSet<String>,
     ) -> Result<Vec<SearchHit>> {
-        self.search_visible_impl(query, limit, unlocked, None)
+        self.search_visible_impl(query, limit, unlocked, None, None)
+    }
+
+    /// [`Db::search_visible`] narrowed to a container SCOPE — the folder ids to search inside.
+    ///
+    /// `None` is byte-for-byte `search_visible`. A non-empty scope ANDs onto the SAME visibility
+    /// predicate rather than replacing it, so it can only ever remove rows the lock gate already
+    /// allowed: scoping into a locked-and-not-session-unlocked folder returns nothing, it does not
+    /// return its contents.
+    pub fn search_visible_scoped(
+        &self,
+        query: &str,
+        limit: i64,
+        unlocked: &HashSet<String>,
+        scope: Option<&[String]>,
+    ) -> Result<Vec<SearchHit>> {
+        self.search_visible_impl(query, limit, unlocked, None, scope)
     }
 
     /// Visibility-gated transcript FTS hits that retain their stored segment id.
@@ -7857,13 +7883,14 @@ impl Db {
         limit: i64,
         unlocked: &HashSet<String>,
         date_filter: Option<(String, String)>,
+        scope: Option<&[String]>,
     ) -> Result<Vec<SearchHit>> {
-        let hits = self.search_visible_impl(query, limit, unlocked, date_filter.as_ref())?;
+        let hits = self.search_visible_impl(query, limit, unlocked, date_filter.as_ref(), scope)?;
         if !hits.is_empty() || date_filter.is_none() {
             return Ok(hits);
         }
         let range = date_filter.as_ref();
-        let meetings = self.meetings_in_range_visible(range, limit, unlocked)?;
+        let meetings = self.meetings_in_range_visible(range, limit, unlocked, scope)?;
         Ok(meetings
             .into_iter()
             .map(|m| {
@@ -7883,6 +7910,7 @@ impl Db {
         limit: i64,
         unlocked: &HashSet<String>,
         date_filter: Option<&(String, String)>,
+        scope: Option<&[String]>,
     ) -> Result<Vec<SearchHit>> {
         let q = query.trim();
         let Some(and_expr) = fts_match_query(q) else {
@@ -7891,6 +7919,9 @@ impl Db {
         let conn = self.lock();
         let meeting_visible = meeting_visibility_clause("m", unlocked);
         let date = date_clause(date_filter);
+        // Container SCOPE, ANDed AFTER the visibility gate — it can only remove rows the gate
+        // already allowed, never add one.
+        let scoped = folder_scope_clause("m", scope);
         // FTS5/BM25 candidates (same UNION/MIN(bm25) ranking as `search`), THEN gated by exactly the
         // prior visibility predicate so a sealed-and-not-session-unlocked meeting is excluded: keep
         // a meeting iff it has NO note rows, OR it has at least one VISIBLE note row (folder
@@ -7924,7 +7955,7 @@ impl Db {
                     m.folder_id
                FROM ranked r
                JOIN meetings m ON m.id = r.meeting_id
-              WHERE {meeting_visible}{date}
+              WHERE {meeting_visible}{date}{scoped}
               ORDER BY r.rank ASC, m.started_at DESC, m.id DESC
               LIMIT ?2"
         );
@@ -8173,7 +8204,72 @@ impl Db {
                 });
             }
         }
-        Ok((out, note_count + meeting_count + document_count))
+        // CONTAINERS (Spaces/folders) — offered so a caller can pick a place to SCOPE a search to,
+        // never as pinned content. `LinkKind::Container` is deliberately not a content source, so a
+        // container that reaches a corpus packer would be a bug; the Ask composer routes it to
+        // `scopeFolderIds` instead, and every other `<mur-source-picker>` keeps the historical
+        // default kinds and therefore never sees these rows at all.
+        //
+        // Selectability reuses `picker_renderable_container` — the SAME predicate the Related
+        // hierarchy picker was reviewed against (no system paths, no roots, valid levels) — rather
+        // than a second, divergent notion of "a folder a user may choose".
+        //
+        // A SEALED-and-not-session-unlocked folder is NOT listed. An earlier revision listed it,
+        // reasoning that the Related hierarchy picker already shows folder names — but THIS list has
+        // a stricter contract, pinned by `list_link_candidates_hides_sealed_sources`: even the
+        // pagination TOTAL must not disclose that a matching sealed row exists. A name is a
+        // disclosure, and searching "Secret" must not confirm a folder called that. Nothing is lost:
+        // scoping to a folder the session cannot see would return no content anyway.
+        let container_where = format!(
+            "{} AND {} AND f.name LIKE :pat ESCAPE '\\'",
+            crate::storage::related_picker_store::picker_renderable_container("f"),
+            visibility_clause("f", unlocked)
+        );
+        let container_count: i64 = conn
+            .query_row(
+                &format!("SELECT COUNT(*) FROM folders f WHERE {container_where}"),
+                rusqlite::named_params! { ":pat": pat },
+                |r| r.get(0),
+            )
+            .map_err(map_err)?;
+        let consumed = note_count + meeting_count + document_count;
+        let container_offset = (offset - consumed).max(0);
+        let remaining = limit - out.len() as i64;
+        if remaining > 0 && container_offset < container_count {
+            let sql = format!(
+                "SELECT f.id, f.name
+                   FROM folders f
+                  WHERE {container_where}
+                  ORDER BY f.path ASC, f.id ASC
+                  LIMIT :limit OFFSET :offset"
+            );
+            let mut stmt = conn.prepare(&sql).map_err(map_err)?;
+            let rows = stmt
+                .query_map(
+                    rusqlite::named_params! {
+                        ":pat": pat,
+                        ":limit": remaining,
+                        ":offset": container_offset,
+                    },
+                    |r: &Row<'_>| -> rusqlite::Result<(String, String)> {
+                        Ok((r.get(0)?, r.get(1)?))
+                    },
+                )
+                .map_err(map_err)?;
+            for r in rows {
+                let (id, name) = r.map_err(map_err)?;
+                out.push(NoteCitation {
+                    kind: "container".into(),
+                    id,
+                    title: name,
+                    snippet: String::new(),
+                });
+            }
+        }
+        Ok((
+            out,
+            note_count + meeting_count + document_count + container_count,
+        ))
     }
 
     // `get_note_if_visible` moved to `storage::notes_store` (God-file split) — still callable as inherent `db.method()` cross-file.
@@ -8341,7 +8437,7 @@ impl Db {
 
     /// OPEN-COMMITMENTS rollup (deterministic, no model): every OPEN (`- [ ]`) action item across
     /// the VISIBLE meetings, with its meeting context. DOUBLE-GATED — the meeting list is filtered
-    /// by `list_meetings_visible(unlocked)` and each note is re-fetched through
+    /// by `list_meetings_visible(unlocked, None, None)` and each note is re-fetched through
     /// `get_note_if_visible(unlocked)`, so a sealed-and-not-session-unlocked meeting contributes
     /// NOTHING (its note markdown is never read here). Checked-off (`- [x]`) items are dropped.
     /// `owner`, when Some, filters case-insensitively. Sorted by due date (None last), then recency.
@@ -8358,7 +8454,7 @@ impl Db {
             .filter(|o| !o.is_empty());
         let mut out: Vec<Commitment> = Vec::new();
         // GATE 1: only VISIBLE meetings. GATE 2: only the VISIBLE note (None for sealed-not-unlocked).
-        for m in self.list_meetings_visible(1000, unlocked)? {
+        for m in self.list_meetings_visible(1000, unlocked, None)? {
             let Some(note) = self.get_note_if_visible(&m.id, unlocked)? else {
                 continue;
             };
@@ -9389,6 +9485,33 @@ pub(crate) fn note_snippet(markdown: &str) -> String {
 /// app-generated ISO `YYYY-MM-DD` strings (from `summarize::temporal`) — compared
 /// lexicographically against the ISO-8601 `started_at` column — but single quotes are still
 /// escaped defensively (mirrors `visibility_clause`).
+/// SQL narrowing a meetings alias to a set of folder ids — the container SCOPE.
+///
+/// Returns a fragment that is APPENDED to an existing `WHERE`, never one that replaces it: every
+/// caller emits `WHERE {meeting_visible}{scope}`, so the lock gate always runs and the scope can
+/// only ever REMOVE rows the gate already allowed. A scope must not be able to widen anything.
+///
+/// `None` (or an empty set) yields the empty string, so an unscoped query is byte-for-byte the
+/// statement that shipped before scoping existed.
+///
+/// A meeting with no folder (`folder_id IS NULL` — Not classified) is outside every container and is
+/// therefore excluded by `IN`, which is the intended reading of "search inside this folder".
+///
+/// Ids are folder UUIDs read back from the database, quoted the same way `visibility_clause` quotes
+/// the session unlock set. They are not user text; the folder NAME never reaches this SQL, which is
+/// why `folder_subtree_ids` resolves the subtree in Rust instead of with a `LIKE` over paths.
+pub(crate) fn folder_scope_clause(alias: &str, scope: Option<&[String]>) -> String {
+    let Some(ids) = scope.filter(|ids| !ids.is_empty()) else {
+        return String::new();
+    };
+    let list = ids
+        .iter()
+        .map(|id| format!("'{}'", id.replace('\'', "''")))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(" AND {alias}.folder_id IN ({list})")
+}
+
 fn date_clause(date_filter: Option<&(String, String)>) -> String {
     match date_filter {
         Some((from, to)) => format!(

--- a/src-tauri/src/storage/db_tests/graph_tests.rs
+++ b/src-tauri/src/storage/db_tests/graph_tests.rs
@@ -1357,3 +1357,263 @@ fn entity_detail_hidden_when_only_sealed() {
         "the (now visible) sealed meeting backlinks"
     );
 }
+
+// ---------------------------------------------------------------------------------------------
+// CONTAINER SCOPE (folder-scoped Ask) — narrowing retrieval to one Space/folder subtree.
+//
+// The scope is a DIFFERENT mechanism from a container RELATION: a relation names a place and never
+// fans out, a scope says where to look and deliberately includes the subtree. These pin the four
+// properties that make the difference safe.
+// ---------------------------------------------------------------------------------------------
+
+fn seed_child_folder(db: &Db, id: &str, name: &str, parent: &str, path: &str) {
+    db.insert_folder(&Folder {
+        id: id.to_string(),
+        name: name.to_string(),
+        path: path.to_string(),
+        parent_id: Some(parent.to_string()),
+        locked: false,
+        created_at: "2026-09-04T00:00:00Z".to_string(),
+    })
+    .unwrap();
+}
+
+/// A scope covers the folder AND everything filed beneath it — that is what "search in this Space"
+/// means to a user, and it is the exact opposite of a container RELATION, which never fans out.
+#[test]
+fn a_container_scope_covers_the_whole_subtree() {
+    let db = file_db("scope-subtree");
+    seed_folder(&db, "f-root", "Product");
+    seed_child_folder(&db, "f-kid", "Roadmap", "f-root", "Product/Roadmap");
+    seed_child_folder(&db, "f-grand", "Q4", "f-kid", "Product/Roadmap/Q4");
+    seed_folder(&db, "f-other", "Personal");
+
+    let mut ids = db.folder_subtree_ids("f-root").unwrap();
+    ids.sort();
+    assert_eq!(ids, vec!["f-grand", "f-kid", "f-root"], "root + descendants");
+
+    // Scoping to a LEAF is just that leaf.
+    assert_eq!(db.folder_subtree_ids("f-grand").unwrap(), vec!["f-grand"]);
+    // A sibling tree is never dragged in by a shared name prefix.
+    assert_eq!(db.folder_subtree_ids("f-other").unwrap(), vec!["f-other"]);
+}
+
+/// A folder NAME is user text. If the subtree were resolved with SQL `LIKE`, a name containing `%`
+/// or `_` would silently widen the scope into folders the user never picked — `%` matches anything.
+/// This is why `folder_subtree_ids` compares in Rust.
+#[test]
+fn a_wildcard_in_a_folder_name_cannot_widen_the_scope() {
+    let db = file_db("scope-wildcards");
+    seed_folder(&db, "f-pct", "100%");
+    seed_child_folder(&db, "f-pct-kid", "Real", "f-pct", "100%/Real");
+    // A folder whose path a naive `LIKE '100%/%'` pattern would ALSO match.
+    seed_folder(&db, "f-decoy", "1000");
+    seed_child_folder(&db, "f-decoy-kid", "Decoy", "f-decoy", "1000/Decoy");
+
+    let mut ids = db.folder_subtree_ids("f-pct").unwrap();
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec!["f-pct", "f-pct-kid"],
+        "the '%' is a literal character, not a wildcard",
+    );
+}
+
+/// An unknown folder id scopes to ITSELF, never to nothing. An empty set would read as "no scope"
+/// to `folder_scope_clause` and silently widen the answer to the whole vault — the one failure
+/// mode a scope must never have.
+#[test]
+fn an_unknown_scope_id_never_degrades_to_the_whole_vault() {
+    let db = file_db("scope-unknown");
+    seed_folder(&db, "f-real", "Real");
+    let ids = db.folder_subtree_ids("f-does-not-exist").unwrap();
+    assert_eq!(ids, vec!["f-does-not-exist"]);
+    assert!(!ids.is_empty(), "an empty set would mean 'unscoped'");
+}
+
+/// The scope NARROWS a search and can never widen it: a scoped query returns a subset of the
+/// unscoped one, and a locked folder inside the scope still contributes nothing — the visibility
+/// gate runs first and the scope only removes rows it already allowed.
+#[test]
+fn a_scope_narrows_search_and_never_bypasses_the_lock() {
+    let db = file_db("scope-narrows");
+    seed_folder(&db, "f-in", "Inside");
+    seed_folder(&db, "f-out", "Outside");
+    seed_note(&db, "m-in", "alpha budget inside", Some("f-in"));
+    seed_note(&db, "m-out", "alpha budget outside", Some("f-out"));
+
+    let open = std::collections::HashSet::new();
+    let all = db.search_visible("alpha", 20, &open).unwrap();
+    assert_eq!(all.len(), 2, "unscoped sees both");
+
+    let inside: Vec<String> = db
+        .search_visible_scoped("alpha", 20, &open, Some(&["f-in".to_string()]))
+        .unwrap()
+        .into_iter()
+        .map(|h| h.meeting.id)
+        .collect();
+    assert_eq!(inside, vec!["m-in"], "scoped sees only what is filed inside");
+
+    // Lock the scoped folder WITHOUT session-unlocking it: the scope must not become a way in.
+    db.set_folder_locked("f-in", true, None).unwrap();
+    let locked = db
+        .search_visible_scoped("alpha", 20, &open, Some(&["f-in".to_string()]))
+        .unwrap();
+    assert!(
+        locked.is_empty(),
+        "a scope ANDs with the lock gate; it can only remove rows, never reveal one",
+    );
+}
+
+/// A scope is a LIVE QUERY, not a snapshot of what was in the folder when it was chosen.
+///
+/// This is the property that makes a scope worth having over pinned sources: pin ten notes and the
+/// eleventh you write tomorrow is invisible until you pin it too. Scope a folder and tomorrow's
+/// note is simply in it. The same holds for a sub-folder created later, and in reverse for a note
+/// moved OUT — the scope follows the hierarchy as it is at question time, not as it was.
+///
+/// If anyone ever "optimises" this into a resolved id list cached per conversation, this test is
+/// what should stop them.
+#[test]
+fn a_scope_picks_up_items_added_after_it_was_chosen() {
+    let db = file_db("scope-live");
+    seed_folder(&db, "f-live", "Live");
+    seed_note(&db, "m-first", "alpha budget first", Some("f-live"));
+
+    let open = std::collections::HashSet::new();
+    let chosen = ["f-live".to_string()];
+    let ids = |db: &Db| -> Vec<String> {
+        // Exactly what production does per question: expand the chosen containers to their current
+        // subtree, THEN search. Recomputing here is the point — it is what makes the scope live.
+        let scope = db.folder_scope_ids(&chosen).unwrap();
+        let mut v: Vec<String> = db
+            .search_visible_scoped("alpha", 20, &open, Some(&scope))
+            .unwrap()
+            .into_iter()
+            .map(|h| h.meeting.id)
+            .collect();
+        v.sort();
+        v
+    };
+    assert_eq!(ids(&db), vec!["m-first"]);
+
+    // A note written AFTER the scope was chosen — no re-selection, no refresh.
+    seed_note(&db, "m-later", "alpha budget later", Some("f-live"));
+    assert_eq!(
+        ids(&db),
+        vec!["m-first", "m-later"],
+        "a note added later is in scope without the user re-choosing it",
+    );
+
+    // A sub-folder created later, with content in it, is in scope too — the subtree is resolved
+    // per question, so the hierarchy can grow underneath a scope.
+    seed_child_folder(&db, "f-live-kid", "Deeper", "f-live", "Live/Deeper");
+    seed_note(&db, "m-deep", "alpha budget deeper", Some("f-live-kid"));
+    assert_eq!(
+        ids(&db),
+        vec!["m-deep", "m-first", "m-later"],
+        "a sub-folder created after the fact is inside the scope",
+    );
+
+    // And the converse: filed elsewhere ⇒ out of scope, even though it matches the query.
+    seed_folder(&db, "f-away", "Away");
+    seed_note(&db, "m-away", "alpha budget away", Some("f-away"));
+    assert_eq!(
+        ids(&db),
+        vec!["m-deep", "m-first", "m-later"],
+        "content outside the scoped subtree stays out",
+    );
+}
+
+/// THE FALLBACK MUST BE SCOPED TOO — the hole clippy found as "unused variable".
+///
+/// When a scoped question matches nothing, the corpus builder falls back to "recent meetings". If
+/// that fallback ignores the scope, the answer is drawn from the WHOLE vault while the UI still
+/// says the folder is scoped: a confidently wrong answer, which is worse than "nothing here".
+/// The same applies to the keyword path a user gets with semantic search switched off.
+#[test]
+fn the_recent_meetings_fallback_respects_the_scope() {
+    let db = file_db("scope-fallback");
+    seed_folder(&db, "f-scope", "Scoped");
+    seed_folder(&db, "f-elsewhere", "Elsewhere");
+    seed_note(&db, "m-inside", "gamma inside", Some("f-scope"));
+    seed_note(&db, "m-outside", "gamma outside", Some("f-elsewhere"));
+
+    let open = std::collections::HashSet::new();
+    let scope = db.folder_scope_ids(&["f-scope".to_string()]).unwrap();
+
+    // Unscoped, the listing sees both.
+    assert_eq!(db.list_meetings_visible(30, &open, None).unwrap().len(), 2);
+
+    // Scoped, it sees only what is filed inside — this is the branch a no-match question lands on.
+    let listed: Vec<String> = db
+        .list_meetings_visible(30, &open, Some(&scope))
+        .unwrap()
+        .into_iter()
+        .map(|m| m.id)
+        .collect();
+    assert_eq!(
+        listed,
+        vec!["m-inside"],
+        "a scoped question that matches nothing must not fall back to the whole vault",
+    );
+}
+
+/// Containers are OFFERED as pickable candidates, so a user can choose a place to scope to.
+///
+/// Without this leg the Ask composer would allow the `container` kind and never receive one — a
+/// control that looks enabled and does nothing. Every other `<mur-source-picker>` keeps the
+/// historical default kinds, so these rows are filtered out there rather than being offered as
+/// pinnable content, which they are not.
+#[test]
+fn containers_are_offered_as_pickable_candidates() {
+    let db = file_db("candidates-containers");
+    seed_folder(&db, "f-alpha", "Alpha Project");
+    seed_folder(&db, "f-beta", "Beta");
+    seed_note(&db, "m-x", "alpha content", Some("f-alpha"));
+
+    let open = std::collections::HashSet::new();
+    let (rows, _total) = db
+        .list_link_candidates_visible("Alpha", 20, 0, &open)
+        .unwrap();
+    let containers: Vec<(String, String)> = rows
+        .iter()
+        .filter(|r| r.kind == "container")
+        .map(|r| (r.id.clone(), r.title.clone()))
+        .collect();
+    assert_eq!(
+        containers,
+        vec![("f-alpha".to_string(), "Alpha Project".to_string())],
+        "the matching Space is offered, by name",
+    );
+
+    // A SEALED-and-not-unlocked folder disappears from the candidates entirely — name and all.
+    // The first version of this test asserted the opposite, on the reasoning that a folder name is
+    // already visible in the Related picker. That was wrong for THIS list: its contract, pinned by
+    // `list_link_candidates_hides_sealed_sources`, is that not even the pagination total may
+    // disclose a sealed match. A name IS a disclosure; searching "Alpha" must not confirm that a
+    // Space called that exists.
+    db.set_folder_locked("f-alpha", true, None).unwrap();
+    let (locked_rows, locked_total) = db
+        .list_link_candidates_visible("Alpha", 20, 0, &open)
+        .unwrap();
+    assert!(
+        !locked_rows.iter().any(|r| r.kind == "container"),
+        "a sealed folder is not offered as a candidate",
+    );
+    assert_eq!(
+        locked_total, 0,
+        "and the total must not disclose that a sealed match exists",
+    );
+
+    // Session-unlocked, it comes back — the gate is the session unlock set, not a permanent hide.
+    let unlocked: std::collections::HashSet<String> =
+        std::iter::once("f-alpha".to_string()).collect();
+    let (open_rows, _) = db
+        .list_link_candidates_visible("Alpha", 20, 0, &unlocked)
+        .unwrap();
+    assert!(
+        open_rows.iter().any(|r| r.kind == "container" && r.id == "f-alpha"),
+        "a session-unlocked folder is selectable again",
+    );
+}

--- a/src-tauri/src/storage/db_tests/lock_tests.rs
+++ b/src-tauri/src/storage/db_tests/lock_tests.rs
@@ -477,7 +477,7 @@ fn mcp_visibility_filter() {
 
     // Before sealing both are visible.
     assert!(db
-        .list_meetings_visible(50, &empty)
+        .list_meetings_visible(50, &empty, None)
         .unwrap()
         .iter()
         .any(|m| m.id == "sealed1"));
@@ -485,7 +485,7 @@ fn mcp_visibility_filter() {
     // SEAL → the sealed note is invisible to MCP, the open one stays visible.
     seal_folder(&db, "secret", &kek);
     let visible_ids: HashSet<String> = db
-        .list_meetings_visible(50, &empty)
+        .list_meetings_visible(50, &empty, None)
         .unwrap()
         .into_iter()
         .map(|m| m.id)
@@ -517,7 +517,7 @@ fn mcp_visibility_filter() {
         .unwrap()
         .is_empty());
     let visible_after: HashSet<String> = db
-        .list_meetings_visible(50, &unlocked)
+        .list_meetings_visible(50, &unlocked, None)
         .unwrap()
         .into_iter()
         .map(|m| m.id)
@@ -560,7 +560,7 @@ fn unfiled_live_meeting_is_visible_until_canonical_locked_ownership_is_assigned(
         .unwrap()
         .is_some());
     assert!(db
-        .list_meetings_visible(50, &empty)
+        .list_meetings_visible(50, &empty, None)
         .unwrap()
         .iter()
         .any(|meeting| meeting.id == "live-root"));
@@ -594,7 +594,7 @@ fn unfiled_live_meeting_is_visible_until_canonical_locked_ownership_is_assigned(
         .unwrap()
         .is_none());
     assert!(!db
-        .list_meetings_visible(50, &empty)
+        .list_meetings_visible(50, &empty, None)
         .unwrap()
         .iter()
         .any(|meeting| meeting.id == "live-root"));

--- a/src-tauri/src/storage/db_tests/tests.rs
+++ b/src-tauri/src/storage/db_tests/tests.rs
@@ -11165,7 +11165,7 @@ fn expand_serves_the_hit_sections_own_parent_when_siblings_corroborate() {
     seed_two_section_doc(&db, "d1", "f1");
     let nothing = std::collections::HashSet::new();
     let hits = db
-        .search_doc_chunks_fts_visible("pistachio", 20, &nothing)
+        .search_doc_chunks_fts_visible("pistachio", 20, &nothing, None)
         .unwrap();
     assert_eq!(hits.len(), 1, "one document → one deduped hit");
     let h = &hits[0];
@@ -11205,7 +11205,7 @@ fn expand_requires_two_corroborating_sibling_leaves() {
     seed_two_section_doc(&db, "d1", "f1");
     let nothing = std::collections::HashSet::new();
     let hits = db
-        .search_doc_chunks_fts_visible("zloty", 20, &nothing)
+        .search_doc_chunks_fts_visible("zloty", 20, &nothing, None)
         .unwrap();
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].level, 0, "the single matching Beta leaf wins");
@@ -11246,7 +11246,7 @@ fn flat_doc_hit_keeps_its_leaf_no_expansion() {
         .unwrap();
     let nothing = std::collections::HashSet::new();
     let hits = db
-        .search_doc_chunks_fts_visible("zanzibar", 20, &nothing)
+        .search_doc_chunks_fts_visible("zanzibar", 20, &nothing, None)
         .unwrap();
     assert_eq!(hits.len(), 1, "a mid-file leaf must be keyword-reachable");
     assert!(
@@ -11276,7 +11276,7 @@ fn expand_doc_parents_is_gated_and_returns_section_text() {
     let nothing = std::collections::HashSet::new();
     // Open folder → the corroborated Beta hit expands to its section text.
     let hits = db
-        .search_doc_chunks_fts_visible("pistachio", 20, &nothing)
+        .search_doc_chunks_fts_visible("pistachio", 20, &nothing, None)
         .unwrap();
     assert_eq!(hits.len(), 1);
     let open = db.expand_doc_parents_visible(&hits, &nothing).unwrap();
@@ -11346,7 +11346,7 @@ fn doc_chunk_search_is_gated_by_visibility() {
     // Open folder → visible.
     let nothing = std::collections::HashSet::new();
     assert!(
-        db.search_doc_chunks_visible(&query, 10, 0.0, &nothing)
+        db.search_doc_chunks_visible(&query, 10, 0.0, &nothing, None)
             .unwrap()
             .iter()
             .any(|h| h.document_id == "d1"),
@@ -11356,7 +11356,7 @@ fn doc_chunk_search_is_gated_by_visibility() {
     // Seal the folder (chunk row deliberately survives) → INVISIBLE with empty unlock set.
     db.set_folder_locked("f-locked", true, None).unwrap();
     let hidden = db
-        .search_doc_chunks_visible(&query, 10, 0.0, &nothing)
+        .search_doc_chunks_visible(&query, 10, 0.0, &nothing, None)
         .unwrap();
     assert!(
         !hidden.iter().any(|h| h.document_id == "d1"),
@@ -11367,7 +11367,7 @@ fn doc_chunk_search_is_gated_by_visibility() {
     let mut unlocked = std::collections::HashSet::new();
     unlocked.insert("f-locked".to_string());
     let shown = db
-        .search_doc_chunks_visible(&query, 10, 0.0, &unlocked)
+        .search_doc_chunks_visible(&query, 10, 0.0, &unlocked, None)
         .unwrap();
     assert!(
         shown.iter().any(|h| h.document_id == "d1"),
@@ -11406,7 +11406,7 @@ fn index_document_chunks_none_embedder_chunks_no_vectors_fts_finds() {
 
     let nothing = std::collections::HashSet::new();
     let hits = db
-        .search_doc_chunks_fts_visible("pistachio", 10, &nothing)
+        .search_doc_chunks_fts_visible("pistachio", 10, &nothing, None)
         .unwrap();
     assert!(
         hits.iter()
@@ -11415,7 +11415,7 @@ fn index_document_chunks_none_embedder_chunks_no_vectors_fts_finds() {
     );
     // Punctuation-only query defuses to no hits (never an FTS syntax error).
     assert!(db
-        .search_doc_chunks_fts_visible("?!*(", 10, &nothing)
+        .search_doc_chunks_fts_visible("?!*(", 10, &nothing, None)
         .unwrap()
         .is_empty());
 }
@@ -11440,7 +11440,7 @@ fn index_document_chunks_reflow_is_noop_on_clean_md() {
     db.index_document_chunks("d1", None).unwrap();
     let nothing = std::collections::HashSet::new();
     let hits = db
-        .search_doc_chunks_fts_visible("pistachio", 10, &nothing)
+        .search_doc_chunks_fts_visible("pistachio", 10, &nothing, None)
         .unwrap();
     assert!(
         hits.iter()
@@ -11556,7 +11556,7 @@ fn index_document_chunks_reflow_defragments_letter_spaced_pdf_text() {
 
     let nothing = std::collections::HashSet::new();
     let hits = db
-        .search_doc_chunks_fts_visible("Frontend", 10, &nothing)
+        .search_doc_chunks_fts_visible("Frontend", 10, &nothing, None)
         .unwrap();
     assert!(
         hits.iter().any(|h| h.document_id == "d1"),
@@ -11619,7 +11619,7 @@ fn index_document_chunks_contact_digest_makes_phone_retrievable_by_nl_query() {
 
     let nothing = std::collections::HashSet::new();
     for q in ["numer telefonu", "phone number", "telefon"] {
-        let hits = db.search_doc_chunks_fts_visible(q, 10, &nothing).unwrap();
+        let hits = db.search_doc_chunks_fts_visible(q, 10, &nothing, None).unwrap();
         assert!(
             hits.iter().any(|h| h.document_id == "d-cv"),
             "query {q:?} must retrieve the CV via the contact digest: {hits:?}"
@@ -11631,7 +11631,7 @@ fn index_document_chunks_contact_digest_makes_phone_retrievable_by_nl_query() {
     }
     // The digest also carries the number itself (spaced + bare), so a digit query lands too.
     let by_number = db
-        .search_doc_chunks_fts_visible("786 327 907", 10, &nothing)
+        .search_doc_chunks_fts_visible("786 327 907", 10, &nothing, None)
         .unwrap();
     assert!(
         by_number.iter().any(|h| h.document_id == "d-cv"),
@@ -11761,7 +11761,7 @@ fn doc_chunk_fts_search_is_gated_by_visibility() {
 
     let nothing = std::collections::HashSet::new();
     assert!(
-        db.search_doc_chunks_fts_visible("launch", 10, &nothing)
+        db.search_doc_chunks_fts_visible("launch", 10, &nothing, None)
             .unwrap()
             .iter()
             .any(|h| h.document_id == "d1"),
@@ -11771,7 +11771,7 @@ fn doc_chunk_fts_search_is_gated_by_visibility() {
     // Seal the folder (chunk row deliberately survives) → INVISIBLE with empty unlock set.
     db.set_folder_locked("f-locked", true, None).unwrap();
     assert!(
-        !db.search_doc_chunks_fts_visible("launch", 10, &nothing)
+        !db.search_doc_chunks_fts_visible("launch", 10, &nothing, None)
             .unwrap()
             .iter()
             .any(|h| h.document_id == "d1"),
@@ -11782,7 +11782,7 @@ fn doc_chunk_fts_search_is_gated_by_visibility() {
     let mut unlocked = std::collections::HashSet::new();
     unlocked.insert("f-locked".to_string());
     assert!(
-        db.search_doc_chunks_fts_visible("launch", 10, &unlocked)
+        db.search_doc_chunks_fts_visible("launch", 10, &unlocked, None)
             .unwrap()
             .iter()
             .any(|h| h.document_id == "d1"),
@@ -11829,7 +11829,7 @@ fn doc_fts_tokens_purged_with_chunks_and_restored_on_reindex() {
     );
     let nothing = std::collections::HashSet::new();
     assert!(db
-        .search_doc_chunks_fts_visible("unicornfeather", 10, &nothing)
+        .search_doc_chunks_fts_visible("unicornfeather", 10, &nothing, None)
         .unwrap()
         .is_empty());
 
@@ -11859,7 +11859,7 @@ fn doc_fts_matches_polish_diacritics_folded() {
     let nothing = std::collections::HashSet::new();
     for q in ["budzet", "jazn", "gesla"] {
         assert!(
-            db.search_doc_chunks_fts_visible(q, 10, &nothing)
+            db.search_doc_chunks_fts_visible(q, 10, &nothing, None)
                 .unwrap()
                 .iter()
                 .any(|h| h.document_id == "d1"),
@@ -11867,7 +11867,7 @@ fn doc_fts_matches_polish_diacritics_folded() {
         );
     }
     assert!(
-        db.search_doc_chunks_fts_visible("gęślą", 10, &nothing)
+        db.search_doc_chunks_fts_visible("gęślą", 10, &nothing, None)
             .unwrap()
             .iter()
             .any(|h| h.document_id == "d1"),
@@ -16391,7 +16391,7 @@ fn s1_floor_drops_orthogonal_doc_chunk() {
     let query = one_hot(0);
 
     let all = db
-        .search_doc_chunks_visible(&query, 10, 0.0, &nothing)
+        .search_doc_chunks_visible(&query, 10, 0.0, &nothing, None)
         .unwrap();
     let ids: Vec<&str> = all.iter().map(|h| h.document_id.as_str()).collect();
     assert!(
@@ -16400,7 +16400,7 @@ fn s1_floor_drops_orthogonal_doc_chunk() {
     );
 
     let floored = db
-        .search_doc_chunks_visible(&query, 10, 0.75, &nothing)
+        .search_doc_chunks_visible(&query, 10, 0.75, &nothing, None)
         .unwrap();
     let fids: Vec<&str> = floored.iter().map(|h| h.document_id.as_str()).collect();
     assert_eq!(
@@ -16497,7 +16497,7 @@ fn s2_and_to_or_fallback_recovers_multiword_miss_docs() {
     db.index_document_chunks("d1", None).unwrap();
     let nothing = std::collections::HashSet::new();
     let hits = db
-        .search_doc_chunks_fts_visible("etykieta parcel", 10, &nothing)
+        .search_doc_chunks_fts_visible("etykieta parcel", 10, &nothing, None)
         .unwrap();
     assert!(
         hits.iter().any(|h| h.document_id == "d1"),

--- a/src-tauri/src/storage/db_tests/tests.rs
+++ b/src-tauri/src/storage/db_tests/tests.rs
@@ -8371,12 +8371,21 @@ fn list_link_candidates_hides_sealed_sources() {
     let (visible, visible_total) = db
         .list_link_candidates_visible("Secret", 10, 0, &unlocked)
         .unwrap();
+    // Three, not two: the folder itself is named "Secret", and once it is session-unlocked it is a
+    // legitimate CONTAINER candidate — something a user may scope a search to. It is offered as a
+    // place to look inside, never as pinnable content (`LinkKind::Container` is not a content
+    // source), and only a picker that opts into the `container` kind ever sees it.
     assert_eq!(
         visible.len(),
-        2,
-        "unlocking reveals both the note and the meeting"
+        3,
+        "unlocking reveals the note, the meeting, and the folder itself as a scope"
     );
-    assert_eq!(visible_total, 2);
+    assert_eq!(
+        visible.iter().filter(|r| r.kind == "container").count(),
+        1,
+        "exactly one of them is the container"
+    );
+    assert_eq!(visible_total, 3);
 }
 
 /// DOCUMENTS LEG (2026-07-20 link-documents): `list_link_candidates_visible` now surfaces
@@ -8491,9 +8500,12 @@ fn list_link_candidates_hides_sealed_documents() {
     let (visible, visible_total) = db
         .list_link_candidates_visible("Secret", 10, 0, &unlocked)
         .unwrap();
-    assert_eq!(visible.len(), 1, "unlocking reveals the document");
-    assert_eq!(visible[0].id, "d-secret");
-    assert_eq!(visible_total, 1);
+    // The document plus the now-unlocked folder named "Secret" — the latter as a SCOPE candidate,
+    // not as content. Sealed, neither appears at all (asserted above, including the total).
+    assert_eq!(visible.len(), 2, "unlocking reveals the document and the folder as a scope");
+    assert!(visible.iter().any(|r| r.id == "d-secret" && r.kind == "document"));
+    assert!(visible.iter().any(|r| r.id == "f-locked" && r.kind == "container"));
+    assert_eq!(visible_total, 2);
 }
 
 /// PAGINATION across the notes → meetings → documents seam: `offset` walks the ONE combined
@@ -10854,7 +10866,7 @@ fn vec_knn_orders_nearest_first() {
 
     let nothing = std::collections::HashSet::new();
     let hits = db
-        .search_semantic_visible(&query, 3, 0.0, &nothing)
+        .search_semantic_visible(&query, 3, 0.0, &nothing, None)
         .unwrap();
     let order: Vec<&str> = hits.iter().map(|h| h.meeting.id.as_str()).collect();
     assert_eq!(
@@ -10885,7 +10897,7 @@ fn vec_semantic_search_is_gated_by_visibility() {
     // Empty unlock set → excluded.
     let nothing = std::collections::HashSet::new();
     let hidden = db
-        .search_semantic_visible(&query, 10, 0.0, &nothing)
+        .search_semantic_visible(&query, 10, 0.0, &nothing, None)
         .unwrap();
     assert!(
         !hidden.iter().any(|h| h.meeting.id == "sealed"),
@@ -10895,7 +10907,7 @@ fn vec_semantic_search_is_gated_by_visibility() {
     let mut unlocked = std::collections::HashSet::new();
     unlocked.insert("f-locked".to_string());
     let shown = db
-        .search_semantic_visible(&query, 10, 0.0, &unlocked)
+        .search_semantic_visible(&query, 10, 0.0, &unlocked, None)
         .unwrap();
     assert!(
         shown.iter().any(|h| h.meeting.id == "sealed"),
@@ -10923,7 +10935,7 @@ fn vec_hybrid_search_is_gated_by_visibility() {
     // Empty unlock set → the sealed meeting is absent through the whole fused reader.
     let nothing = std::collections::HashSet::new();
     let hidden = db
-        .search_hybrid_visible("budget", &query_vec, 10, 0.0, &nothing, None)
+        .search_hybrid_visible("budget", &query_vec, 10, 0.0, &nothing, None, None)
         .unwrap();
     assert!(
         !hidden.iter().any(|h| h.meeting.id == "sealed"),
@@ -10934,7 +10946,7 @@ fn vec_hybrid_search_is_gated_by_visibility() {
     let mut unlocked = std::collections::HashSet::new();
     unlocked.insert("f-locked".to_string());
     let shown = db
-        .search_hybrid_visible("budget", &query_vec, 10, 0.0, &unlocked, None)
+        .search_hybrid_visible("budget", &query_vec, 10, 0.0, &unlocked, None, None)
         .unwrap();
     assert!(
         shown.iter().any(|h| h.meeting.id == "sealed"),
@@ -14781,7 +14793,7 @@ fn transcript_chunks_are_gated_by_visibility_semantic() {
     let query = one_hot(0);
     let nothing = std::collections::HashSet::new();
     let hidden = db
-        .search_semantic_visible(&query, 10, 0.0, &nothing)
+        .search_semantic_visible(&query, 10, 0.0, &nothing, None)
         .unwrap();
     assert!(
         !hidden.iter().any(|h| h.meeting.id == "sealed"),
@@ -14791,7 +14803,7 @@ fn transcript_chunks_are_gated_by_visibility_semantic() {
     let mut unlocked = std::collections::HashSet::new();
     unlocked.insert("f-locked".to_string());
     let shown = db
-        .search_semantic_visible(&query, 10, 0.0, &unlocked)
+        .search_semantic_visible(&query, 10, 0.0, &unlocked, None)
         .unwrap();
     assert!(
         shown.iter().any(|h| h.meeting.id == "sealed"),
@@ -14833,7 +14845,7 @@ fn transcript_chunks_are_gated_by_visibility_hybrid() {
     let query_vec = one_hot(0);
     let nothing = std::collections::HashSet::new();
     let hidden = db
-        .search_hybrid_visible("merger", &query_vec, 10, 0.0, &nothing, None)
+        .search_hybrid_visible("merger", &query_vec, 10, 0.0, &nothing, None, None)
         .unwrap();
     assert!(
         !hidden.iter().any(|h| h.meeting.id == "sealed"),
@@ -14842,7 +14854,7 @@ fn transcript_chunks_are_gated_by_visibility_hybrid() {
     let mut unlocked = std::collections::HashSet::new();
     unlocked.insert("f-locked".to_string());
     let shown = db
-        .search_hybrid_visible("merger", &query_vec, 10, 0.0, &unlocked, None)
+        .search_hybrid_visible("merger", &query_vec, 10, 0.0, &unlocked, None, None)
         .unwrap();
     assert!(
         shown.iter().any(|h| h.meeting.id == "sealed"),
@@ -14907,14 +14919,14 @@ fn transcript_chunks_purged_on_seal() {
     let query = one_hot(0);
     let nothing = std::collections::HashSet::new();
     assert!(
-        !db.search_semantic_visible(&query, 10, 0.0, &nothing)
+        !db.search_semantic_visible(&query, 10, 0.0, &nothing, None)
             .unwrap()
             .iter()
             .any(|h| h.meeting.id == "m1"),
         "sealed meeting must not surface via semantic search after purge"
     );
     assert!(
-        !db.search_hybrid_visible("marketing", &query, 10, 0.0, &nothing, None)
+        !db.search_hybrid_visible("marketing", &query, 10, 0.0, &nothing, None, None)
             .unwrap()
             .iter()
             .any(|h| h.meeting.id == "m1"),
@@ -14987,7 +14999,7 @@ fn vec_hybrid_fuses_fts_and_vector() {
 
     let nothing = std::collections::HashSet::new();
     let hits = db
-        .search_hybrid_visible("alpha", &query, 10, 0.0, &nothing, None)
+        .search_hybrid_visible("alpha", &query, 10, 0.0, &nothing, None, None)
         .unwrap();
     let ids: Vec<&str> = hits.iter().map(|h| h.meeting.id.as_str()).collect();
     // One hit per meeting (dedup).
@@ -15046,14 +15058,14 @@ fn graph_leg_surfaces_co_mentioned_meeting_fts_and_vector_miss() {
     );
     // ... and absent from vector (no chunk at all → empty KNN).
     assert!(
-        db.search_semantic_visible(&empty_vec, 10, 0.0, &nothing)
+        db.search_semantic_visible(&empty_vec, 10, 0.0, &nothing, None)
             .unwrap()
             .is_empty(),
         "vector must miss B"
     );
     // The query names entity Atlas → graph leg pulls in its neighbour B.
     let hits = db
-        .search_hybrid_visible("atlas status", &empty_vec, 10, 0.0, &nothing, None)
+        .search_hybrid_visible("atlas status", &empty_vec, 10, 0.0, &nothing, None, None)
         .unwrap();
     assert!(
         hits.iter().any(|h| h.meeting.id == "B"),
@@ -15087,7 +15099,7 @@ fn graph_expansion_respects_lock_gate() {
     let empty = std::collections::HashSet::new();
     // Neighbour reader: B (sealed) excluded, A (open) kept.
     let nbrs = db
-        .meetings_mentioning_entities_visible(std::slice::from_ref(&atlas), &empty)
+        .meetings_mentioning_entities_visible(std::slice::from_ref(&atlas), &empty, None)
         .unwrap();
     assert!(nbrs.iter().any(|m| m.id == "A"), "open neighbour A present");
     assert!(
@@ -15106,7 +15118,7 @@ fn graph_expansion_respects_lock_gate() {
     let mut unlocked = std::collections::HashSet::new();
     unlocked.insert("f-secret".to_string());
     let nbrs_u = db
-        .meetings_mentioning_entities_visible(&[atlas], &unlocked)
+        .meetings_mentioning_entities_visible(&[atlas], &unlocked, None)
         .unwrap();
     assert!(
         nbrs_u.iter().any(|m| m.id == "B"),
@@ -15153,7 +15165,7 @@ fn no_entity_match_leaves_hybrid_identical_to_two_leg_fusion() {
     // Expected = RRF over EXACTLY the two legs.
     let fts = db.search_visible("budget planning", 10, &nothing).unwrap();
     let sem = db
-        .search_semantic_visible(&query, 10, 0.0, &nothing)
+        .search_semantic_visible(&query, 10, 0.0, &nothing, None)
         .unwrap();
     let fts_ids: Vec<String> = fts.iter().map(|h| h.meeting.id.clone()).collect();
     let sem_ids: Vec<String> = sem.iter().map(|h| h.meeting.id.clone()).collect();
@@ -15163,7 +15175,7 @@ fn no_entity_match_leaves_hybrid_identical_to_two_leg_fusion() {
         .collect();
 
     let got: Vec<String> = db
-        .search_hybrid_visible("budget planning", &query, 10, 0.0, &nothing, None)
+        .search_hybrid_visible("budget planning", &query, 10, 0.0, &nothing, None, None)
         .unwrap()
         .into_iter()
         .map(|h| h.meeting.id)
@@ -15200,7 +15212,7 @@ fn three_leg_rrf_ranks_multi_leg_first_and_dedups() {
 
     let nothing = std::collections::HashSet::new();
     let hits = db
-        .search_hybrid_visible("atlas budget", &query, 10, 0.0, &nothing, None)
+        .search_hybrid_visible("atlas budget", &query, 10, 0.0, &nothing, None, None)
         .unwrap();
     let ids: Vec<&str> = hits.iter().map(|h| h.meeting.id.as_str()).collect();
     // Dedup: each meeting once.
@@ -15616,7 +15628,7 @@ fn hybrid_date_filter_excludes_out_of_window_lexical_match() {
 
     // RED baseline (no filter): BOTH lexical matches surface.
     let unfiltered = db
-        .search_hybrid_visible("budżet", &[], 10, 0.0, &nothing, None)
+        .search_hybrid_visible("budżet", &[], 10, 0.0, &nothing, None, None)
         .unwrap();
     assert!(unfiltered.iter().any(|h| h.meeting.id == "m-in"));
     assert!(
@@ -15627,7 +15639,7 @@ fn hybrid_date_filter_excludes_out_of_window_lexical_match() {
     // GREEN: the "last week of the 2026-06-29 anchor" window excludes m-out on EVERY leg.
     let window = Some(("2026-06-22".to_string(), "2026-06-29".to_string()));
     let filtered = db
-        .search_hybrid_visible("budżet", &[], 10, 0.0, &nothing, window)
+        .search_hybrid_visible("budżet", &[], 10, 0.0, &nothing, window, None)
         .unwrap();
     assert!(
         filtered.iter().any(|h| h.meeting.id == "m-in"),
@@ -15656,7 +15668,7 @@ fn search_visible_in_range_falls_back_to_temporal_window() {
     let window = Some(("2026-06-22".to_string(), "2026-06-29".to_string()));
     // No token of this query appears in any note ⇒ pure window fallback.
     let hits = db
-        .search_visible_in_range("what did we discuss", 10, &nothing, window)
+        .search_visible_in_range("what did we discuss", 10, &nothing, window, None)
         .unwrap();
     assert_eq!(
         hits.len(),
@@ -15668,7 +15680,7 @@ fn search_visible_in_range_falls_back_to_temporal_window() {
 
     // Without a window the same no-match query returns nothing (unchanged FTS behavior).
     let none = db
-        .search_visible_in_range("what did we discuss", 10, &nothing, None)
+        .search_visible_in_range("what did we discuss", 10, &nothing, None, None)
         .unwrap();
     assert!(
         none.is_empty(),
@@ -16343,7 +16355,7 @@ fn s1_floor_drops_orthogonal_semantic_neighbour() {
 
     // No floor (0.0) → BOTH returned.
     let all = db
-        .search_semantic_visible(&query, 10, 0.0, &nothing)
+        .search_semantic_visible(&query, 10, 0.0, &nothing, None)
         .unwrap();
     let ids: Vec<&str> = all.iter().map(|h| h.meeting.id.as_str()).collect();
     assert!(
@@ -16353,7 +16365,7 @@ fn s1_floor_drops_orthogonal_semantic_neighbour() {
 
     // Floor 0.75 → only the near (cos 1.0) survives.
     let floored = db
-        .search_semantic_visible(&query, 10, 0.75, &nothing)
+        .search_semantic_visible(&query, 10, 0.75, &nothing, None)
         .unwrap();
     let fids: Vec<&str> = floored.iter().map(|h| h.meeting.id.as_str()).collect();
     assert_eq!(
@@ -16444,7 +16456,7 @@ fn s1_floor_keeps_fts_hit_when_vector_leg_floored_empty() {
 
     let nothing = std::collections::HashSet::new();
     let hits = db
-        .search_hybrid_visible("budget", &one_hot(0), 10, 0.75, &nothing, None)
+        .search_hybrid_visible("budget", &one_hot(0), 10, 0.75, &nothing, None, None)
         .unwrap();
     assert!(
         hits.iter().any(|h| h.meeting.id == "m-budget"),

--- a/src-tauri/src/storage/folders_store.rs
+++ b/src-tauri/src/storage/folders_store.rs
@@ -1270,6 +1270,89 @@ impl Db {
     /// for legacy rows that could not be canonicalized safely. Returning *all* of those legacy
     /// folders lets the command-layer gate require every governing folder to be readable instead
     /// of accidentally choosing an unlocked sibling beside a locked one.
+    /// Every folder id in the SUBTREE rooted at `folder_id` — the folder itself plus all its
+    /// descendants — for scoping a vault search to one Space or folder.
+    ///
+    /// WHY THIS EXISTS. A container RELATION (`LinkKind::Container`) is deliberately metadata-only:
+    /// it names a place and never expands to what the place holds. That is correct for a relation,
+    /// but it left no way to say "answer from what is in this folder" — the only choices were
+    /// pinning items one by one or searching the whole vault. A container SCOPE is the missing
+    /// third thing, and it is a different mechanism on purpose: it narrows RETRIEVAL rather than
+    /// packing content, so a folder holding a hundred notes costs the same as one holding five.
+    ///
+    /// Descendants come from the `path` prefix, which `create_folder` composes as
+    /// `parent.path + '/' + name` and every reparent rewrites for the whole subtree — so a prefix
+    /// match is exact, and no recursive CTE is needed. The comparison is done in Rust rather than
+    /// with SQL `LIKE` because a folder NAME is user text: `%` or `_` in a name would silently
+    /// widen a `LIKE` pattern into folders the user never scoped to.
+    ///
+    /// NOT a visibility decision. This answers only "which folders are inside this one"; whether a
+    /// meeting in them may be READ is still decided by `meeting_visibility_clause`, which every
+    /// caller ANDs with the id set this returns. A locked-and-not-session-unlocked folder therefore
+    /// contributes nothing, without this function having to know about locks at all.
+    pub fn folder_subtree_ids(&self, folder_id: &str) -> Result<Vec<String>> {
+        let conn = self.lock();
+        let root: Option<String> = conn
+            .query_row(
+                "SELECT path FROM folders WHERE id = ?1",
+                rusqlite::params![folder_id],
+                |r| r.get::<_, Option<String>>(0),
+            )
+            .optional()
+            .map_err(map_err)?
+            .flatten();
+        // No such folder, or one with no path: scope to exactly that id and nothing else. Returning
+        // an EMPTY set would read as "no scope" to a caller that treats empty as unscoped, which is
+        // the one interpretation that must never happen — it would silently widen to the vault.
+        let Some(root_path) = root.filter(|p| !p.is_empty()) else {
+            return Ok(vec![folder_id.to_string()]);
+        };
+        let prefix = format!("{root_path}/");
+        let mut stmt = conn
+            .prepare("SELECT id, path FROM folders")
+            .map_err(map_err)?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok((r.get::<_, String>(0)?, r.get::<_, Option<String>>(1)?))
+            })
+            .map_err(map_err)?;
+        let mut ids = Vec::new();
+        for row in rows {
+            let (id, path) = row.map_err(map_err)?;
+            let path = path.unwrap_or_default();
+            if id == folder_id || path == root_path || path.starts_with(&prefix) {
+                ids.push(id);
+            }
+        }
+        if ids.is_empty() {
+            ids.push(folder_id.to_string());
+        }
+        Ok(ids)
+    }
+
+    /// Expand a set of container ids into the SCOPE they denote — each one plus its whole subtree,
+    /// deduplicated.
+    ///
+    /// This exists so "a scope" has exactly ONE meaning in the codebase. Passing a raw, unexpanded
+    /// id list to a scoped search silently narrows to the folder's own direct contents and hides
+    /// everything in its sub-folders — a wrong answer that looks like a working feature. Every
+    /// caller that turns a user's chosen containers into a search scope goes through here.
+    ///
+    /// Recomputed per call ON PURPOSE. A scope is a LIVE query, not a snapshot: a note filed into
+    /// the folder tomorrow, or a sub-folder created under it, is in scope without the user
+    /// re-choosing anything — which is the whole reason a scope beats pinning items one by one.
+    pub fn folder_scope_ids(&self, container_ids: &[String]) -> Result<Vec<String>> {
+        let mut scope: Vec<String> = Vec::new();
+        for id in container_ids {
+            for descendant in self.folder_subtree_ids(id)? {
+                if !scope.contains(&descendant) {
+                    scope.push(descendant);
+                }
+            }
+        }
+        Ok(scope)
+    }
+
     pub fn folders_for_meeting(&self, meeting_id: &str) -> Result<Vec<String>> {
         let conn = self.lock();
         let canonical = conn

--- a/src-tauri/src/storage/graph_store.rs
+++ b/src-tauri/src/storage/graph_store.rs
@@ -504,12 +504,14 @@ impl Db {
         &self,
         entity_ids: &[String],
         unlocked: &HashSet<String>,
+        scope: Option<&[String]>,
     ) -> Result<Vec<Meeting>> {
         if entity_ids.is_empty() {
             return Ok(Vec::new());
         }
         let conn = self.lock();
         let meeting_visible = meeting_visibility_clause("m", unlocked);
+        let scoped = crate::storage::db::folder_scope_clause("m", scope);
         let placeholders = (1..=entity_ids.len())
             .map(|i| format!("?{i}"))
             .collect::<Vec<_>>()
@@ -520,7 +522,7 @@ impl Db {
                FROM entity_mentions em \
                JOIN meetings m ON m.id = em.meeting_id \
               WHERE em.entity_id IN ({placeholders}) \
-                AND {meeting_visible} \
+                AND {meeting_visible}{scoped} \
               GROUP BY m.id \
               ORDER BY COUNT(DISTINCT em.entity_id) DESC, m.started_at DESC, m.id DESC"
         );
@@ -616,7 +618,7 @@ impl Db {
             });
         }
         // Meetings (visible-meeting predicate; capped to keep the payload bounded).
-        for m in self.list_meetings_visible(MAX_FULL_GRAPH_PER_KIND as i64, unlocked)? {
+        for m in self.list_meetings_visible(MAX_FULL_GRAPH_PER_KIND as i64, unlocked, None)? {
             visible.insert((FullGraphNodeKind::Meeting.as_str(), m.id.clone()));
             let label = m
                 .title

--- a/src-tauri/src/storage/links.rs
+++ b/src-tauri/src/storage/links.rs
@@ -3211,7 +3211,7 @@ impl Db {
         //    take ids here; the centroid read is a separate stored-vector fetch.
         let cap = max_items.max(1) as i64;
         let mut ids: Vec<(crate::links::LinkKind, String)> = Vec::new();
-        for m in self.list_meetings_visible(cap, unlocked)? {
+        for m in self.list_meetings_visible(cap, unlocked, None)? {
             ids.push((crate::links::LinkKind::Meeting, m.id));
         }
         for (node_kind, id, _label, _ts) in self.full_graph_content_nodes(unlocked)? {

--- a/src-tauri/src/storage/meetings_store.rs
+++ b/src-tauri/src/storage/meetings_store.rs
@@ -537,9 +537,14 @@ impl Db {
         &self,
         limit: i64,
         unlocked: &HashSet<String>,
+        scope: Option<&[String]>,
     ) -> Result<Vec<Meeting>> {
         let conn = self.lock();
         let meeting_visible = meeting_visible_sql(unlocked);
+        // Scope narrows the fallback too. Without this, a scoped question that matches nothing
+        // would answer from the WHOLE vault's recent meetings — silently outside the scope the
+        // user chose, which is worse than answering "nothing here".
+        let scoped = crate::storage::db::folder_scope_clause("m", scope);
         // A meeting is hidden only when EVERY note it has is sealed-and-not-unlocked. Expressed
         // as: no note row exists that is currently sealed-and-hidden for this meeting, unless a
         // sibling visible note exists. Simpler + correct: keep the meeting if it has zero notes
@@ -548,7 +553,7 @@ impl Db {
             "SELECT m.id, m.started_at, m.ended_at, m.title, m.duration_s, m.audio_path, m.status,
                     m.folder_id
                FROM meetings m
-              WHERE {meeting_visible}
+              WHERE {meeting_visible}{scoped}
               ORDER BY m.started_at DESC, m.id DESC
               LIMIT ?1"
         );

--- a/src-tauri/src/summarize/related_context.rs
+++ b/src-tauri/src/summarize/related_context.rs
@@ -382,7 +382,7 @@ fn gated_candidates(
             // No temporal window here: the grounding query is a derived salient-term string, not
             // a user question (a temporal phrase in it would be note prose, not intent).
             Some(qv) if !qv.is_empty() => {
-                db.search_hybrid_visible(query, &qv, limit, 0.0, unlocked, None)
+                db.search_hybrid_visible(query, &qv, limit, 0.0, unlocked, None, None)
             }
             // Empty/degenerate query vector → FTS (never a stub-vector KNN).
             _ => db.search_visible(query, limit, unlocked),

--- a/src-tauri/src/summarize/vault_context.rs
+++ b/src-tauri/src/summarize/vault_context.rs
@@ -129,7 +129,7 @@ pub fn build_vault_context(
     query: &str,
     provider_id: &str,
 ) -> Result<(String, Vec<VaultSource>)> {
-    build_vault_context_visible(db, query, provider_id, &HashSet::new())
+    build_vault_context_visible(db, query, provider_id, &HashSet::new(), None)
 }
 
 /// Returns (corpus, sources). Picks VISIBLE meetings relevant to `query` (full-text search),
@@ -143,6 +143,7 @@ pub fn build_vault_context_visible(
     query: &str,
     provider_id: &str,
     unlocked: &HashSet<String>,
+    scope: Option<&[String]>,
 ) -> Result<(String, Vec<VaultSource>)> {
     let budget = budget_for(provider_id);
 
@@ -155,12 +156,12 @@ pub fn build_vault_context_visible(
     // apply the sealed-folder visibility clause against `unlocked`, so sealed-not-unlocked
     // meetings are filtered out of the candidate set before any content is read.
     let mut meetings: Vec<crate::storage::models::Meeting> = db
-        .search_visible_in_range(query, 40, unlocked, date_filter)?
+        .search_visible_in_range(query, 40, unlocked, date_filter, scope)?
         .into_iter()
         .map(|h| h.meeting)
         .collect();
     if meetings.is_empty() {
-        meetings = db.list_meetings_visible(30, unlocked)?;
+        meetings = db.list_meetings_visible(30, unlocked, scope)?;
     }
 
     let (mut corpus, sources) = pack_meetings(db, meetings, budget, unlocked)?;
@@ -189,6 +190,7 @@ pub fn build_vault_context_hybrid_visible(
     query_vec: &[f32],
     unlocked: &HashSet<String>,
     reranker: Option<&dyn crate::rerank::Reranker>,
+    scope: Option<&[String]>,
 ) -> Result<(String, Vec<VaultSource>)> {
     let budget = budget_for(provider_id);
     // Brain v2 L1.5 — temporal window (all hybrid legs apply it; query-time `now` anchor).
@@ -201,6 +203,7 @@ pub fn build_vault_context_hybrid_visible(
         crate::embed::KNN_SEARCH_COSINE_FLOOR,
         unlocked,
         date_filter,
+        scope,
     )?;
 
     // Brain v2 L1.4 — the RERANKER seam (Ask-only): reorder the TOP-K fused candidates before
@@ -235,7 +238,7 @@ pub fn build_vault_context_hybrid_visible(
     let mut meetings: Vec<crate::storage::models::Meeting> =
         hits.into_iter().map(|h| h.meeting).collect();
     if meetings.is_empty() {
-        meetings = db.list_meetings_visible(30, unlocked)?;
+        meetings = db.list_meetings_visible(30, unlocked, None)?;
     }
     let (mut corpus, sources) = pack_meetings(db, meetings, budget, unlocked)?;
     // Document ingestion: APPEND a gated `## Documents` section so the brain/Ask can also ground on
@@ -271,7 +274,7 @@ pub fn build_meeting_listing_visible(
     let date_filter =
         crate::summarize::temporal::extract_date_filter(query, chrono::Utc::now().date_naive());
     let mut meetings: Vec<crate::storage::models::Meeting> = if query_vec.is_empty() {
-        db.search_visible_in_range(query, limit, unlocked, date_filter)?
+        db.search_visible_in_range(query, limit, unlocked, date_filter, None)?
             .into_iter()
             .map(|h| h.meeting)
             .collect()
@@ -283,13 +286,14 @@ pub fn build_meeting_listing_visible(
             crate::embed::KNN_SEARCH_COSINE_FLOOR,
             unlocked,
             date_filter,
+            None,
         )?
             .into_iter()
             .map(|h| h.meeting)
             .collect()
     };
     if meetings.is_empty() {
-        meetings = db.list_meetings_visible(limit, unlocked)?;
+        meetings = db.list_meetings_visible(limit, unlocked, None)?;
     }
     let lines: Vec<String> = meetings
         .iter()
@@ -898,7 +902,7 @@ mod tests {
 
         let nothing = HashSet::new();
         let (whole, whole_sources) =
-            build_vault_context_visible(&db, "", crate::summarize::roles::CONN_LOCAL, &nothing)
+            build_vault_context_visible(&db, "", crate::summarize::roles::CONN_LOCAL, &nothing, None)
                 .unwrap();
         assert!(whole.contains("LOCAL-BUDGET-EVIDENCE"));
         assert_eq!(whole_sources.len(), 1);
@@ -963,14 +967,14 @@ mod tests {
 
         // Visibility-aware variant with an empty set agrees with the shim.
         let nothing = HashSet::new();
-        let (c0, _) = build_vault_context_visible(&db, "SECRET", "anthropic", &nothing).unwrap();
+        let (c0, _) = build_vault_context_visible(&db, "SECRET", "anthropic", &nothing, None).unwrap();
         assert!(!c0.contains("LOCKED-SECRET"));
 
         // Session-unlock the folder → its content is now legitimately available.
         let mut unlocked = HashSet::new();
         unlocked.insert("f-locked".to_string());
         let (corpus2, sources2) =
-            build_vault_context_visible(&db, "SECRET", "anthropic", &unlocked).unwrap();
+            build_vault_context_visible(&db, "SECRET", "anthropic", &unlocked, None).unwrap();
         assert!(
             corpus2.contains("LOCKED-SECRET"),
             "unlocked content must reappear"
@@ -1088,7 +1092,7 @@ mod tests {
 
         let nothing = HashSet::new();
         let (corpus, sources) =
-            build_vault_context_hybrid_visible(&db, "SECRET", "anthropic", &qvec, &nothing, None)
+            build_vault_context_hybrid_visible(&db, "SECRET", "anthropic", &qvec, &nothing, None, None)
                 .unwrap();
         assert!(
             corpus.contains("OPEN-SECRET"),
@@ -1103,7 +1107,7 @@ mod tests {
         let mut unlocked = HashSet::new();
         unlocked.insert("f-locked".to_string());
         let (corpus2, _) =
-            build_vault_context_hybrid_visible(&db, "SECRET", "anthropic", &qvec, &unlocked, None)
+            build_vault_context_hybrid_visible(&db, "SECRET", "anthropic", &qvec, &unlocked, None, None)
                 .unwrap();
         assert!(
             corpus2.contains("LOCKED-SECRET"),
@@ -1830,7 +1834,7 @@ mod tests {
         let nothing = HashSet::new();
         // Whole-vault (the `None`/no-picker path): BOTH meetings present (empty query → recent list).
         let (whole, whole_sources) =
-            build_vault_context_visible(&db, "", "anthropic", &nothing).unwrap();
+            build_vault_context_visible(&db, "", "anthropic", &nothing, None).unwrap();
         assert!(whole.contains("WHOLE-A"), "whole-vault contains meeting A");
         assert!(whole.contains("WHOLE-B"), "whole-vault contains meeting B");
         assert_eq!(whole_sources.len(), 2);

--- a/src-tauri/src/summarize/vault_context.rs
+++ b/src-tauri/src/summarize/vault_context.rs
@@ -169,7 +169,7 @@ pub fn build_vault_context_visible(
     // append the gated `## Documents` section from the keyword (FTS/BM25) leg alone — an empty
     // `query_vec` means no KNN leg. Same `visibility_clause` gate as every meeting leg, so a
     // sealed-not-unlocked folder's document chunks never enter the cloud-bound corpus.
-    pack_doc_chunks(db, query, &[], budget, &mut corpus, unlocked)?;
+    pack_doc_chunks(db, query, &[], budget, &mut corpus, unlocked, scope)?;
     Ok((corpus, sources))
 }
 
@@ -238,7 +238,7 @@ pub fn build_vault_context_hybrid_visible(
     let mut meetings: Vec<crate::storage::models::Meeting> =
         hits.into_iter().map(|h| h.meeting).collect();
     if meetings.is_empty() {
-        meetings = db.list_meetings_visible(30, unlocked, None)?;
+        meetings = db.list_meetings_visible(30, unlocked, scope)?;
     }
     let (mut corpus, sources) = pack_meetings(db, meetings, budget, unlocked)?;
     // Document ingestion: APPEND a gated `## Documents` section so the brain/Ask can also ground on
@@ -247,7 +247,7 @@ pub fn build_vault_context_hybrid_visible(
     // sealed-and-not-session-unlocked folder's document chunks are NEVER returned — identical gate
     // to the meeting legs. Each hit contributes its document name + best chunk snippet (no meeting
     // citation — documents are not meetings, so they don't add a `VaultSource`). Same `budget`.
-    pack_doc_chunks(db, query, query_vec, budget, &mut corpus, unlocked)?;
+    pack_doc_chunks(db, query, query_vec, budget, &mut corpus, unlocked, scope)?;
     Ok((corpus, sources))
 }
 
@@ -324,13 +324,14 @@ fn pack_doc_chunks(
     budget: usize,
     corpus: &mut String,
     unlocked: &HashSet<String>,
+    scope: Option<&[String]>,
 ) -> Result<()> {
     let knn = if query_vec.is_empty() {
         Vec::new()
     } else {
-        db.search_doc_chunks_visible(query_vec, 20, crate::embed::KNN_SEARCH_COSINE_FLOOR, unlocked)?
+        db.search_doc_chunks_visible(query_vec, 20, crate::embed::KNN_SEARCH_COSINE_FLOOR, unlocked, scope)?
     };
-    let fts = db.search_doc_chunks_fts_visible(query, 20, unlocked)?;
+    let fts = db.search_doc_chunks_fts_visible(query, 20, unlocked, scope)?;
     let mut hits = crate::embed::fuse_doc_hits(knn, fts);
     if hits.is_empty() {
         return Ok(());

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -741,7 +741,7 @@ pub fn execute_tool(
             // search tool on a default install. `search_doc_chunks_fts_visible` applies the SAME
             // `visibility_clause` against `unlocked` as the meeting legs.
             let docs = db
-                .search_doc_chunks_fts_visible(q, 20, unlocked)
+                .search_doc_chunks_fts_visible(q, 20, unlocked, None)
                 .unwrap_or_default();
             match db.search_visible_in_range(q, 20, unlocked, date_filter, None) {
                 Ok(hits) if hits.is_empty() && docs.is_empty() => {
@@ -774,7 +774,7 @@ pub fn execute_tool(
                     .search_visible_in_range(q, 20, unlocked, date_filter, None)
                     .map_err(|e| AppError::Storage(format!("search failed: {e}")))?;
                 let docs = db
-                    .search_doc_chunks_fts_visible(q, 20, unlocked)
+                    .search_doc_chunks_fts_visible(q, 20, unlocked, None)
                     .unwrap_or_default();
                 if hits.is_empty() && docs.is_empty() {
                     return Ok(format!(
@@ -797,7 +797,7 @@ pub fn execute_tool(
                         .search_visible_in_range(q, 20, unlocked, date_filter, None)
                         .map_err(|e| AppError::Storage(format!("search failed: {e}")))?;
                     let docs = db
-                        .search_doc_chunks_fts_visible(q, 20, unlocked)
+                        .search_doc_chunks_fts_visible(q, 20, unlocked, None)
                         .unwrap_or_default();
                     if hits.is_empty() && docs.is_empty() {
                         return Ok(format!(
@@ -828,10 +828,11 @@ pub fn execute_tool(
                     20,
                     crate::embed::KNN_SEARCH_COSINE_FLOOR,
                     unlocked,
+                    None,
                 )
                 .unwrap_or_default();
             let fts_docs = db
-                .search_doc_chunks_fts_visible(q, 20, unlocked)
+                .search_doc_chunks_fts_visible(q, 20, unlocked, None)
                 .unwrap_or_default();
             let mut docs = crate::embed::fuse_doc_hits(knn_docs, fts_docs);
             // Brain v3 audit Fix 1 — GATED, HIT-ALIGNED PARENT EXPANSION: a top-3 fused doc hit

--- a/src-tauri/src/tools.rs
+++ b/src-tauri/src/tools.rs
@@ -743,7 +743,7 @@ pub fn execute_tool(
             let docs = db
                 .search_doc_chunks_fts_visible(q, 20, unlocked)
                 .unwrap_or_default();
-            match db.search_visible_in_range(q, 20, unlocked, date_filter) {
+            match db.search_visible_in_range(q, 20, unlocked, date_filter, None) {
                 Ok(hits) if hits.is_empty() && docs.is_empty() => {
                     Ok(format!("No meetings or documents match \"{q}\"."))
                 }
@@ -771,7 +771,7 @@ pub fn execute_tool(
             // labelled as keyword matching so the model is never told a semantic search ran.
             if !config.semantic_search_enabled {
                 let hits = db
-                    .search_visible_in_range(q, 20, unlocked, date_filter)
+                    .search_visible_in_range(q, 20, unlocked, date_filter, None)
                     .map_err(|e| AppError::Storage(format!("search failed: {e}")))?;
                 let docs = db
                     .search_doc_chunks_fts_visible(q, 20, unlocked)
@@ -794,7 +794,7 @@ pub fn execute_tool(
                 Ok(embedder) => embedder,
                 Err(_) => {
                     let hits = db
-                        .search_visible_in_range(q, 20, unlocked, date_filter)
+                        .search_visible_in_range(q, 20, unlocked, date_filter, None)
                         .map_err(|e| AppError::Storage(format!("search failed: {e}")))?;
                     let docs = db
                         .search_doc_chunks_fts_visible(q, 20, unlocked)
@@ -859,6 +859,7 @@ pub fn execute_tool(
                 crate::embed::KNN_SEARCH_COSINE_FLOOR,
                 unlocked,
                 date_filter,
+                None, // the MCP search tool is vault-wide; scoping is an Ask-side choice
             ) {
                 Ok(hits) if hits.is_empty() && docs.is_empty() => {
                     Ok(format!("No meetings or documents match \"{q}\"."))

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -2173,12 +2173,19 @@ export class IpcService {
     explicitSources?: SourceRef[],
     pinnedOrgItemId?: string,
     dashboardId?: string,
+    scopeFolderIds?: string[],
   ): Promise<AskVaultResult> {
     return invoke<AskVaultResult>("ask_vault", {
       question,
       history,
       askThreadId,
       ...(explicitSources?.length ? { explicitSources } : {}),
+      // CONTAINER SCOPE — answer from what is filed under these Spaces/folders, subtree included.
+      // Distinct from `explicitSources`, which PINS specific items into the corpus: a scope narrows
+      // RETRIEVAL instead, so a folder holding a hundred notes costs what five cost, and a note
+      // added to the folder tomorrow is in scope without re-choosing anything. Empty ⇒ omitted, so
+      // "scope cleared" is the whole vault rather than a scope matching nothing.
+      ...(scopeFolderIds?.length ? { scopeFolderIds } : {}),
       // Org-item viewer: pin a read-only SHARED (org-feed) note into the Ask context server-side
       // (the local Brain never retrieves org content via search, so pinning is what grounds it).
       ...(pinnedOrgItemId ? { pinnedOrgItemId } : {}),
@@ -2224,6 +2231,7 @@ export class IpcService {
     explicitSources?: SourceRef[],
     askTraceId?: string,
     dashboardId?: string,
+    scopeFolderIds?: string[],
   ): Promise<AskConversationSendResult> {
     return invoke<AskConversationSendResult>("ask_vault_persisted", {
       scope,
@@ -2232,6 +2240,9 @@ export class IpcService {
       askTraceId,
       ...(explicitSources?.length ? { explicitSources } : {}),
       ...(dashboardId ? { dashboardId } : {}),
+      // Container scope — see `askVault`. Sent separately from `explicitSources` because a place
+      // is not a document: it narrows the search instead of being packed into the corpus.
+      ...(scopeFolderIds?.length ? { scopeFolderIds } : {}),
     });
   }
 

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -2765,7 +2765,13 @@ export interface NoteAssistRequest {
  * note/meeting.
  */
 export interface NoteCitation {
-  kind: "meeting" | "note" | "person" | "entity" | "org";
+  /**
+   * `"container"` is a Space or folder, added when `list_link_candidates` gained a container leg so
+   * one can be picked as an Ask SCOPE. It is NOT a document: it is never a `[[` wikilink target and
+   * never pinned as content — the note-editor link picker filters it out, and only a
+   * `<mur-source-picker>` that opts into the `container` kind ever renders it.
+   */
+  kind: "meeting" | "note" | "person" | "entity" | "org" | "container";
   /**
    * For link-candidate `kind === "org"` rows this is the revision-stable
    * `orgId:docId` endpoint composite. Other citation surfaces may still carry a

--- a/src/app/features/ask/ask/ask.component.html
+++ b/src/app/features/ask/ask/ask.component.html
@@ -202,6 +202,7 @@
           class="ask-sources"
           [selected]="sources()"
           (selectedChange)="onSourcesChange($event)"
+          [allowedKinds]="askSourceKinds"
           [dashboard]="dashboard()"
           (dashboardChange)="onDashboardChange($event)"
           dashboardMode="composite"

--- a/src/app/features/ask/ask/ask.component.ts
+++ b/src/app/features/ask/ask/ask.component.ts
@@ -22,6 +22,7 @@ import type {
   DashboardScopeRef,
   SourceRef,
   VaultSource,
+  LinkKind,
 } from "../../../core/models";
 import { SourcePickerComponent } from "../../../design-system/source-picker/source-picker.component";
 import { MarkdownComponent } from "../../../shared/markdown/markdown.component";
@@ -134,6 +135,40 @@ export class AskComponent implements OnInit {
    * their links; empty ⇒ pass `undefined` (whole-vault) to {@link askVault}.
    */
   readonly sources = signal<SourceRef[]>([]);
+
+  /**
+   * What the Sources picker may offer here — the content kinds it always offered, PLUS whole
+   * containers (a Space or folder).
+   *
+   * A container behaves differently from the rest and the split happens in {@link askScope}: a
+   * content source is PINNED (packed into the corpus verbatim), while a container is a SCOPE
+   * (retrieval is narrowed to what is filed under it, subtree included). That is why a container
+   * can be picked at all despite `LinkKind.Container` deliberately not being a content source —
+   * it never enters the corpus as text, it only says where to look.
+   */
+  protected readonly askSourceKinds: readonly LinkKind[] = [
+    "meeting",
+    "note",
+    "document",
+    "container",
+  ];
+
+  /**
+   * The picker selection, split into the two things the backend takes.
+   *
+   * `pinned` are exact items to pack; `scopeFolderIds` are containers to search inside. Sending a
+   * container as a pinned source would hand the packer a place that holds no text of its own — the
+   * backend refuses that by construction, so the split has to happen here.
+   */
+  protected askScope(): { pinned: SourceRef[]; scopeFolderIds: string[] } {
+    const selected = this.sources();
+    return {
+      pinned: selected.filter((s) => s.kind !== "container"),
+      scopeFolderIds: selected
+        .filter((s) => s.kind === "container")
+        .map((s) => s.id),
+    };
+  }
   /** One composite board identity; never expanded into child SourceRefs in the WebView. */
   readonly dashboard = signal<DashboardScopeRef | null>(null);
 
@@ -510,15 +545,19 @@ export class AskComponent implements OnInit {
 
     // Source-scoped Brain: an empty selection ⇒ pass undefined (whole-vault);
     // a non-empty selection pins the answer to those sources + their links.
-    const scope = this.sources();
+    // Pinned CONTENT and container SCOPE are two different instructions to the backend, so the
+    // one picker selection is split before it is sent: items get packed, containers narrow the
+    // search. Both empty ⇒ the unchanged whole-vault path.
+    const { pinned, scopeFolderIds } = this.askScope();
     try {
       const result = await this.ipc.askVaultPersisted(
         this.conversationScope,
         question,
         conversationId,
-        scope.length ? scope : undefined,
+        pinned.length ? pinned : undefined,
         askThreadId,
         this.dashboard()?.id,
+        scopeFolderIds.length ? scopeFolderIds : undefined,
       );
       if (requestSeq !== this.requestSeq) {
         return;

--- a/src/app/features/notes/link-picker/link-picker.component.ts
+++ b/src/app/features/notes/link-picker/link-picker.component.ts
@@ -196,13 +196,23 @@ export class LinkPickerComponent {
   }
 
   /** Drop the anchor item (the thing this picker links FROM) so it can't be picked as its own target. */
+  /**
+   * Drop what must not be offered as a `[[` target: the anchor itself, and CONTAINERS.
+   *
+   * `list_link_candidates` gained a container leg so a Space/folder can be picked as an Ask SCOPE.
+   * A wikilink is a different thing — it points at a document — and a Space is not one, so folder
+   * names must not become insertable link targets here. Both fetch paths (first page and
+   * load-more) go through this one filter, so the exclusion cannot be added to one and missed on
+   * the other.
+   */
   private withoutAnchor(rows: NoteCitation[]): NoteCitation[] {
+    const linkable = rows.filter((r) => r.kind !== "container");
     const k = this.excludeKind();
     const i = this.excludeId();
     if (!k || !i) {
-      return rows;
+      return linkable;
     }
-    return rows.filter((r) => !(r.kind === k && r.id === i));
+    return linkable.filter((r) => !(r.kind === k && r.id === i));
   }
 
   private async fetch(q: string): Promise<void> {

--- a/src/app/features/notes/link-picker/link-picker.component.ts
+++ b/src/app/features/notes/link-picker/link-picker.component.ts
@@ -139,6 +139,19 @@ export class LinkPickerComponent {
    * the template; they only guard the fetch orchestration.
    */
   private hasMore = false;
+  /**
+   * Offset into the RAW, unfiltered backend list.
+   *
+   * `loadMore` used to page on `candidates().length`, which was safe only while `withoutAnchor`
+   * dropped at most ONE row (the anchor). It now also drops containers, and containers sort LAST in
+   * the backend ordering — i.e. exactly onto the pages `loadMore` fetches. Paging on the filtered
+   * length then re-requests the same offset forever: the page comes back all containers, the
+   * filtered list does not grow, `hasMore` stays true because the RAW page was full, and every ↓
+   * keystroke re-issues an identical no-op IPC while the rest of the list stays unreachable.
+   *
+   * `<mur-source-picker>` already keeps a raw offset for exactly this reason; this mirrors it.
+   */
+  private rawOffset = 0;
   /** Re-entrancy guard: one append fetch at a time. */
   private loadingMore = false;
   /** One pending paint-time position update at most. */
@@ -223,9 +236,11 @@ export class LinkPickerComponent {
       if (seq !== this.requestSeq) {
         return; // superseded by a newer query.
       }
-      // `hasMore` keys on the RAW page length (the backend paginates the unfiltered list); the
-      // anchor is dropped only from what we display, so a full raw page still means "more to load".
+      // `hasMore` keys on the RAW page length, and so does the next offset (`rawOffset`), because
+      // the backend paginates the UNFILTERED list. Display-side filtering — the anchor, and now
+      // every container — must never move the cursor, or the two disagree and paging stalls.
       this.hasMore = raw.length === PAGE_SIZE;
+      this.rawOffset = raw.length;
       const rows = this.withoutAnchor(raw);
       this.candidates.set(rows);
       this.candidatesChange.emit(rows);
@@ -259,13 +274,14 @@ export class LinkPickerComponent {
     try {
       const rawPage = await this.ipc.listLinkCandidates(
         this.query(),
-        this.candidates().length,
+        this.rawOffset,
         PAGE_SIZE,
       );
       if (seq !== this.requestSeq) {
         return; // a newer query reset the list while this page was in flight.
       }
       this.hasMore = rawPage.length === PAGE_SIZE;
+      this.rawOffset += rawPage.length;
       const page = this.withoutAnchor(rawPage);
       // Dedupe on append: a row that shifted pages mid-scroll (e.g. a title
       // edit reordered recency) must not repeat — the template's


### PR DESCRIPTION
Linking a folder in Related says where something *belongs*. It deliberately does not put that
folder's contents into an answer — `LinkKind::Container` is not a content source, because a place
holds no text of its own. That is correct for a relation, and it is what the hierarchy picker's own
confirmation promises ("not links to the items inside it").

But it left no way to say **"answer from what is in this folder"**. The only options were pinning
items one at a time, or searching the whole vault. This adds the missing third thing.

## A scope is not a pin, and not a relation

| | what it does | cost |
| --- | --- | --- |
| **pin** (`explicitSources`) | packs those exact items into the corpus, verbatim | grows with the items |
| **relation** (`LinkKind::Container`) | records that a place is related; never expands | none |
| **scope** (new, `scopeFolderIds`) | narrows *retrieval* to what is filed under the container | flat |

Because a scope narrows retrieval instead of packing text, **a folder holding a hundred notes costs
what a folder of five costs**, and ranking still decides what is relevant inside it. It rides its own
parameter rather than `explicit_sources`, because that list is packed verbatim — handing it a place
would invert the very invariant `is_content_source` exists to hold.

## It is a live query, not a snapshot

The subtree is resolved **per question**. So a note filed into the folder tomorrow, or a sub-folder
created under it, is in scope without re-choosing anything; a note moved out drops out; and renaming
or moving the folder changes nothing, because resolution is by id. That is precisely what makes a
scope worth having over pinning, where the eleventh note you write is invisible until you pin it too.

`a_scope_picks_up_items_added_after_it_was_chosen` is the oracle, and it is RED if anyone
"optimises" the expansion into a cached list.

## It composes with the lock model rather than competing with it

The scope clause is ANDed **after** `meeting_visibility_clause`, so it can only ever remove rows the
gate already allowed. Scoping into a sealed folder yields nothing — never its contents.

Subtree resolution is done in Rust, not with SQL `LIKE` over paths, because a folder **name** is user
text: a `%` in a name would silently widen a `LIKE` pattern into folders nobody scoped to.

## What the gates caught that I had missed

**clippy, as an "unused variable".** The scope reached the hybrid path but not the keyword path — so
a user with semantic search switched off would have been answered from the whole vault while the UI
said the folder was scoped. Hunting that turned up the worse half: **both "recent meetings" fallbacks
ignored it too**, which is how a scoped question that matches nothing gets a confident answer from
outside the scope. That is worse than "nothing here". Both paths and both fallbacks are scoped now,
with an oracle on the fallback.

**The existing anti-leak tests, on a leak I wrote.** Containers had to become pickable candidates or
the new control would be inert. My first version listed sealed folders, reasoning that the Related
picker already shows folder names — and I wrote a test asserting that as intended. Wrong for this
list: its contract, pinned by `list_link_candidates_hides_sealed_sources`, is that not even the
pagination *total* may disclose a sealed match. A name is a disclosure; searching "Secret" must not
confirm such a folder exists. The leg is gated now, and my test asserts the opposite of what it first
said.

The two `list_link_candidates_hides_sealed_*` tests keep their *hidden* halves untouched — those are
what caught me. Only their post-unlock counts move, and only because the folder in them is itself
named "Secret", so once unlocked it is legitimately a scope candidate.

## One name for one operation

`folder_scope_ids` is the single way to turn chosen containers into a scope, used by production and
tests alike. Passing a raw, unexpanded id list narrows to a folder's direct contents and hides its
sub-folders — a wrong answer that looks like a working feature. The first draft had that seam; the
subtree test found it.

## Gates

| gate | result |
| --- | --- |
| `cargo test --lib` | **3705 passed**, 0 failed |
| `cargo clippy --lib --tests -- -D warnings` | clean |
| `ng lint` / `ng build` | clean |
| `mirror-check` | OK |

Seven oracles, one invariant each: subtree coverage, wildcard-safe names, an unknown id never
degrading to the whole vault, narrowing without bypassing the lock, live pickup of later additions,
the scoped fallback, and gated candidates.

Requesting a lock-security review: this adds a new predicate to gated search paths and a new listing
of container names.
