### PR TITLE
chore(release): 2.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4637,7 +4637,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "2.5.0"
+version = "2.6.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murmur",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murmur",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "dependencies": {
         "@angular/common": "^22.0.8",
         "@angular/compiler": "^22.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "scripts": {
     "start": "cargo build -p murmur-brain && ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "2.5.0"
+version = "2.6.0"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump for 2.6.0: `package.json`, `package-lock.json` (top-level key and the `""` root entry), `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `Cargo.lock` re-pinned. Six lines across five files; `identifier` stays `com.meetnotes.app`.

The lockfile holds **four** `"version": "2.5.0"` strings — the other two are `spdx-exceptions` and `ts-api-utils`, real dependencies. Bounded to the first two, which is why the runbook forbids a repo-wide `sed` here.

Headline: **Ask can be scoped to a Space or folder** (#689) — retrieval is narrowed to what is filed under it, subtree included, so a folder of a hundred notes costs what five cost and a note added tomorrow is in scope without re-choosing anything. It went through four rounds of lock-security review; the first found the feature was unreachable in production while CI was 8/8 green on it.

Also shipping since 2.5.0 was cut: nothing else — the picker (#685) and the Me/Others retry fix (#686) are already in 2.5.0.