### PR TITLE
chore(release): 2.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4637,7 +4637,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murmur",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murmur",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "dependencies": {
         "@angular/common": "^22.0.8",
         "@angular/compiler": "^22.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "scripts": {
     "start": "cargo build -p murmur-brain && ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "2.6.0"
+version = "2.7.0"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump + release 2.7.0.

Ships the appearance-skins and note-reminders work merged since v2.6.0 (31 commits):

- **Theme skins** — an Appearance skin picker with a quiet **Paper** skin: glues the shell to the window, and reads/writes the note at one size (16px/1.7) in every theme.
- **Reminders drawer** — the note gets a reminders drawer in place of the inline create button; the row takes Apple Reminders' shape and is now one component shared by the page and the drawer.
- **Reopen a reminder** — a completed reminder can be reopened (additive backend command + store method, covered by `reminder_tests.rs`).
- **Notes/appearance fixes** — a rename reaches the sidebar and not just the tab; the tool pane's header controls take a click on their whole surface; the sidebar's top row is re-levelled; closing the reminders composer no longer loses focus entirely on WebKit.
