### PR TITLE
fix(org): unwedge "Sync now", drain the feed, and refresh orgs after sign-in

### DIFF
--- a/e2e/org/org-sync-resilience.spec.ts
+++ b/e2e/org/org-sync-resilience.spec.ts
@@ -1,0 +1,385 @@
+import { test, expect } from "@playwright/test";
+import { mockTauri } from "../settings-ai/mock-invoke";
+
+/**
+ * Settings › Organizations — the panel must not LIE about org state.
+ *
+ * Two reported failures, both of which the section reported as good news:
+ *
+ *  1. "sometimes I can't see the organizations and the background is empty, I have to open Settings
+ *     again". The roster lived in a component-local signal inside a `@switch`, so it was wiped on
+ *     every remount, and a read that FAILED fell through to the same branch as a read that found
+ *     nothing: "You're not in any organization yet — create one, or ask a teammate to invite you by
+ *     email." A member of two orgs was told they belonged to none, and the only recovery was to
+ *     leave the section and come back hoping for a luckier attempt.
+ *
+ *  2. "Sync now never finishes / it works with a delay". A manual sync takes bounded feed pages, and
+ *     a drain that stopped on its own cap used to be indistinguishable from one that caught up — the
+ *     panel said "Synced — up to date." about an org that was still behind.
+ *
+ * Driven with a mocked Tauri IPC (no Rust core): render + honesty, not end-to-end sync.
+ * Overrides run PAGE-SIDE (serialized to strings), so they must be self-contained.
+ */
+
+const ACCOUNT_STATUS = () => ({
+  loggedIn: true,
+  email: "you@example.com",
+  unlockedForSharing: true,
+  shareConsented: true,
+  serverConfigured: true,
+  biometricUnlockAvailable: true,
+});
+
+const EMPTY_STATE_COPY =
+  "You're not in any organization yet — create one, or ask a teammate to invite you by email.";
+
+async function openOrgSection(
+  page: import("@playwright/test").Page,
+): Promise<void> {
+  await page.getByRole("button", { name: "Organization" }).first().click();
+  await expect(page.locator("app-settings-organization-section")).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+test.describe("Settings › Organizations — honest state (mocked IPC)", () => {
+  test("a FAILED roster read keeps the known orgs and never claims the user is in none", async ({
+    page,
+  }) => {
+    // Succeeds once (the first open), then fails forever — the shape of a relay that goes away
+    // mid-session, which is when the user hit this.
+    await mockTauri(page, {
+      account_status: ACCOUNT_STATUS,
+      org_refresh: () => null,
+      org_list_statuses: () => {
+        const w = window as unknown as { __orgReads?: number };
+        w.__orgReads = (w.__orgReads ?? 0) + 1;
+        if (w.__orgReads > 1) {
+          throw new Error("relay unreachable");
+        }
+        return [
+          {
+            orgId: "org-owned",
+            name: "Acme Inc.",
+            role: "owner",
+            memberCount: 3,
+            consented: true,
+            lastSeq: 42,
+            itemCount: 12,
+            receivedCount: 12,
+            pendingShares: 0,
+            contextEnabled: true,
+          },
+        ];
+      },
+      org_status: () => null,
+    });
+
+    await page.goto("/settings");
+    await openOrgSection(page);
+    await expect(page.locator(".org-card", { hasText: "Acme Inc." })).toBeVisible();
+
+    // Leave the section and come back: the component is destroyed and recreated, and its reload
+    // now fails. RED before the fix: the card disappears and the empty-state copy appears.
+    await page.getByRole("button", { name: "Account" }).first().click();
+    await openOrgSection(page);
+
+    await expect(
+      page.locator(".org-card", { hasText: "Acme Inc." }),
+    ).toBeVisible();
+    await expect(page.getByText(EMPTY_STATE_COPY)).toHaveCount(0);
+    await expect(
+      page.getByText("Couldn't refresh your organizations just now"),
+    ).toBeVisible();
+  });
+
+  test("a destroyed section's late response cannot overwrite the live roster", async ({
+    page,
+  }) => {
+    // Call #1 — the instance the user is about to leave — resolves slowly with STALE. Every later
+    // call resolves at once with FRESH. Moving the roster into a root store made this matter: the
+    // stale-result guard was a COMPONENT field, so a destroyed instance's response still matched
+    // its own token and wrote over data a newer instance had already rendered. Before the move the
+    // write landed on a dead component-local signal and was invisible.
+    await mockTauri(page, {
+      account_status: ACCOUNT_STATUS,
+      org_refresh: () => null,
+      org_status: () => null,
+      org_list_statuses: () => {
+        const w = window as unknown as { __rosterReads?: number };
+        w.__rosterReads = (w.__rosterReads ?? 0) + 1;
+        const row = (name: string) => [
+          {
+            orgId: "org-owned",
+            name,
+            role: "owner",
+            memberCount: 3,
+            consented: true,
+            lastSeq: 42,
+            itemCount: 12,
+            receivedCount: 12,
+            pendingShares: 0,
+            contextEnabled: true,
+          },
+        ];
+        if (w.__rosterReads === 1) {
+          return new Promise((resolve) =>
+            setTimeout(() => resolve(row("STALE ORG")), 3000),
+          );
+        }
+        return row("FRESH ORG");
+      },
+    });
+
+    await page.goto("/settings");
+    // Do not wait for the first (slow) read: leave while it is still in flight.
+    await page.getByRole("button", { name: "Organization" }).first().click();
+    await page.getByRole("button", { name: "Account" }).first().click();
+    await openOrgSection(page);
+    await expect(
+      page.locator(".org-card", { hasText: "FRESH ORG" }),
+    ).toBeVisible();
+
+    // Let the abandoned instance's response land. RED before the shared load token: it replaces
+    // FRESH with STALE, with no user action in between.
+    await page.waitForTimeout(4000);
+    await expect(
+      page.locator(".org-card", { hasText: "FRESH ORG" }),
+    ).toBeVisible();
+    await expect(page.locator(".org-card", { hasText: "STALE ORG" })).toHaveCount(
+      0,
+    );
+  });
+
+  test("a CAPPED sync says more is still coming instead of 'up to date'", async ({
+    page,
+  }) => {
+    await mockTauri(page, {
+      account_status: ACCOUNT_STATUS,
+      org_refresh: () => null,
+      org_list_statuses: () => [
+        {
+          orgId: "org-owned",
+          name: "Acme Inc.",
+          role: "owner",
+          memberCount: 3,
+          consented: true,
+          lastSeq: 42,
+          itemCount: 12,
+          receivedCount: 12,
+          pendingShares: 0,
+          contextEnabled: true,
+        },
+      ],
+      org_status: () => null,
+      org_sync_now: () => ({
+        pulled: 160,
+        ingested: 40,
+        tombstoned: 0,
+        lastSeq: 202,
+        ftsOnly: false,
+        errors: [],
+        morePending: true,
+      }),
+    });
+
+    await page.goto("/settings");
+    await openOrgSection(page);
+    const card = page.locator(".org-card", { hasText: "Acme Inc." });
+    await card.getByRole("button", { name: "Sync now" }).click();
+
+    const toast = page.locator(".toast.is-success .toast-msg");
+    await expect(toast).toContainText("40 new items");
+    // RED before the fix: the toast stopped at the item count, so a press that ran into its own
+    // page cap read exactly like a completed sync.
+    await expect(toast).toContainText("More is still arriving in the background.");
+    // And the button comes back — a sync that ends must never leave the control parked.
+    await expect(card.getByRole("button", { name: "Sync now" })).toBeEnabled();
+  });
+
+  test("the Sync now button reports the live stage while the sync runs", async ({
+    page,
+  }) => {
+    // `org_sync_now` parks until the test releases it, so the press is observably in flight while
+    // progress events land — the situation a user reported as "it keeps syncing and you don't know
+    // the status".
+    await mockTauri(page, {
+      account_status: ACCOUNT_STATUS,
+      org_refresh: () => null,
+      org_list_statuses: () => [
+        {
+          orgId: "org-owned",
+          name: "Acme Inc.",
+          role: "owner",
+          memberCount: 3,
+          consented: true,
+          lastSeq: 42,
+          itemCount: 12,
+          receivedCount: 12,
+          pendingShares: 0,
+          contextEnabled: true,
+        },
+      ],
+      org_status: () => null,
+      org_sync_now: () =>
+        new Promise((resolve) => {
+          (
+            window as unknown as { __releaseSync: () => void }
+          ).__releaseSync = () =>
+            resolve({
+              pulled: 12,
+              ingested: 12,
+              tombstoned: 0,
+              lastSeq: 54,
+              ftsOnly: false,
+              errors: [],
+              morePending: false,
+            });
+        }),
+    });
+
+    await page.goto("/settings");
+    await openOrgSection(page);
+    const card = page.locator(".org-card", { hasText: "Acme Inc." });
+    const button = card.getByRole("button", { name: /Sync/ });
+    await button.click();
+    await expect(button).toHaveText("Syncing…");
+
+    // RED before the fix: no progress event exists, so the label never moves off "Syncing…".
+    await page.evaluate(() =>
+      (
+        window as unknown as {
+          __demoEmit: (event: string, payload: unknown) => void;
+        }
+      ).__demoEmit("murmur://org-sync-progress", {
+        orgId: "org-owned",
+        stage: "feed",
+        pulled: 8,
+        ingested: 8,
+      }),
+    );
+    await expect(button).toHaveText("Syncing… 8");
+
+    await page.evaluate(() =>
+      (
+        window as unknown as {
+          __demoEmit: (event: string, payload: unknown) => void;
+        }
+      ).__demoEmit("murmur://org-sync-progress", {
+        orgId: "org-owned",
+        stage: "containers",
+        pulled: 12,
+        ingested: 12,
+      }),
+    );
+    await expect(button).toHaveText("Syncing folders…");
+
+    await page.evaluate(() =>
+      (window as unknown as { __releaseSync: () => void }).__releaseSync(),
+    );
+    await expect(page.locator(".toast.is-success .toast-msg")).toContainText(
+      "12 new items",
+    );
+    await expect(button).toHaveText("Sync now");
+  });
+
+  test("a progress event outside a press cannot make the button claim it is syncing", async ({
+    page,
+  }) => {
+    // The progress listener is guarded by "is THIS org syncing", and that guard is documented as
+    // having one bound: a trailing event from a finished press, arriving during the next press on
+    // the same org, is accepted. Correlating presses needs an id echoed through the command, which
+    // the symptom — one page's worth of stale count — does not earn. What CAN be pinned cheaply is
+    // the half that matters: a progress event with no press in flight must change nothing. Without
+    // it, a later change that makes the label sticky or reuses the progress signal across presses
+    // reintroduces the whole class silently.
+    await mockTauri(page, {
+      account_status: ACCOUNT_STATUS,
+      org_refresh: () => null,
+      org_status: () => null,
+      org_list_statuses: () => [
+        {
+          orgId: "org-owned",
+          name: "Acme Inc.",
+          role: "owner",
+          memberCount: 3,
+          consented: true,
+          lastSeq: 42,
+          itemCount: 12,
+          receivedCount: 12,
+          pendingShares: 0,
+          contextEnabled: true,
+        },
+      ],
+    });
+
+    await page.goto("/settings");
+    await openOrgSection(page);
+    const button = page
+      .locator(".org-card", { hasText: "Acme Inc." })
+      .getByRole("button", { name: /Sync/ });
+    await expect(button).toHaveText("Sync now");
+
+    await page.evaluate(() =>
+      (
+        window as unknown as {
+          __demoEmit: (event: string, payload: unknown) => void;
+        }
+      ).__demoEmit("murmur://org-sync-progress", {
+        orgId: "org-owned",
+        stage: "feed",
+        pulled: 99,
+        ingested: 99,
+      }),
+    );
+
+    await expect(button).toHaveText("Sync now");
+    await expect(button).toBeEnabled();
+  });
+
+  // CONTROL, not coverage: this one passes against the pre-fix components too. It is here so the
+  // three assertions above cannot be satisfied by a change that simply stops saying "up to date".
+  test("a sync that finds nothing new still says up to date", async ({
+    page,
+  }) => {
+    await mockTauri(page, {
+      account_status: ACCOUNT_STATUS,
+      org_refresh: () => null,
+      org_list_statuses: () => [
+        {
+          orgId: "org-owned",
+          name: "Acme Inc.",
+          role: "owner",
+          memberCount: 3,
+          consented: true,
+          lastSeq: 42,
+          itemCount: 12,
+          receivedCount: 12,
+          pendingShares: 0,
+          contextEnabled: true,
+        },
+      ],
+      org_status: () => null,
+      org_sync_now: () => ({
+        pulled: 0,
+        ingested: 0,
+        tombstoned: 0,
+        lastSeq: 42,
+        ftsOnly: false,
+        errors: [],
+        morePending: false,
+      }),
+    });
+
+    await page.goto("/settings");
+    await openOrgSection(page);
+    await page
+      .locator(".org-card", { hasText: "Acme Inc." })
+      .getByRole("button", { name: "Sync now" })
+      .click();
+
+    await expect(page.locator(".toast.is-success .toast-msg")).toContainText(
+      "Synced — up to date.",
+    );
+  });
+});

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -14320,9 +14320,26 @@ pub async fn account_login(
     // Membership discovery: reconcile the org set the server says we belong to (owned AND invited)
     // into local `org_state` now the session is cached — so an org we were invited to appears (and
     // becomes syncable) at login, not only after a create. Best-effort: a failure never blocks login.
-    if let Err(e) = org_reconcile_memberships_notifying(state.inner(), Some(&app)).await {
-        tracing::warn!(target: "org", error = %brief_err(&e), "org membership reconcile at login failed (non-fatal)");
+    // Serialized like `org_refresh` and the biometric-unlock path: an unlocked reconcile can
+    // `purge_org_replica` while the background tick is mid-ingest, and the items committed after
+    // that purge re-create a searchable local copy for an org the user has just left. Bounded and
+    // best-effort — a busy lock means the next tick reconciles instead.
+    match acquire_share_mutation_within(state.inner(), SHARE_MUTATION_WAIT).await {
+        Ok(_mutation) => {
+            if let Err(e) = org_reconcile_memberships_notifying(state.inner(), Some(&app)).await {
+                tracing::warn!(target: "org", error = %brief_err(&e), "org membership reconcile at login failed (non-fatal)");
+            }
+        }
+        Err(e) => {
+            tracing::warn!(target: "org", error = %brief_err(&e), "org membership reconcile at login skipped — sharing busy");
+        }
     }
+    // Then tell every open view to re-read, UNCONDITIONALLY — the reconcile above only pings when
+    // MEMBERSHIP changed, and what actually went stale is every org-derived read the frontend took
+    // while there was no session (the sidebar's received forest included). Content-free, and every
+    // consumer answers it with local reads, so it costs no egress. Mirrors the same emit in
+    // `unlock_sharing_with_biometric`, which is the path most people actually use at launch.
+    crate::events::emit_org_feed_updated(&app, 0);
 
     // Build every fallible field BEFORE stamping the one-way latch. Once the latch is set there are
     // no remaining `?` paths: this invocation is committed to return `Ok(AccountStatus)`.
@@ -14423,6 +14440,7 @@ pub async fn account_logout(state: State<'_, AppState>) -> Result<(), AppError> 
 /// back to the password login. The MK never touches the log.
 #[tauri::command]
 pub async fn unlock_sharing_with_biometric(
+    app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<AccountStatus, AppError> {
     // Must be logged in (tokens present) to have anything to restore.
@@ -14467,6 +14485,45 @@ pub async fn unlock_sharing_with_biometric(
         target: "share",
         "unlock_sharing_with_biometric: session restored from the biometric MK cache"
     );
+
+    // Tell every open view to re-read, UNCONDITIONALLY and IMMEDIATELY. What went stale here is
+    // every org-derived read the frontend took while there was no session — the sidebar's received
+    // forest included. The event is content-free and every consumer answers it with LOCAL reads, so
+    // it costs no egress and does not wait on the network.
+    crate::events::emit_org_feed_updated(&app, 0);
+
+    // A restored session is a SIGN-IN, and `account_login` has always treated it as one: it
+    // reconciles the org set the server says we belong to, so an org we were invited to appears
+    // without a restart. This path — the Touch ID tap most people actually use at launch, since the
+    // password login only happens once per device — did neither. It restored the session and
+    // returned, and nothing else asked the server anything until the background tick a minute
+    // later, which only notifies when membership genuinely CHANGED. So the sidebar and the org
+    // lists kept whatever they had read before the user signed in, and the only reliable way to see
+    // an org was to quit and reopen the app.
+    //
+    // DETACHED on purpose: it is a `GET /v1/orgs` behind a 30 s client timeout, and making the user
+    // watch the Touch ID sheet's aftermath for that long to learn something the panel refreshes on
+    // its own is the wrong trade. It emits its own `org-feed-updated` if membership actually moved.
+    //
+    // UNDER THE ORG MUTATION LOCK, like `org_refresh` — the reconcile can `purge_org_replica` an org
+    // the server no longer lists, and the background sync tick commits ingested feed items one
+    // transaction at a time. Unserialized, a purge landing mid-tick lets the items the tick commits
+    // afterwards re-create `org_items`/`org_chunks`/FTS rows for an org the user has just left,
+    // which is exactly the searchable-copy-after-departure the purge exists to prevent. Bounded, and
+    // skipped if the lock is busy: this is best-effort discovery, and the tick reconciles anyway.
+    let handle = app.clone();
+    tauri::async_runtime::spawn(async move {
+        let Some(state) = handle.try_state::<AppState>() else {
+            return;
+        };
+        let Ok(_mutation) = acquire_share_mutation_within(state.inner(), SHARE_MUTATION_WAIT).await
+        else {
+            return;
+        };
+        if let Err(e) = org_reconcile_memberships_notifying(state.inner(), Some(&handle)).await {
+            tracing::warn!(target: "org", error = %brief_err(&e), "org membership reconcile after biometric unlock failed (non-fatal)");
+        }
+    });
 
     account_status(state)
 }

--- a/src-tauri/src/commands/org.rs
+++ b/src-tauri/src/commands/org.rs
@@ -3260,6 +3260,13 @@ async fn org_reconcile_memberships_with_policy(
         return Ok(());
     }
     let client = crate::share::client::ShareClient::new(&base)?;
+    // Every cloud call this app makes is visible in the egress ledger, and this one was not. It is
+    // content-free — a bearer and the account's membership metadata, never a title or a note byte —
+    // but "content-free" is not the ledger's admission criterion; leaving a route off it makes the
+    // ledger an incomplete picture of what the app talks to, which is the one thing it exists to
+    // rule out. It now also fires from `unlock_sharing_with_biometric`, which had no network calls
+    // at all before, so an unrecorded route there is a new blind spot rather than an old one.
+    crate::share::ledger_row(&state.db, &client.host(), "org_membership_refresh", 0);
     // A pull failure (network/5xx) is best-effort: keep the cached rows, retry next tick.
     let mut server_orgs = match client.org_list(&access).await {
         Ok(o) => o,
@@ -9504,6 +9511,66 @@ pub(crate) async fn revoke_org_shares_for_source_notifying(
 pub const ORG_SYNC_FIRST_DELAY_SECS: u64 = 20;
 pub const ORG_SYNC_TICK_SECS: u64 = 60;
 
+/// Cadence for the NEXT tick while the loop is still CATCHING UP.
+///
+/// A tick that actually changed the local replica is evidence that the feed had a backlog, and a
+/// backlog drains one bounded [`ORG_FEED_PAGE`] per tick. At the flat 60 s cadence that is four
+/// objects a minute: a colleague sharing a Space of thirty notes appeared on the member's machine as
+/// the Space row, then its folders several minutes later, then the notes later still — which reads
+/// as a broken sync rather than a slow one. Backing off only once the replica has stopped changing
+/// keeps the steady-state cost identical (a quiet feed still ticks once a minute) while a real
+/// backlog lands in seconds.
+pub const ORG_SYNC_CATCHUP_SECS: u64 = 3;
+
+/// How many consecutive catch-up-cadence ticks the loop may take before returning to
+/// [`ORG_SYNC_TICK_SECS`] regardless. A tick that reports "changed" forever — a feed row that
+/// re-ingests every pass, a sweep that never converges — must not become a 3 s poll for the life of
+/// the process. At [`ORG_FEED_PAGE`] per tick this still covers a several-hundred-object backlog
+/// before the loop pauses for breath, and the next normal tick simply resumes catching up.
+pub const ORG_SYNC_MAX_CATCHUP_TICKS: u32 = 60;
+
+/// How long the background loop should sleep after one tick, given whether that tick CHANGED the
+/// local replica, advancing the caller's consecutive-catch-up counter.
+///
+/// Extracted from the loop in `lib.rs` because the property that matters is not the constant, it is
+/// the emergent DUTY CYCLE — and the first version of this got that wrong in a way no constant-range
+/// assertion could see. It reset the counter in the same branch that enforced the cap, so a tick that
+/// always reported "changed" settled into 60 fast ticks, one slow one, 60 fast ones… — about one tick
+/// every 3.9 s forever, when the cap exists precisely to stop a permanent fast poll. Resetting only
+/// on a QUIET tick is what makes the cap a cap. See
+/// `org_sync_catchup_backs_off_permanently_when_a_tick_always_reports_changed`.
+pub(crate) fn org_sync_next_delay_secs(changed: bool, catching_up: &mut u32) -> u64 {
+    if !changed {
+        *catching_up = 0;
+        return ORG_SYNC_TICK_SECS;
+    }
+    if *catching_up < ORG_SYNC_MAX_CATCHUP_TICKS {
+        *catching_up += 1;
+        return ORG_SYNC_CATCHUP_SECS;
+    }
+    // Capped: stay at the idle cadence and DO NOT reset — only a genuinely quiet tick earns another
+    // catch-up burst.
+    ORG_SYNC_TICK_SECS
+}
+
+/// The catch-up cadence's invariants, checked at COMPILE time rather than by a test: they are
+/// relations between three constants, so there is nothing to run — a violating edit should not
+/// build, not merely fail a suite somebody can skip.
+const _: () = {
+    assert!(
+        ORG_SYNC_CATCHUP_SECS >= 1,
+        "a zero catch-up sleep is a busy loop, not a cadence"
+    );
+    assert!(
+        ORG_SYNC_CATCHUP_SECS * 4 < ORG_SYNC_TICK_SECS,
+        "a catch-up tick that is not materially faster than the idle one is not a catch-up"
+    );
+    assert!(
+        ORG_SYNC_MAX_CATCHUP_TICKS >= 1 && ORG_SYNC_MAX_CATCHUP_TICKS <= 200,
+        "the fast cadence must be capped — a feed that always reports 'changed' must not poll forever"
+    );
+};
+
 /// One background org-sync tick: advance at most one outbound queue action, then pull + ingest one
 /// bounded inbound-feed page for one round-robin org into the local int8 partition. This is what
 /// makes the org brain a REPLICATED brain — every
@@ -10228,7 +10295,7 @@ async fn org_sweep_pending_with_policy(
     Ok(advanced)
 }
 
-/// `org_sync_now(org_id?)` — pull one bounded org-feed page, OPEN each ciphertext blob
+/// `org_sync_now(org_id?)` — pull the org feed in bounded pages, OPEN each ciphertext blob
 /// with the (RAM-cached / grant-unwrapped) OCK, and INGEST it into the local decrypted replica + int8
 /// retrieval partition. A TOMBSTONE evicts the item's chunks/vectors/FTS. Returns a content-free
 /// [`OrgSyncReport`] (counts + `fts_only` + per-item error strings). Best-effort per item: a single
@@ -10236,34 +10303,87 @@ async fn org_sweep_pending_with_policy(
 /// crashing the whole sync — the cursor still advances past a tombstone but STOPS at the first
 /// un-openable LIVE item so a transient key gap is retried next sync (no silent skip-forward).
 ///
-/// `org_id`: `Some(id)` syncs ONLY that (FE-picked, membership-checked) org; `None` selects one joined
-/// org per call by process-local round-robin. This makes the page/RAM bound global to the invocation,
-/// while the normal background cadence still services every joined org fairly.
+/// `drain`: `Some(false)` takes exactly ONE page for a caller that only needs this org's current
+/// head (the org viewer resolving an edit conflict). Anything else drains — that is what the "Sync
+/// now" button means.
+///
+/// `org_id`: `Some(id)` syncs ONLY that (FE-picked, membership-checked) org and DRAINS it —
+/// [`ORG_MANUAL_SYNC_MAX_PAGES`] bounded pages, or until the feed runs out or
+/// [`ORG_MANUAL_SYNC_DEADLINE`] elapses, whichever comes first. `None` selects one joined org per
+/// call by process-local round-robin and takes a single page, because that path is the untargeted /
+/// internal one and the background cadence services every joined org fairly.
+///
+/// WHY THE DRAIN (2026-09-08). One invocation used to be exactly ONE [`ORG_FEED_PAGE`] — four items.
+/// A member who had just been given a shared Space watched it materialize four objects at a time, a
+/// minute apart: the Space row first, its folders several minutes later, the notes later still.
+/// Pressing "Sync now" advanced it by four and reported "Synced — 4 new items", which reads as
+/// finished. The page bound exists to cap the DECRYPTED PAGE held in memory at once, and draining
+/// sequentially page-by-page keeps that ceiling exactly where it was; only the number of round trips
+/// per press changes. `more_pending` tells the caller the CAP — not the feed — ended the drain, so
+/// the UI can say so instead of claiming the org is up to date.
+///
+/// WHY THE LOCK IS SCOPED (2026-09-08 — the wedge this shipped with). The guard used to be this
+/// function's FIRST statement, and so was still held when `reconcile_container_shares` ran below.
+/// That callee reaches `share_to_org_placed_notifying`, whose first statement acquires the SAME
+/// non-reentrant mutex — so the task awaited a lock it already held: it never returned, never
+/// dropped its guard, and every later org operation in the process blocked forever. The symptom was
+/// a "Syncing…" button that never came back and an app that needed a restart before any org work
+/// happened again. `org_background_sync_tick` had the identical bug and was fixed on 2026-09-03;
+/// this command was missed because the oracle that caught it only looked at the tick. It now looks
+/// at every function (`commands::tests::org_mutex_scope_tests`).
 #[tauri::command]
 pub async fn org_sync_now(
     app: AppHandle,
     state: State<'_, AppState>,
     org_id: Option<String>,
+    drain: Option<bool>,
 ) -> Result<crate::storage::models::OrgSyncReport, AppError> {
-    let _mutation = state.lock_org_mutation().await;
     // The FE passes a SPECIFIC org id (→ sync only that org); the background tick / internal callers
     // pass `None` (→ sync the next round-robin org). This is the command-boundary
     // dispatch of the multi-org fix: a user-triggered "Sync now" from a picked org must not sync (or
     // report against) the wrong org.
-    let mut report = match org_id {
-        Some(id) => org_sync_one_now_with_app(state.inner(), &id, Some(app.clone())).await,
+    let mut report = match org_id.as_deref() {
+        // `drain: Some(false)` is for a caller that wants ONE page because it only needs this org's
+        // current head — the viewer resolving an edit conflict, not a user asking to catch up. It
+        // used to get one page for free; without this it would inherit the whole drain, turning a
+        // conflict-resolution click into a minute-long wait. It restores exactly the pre-drain cost:
+        // the container reconcile below still runs, for every arm, as it always did.
+        Some(id) if drain == Some(false) => {
+            let _mutation =
+                acquire_share_mutation_within(state.inner(), SHARE_MUTATION_WAIT).await?;
+            let mut report = crate::storage::models::OrgSyncReport::default();
+            let _outcome =
+                org_sync_one_page_into(state.inner(), id, Some(app.clone()), &mut report).await?;
+            report
+        }
+        Some(id) => drain_org_feed_now(state.inner(), id, Some(app.clone())).await?,
         None => {
+            // BOUNDED like every other user-reachable acquisition on this path: a busy — or wedged —
+            // holder must answer "busy", never park a button forever.
+            let _mutation =
+                acquire_share_mutation_within(state.inner(), SHARE_MUTATION_WAIT).await?;
             org_sync_now_inner_with_policy(
                 state.inner(),
                 OrgWorkPolicy::manual(),
                 Some(app.clone()),
             )
-            .await
+            .await?
         }
-    }?;
+    };
     // A manual "Sync now" should converge the containers too, not just the item feed — otherwise a
     // user who just renamed a shared folder presses Sync and nothing happens. Best-effort: a
     // container failure never turns a successful feed sync into an error.
+    //
+    // NO org-mutation guard is held here, and none may ever be: see this function's doc comment.
+    if let Some(id) = org_id.as_deref() {
+        crate::events::emit_org_sync_progress(
+            &app,
+            id,
+            "containers",
+            report.pulled,
+            report.ingested,
+        );
+    }
     if let Err(e) =
         crate::commands::org_containers::reconcile_container_shares(state.inner(), Some(&app)).await
     {
@@ -10271,6 +10391,148 @@ pub async fn org_sync_now(
         note_container_failure(&mut report, &e);
     }
     Ok(report)
+}
+
+/// How many bounded [`ORG_FEED_PAGE`] pages ONE user-triggered "Sync now" may drain. The product
+/// (160 items) is a press that visibly finishes a normal backlog; the cap is what keeps a
+/// pathological — or hostile — feed from turning one button into an unbounded download.
+const ORG_MANUAL_SYNC_MAX_PAGES: u32 = 40;
+
+/// How long the drain may keep STARTING new pages. A press must hand the UI back a report while the
+/// user is still watching it, even against a slow relay; whatever is left rides the background
+/// cadence, which now catches up in seconds rather than minutes. This is not a wall-clock ceiling on
+/// the call: the page in flight when it elapses always finishes (it holds the mutation lock and owes
+/// a durable cursor commit), and the container reconcile that follows is unbounded by design — the
+/// `org-sync-progress` event is what keeps the button honest meanwhile.
+const ORG_MANUAL_SYNC_DEADLINE: std::time::Duration = std::time::Duration::from_secs(20);
+
+/// Drain ONE org's feed for a user-triggered sync: bounded pages until the feed is exhausted, the
+/// page cap is reached, or the deadline elapses.
+///
+/// The org mutation lock is taken and released PER PAGE, never across the whole drain. Holding it
+/// for the duration would serialize every share/revoke/unlock in the app behind a loop of network
+/// round trips — the exact shape `org_background_sync_tick` was fixed out of on 2026-09-03. Per page
+/// the worst case is one page's round trips, which is what the single-page command already cost.
+///
+/// A page that cannot take the lock is not an error once at least one page has landed: the drain
+/// stops, reports `more_pending`, and the background loop finishes the job.
+async fn drain_org_feed_now(
+    state: &AppState,
+    org_id: &str,
+    app: Option<AppHandle>,
+) -> Result<crate::storage::models::OrgSyncReport, AppError> {
+    let deadline = std::time::Instant::now() + ORG_MANUAL_SYNC_DEADLINE;
+    let mut report = crate::storage::models::OrgSyncReport::default();
+    let mut pages = 0u32;
+    loop {
+        // The deadline gates the START of a page, and a page already in flight always finishes: it
+        // holds the mutation lock and has a durable cursor commit to make, so abandoning it midway
+        // would be the one shape that could lose work. A page can wait up to `SHARE_MUTATION_WAIT`
+        // for the lock and then up to the client's 30 s request timeout, so the deadline bounds how
+        // long the drain keeps STARTING work, not the wall clock of the call.
+        if pages > 0 && std::time::Instant::now() >= deadline {
+            report.more_pending = true;
+            break;
+        }
+        let before_pulled = report.pulled;
+        let outcome = {
+            let mutation = match acquire_share_mutation_within(state, SHARE_MUTATION_WAIT).await {
+                Ok(guard) => guard,
+                // Partial progress plus an honest "there is more" beats failing a press that has
+                // already moved the replica forward.
+                Err(_) if pages > 0 => {
+                    report.more_pending = true;
+                    break;
+                }
+                Err(e) => return Err(e),
+            };
+            let page = org_sync_one_page_into(state, org_id, app.clone(), &mut report).await;
+            drop(mutation);
+            match page {
+                Ok(outcome) => outcome,
+                // Page ONE failing is the whole press failing — report it as such.
+                Err(e) if pages == 0 => return Err(e),
+                // A LATER page is different: everything the earlier pages committed is already in
+                // the local replica, and throwing that away as a bare error would hide real
+                // progress behind "Sync failed". Record the reason FIRST (it is the actionable one)
+                // and stop.
+                Err(e) => {
+                    report
+                        .errors
+                        .insert(0, format!("sync stopped: {}", brief_err(&e)));
+                    report.more_pending = true;
+                    break;
+                }
+            }
+        };
+        pages += 1;
+        // Say what the press has actually done so far. A press against a real backlog is many
+        // sequential round trips, and a label that never moves is indistinguishable from a wedge.
+        if let Some(handle) = app.as_ref() {
+            crate::events::emit_org_sync_progress(
+                handle,
+                org_id,
+                "feed",
+                report.pulled,
+                report.ingested,
+            );
+        }
+
+        let pulled_this_page = report.pulled - before_pulled;
+        // A FULL page is the only evidence that more may remain; anything short means the live feed
+        // is caught up.
+        //
+        // An AUTHOR-BACKFILL turn is neither: it spends the invocation repairing legacy NULL-author
+        // rows and never consults the live cursor, and it legitimately repairs ZERO of them. Judging
+        // it by the counts said "nothing happened, so we must be caught up" about a page that never
+        // asked — which is how a press could stop on such a turn and toast "Synced — up to date."
+        // with the server still holding pages.
+        //
+        // The turn scheduler is a PROCESS-GLOBAL atomic that the background tick toggles too, and
+        // this loop releases the mutex between pages, so consecutive backfill turns are possible —
+        // do not read this as "the next page is guaranteed to be live". It costs round trips, never
+        // termination: the page cap and the deadline bound the loop either way, and a drain that
+        // ends on one of them says `more_pending`.
+        let maybe_more = match outcome {
+            FeedPageOutcome::AuthorBackfill => true,
+            FeedPageOutcome::Live => pulled_this_page >= ORG_FEED_PAGE,
+        };
+        if !maybe_more {
+            break;
+        }
+        if pages >= ORG_MANUAL_SYNC_MAX_PAGES {
+            report.more_pending = true;
+            break;
+        }
+    }
+    tracing::info!(
+        target: "org",
+        pages,
+        pulled = report.pulled,
+        ingested = report.ingested,
+        tombstoned = report.tombstoned,
+        more_pending = report.more_pending,
+        errors = report.errors.len(),
+        "org feed drained (manual sync)"
+    );
+    Ok(report)
+}
+
+/// What one [`org_sync_one`] invocation actually spent its single page budget on.
+///
+/// The drain needs this and cannot infer it from the counts. An AUTHOR-BACKFILL turn consumes the
+/// invocation WITHOUT consulting the live cursor, and it legitimately repairs zero rows (the re-pull
+/// failed, the page failed validation, no row matched, the author id came back empty) — so both
+/// `pulled` and `authors_backfilled` read zero and a count-based "did anything happen?" concludes the
+/// feed is exhausted. It is not: nothing asked. That made a press stop on a backfill turn and toast
+/// "Synced — up to date." with pages still on the server, which is the same lie the drain exists to
+/// remove, reached from a different direction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FeedPageOutcome {
+    /// The live cursor was consulted; the report's `pulled` delta says how much came back.
+    Live,
+    /// The budget went to repairing legacy NULL-author rows. The live feed is UNKNOWN after this.
+    AuthorBackfill,
 }
 
 /// One deliberately small feed page per org-sync invocation. A protocol-valid org blob may be up to
@@ -10385,6 +10647,28 @@ pub(crate) fn repair_missing_org_embeddings(
     Ok(repaired)
 }
 
+/// The ONE-PAGE mode of [`org_sync_now`] (`drain: Some(false)`), reachable without a
+/// `tauri::AppHandle`. Mirrors that arm exactly so an oracle can bind "one page" to it.
+#[cfg(test)]
+pub(crate) async fn org_sync_now_single_page_inner(
+    state: &AppState,
+    org_id: &str,
+) -> Result<crate::storage::models::OrgSyncReport, AppError> {
+    let _mutation = acquire_share_mutation_within(state, SHARE_MUTATION_WAIT).await?;
+    let mut report = crate::storage::models::OrgSyncReport::default();
+    let _outcome = org_sync_one_page_into(state, org_id, None, &mut report).await?;
+    Ok(report)
+}
+
+/// The drain [`org_sync_now`] runs for an FE-targeted org, reachable without a `tauri::AppHandle`.
+#[cfg(test)]
+pub(crate) async fn org_sync_now_drain_inner(
+    state: &AppState,
+    org_id: &str,
+) -> Result<crate::storage::models::OrgSyncReport, AppError> {
+    drain_org_feed_now(state, org_id, None).await
+}
+
 /// Sync exactly ONE (FE-targeted) org's feed — the single-org boundary of [`org_sync_now`]. Resolves
 /// the org (membership-checked, never `.next()`), then runs the same per-org pull/ingest via
 /// `org_sync_one` used by the round-robin scheduler. Offline / logged-out ⇒ an empty report (no-op),
@@ -10395,15 +10679,7 @@ pub(crate) async fn org_sync_one_now_inner(
     org_id: &str,
 ) -> Result<crate::storage::models::OrgSyncReport, AppError> {
     let _mutation = state.lock_org_mutation().await;
-    org_sync_one_now_with_app(state, org_id, None).await
-}
-
-async fn org_sync_one_now_with_app(
-    state: &AppState,
-    org_id: &str,
-    app: Option<AppHandle>,
-) -> Result<crate::storage::models::OrgSyncReport, AppError> {
-    org_sync_one_now_with_app_and_policy(state, org_id, app, OrgWorkPolicy::manual()).await
+    org_sync_one_now_with_app_and_policy(state, org_id, None, OrgWorkPolicy::manual()).await
 }
 
 #[cfg(test)]
@@ -10415,6 +10691,7 @@ pub(crate) async fn org_sync_one_now_with_pre_task_reader(
     org_sync_one_now_with_app_and_policy(state, org_id, None, OrgWorkPolicy::pre_task_reader()).await
 }
 
+#[cfg(test)]
 async fn org_sync_one_now_with_app_and_policy(
     state: &AppState,
     org_id: &str,
@@ -10422,29 +10699,7 @@ async fn org_sync_one_now_with_app_and_policy(
     policy: OrgWorkPolicy,
 ) -> Result<crate::storage::models::OrgSyncReport, AppError> {
     let mut report = crate::storage::models::OrgSyncReport::default();
-    let org = resolve_org(state, org_id)?;
-    let base = share_base_url(state)?;
-    if base.trim().is_empty() {
-        return Ok(report);
-    }
-    let access = match reconcile_token_outcome(valid_access_token(state).await) {
-        TokenOutcome::Proceed(a) => a,
-        // A dead session must not masquerade as a clean sync: an empty report renders as
-        // "Synced — up to date.", which is the most misleading thing the panel can say.
-        TokenOutcome::Fatal(e) => return Err(e),
-        TokenOutcome::SkipQuietly => return Ok(report),
-    };
-    let client = crate::share::client::ShareClient::new(&base)?;
-    org_sync_one(
-        state,
-        &client,
-        &access,
-        &org,
-        &mut report,
-        policy,
-        app,
-    )
-    .await?;
+    let _outcome = org_sync_one_page_with_policy(state, org_id, app, policy, &mut report).await?;
     tracing::info!(
         target: "org",
         pulled = report.pulled,
@@ -10455,6 +10710,42 @@ async fn org_sync_one_now_with_app_and_policy(
         "org feed sync (single org)"
     );
     Ok(report)
+}
+
+/// One bounded feed page for ONE org, ACCUMULATED into an existing report.
+///
+/// Split out of [`org_sync_one_now_with_app_and_policy`] so [`drain_org_feed_now`] can take several
+/// pages under one report without each page resetting the counts the caller is about to show.
+async fn org_sync_one_page_into(
+    state: &AppState,
+    org_id: &str,
+    app: Option<AppHandle>,
+    report: &mut crate::storage::models::OrgSyncReport,
+) -> Result<FeedPageOutcome, AppError> {
+    org_sync_one_page_with_policy(state, org_id, app, OrgWorkPolicy::manual(), report).await
+}
+
+async fn org_sync_one_page_with_policy(
+    state: &AppState,
+    org_id: &str,
+    app: Option<AppHandle>,
+    policy: OrgWorkPolicy,
+    report: &mut crate::storage::models::OrgSyncReport,
+) -> Result<FeedPageOutcome, AppError> {
+    let org = resolve_org(state, org_id)?;
+    let base = share_base_url(state)?;
+    if base.trim().is_empty() {
+        return Ok(FeedPageOutcome::Live);
+    }
+    let access = match reconcile_token_outcome(valid_access_token(state).await) {
+        TokenOutcome::Proceed(a) => a,
+        // A dead session must not masquerade as a clean sync: an empty report renders as
+        // "Synced — up to date.", which is the most misleading thing the panel can say.
+        TokenOutcome::Fatal(e) => return Err(e),
+        TokenOutcome::SkipQuietly => return Ok(FeedPageOutcome::Live),
+    };
+    let client = crate::share::client::ShareClient::new(&base)?;
+    org_sync_one(state, &client, &access, &org, report, policy, app).await
 }
 
 #[cfg(test)]
@@ -10545,9 +10836,9 @@ async fn org_sync_one(
     report: &mut crate::storage::models::OrgSyncReport,
     policy: OrgWorkPolicy,
     app: Option<AppHandle>,
-) -> Result<(), AppError> {
+) -> Result<FeedPageOutcome, AppError> {
     if !policy.is_current() {
-        return Ok(());
+        return Ok(FeedPageOutcome::Live);
     }
 
     // Legacy author repair consumes this invocation's SAME single-page budget instead of issuing a
@@ -10563,7 +10854,7 @@ async fn org_sync_one(
     if take_backfill_turn {
         backfill_null_org_item_authors(state, client, access, &org.org_id, report, policy).await;
         report.last_seq = state.db.org_last_seq_for(&org.org_id)?;
-        return Ok(());
+        return Ok(FeedPageOutcome::AuthorBackfill);
     }
 
     // ── ASYNC PULL PHASE — fetch one page, opening each cell; buffer only that bounded page ───────
@@ -10637,7 +10928,7 @@ async fn org_sync_one(
         .org_feed(access, &org.org_id, cursor, ORG_FEED_PAGE)
         .await?;
     if !policy.is_current() {
-        return Ok(());
+        return Ok(FeedPageOutcome::Live);
     }
     if feed.items.len() > ORG_FEED_PAGE as usize {
         return Err(AppError::Unavailable(
@@ -10649,7 +10940,7 @@ async fn org_sync_one(
     let mut last_feed_seq = cursor;
     'items: for item in &feed.items {
         if !policy.is_current() {
-            return Ok(());
+            return Ok(FeedPageOutcome::Live);
         }
         if item.seq <= last_feed_seq {
             return Err(AppError::Unavailable(
@@ -10697,7 +10988,7 @@ async fn org_sync_one(
                 Ok(k) => k,
                 Err(e) => {
                     if !policy.is_current() {
-                        return Ok(());
+                        return Ok(FeedPageOutcome::Live);
                     }
                     report.errors.push(format!(
                         "item {}: key unavailable ({})",
@@ -10708,13 +10999,13 @@ async fn org_sync_one(
                 }
             };
         if !policy.is_current() {
-            return Ok(());
+            return Ok(FeedPageOutcome::Live);
         }
         let ciphertext = match client.get_blob(access, &blob_id).await {
             Ok(c) => c,
             Err(e) => {
                 if !policy.is_current() {
-                    return Ok(());
+                    return Ok(FeedPageOutcome::Live);
                 }
                 // TRANSIENT: a network blob-fetch failure may succeed next sync → STOP, don't skip.
                 report.errors.push(format!(
@@ -10726,7 +11017,7 @@ async fn org_sync_one(
             }
         };
         if !policy.is_current() {
-            return Ok(());
+            return Ok(FeedPageOutcome::Live);
         }
         if ciphertext.len() > murmur_protocol::caps::MAX_ORG_ITEM_BLOB_BYTES {
             report.errors.push(format!(
@@ -11107,7 +11398,7 @@ async fn org_sync_one(
 
     // `report.last_seq` reflects the LAST org synced (per-org field on an aggregate report).
     report.last_seq = state.db.org_last_seq_for(&org.org_id)?;
-    Ok(())
+    Ok(FeedPageOutcome::Live)
 }
 
 // ── ANTI-ENTROPY RECONCILE SWEEP (2026-07-26) ─────────────────────────────────────────────────────

--- a/src-tauri/src/commands/tests/lifecycle_tests.rs
+++ b/src-tauri/src/commands/tests/lifecycle_tests.rs
@@ -29175,6 +29175,450 @@
         );
     }
 
+    /// `OrgSyncReport` crosses IPC, so its SERIALIZED key names are the contract — not the Rust
+    /// field names, and not what a hand-written frontend mock happens to say (`rust-tauri.md` §2b,
+    /// `angular-zoneless.md` T6). A snake_case `more_pending` would arrive as `undefined`, and the
+    /// panel would go back to calling a capped sync "up to date" with nothing failing anywhere.
+    #[test]
+    fn org_sync_report_wire_shape_is_camel_case() {
+        let json = serde_json::to_value(crate::storage::models::OrgSyncReport {
+            pulled: 8,
+            ingested: 6,
+            tombstoned: 1,
+            last_seq: 42,
+            fts_only: false,
+            errors: vec!["item x: live entry missing blob".into()],
+            authors_backfilled: 2,
+            more_pending: true,
+        })
+        .unwrap();
+        let keys: Vec<String> = json
+            .as_object()
+            .expect("the report serializes as an object")
+            .keys()
+            .cloned()
+            .collect();
+        for key in &keys {
+            assert!(
+                !key.contains('_')
+                    && key
+                        .chars()
+                        .next()
+                        .is_some_and(|c| c.is_ascii_lowercase() && c.is_ascii_alphabetic()),
+                "`{key}` is not camelCase — the frontend reads these keys verbatim"
+            );
+        }
+        assert!(
+            keys.iter().any(|k| k == "morePending"),
+            "the drain's honesty flag must reach the frontend: {keys:?}"
+        );
+        assert_eq!(json["morePending"], serde_json::json!(true));
+    }
+
+    /// A drain must not stop on an AUTHOR-BACKFILL turn and call the org caught up.
+    ///
+    /// `org_sync_one` alternates a live-cursor turn with a bounded author-backfill turn whenever any
+    /// local row still has a NULL `author_user_id`. A backfill turn spends the invocation WITHOUT
+    /// consulting the live cursor, and it legitimately repairs ZERO rows — here the re-pull answers
+    /// with an empty page, one of four ways that happens in production. Both `pulled` and
+    /// `authors_backfilled` therefore read zero for that page.
+    ///
+    /// RED on the count-based continuation (`pulled >= PAGE || backfilled > 0`): the drain concluded
+    /// "nothing happened, so the feed must be exhausted" about a page that never asked, returned
+    /// `pulled: 0, more_pending: false`, and the panel toasted "Synced — up to date." with the
+    /// server still holding items — the same lie the drain exists to remove, reached from the other
+    /// side. Reproduced by the adversarial verifier before this test existed.
+    ///
+    /// The seeded NULL-author row sits at seq 3 with the cursor at 0, so the FIRST invocation takes
+    /// the backfill turn; the drain must go on to the live page behind it.
+    #[test]
+    fn a_drain_does_not_mistake_an_author_backfill_turn_for_a_caught_up_feed() {
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+            let mut served = 0usize;
+            let mut live_pages = 0usize;
+            // Generous, because `ORG_AUTHOR_BACKFILL_TURN` is a PROCESS-GLOBAL atomic that a sibling
+            // test also toggles: under a parallel run this drain can be handed extra backfill turns,
+            // and a tight request budget would turn that interleave into a flake rather than a
+            // finding. The empty `sinceSeq=2` answer is idempotent, so serving more of them is free.
+            while served < 12 && std::time::Instant::now() < deadline {
+                let (mut sock, _) = match listener.accept() {
+                    Ok(v) => v,
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(10));
+                        continue;
+                    }
+                    Err(e) => panic!("backfill-drain mock accept failed: {e}"),
+                };
+                sock.set_nonblocking(false).unwrap();
+                sock.set_read_timeout(Some(std::time::Duration::from_secs(2)))
+                    .unwrap();
+                served += 1;
+                let mut buf = [0u8; 8192];
+                let n = sock.read(&mut buf).unwrap();
+                let req = String::from_utf8_lossy(&buf[..n]).into_owned();
+                let entry = |seq: u64| {
+                    format!(
+                        r#"{{"itemId":"drain-{seq}","seq":{seq},"authorUserId":"anna","rev":1,"generation":1,"createdAt":"2026-07-11T09:00:00Z","tombstoned":false}}"#
+                    )
+                };
+                // The BACKFILL turn re-pulls from just before the stale row's seq and finds nothing
+                // it can match — a real production outcome, and the one that made the drain stop.
+                let body = if req.contains("sinceSeq=2") {
+                    r#"{"items":[],"nextSeq":2}"#.to_string()
+                } else if req.contains("sinceSeq=0") {
+                    live_pages += 1;
+                    let items = (1..=4).map(entry).collect::<Vec<_>>().join(",");
+                    format!(r#"{{"items":[{items}],"nextSeq":4}}"#)
+                } else if req.contains("sinceSeq=4") {
+                    live_pages += 1;
+                    let items = (5..=6).map(entry).collect::<Vec<_>>().join(",");
+                    format!(r#"{{"items":[{items}],"nextSeq":6}}"#)
+                } else {
+                    panic!("unexpected backfill-drain request: {req}")
+                };
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = sock.write_all(resp.as_bytes());
+                let _ = sock.flush();
+                let _ = sock.shutdown(std::net::Shutdown::Write);
+                let mut drain = [0u8; 64];
+                loop {
+                    match sock.read(&mut drain) {
+                        Ok(0) | Err(_) => break,
+                        Ok(_) => continue,
+                    }
+                }
+            }
+            live_pages
+        });
+
+        let state = build_state("org-sync-drain-backfill");
+        seed_org(&state.db, "org-drain", "Drain", "member", 1);
+        // A row ingested before author stamping existed: NULL author at seq 3. Its presence is what
+        // makes `org_sync_one` spend an invocation on the backfill turn.
+        state
+            .db
+            .upsert_org_item(
+                "item-stale",
+                "org-drain",
+                3,
+                "anna",
+                "Old note",
+                "# body",
+                "2026-07-11T09:00:00Z",
+                1,
+                1,
+                &[9u8; 32],
+                Some("document"),
+                None,
+                None,
+            )
+            .unwrap();
+        state.config.lock().unwrap().share_base_url = format!("http://{addr}");
+        seed_live_session(&state);
+
+        let report = block_on(org_sync_now_drain_inner(&state, "org-drain")).unwrap();
+        let live_pages = server.join().unwrap();
+
+        assert!(
+            live_pages >= 2,
+            "the drain stopped on the backfill turn: it took {live_pages} live page(s), so it never \
+             reached the items waiting behind it"
+        );
+        assert_eq!(
+            report.pulled, 6,
+            "every live item behind the backfill turn must still be drained"
+        );
+        assert!(
+            !report.more_pending,
+            "the final live page was SHORT, so the feed really is caught up"
+        );
+    }
+
+    /// `drain: Some(false)` must take EXACTLY ONE page, and the frontend must actually ask for it.
+    ///
+    /// The org viewer resolves an edit conflict by syncing purely to learn this org's current head.
+    /// It used to cost one page; once "Sync now" started draining, that same call would have
+    /// inherited the whole backlog and turned a click into a minute of waiting. The one-page mode
+    /// exists for it — and nothing bound either half until now: not "one page", and not the ARGUMENT
+    /// NAME, which is the half this project has already been burned by twice (`rust-tauri.md` §2b,
+    /// `angular-zoneless.md` T6). A frontend that sent `noDrain` instead of `drain` would
+    /// deserialize as `None`, silently take the drain, and leave every gate green.
+    ///
+    /// The mock serves ONE full page and would answer a second; taking it fails the request budget.
+    #[test]
+    fn one_page_mode_takes_exactly_one_page() {
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(6);
+            let mut served = 0usize;
+            while served < 3 && std::time::Instant::now() < deadline {
+                let (mut sock, _) = match listener.accept() {
+                    Ok(v) => v,
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(10));
+                        continue;
+                    }
+                    Err(e) => panic!("one-page mock accept failed: {e}"),
+                };
+                sock.set_nonblocking(false).unwrap();
+                sock.set_read_timeout(Some(std::time::Duration::from_secs(2)))
+                    .unwrap();
+                served += 1;
+                let mut buf = [0u8; 8192];
+                let n = sock.read(&mut buf).unwrap();
+                let req = String::from_utf8_lossy(&buf[..n]).into_owned();
+                let entry = |seq: u64| {
+                    format!(
+                        r#"{{"itemId":"page-{seq}","seq":{seq},"authorUserId":"anna","rev":1,"generation":1,"createdAt":"2026-07-11T09:00:00Z","tombstoned":false}}"#
+                    )
+                };
+                let body = if req.contains("sinceSeq=0") {
+                    let items = (1..=4).map(entry).collect::<Vec<_>>().join(",");
+                    format!(r#"{{"items":[{items}],"nextSeq":4}}"#)
+                } else if req.contains("sinceSeq=4") {
+                    let items = (5..=8).map(entry).collect::<Vec<_>>().join(",");
+                    format!(r#"{{"items":[{items}],"nextSeq":8}}"#)
+                } else {
+                    panic!("unexpected one-page request: {req}")
+                };
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = sock.write_all(resp.as_bytes());
+                let _ = sock.flush();
+                let _ = sock.shutdown(std::net::Shutdown::Write);
+                let mut drain = [0u8; 64];
+                loop {
+                    match sock.read(&mut drain) {
+                        Ok(0) | Err(_) => break,
+                        Ok(_) => continue,
+                    }
+                }
+            }
+            served
+        });
+
+        let state = build_state("org-sync-one-page");
+        seed_org(&state.db, "org-page", "Page", "member", 1);
+        state.config.lock().unwrap().share_base_url = format!("http://{addr}");
+        seed_live_session(&state);
+
+        let report = block_on(org_sync_now_single_page_inner(&state, "org-page")).unwrap();
+        let served = server.join().unwrap();
+
+        assert_eq!(
+            served, 1,
+            "one-page mode must issue exactly one feed request even when the page comes back FULL"
+        );
+        assert_eq!(report.pulled, 4, "one page's worth, not a drain's");
+        assert_eq!(
+            state.db.get_org_state("org-page").unwrap().unwrap().last_seq,
+            4
+        );
+    }
+
+    /// The `drain` argument the frontend sends must be the one the command declares.
+    ///
+    /// Tauri matches command arguments by NAME. A rename on either side leaves the parameter `None`,
+    /// which means "drain" — so the conflict viewer would quietly go back to paying for the whole
+    /// backlog with nothing failing anywhere. Assert the two spellings against each other rather
+    /// than trusting that they were written on the same day.
+    #[test]
+    fn the_frontend_sends_the_drain_argument_the_command_declares() {
+        let rust = std::fs::read_to_string(
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("src")
+                .join("commands")
+                .join("org.rs"),
+        )
+        .expect("org.rs");
+        assert!(
+            rust.contains("    drain: Option<bool>,"),
+            "org_sync_now no longer declares `drain: Option<bool>` — update both sides deliberately"
+        );
+        let ts = std::fs::read_to_string(
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .parent()
+                .expect("repo root")
+                .join("src/app/core/ipc.service.ts"),
+        )
+        .expect("ipc.service.ts");
+        assert!(
+            ts.contains(r#"invoke<OrgSyncReport>("org_sync_now", { orgId, drain })"#),
+            "the frontend no longer sends `drain` to org_sync_now; a mismatched name deserializes \
+             as None, which silently means DRAIN"
+        );
+    }
+
+    /// The catch-up cadence must back off PERMANENTLY against a tick that always reports "changed".
+    ///
+    /// RED→GREEN on my own first version of `org_sync_next_delay_secs`, which reset the counter in
+    /// the same branch that enforced the cap: an always-changing feed then ran 60 fast ticks, one
+    /// slow one, 60 fast ones — roughly one tick every 3.9 s forever, each tick four network phases,
+    /// while the constant's doc claimed the cap prevented exactly that. A range assertion on the
+    /// constants cannot see this; only the emergent duty cycle can.
+    #[test]
+    fn org_sync_catchup_backs_off_permanently_when_a_tick_always_reports_changed() {
+        let mut catching_up = 0u32;
+        let ticks = 500usize;
+        let fast = (0..ticks)
+            .filter(|_| {
+                crate::commands::org_sync_next_delay_secs(true, &mut catching_up)
+                    == crate::commands::ORG_SYNC_CATCHUP_SECS
+            })
+            .count();
+        assert_eq!(
+            fast,
+            crate::commands::ORG_SYNC_MAX_CATCHUP_TICKS as usize,
+            "an always-changing feed took {fast} fast ticks over {ticks}; the cap is \
+             {} and must hold for the rest of the process, not re-arm after one slow tick",
+            crate::commands::ORG_SYNC_MAX_CATCHUP_TICKS
+        );
+
+        // A genuinely QUIET tick is what earns another burst — that is the state the cap is waiting
+        // for, and without it the loop could never catch up on a second backlog.
+        assert_eq!(
+            crate::commands::org_sync_next_delay_secs(false, &mut catching_up),
+            crate::commands::ORG_SYNC_TICK_SECS
+        );
+        assert_eq!(
+            crate::commands::org_sync_next_delay_secs(true, &mut catching_up),
+            crate::commands::ORG_SYNC_CATCHUP_SECS,
+            "a quiet tick must re-arm the catch-up budget"
+        );
+    }
+
+    /// "SYNC NOW" DRAINS THE FEED (RED→GREEN). One invocation used to be exactly ONE bounded
+    /// `ORG_FEED_PAGE` — four items — and the button reported the result as a finished sync. A member
+    /// given a shared Space therefore watched it arrive four objects at a time: the Space row first,
+    /// its folders minutes later, the notes later still, while "Sync now" answered
+    /// "Synced — 4 new items" each press. The page bound is a ceiling on the DECRYPTED PAGE held in
+    /// memory, not a budget for the press, so the drain takes pages SEQUENTIALLY — same ceiling, more
+    /// round trips.
+    ///
+    /// The mock serves six live entries with no `blobId`. That is the TERMINAL-skip path, which
+    /// advances the cursor without needing an OCK, a blob, or an embedder — so this exercises the
+    /// PAGING decision and nothing else. Page one is FULL (4 = `ORG_FEED_PAGE`, "there may be more"),
+    /// page two is SHORT (2, "caught up"), so the drain must stop on its own rather than on its cap.
+    ///
+    /// RED on the pre-fix single-page command: `pulled == 4`, one feed request, and `more_pending`
+    /// absent — a caller told it was up to date while two items were still on the server.
+    #[test]
+    fn manual_org_sync_drains_the_feed_past_one_page() {
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let addr = listener.local_addr().unwrap();
+        // Bounded at THREE so a regression that loops fails the assertion instead of hanging the suite.
+        let server = std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+            let mut served = 0usize;
+            while served < 3 && std::time::Instant::now() < deadline {
+                let (mut sock, _) = match listener.accept() {
+                    Ok(v) => v,
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(10));
+                        continue;
+                    }
+                    Err(e) => panic!("drain mock accept failed: {e}"),
+                };
+                sock.set_nonblocking(false).unwrap();
+                sock.set_read_timeout(Some(std::time::Duration::from_secs(2)))
+                    .unwrap();
+                served += 1;
+                let mut buf = [0u8; 8192];
+                let n = sock.read(&mut buf).unwrap();
+                let req = String::from_utf8_lossy(&buf[..n]).into_owned();
+                // A live entry with NO blobId is terminal-skippable: pulled, recorded, cursor advanced.
+                let entry = |seq: u64| {
+                    format!(
+                        r#"{{"itemId":"drain-{seq}","seq":{seq},"authorUserId":"anna","rev":1,"generation":1,"createdAt":"2026-07-11T09:00:00Z","tombstoned":false}}"#
+                    )
+                };
+                let body = if req.contains("sinceSeq=0") {
+                    let items = (1..=4).map(entry).collect::<Vec<_>>().join(",");
+                    format!(r#"{{"items":[{items}],"nextSeq":4}}"#)
+                } else if req.contains("sinceSeq=4") {
+                    let items = (5..=6).map(entry).collect::<Vec<_>>().join(",");
+                    format!(r#"{{"items":[{items}],"nextSeq":6}}"#)
+                } else {
+                    panic!("unexpected drain feed request: {req}")
+                };
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = sock.write_all(resp.as_bytes());
+                let _ = sock.flush();
+                let _ = sock.shutdown(std::net::Shutdown::Write);
+                let mut drain = [0u8; 64];
+                loop {
+                    match sock.read(&mut drain) {
+                        Ok(0) | Err(_) => break,
+                        Ok(_) => continue,
+                    }
+                }
+            }
+            served
+        });
+
+        let state = build_state("org-sync-drain");
+        seed_org(&state.db, "org-drain", "Drain", "member", 1);
+        state.config.lock().unwrap().share_base_url = format!("http://{addr}");
+        seed_live_session(&state);
+
+        // The drain is the shape the button actually runs, so the membership gate is asserted on IT
+        // and not only on the single-page test wrapper — an oracle scoped to one call site is how
+        // this bug lived through five days of green suites in the first place.
+        assert!(
+            matches!(
+                block_on(org_sync_now_drain_inner(&state, "org-not-joined")),
+                Err(AppError::InvalidArg(_))
+            ),
+            "the drain must refuse an org the caller is not a local member of, before any socket"
+        );
+
+        let report = block_on(org_sync_now_drain_inner(&state, "org-drain")).unwrap();
+        let served = server.join().unwrap();
+
+        assert_eq!(
+            served, 2,
+            "one press must take a SECOND page after a full first one (RED: 1 request)"
+        );
+        assert_eq!(
+            report.pulled, 6,
+            "the drain must report every item it consumed, not one page's worth (RED: 4)"
+        );
+        assert_eq!(report.errors.len(), 6, "each blob-less entry is recorded");
+        assert!(
+            !report.more_pending,
+            "a SHORT final page means the feed is caught up — claiming otherwise is the mirror of \
+             the bug this fixes"
+        );
+        assert_eq!(
+            state
+                .db
+                .get_org_state("org-drain")
+                .unwrap()
+                .unwrap()
+                .last_seq,
+            6,
+            "the durable cursor must reflect every drained page"
+        );
+    }
+
     /// F1 (MULTI-ORG TARGETING, RED→GREEN for the `.next()` misroute): with TWO local orgs, the org
     /// commands must resolve the SPECIFIC org the FE passed, never the FIRST. `resolve_org` — the
     /// shared resolution seam every per-org command now uses — must return the SECOND org's row when

--- a/src-tauri/src/commands/tests/org_diagnosability_tests.rs
+++ b/src-tauri/src/commands/tests/org_diagnosability_tests.rs
@@ -105,6 +105,32 @@ async fn a_held_share_mutation_lock_yields_busy_rather_than_hanging() {
     drop(held);
 }
 
+/// A BOUNDED guard held across a nested UNBOUNDED acquisition must panic, not hang.
+///
+/// The bounded door used not to register its holder, on the reasoning that a bounded ATTEMPT cannot
+/// deadlock — true, and the wrong half of the problem. A bounded guard that is HELD while a callee
+/// takes the unbounded door wedges exactly like any other re-entrancy, and with no registration the
+/// inner `enter()` found an empty set, asserted nothing, and the process stopped doing org work in
+/// silence. That mattered the moment the "Sync now" fix moved both of its paths onto this door: they
+/// left the only check that was watching them.
+///
+/// RED CONTROL (run 2026-09-08, observed): with `enter_bounded` reverted to not registering, this
+/// test does not fail — it HANGS, and takes the test binary with it until it is killed. That is the
+/// finding, not a flaw in the control: the defect being fixed is a wait that never returns, so its
+/// RED is a hang. It is also why this oracle earns its keep in a way a source-level check could not.
+#[cfg(debug_assertions)]
+#[tokio::test]
+#[should_panic(expected = "acquired re-entrantly")]
+async fn a_bounded_guard_makes_a_nested_unbounded_acquisition_panic_instead_of_hanging() {
+    let state = AppState::for_tests(fresh_db("bounded-reentrancy"));
+    let _outer = acquire_share_mutation_within(&state, std::time::Duration::from_millis(50))
+        .await
+        .expect("an uncontended lock must be acquired");
+    // In release this would wait forever and hold the mutex for the rest of the process. The
+    // bookkeeping turns it into a loud, immediately investigable panic BEFORE the await.
+    let _inner = state.lock_org_mutation().await;
+}
+
 /// A free lock is still acquired normally — the bound must not break the happy path.
 #[tokio::test]
 async fn a_free_share_mutation_lock_is_acquired() {

--- a/src-tauri/src/commands/tests/org_mutex_scope_tests.rs
+++ b/src-tauri/src/commands/tests/org_mutex_scope_tests.rs
@@ -108,6 +108,13 @@ fn body_of(file: &str, name: &str) -> String {
 /// the door was renamed, which is how a source oracle goes quietly vacuous.
 const ACQUIRE: &str = "lock_org_mutation(";
 
+/// BOTH doors onto the mutex. `acquire_share_mutation_within` is a second, bounded way to take the
+/// same lock, and a guard-lifetime model that only knows the unbounded one is blind to exactly the
+/// call sites that use the bounded one — which is every user-facing org command, since a button must
+/// never wait forever. The scope property is identical for both: the guard lives until its block
+/// closes, and a re-entrant callee under either one hangs.
+const ACQUISITIONS: [&str; 2] = ["lock_org_mutation(", "acquire_share_mutation_within("];
+
 /// `unlock_folder` must not hold the org mutex across the Touch ID sheet.
 ///
 /// RED CONTROL (run 2026-09-03, observed): hoisting the acquisition back to the command's first
@@ -181,34 +188,213 @@ fn the_org_background_tick_never_holds_the_mutex_across_a_network_phase() {
 /// Positions in `body` where an `org_share_mutation_lock` guard is still IN SCOPE.
 ///
 /// Models the guard's lifetime rather than its mere presence: an acquisition at brace depth `d`
-/// lives until the block at depth `d` closes. Returns every byte offset at which at least one guard
-/// is held.
-fn guard_is_held_at(body: &str) -> Vec<(usize, bool)> {
-    let chars: Vec<char> = body.chars().collect();
+/// lives until the block at depth `d` closes. Indexed by BYTE offset, so a `str::find` result can be
+/// used directly — the earlier char-indexed version happened to agree only because everything before
+/// the site it was written for was ASCII.
+///
+/// An acquisition that is itself a `fn` DEFINITION is not an acquisition. Counting one would open a
+/// guard at module depth that nothing ever closes, and every later call in the file would then look
+/// like it ran under the lock.
+fn guard_is_held_at(body: &str) -> Vec<bool> {
     let mut depth = 0usize;
     let mut open_guards: Vec<usize> = Vec::new();
-    let mut marks = Vec::with_capacity(chars.len());
-    let mut i = 0;
-    while i < chars.len() {
-        match chars[i] {
+    let mut marks = vec![false; body.len()];
+    for (offset, ch) in body.char_indices() {
+        match ch {
             '{' => depth += 1,
             '}' => {
                 depth = depth.saturating_sub(1);
                 open_guards.retain(|d| *d <= depth);
             }
             _ => {
-                if body[i..].starts_with(ACQUIRE) {
+                if ACQUISITIONS
+                    .iter()
+                    .any(|needle| body[offset..].starts_with(needle))
+                    && !body[..offset].trim_end().ends_with("fn")
+                {
                     open_guards.push(depth);
                 }
             }
         }
-        marks.push((i, !open_guards.is_empty()));
-        i += 1;
+        marks[offset..offset + ch.len_utf8()].fill(!open_guards.is_empty());
     }
     marks
 }
 
-/// The container-reconcile phase must NOT run under `org_share_mutation_lock`.
+/// Blank every COMMENT body, STRING literal (ordinary and raw), and CHAR literal, preserving byte
+/// offsets so a `str::find` result still indexes the guard model.
+///
+/// One pass, not two, because the four constructs are mutually ambiguous: a `'"'` char literal opens
+/// a string for a naive scanner, a `//` inside a string opens a comment, and a raw string may
+/// contain both. {@link strip_comments} above understands only the first two and is kept for the
+/// legacy per-function oracles, which read known-clean bodies.
+///
+/// It matters here because the guard model counts braces, and one desynchronizing `'{'` or raw `"`
+/// silently turns the file-wide scan into a FALSE NEGATIVE — the scan still reports "N sites across
+/// M files", so the vacuity guard passes while the check has stopped seeing anything. That is
+/// exactly how this module's own header says a source oracle dies. `commands/` already contains raw
+/// strings (`reminders.rs`, `trash.rs`, `calendar.rs`); that none of them sits near a call site
+/// today is luck, not a property.
+fn sanitize_for_scan(source: &str) -> String {
+    let bytes = source.as_bytes();
+    let mut out = String::with_capacity(source.len());
+    let mut i = 0usize;
+
+    // Blank `count` bytes starting at `from`, keeping newlines so line numbers survive.
+    let blank = |out: &mut String, span: &str| {
+        for ch in span.chars() {
+            out.push(if ch == '\n' { '\n' } else { ' ' });
+            for _ in 1..ch.len_utf8() {
+                out.push(' ');
+            }
+        }
+    };
+
+    while i < bytes.len() {
+        // Line comment.
+        if bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'/') {
+            let end = source[i..].find('\n').map_or(bytes.len(), |off| i + off);
+            blank(&mut out, &source[i..end]);
+            i = end;
+            continue;
+        }
+        // Block comment (nesting is legal in Rust).
+        if bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'*') {
+            let mut depth = 1usize;
+            let mut j = i + 2;
+            while j < bytes.len() && depth > 0 {
+                if bytes[j] == b'/' && bytes.get(j + 1) == Some(&b'*') {
+                    depth += 1;
+                    j += 2;
+                } else if bytes[j] == b'*' && bytes.get(j + 1) == Some(&b'/') {
+                    depth -= 1;
+                    j += 2;
+                } else {
+                    j += 1;
+                }
+            }
+            blank(&mut out, &source[i..j.min(bytes.len())]);
+            i = j.min(bytes.len());
+            continue;
+        }
+        // Char literal — `'x'`, `'\n'`, `'\''`. A lifetime (`'a`) has no closing quote nearby.
+        if bytes[i] == b'\'' {
+            if let Some(end) = char_literal_end(bytes, i) {
+                out.push('\'');
+                blank(&mut out, &source[i + 1..end]);
+                out.push('\'');
+                i = end + 1;
+                continue;
+            }
+            out.push('\'');
+            i += 1;
+            continue;
+        }
+        // Raw string — `r"…"` / `r#"…"#`, any number of hashes, no escapes inside.
+        if bytes[i] == b'r' && !is_ident_byte(i.checked_sub(1).map(|p| bytes[p])) {
+            let mut hashes = 0usize;
+            while bytes.get(i + 1 + hashes) == Some(&b'#') {
+                hashes += 1;
+            }
+            if bytes.get(i + 1 + hashes) == Some(&b'"') {
+                let body = i + 2 + hashes;
+                let mut terminator = String::with_capacity(hashes + 1);
+                terminator.push('"');
+                for _ in 0..hashes {
+                    terminator.push('#');
+                }
+                let end = source
+                    .get(body..)
+                    .and_then(|rest| rest.find(&terminator))
+                    .map_or(bytes.len(), |off| body + off);
+                out.push_str(&source[i..body.min(bytes.len())]);
+                blank(&mut out, &source[body.min(bytes.len())..end]);
+                let close = (end + terminator.len()).min(bytes.len());
+                out.push_str(&source[end..close]);
+                i = close;
+                continue;
+            }
+        }
+        // Ordinary string.
+        if bytes[i] == b'"' {
+            out.push('"');
+            i += 1;
+            while i < bytes.len() {
+                if bytes[i] == b'\\' {
+                    out.push(' ');
+                    i += 1;
+                    if i < bytes.len() {
+                        let ch = source[i..].chars().next().expect("char boundary");
+                        blank(&mut out, &source[i..i + ch.len_utf8()]);
+                        i += ch.len_utf8();
+                    }
+                    continue;
+                }
+                if bytes[i] == b'"' {
+                    out.push('"');
+                    i += 1;
+                    break;
+                }
+                let ch = source[i..].chars().next().expect("char boundary");
+                blank(&mut out, &source[i..i + ch.len_utf8()]);
+                i += ch.len_utf8();
+            }
+            continue;
+        }
+        let ch = source[i..].chars().next().expect("char boundary");
+        out.push(ch);
+        i += ch.len_utf8();
+    }
+    debug_assert_eq!(out.len(), source.len(), "sanitize must preserve byte offsets");
+    out
+}
+
+fn is_ident_byte(b: Option<u8>) -> bool {
+    matches!(b, Some(c) if c.is_ascii_alphanumeric() || c == b'_')
+}
+
+/// The index of a char literal's closing quote, or `None` when this quote opens a lifetime.
+fn char_literal_end(bytes: &[u8], open: usize) -> Option<usize> {
+    let escaped = bytes.get(open + 1) == Some(&b'\\');
+    let limit = if escaped { open + 8 } else { open + 5 };
+    let mut i = open + if escaped { 2 } else { 1 };
+    while i < bytes.len() && i <= limit {
+        if bytes[i] == b'\'' {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// The sanitizer must actually neutralize the constructs that would desynchronize the brace model.
+///
+/// Without this, a future edit that breaks `sanitize_for_scan` turns the file-wide scan into a
+/// silent pass — the exact failure this module exists to prevent, one level up.
+#[test]
+fn the_scan_sanitizer_neutralizes_braces_hidden_in_literals() {
+    let source = r####"
+fn a() { let brace = '{'; let quote = '"'; }
+fn b() { let raw = r#"} " { lock_org_mutation("#; }
+// lock_org_mutation( in a comment
+fn c() { let s = "} { \" lock_org_mutation("; }
+"####;
+    let clean = sanitize_for_scan(source);
+    assert_eq!(clean.len(), source.len(), "byte offsets must survive");
+    assert_eq!(
+        clean.matches('{').count(),
+        3,
+        "only the three real function-body braces may survive: {clean}"
+    );
+    assert_eq!(clean.matches('}').count(), 3);
+    assert_eq!(
+        clean.matches("lock_org_mutation(").count(),
+        0,
+        "an acquisition named inside a literal or comment is not an acquisition"
+    );
+}
+
+/// The container-reconcile phase of the BACKGROUND TICK must not run under the org mutex.
 ///
 /// `reconcile_container_shares` -> `reconcile_one_container_root` -> `share_to_org_placed_notifying`,
 /// whose FIRST statement acquires this same mutex. `tokio::sync::Mutex` is not reentrant, so holding
@@ -219,6 +405,10 @@ fn guard_is_held_at(body: &str) -> Vec<(usize, bool)> {
 /// This is why the FE's own "sync now" (`sync_container_shares`) calls the same function with no
 /// lock — the serialization lives inside `share_to_org_placed_notifying`.
 ///
+/// Kept ALONGSIDE the file-wide scan below, not replaced by it: this one names the tick and fails
+/// with the tick's own byte offset, and it reads the function BODY rather than the whole file, so
+/// the two disagree if the body extractor and the file scanner ever drift apart.
+///
 /// RED CONTROL (run 2026-09-03): wrapping the call in `{ let _m = …lock().await; … }` — the shape
 /// this PR shipped before review — fails this test.
 #[test]
@@ -228,12 +418,111 @@ fn the_container_reconcile_phase_does_not_run_under_the_org_mutex() {
         .find("reconcile_container_shares(")
         .expect("the tick no longer reconciles container shares — update this oracle deliberately");
     let held = guard_is_held_at(&body);
-    let (_, holding) = held[call];
     assert!(
-        !holding,
+        !held[call],
         "`reconcile_container_shares` is called while `{ACQUIRE}` is held. Its callee \
          `share_to_org_placed_notifying` acquires the same non-reentrant mutex as its first \
          statement, so this deadlocks permanently and takes every later org operation with it."
+    );
+}
+
+/// NO production call site may run a KNOWN RE-ENTRANT callee under the org mutex — not just the tick.
+///
+/// WHY THIS EXISTS AS WELL AS THE TEST ABOVE (2026-09-08). The tick-only oracle above was written on
+/// 2026-09-03 for the deadlock it had just caught, and it passed for five more days while
+/// `org_sync_now` — the command behind the "Sync now" button — held the guard from its first
+/// statement straight through the same `reconcile_container_shares` call. Pressing that button
+/// deadlocked the task permanently: it never returned, its guard was never dropped, and every
+/// subsequent org operation in the process blocked forever, so the app had to be restarted before
+/// any org work happened again. A user reported it as "sync never finishes and the sidebar never
+/// updates".
+///
+/// The property was never "the TICK does not do this". It was "NOTHING does this". An oracle scoped
+/// to the one site that was broken cannot see the second one, and there was a second one. It now
+/// scans the WHOLE crate, not just `commands/` — a guard held in `lib.rs` or `pipeline.rs` across
+/// such a call wedges identically — and it watches `share_to_org_placed_notifying`, the symbol that
+/// actually re-acquires, as well as the reconcile that reaches it.
+///
+/// LIMIT, stated rather than left to be discovered: this matches CALL TEXT, so moving the call one
+/// level down into a helper hides it. An adversarial review demonstrated exactly that. I tried
+/// replacing it with a name-based transitive call-graph closure and threw that away: this codebase's
+/// correct pattern is "public wrapper takes the lock, then calls the lock-free `_inner`", which such
+/// a closure cannot distinguish from a wedge — it flagged ~40 correct sites, and a check that fails
+/// on correct code gets deleted rather than fixed.
+///
+/// DEPTH IS COVERED AT RUNTIME INSTEAD, and better: `state.rs`'s debug re-entrancy bookkeeping sees
+/// the real dynamic path — any depth, through closures, trait objects and macros alike — and since
+/// 2026-09-08 it registers the BOUNDED door too, so it covers both ways in. This oracle's job is the
+/// static one it can actually do: catch the hoist that keeps happening.
+///
+/// WHERE NEITHER NET REACHES, said plainly. The runtime guard only fires on a path that EXECUTES in
+/// a debug build, and nothing in `cargo test --lib` can execute `org_sync_now`'s container-reconcile
+/// phase — it needs a real `tauri::AppHandle`. So a wedge on that specific phase, hidden behind one
+/// level of indirection, is caught by neither: it surfaces when somebody presses Sync now in the dev
+/// app. That is the honest residual, and it is why the hoist-catching half above is worth keeping
+/// even though it is only a text scan.
+///
+/// RED CONTROL (run 2026-09-08, observed): restoring `org_sync_now`'s guard to the function's first
+/// statement fails with "org.rs: `reconcile_container_shares` is called at byte … while an
+/// org_share_mutation_lock guard is held".
+#[test]
+fn no_production_call_site_runs_a_reentrant_callee_under_the_org_mutex() {
+    /// Callees known to acquire the same mutex, directly or one hop down.
+    const REENTRANT: [&str; 2] = [
+        "reconcile_container_shares(",
+        "share_to_org_placed_notifying(",
+    ];
+    let mut offenders = Vec::new();
+    let mut scanned = 0usize;
+    let mut sites = 0usize;
+    let mut stack = vec![PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src")];
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).unwrap_or_else(|e| panic!("read {dir:?}: {e}")) {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                // Test support may legitimately hold the guard while calling anything; the property
+                // under test is about what SHIPS.
+                if path.file_name().and_then(|n| n.to_str()) != Some("tests") {
+                    stack.push(path);
+                }
+                continue;
+            }
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if !(name.ends_with(".rs") || name.ends_with(".inc")) {
+                continue;
+            }
+            let text = sanitize_for_scan(&std::fs::read_to_string(&path).unwrap_or_default());
+            scanned += 1;
+            let held = guard_is_held_at(&text);
+            for needle in REENTRANT {
+                let mut from = 0usize;
+                while let Some(found) = text[from..].find(needle) {
+                    let at = from + found;
+                    from = at + 1;
+                    // The definition itself is not a call site.
+                    if text[..at].trim_end().ends_with("fn") {
+                        continue;
+                    }
+                    sites += 1;
+                    if held[at] {
+                        offenders.push(format!("{name}: {needle} at byte {at}"));
+                    }
+                }
+            }
+        }
+    }
+    // Six real call sites today (three per needle). A margin loose enough to survive halving the
+    // coverage is not a vacuity guard.
+    assert!(
+        scanned > 20 && sites >= 5,
+        "the scan found {sites} call sites across {scanned} files — it has gone vacuous, fix it"
+    );
+    assert!(
+        offenders.is_empty(),
+        "a callee that acquires `org_share_mutation_lock` is called while a guard on that same \
+         mutex is held, at {offenders:?}. `tokio::sync::Mutex` is not reentrant, so this deadlocks \
+         permanently and takes every later org operation with it — the app then needs a restart. \
+         Drop the guard before the call."
     );
 }
 

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -533,6 +533,51 @@ pub const EVENT_ORG_FEED_UPDATED: &str = "murmur://org-feed-updated";
 /// a whole Space is N sequential round-trips and a spinner cannot say how far it got.
 pub const EVENT_CONTAINER_SHARE_PROGRESS: &str = "murmur://container-share-progress";
 
+/// Progress of ONE user-triggered "Sync now". Counts and a stage name only, NO PII (no org name,
+/// item id, or title — the org id is a server-issued opaque id the FE already holds).
+///
+/// A manual sync is several bounded feed pages followed by a container reconcile that can publish or
+/// withdraw many documents, all sequential network round trips. Without this the button is an
+/// indeterminate "Syncing…" for the whole thing, which is what a user reported as "it keeps syncing
+/// and you don't know the status" — a spinner cannot distinguish working from wedged.
+pub const EVENT_ORG_SYNC_PROGRESS: &str = "murmur://org-sync-progress";
+
+/// Payload for [`EVENT_ORG_SYNC_PROGRESS`].
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrgSyncProgressPayload {
+    /// The org being synced, so a stale event from a previous press is dropped rather than shown.
+    pub org_id: String,
+    /// `"feed"` while draining bounded feed pages, `"containers"` while reconciling shared folders.
+    pub stage: &'static str,
+    /// Feed items consumed so far this press.
+    pub pulled: u32,
+    /// Feed items ingested into the local replica so far this press.
+    pub ingested: u32,
+}
+
+/// Emit [`EVENT_ORG_SYNC_PROGRESS`] (best-effort). A failed emit only costs the button a label
+/// update; it must never affect the sync itself.
+pub fn emit_org_sync_progress(
+    app: &AppHandle,
+    org_id: &str,
+    stage: &'static str,
+    pulled: u32,
+    ingested: u32,
+) {
+    if let Err(e) = app.emit(
+        EVENT_ORG_SYNC_PROGRESS,
+        OrgSyncProgressPayload {
+            org_id: org_id.to_string(),
+            stage,
+            pulled,
+            ingested,
+        },
+    ) {
+        tracing::warn!(target: "org", error = %e, "failed to emit org-sync progress");
+    }
+}
+
 /// Payload for [`EVENT_CONTAINER_SHARE_PROGRESS`]. Two counts only — NO PII.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -892,6 +937,29 @@ mod tests {
     #[test]
     fn org_sync_tick_cadence_is_one_minute() {
         assert_eq!(crate::commands::ORG_SYNC_TICK_SECS, 60);
+    }
+
+    /// The FE reads these keys off the progress event; a snake_case field is `undefined` on arrival
+    /// and the button silently keeps its static label (`rust-tauri.md` §2b).
+    #[test]
+    fn org_sync_progress_payload_is_camel_case() {
+        let json = serde_json::to_string(&OrgSyncProgressPayload {
+            org_id: "org-1".into(),
+            stage: "feed",
+            pulled: 8,
+            ingested: 6,
+        })
+        .unwrap();
+        assert_eq!(
+            json,
+            r#"{"orgId":"org-1","stage":"feed","pulled":8,"ingested":6}"#
+        );
+    }
+
+    /// The FE listens on this exact event name; a rename silently drops the sync-progress label.
+    #[test]
+    fn org_sync_progress_event_name_is_stable() {
+        assert_eq!(EVENT_ORG_SYNC_PROGRESS, "murmur://org-sync-progress");
     }
 
     /// The FE listens on this exact event name; a rename silently drops the import progress bar.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1043,7 +1043,12 @@ pub fn run() {
                         crate::commands::ORG_SYNC_FIRST_DELAY_SECS,
                     ))
                     .await;
+                    // Consecutive productive ticks taken at the catch-up cadence. Reset by any
+                    // quiet tick, and capped so a feed that always reports "changed" can never
+                    // become a permanent 3 s poll (`ORG_SYNC_MAX_CATCHUP_TICKS`).
+                    let mut catching_up = 0_u32;
                     loop {
+                        let mut changed = false;
                         if let Some(state) = handle.try_state::<AppState>() {
                             // On a PRODUCTIVE tick (≥1 ingest/tombstone) emit a content-free
                             // `org-feed-updated` ping so an open FE view (Notes org picker /
@@ -1057,12 +1062,19 @@ pub fn run() {
                             .await
                             {
                                 crate::events::emit_org_feed_updated(&handle, 1);
+                                changed = true;
                             }
                         }
-                        tokio::time::sleep(std::time::Duration::from_secs(
-                            crate::commands::ORG_SYNC_TICK_SECS,
-                        ))
-                        .await;
+                        // A tick that moved the replica means the feed had a backlog, and one tick
+                        // drains one bounded page. Sleeping the full minute anyway is what made a
+                        // freshly shared Space arrive four objects at a time over several minutes.
+                        // The decision lives in `org_sync_next_delay_secs` so its DUTY CYCLE — not
+                        // just its constants — can be asserted.
+                        let sleep_secs = crate::commands::org_sync_next_delay_secs(
+                            changed,
+                            &mut catching_up,
+                        );
+                        tokio::time::sleep(std::time::Duration::from_secs(sleep_secs)).await;
                     }
                 });
             }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -449,6 +449,27 @@ mod org_mutex_reentrancy {
         );
     }
 
+    /// Record a BOUNDED acquisition without asserting on it, returning whether this holder was
+    /// newly recorded (only then may its guard remove the id on drop).
+    ///
+    /// Asymmetric on purpose, and the asymmetry is the whole point. A bounded ATTEMPT cannot hang —
+    /// if the caller already holds the lock the timeout simply elapses — so asserting on entry here
+    /// would be the guard mistaking a refusal-by-design for a deadlock. But a bounded guard that is
+    /// HELD across a callee taking the unbounded door hangs exactly like any other re-entrancy, and
+    /// until this existed the bookkeeping could not see it: the outer holder was never recorded, so
+    /// the inner `enter()` found an empty set and the process wedged in silence.
+    ///
+    /// That is not hypothetical. The change that fixed the `org_sync_now` deadlock moved both of the
+    /// "Sync now" paths onto this bounded door, and so out from under the only check that was
+    /// watching them.
+    pub(super) fn enter_bounded() -> bool {
+        let id = holder_id();
+        let mut set = holders()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        set.insert(id)
+    }
+
     pub(super) fn leave() {
         let id = holder_id();
         let mut set = holders()
@@ -467,8 +488,9 @@ mod org_mutex_reentrancy {
 pub struct OrgMutationGuard<'a> {
     _inner: tokio::sync::MutexGuard<'a, ()>,
     /// Whether this guard registered itself with the re-entrancy bookkeeping, so only guards that
-    /// entered ever leave. A bounded acquisition never enters, and must not remove an id the
-    /// unbounded holder on the same thread put there.
+    /// registered ever unregister. BOTH doors register on SUCCESS now; the flag exists because
+    /// `insert` can legitimately report "already present" and a guard must never remove an id it
+    /// did not put there.
     #[cfg(debug_assertions)]
     checked: bool,
 }
@@ -499,14 +521,19 @@ impl AppState {
 
     /// Acquire it, or give up after `wait`.
     ///
-    /// DELIBERATELY NOT re-entrancy-checked, and the distinction is the whole point: a BOUNDED
-    /// attempt cannot deadlock. If the caller already holds the lock the timeout simply elapses and
-    /// the caller is told the resource is busy — which is a correct, recoverable outcome, and one
-    /// the suite asserts on purpose in
+    /// It does not ASSERT on entry, and the distinction is the whole point: a BOUNDED attempt
+    /// cannot deadlock. If the caller already holds the lock the timeout simply elapses and the
+    /// caller is told the resource is busy — a correct, recoverable outcome, and one the suite
+    /// asserts on purpose in
     /// `org_diagnosability_tests::a_held_share_mutation_lock_yields_busy_rather_than_hanging`.
-    ///
     /// Panicking there would have been the guard mistaking "an attempt designed to be refused" for
     /// "a hang", which is exactly the false positive that gets a check deleted rather than fixed.
+    ///
+    /// It DOES register the holder on success, which it did not used to. A bounded guard is still a
+    /// held guard: a callee that takes the unbounded door underneath one waits forever exactly like
+    /// any other re-entrancy, and with no registration the inner `enter()` saw an empty set and the
+    /// process wedged in silence. Registering here is what lets that inner acquisition panic
+    /// instead — and it costs nothing at the bounded call site, which never asserts.
     pub(crate) async fn lock_org_mutation_within(
         &self,
         wait: std::time::Duration,
@@ -517,7 +544,7 @@ impl AppState {
             .map(|inner| OrgMutationGuard {
                 _inner: inner,
                 #[cfg(debug_assertions)]
-                checked: false,
+                checked: org_mutex_reentrancy::enter_bounded(),
             })
     }
 }

--- a/src-tauri/src/storage/models.rs
+++ b/src-tauri/src/storage/models.rs
@@ -858,7 +858,8 @@ pub struct OrgOwnedSource {
 /// Shared Brain v1 — the content-free result of a manual `org_sync_now()` (counts + errors only).
 /// `fts_only` is true when the local member has no real embedder (StubEmbedder ⇒ the org partition
 /// is indexed FTS-only until a model appears + a re-embed runs). Mirrors the FE `OrgSyncReport`
-/// (camelCase: `pulled, ingested, tombstoned, lastSeq, ftsOnly, errors, authorsBackfilled`).
+/// (camelCase: `pulled, ingested, tombstoned, lastSeq, ftsOnly, errors, authorsBackfilled,
+/// morePending`) — asserted by `org_sync_report_wire_shape_is_camel_case`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct OrgSyncReport {
@@ -874,6 +875,15 @@ pub struct OrgSyncReport {
     /// full-feed re-pull (`org_sync_one` → the null-author backfill pass). Content-free — an id/author
     /// count only. (2026-07-15.)
     pub authors_backfilled: u32,
+    /// The drain stopped on ITS OWN bound (page cap, deadline, or a busy mutation lock) rather than
+    /// because the feed ran out — so more items are still waiting on the server.
+    ///
+    /// This exists because the alternative is a lie. A manual sync takes bounded pages, and without
+    /// this flag a capped drain returns the same shape as a completed one, which the panel renders
+    /// as "Synced — up to date." while the org is demonstrably behind. Content-free: one bool.
+    /// (2026-09-08.)
+    #[serde(default)]
+    pub more_pending: bool,
 }
 
 /// A standalone authored note — the LIST-row DTO (leak-free: no body for a sealed note). A note is a

--- a/src/app/core/ipc.service.ts
+++ b/src/app/core/ipc.service.ts
@@ -119,6 +119,7 @@ import type {
   OrgSourceRef,
   OrgSourceShareStatus,
   OrgStatus,
+  OrgSyncProgress,
   OrgSyncReport,
   OrgTask,
   PeopleList,
@@ -234,6 +235,14 @@ export const EVENT_ORG_FEED_UPDATED = "murmur://org-feed-updated";
 /** Progress of one container share. Counts only — no folder name, no item id. */
 export const EVENT_CONTAINER_SHARE_PROGRESS =
   "murmur://container-share-progress";
+/**
+ * Progress of one user-triggered org "Sync now". Counts + a stage name only.
+ *
+ * A manual sync is several bounded feed pages followed by a container reconcile, all sequential
+ * network round trips. Without this the button is an indeterminate "Syncing…" for the duration,
+ * which is exactly what got reported as "it keeps syncing and you don't know the status".
+ */
+export const EVENT_ORG_SYNC_PROGRESS = "murmur://org-sync-progress";
 // Delete fan-out fix — a note/meeting delete FULLY succeeded (local rows gone + any org shares
 // revoked); lets OTHER open surfaces (the tab-strip) prune themselves. Content-free (id + kind only).
 export const EVENT_CONTENT_DELETED = "murmur://content-deleted";
@@ -964,8 +973,13 @@ export class IpcService {
   }
 
   /** Manually pull + ingest a SPECIFIC org's feed now → the {@link OrgSyncReport} (counts + errors only). */
-  orgSyncNow(orgId: string): Promise<OrgSyncReport> {
-    return invoke<OrgSyncReport>("org_sync_now", { orgId });
+  /**
+   * Sync one org now. `drain` (default) walks bounded feed pages until the org is caught up or the
+   * command's own cap stops it — what the "Sync now" button means. Pass `false` when you only need
+   * this org's current head (the conflict viewer), so a click does not inherit a whole backlog.
+   */
+  orgSyncNow(orgId: string, drain = true): Promise<OrgSyncReport> {
+    return invoke<OrgSyncReport>("org_sync_now", { orgId, drain });
   }
 
   /**
@@ -3986,6 +4000,19 @@ export class IpcService {
     return listen<{ done: number; total: number }>(
       EVENT_CONTAINER_SHARE_PROGRESS,
       (e) => cb(e.payload.done, e.payload.total),
+    );
+  }
+
+  /**
+   * Progress of the org "Sync now" in flight. `stage` is `"feed"` while feed pages are draining and
+   * `"containers"` while shared folders reconcile; the counts are what the press has consumed so
+   * far. `orgId` lets a listener drop an event from a previous press.
+   */
+  onOrgSyncProgress(
+    cb: (progress: OrgSyncProgress) => void,
+  ): Promise<UnlistenFn> {
+    return listen<OrgSyncProgress>(EVENT_ORG_SYNC_PROGRESS, (e) =>
+      cb(e.payload),
     );
   }
 }

--- a/src/app/core/models.ts
+++ b/src/app/core/models.ts
@@ -3345,6 +3345,19 @@ export interface OrgSourceRef {
  * the org partition is FTS-only until a model appears + a re-embed runs).
  * Mirrors the Rust `OrgSyncReport`.
  */
+/**
+ * Payload of `murmur://org-sync-progress` (`onOrgSyncProgress`) — what the "Sync now" press in
+ * flight has done so far. Counts and a stage name only; the org id is the same opaque server id the
+ * FE already holds, so a listener can drop an event from a previous press.
+ */
+export interface OrgSyncProgress {
+  orgId: string;
+  /** `"feed"` while bounded feed pages drain; `"containers"` while shared folders reconcile. */
+  stage: "feed" | "containers";
+  pulled: number;
+  ingested: number;
+}
+
 export interface OrgSyncReport {
   pulled: number;
   ingested: number;
@@ -3353,6 +3366,13 @@ export interface OrgSyncReport {
   /** No real embedder → org partition indexed FTS-only (re-embed when a model lands). */
   ftsOnly: boolean;
   errors: string[];
+  /**
+   * The drain stopped on its OWN bound (page cap, deadline, or a busy mutation lock), not because
+   * the feed ran out — so the org is still behind and the background loop is still catching up.
+   * Without this a capped sync is indistinguishable from a completed one, and the panel says
+   * "Synced — up to date." about an org that demonstrably is not.
+   */
+  morePending: boolean;
 }
 
 /**

--- a/src/app/features/org/org-item-viewer/org-item-viewer.component.ts
+++ b/src/app/features/org/org-item-viewer/org-item-viewer.component.ts
@@ -539,7 +539,9 @@ export class OrgItemViewerComponent {
     this.openingLatest.set(true);
     this._openLatestFailed.set(false);
     try {
-      await this.ipc.orgSyncNow(orgId);
+      // One page, not a drain: this needs THIS item's current head, and the user is waiting on a
+      // click. Catching the whole org up is the Sync-now button's job and the background loop's.
+      await this.ipc.orgSyncNow(orgId, false);
       const latest = await this.ipc.orgGetItem(linkId);
       if (this.itemId() !== routeId || this._item() !== conflicted) {
         return;

--- a/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.html
+++ b/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.html
@@ -22,9 +22,18 @@
       </div>
     </div>
 
-    @if (!loaded()) {
+    <!-- The spinner is gated on "nothing to show YET", never on "a read is in flight": a return
+         visit renders the last-known rows from the root roster store while the reload runs
+         underneath (angular-zoneless.md §8). -->
+    @if (!loaded() && !hasOrgs()) {
       <p class="text-muted account-note">Loading organizations…</p>
     } @else {
+      @if (loadFailed() && hasOrgs()) {
+        <p class="text-muted account-note" role="status">
+          Couldn't refresh your organizations just now — showing the last known
+          state.
+        </p>
+      }
       <!-- ── Your organizations ── -->
       @if (hasOrgs()) {
         <div class="account-section">
@@ -116,13 +125,16 @@
                       {{ expandedOrgId() === o.orgId ? "Hide members" : "Invite & members" }}
                     </button>
                   }
+                  <!-- The label carries the LIVE stage + count while this org is syncing: a
+                       manual sync is several sequential round trips, and a static "Syncing…" cannot
+                       be told apart from a wedge. -->
                   <button
                     type="button"
                     class="btn btn-ghost mini-btn"
                     (click)="syncNow(o)"
                     [disabled]="syncingOrgId() !== null"
                   >
-                    {{ syncingOrgId() === o.orgId ? "Syncing…" : "Sync now" }}
+                    {{ syncingOrgId() === o.orgId ? syncLabel() : "Sync now" }}
                   </button>
                   <button
                     type="button"
@@ -273,8 +285,18 @@
             }
           </div>
         </div>
+      } @else if (loadFailed()) {
+        <!-- A read that FAILED is not evidence of an empty membership. Telling somebody they are in
+             no organization because the relay was unreachable is the bug this branch exists to
+             prevent — the error line below carries the reason. -->
+        <div class="account-section">
+          <p class="text-secondary account-note org-empty">
+            Couldn't read your organizations. Nothing has been changed — try
+            again in a moment.
+          </p>
+        </div>
       } @else {
-        <!-- ── Empty state: in no org ── -->
+        <!-- ── Empty state: in no org (a read that SUCCEEDED and found none) ── -->
         <div class="account-section">
           <p class="text-secondary account-note org-empty">
             You're not in any organization yet — create one, or ask a teammate to

--- a/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.ts
+++ b/src/app/features/settings/sections/settings-organization-section/settings-organization-section.component.ts
@@ -14,9 +14,11 @@ import type {
   OrgItemHeader,
   OrgMember,
   OrgStatus,
+  OrgSyncProgress,
 } from "../../../../core/models";
 import { ErrorCopyService } from "../../../../core/copy/error-copy.service";
 import { DateFormatService } from "../../../../core/date-format.service";
+import { OrgRosterStore } from "../../../../services/org-roster.store";
 
 /**
  * Settings → Organization section (Shared Brain v1, MULTI-ORG).
@@ -58,13 +60,25 @@ export class SettingsOrganizationSectionComponent {
   private readonly toast = inject(ToastService);
   private readonly errorCopy = inject(ErrorCopyService);
 
-  /** Every org the user belongs to (created OR invited-into). Empty ⇒ empty state. */
-  private readonly _orgs = signal<OrgStatus[]>([]);
+  /**
+   * Every org the user belongs to (created OR invited-into), held in a ROOT store so the rows
+   * survive this section's destroy+recreate and a failed refresh never blanks them
+   * ({@link OrgRosterStore} carries the full rationale).
+   */
+  private readonly roster = inject(OrgRosterStore);
+  private readonly _orgs = this.roster.orgs;
   readonly orgs = this._orgs.asReadonly();
 
-  /** True until the first list load resolves (avoids an empty-state flash). */
-  private readonly _loaded = signal(false);
+  /** True once a roster read has settled at least once (avoids an empty-state flash). */
+  private readonly _loaded = this.roster.loaded;
   readonly loaded = this._loaded.asReadonly();
+
+  /**
+   * The last roster read failed. The list keeps its last-known rows; the template says so instead
+   * of rendering the "you're not in any organization yet" copy at somebody who is.
+   */
+  private readonly _loadFailed = this.roster.loadFailed;
+  readonly loadFailed = this._loadFailed.asReadonly();
 
   /** A general org error (list load / mutate failure). */
   private readonly _error = signal<string | null>(null);
@@ -83,7 +97,7 @@ export class SettingsOrganizationSectionComponent {
   readonly email = this._email.asReadonly();
 
   /** True while at least one org is present. */
-  readonly hasOrgs = computed(() => this._orgs().length > 0);
+  readonly hasOrgs = this.roster.hasOrgs;
 
   /** True while the global org-egress consent is granted (any org's flag ⇒ global grant). */
   private readonly _consented = signal(false);
@@ -91,10 +105,27 @@ export class SettingsOrganizationSectionComponent {
   readonly consentBusy = signal(false);
 
   // ── Reload trigger + stale-result guard ─────────────────────────────────────
+  //
+  // The load TOKEN lives in the root store, not here: the signals it guards are shared, so a
+  // per-instance token stops guarding anything the moment a destroyed section's response lands on
+  // a live one's data. See {@link OrgRosterStore.beginLoad}.
   /** Bump to re-run the load effect (open, after create/leave/invite). */
   private readonly _reloadTick = signal(0);
-  /** Monotonic load token — a resolved fetch writes only if it is still the latest. */
-  private _loadSeq = 0;
+  /**
+   * COALESCE live-refresh bursts. A reload here is a real network round trip per org
+   * (`org_refresh`, then `org_status` + `org_list_members` for each), and `org-feed-updated` now
+   * arrives every few seconds while the background loop is catching a backlog up rather than once a
+   * minute. Without this, each ping would start another overlapping fan-out on top of the one still
+   * in flight. At most ONE follow-up is queued: the reason to reload is "something changed", and one
+   * reload after the current one observes every change that landed while it ran.
+   *
+   * The flag is released by the NEWEST run's `finally` (a superseded run deliberately does not touch
+   * it, or a slow stale response would free a slot its successor owns). That makes an unsettled
+   * newest request the one way to stall live refresh — bounded, because every command on this path
+   * is bounded backend-side, and a user action calls {@link reload} directly regardless.
+   */
+  private _reloadInFlight = false;
+  private _reloadQueued = false;
 
   // ── Create form ─────────────────────────────────────────────────────────────
   readonly createName = signal("");
@@ -127,6 +158,29 @@ export class SettingsOrganizationSectionComponent {
   /** The org id currently syncing (locks its Sync now button). */
   private readonly _syncingOrgId = signal<string | null>(null);
   readonly syncingOrgId = this._syncingOrgId.asReadonly();
+  /**
+   * What the sync in flight has done so far, straight off `murmur://org-sync-progress`.
+   *
+   * A manual sync is several bounded feed pages and then a container reconcile — sequential network
+   * round trips that can take a while on a real backlog. A label that never changes is
+   * indistinguishable from a wedge, which is how this was reported: "it keeps syncing and you don't
+   * know the status". `null` between presses.
+   */
+  private readonly _syncProgress = signal<OrgSyncProgress | null>(null);
+
+  /**
+   * The live label for the ONE org that can be syncing at a time. Derived, not recomputed per row:
+   * the template picks it only for the row whose id matches {@link syncingOrgId}.
+   */
+  readonly syncLabel = computed<string>(() => {
+    const progress = this._syncProgress();
+    if (!progress || progress.orgId !== this._syncingOrgId()) {
+      return "Syncing…";
+    }
+    return progress.stage === "containers"
+      ? "Syncing folders…"
+      : `Syncing… ${progress.pulled}`;
+  });
 
   // ── Browse the shared brain (fix A) — per-org item list ──────────────────────
   /** The org id whose "Shared brain" browse list is expanded (one at a time). */
@@ -146,6 +200,8 @@ export class SettingsOrganizationSectionComponent {
   private readonly destroyRef = inject(DestroyRef);
   /** Released on destroy to detach the org-feed-updated live-refresh listener. */
   private orgFeedUnlisten: (() => void) | null = null;
+  /** Released on destroy to detach the org-sync-progress listener. */
+  private syncProgressUnlisten: (() => void) | null = null;
   /** True once destroyed — so a `listen()` that resolves AFTER teardown releases immediately
    * (distinct from `orgFeedUnlisten === null`, which also means "not yet resolved"). */
   private orgFeedDestroyed = false;
@@ -156,13 +212,14 @@ export class SettingsOrganizationSectionComponent {
     // invite can re-run it; a stale-result guard drops a superseded response.
     effect(() => {
       this._reloadTick(); // dependency: any bump re-runs the load
-      const seq = ++this._loadSeq;
+      const seq = this.roster.beginLoad();
       this._error.set(null);
+      this._reloadInFlight = true;
       void (async () => {
         // Account email (best-effort — a logged-out user still sees the section).
         try {
           const acct = await this.ipc.accountStatus();
-          if (seq === this._loadSeq) {
+          if (this.roster.isCurrentLoad(seq)) {
             this._email.set(acct.email);
           }
         } catch {
@@ -177,19 +234,29 @@ export class SettingsOrganizationSectionComponent {
         }
         try {
           const list = await this.ipc.orgListStatuses();
-          if (seq !== this._loadSeq) {
+          if (!this.roster.isCurrentLoad(seq)) {
             return; // a newer reload superseded this one — drop the result
           }
+          this._loadFailed.set(false);
           this._orgs.set(list);
           this._consented.set(list.some((o) => o.consented));
           this.reconcileExpanded(list);
         } catch (e) {
-          if (seq === this._loadSeq) {
+          if (this.roster.isCurrentLoad(seq)) {
+            // Record the failure; do NOT clear the rows. A read that could not reach the relay
+            // rendered as "You're not in any organization yet" — the app telling a member of three
+            // orgs that they belong to none, with no retry but closing and reopening the section.
+            this._loadFailed.set(true);
             this._error.set(this.errorCopy.humanize(e));
           }
         } finally {
-          if (seq === this._loadSeq) {
+          if (this.roster.isCurrentLoad(seq)) {
             this._loaded.set(true);
+            this._reloadInFlight = false;
+            if (this._reloadQueued) {
+              this._reloadQueued = false;
+              this.reload();
+            }
           }
         }
       })();
@@ -203,10 +270,36 @@ export class SettingsOrganizationSectionComponent {
       this.orgFeedDestroyed = true;
       this.orgFeedUnlisten?.();
       this.orgFeedUnlisten = null;
+      this.syncProgressUnlisten?.();
+      this.syncProgressUnlisten = null;
     });
     void this.ipc
+      .onOrgSyncProgress((progress) => {
+        // Drop an event from a press that is already over, or from another org's press.
+        //
+        // KNOWN BOUND: a trailing event from press N, delivered after press N+1 has started on the
+        // SAME org, is accepted and shows press N's counts until press N+1's first event replaces
+        // them. Distinguishing them needs a correlation id echoed through the command, and the
+        // symptom — a count that reads high for one page before correcting — is not worth widening
+        // the IPC surface for. The window is small because the backend emits every progress event
+        // before the command it belongs to resolves, and the button stays disabled until it does.
+        if (this._syncingOrgId() === progress.orgId) {
+          this._syncProgress.set(progress);
+        }
+      })
+      .then((un) => {
+        if (this.orgFeedDestroyed) {
+          un();
+        } else {
+          this.syncProgressUnlisten = un;
+        }
+      })
+      .catch(() => {
+        /* best-effort: no Tauri host (e.g. plain browser) → no live progress */
+      });
+    void this.ipc
       .onOrgFeedUpdated(() => {
-        this.reload();
+        this.requestReload();
         // Keep an open browse list fresh too (the reload only refreshes the org cards/counts).
         const open = this._browseOrgId();
         if (open !== null) {
@@ -229,6 +322,19 @@ export class SettingsOrganizationSectionComponent {
   /** Re-run the load effect (server discovery + list). */
   private reload(): void {
     this._reloadTick.update((n) => n + 1);
+  }
+
+  /**
+   * Reload for a LIVE-REFRESH ping, coalescing a burst into at most one follow-up. A user action
+   * (create / leave / invite / sync) still calls {@link reload} directly — that one must not be
+   * folded into somebody else's in-flight fetch.
+   */
+  private requestReload(): void {
+    if (this._reloadInFlight) {
+      this._reloadQueued = true;
+      return;
+    }
+    this.reload();
   }
 
   /** Drop the expanded member manager / browse list if their org is gone. */
@@ -457,10 +563,16 @@ export class SettingsOrganizationSectionComponent {
       return;
     }
     this._syncingOrgId.set(org.orgId);
+    this._syncProgress.set(null);
     this._error.set(null);
     try {
       const report = await this.ipc.orgSyncNow(org.orgId);
       const stalled = report.pulled > 0 && report.ingested === 0;
+      // A drain that stopped on its OWN bound (page cap / deadline / a busy lock) has NOT caught
+      // up. Saying "up to date" there is the same lie the single-page sync used to tell.
+      const tail = report.morePending
+        ? " More is still arriving in the background."
+        : "";
       if (report.errors.length > 0 || stalled) {
         // Name the FIRST real error rather than always guessing "a key may not be granted yet".
         // The report now also carries shared-folder publish failures, which that guess describes
@@ -469,14 +581,16 @@ export class SettingsOrganizationSectionComponent {
         this.toast.danger(
           `${report.pulled} pulled, ${report.ingested} ingested, ` +
             `${report.errors.length} error${report.errors.length === 1 ? "" : "s"} — ` +
-            `${detail}.`,
+            `${detail}.${tail}`,
         );
-      } else {
+      } else if (report.ingested > 0) {
         this.toast.success(
-          report.ingested > 0
-            ? `Synced — ${report.ingested} new item${report.ingested === 1 ? "" : "s"}.`
-            : "Synced — up to date.",
+          `Synced — ${report.ingested} new item${report.ingested === 1 ? "" : "s"}.${tail}`,
         );
+      } else if (report.morePending) {
+        this.toast.success("Synced — still catching up in the background.");
+      } else {
+        this.toast.success("Synced — up to date.");
       }
       this.reload();
       // Keep an open browse list fresh after a sync brings in new items.
@@ -488,6 +602,7 @@ export class SettingsOrganizationSectionComponent {
       this.toast.danger(this.errorCopy.because("Sync failed", e));
     } finally {
       this._syncingOrgId.set(null);
+      this._syncProgress.set(null);
     }
   }
 

--- a/src/app/services/org-roster.store.ts
+++ b/src/app/services/org-roster.store.ts
@@ -1,0 +1,70 @@
+import { Injectable, computed, signal } from "@angular/core";
+import type { OrgStatus } from "../core/models";
+
+/**
+ * Root-persisted backing signals for Settings → Organizations.
+ *
+ * The section lives inside a `@switch` on the settings tab, so it is destroyed and recreated every
+ * time the user leaves the Organization tab and comes back — and its roster used to be a
+ * component-local `signal<OrgStatus[]>([])`, wiped to empty on each remount. Its template then read
+ * a single `loaded` flag: "Loading organizations…" until the fetch settled, and, if that fetch
+ * FAILED, the empty branch — "You're not in any organization yet — create one, or ask a teammate to
+ * invite you by email." A refresh that could not reach the relay therefore told a member of three
+ * orgs that they belonged to none, and the only way back was to close the section and reopen it,
+ * hoping for a better attempt. That is the shape `angular-zoneless.md` §8 exists to prevent.
+ *
+ * A root instance outlives the component, so a return visit renders the LAST-KNOWN rows instantly
+ * while the section's own (unchanged, still unconditional) reload replaces them underneath.
+ *
+ * Deliberately a thin signal HOLDER with no load()/CRUD of its own — the section keeps every bit of
+ * its orchestration (server discovery, consent, invite, leave, sync) and simply reads and writes
+ * these signals instead of component-local ones. Same sanctioned shape as {@link MeetingsListStore}.
+ *
+ * This is the UNFILTERED roster on purpose: {@link OrgBrainService} narrows to
+ * `contextEnabled` orgs because those are the ones that contribute content, while Settings must
+ * keep every joined org reachable so its per-device toggle can be turned back on.
+ */
+@Injectable({ providedIn: "root" })
+export class OrgRosterStore {
+  /** Every org this user belongs to — created OR invited-into, enabled or not. */
+  readonly orgs = signal<OrgStatus[]>([]);
+  /** True once a roster read has settled at least once in this app session. */
+  readonly loaded = signal(false);
+  /**
+   * The LAST roster read could not be completed.
+   *
+   * Kept separate from {@link orgs} on purpose: the rows stay on screen while this is true, so a
+   * failed refresh degrades to "possibly stale" instead of blanking what the user was reading — and
+   * the template can tell "we could not find out" apart from "you are in no organization".
+   */
+  readonly loadFailed = signal(false);
+
+  /** True while at least one org is known. */
+  readonly hasOrgs = computed(() => this.orgs().length > 0);
+
+  /**
+   * The load token, held HERE rather than in the section, because the signals it guards live here.
+   *
+   * The section is destroyed and recreated on every tab switch, and its stale-result guard used to
+   * be a component field. Once the roster moved into this shared store, that guard stopped guarding
+   * anything across instances: a destroyed section's in-flight `orgListStatuses()` still matched its
+   * OWN token, so it wrote its result over the roster a NEWER instance had already rendered. Before
+   * the move the write landed on a dead component-local signal and was invisible; afterwards it
+   * silently replaced live data with older data — reproduced in a browser, with no user action in
+   * between, by making the first read slow and switching tabs while it was in flight.
+   *
+   * One token per store means "latest wins" spans instances, which is what "latest" has to mean when
+   * the destination is shared.
+   */
+  private _loadSeq = 0;
+
+  /** Claim the next load token. The caller writes only while {@link isCurrentLoad} holds for it. */
+  beginLoad(): number {
+    return ++this._loadSeq;
+  }
+
+  /** Whether `seq` is still the newest load — across every instance of the section. */
+  isCurrentLoad(seq: number): boolean {
+    return seq === this._loadSeq;
+  }
+}

--- a/src/app/services/shared-workspace.service.ts
+++ b/src/app/services/shared-workspace.service.ts
@@ -104,6 +104,21 @@ export class SharedWorkspaceService {
   private loadSeq = 0;
   private feedUnlisten: (() => void) | null = null;
   private feedDestroyed = false;
+  /**
+   * Re-read the received forest when the window comes back to the front.
+   *
+   * Every read here is LOCAL — `list_shared_workspace` touches `org_*` tables only and makes no
+   * network call — so this is not an egress event, it is the same three SQLite reads the sidebar
+   * already does. It exists because the backend's `org-feed-updated` ping is the only other thing
+   * that refreshes this tree, and that ping fires only when a background tick actually CHANGED the
+   * replica. Anything that changed the replica while this window was in the background and did not
+   * ping (or pinged before the listener resolved) left the sidebar showing what it read at launch
+   * until the app was restarted. {@link OrgBrainService} already refreshes on focus for exactly
+   * this reason; the sidebar had no such recovery.
+   */
+  private readonly onWindowFocus = (): void => {
+    void this.load();
+  };
 
   constructor() {
     // A workspace mutation can change what a shared container HOLDS — a note
@@ -116,11 +131,13 @@ export class SharedWorkspaceService {
         void this.syncAfterWorkspaceMutation();
       }
     });
+    window.addEventListener("focus", this.onWindowFocus);
     this.destroyRef.onDestroy(() => {
       // A root service is never actually destroyed in practice; honor the
       // contract in case a test harness tears it down.
       this.feedDestroyed = true;
       this.feedUnlisten?.();
+      window.removeEventListener("focus", this.onWindowFocus);
     });
     void this.ipc
       .onOrgFeedUpdated(() => void this.load())


### PR DESCRIPTION
Five reported symptoms, four causes. The first one wedged the whole org subsystem until the app was restarted.

## The deadlock

`org_sync_now` took `org_share_mutation_lock` in its first statement and still held it when it called `reconcile_container_shares`, whose callee `share_to_org_placed_notifying` acquires the same non-reentrant tokio mutex. The task awaited a lock it already held: it never returned, its guard was never dropped, and every later org operation in the process blocked forever. That is "Sync now never finishes", "the sidebar never updates", and "I have to reset the app for it to fetch" — one bug wearing three faces.

`org_background_sync_tick` had the identical bug and was fixed on 2026-09-03. The command behind the button was missed because the oracle that caught it looked only at the tick. The property was never "the tick does not do this".

The guard is now scoped — bounded, taken and released per feed page — and the container reconcile runs with none held.

## One page per press

A manual sync took a single bounded four-item feed page and reported it as finished. A shared Space therefore materialized four objects at a time, a minute apart: the Space row, its folders minutes later, the notes later still, while each press answered "Synced — up to date."

`Sync now` now drains bounded pages (40 pages, and a 20 s budget on *starting* one), and the report carries `morePending` so a capped drain stops claiming it caught up. The page bound is a ceiling on the decrypted page held in memory; draining sequentially leaves that ceiling exactly where it was. The background loop also backs off to a 3 s cadence while it is still catching up — capped, and re-armed only by a genuinely quiet tick.

## Nothing refreshed after sign-in

`account_login` reconciles org membership. `unlock_sharing_with_biometric` — the Touch ID tap most people actually use at launch — restored the session and returned. The next thing to ask the server was the background tick a minute later, which pings only when membership genuinely *changed*, so the sidebar kept what it had read before the user signed in until the app was restarted.

Both paths now reconcile and emit `org-feed-updated` unconditionally. The sidebar's received forest also re-reads on window focus, which is three local SQLite reads and no egress.

## The panel lied

Settings → Organizations kept its roster in a component-local signal inside a `@switch`, wiped on every remount, and a **failed** read fell through to the same branch as an empty one: "You're not in any organization yet", shown to a member of several. The roster moves to a root store, a failed read is its own branch, and the Sync button reports a live stage from a new content-free `org-sync-progress` event instead of a spinner that cannot be told apart from a wedge.

## What review found that I did not

Adversarial review reproduced two more defects in a browser and a mock relay before they were fixed:

- The drain stopped on an **author-backfill turn** — a page that spends its budget repairing legacy `NULL`-author rows, never consults the live cursor, and legitimately repairs zero of them — and reported the org caught up. Counts cannot distinguish "nothing happened" from "nothing asked"; the decision now reads the page's outcome (`FeedPageOutcome`).
- The section's stale-result token stayed a **component** field after the roster moved to a **shared** store, so a destroyed instance's late response overwrote a live one's data. Reproduced as `FRESH ORG` → `STALE ORG` with no user action in between. The token moved into the store, where "latest" can mean what it has to mean.

Lock-security review added a third: the membership reconcile could `purge_org_replica` mid-ingest, letting items committed afterwards re-create a searchable local copy for an org the user had just left. Both reconcile call sites are now serialized against the tick, and the call is ledgered as `org_membership_refresh` — it was previously unrecorded cloud egress, on a command that had none at all before this PR.

## Oracles

Each was RED-checked against the code before its fix:

- `no_production_call_site_runs_a_reentrant_callee_under_the_org_mutex`, plus `the_scan_sanitizer_neutralizes_braces_hidden_in_literals` — the scan's brace model is silently defeated by one `'{'` or raw string, which is how a source oracle goes vacuous while still reporting that it looked.
- `a_bounded_guard_makes_a_nested_unbounded_acquisition_panic_instead_of_hanging` — the bounded door now registers its holder, so depth is covered at runtime where a text scan cannot follow. Its RED control is a hang, not a failure.
- `manual_org_sync_drains_the_feed_past_one_page`, `a_drain_does_not_mistake_an_author_backfill_turn_for_a_caught_up_feed`, `one_page_mode_takes_exactly_one_page`, `the_frontend_sends_the_drain_argument_the_command_declares`
- `org_sync_catchup_backs_off_permanently_when_a_tick_always_reports_changed` — RED against my own first version, which re-armed the cap after one slow tick and settled into a permanent ~4 s poll.
- `org_sync_report_wire_shape_is_camel_case`, `org_sync_progress_payload_is_camel_case`
- `e2e/org/org-sync-resilience.spec.ts` — six tests, one of them a labelled control that passes both ways on purpose.

## Judgement calls worth disagreeing with

- I built the transitive call-graph oracle that would close the mutex scan's indirection gap, and **threw it away**. On this tree it flagged ~40 correct sites, because the codebase's correct pattern is "public wrapper takes the lock, then calls the lock-free `_inner`" and a name-based closure cannot tell that from a wedge. A check that fails on correct code gets suppressed, not fixed. The scan instead widened to the whole crate and to both re-entrant symbols, and the doc states the residual plainly: a wedge hidden behind one level of indirection *on the container-reconcile phase specifically* is caught by neither net, because that phase needs a real `AppHandle` and so cannot execute in `cargo test --lib`. It surfaces when somebody presses the button in the dev app.
- The progress event is correlated by org id, not by a press token. A trailing event from a finished press, arriving during the next press on the same org, shows one page's worth of stale count. Fixing it properly needs a correlation id echoed through the command; the half that *can* be pinned cheaply — a progress event with no press in flight must change nothing — has a test.

## Gates

`scripts/ci.sh` green (full stage). `cargo test --lib` 3723 passing, 0 failing. `ng lint`, `ng build` clean. `e2e/org/` 39 passing.

Touch ID, lock-at-rest and screen-share auto-relock verify only on a signed build, so "the sidebar refreshes after the Touch ID tap without a restart" is verified here as code shape plus the emit plus the serialized reconcile — not as a real biometric round trip.
