### PR TITLE
chore(release): 2.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4637,7 +4637,7 @@ dependencies = [
 
 [[package]]
 name = "murmur"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "murmur",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "murmur",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "dependencies": {
         "@angular/common": "^22.0.8",
         "@angular/compiler": "^22.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "murmur",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "scripts": {
     "start": "cargo build -p murmur-brain && ng serve --port 1420",
     "build": "ng build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "murmur"
-version = "2.7.0"
+version = "2.7.1"
 description = "Murmur — local meeting capture, transcription, and AI notes for Obsidian"
 edition = "2021"
 rust-version = "1.77"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Murmur",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "identifier": "com.meetnotes.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
Version bump + release 2.7.1.

Patch release. The only change on trunk since v2.7.0 is #694, which unwedges the org subsystem: `org_sync_now` held `org_share_mutation_lock` across `reconcile_container_shares`, whose callee re-acquires the same non-reentrant mutex, so pressing "Sync now" deadlocked the task permanently and every later org operation blocked until the app was restarted.

Also in it: a manual sync drains the feed instead of taking one four-item page, the background loop catches a backlog up in seconds rather than four objects a minute, sign-in refreshes the org roster and the sidebar, and Settings › Organizations no longer tells a member of several orgs that they belong to none when a read fails.
